### PR TITLE
feat(binder): refactor signature to prepare for catalog access

### DIFF
--- a/rust/frontend/src/binder/expr/binary_op.rs
+++ b/rust/frontend/src/binder/expr/binary_op.rs
@@ -4,7 +4,7 @@ use risingwave_sqlparser::ast::{BinaryOperator, Expr};
 use crate::binder::Binder;
 use crate::expr::{Expr as _, ExprType, FunctionCall};
 
-impl Binder {
+impl Binder<'_> {
     pub(super) fn bind_binary_op(
         &mut self,
         left: Expr,

--- a/rust/frontend/src/binder/expr/mod.rs
+++ b/rust/frontend/src/binder/expr/mod.rs
@@ -7,7 +7,7 @@ use crate::expr::ExprImpl;
 mod binary_op;
 mod value;
 
-impl Binder {
+impl Binder<'_> {
     pub(super) fn bind_expr(&mut self, expr: Expr) -> Result<ExprImpl> {
         match expr {
             Expr::Value(v) => Ok(ExprImpl::Literal(Box::new(self.bind_value(v)?))),

--- a/rust/frontend/src/binder/mod.rs
+++ b/rust/frontend/src/binder/mod.rs
@@ -12,12 +12,16 @@ pub use set_expr::BoundSetExpr;
 pub use statement::BoundStatement;
 pub use values::BoundValues;
 
-pub struct Binder {}
+use crate::session::RwSession;
 
-impl Binder {
-    #[allow(clippy::new_without_default)]
-    pub fn new() -> Binder {
-        Binder {}
+pub struct Binder<'session> {
+    #[allow(dead_code)]
+    session: &'session RwSession,
+}
+
+impl Binder<'_> {
+    pub fn new(session: &RwSession) -> Binder {
+        Binder { session }
     }
     pub async fn bind(&mut self, stmt: Statement) -> Result<BoundStatement> {
         self.bind_statement(stmt).await

--- a/rust/frontend/src/binder/query.rs
+++ b/rust/frontend/src/binder/query.rs
@@ -10,7 +10,7 @@ pub struct BoundQuery {
     pub body: BoundSetExpr,
 }
 
-impl Binder {
+impl Binder<'_> {
     pub(super) async fn bind_query(&mut self, query: Query) -> Result<BoundQuery> {
         Ok(BoundQuery {
             body: self.bind_set_expr(query.body).await?,

--- a/rust/frontend/src/binder/set_expr.rs
+++ b/rust/frontend/src/binder/set_expr.rs
@@ -10,7 +10,7 @@ pub enum BoundSetExpr {
     Values(Box<BoundValues>),
 }
 
-impl Binder {
+impl Binder<'_> {
     pub(super) async fn bind_set_expr(&mut self, set_expr: SetExpr) -> Result<BoundSetExpr> {
         match set_expr {
             SetExpr::Values(v) => Ok(BoundSetExpr::Values(Box::new(self.bind_values(v)?))),

--- a/rust/frontend/src/binder/statement.rs
+++ b/rust/frontend/src/binder/statement.rs
@@ -8,7 +8,7 @@ pub enum BoundStatement {
     Query(Box<BoundQuery>),
 }
 
-impl Binder {
+impl Binder<'_> {
     pub(super) async fn bind_statement(&mut self, stmt: Statement) -> Result<BoundStatement> {
         match stmt {
             Statement::Query(q) => Ok(BoundStatement::Query(Box::new(self.bind_query(*q).await?))),

--- a/rust/frontend/src/binder/values.rs
+++ b/rust/frontend/src/binder/values.rs
@@ -11,7 +11,7 @@ pub struct BoundValues {
     pub schema: Schema,
 }
 
-impl Binder {
+impl Binder<'_> {
     pub(super) fn bind_values(&mut self, values: Values) -> Result<BoundValues> {
         let vec2d = values.0;
         let bound = vec2d

--- a/rust/frontend/src/handler/mod.rs
+++ b/rust/frontend/src/handler/mod.rs
@@ -12,7 +12,7 @@ pub(super) async fn handle(session: &RwSession, stmt: Statement) -> Result<PgRes
     match stmt {
         Statement::Explain {
             statement, verbose, ..
-        } => explain::handle_explain(*statement, verbose).await,
+        } => explain::handle_explain(session, *statement, verbose).await,
         Statement::CreateSource(stmt) => create_source::handle_create_source(session, stmt).await,
         Statement::CreateTable { name, columns, .. } => {
             create_table::handle_create_table(session, name, columns).await


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
- make Binder functions `async` so that we can await `catalog_mgr.lock()`;
- add a reference to session to Binder;

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
