### PR TITLE
fix(riselab): minio not initialized

### DIFF
--- a/.github/workflow-template/template.yml
+++ b/.github/workflow-template/template.yml
@@ -127,6 +127,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
 
       - name: e2e test w/ Hummock w/o cache
@@ -138,6 +139,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
 
       - name: e2e test batch 3-node
@@ -149,7 +151,12 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
+
+      - name: Dump last 100 lines of logs on failure
+        if: ${{ failure() }}
+        run: ~/cargo-make/makers logs
 
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
@@ -266,7 +273,7 @@ jobs:
         run: |
           ./scripts/kill_cluster.sh
 
-  # Start 2 runners (a/b) to run build and test in parallel. 
+  # Start 2 runners (a/b) to run build and test in parallel.
   start-runner-a:
     name: ec2-start-a
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,6 +114,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
       - name: e2e test w/ Hummock w/o cache
         run: |
@@ -123,6 +124,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
       - name: e2e test batch 3-node
         run: |
@@ -132,7 +134,11 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
+      - name: Dump last 100 lines of logs on failure
+        if: ${{ failure() }}
+        run: ~/cargo-make/makers logs
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         name: Upload RiseLAB logs on failure (You may find it in artifacts)

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
       - name: e2e test w/ Hummock w/o cache
         run: |
@@ -122,6 +123,7 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
       - name: e2e test batch 3-node
         run: |
@@ -131,7 +133,11 @@ jobs:
       - name: Kill cluster
         run: |
           ~/cargo-make/makers k
+          ~/cargo-make/makers logs
           ~/cargo-make/makers check-logs
+      - name: Dump last 100 lines of logs on failure
+        if: ${{ failure() }}
+        run: ~/cargo-make/makers logs
       - uses: actions/upload-artifact@v2
         if: ${{ failure() }}
         name: Upload RiseLAB logs on failure (You may find it in artifacts)

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -48,7 +48,7 @@ do
   echo "=== Dump log file $out_file ==="
   echo "==="
   echo ""
-  cat "$out_file"
+  cat "$out_file" | tail -n 100
 done
 '''
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

MinIO would still be in the state of uninitialized even when health port probes 200 OK. This PR fixes this by retrying.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
