### PR TITLE
fix(frontend): use original string for BigDecimal instead of parseDouble

### DIFF
--- a/e2e_test/streaming/tpch/create_views.slt.part
+++ b/e2e_test/streaming/tpch/create_views.slt.part
@@ -214,7 +214,7 @@ create materialized view tpch_q10 as
 select
 	c_custkey,
 	c_name,
-	sum(l_extendedprice * (1 - l_discount)) as revenue,
+	sum(l_extendedprice * (1.00 - l_discount)) as revenue,
 	c_acctbal,
 	n_name,
 	c_address,

--- a/e2e_test/streaming/tpch/q10.slt.part
+++ b/e2e_test/streaming/tpch/q10.slt.part
@@ -8,16 +8,16 @@ select * from tpch_q10;
 94 Customer#000000094 109328.4416 5500.11 INDONESIA IfVNIN9KtkScJ9dUjK3Pg5gY1aFeaXewwf 19-953-499-8833 latelets across the bold, final requests sleep according to the fluffily bold accounts. unusual deposits amon
 118 Customer#000000118 108519.0568 3582.37 CHINA OVnFuHygK9wx3xpg8 28-639-943-7051 uick packages alongside of the furiously final deposits haggle above the fluffily even foxes. blithely dogged dep
 139 Customer#000000139 102799.6791 7897.78 INDONESIA 3ElvBwudHKL02732YexGVFVt 19-140-352-1403 nstructions. quickly ironic ideas are carefully. bold,
-25 Customer#000000025 80561.6934 7133.7 JAPAN Hp8GyFQgGHFYSilH5tBfe 22-603-468-3533 y. accounts sleep ruthlessly according to the regular theodolites. unusual instructions sleep. ironic, final
+25 Customer#000000025 80561.6934 7133.70 JAPAN Hp8GyFQgGHFYSilH5tBfe 22-603-468-3533 y. accounts sleep ruthlessly according to the regular theodolites. unusual instructions sleep. ironic, final
 128 Customer#000000128 74326.7714 -986.96 EGYPT AmKUMlJf2NRHcKGmKjLS 14-280-874-8044 ing packages integrate across the slyly unusual dugouts. blithely silent ideas sublate carefully. blithely expr
 4 Customer#000000004 68199.2151 2866.83 EGYPT XxVSJsLAGtn 14-128-190-5944 requests. final, regular ideas sleep final accou
-14 Customer#000000014 63310.3940 5266.3 ARGENTINA KXkletMlL2JQEA 11-845-129-3851 , ironic packages across the unus
+14 Customer#000000014 63310.3940 5266.30 ARGENTINA KXkletMlL2JQEA 11-845-129-3851 , ironic packages across the unus
 55 Customer#000000055 54376.8534 4572.11 IRAN zIRBR4KNEl HzaiV3a i9n6elrxzDEh8r8pDom 20-180-440-8525 ully unusual packages wake bravely bold packages. unusual requests boost deposits! blithely ironic packages ab
+46 Customer#000000046 46956.6000 5744.59 FRANCE eaTXWWm10L9 16-357-681-2007 ctions. accounts sleep furiously even requests. regular, regular accounts cajole blithely around the final pa
 23 Customer#000000023 46655.3250 3332.02 CANADA OdY W13N7Be3OC5MpgfmcYss0Wn6TKT 13-312-472-8245 deposits. special deposits cajole slyly. fluffily special deposits about the furiously
 61 Customer#000000061 45467.8872 1536.24 PERU 9kndve4EAJxhg3veF BfXr7AqOsT39o gtqjaYE 27-626-559-8599 egular packages shall have to impress along the
-40 Customer#000000040 44161.9506 1335.3 CANADA gOnGWAyhSV1ofv 13-652-915-8939 rges impress after the slyly ironic courts. foxes are. blithely
+40 Customer#000000040 44161.9506 1335.30 CANADA gOnGWAyhSV1ofv 13-652-915-8939 rges impress after the slyly ironic courts. foxes are. blithely
+19 Customer#000000019 35730.0870 8914.71 CHINA uc,3bHIx84H,wdrmLOjVsiqXCq2tr 28-396-526-5053 nag. furiously careful packages are slyly at the accounts. furiously regular in
+130 Customer#000000130 31499.4100 5073.58 INDONESIA RKPx2OfZy0Vn 8wGWZ7F2EAvmMORl1k8iH 19-190-993-9281 ix slowly. express packages along the furiously ironic requests integrate daringly deposits. fur
 88 Customer#000000088 29032.1268 8031.44 MOZAMBIQUE wtkjBN9eyrFuENSMmMFlJ3e7jE5KXcg 26-516-273-2566 s are quickly above the quickly ironic instructions; even requests about the carefully final deposi
