### PR TITLE
feat(common): add search expression

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -62,6 +62,9 @@ message ExprNode {
     IS_NOT_NULL = 306;
     // Unary operators
     NEG = 401;
+    // Search operator and Search ARGument
+    SEARCH = 998;
+    SARG = 999;
     STREAM_NULL_BY_ROW_COUNT = 1000;
   }
   Type expr_type = 1;

--- a/rust/common/src/expr/expr_search.rs
+++ b/rust/common/src/expr/expr_search.rs
@@ -1,0 +1,94 @@
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use itertools::Itertools;
+
+use crate::array::{ArrayBuilder, ArrayRef, BoolArrayBuilder, DataChunk};
+use crate::expr::{BoxedExpression, Expression};
+use crate::types::{DataType, Datum, ToOwnedDatum};
+
+#[derive(Debug)]
+pub(crate) struct SearchExpression {
+    input_ref: BoxedExpression,
+    sarg: HashSet<Datum>,
+    return_type: DataType,
+}
+
+impl SearchExpression {
+    pub fn new(
+        input_ref: BoxedExpression,
+        data: impl Iterator<Item = Datum>,
+        return_type: DataType,
+    ) -> Self {
+        let mut sarg = HashSet::new();
+        for datum in data {
+            sarg.insert(datum);
+        }
+        Self {
+            input_ref,
+            sarg,
+            return_type,
+        }
+    }
+
+    fn check_in_sarg(&self, datum: &Datum) -> bool {
+        self.sarg.contains(datum)
+    }
+}
+
+impl Expression for SearchExpression {
+    fn return_type(&self) -> DataType {
+        self.return_type
+    }
+
+    fn eval(&mut self, input: &DataChunk) -> crate::error::Result<ArrayRef> {
+        let input_array = self.input_ref.eval(input)?;
+        let visibility = input.visibility();
+        let mut output_array = BoolArrayBuilder::new(input.cardinality())?;
+        match visibility {
+            Some(bitmap) => {
+                for (data, vis) in input_array.iter().zip_eq(bitmap.iter()) {
+                    if !vis {
+                        continue;
+                    }
+                    let ret = self.check_in_sarg(&data.to_owned_datum());
+                    output_array.append(Some(ret))?;
+                }
+            }
+            None => {
+                for data in input_array.iter() {
+                    let ret = self.check_in_sarg(&data.to_owned_datum());
+                    output_array.append(Some(ret))?;
+                }
+            }
+        };
+        Ok(Arc::new(output_array.finish()?.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::array::{DataChunk, Utf8Array};
+    use crate::column;
+    use crate::expr::expr_search::SearchExpression;
+    use crate::expr::{Expression, InputRefExpression};
+    use crate::types::{DataType, ScalarImpl};
+
+    #[test]
+    fn test_search_expr() {
+        let input_ref = Box::new(InputRefExpression::new(DataType::Char, 0));
+        let data = vec![
+            Some(ScalarImpl::Utf8("abc".to_string())),
+            Some(ScalarImpl::Utf8("def".to_string())),
+        ];
+        let mut search_expr = SearchExpression::new(input_ref, data.into_iter(), DataType::Boolean);
+        let column = column! {Utf8Array, [Some("abc"), Some("a"), Some("def"), Some("abc")]};
+        let data_chunk = DataChunk::builder().columns(vec![column]).build();
+        let res = search_expr.eval(&data_chunk).unwrap();
+        assert_eq!(res.datum_at(0), Some(ScalarImpl::Bool(true)));
+        assert_eq!(res.datum_at(1), Some(ScalarImpl::Bool(false)));
+        assert_eq!(res.datum_at(2), Some(ScalarImpl::Bool(true)));
+        assert_eq!(res.datum_at(3), Some(ScalarImpl::Bool(true)));
+    }
+}

--- a/rust/common/src/expr/mod.rs
+++ b/rust/common/src/expr/mod.rs
@@ -8,6 +8,7 @@ mod expr_case;
 mod expr_input_ref;
 mod expr_is_null;
 mod expr_literal;
+mod expr_search;
 mod expr_ternary_bytes;
 pub mod expr_unary;
 mod pg_sleep;
@@ -69,6 +70,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         InputRef => InputRefExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Case => build_case_expr(prost),
         Translate => build_translate_expr(prost),
+        Search => build_search_expr(prost),
         _ => Err(InternalError(format!(
             "Unsupported expression type: {:?}",
             prost.get_expr_type()


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
Support `in`.

We have a new `search` function, which contains two arguments. The first one is typically an input ref expression, the second one is a set of values. This is how Calcite unifies `in` and `between`. 

Sort of ugly on the java frontend side. But will keep modifying the code when supporting `between` later and other cases of `in` if there is any more.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
closes #192 