### PR TITLE
feat(dashboard): resolve chain node of mv on mv

### DIFF
--- a/rust/meta/src/dashboard/index.html
+++ b/rust/meta/src/dashboard/index.html
@@ -483,18 +483,18 @@
     $(`#actor-wrapper-${operatorId}`).css("height", `${gHeight / 16}rem`)
   }
 
-  fetch('http://127.0.0.1:5691/api/clusters/0')
+  fetch('/api/clusters/0')
     .then(response => response.json())
     .then(data => data.forEach(
       data => $("#clusters").append(cluster("Frontend", data))))
-  fetch('http://127.0.0.1:5691/api/clusters/1')
+  fetch('/api/clusters/1')
     .then(response => response.json())
     .then(data => data.forEach(
       data => $("#clusters").append(cluster("Compute Node", data))))
   $("#clusters").append(cluster("Meta Node", { host: { host: "127.0.0.1", port: "2333" } }))
 
   const loadActors = () => {
-    fetch('http://127.0.0.1:5691/api/actors')
+    fetch('/api/actors')
       .then(response => response.json())
       .then(data => data.forEach(
         (data, operatorId) => {


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
This PR introduces an **optional** feature "resolving mv on mv" for dashboard.
Note that the fragments of base MV might be rendered multiple times in different MVs.

<img width="1062" alt="Screen Shot 2022-02-09 at 3 52 53 PM" src="https://user-images.githubusercontent.com/25862682/153146083-15badde6-4619-4cd9-93eb-60e9064bf42d.png">


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
