### PR TITLE
fix: enable block cache for hummock+s3 state store

### DIFF
--- a/rust/storage/src/store.rs
+++ b/rust/storage/src/store.rs
@@ -214,7 +214,11 @@ impl StateStoreImpl {
                             remote_dir: remote_dir.to_string(),
                             checksum_algo: ChecksumAlg::Crc32c,
                         },
-                        Arc::new(LocalVersionManager::new(s3_store, remote_dir, None)),
+                        Arc::new(LocalVersionManager::new(
+                            s3_store,
+                            remote_dir,
+                            Some(Arc::new(Cache::new(65536))),
+                        )),
                         Arc::new(RPCHummockMetaClient::new(meta_client)),
                     )
                     .await


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
