### PR TITLE
fix(dashboard): fix performance issue

### DIFF
--- a/dashboard/components/StreamingView.js
+++ b/dashboard/components/StreamingView.js
@@ -33,11 +33,13 @@ export default function StreamingView(props) {
 
   actorProto.actors = actorProto.actors || [];
 
+  const exprNode = (actorNode) => (({ input, ...o }) => o)(actorNode)
+
   const onNodeClick = (e, node) => {
     setShowInfoPane(true);
     setNodeJson(node.dispatcherType
       ? JSON.stringify({ dispatcher: { type: node.dispatcherType }, downstreamActorId: node.downstreamActorId }, null, 2)
-      : JSON.stringify(node.nodeProto, null, 2));
+      : JSON.stringify(exprNode(node.nodeProto), null, 2));
   };
 
   useEffect(() => {
@@ -65,6 +67,8 @@ export default function StreamingView(props) {
           transform.invert(d3.pointer(event));
         });
       ;
+
+      return () => d3.select(d3Container.current).selectAll("*").remove();
     }
   }, []);
 

--- a/dashboard/lib/streamPlan/parser.js
+++ b/dashboard/lib/streamPlan/parser.js
@@ -40,7 +40,7 @@ class StreamNode extends Node {
   parseType(nodeProto) {
     let types = ["tableSourceNode", "sourceNode", "projectNode", "filterNode",
       "mviewNode", "simpleAggNode", "hashAggNode", "topNNode",
-      "hashJoinNode", "mergeNode", "exchangeNode", "chainNode"];
+      "hashJoinNode", "mergeNode", "exchangeNode", "chainNode", "localSimpleAggNode"];
     for (let type of types) {
       if (type in nodeProto) {
         return type;

--- a/dashboard/lib/streamPlan/streamChartHelper.js
+++ b/dashboard/lib/streamPlan/streamChartHelper.js
@@ -485,21 +485,22 @@ export class StreamChartHelper {
     // dataflow effect
     group.selectAll("path")
       .attr("stroke-dasharray", linkStrokeDash);
+
     if (DrawLinkEffect) {
-      function repeat() {
-        group.selectAll("path")
-          .attr("stroke-dashoffset", "0")
-          .transition()
-          .duration(linkFlowEffectDuration / 2)
-          .ease(d3.easeLinear)
-          .attr("stroke-dashoffset", "20")
-          .transition()
-          .duration(linkFlowEffectDuration / 2)
-          .ease(d3.easeLinear)
-          .attr("stroke-dashoffset", "40")
-          .on("end", repeat);
-      }
-      repeat();
+      group.selectAll("path")
+        .attr("stroke-dashoffset", "0")
+        .transition()
+        .duration(linkFlowEffectDuration)
+        .ease(d3.easeLinear)
+        .on("start", function repeat() {
+          d3.active(this)
+            .attr("stroke-dashoffset", "20")
+            .transition()
+            .on("start", function () {
+              d3.select(this).attr("stroke-dashoffset", "0");
+              repeat.bind(this)();
+            })
+        });
     }
 
     // ~ END OF dataflow effect 
@@ -658,20 +659,20 @@ export class StreamChartHelper {
     linkLayer.selectAll("path")
       .attr("stroke-dasharray", "20, 20");
     if (DrawLinkEffect) {
-      function repeat() {
-        linkLayer.selectAll("path")
-          .attr("stroke-dashoffset", "40")
-          .transition()
-          .duration(linkFlowEffectDuration / 2)
-          .ease(d3.easeLinear)
-          .attr("stroke-dashoffset", "20")
-          .transition()
-          .duration(linkFlowEffectDuration / 2)
-          .ease(d3.easeLinear)
-          .attr("stroke-dashoffset", "0")
-          .on("end", repeat);
-      }
-      repeat();
+      linkLayer.selectAll("path")
+        .attr("stroke-dashoffset", "40")
+        .transition()
+        .duration(linkFlowEffectDuration)
+        .ease(d3.easeLinear)
+        .on("start", function repeat() {
+          d3.active(this)
+            .attr("stroke-dashoffset", "0")
+            .transition()
+            .on("start", function () {
+              d3.select(this).attr("stroke-dashoffset", "40");
+              repeat.bind(this)();
+            })
+        });
     }
     // ~ END OF dataflow effect 
 
@@ -771,6 +772,6 @@ export class StreamChartHelper {
  * @param {(clickEvent, node) => void} onNodeClick callback when a node (operator) is clicked.
  * @returns void
  */
-export default function createView(g, actorProto, onNodeClick){
+export default function createView(g, actorProto, onNodeClick) {
   return new StreamChartHelper(g, actorProto, onNodeClick).drawManyFlow();
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

This PR contains various fix for the new dashboard.

* Performance issue: the animation will stuck about every 1 sec, and the whole webpage will stop to respond if there are too many links. The root cause is that, `transition` should be called on `d3.active(this)` instead of `d3.selectAll`. Otherwise there will be `number^{repeat time}` timers in the background -- every call on `on("end")` will trigger every d3 component.
* Add `localSimpleAgg`.
* Remove `input` from JSON output (so as not to include input children in JSON).


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
