### PR TITLE
fix(tracing): barrier aggregation tracing

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -143,6 +143,7 @@ message Barrier {
     UpdateMutation update = 4;
     AddMutation add = 5;
   }
+  bytes span = 6;
 }
 
 message Terminate {}

--- a/rust/meta/src/barrier/mod.rs
+++ b/rust/meta/src/barrier/mod.rs
@@ -172,6 +172,8 @@ impl BarrierManager {
                     let barrier = Barrier {
                         epoch,
                         mutation: Some(mutation),
+                        // TODO(chi): add distributed tracing
+                        span: vec![],
                     };
 
                     async move {

--- a/rust/server/src/bin/compute_node.rs
+++ b/rust/server/src/bin/compute_node.rs
@@ -12,9 +12,14 @@ use tracing_subscriber::prelude::*;
 #[allow(dead_code)]
 fn configure_risingwave_targets(targets: filter::Targets) -> filter::Targets {
     targets
+        // enable trace for most modules
         .with_target("risingwave_stream", Level::TRACE)
         .with_target("risingwave_batch", Level::TRACE)
         .with_target("risingwave_storage", Level::TRACE)
+        // disable events that are too verbose
+        // if you want to enable any of them, find the target name and set it to `TRACE`
+        // .with_target("events::stream::mview::scan", Level::TRACE)
+        .with_target("events", Level::ERROR)
 }
 
 #[cfg(not(tarpaulin_include))]

--- a/rust/storage/src/hummock/sstable/mod.rs
+++ b/rust/storage/src/hummock/sstable/mod.rs
@@ -218,7 +218,13 @@ impl SSTable {
                 .await
                 .map_err(|e| HummockError::ObjectIoError(e.to_string()))?;
 
-            tracing::trace!(table_id = self.id, block_id = idx, block_loc = ?block_loc, "table read block");
+            tracing::trace!(
+                target: "events::storage::sstable::block_read",
+                "table read block: table_id = {}, block_id = {}, block_loc = {:?}",
+                self.id,
+                idx,
+                block_loc
+            );
 
             let block_data = Bytes::from(block_data);
 

--- a/rust/storage/src/hummock/sstable/sstable_iterator.rs
+++ b/rust/storage/src/hummock/sstable/sstable_iterator.rs
@@ -42,9 +42,10 @@ impl SSTableIterator {
     /// Seek to a block, and then seek to the key if `seek_key` is given.
     async fn seek_idx(&mut self, idx: usize, seek_key: Option<&[u8]>) -> HummockResult<()> {
         tracing::trace!(
-            table_id = self.table.id,
-            block_id = idx,
-            "table iterator seek"
+            target: "events::storage::sstable::block_seek",
+            "table iterator seek: table_id = {}, block_id = {}",
+            self.table.id,
+            idx,
         );
         if idx >= self.table.block_count() {
             self.block_iter = None;

--- a/rust/storage/src/table/mview.rs
+++ b/rust/storage/src/table/mview.rs
@@ -238,7 +238,8 @@ impl<S: StateStore> TableIter for MViewTableIter<S> {
             self.next_idx += 1;
 
             tracing::trace!(
-                "scanned key = {:?}, value = {:?}",
+                target: "events::stream::mview::scan",
+                "mview scanned key = {:?}, value = {:?}",
                 bytes::Bytes::copy_from_slice(key),
                 bytes::Bytes::copy_from_slice(value)
             );

--- a/rust/stream/src/task/barrier_manager.rs
+++ b/rust/stream/src/task/barrier_manager.rs
@@ -1,11 +1,14 @@
 use std::collections::{HashMap, HashSet};
 
-use itertools::Itertools;
 use risingwave_common::error::Result;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 
 use crate::executor::*;
+
+/// If enabled, all actors will be grouped in the same tracing span within one epoch.
+/// Note that this option will significantly increase the overhead of tracing.
+pub const ENABLE_BARRIER_AGGREGATION: bool = false;
 
 struct ManagedBarrierState {
     epoch: u64,
@@ -130,18 +133,6 @@ impl LocalBarrierManager {
             }
         };
 
-        let barrier = {
-            let mut barrier = barrier.clone();
-            if ENABLE_BARRIER_EVENT {
-                let receiver_ids = to_send.iter().cloned().join(", ");
-                // TODO: not a correct usage of span -- the span ends once it goes out of scope, but
-                // we still have events in the background.
-                let span = tracing::info_span!("send_barrier", epoch = barrier.epoch, mutation = ?barrier.mutation, receivers = %receiver_ids);
-                barrier.span = span;
-            }
-            barrier
-        };
-
         for actor_id in to_send {
             let sender = self
                 .senders
@@ -179,8 +170,9 @@ impl LocalBarrierManager {
                 let state = managed_state.as_mut().unwrap();
                 state.remaining_actors.remove(&actor_id);
 
-                trace!(
-                    "collect barrier epoch {} from actor {}, remaining actors {:?}",
+                tracing::trace!(
+                    target: "events::stream::barrier::collect_barrier",
+                    "collect_barrier: epoch = {}, actor_id = {}, remaining_actors = {:?}",
                     barrier.epoch,
                     actor_id,
                     state.remaining_actors
@@ -212,6 +204,7 @@ impl LocalBarrierManager {
 
 #[cfg(test)]
 mod tests {
+    use itertools::Itertools;
     use tokio::sync::mpsc::unbounded_channel;
 
     use super::*;


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

This PR fixes the barrier aggregation functionality after barrier manager has been migrated to meta service.

At the same time, we also moved all verbose events to a separate target `events::`, so as to reduce tracing events and reduce CPU time.

When tracing is enabled, we still need ~200% CPU for compute node, ~50% CPU for jaeger, and ~15GB memory for jaeger.

Note that we still didn't finish the distributed tracing part. Will do later.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

part of https://github.com/singularity-data/risingwave-dev/issues/185