### PR TITLE
(WIP)refactor(hummock): periodically fetch the latest version from meta

### DIFF
--- a/rust/storage/src/hummock/compactor.rs
+++ b/rust/storage/src/hummock/compactor.rs
@@ -251,14 +251,6 @@ impl Compactor {
             .report_compaction_task(compact_task, is_task_ok)
             .await;
 
-        // TODO: #2336 The transaction flow is not ready yet. Before that we
-        // update_local_version after each write_batch to make uncommitted write
-        // visible.
-        context
-            .local_version_manager
-            .update_local_version(context.hummock_meta_client.as_ref())
-            .await?;
-
         report_result?;
 
         if is_task_ok {

--- a/rust/storage/src/hummock/hummock_meta_client.rs
+++ b/rust/storage/src/hummock/hummock_meta_client.rs
@@ -48,6 +48,7 @@ pub trait HummockMetaClient: Send + Sync + 'static {
 pub struct RPCHummockMetaClient {
     meta_client: MetaClient,
     stats: Arc<StateStoreStats>,
+    // TODO #372: Use worker node id as context_id in RPC
 }
 
 impl RPCHummockMetaClient {

--- a/rust/storage/src/hummock/snapshot_tests.rs
+++ b/rust/storage/src/hummock/snapshot_tests.rs
@@ -53,7 +53,6 @@ async fn gen_and_upload_table(
         )
         .await
         .unwrap();
-    // TODO #2336 we need to maintain local version.
     vm.update_local_version(hummock_meta_client).await.unwrap();
 }
 

--- a/rust/storage/src/hummock/state_store.rs
+++ b/rust/storage/src/hummock/state_store.rs
@@ -2,7 +2,7 @@ use std::ops::RangeBounds;
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use risingwave_common::error::Result;
+use risingwave_common::error::{Result, RwError};
 
 use super::HummockStorage;
 use crate::hummock::iterator::DirectedUserIterator;
@@ -71,9 +71,11 @@ impl StateStore for HummockStateStore {
         Ok(HummockStateStoreIter(DirectedUserIterator::Backward(res)))
     }
 
-    async fn update_local_version(&self) -> Result<()> {
-        self.storage.update_local_version().await?;
-        Ok(())
+    async fn wait_epoch_in_version(&self, epoch: u64) -> Result<()> {
+        self.storage
+            .wait_epoch_in_version(epoch)
+            .await
+            .map_err(RwError::from)
     }
 }
 

--- a/rust/storage/src/store.rs
+++ b/rust/storage/src/store.rs
@@ -91,11 +91,7 @@ pub trait StateStore: Send + Sync + 'static + Clone {
         WriteBatch::new(self.clone())
     }
 
-    /// Update local version for this state store. This is currently no-op on stores other than
-    /// Hummock.
-    ///
-    /// TODO: remove this after we implement periodical version updating.
-    async fn update_local_version(&self) -> Result<()> {
+    async fn wait_epoch_in_version(&self, _epoch: u64) -> Result<()> {
         Ok(())
     }
 }

--- a/rust/storage/src/table/mview.rs
+++ b/rust/storage/src/table/mview.rs
@@ -175,10 +175,7 @@ impl<'a, S: StateStore> MViewTableIter<S> {
         pk_columns: Vec<usize>,
         epoch: u64,
     ) -> Result<Self> {
-        // The table might be updated from other compute nodes, and we are not aware of the latest
-        // version in Hummock's local version manager.
-        // TODO: remove this after we implement periodical version updating.
-        keyspace.state_store().update_local_version().await?;
+        keyspace.state_store().wait_epoch_in_version(epoch).await?;
 
         let iter = Self {
             keyspace,


### PR DESCRIPTION
<!-- Following the [contributing guidelines](https://github.com/singularity-data/risingwave-dev/blob/main/CONTRIBUTING.md) will make it easier for us to review and accept your PR. -->

## What's changed and what's your intention?
The CI should fail because u64::MAX is used as read epoch.
Implement checkpoint commit to fix.

## Checklist

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave-dev/issues/365
