### PR TITLE
fix: fix tikv statestore scanning with `None` limit

### DIFF
--- a/rust/storage/src/tikv.rs
+++ b/rust/storage/src/tikv.rs
@@ -74,7 +74,7 @@ impl StateStore for TikvStateStore {
         }
         let scan_limit = match limit {
             Some(x) => x as u32,
-            None => return Ok(vec![]),
+            None => u32::MAX,
         };
 
         let range = (


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
   fix tikv statestore: scan all instead none while limit is None
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
