### PR TITLE
fix(frontend): bypass Sarg optimization in project

### DIFF
--- a/java/planner/src/main/java/com/risingwave/planner/rel/logical/RwLogicalProject.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/logical/RwLogicalProject.java
@@ -1,5 +1,6 @@
 package com.risingwave.planner.rel.logical;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.plan.Convention;
 import org.apache.calcite.plan.RelOptCluster;
@@ -12,6 +13,7 @@ import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalProject;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexUtil;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Customized LogicalProject * */
@@ -54,12 +56,18 @@ public class RwLogicalProject extends Project implements RisingWaveLogicalRel {
       LogicalProject logicalProject = (LogicalProject) rel;
       var input = logicalProject.getInput();
       var newInput = RelOptRule.convert(input, input.getTraitSet().plus(LOGICAL));
+      var newProjects = new ArrayList<RexNode>();
+      for (var project : logicalProject.getProjects()) {
+        // Hack here to remove Sarg optimization of Calcite.
+        var newProject = RexUtil.expandSearch(rel.getCluster().getRexBuilder(), null, project);
+        newProjects.add(newProject);
+      }
       return new RwLogicalProject(
           rel.getCluster(),
           rel.getTraitSet().plus(LOGICAL),
           logicalProject.getHints(),
           newInput,
-          logicalProject.getProjects(),
+          newProjects,
           logicalProject.getRowType());
     }
   }

--- a/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
@@ -1205,10 +1205,10 @@ RwBatchSortAgg(group=[{}], revenue=[SUM($0)])
     RwBatchSortAgg(group=[{}], revenue=[SUM($0)])
       RwBatchProject($f0=[$1])
         RwBatchNestedLoopJoin(condition=[OR(AND(=($10, $0), $11, $12, $2, $3, $13, $4, $5), AND(=($10, $0), $14, $15, $6, $7, $16, $4, $5), AND(=($10, $0), $17, $18, $8, $9, $19, $4, $5))], joinType=[inner])
-          RwBatchProject(l_partkey=[$0], *=[*($2, -(1, $3))], >==[>=($1, 8)], <==[<=($1, +(8, 10))], OR=[SEARCH($5, Sarg['AIR':CHAR(7), 'AIR REG']:CHAR(7))], ==[=($4, CAST('DELIVER IN PERSON'):CHAR(25) NOT NULL)], >=6=[>=($1, 10)], <=7=[<=($1, +(10, 10))], >=8=[>=($1, 24)], <=9=[<=($1, +(24, 10))])
+          RwBatchProject(l_partkey=[$0], *=[*($2, -(1, $3))], >==[>=($1, 8)], <==[<=($1, +(8, 10))], OR=[OR(=($5, 'AIR'), =($5, 'AIR REG'))], ==[=($4, CAST('DELIVER IN PERSON'):CHAR(25) NOT NULL)], >=6=[>=($1, 10)], <=7=[<=($1, +(10, 10))], >=8=[>=($1, 24)], <=9=[<=($1, +(24, 10))])
             RwBatchTableScan(table=[[test_schema, lineitem]], columns=[l_partkey,l_quantity,l_extendedprice,l_discount,l_shipinstruct,l_shipmode])
           RwBatchExchange(distribution=[RwDistributionTrait{type=BROADCAST_DISTRIBUTED, keys=[]}], collation=[[]])
-            RwBatchProject(p_partkey=[$0], ==[=($1, CAST('Brand#22'):CHAR(10) NOT NULL)], OR=[SEARCH($3, Sarg['SM BOX':CHAR(7), 'SM CASE', 'SM PACK', 'SM PKG':CHAR(7)]:CHAR(7))], OR3=[OR(AND(>=($2, 1), <=($2, 5)), <>($2, $2))], =4=[=($1, CAST('Brand#23'):CHAR(10) NOT NULL)], OR5=[SEARCH($3, Sarg['MED BAG':CHAR(8), 'MED BOX':CHAR(8), 'MED PACK', 'MED PKG':CHAR(8)]:CHAR(8))], OR6=[OR(AND(>=($2, 1), <=($2, 10)), <>($2, $2))], =7=[=($1, CAST('Brand#12'):CHAR(10) NOT NULL)], OR8=[SEARCH($3, Sarg['LG BOX':CHAR(7), 'LG CASE', 'LG PACK', 'LG PKG':CHAR(7)]:CHAR(7))], OR9=[OR(AND(>=($2, 1), <=($2, 15)), <>($2, $2))])
+            RwBatchProject(p_partkey=[$0], ==[=($1, CAST('Brand#22'):CHAR(10) NOT NULL)], OR=[OR(=($3, 'SM BOX'), =($3, 'SM CASE'), =($3, 'SM PACK'), =($3, 'SM PKG'))], OR3=[OR(AND(>=($2, 1), <=($2, 5)), <>($2, $2))], =4=[=($1, CAST('Brand#23'):CHAR(10) NOT NULL)], OR5=[OR(=($3, 'MED BAG'), =($3, 'MED BOX'), =($3, 'MED PACK'), =($3, 'MED PKG'))], OR6=[OR(AND(>=($2, 1), <=($2, 10)), <>($2, $2))], =7=[=($1, CAST('Brand#12'):CHAR(10) NOT NULL)], OR8=[OR(=($3, 'LG BOX'), =($3, 'LG CASE'), =($3, 'LG PACK'), =($3, 'LG PKG'))], OR9=[OR(AND(>=($2, 1), <=($2, 15)), <>($2, $2))])
               RwBatchTableScan(table=[[test_schema, part]], columns=[p_partkey,p_brand,p_size,p_container])
 ]]>
         </Resource>


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
`Sarg` blocks queries containing expressions like `in ('XXX', 'YYY')`.

Blocks multiple queries in tpch.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
