### PR TITLE
fix(streaming): correct vec capacity in get_hash_values 

### DIFF
--- a/rust/common/src/array/stream_chunk.rs
+++ b/rust/common/src/array/stream_chunk.rs
@@ -191,7 +191,7 @@ impl StreamChunk {
         keys: &[usize],
         hasher_builder: H,
     ) -> Result<Vec<u64>> {
-        let mut states = vec![]; 
+        let mut states = vec![];
         states.resize_with(self.capacity(), || hasher_builder.build_hasher());
         for key in keys {
             let array = self.columns[*key].array();


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
- correct vec capacity in get_hash_values 

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
