### PR TITLE
refactor(frontend): simplify/rename BoundExpr to Expr

### DIFF
--- a/rust/frontend/src/binder/expr/binary_op.rs
+++ b/rust/frontend/src/binder/expr/binary_op.rs
@@ -2,7 +2,7 @@ use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{BinaryOperator, Expr};
 
 use crate::binder::Binder;
-use crate::expr::{BoundExpr as _, BoundFunctionCall, ExprType};
+use crate::expr::{Expr as _, ExprType, FunctionCall};
 
 impl Binder {
     pub(super) fn bind_binary_op(
@@ -10,7 +10,7 @@ impl Binder {
         left: Expr,
         op: BinaryOperator,
         right: Expr,
-    ) -> Result<BoundFunctionCall> {
+    ) -> Result<FunctionCall> {
         let bound_left = self.bind_expr(left)?;
         let bound_right = self.bind_expr(right)?;
         let func_type = match op {
@@ -27,7 +27,7 @@ impl Binder {
             op,
             bound_right.return_type(),
         );
-        BoundFunctionCall::new(func_type, vec![bound_left, bound_right])
+        FunctionCall::new(func_type, vec![bound_left, bound_right])
             .ok_or_else(|| ErrorCode::NotImplementedError(desc).into())
     }
 }

--- a/rust/frontend/src/binder/expr/mod.rs
+++ b/rust/frontend/src/binder/expr/mod.rs
@@ -2,16 +2,16 @@ use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::Expr;
 
 use crate::binder::Binder;
-use crate::expr::BoundExprImpl;
+use crate::expr::ExprImpl;
 
 mod binary_op;
 mod value;
 
 impl Binder {
-    pub(super) fn bind_expr(&mut self, expr: Expr) -> Result<BoundExprImpl> {
+    pub(super) fn bind_expr(&mut self, expr: Expr) -> Result<ExprImpl> {
         match expr {
-            Expr::Value(v) => Ok(BoundExprImpl::Literal(Box::new(self.bind_value(v)?))),
-            Expr::BinaryOp { left, op, right } => Ok(BoundExprImpl::FunctionCall(Box::new(
+            Expr::Value(v) => Ok(ExprImpl::Literal(Box::new(self.bind_value(v)?))),
+            Expr::BinaryOp { left, op, right } => Ok(ExprImpl::FunctionCall(Box::new(
                 self.bind_binary_op(*left, op, *right)?,
             ))),
             Expr::Nested(expr) => self.bind_expr(*expr),

--- a/rust/frontend/src/binder/expr/value.rs
+++ b/rust/frontend/src/binder/expr/value.rs
@@ -3,13 +3,13 @@ use risingwave_common::types::{DataTypeKind, Decimal, ScalarImpl};
 use risingwave_sqlparser::ast::Value;
 
 use crate::binder::Binder;
-use crate::expr::BoundLiteral;
+use crate::expr::Literal;
 
 impl Binder {
-    pub(super) fn bind_value(&mut self, value: Value) -> Result<BoundLiteral> {
+    pub(super) fn bind_value(&mut self, value: Value) -> Result<Literal> {
         match value {
             Value::Number(s, b) => self.bind_number(s, b),
-            Value::SingleQuotedString(s) => Ok(BoundLiteral::new(
+            Value::SingleQuotedString(s) => Ok(Literal::new(
                 Some(ScalarImpl::Utf8(s)),
                 DataTypeKind::Varchar,
             )),
@@ -17,7 +17,7 @@ impl Binder {
         }
     }
 
-    fn bind_number(&mut self, s: String, _b: bool) -> Result<BoundLiteral> {
+    fn bind_number(&mut self, s: String, _b: bool) -> Result<Literal> {
         let (data, data_type) = if let Ok(int_32) = s.parse::<i32>() {
             (Some(ScalarImpl::Int32(int_32)), DataTypeKind::Int32)
         } else if let Ok(int_64) = s.parse::<i64>() {
@@ -34,7 +34,7 @@ impl Binder {
                 DataTypeKind::Decimal { prec, scale },
             )
         };
-        Ok(BoundLiteral::new(data, data_type))
+        Ok(Literal::new(data, data_type))
     }
 }
 
@@ -80,7 +80,7 @@ mod tests {
         for i in 0..values.len() {
             let value = Value::Number(String::from(values[i]), false);
             let res = binder.bind_value(value).unwrap();
-            let ans = BoundLiteral::new(data[i].clone(), data_type[i]);
+            let ans = Literal::new(data[i].clone(), data_type[i]);
             assert_eq!(res, ans);
         }
     }

--- a/rust/frontend/src/binder/values.rs
+++ b/rust/frontend/src/binder/values.rs
@@ -3,11 +3,11 @@ use risingwave_common::error::Result;
 use risingwave_sqlparser::ast::Values;
 
 use crate::binder::Binder;
-use crate::expr::{BoundExpr as _, BoundExprImpl};
+use crate::expr::{Expr as _, ExprImpl};
 
 #[derive(Debug)]
 pub struct BoundValues {
-    pub rows: Vec<Vec<BoundExprImpl>>,
+    pub rows: Vec<Vec<ExprImpl>>,
     pub schema: Schema,
 }
 

--- a/rust/frontend/src/expr/agg_call.rs
+++ b/rust/frontend/src/expr/agg_call.rs
@@ -1,38 +1,38 @@
 use risingwave_common::expr::AggKind;
 use risingwave_common::types::DataTypeKind;
 
-use super::{BoundExpr, BoundExprImpl};
+use super::{Expr, ExprImpl};
 
 #[derive(Clone, Debug)]
-pub struct BoundAggCall {
+pub struct AggCall {
     agg_kind: AggKind,
     return_type: DataTypeKind,
-    inputs: Vec<BoundExprImpl>,
+    inputs: Vec<ExprImpl>,
 }
-impl BoundAggCall {
+impl AggCall {
     #![allow(unreachable_code)]
     #![allow(unused_variables)]
     #![allow(clippy::diverging_sub_expression)]
-    pub fn new(agg_kind: AggKind, inputs: Vec<BoundExprImpl>) -> Option<Self> {
+    pub fn new(agg_kind: AggKind, inputs: Vec<ExprImpl>) -> Option<Self> {
         let return_type = todo!(); // should be derived from inputs
-        Some(BoundAggCall {
+        Some(AggCall {
             agg_kind,
             return_type,
             inputs,
         })
     }
-    pub fn decompose(self) -> (AggKind, Vec<BoundExprImpl>) {
+    pub fn decompose(self) -> (AggKind, Vec<ExprImpl>) {
         (self.agg_kind, self.inputs)
     }
     pub fn agg_kind(&self) -> AggKind {
         self.agg_kind.clone()
     }
 }
-impl BoundExpr for BoundAggCall {
+impl Expr for AggCall {
     fn return_type(&self) -> DataTypeKind {
         self.return_type
     }
-    fn bound_expr(self) -> BoundExprImpl {
-        BoundExprImpl::AggCall(Box::new(self))
+    fn bound_expr(self) -> ExprImpl {
+        ExprImpl::AggCall(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/function_call.rs
+++ b/rust/frontend/src/expr/function_call.rs
@@ -1,16 +1,16 @@
 use risingwave_common::types::DataTypeKind;
 
-use super::{infer_type, BoundExpr, BoundExprImpl};
+use super::{infer_type, Expr, ExprImpl};
 use crate::expr::ExprType;
 
 #[derive(Clone, Debug)]
-pub struct BoundFunctionCall {
+pub struct FunctionCall {
     func_type: ExprType,
     return_type: DataTypeKind,
-    inputs: Vec<BoundExprImpl>,
+    inputs: Vec<ExprImpl>,
 }
-impl BoundFunctionCall {
-    pub fn new(func_type: ExprType, inputs: Vec<BoundExprImpl>) -> Option<Self> {
+impl FunctionCall {
+    pub fn new(func_type: ExprType, inputs: Vec<ExprImpl>) -> Option<Self> {
         let return_type = infer_type(
             func_type,
             inputs.iter().map(|expr| expr.return_type()).collect(),
@@ -21,28 +21,28 @@ impl BoundFunctionCall {
     /// used for expressions like cast
     pub fn new_with_return_type(
         func_type: ExprType,
-        inputs: Vec<BoundExprImpl>,
+        inputs: Vec<ExprImpl>,
         return_type: DataTypeKind,
     ) -> Self {
-        BoundFunctionCall {
+        FunctionCall {
             func_type,
             return_type,
             inputs,
         }
     }
 
-    pub fn decompose(self) -> (ExprType, Vec<BoundExprImpl>) {
+    pub fn decompose(self) -> (ExprType, Vec<ExprImpl>) {
         (self.func_type, self.inputs)
     }
     pub fn get_expr_type(&self) -> ExprType {
         self.func_type
     }
 }
-impl BoundExpr for BoundFunctionCall {
+impl Expr for FunctionCall {
     fn return_type(&self) -> DataTypeKind {
         self.return_type
     }
-    fn bound_expr(self) -> BoundExprImpl {
-        BoundExprImpl::FunctionCall(Box::new(self))
+    fn bound_expr(self) -> ExprImpl {
+        ExprImpl::FunctionCall(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/input_ref.rs
+++ b/rust/frontend/src/expr/input_ref.rs
@@ -1,29 +1,29 @@
 use risingwave_common::types::DataTypeKind;
 
-use super::{BoundExpr, BoundExprImpl};
+use super::{Expr, ExprImpl};
 use crate::expr::ExprType;
 #[derive(Clone)]
-pub struct BoundInputRef {
+pub struct InputRef {
     index: usize,
     data_type: DataTypeKind,
 }
-impl BoundInputRef {
+impl InputRef {
     pub fn new(index: usize, data_type: DataTypeKind) -> Self {
-        BoundInputRef { index, data_type }
+        InputRef { index, data_type }
     }
     pub fn get_expr_type(&self) -> ExprType {
         ExprType::InputRef
     }
 }
-impl BoundExpr for BoundInputRef {
+impl Expr for InputRef {
     fn return_type(&self) -> DataTypeKind {
         self.data_type
     }
-    fn bound_expr(self) -> BoundExprImpl {
-        BoundExprImpl::InputRef(Box::new(self))
+    fn bound_expr(self) -> ExprImpl {
+        ExprImpl::InputRef(Box::new(self))
     }
 }
-impl std::fmt::Debug for BoundInputRef {
+impl std::fmt::Debug for InputRef {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.index)
     }

--- a/rust/frontend/src/expr/literal.rs
+++ b/rust/frontend/src/expr/literal.rs
@@ -1,26 +1,26 @@
 use risingwave_common::types::{DataTypeKind, Datum};
 
-use super::{BoundExpr, BoundExprImpl};
+use super::{Expr, ExprImpl};
 use crate::expr::ExprType;
 #[derive(Clone, Debug, PartialEq)]
-pub struct BoundLiteral {
+pub struct Literal {
     #[allow(dead_code)]
     data: Datum,
     data_type: DataTypeKind,
 }
-impl BoundLiteral {
+impl Literal {
     pub fn new(data: Datum, data_type: DataTypeKind) -> Self {
-        BoundLiteral { data, data_type }
+        Literal { data, data_type }
     }
     pub fn get_expr_type(&self) -> ExprType {
         ExprType::ConstantValue
     }
 }
-impl BoundExpr for BoundLiteral {
+impl Expr for Literal {
     fn return_type(&self) -> DataTypeKind {
         self.data_type
     }
-    fn bound_expr(self) -> BoundExprImpl {
-        BoundExprImpl::Literal(Box::new(self))
+    fn bound_expr(self) -> ExprImpl {
+        ExprImpl::Literal(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/mod.rs
+++ b/rust/frontend/src/expr/mod.rs
@@ -15,28 +15,28 @@ pub use utils::*;
 pub type ExprType = risingwave_pb::expr::expr_node::Type;
 
 /// the trait of bound exprssions
-pub trait BoundExpr {
+pub trait Expr {
     fn return_type(&self) -> DataTypeKind;
-    fn bound_expr(self) -> BoundExprImpl;
+    fn bound_expr(self) -> ExprImpl;
 }
 #[derive(Clone, Debug)]
-pub enum BoundExprImpl {
+pub enum ExprImpl {
     // ColumnRef(Box<BoundColumnRef>), might be used in binder.
-    InputRef(Box<BoundInputRef>),
-    Literal(Box<BoundLiteral>),
-    FunctionCall(Box<BoundFunctionCall>),
-    AggCall(Box<BoundAggCall>),
+    InputRef(Box<InputRef>),
+    Literal(Box<Literal>),
+    FunctionCall(Box<FunctionCall>),
+    AggCall(Box<AggCall>),
 }
-impl BoundExpr for BoundExprImpl {
+impl Expr for ExprImpl {
     fn return_type(&self) -> DataTypeKind {
         match self {
-            BoundExprImpl::InputRef(expr) => expr.return_type(),
-            BoundExprImpl::Literal(expr) => expr.return_type(),
-            BoundExprImpl::FunctionCall(expr) => expr.return_type(),
-            BoundExprImpl::AggCall(expr) => expr.return_type(),
+            ExprImpl::InputRef(expr) => expr.return_type(),
+            ExprImpl::Literal(expr) => expr.return_type(),
+            ExprImpl::FunctionCall(expr) => expr.return_type(),
+            ExprImpl::AggCall(expr) => expr.return_type(),
         }
     }
-    fn bound_expr(self) -> BoundExprImpl {
+    fn bound_expr(self) -> ExprImpl {
         self
     }
 }

--- a/rust/frontend/src/expr/utils.rs
+++ b/rust/frontend/src/expr/utils.rs
@@ -1,11 +1,11 @@
 use bit_set::BitSet;
 
-use super::BoundExprImpl;
+use super::ExprImpl;
 use crate::expr::ExprType;
 
-fn to_conjunctions_inner(expr: BoundExprImpl, rets: &mut Vec<BoundExprImpl>) {
+fn to_conjunctions_inner(expr: ExprImpl, rets: &mut Vec<ExprImpl>) {
     match expr {
-        BoundExprImpl::FunctionCall(func_call) if func_call.get_expr_type() == ExprType::And => {
+        ExprImpl::FunctionCall(func_call) if func_call.get_expr_type() == ExprType::And => {
             let (_, exprs) = func_call.decompose();
             for expr in exprs.into_iter() {
                 to_conjunctions_inner(expr, rets);
@@ -17,7 +17,7 @@ fn to_conjunctions_inner(expr: BoundExprImpl, rets: &mut Vec<BoundExprImpl>) {
 
 /// give a bool expression, and transform it to Conjunctive form. e.g. given expression is
 /// (expr1 AND expr2 AND expr3) the function will return Vec[expr1, expr2, expr3].
-pub fn to_conjunctions(expr: BoundExprImpl) -> Vec<BoundExprImpl> {
+pub fn to_conjunctions(expr: ExprImpl) -> Vec<ExprImpl> {
     let mut rets = vec![];
     to_conjunctions_inner(expr, &mut rets);
     // TODO: extract common factors fromm the conjunctions with OR expression.
@@ -26,12 +26,12 @@ pub fn to_conjunctions(expr: BoundExprImpl) -> Vec<BoundExprImpl> {
 }
 
 /// give a expression, and get all columns in its input_ref expressions.
-pub fn get_col_refs(_expr: &BoundExprImpl) -> BitSet {
+pub fn get_col_refs(_expr: &ExprImpl) -> BitSet {
     todo!()
 }
 /// give a expression, and check all columns in its input_ref expressions less than the input
 /// column number.
-pub fn assert_input_ref(expr: &BoundExprImpl, input_col_num: usize) {
+pub fn assert_input_ref(expr: &ExprImpl, input_col_num: usize) {
     let cols = get_col_refs(expr);
     for col in cols.iter() {
         assert!(col < input_col_num);

--- a/rust/frontend/src/optimizer/plan_node/col_pruning.rs
+++ b/rust/frontend/src/optimizer/plan_node/col_pruning.rs
@@ -2,7 +2,7 @@ use bit_set::BitSet;
 use paste::paste;
 
 use super::*;
-use crate::expr::{BoundExpr, BoundExprImpl, BoundInputRef};
+use crate::expr::{Expr, ExprImpl, InputRef};
 use crate::optimizer::property::WithSchema;
 use crate::{for_batch_plan_nodes, for_stream_plan_nodes};
 
@@ -11,9 +11,9 @@ pub trait ColPrunable: WithSchema + IntoPlanRef {
     /// transform the plan node to only output the required columns ordered by index number.
     fn prune_col(&self, required_cols: BitSet) -> PlanRef {
         let schema = self.schema();
-        let exprs: Vec<BoundExprImpl> = required_cols
+        let exprs: Vec<ExprImpl> = required_cols
             .iter()
-            .map(|i| BoundInputRef::new(i, schema.fields()[i].data_type()).bound_expr())
+            .map(|i| InputRef::new(i, schema.fields()[i].data_type()).bound_expr())
             .collect();
         let alias = vec![None; required_cols.len()];
         LogicalProject::create(self.clone_as_plan_ref(), exprs, alias)

--- a/rust/frontend/src/optimizer/plan_node/join_predicate.rs
+++ b/rust/frontend/src/optimizer/plan_node/join_predicate.rs
@@ -1,11 +1,11 @@
-use crate::expr::{get_col_refs, to_conjunctions, BoundExprImpl};
+use crate::expr::{get_col_refs, to_conjunctions, ExprImpl};
 #[derive(Debug, Clone)]
 /// the join predicate used in optimizer
 pub struct JoinPredicate {
     /// other conditions, linked with AND conjunction.
     /// 1. the non equal conditons
     /// 2. the conditions in the same side,
-    other_conds: Vec<BoundExprImpl>,
+    other_conds: Vec<ExprImpl>,
     /// the equal columns indexes(in the input schema) both sides, now all are normal equal(not
     /// null-safe-equal),
     keys: Vec<(usize, usize)>,
@@ -13,7 +13,7 @@ pub struct JoinPredicate {
 #[allow(dead_code)]
 impl JoinPredicate {
     /// the new method for `JoinPredicate` without any analysis, check or rewrite.
-    pub fn new(other_conds: Vec<BoundExprImpl>, keys: Vec<(usize, usize)>) -> Self {
+    pub fn new(other_conds: Vec<ExprImpl>, keys: Vec<(usize, usize)>) -> Self {
         JoinPredicate { other_conds, keys }
     }
     /// `create` will analyze the on clause condition and construct a `JoinPredicate`.
@@ -32,7 +32,7 @@ impl JoinPredicate {
     ///   keys= Vec[(1,1)]
     /// ```
     #[allow(unused_variables)]
-    pub fn create(left_cols_num: usize, on_clause: BoundExprImpl) -> Self {
+    pub fn create(left_cols_num: usize, on_clause: ExprImpl) -> Self {
         let conds = to_conjunctions(on_clause);
         for cond in conds {
             let cols = get_col_refs(&cond);
@@ -56,7 +56,7 @@ impl JoinPredicate {
     }
 
     /// Get a reference to the join predicate's other conds.
-    pub fn other_conds(&self) -> &[BoundExprImpl] {
+    pub fn other_conds(&self) -> &[ExprImpl] {
         self.other_conds.as_ref()
     }
     // TODO: our backend not support some equal columns and sonm NonEqual condition

--- a/rust/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -6,7 +6,7 @@ use risingwave_common::expr::AggKind;
 use risingwave_common::types::DataTypeKind;
 
 use super::{ColPrunable, IntoPlanRef, PlanRef, PlanTreeNodeUnary, ToBatch, ToStream};
-use crate::expr::BoundExprImpl;
+use crate::expr::ExprImpl;
 use crate::optimizer::property::{WithDistribution, WithOrder, WithSchema};
 #[derive(Clone, Debug)]
 pub struct PlanAggCall {
@@ -76,9 +76,9 @@ impl LogicalAgg {
     /// LogicalProject-LogicalAgg-LogicalProject-input
     #[allow(unused_variables)]
     pub fn create(
-        select_exprs: Vec<BoundExprImpl>,
+        select_exprs: Vec<ExprImpl>,
         select_alias: Vec<Option<String>>,
-        group_exprs: Vec<BoundExprImpl>,
+        group_exprs: Vec<ExprImpl>,
         input: PlanRef,
     ) -> PlanRef {
         todo!()

--- a/rust/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -5,18 +5,18 @@ use risingwave_common::error::Result;
 use risingwave_common::types::DataTypeKind;
 
 use super::{ColPrunable, IntoPlanRef, PlanRef, PlanTreeNodeUnary, ToBatch, ToStream};
-use crate::expr::{assert_input_ref, to_conjunctions, BoundExpr, BoundExprImpl};
+use crate::expr::{assert_input_ref, to_conjunctions, Expr, ExprImpl};
 use crate::optimizer::property::{WithDistribution, WithOrder, WithSchema};
 
 #[derive(Debug, Clone)]
 pub struct LogicalFilter {
     /// condition bool expressions, linked with AND conjunction
-    conds: Vec<BoundExprImpl>,
+    conds: Vec<ExprImpl>,
     input: PlanRef,
     schema: Schema,
 }
 impl LogicalFilter {
-    fn new(input: PlanRef, conds: Vec<BoundExprImpl>) -> Self {
+    fn new(input: PlanRef, conds: Vec<ExprImpl>) -> Self {
         for cond in &conds {
             assert_eq!(cond.return_type(), DataTypeKind::Boolean);
             assert_input_ref(cond, input.schema().fields().len());
@@ -30,7 +30,7 @@ impl LogicalFilter {
     }
 
     /// the function will check if the cond is bool expression
-    pub fn create(input: PlanRef, cond: BoundExprImpl) -> Result<PlanRef> {
+    pub fn create(input: PlanRef, cond: ExprImpl) -> Result<PlanRef> {
         let conds = to_conjunctions(cond);
         Ok(Self::new(input, conds).into_plan_ref())
     }

--- a/rust/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_join.rs
@@ -8,7 +8,7 @@ use super::{
     ColPrunable, IntoPlanRef, JoinPredicate, PlanRef, PlanTreeNodeBinary, StreamHashJoin, ToBatch,
     ToStream,
 };
-use crate::expr::{assert_input_ref, BoundExpr, BoundExprImpl};
+use crate::expr::{assert_input_ref, Expr, ExprImpl};
 use crate::optimizer::plan_node::{BatchHashJoin, BatchSortMergeJoin};
 use crate::optimizer::property::{Distribution, Order, WithDistribution, WithOrder, WithSchema};
 
@@ -54,7 +54,7 @@ impl LogicalJoin {
         left: PlanRef,
         right: PlanRef,
         join_type: JoinType,
-        on_clause: BoundExprImpl,
+        on_clause: ExprImpl,
     ) -> PlanRef {
         let left_cols_num = left.schema().fields.len();
         let predicate = JoinPredicate::create(left_cols_num, on_clause);

--- a/rust/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_project.rs
@@ -7,18 +7,18 @@ use super::{
     BatchProject, ColPrunable, IntoPlanRef, PlanRef, PlanTreeNodeUnary, StreamProject, ToBatch,
     ToStream,
 };
-use crate::expr::{assert_input_ref, BoundExpr, BoundExprImpl};
+use crate::expr::{assert_input_ref, Expr, ExprImpl};
 use crate::optimizer::property::{Distribution, WithDistribution, WithOrder, WithSchema};
 
 #[derive(Debug, Clone)]
 pub struct LogicalProject {
-    exprs: Vec<BoundExprImpl>,
+    exprs: Vec<ExprImpl>,
     expr_alias: Vec<Option<String>>,
     input: PlanRef,
     schema: Schema,
 }
 impl LogicalProject {
-    fn new(input: PlanRef, exprs: Vec<BoundExprImpl>, expr_alias: Vec<Option<String>>) -> Self {
+    fn new(input: PlanRef, exprs: Vec<ExprImpl>, expr_alias: Vec<Option<String>>) -> Self {
         let schema = Self::derive_schema(&exprs, &expr_alias);
         for expr in &exprs {
             assert_input_ref(expr, input.schema().fields().len());
@@ -32,13 +32,13 @@ impl LogicalProject {
     }
     pub fn create(
         input: PlanRef,
-        exprs: Vec<BoundExprImpl>,
+        exprs: Vec<ExprImpl>,
         expr_alias: Vec<Option<String>>,
     ) -> PlanRef {
         Self::new(input, exprs, expr_alias).into_plan_ref()
     }
 
-    fn derive_schema(exprs: &[BoundExprImpl], expr_alias: &[Option<String>]) -> Schema {
+    fn derive_schema(exprs: &[ExprImpl], expr_alias: &[Option<String>]) -> Schema {
         let fields = exprs
             .iter()
             .zip_eq(expr_alias.iter())
@@ -53,7 +53,7 @@ impl LogicalProject {
             .collect();
         Schema { fields }
     }
-    pub fn exprs(&self) -> &Vec<BoundExprImpl> {
+    pub fn exprs(&self) -> &Vec<ExprImpl> {
         &self.exprs
     }
 

--- a/rust/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_values.rs
@@ -4,18 +4,18 @@ use risingwave_common::catalog::Schema;
 use risingwave_common::error::Result;
 
 use super::{ColPrunable, PlanRef, ToBatch, ToStream};
-use crate::expr::{BoundExpr, BoundExprImpl};
+use crate::expr::{Expr, ExprImpl};
 use crate::optimizer::plan_node::IntoPlanRef;
 use crate::optimizer::property::{WithDistribution, WithOrder, WithSchema};
 #[derive(Debug, Clone)]
 pub struct LogicalValues {
-    rows: Vec<Vec<BoundExprImpl>>,
+    rows: Vec<Vec<ExprImpl>>,
     schema: Schema,
 }
 
 impl LogicalValues {
     /// Create a LogicalValues node. Used internally by optimizer.
-    pub fn new(rows: Vec<Vec<BoundExprImpl>>, schema: Schema) -> Self {
+    pub fn new(rows: Vec<Vec<ExprImpl>>, schema: Schema) -> Self {
         for exprs in &rows {
             for (i, expr) in exprs.iter().enumerate() {
                 assert_eq!(schema.fields()[i].data_type(), expr.return_type())
@@ -25,13 +25,13 @@ impl LogicalValues {
     }
 
     /// Create a LogicalValues node. Used by planner.
-    pub fn create(rows: Vec<Vec<BoundExprImpl>>, schema: Schema) -> Result<Self> {
+    pub fn create(rows: Vec<Vec<ExprImpl>>, schema: Schema) -> Result<Self> {
         // No additional checks after binder.
         Ok(Self::new(rows, schema))
     }
 
     /// Get a reference to the logical values's rows.
-    pub fn rows(&self) -> &[Vec<BoundExprImpl>] {
+    pub fn rows(&self) -> &[Vec<ExprImpl>] {
         self.rows.as_ref()
     }
 }


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

(Discussion) The naming convention "BoundXxxx" looks fine in Binder, but considering that most of the planner's code will interact with these bounded functions instead of AST nodes, can we simplify it like "FunctionCall" or "InputRef" ?

_Originally posted by @fuyufjh in legacy 2683#discussion_r786374968_

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
