### PR TITLE
fix(riselab): add back tracing option

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,9 @@ Uncomment `grafana` and `prometheus` services in `riselab.yml`, and you can view
 
 ## Tracing
 
-Compute node supports streaming tracing. Simply uncomment `jaeger` service in `riselab.yml`.
+Compute node supports streaming tracing. Tracing is not enabled by default, and you will need to
+use `./riselab configure` to enable tracing components. After that, simply uncomment `jaeger`
+service in `riselab.yml`.
 
 ## Dashboard
 

--- a/rust/riselab/src/bin/riselab-config.rs
+++ b/rust/riselab/src/bin/riselab-config.rs
@@ -11,9 +11,9 @@ use itertools::Itertools;
 pub enum Components {
     MinIO,
     PrometheusAndGrafana,
+    Tracing,
     ComputeNodeAndMetaNode,
     Frontend,
-    Tracing,
     Release,
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

Previously I thought the `ENABLE_COMPUTE_TRACING` options is only used to control the logging framework used in compute node... It turns out that it is also used to control whether to download jaeger.

This PR adds it back.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
