### PR TITLE
feat: add more info to identity string of executors

### DIFF
--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/BatchPlan.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/BatchPlan.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import com.risingwave.proto.plan.ExchangeInfo;
 import com.risingwave.proto.plan.PlanFragment;
 import com.risingwave.proto.plan.PlanNode;
+import org.apache.calcite.rel.RelNode;
 
 /**
  * Plan for adhoc query execution. The counterpart is streaming plan, which is designed for
@@ -28,5 +29,20 @@ public class BatchPlan {
     PlanNode rootNode = root.serialize();
 
     return PlanFragment.newBuilder().setRoot(rootNode).setExchangeInfo(exchangeInfo).build();
+  }
+
+  public static String getCurrentNodeIdentity(RelNode node) {
+    var nodeWithItsChildren = node.explain();
+    var endIndex = nodeWithItsChildren.indexOf("\n  RwBatch");
+    String identity = "";
+    if (endIndex != -1) {
+      identity = nodeWithItsChildren.substring(0, endIndex);
+    } else {
+      identity = nodeWithItsChildren;
+    }
+    if (identity.charAt(identity.length() - 1) == '\n') {
+      identity = identity.substring(0, identity.length() - 1);
+    }
+    return identity;
   }
 }

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchExchange.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchExchange.java
@@ -98,9 +98,15 @@ public class RwBatchExchange extends Exchange implements RisingWaveBatchPhyRel {
       }
       MergeSortExchangeNode.Builder builder = MergeSortExchangeNode.newBuilder();
       builder.addAllColumnOrders(columnOrders);
-      return PlanNode.newBuilder().setMergeSortExchange(builder.build()).build();
+      return PlanNode.newBuilder()
+          .setMergeSortExchange(builder.build())
+          .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+          .build();
     } else {
-      return PlanNode.newBuilder().setExchange(ExchangeNode.newBuilder().build()).build();
+      return PlanNode.newBuilder()
+          .setExchange(ExchangeNode.newBuilder().build())
+          .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+          .build();
     }
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchFilter.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchFilter.java
@@ -37,6 +37,7 @@ public class RwBatchFilter extends Filter implements RisingWaveBatchPhyRel, Phys
     return PlanNode.newBuilder()
         .setFilter(filter)
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchGenerateSeries.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchGenerateSeries.java
@@ -69,7 +69,10 @@ public class RwBatchGenerateSeries extends TableFunctionScan implements RisingWa
     if (node == null) {
       throw new IllegalArgumentException("no matching overload of generate_series");
     }
-    return PlanNode.newBuilder().setGenerateInt32Series(node).build();
+    return PlanNode.newBuilder()
+        .setGenerateInt32Series(node)
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+        .build();
   }
 
   private GenerateInt32SeriesNode serializeI32(RexLiteral start, RexLiteral stop) {

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchHashAgg.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchHashAgg.java
@@ -54,6 +54,7 @@ public class RwBatchHashAgg extends RwAggregate implements RisingWaveBatchPhyRel
     return PlanNode.newBuilder()
         .setHashAgg(serializeHashAgg())
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchInsert.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchInsert.java
@@ -89,10 +89,18 @@ public class RwBatchInsert extends TableModify implements RisingWaveBatchPhyRel 
     InsertNode.Builder insertNodeBuilder =
         InsertNode.newBuilder().setTableRefId(Messages.getTableRefId(tableCatalog.getId()));
 
+    var identity =
+        "RwBatchInsertExecutor(TableName:"
+            + this.table.getQualifiedName()
+            + ",ColumnIds:"
+            + columnIds
+            + ")";
+
     insertNodeBuilder.addAllColumnIds(columnIds);
     return PlanNode.newBuilder()
         .setInsert(insertNodeBuilder.build())
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(identity)
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchLimit.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchLimit.java
@@ -68,6 +68,7 @@ public class RwBatchLimit extends SingleRel implements RisingWaveBatchPhyRel, Ph
     return PlanNode.newBuilder()
         .setLimit(limitNode)
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchMaterializedViewScan.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchMaterializedViewScan.java
@@ -58,6 +58,9 @@ public class RwBatchMaterializedViewScan extends RwScan implements RisingWaveBat
     TableRefId tableRefId = Messages.getTableRefId(tableId);
     RowSeqScanNode.Builder builder = RowSeqScanNode.newBuilder().setTableRefId(tableRefId);
     columnIds.forEach(c -> builder.addColumnIds(c.getValue()));
-    return PlanNode.newBuilder().setRowSeqScan(builder.build()).build();
+    return PlanNode.newBuilder()
+        .setRowSeqScan(builder.build())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+        .build();
   }
 }

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchProject.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchProject.java
@@ -56,6 +56,7 @@ public class RwBatchProject extends Project implements RisingWaveBatchPhyRel, Ph
     return PlanNode.newBuilder()
         .setProject(projectNodeBuilder.build())
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSort.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSort.java
@@ -95,6 +95,7 @@ public class RwBatchSort extends Sort implements RisingWaveBatchPhyRel, Physical
       return PlanNode.newBuilder()
           .setTopN(topnNodeBuilder.build())
           .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+          .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
           .build();
     } else {
       // serialize to OrderByNode
@@ -103,6 +104,7 @@ public class RwBatchSort extends Sort implements RisingWaveBatchPhyRel, Physical
       return PlanNode.newBuilder()
           .setOrderBy(orderByNodeBuilder.build())
           .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+          .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
           .build();
     }
   }

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSortAgg.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSortAgg.java
@@ -64,6 +64,7 @@ public class RwBatchSortAgg extends RwAggregate implements RisingWaveBatchPhyRel
     return PlanNode.newBuilder()
         .setSortAgg(serializeSortAgg())
         .addChildren(((RisingWaveBatchPhyRel) input).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSourceScan.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchSourceScan.java
@@ -61,6 +61,9 @@ public class RwBatchSourceScan extends RwScan implements RisingWaveBatchPhyRel {
             .setTableRefId(tableRefId)
             .setTimestampMs(System.currentTimeMillis());
     columnIds.forEach(c -> streamScanNodeBuilder.addColumnIds(c.getValue()));
-    return PlanNode.newBuilder().setSourceScan(streamScanNodeBuilder.build()).build();
+    return PlanNode.newBuilder()
+        .setSourceScan(streamScanNodeBuilder.build())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+        .build();
   }
 }

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchTableScan.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchTableScan.java
@@ -71,6 +71,9 @@ public class RwBatchTableScan extends RwScan implements RisingWaveBatchPhyRel {
                   .build());
           ;
         });
-    return PlanNode.newBuilder().setSeqScan(seqScanNodeBuilder.build()).build();
+    return PlanNode.newBuilder()
+        .setSeqScan(seqScanNodeBuilder.build())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
+        .build();
   }
 }

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchValues.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/RwBatchValues.java
@@ -59,7 +59,10 @@ public class RwBatchValues extends RwValues implements RisingWaveBatchPhyRel {
           Field.newBuilder().setDataType(dataType).setName(field.getName()).build());
     }
 
-    return PlanNode.newBuilder().setValues(valuesNodeBuilder.build()).build();
+    return PlanNode.newBuilder()
+        .setValues(valuesNodeBuilder.build())
+        .setIdentity("RwBatchValuesExecutor")
+        .build();
   }
 
   public RelNode copy(RelTraitSet traitSet) {

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchHashJoin.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchHashJoin.java
@@ -7,6 +7,7 @@ import static com.risingwave.planner.rel.logical.RisingWaveLogicalRel.LOGICAL;
 import static com.risingwave.planner.rel.physical.join.BatchJoinUtils.isEquiJoin;
 
 import com.risingwave.planner.rel.logical.RwLogicalJoin;
+import com.risingwave.planner.rel.physical.BatchPlan;
 import com.risingwave.planner.rel.physical.RisingWaveBatchPhyRel;
 import com.risingwave.proto.plan.HashJoinNode;
 import com.risingwave.proto.plan.PlanNode;
@@ -64,6 +65,7 @@ public class RwBatchHashJoin extends RwBufferJoinBase implements RisingWaveBatch
         .addChildren(leftChild)
         .addChildren(rightChild)
         .setHashJoin(hashJoinNode)
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchNestedLoopJoin.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchNestedLoopJoin.java
@@ -4,6 +4,7 @@ import static com.risingwave.planner.rel.logical.RisingWaveLogicalRel.LOGICAL;
 import static com.risingwave.planner.rel.physical.join.BatchJoinUtils.isEquiJoin;
 
 import com.risingwave.planner.rel.logical.RwLogicalJoin;
+import com.risingwave.planner.rel.physical.BatchPlan;
 import com.risingwave.planner.rel.physical.RisingWaveBatchPhyRel;
 import com.risingwave.planner.rel.serialization.RexToProtoSerializer;
 import com.risingwave.proto.plan.NestedLoopJoinNode;
@@ -47,6 +48,7 @@ public class RwBatchNestedLoopJoin extends RwBufferJoinBase implements RisingWav
         .setNestedLoopJoin(joinNode)
         .addChildren(((RisingWaveBatchPhyRel) left).serialize())
         .addChildren(((RisingWaveBatchPhyRel) right).serialize())
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchSortMergeJoin.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/physical/join/RwBatchSortMergeJoin.java
@@ -7,6 +7,7 @@ import static com.risingwave.planner.rel.logical.RisingWaveLogicalRel.LOGICAL;
 import static com.risingwave.planner.rel.physical.join.BatchJoinUtils.isEquiJoin;
 
 import com.risingwave.planner.rel.logical.RwLogicalJoin;
+import com.risingwave.planner.rel.physical.BatchPlan;
 import com.risingwave.planner.rel.physical.RisingWaveBatchPhyRel;
 import com.risingwave.proto.plan.OrderType;
 import com.risingwave.proto.plan.PlanNode;
@@ -84,6 +85,7 @@ public class RwBatchSortMergeJoin extends RwBufferJoinBase implements RisingWave
         .addChildren(leftChild)
         .addChildren(rightChild)
         .setSortMergeJoin(node)
+        .setIdentity(BatchPlan.getCurrentNodeIdentity(this))
         .build();
   }
 

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/bool_literal.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/bool_literal.json
@@ -18,7 +18,8 @@
         },
         "name": "ZERO"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "project": {
     "selectList": [{
@@ -66,5 +67,6 @@
         }]
       }
     }]
-  }
+  },
+  "identity": "RwBatchProject(EXPR$0\u003d[AND(false, null)], EXPR$1\u003d[OR(true, null)])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/extract.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/extract.json
@@ -18,7 +18,8 @@
         },
         "name": "ZERO"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "project": {
     "selectList": [{
@@ -58,5 +59,6 @@
         }]
       }
     }]
-  }
+  },
+  "identity": "RwBatchProject(EXPR$0\u003d[EXTRACT(FLAG(DAY), CAST(\u00271999-1-2\u0027):DATE NOT NULL)])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/hash_inner_join.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/hash_inner_join.json
@@ -24,7 +24,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2,v3])"
   }, {
     "seqScan": {
       "tableRefId": {
@@ -41,12 +42,14 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t3]], columns\u003d[v1])"
   }],
   "hashJoin": {
     "leftKey": [0],
     "leftOutput": [0, 1, 2],
     "rightKey": [0],
     "rightOutput": [0]
-  }
+  },
+  "identity": "RwBatchHashJoin(condition\u003d[\u003d($0, $3)], joinType\u003d[inner])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert.json
@@ -122,7 +122,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "insert": {
     "tableRefId": {
@@ -132,5 +133,6 @@
       }
     },
     "columnIds": [1, 2, 3]
-  }
+  },
+  "identity": "RwBatchInsertExecutor(TableName:[test_schema, t],ColumnIds:[1, 2, 3])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_cast_real.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_cast_real.json
@@ -25,7 +25,8 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "insert": {
     "tableRefId": {
@@ -36,5 +37,6 @@
       "tableId": 1
     },
     "columnIds": [1]
-  }
+  },
+  "identity": "RwBatchInsertExecutor(TableName:[test_schema, f],ColumnIds:[1])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_cast_time.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_cast_time.json
@@ -19,7 +19,8 @@
           },
           "name": "ZERO"
         }]
-      }
+      },
+      "identity": "RwBatchValuesExecutor"
     }],
     "project": {
       "selectList": [{
@@ -91,7 +92,8 @@
           }]
         }
       }]
-    }
+    },
+    "identity": "RwBatchProject(v1\u003d[CAST(\u00271970-01-01\u0027):DATE NOT NULL], v2\u003d[CAST(\u002704:05:06\u0027):TIME(0) NOT NULL], v3\u003d[CAST(\u00271970-01-01 04:05:06\u0027):TIMESTAMP(0) NOT NULL], v4\u003d[CAST(\u00271970-01-01 04:05:06 -08:00\u0027):TIMESTAMP_WITH_LOCAL_TIME_ZONE(0) NOT NULL])"
   }],
   "insert": {
     "tableRefId": {
@@ -101,5 +103,6 @@
       }
     },
     "columnIds": [1, 2, 3, 4]
-  }
+  },
+  "identity": "RwBatchInsertExecutor(TableName:[test_schema, t],ColumnIds:[1, 2, 3, 4])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_null.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/insert_null.json
@@ -15,7 +15,8 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "insert": {
     "tableRefId": {
@@ -26,5 +27,6 @@
       "tableId": 3
     },
     "columnIds": [1]
-  }
+  },
+  "identity": "RwBatchInsertExecutor(TableName:[test_schema, t4],ColumnIds:[1])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/limit.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/limit.json
@@ -18,10 +18,12 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t5]], columns\u003d[v1])"
   }],
   "limit": {
     "limit": 1,
     "offset": 1
-  }
+  },
+  "identity": "RwBatchLimit(offset\u003d[1], fetch\u003d[1])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/nested_loop_join.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/nested_loop_join.json
@@ -24,7 +24,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2,v3])"
   }, {
     "seqScan": {
       "tableRefId": {
@@ -41,7 +42,8 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t3]], columns\u003d[v1])"
   }],
   "nestedLoopJoin": {
     "joinCond": {
@@ -68,5 +70,6 @@
         }]
       }
     }
-  }
+  },
+  "identity": "RwBatchNestedLoopJoin(condition\u003d[\u003e($0, $3)], joinType\u003d[inner])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/round_digit.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/round_digit.json
@@ -18,7 +18,8 @@
         },
         "name": "v1"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t5]], columns\u003d[v1])"
   }],
   "project": {
     "selectList": [{
@@ -51,5 +52,6 @@
         }]
       }
     }]
-  }
+  },
+  "identity": "RwBatchProject(EXPR$0\u003d[ROUND($0, 4)])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_interval.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_interval.json
@@ -18,7 +18,8 @@
         },
         "name": "ZERO"
       }]
-    }
+    },
+    "identity": "RwBatchValuesExecutor"
   }],
   "project": {
     "selectList": [{
@@ -73,5 +74,6 @@
         }]
       }
     }]
-  }
+  },
+  "identity": "RwBatchProject(EXPR$0\u003d[+(+(CAST(\u00272021-10-1\u0027):DATE NOT NULL, 12288:INTERVAL YEAR(9)), 88473600000:INTERVAL DAY(9))])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_less_with_sort_by.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_less_with_sort_by.json
@@ -20,7 +20,8 @@
           },
           "name": "v2"
         }]
-      }
+      },
+      "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2])"
     }],
     "orderBy": {
       "columnOrders": [{
@@ -32,7 +33,8 @@
           "typeName": "INT32"
         }
       }]
-    }
+    },
+    "identity": "RwBatchSort(sort0\u003d[$1], dir0\u003d[ASC])"
   }],
   "project": {
     "selectList": [{
@@ -43,5 +45,6 @@
       "inputRef": {
       }
     }]
-  }
+  },
+  "identity": "RwBatchProject(v1\u003d[$0])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_filter.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_filter.json
@@ -24,7 +24,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2,v3])"
   }],
   "filter": {
     "searchCondition": {
@@ -115,5 +116,6 @@
         }]
       }
     }
-  }
+  },
+  "identity": "RwBatchFilter(condition\u003d[AND(\u003e($0, 1), \u003e($1, 1), \u003e($2, 1))])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_order_by.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_order_by.json
@@ -24,7 +24,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2,v3])"
   }],
   "orderBy": {
     "columnOrders": [{
@@ -35,5 +36,6 @@
         "typeName": "INT32"
       }
     }]
-  }
+  },
+  "identity": "RwBatchSort(sort0\u003d[$0], dir0\u003d[ASC])"
 }

--- a/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_order_by_limit.json
+++ b/java/planner/src/test/resources/com/risingwave/planner/json/batch/basic/select_with_order_by_limit.json
@@ -24,7 +24,8 @@
         },
         "name": "v3"
       }]
-    }
+    },
+    "identity": "RwBatchTableScan(table\u003d[[test_schema, t]], columns\u003d[v1,v2,v3])"
   }],
   "topN": {
     "columnOrders": [{
@@ -36,5 +37,6 @@
       }
     }],
     "limit": 1
-  }
+  },
+  "identity": "RwBatchSort(sort0\u003d[$0], dir0\u003d[ASC], fetch\u003d[1])"
 }

--- a/proto/plan.proto
+++ b/proto/plan.proto
@@ -268,6 +268,7 @@ message PlanNode {
     SortMergeJoinNode sort_merge_join = 22;
     GenerateInt32SeriesNode generate_int32_series = 23;
   }
+  string identity = 24;
 }
 
 message ExchangeInfo {

--- a/rust/batch/src/executor/filter.rs
+++ b/rust/batch/src/executor/filter.rs
@@ -116,7 +116,7 @@ impl BoxedExecutorBuilder for FilterExecutor {
                 child,
                 chunk_builder,
                 last_input: None,
-                identity: "FilterExecutor".to_string(),
+                identity: source.plan_node().get_identity().clone(),
                 child_can_be_nexted: true,
             }));
         }

--- a/rust/batch/src/executor/generate_series.rs
+++ b/rust/batch/src/executor/generate_series.rs
@@ -33,7 +33,7 @@ impl BoxedExecutorBuilder for GenerateSeriesI32Executor {
             step: node.step,
             cur: node.start,
             schema: Schema::new(vec![Field::unnamed(DataType::Int32)]),
-            identity: "GenerateSeriesI32Executor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/generic_exchange.rs
+++ b/rust/batch/src/executor/generic_exchange.rs
@@ -92,7 +92,7 @@ impl<CS: 'static + CreateSource> BoxedExecutorBuilder for GenericExchangeExecuto
             current_source: None,
             schema: Schema { fields },
             task_id: source.task_id.clone(),
-            identity: "GenericExchangeExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/limit.rs
+++ b/rust/batch/src/executor/limit.rs
@@ -42,7 +42,7 @@ impl BoxedExecutorBuilder for LimitExecutor {
                 offset,
                 skipped: 0,
                 returned: 0,
-                identity: "LimitExecutor".to_string(),
+                identity: source.plan_node().get_identity().clone(),
             }));
         }
         Err(InternalError("Limit must have one child".to_string()).into())

--- a/rust/batch/src/executor/merge_sort_exchange.rs
+++ b/rust/batch/src/executor/merge_sort_exchange.rs
@@ -213,7 +213,7 @@ impl<CS: 'static + CreateSource> BoxedExecutorBuilder for MergeSortExchangeExecu
             schema: Schema { fields },
             first_execution: true,
             task_id: source.task_id.clone(),
-            identity: "MergeSortExchangeExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/order_by.rs
+++ b/rust/batch/src/executor/order_by.rs
@@ -57,7 +57,7 @@ impl BoxedExecutorBuilder for OrderByExecutor {
                 encoded_keys: vec![],
                 encodable: false,
                 disable_encoding: false,
-                identity: "OrderByExecutor".to_string(),
+                identity: source.plan_node().get_identity().clone(),
             }));
         }
         Err(InternalError("OrderBy must have one child".to_string()).into())

--- a/rust/batch/src/executor/projection.rs
+++ b/rust/batch/src/executor/projection.rs
@@ -83,7 +83,7 @@ impl BoxedExecutorBuilder for ProjectionExecutor {
             expr: project_exprs,
             child: child_node,
             schema: Schema { fields },
-            identity: "ProjectionExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/row_seq_scan.rs
+++ b/rust/batch/src/executor/row_seq_scan.rs
@@ -26,7 +26,12 @@ impl RowSeqScanExecutor {
     // TODO: decide the chunk size for row seq scan
     pub const DEFAULT_CHUNK_SIZE: usize = 1024;
 
-    pub fn new(table: Arc<dyn ScannableTable>, column_ids: Vec<i32>, chunk_size: usize) -> Self {
+    pub fn new(
+        table: Arc<dyn ScannableTable>,
+        column_ids: Vec<i32>,
+        chunk_size: usize,
+        identity: String,
+    ) -> Self {
         // Currently row_id for table_v2 is totally a mess, we override this function to match the
         // behavior of column ids of mviews.
         // FIXME: remove this hack
@@ -48,7 +53,7 @@ impl RowSeqScanExecutor {
             column_indices,
             chunk_size,
             schema,
-            identity: "RowSeqScanExecutor".to_string(),
+            identity,
         }
     }
 }
@@ -73,6 +78,7 @@ impl BoxedExecutorBuilder for RowSeqScanExecutor {
             table,
             column_ids,
             Self::DEFAULT_CHUNK_SIZE,
+            source.plan_node().get_identity().clone(),
         )))
     }
 }

--- a/rust/batch/src/executor/seq_scan.rs
+++ b/rust/batch/src/executor/seq_scan.rs
@@ -21,13 +21,18 @@ pub struct SeqScanExecutor {
 }
 
 impl SeqScanExecutor {
-    pub fn new(table: ScannableTableRef, column_ids: Vec<i32>, schema: Schema) -> Self {
+    pub fn new(
+        table: ScannableTableRef,
+        column_ids: Vec<i32>,
+        schema: Schema,
+        identity: String,
+    ) -> Self {
         Self {
             table,
             column_ids,
             schema,
             snapshot: Default::default(),
-            identity: "SeqScanExecutor".to_string(),
+            identity,
         }
     }
 }
@@ -61,7 +66,12 @@ impl BoxedExecutorBuilder for SeqScanExecutor {
                 .collect::<Result<Vec<Field>>>()?,
         );
 
-        Ok(Box::new(Self::new(table_ref, column_ids.to_vec(), schema)))
+        Ok(Box::new(Self::new(
+            table_ref,
+            column_ids.to_vec(),
+            schema,
+            source.plan_node().get_identity().clone(),
+        )))
     }
 }
 

--- a/rust/batch/src/executor/sort_agg.rs
+++ b/rust/batch/src/executor/sort_agg.rs
@@ -76,7 +76,7 @@ impl BoxedExecutorBuilder for SortAggExecutor {
             child,
             child_done: false,
             schema: Schema { fields },
-            identity: "SortAggExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/stream_scan.rs
+++ b/rust/batch/src/executor/stream_scan.rs
@@ -74,7 +74,7 @@ impl BoxedExecutorBuilder for StreamScanExecutor {
             reader,
             done: false,
             schema: Schema { fields },
-            identity: "StreamScanExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
         }))
     }
 }

--- a/rust/batch/src/executor/top_n.rs
+++ b/rust/batch/src/executor/top_n.rs
@@ -84,7 +84,7 @@ impl BoxedExecutorBuilder for TopNExecutor {
                 child,
                 order_pairs,
                 top_n_node.get_limit() as usize,
-                "TopNExecutor".to_string(),
+                source.plan_node().get_identity().clone(),
             )));
         }
         Err(InternalError("TopN must have one child".to_string()).into())

--- a/rust/batch/src/executor/values.rs
+++ b/rust/batch/src/executor/values.rs
@@ -114,7 +114,7 @@ impl BoxedExecutorBuilder for ValuesExecutor {
         Ok(Box::new(Self {
             rows,
             schema: Schema { fields },
-            identity: "ValuesExecutor".to_string(),
+            identity: source.plan_node().get_identity().clone(),
             chunk_size: source.global_task_env().config().chunk_size as usize,
         }))
     }

--- a/rust/batch/src/task/test_utils.rs
+++ b/rust/batch/src/task/test_utils.rs
@@ -217,6 +217,7 @@ impl<'a> TableBuilder<'a> {
             root: Some(PlanNode {
                 children: vec![],
                 node_body: Some(NodeBody::CreateTable(create)),
+                identity: "CreateTableExecutor".to_string(),
             }),
 
             exchange_info: Some(ExchangeInfo {
@@ -254,8 +255,10 @@ impl<'a> TableBuilder<'a> {
                 children: vec![PlanNode {
                     children: vec![],
                     node_body: Some(NodeBody::Values(ValuesNode { tuples, fields })),
+                    identity: "ValuesExecutor".to_string(),
                 }],
                 node_body: Some(NodeBody::Insert(insert)),
+                identity: "InsertExecutor".to_string(),
             }),
 
             exchange_info: Some(ExchangeInfo {
@@ -329,6 +332,7 @@ impl<'a> SelectBuilder<'a> {
                 root: Some(PlanNode {
                     children: vec![],
                     node_body: None,
+                    identity: "PlaceHolderExecutor".to_string(),
                 }),
                 exchange_info: Some(ExchangeInfo {
                     mode: 0,
@@ -358,6 +362,7 @@ impl<'a> SelectBuilder<'a> {
                 root: Some(PlanNode {
                     children: vec![],
                     node_body: Some(NodeBody::SeqScan(scan)),
+                    identity: "SeqScanExecutor".to_string(),
                 }),
                 exchange_info: Some(ExchangeInfo {
                     mode: 0,

--- a/rust/server/tests/row_seq_scan.rs
+++ b/rust/server/tests/row_seq_scan.rs
@@ -40,7 +40,8 @@ async fn test_row_seq_scan() -> Result<()> {
         orderings,
     ));
 
-    let mut executor = RowSeqScanExecutor::new(table, vec![0, 1], 1);
+    let mut executor =
+        RowSeqScanExecutor::new(table, vec![0, 1], 1, "RowSeqScanExecutor".to_string());
 
     let epoch: u64 = 0;
     state.put(

--- a/rust/server/tests/table_v2_materialize.rs
+++ b/rust/server/tests/table_v2_materialize.rs
@@ -171,7 +171,12 @@ async fn test_table_v2_materialize() -> Result<()> {
     let table = table_manager.get_table(&mview_id)?;
     let data_column_ids = vec![0];
 
-    let mut scan = RowSeqScanExecutor::new(table.clone(), data_column_ids.clone(), 1024);
+    let mut scan = RowSeqScanExecutor::new(
+        table.clone(),
+        data_column_ids.clone(),
+        1024,
+        "RowSeqExecutor".to_string(),
+    );
     scan.open().await?;
     assert!(scan.next().await?.is_none());
 
@@ -201,7 +206,12 @@ async fn test_table_v2_materialize() -> Result<()> {
     ));
 
     // Scan the table again, we are able to get the data now!
-    let mut scan = RowSeqScanExecutor::new(table.clone(), data_column_ids.clone(), 1024);
+    let mut scan = RowSeqScanExecutor::new(
+        table.clone(),
+        data_column_ids.clone(),
+        1024,
+        "RowSeqScanExecutor".to_string(),
+    );
     scan.open().await?;
     let c = scan.next().await?.unwrap();
     let col_data = c.columns()[0].array_ref().as_float64();


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
#274 , We put the string generated by `ExplainTerms` in the java frontend to the identity of executors, i.e. the rows shown by `Explain a plan`. This makes debugging easier. 

Will change the test cases in the java frontend if gets approved.

## Refer to a related PR or issue link (optional)
#274 