### PR TITLE
feat(frontend): get compute nodes's address from meta server when java frontend starts

### DIFF
--- a/java/meta/src/main/kotlin/com/risingwave/rpc/GrpcMetaClient.kt
+++ b/java/meta/src/main/kotlin/com/risingwave/rpc/GrpcMetaClient.kt
@@ -96,4 +96,14 @@ class GrpcMetaClient(private val channel: Channel) : MetaClient {
       throw rpcException("flush", e)
     }
   }
+
+  override fun listAllNodes(request: ListAllNodesRequest): ListAllNodesResponse {
+    val stub = ClusterServiceGrpc.newBlockingStub(channel)
+    try {
+      return stub.listAllNodes(request)
+    } catch (e: StatusRuntimeException) {
+      LOGGER.warn("RPC failed: {}", e.status)
+      throw rpcException("listAllNodes", e)
+    }
+  }
 }

--- a/java/meta/src/main/kotlin/com/risingwave/rpc/MetaClient.kt
+++ b/java/meta/src/main/kotlin/com/risingwave/rpc/MetaClient.kt
@@ -19,4 +19,6 @@ interface MetaClient {
   fun dropMaterializedView(request: DropMaterializedViewRequest): DropMaterializedViewResponse
 
   fun flush(request: FlushRequest): FlushResponse
+
+  fun listAllNodes(request: ListAllNodesRequest): ListAllNodesResponse
 }

--- a/java/pgserver/src/main/resources/server.properties
+++ b/java/pgserver/src/main/resources/server.properties
@@ -2,7 +2,6 @@
 risingwave.pgserver.ip="0.0.0.0"
 risingwave.pgserver.port=4567
 risingwave.leader.clustermode=Distributed
-risingwave.leader.computenodes=127.0.0.1:5688
 
 ## optional metadata service config
 risingwave.catalog.mode=Remote

--- a/java/planner/src/main/java/com/risingwave/node/RemoteWorkerNodeManager.java
+++ b/java/planner/src/main/java/com/risingwave/node/RemoteWorkerNodeManager.java
@@ -1,9 +1,16 @@
 package com.risingwave.node;
 
-import static com.risingwave.common.config.LeaderServerConfigurations.COMPUTE_NODES;
-
 import com.google.common.collect.ImmutableList;
 import com.risingwave.common.config.Configuration;
+import com.risingwave.common.config.FrontendServerConfigurations;
+import com.risingwave.common.exception.PgErrorCode;
+import com.risingwave.common.exception.PgException;
+import com.risingwave.proto.common.Status;
+import com.risingwave.proto.common.WorkerType;
+import com.risingwave.proto.metanode.ListAllNodesRequest;
+import com.risingwave.proto.metanode.ListAllNodesResponse;
+import com.risingwave.rpc.MetaClient;
+import com.risingwave.rpc.MetaClientManager;
 import java.util.Random;
 import javax.inject.Inject;
 
@@ -17,9 +24,23 @@ public class RemoteWorkerNodeManager implements WorkerNodeManager {
   private final Random random = new Random(1024);
 
   @Inject
-  public RemoteWorkerNodeManager(Configuration conf) {
+  public RemoteWorkerNodeManager(Configuration conf, MetaClientManager metaClientManager) {
+    String address = conf.get(FrontendServerConfigurations.META_SERVICE_ADDRESS);
+    DefaultWorkerNode node = DefaultWorkerNode.from(address);
+    MetaClient metaClient =
+        metaClientManager.getOrCreate(
+            node.getRpcEndPoint().getHost(), node.getRpcEndPoint().getPort());
+
+    ListAllNodesRequest request =
+        ListAllNodesRequest.newBuilder().setWorkerType(WorkerType.COMPUTE_NODE).build();
+    ListAllNodesResponse response = metaClient.listAllNodes(request);
+    if (response.getStatus().getCode() != Status.Code.OK) {
+      throw new PgException(PgErrorCode.INTERNAL_ERROR, "list all nodes failed");
+    }
+
     workerNodes =
-        conf.get(COMPUTE_NODES).stream()
+        response.getNodesList().stream()
+            .map((e) -> String.format("%s:%d", e.getHost().getHost(), e.getHost().getPort()))
             .map(DefaultWorkerNode::from)
             .collect(ImmutableList.toImmutableList());
   }


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
When Java frontend starts, get compute nodes's address from meta server using `ListAllNodes` rpc interface instead of reading from properties file.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
related #61 