### PR TITLE
fix(streaming): ignore notifier send error of local barrier manager

### DIFF
--- a/rust/stream/src/task/barrier_manager.rs
+++ b/rust/stream/src/task/barrier_manager.rs
@@ -190,9 +190,15 @@ impl LocalBarrierManager {
                 if state.remaining_actors.is_empty() {
                     let state = managed_state.take().unwrap();
                     self.last_epoch = Some(state.epoch);
+
                     // Notify about barrier finishing.
                     let tx = state.collect_notifier;
-                    tx.send(()).unwrap();
+                    if tx.send(()).is_err() {
+                        warn!(
+                            "failed to notify barrier collection with epoch {}: rx is dropped",
+                            state.epoch
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
Sometimes the rx of notifier is dropped unexpectedly due to shutdown or some other reasons. We may ignore this send error.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Failing example: https://github.com/singularity-data/risingwave-dev/runs/5105442552?check_suite_focus=true