### PR TITLE
fix(storage): mview scan will miss keys

### DIFF
--- a/rust/storage/src/table/mview.rs
+++ b/rust/storage/src/table/mview.rs
@@ -190,13 +190,11 @@ impl<'a, S: StateStore> MViewTableIter<S> {
                 .keyspace
                 .scan_with_start_key(last_key.to_vec(), Some(limit), self.epoch)
                 .await?;
-            assert!(!self.buf.is_empty());
-            assert_eq!(self.buf.first().as_ref().unwrap().0, last_key);
-            // TODO: remove clone here
+            assert!(!buf.is_empty());
+            assert_eq!(buf.first().as_ref().unwrap().0, last_key);
+            // TODO: remove the unnecessary clone here
             self.buf = buf[1..].to_vec();
         }
-
-        self.next_idx = 0;
 
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

In the original implementation, if we have:

a, ab, bc

and it occurs that the last key we get is `a`. next_key(a) = `b`. We will miss `ab`.

This PR fixes the bug.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

https://github.com/singularity-data/risingwave-dev/pull/62