### PR TITLE
refactor(catalog): remove primary keys and use Map instead of vector

### DIFF
--- a/rust/frontend/src/catalog/column_catalog.rs
+++ b/rust/frontend/src/catalog/column_catalog.rs
@@ -7,19 +7,11 @@ use crate::catalog::ColumnId;
 #[derive(Debug, Clone)]
 pub struct ColumnDesc {
     data_type: DataType,
-    is_primary: bool,
 }
 
 impl ColumnDesc {
-    pub fn new(data_type: DataType, is_primary: bool) -> Self {
-        ColumnDesc {
-            data_type,
-            is_primary,
-        }
-    }
-
-    pub fn is_primary(&self) -> bool {
-        self.is_primary
+    pub fn new(data_type: DataType) -> Self {
+        ColumnDesc { data_type }
     }
 
     pub fn data_type(&self) -> DataType {
@@ -31,7 +23,6 @@ impl From<ProstColumnDesc> for ColumnDesc {
     fn from(col: ProstColumnDesc) -> Self {
         Self {
             data_type: col.get_column_type().expect("column type not found").into(),
-            is_primary: col.is_primary,
         }
     }
 }
@@ -59,10 +50,6 @@ impl ColumnCatalog {
 
     pub fn data_type(&self) -> DataType {
         self.desc.data_type
-    }
-
-    pub fn is_primary(&self) -> bool {
-        self.desc.is_primary()
     }
 
     pub fn col_desc_ref(&self) -> &ColumnDesc {

--- a/rust/frontend/src/catalog/table_catalog.rs
+++ b/rust/frontend/src/catalog/table_catalog.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use risingwave_common::array::RwError;
@@ -5,13 +6,12 @@ use risingwave_common::error::Result;
 use risingwave_pb::meta::Table;
 
 use crate::catalog::column_catalog::{ColumnCatalog, ColumnDesc};
-use crate::catalog::{ColumnId, TableId};
+use crate::catalog::{CatalogError, TableId};
 
 pub struct TableCatalog {
     table_id: TableId,
     next_column_id: AtomicU64,
-    column_by_name: Vec<(String, ColumnCatalog)>,
-    primary_keys: Vec<ColumnId>,
+    column_by_name: HashMap<String, ColumnCatalog>,
 }
 
 impl TableCatalog {
@@ -19,8 +19,7 @@ impl TableCatalog {
         Self {
             table_id,
             next_column_id: AtomicU64::new(0),
-            column_by_name: vec![],
-            primary_keys: vec![],
+            column_by_name: HashMap::new(),
         }
     }
 
@@ -28,32 +27,25 @@ impl TableCatalog {
         let col_catalog = ColumnCatalog::new(
             self.next_column_id.fetch_add(1, Ordering::Relaxed),
             col_name.to_string(),
-            col_desc.clone(),
+            col_desc,
         );
-        if col_desc.is_primary() {
-            self.primary_keys.push(col_catalog.id());
-        }
         self.column_by_name
-            .push((col_name.to_string(), col_catalog));
+            .try_insert(col_name.to_string(), col_catalog)
+            .map_err(|_| RwError::from(CatalogError::Duplicated("column", col_name.to_string())))?;
         Ok(())
     }
 
-    pub fn get_column_by_id(&self, col_id: ColumnId) -> Option<&ColumnCatalog> {
-        self.column_by_name
-            .get(col_id as usize)
-            .map(|(_, col_catalog)| col_catalog)
+    /// Used by binder to do column name resolving: column name to column id.
+    pub fn get_column_by_name(&self, col_name: &str) -> Option<&ColumnCatalog> {
+        self.column_by_name.get(col_name)
     }
 
-    pub fn columns(&self) -> &[(String, ColumnCatalog)] {
-        self.column_by_name.as_slice()
+    pub fn columns(&self) -> &HashMap<String, ColumnCatalog> {
+        &self.column_by_name
     }
 
     pub fn id(&self) -> TableId {
         self.table_id
-    }
-
-    pub fn get_pks(&self) -> Vec<u64> {
-        self.primary_keys.clone()
     }
 }
 
@@ -63,10 +55,7 @@ impl TryFrom<&Table> for TableCatalog {
     fn try_from(tb: &Table) -> Result<Self> {
         let mut table_catalog = Self::new(tb.get_table_ref_id()?.table_id as u64);
         for col in &tb.column_descs {
-            table_catalog.add_column(
-                &col.name,
-                ColumnDesc::new(col.get_column_type()?.into(), col.is_primary),
-            )?;
+            table_catalog.add_column(&col.name, ColumnDesc::new(col.get_column_type()?.into()))?;
         }
         Ok(table_catalog)
     }

--- a/rust/frontend/src/handler/create_source.rs
+++ b/rust/frontend/src/handler/create_source.rs
@@ -48,6 +48,7 @@ pub(super) async fn handle_create_source(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::io::Write;
 
     use risingwave_common::types::DataType;
@@ -101,16 +102,13 @@ mod tests {
             .columns()
             .iter()
             .map(|(col_name, col)| (col_name.clone(), col.data_type()))
-            .collect::<Vec<(String, DataType)>>();
-        assert_eq!(
-            columns,
-            vec![
-                ("id".to_string(), DataType::Int32),
-                ("city".to_string(), DataType::Varchar),
-                ("zipcode".to_string(), DataType::Int64),
-                ("rate".to_string(), DataType::Float32),
-            ]
-        );
+            .collect::<HashMap<String, DataType>>();
+        let mut expected_map = HashMap::new();
+        expected_map.insert("id".to_string(), DataType::Int32);
+        expected_map.insert("city".to_string(), DataType::Varchar);
+        expected_map.insert("zipcode".to_string(), DataType::Int64);
+        expected_map.insert("rate".to_string(), DataType::Float32);
+        assert_eq!(columns, expected_map);
 
         meta.stop().await;
     }

--- a/rust/frontend/src/handler/create_table.rs
+++ b/rust/frontend/src/handler/create_table.rs
@@ -64,6 +64,8 @@ pub(super) async fn handle_create_table(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use risingwave_common::types::DataType;
     use risingwave_meta::test_utils::LocalMeta;
 
@@ -87,18 +89,14 @@ mod tests {
             .columns()
             .iter()
             .map(|(col_name, col)| (col_name.clone(), col.data_type()))
-            .collect::<Vec<(String, DataType)>>();
-        assert_eq!(
-            columns,
-            vec![
-                ("v1".to_string(), DataType::Int16),
-                ("v2".to_string(), DataType::Int32),
-                ("v3".to_string(), DataType::Int64),
-                ("v4".to_string(), DataType::Float32),
-                ("v5".to_string(), DataType::Float64),
-            ]
-        );
-
+            .collect::<HashMap<String, DataType>>();
+        let mut expected_map = HashMap::new();
+        expected_map.insert("v1".to_string(), DataType::Int16);
+        expected_map.insert("v2".to_string(), DataType::Int32);
+        expected_map.insert("v3".to_string(), DataType::Int64);
+        expected_map.insert("v4".to_string(), DataType::Float32);
+        expected_map.insert("v5".to_string(), DataType::Float64);
+        assert_eq!(columns, expected_map);
         meta.stop().await;
     }
 }


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
Previous refactor in #130 is closed, but there are still some work can be done.

* remove primary key declare in frontend.
* Use map instead of Vetcor: Better column name resolving for binder.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
