### PR TITLE
feat: add in expression

### DIFF
--- a/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/tpch/TpchDistributedQueryPlanTest.xml
@@ -806,7 +806,7 @@ RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], col
                   RwBatchScan(table=[[test_schema, orders]], columns=[o_orderkey,o_orderpriority])
               RwBatchExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
                 RwBatchProject(l_orderkey=[$0], l_shipmode=[$4])
-                  RwBatchFilter(condition=[AND(OR(=($4, 'FOB'), =($4, 'SHIP')), <($2, $3), <($1, $2), >=($3, CAST('1994-01-01'):DATE NOT NULL), <(CAST($3):TIMESTAMP(0), +(CAST('1994-01-01'):DATE NOT NULL, 12:INTERVAL YEAR(9))))])
+                  RwBatchFilter(condition=[AND(SEARCH($4, Sarg['FOB':CHAR(4), 'SHIP']:CHAR(4)), <($2, $3), <($1, $2), >=($3, CAST('1994-01-01'):DATE NOT NULL), <(CAST($3):TIMESTAMP(0), +(CAST('1994-01-01'):DATE NOT NULL, 12:INTERVAL YEAR(9))))])
                     RwBatchScan(table=[[test_schema, lineitem]], columns=[l_orderkey,l_shipdate,l_commitdate,l_receiptdate,l_shipmode])
 ]]>
         </Resource>
@@ -1029,7 +1029,7 @@ RwBatchExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], col
                                   RwBatchFilter(condition=[LIKE($1, '%Customer%Complaints%')])
                                     RwBatchScan(table=[[test_schema, supplier]], columns=[s_suppkey,s_comment])
                     RwBatchExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