-19 Customer#000000019 35730.087 8914.71 CHINA uc,3bHIx84H,wdrmLOjVsiqXCq2tr 28-396-526-5053 nag. furiously careful packages are slyly at the accounts. furiously regular in
-85 Customer#000000085 27823.560 3386.64 ETHIOPIA siRerlDwiolhYR 8FgksoezycLj 15-745-585-8219 ronic ideas use above the slowly pendin
-46 Customer#000000046 46956.60 5744.59 FRANCE eaTXWWm10L9 16-357-681-2007 ctions. accounts sleep furiously even requests. regular, regular accounts cajole blithely around the final pa
-130 Customer#000000130 31499.41 5073.58 INDONESIA RKPx2OfZy0Vn 8wGWZ7F2EAvmMORl1k8iH 19-190-993-9281 ix slowly. express packages along the furiously ironic requests integrate daringly deposits. fur
+85 Customer#000000085 27823.5600 3386.64 ETHIOPIA siRerlDwiolhYR 8FgksoezycLj 15-745-585-8219 ronic ideas use above the slowly pendin

--- a/java/planner/src/main/java/com/risingwave/sql/ToCalciteAstVisitor.java
+++ b/java/planner/src/main/java/com/risingwave/sql/ToCalciteAstVisitor.java
@@ -459,7 +459,8 @@ public class ToCalciteAstVisitor extends AstVisitor<SqlNode, Void> {
   @Override
   protected SqlNode visitDoubleLiteral(DoubleLiteral node, Void context) {
     // TODO: Optimize this
-    String value = BigDecimal.valueOf(node.getValue()).toString();
+    BigDecimal decimal = new BigDecimal(node.getValueString());
+    String value = decimal.toString();
     return SqlLiteral.createExactNumeric(value, SqlParserPos.ZERO);
   }
 

--- a/java/planner/src/main/java/com/risingwave/sql/tree/DoubleLiteral.java
+++ b/java/planner/src/main/java/com/risingwave/sql/tree/DoubleLiteral.java
@@ -23,16 +23,24 @@ package com.risingwave.sql.tree;
 
 import static java.util.Objects.requireNonNull;
 
+/** DoubleLiteral */
 public class DoubleLiteral extends Literal {
 
   private final double value;
 
+  private final String valueStr;
+
   public DoubleLiteral(String value) {
+    this.valueStr = value;
     this.value = Double.parseDouble(requireNonNull(value, "value is null"));
   }
 
   public double getValue() {
     return value;
+  }
+
+  public String getValueString() {
+    return valueStr;
   }
 
   @Override

--- a/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
@@ -738,7 +738,7 @@ RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], col
                       RwBatchFilter(condition=[=($1, CAST('ARGENTINA'):CHAR(25) NOT NULL)])
                         RwBatchTableScan(table=[[test_schema, nation]], columns=[n_nationkey,n_name])
         RwBatchExchange(distribution=[RwDistributionTrait{type=BROADCAST_DISTRIBUTED, keys=[]}], collation=[[]])
-          RwBatchProject(EXPR$0=[*($0, 0.00010:DECIMAL(6,5))])
+          RwBatchProject(EXPR$0=[*($0, 0.0001000000:DECIMAL(11,10))])
             RwBatchSortAgg(group=[{}], agg#0=[SUM($0)])
               RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
                 RwBatchSortAgg(group=[{}], agg#0=[SUM($0)])
@@ -878,7 +878,7 @@ where
         </Resource>
         <Resource name="distributed">
             <![CDATA[
-RwBatchProject(promo_revenue=[/(*(100.0:DECIMAL(4,1), $0), $1)])
+RwBatchProject(promo_revenue=[/(*(100.00:DECIMAL(5,2), $0), $1)])
   RwBatchSortAgg(group=[{}], agg#0=[SUM($0)], agg#1=[SUM($1)])
     RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
       RwBatchSortAgg(group=[{}], agg#0=[SUM($0)], agg#1=[SUM($1)])
@@ -1509,7 +1509,7 @@ RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], col
                           RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
                             RwBatchSortAgg(group=[{}], agg#0=[SUM($0)], agg#1=[COUNT($0)])
                               RwBatchProject(c_acctbal=[$1])
-                                RwBatchFilter(condition=[AND(>($1, 0.0), OR(=(SUBSTRING($0, 1, 2), '30'), =(SUBSTRING($0, 1, 2), '24'), =(SUBSTRING($0, 1, 2), '31'), =(SUBSTRING($0, 1, 2), '38'), =(SUBSTRING($0, 1, 2), '25'), =(SUBSTRING($0, 1, 2), '34'), =(SUBSTRING($0, 1, 2), '37')))])
+                                RwBatchFilter(condition=[AND(>($1, 0.00), OR(=(SUBSTRING($0, 1, 2), '30'), =(SUBSTRING($0, 1, 2), '24'), =(SUBSTRING($0, 1, 2), '31'), =(SUBSTRING($0, 1, 2), '38'), =(SUBSTRING($0, 1, 2), '25'), =(SUBSTRING($0, 1, 2), '34'), =(SUBSTRING($0, 1, 2), '37')))])
                                   RwBatchTableScan(table=[[test_schema, customer]], columns=[c_phone,c_acctbal])
                 RwBatchHashAgg(group=[{0}], agg#0=[MIN($1)])
                   RwBatchExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
`create table t1(v1 numeric);`
`insert into t1 values (1.23), (1.20), (1.00);`
`select * from t1`
Previously, it returns 1.23, 1.2, 1.0;
Now, it return 1.23, 1.20, 1.00.

This blocks tpch q18.

`1` in the query of tpch q10 is changed to `1.00` due to reasons in #135. Batch's q10 has a manually added `round`, so may leave it for now.

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
closes #115