### PR TITLE
refactor(meta): remove MetaStore::put_batch[_cf]

### DIFF
--- a/rust/meta/src/storage/sled_metastore.rs
+++ b/rust/meta/src/storage/sled_metastore.rs
@@ -13,7 +13,6 @@ use crate::storage::transaction::{Operation, Precondition, Transaction};
 use crate::storage::Operation::Delete;
 use crate::storage::{
     ColumnFamily, Key, KeyValue, KeyValueVersion, KeyWithVersion, MetaStore, Value,
-    DEFAULT_COLUMN_FAMILY,
 };
 
 impl From<sled::Error> for crate::storage::Error {
@@ -291,14 +290,6 @@ impl MetaStore for SledMetaStore {
         .await
     }
 
-    async fn put_batch_cf(&self, tuples: Vec<(&str, Vec<u8>, Vec<u8>, Epoch)>) -> Result<()> {
-        let ops = tuples
-            .into_iter()
-            .map(|(cf, k, v, e)| (cf.to_owned(), k, e.into_inner(), v))
-            .collect_vec();
-        self.put_impl(ops).await
-    }
-
     async fn get_cf(&self, cf: &str, key: &[u8], version: Epoch) -> Result<Vec<u8>> {
         let result = self
             .get_impl_flatten(&[(
@@ -323,16 +314,6 @@ impl MetaStore for SledMetaStore {
     async fn delete_all_cf(&self, cf: &str, key: &[u8]) -> Result<()> {
         self.delete_impl(vec![(cf.to_owned(), key.to_owned(), None)])
             .await
-    }
-
-    async fn put_batch(&self, tuples: Vec<(Vec<u8>, Vec<u8>, Epoch)>) -> Result<()> {
-        self.put_batch_cf(
-            tuples
-                .into_iter()
-                .map(|(k, v, e)| (DEFAULT_COLUMN_FAMILY, k, v, e))
-                .collect_vec(),
-        )
-        .await
     }
 
     async fn commit_transaction(&self, trx: &mut Transaction) -> Result<()> {
@@ -467,55 +448,6 @@ mod tests {
                 SINGLE_VERSION_EPOCH.into_inner()
             )]
         );
-
-        meta_store
-            .put_batch_cf(vec![
-                (
-                    "cf/cf1",
-                    "k22".as_bytes().to_vec(),
-                    "v22".as_bytes().to_vec(),
-                    Epoch::from(15),
-                ),
-                (
-                    "cf/cf1",
-                    "k1".as_bytes().to_vec(),
-                    "v2".as_bytes().to_vec(),
-                    Epoch::from(20),
-                ),
-                (
-                    "cf/cf1",
-                    "k1".as_bytes().to_vec(),
-                    "v3".as_bytes().to_vec(),
-                    Epoch::from(30),
-                ),
-                (
-                    "cf/cf1",
-                    "k1".as_bytes().to_vec(),
-                    "v1".as_bytes().to_vec(),
-                    Epoch::from(10),
-                ),
-                (
-                    "cf/another_cf",
-                    "another_k1".as_bytes().to_vec(),
-                    "another_v1".as_bytes().to_vec(),
-                    Epoch::from(2),
-                ),
-            ])
-            .await?;
-        let result = meta_store
-            .list_batch_cf(vec!["cf/cf1", "cf/another_cf"])
-            .await?;
-        assert_eq!(2, result.len());
-        assert!(result[0]
-            .iter()
-            .map(|v| std::str::from_utf8(v).unwrap())
-            .sorted()
-            .eq(vec!["v22", "v3"]));
-        assert!(result[1]
-            .iter()
-            .map(|v| std::str::from_utf8(v).unwrap())
-            .sorted()
-            .eq(vec!["another_v1"]));
 
         Ok(())
     }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?

The method is not used, and its signature is strange, e.g., in almost all cases, we will not put a batch of data with different epoch.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