-                      RwBatchFilter(condition=[AND(<>($3, CAST('Brand#45'):CHAR(10) NOT NULL), OR(=($5, 4), =($5, 10), =($5, 11), =($5, 16), =($5, 17), =($5, 19), =($5, 23), =($5, 38)), NOT(LIKE($4, 'SMALL PLATED%')))])
+                      RwBatchFilter(condition=[AND(<>($3, CAST('Brand#45'):CHAR(10) NOT NULL), SEARCH($5, Sarg[4, 10, 11, 16, 17, 19, 23, 38]), NOT(LIKE($4, 'SMALL PLATED%')))])
                         RwBatchScan(table=[[test_schema, part]], columns=[p_partkey,p_name,p_mfgr,p_brand,p_type,p_size,p_container,p_retailprice,p_comment])
               RwBatchHashAgg(group=[{0}], agg#0=[MIN($1)])
                 RwBatchExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
@@ -1205,10 +1205,10 @@ RwBatchSortAgg(group=[{}], revenue=[SUM($0)])
     RwBatchSortAgg(group=[{}], revenue=[SUM($0)])
       RwBatchProject($f0=[$1])
         RwBatchNestedLoopJoin(condition=[OR(AND(=($10, $0), $11, $12, $2, $3, $13, $4, $5), AND(=($10, $0), $14, $15, $6, $7, $16, $4, $5), AND(=($10, $0), $17, $18, $8, $9, $19, $4, $5))], joinType=[inner])
-          RwBatchProject(l_partkey=[$0], *=[*($2, -(1, $3))], >==[>=($1, 8)], <==[<=($1, +(8, 10))], OR=[OR(=($5, 'AIR'), =($5, 'AIR REG'))], ==[=($4, CAST('DELIVER IN PERSON'):CHAR(25) NOT NULL)], >=6=[>=($1, 10)], <=7=[<=($1, +(10, 10))], >=8=[>=($1, 24)], <=9=[<=($1, +(24, 10))])
+          RwBatchProject(l_partkey=[$0], *=[*($2, -(1, $3))], >==[>=($1, 8)], <==[<=($1, +(8, 10))], OR=[SEARCH($5, Sarg['AIR':CHAR(7), 'AIR REG']:CHAR(7))], ==[=($4, CAST('DELIVER IN PERSON'):CHAR(25) NOT NULL)], >=6=[>=($1, 10)], <=7=[<=($1, +(10, 10))], >=8=[>=($1, 24)], <=9=[<=($1, +(24, 10))])
             RwBatchScan(table=[[test_schema, lineitem]], columns=[l_partkey,l_quantity,l_extendedprice,l_discount,l_shipinstruct,l_shipmode])
           RwBatchExchange(distribution=[RwDistributionTrait{type=BROADCAST_DISTRIBUTED, keys=[]}], collation=[[]])
-            RwBatchProject(p_partkey=[$0], ==[=($1, CAST('Brand#22'):CHAR(10) NOT NULL)], OR=[OR(=($3, 'SM BOX'), =($3, 'SM CASE'), =($3, 'SM PACK'), =($3, 'SM PKG'))], OR3=[OR(AND(>=($2, 1), <=($2, 5)), <>($2, $2))], =4=[=($1, CAST('Brand#23'):CHAR(10) NOT NULL)], OR5=[OR(=($3, 'MED BAG'), =($3, 'MED BOX'), =($3, 'MED PACK'), =($3, 'MED PKG'))], OR6=[OR(AND(>=($2, 1), <=($2, 10)), <>($2, $2))], =7=[=($1, CAST('Brand#12'):CHAR(10) NOT NULL)], OR8=[OR(=($3, 'LG BOX'), =($3, 'LG CASE'), =($3, 'LG PACK'), =($3, 'LG PKG'))], OR9=[OR(AND(>=($2, 1), <=($2, 15)), <>($2, $2))])
+            RwBatchProject(p_partkey=[$0], ==[=($1, CAST('Brand#22'):CHAR(10) NOT NULL)], OR=[SEARCH($3, Sarg['SM BOX':CHAR(7), 'SM CASE', 'SM PACK', 'SM PKG':CHAR(7)]:CHAR(7))], OR3=[OR(AND(>=($2, 1), <=($2, 5)), <>($2, $2))], =4=[=($1, CAST('Brand#23'):CHAR(10) NOT NULL)], OR5=[SEARCH($3, Sarg['MED BAG':CHAR(8), 'MED BOX':CHAR(8), 'MED PACK', 'MED PKG':CHAR(8)]:CHAR(8))], OR6=[OR(AND(>=($2, 1), <=($2, 10)), <>($2, $2))], =7=[=($1, CAST('Brand#12'):CHAR(10) NOT NULL)], OR8=[SEARCH($3, Sarg['LG BOX':CHAR(7), 'LG CASE', 'LG PACK', 'LG PKG':CHAR(7)]:CHAR(7))], OR9=[OR(AND(>=($2, 1), <=($2, 15)), <>($2, $2))])
               RwBatchScan(table=[[test_schema, part]], columns=[p_partkey,p_brand,p_size,p_container])
 ]]>
         </Resource>

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -30,6 +30,7 @@ message ExprNode {
     AND = 21;
     OR = 22;
     NOT = 23;
+    IN = 24;
     // date functions
     EXTRACT = 101;
     PG_SLEEP = 102;

--- a/rust/common/src/expr/expr_in.rs
+++ b/rust/common/src/expr/expr_in.rs
@@ -9,13 +9,13 @@ use crate::expr::{BoxedExpression, Expression};
 use crate::types::{DataType, Datum, ToOwnedDatum};
 
 #[derive(Debug)]
-pub(crate) struct SearchExpression {
+pub(crate) struct InExpression {
     input_ref: BoxedExpression,
-    sarg: HashSet<Datum>,
+    set: HashSet<Datum>,
     return_type: DataType,
 }
 
-impl SearchExpression {
+impl InExpression {
     pub fn new(
         input_ref: BoxedExpression,
         data: impl Iterator<Item = Datum>,
@@ -27,17 +27,17 @@ impl SearchExpression {
         }
         Self {
             input_ref,
-            sarg,
+            set: sarg,
             return_type,
         }
     }
 
     fn check_in_sarg(&self, datum: &Datum) -> bool {
-        self.sarg.contains(datum)
+        self.set.contains(datum)
     }
 }
 
-impl Expression for SearchExpression {
+impl Expression for InExpression {
     fn return_type(&self) -> DataType {
         self.return_type
     }
@@ -71,7 +71,7 @@ impl Expression for SearchExpression {
 mod tests {
     use crate::array::{DataChunk, Utf8Array};
     use crate::column;
-    use crate::expr::expr_search::SearchExpression;
+    use crate::expr::expr_in::InExpression;
     use crate::expr::{Expression, InputRefExpression};
     use crate::types::{DataType, ScalarImpl};
 
@@ -82,7 +82,7 @@ mod tests {
             Some(ScalarImpl::Utf8("abc".to_string())),
             Some(ScalarImpl::Utf8("def".to_string())),
         ];
-        let mut search_expr = SearchExpression::new(input_ref, data.into_iter(), DataType::Boolean);
+        let mut search_expr = InExpression::new(input_ref, data.into_iter(), DataType::Boolean);
         let column = column! {Utf8Array, [Some("abc"), Some("a"), Some("def"), Some("abc")]};
         let data_chunk = DataChunk::builder().columns(vec![column]).build();
         let res = search_expr.eval(&data_chunk).unwrap();

--- a/rust/common/src/expr/mod.rs
+++ b/rust/common/src/expr/mod.rs
@@ -5,10 +5,10 @@ mod expr_binary_bytes;
 pub mod expr_binary_nonnull;
 pub mod expr_binary_nullable;
 mod expr_case;
+mod expr_in;
 mod expr_input_ref;
 mod expr_is_null;
 mod expr_literal;
-mod expr_search;
 mod expr_ternary_bytes;
 pub mod expr_unary;
 mod pg_sleep;
@@ -70,7 +70,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         InputRef => InputRefExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Case => build_case_expr(prost),
         Translate => build_translate_expr(prost),
-        Search => build_search_expr(prost),
+        In => build_in_expr(prost),
         _ => Err(InternalError(format!(
             "Unsupported expression type: {:?}",
             prost.get_expr_type()


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Use an customized `In` expression instead of using `Search` for both `in` and `between`. This is because the elements in the `In (XXX, YYY)` is always a scalar, while `between` may have them as `range`.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
This change is limited by some constraints of Calcite:
1. Although `In` is a built-in binary operator, `RexCall` does not allow to have `In` as its operator. Since this is prohibited in its constructor, we cannot inherit `RexCall`. And even if we can, the changes seem to be huge. Therefore, `Search` is unchanged in the java plan, but we serialize it into a special `In` expression when sending the proto to the backend.
2. `in ('FOB', 'SHIP')` would be considered as `CHAR(4)` instead of `VARCHAR`. Therefore, we judge the class type of the `endpoint` in the `Sarg`'s range and serialize `NlsString`'s `getValue`. But for other types, we have to make them `RexLiteral`s first and get the byte representation of them. This is because RexLiteral uses `BigDecimal` for all the numeric types.


- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
closes #192 