### PR TITLE
fix(riselab): do not enable all components on `--default`

### DIFF
--- a/rust/riselab/common.toml
+++ b/rust/riselab/common.toml
@@ -11,8 +11,8 @@ PREFIX_LOG = "${PREFIX}/log"
 PREFIX_TMP = "${PREFIX}/tmp"
 
 HUMMOCK_PATH = "${PREFIX_DATA}/hummock"
-BUILD_MODE_DIR = { source = "${ENABLE_RELEASE_BUILD}", default_value = "debug", mapping = { "true" = "release" } }
-RISINGWAVE_BUILD_PROFILE = { source = "${ENABLE_RELEASE_BUILD}", default_value = "dev", mapping = { "true" = "release" } }
+BUILD_MODE_DIR = { source = "${ENABLE_RELEASE_PROFILE}", default_value = "debug", mapping = { true = "release" } }
+RISINGWAVE_BUILD_PROFILE = { source = "${ENABLE_RELEASE_PROFILE}", default_value = "dev", mapping = { true = "release" } }
 
 [tasks.prepare-dir]
 private = true

--- a/rust/riselab/src/bin/riselab-config.rs
+++ b/rust/riselab/src/bin/riselab-config.rs
@@ -72,7 +72,7 @@ Build RisingWave in release mode"
             Self::ComputeNodeAndMetaNode => "ENABLE_BUILD_RUST",
             Self::Frontend => "ENABLE_BUILD_FRONTEND",
             Self::Tracing => "ENABLE_COMPUTE_TRACING",
-            Self::Release => "ENABLE_RELEASE_BUILD",
+            Self::Release => "ENABLE_RELEASE_PROFILE",
         }
         .into()
     }


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
RiseLAB configuration generator should not enable all components on `--default`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Close #82.