### PR TITLE
chore(stream): separate identity and logical operator info

### DIFF
--- a/rust/stream/src/executor/chain.rs
+++ b/rust/stream/src/executor/chain.rs
@@ -23,6 +23,8 @@ pub struct ChainExecutor {
     state: ChainState,
     schema: Schema,
     column_idxs: Vec<usize>,
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl ChainExecutor {
@@ -31,6 +33,7 @@ impl ChainExecutor {
         mview: Box<dyn Executor>,
         schema: Schema,
         column_idxs: Vec<usize>,
+        op_info: String,
     ) -> Self {
         Self {
             snapshot,
@@ -38,6 +41,7 @@ impl ChainExecutor {
             state: ChainState::Init,
             schema,
             column_idxs,
+            op_info,
         }
     }
 
@@ -123,6 +127,10 @@ impl Executor for ChainExecutor {
     fn identity(&self) -> &str {
         "Chain"
     }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
+    }
 }
 
 #[cfg(test)]
@@ -188,6 +196,10 @@ mod test {
             "MockSnapshot"
         }
 
+        fn logical_operator_info(&self) -> &str {
+            self.identity()
+        }
+
         fn init(&mut self, _: u64) -> Result<()> {
             Ok(())
         }
@@ -241,7 +253,8 @@ mod test {
             ],
         ));
 
-        let mut chain = ChainExecutor::new(first, second, schema, vec![0]);
+        let mut chain =
+            ChainExecutor::new(first, second, schema, vec![0], "ChainExecutor".to_string());
         let mut count = 0;
         loop {
             let k = &chain.next().await.unwrap();

--- a/rust/stream/src/executor/debug/mod.rs
+++ b/rust/stream/src/executor/debug/mod.rs
@@ -46,6 +46,10 @@ where
         self.input().identity()
     }
 
+    fn logical_operator_info(&self) -> &str {
+        self.input().logical_operator_info()
+    }
+
     fn clear_cache(&mut self) -> Result<()> {
         self.input_mut().clear_cache()
     }

--- a/rust/stream/src/executor/debug/schema_check.rs
+++ b/rust/stream/src/executor/debug/schema_check.rs
@@ -60,7 +60,7 @@ impl super::DebugExecutor for SchemaCheckExecutor {
                         match (array, &builder) {
                             $( (Some(ArrayImpl::$variant_name(_)), Some(ArrayBuilderImpl::$variant_name(_))) => {} ),*
                             _ => panic!("schema check failed on {}: column {} should be {:?}, while stream chunk gives {:?}",
-                                                    self.input.identity(), i, builder.map(|b| b.get_ident()), array.map(|a| a.get_ident())),
+                                                    self.input.logical_operator_info(), i, builder.map(|b| b.get_ident()), array.map(|a| a.get_ident())),
                         }
                     };
                 }

--- a/rust/stream/src/executor/dispatch.rs
+++ b/rust/stream/src/executor/dispatch.rs
@@ -668,7 +668,12 @@ mod tests {
     async fn test_configuration_change() {
         let schema = Schema { fields: vec![] };
         let (mut tx, rx) = channel(16);
-        let input = Box::new(ReceiverExecutor::new(schema.clone(), vec![], rx));
+        let input = Box::new(ReceiverExecutor::new(
+            schema.clone(),
+            vec![],
+            rx,
+            "ReceiverExecutor".to_string(),
+        ));
         let data_sink = Arc::new(Mutex::new(vec![]));
         let output = Box::new(MockOutput::new(data_sink));
         let actor_id = 233;

--- a/rust/stream/src/executor/filter.rs
+++ b/rust/stream/src/executor/filter.rs
@@ -22,6 +22,9 @@ pub struct FilterExecutor {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl FilterExecutor {
@@ -29,12 +32,13 @@ impl FilterExecutor {
         input: Box<dyn Executor>,
         expr: BoxedExpression,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         Self {
             input,
             expr,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("FilterExecutor {:X}", executor_id),
+            op_info,
         }
     }
 }
@@ -64,6 +68,10 @@ impl Executor for FilterExecutor {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/global_simple_agg.rs
+++ b/rust/stream/src/executor/global_simple_agg.rs
@@ -53,6 +53,9 @@ pub struct SimpleAggExecutor<S: StateStore> {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore> std::fmt::Debug for SimpleAggExecutor<S> {
@@ -73,7 +76,7 @@ impl<S: StateStore> SimpleAggExecutor<S> {
         keyspace: Keyspace<S>,
         pk_indices: PkIndices,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         // simple agg does not have group key
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, None);
@@ -86,7 +89,8 @@ impl<S: StateStore> SimpleAggExecutor<S> {
             states: None,
             input,
             agg_calls,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("GlobalSimpleAggExecutor {:X}", executor_id),
+            op_info,
         }
     }
 
@@ -199,6 +203,10 @@ impl<S: StateStore> Executor for SimpleAggExecutor<S> {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 
     fn clear_cache(&mut self) -> Result<()> {

--- a/rust/stream/src/executor/hash_agg.rs
+++ b/rust/stream/src/executor/hash_agg.rs
@@ -59,6 +59,9 @@ pub struct HashAggExecutor<S: StateStore> {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore> HashAggExecutor<S> {
@@ -69,7 +72,7 @@ impl<S: StateStore> HashAggExecutor<S> {
         keyspace: Keyspace<S>,
         pk_indices: PkIndices,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, Some(&key_indices));
 
@@ -82,7 +85,8 @@ impl<S: StateStore> HashAggExecutor<S> {
             key_indices,
             state_map: EvictableHashMap::new(1 << 16), // TODO: decide the target cap
             pk_indices,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("HashAggExecutor {:X}", executor_id),
+            op_info,
         }
     }
 
@@ -320,6 +324,10 @@ impl<S: StateStore> Executor for HashAggExecutor<S> {
         );
         self.state_map.clear();
         Ok(())
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/hash_join.rs
+++ b/rust/stream/src/executor/hash_join.rs
@@ -224,6 +224,9 @@ pub struct HashJoinExecutor<S: StateStore, const T: JoinTypePrimitive> {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore, const T: JoinTypePrimitive> std::fmt::Debug for HashJoinExecutor<S, T> {
@@ -272,6 +275,10 @@ impl<S: StateStore, const T: JoinTypePrimitive> Executor for HashJoinExecutor<S,
         self.identity.as_str()
     }
 
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
+    }
+
     fn clear_cache(&mut self) -> Result<()> {
         self.side_l.clear_cache();
         self.side_r.clear_cache();
@@ -291,7 +298,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
         keyspace: Keyspace<S>,
         executor_id: u64,
         cond: Option<RowExpression>,
-        identity: String,
+        op_info: String,
     ) -> Self {
         let debug_l = format!("{:#?}", &input_l);
         let debug_r = format!("{:#?}", &input_r);
@@ -351,7 +358,8 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<S, T> {
             cond,
             debug_l,
             debug_r,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("HashJoinExecutor {:X}", executor_id),
+            op_info,
         }
     }
 

--- a/rust/stream/src/executor/local_simple_agg.rs
+++ b/rust/stream/src/executor/local_simple_agg.rs
@@ -38,6 +38,9 @@ pub struct LocalSimpleAggExecutor {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl LocalSimpleAggExecutor {
@@ -46,7 +49,7 @@ impl LocalSimpleAggExecutor {
         agg_calls: Vec<AggCall>,
         pk_indices: PkIndices,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Result<Self> {
         // simple agg does not have group key
         let schema = generate_agg_schema(input.as_ref(), &agg_calls, None);
@@ -69,7 +72,8 @@ impl LocalSimpleAggExecutor {
             is_dirty: false,
             input,
             agg_calls,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("LocalSimpleAggExecutor {:X}", executor_id),
+            op_info,
         })
     }
 }
@@ -90,6 +94,10 @@ impl Executor for LocalSimpleAggExecutor {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/merge.rs
+++ b/rust/stream/src/executor/merge.rs
@@ -107,6 +107,8 @@ pub struct ReceiverExecutor {
     schema: Schema,
     pk_indices: PkIndices,
     receiver: Receiver<Message>,
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl std::fmt::Debug for ReceiverExecutor {
@@ -119,11 +121,17 @@ impl std::fmt::Debug for ReceiverExecutor {
 }
 
 impl ReceiverExecutor {
-    pub fn new(schema: Schema, pk_indices: PkIndices, receiver: Receiver<Message>) -> Self {
+    pub fn new(
+        schema: Schema,
+        pk_indices: PkIndices,
+        receiver: Receiver<Message>,
+        op_info: String,
+    ) -> Self {
         Self {
             schema,
             pk_indices,
             receiver,
+            op_info,
         }
     }
 }
@@ -150,6 +158,10 @@ impl Executor for ReceiverExecutor {
 
     fn identity(&self) -> &str {
         "ReceiverExecutor"
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 
@@ -180,6 +192,9 @@ pub struct MergeExecutor {
 
     /// Belonged actor id.
     actor_id: u32,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl std::fmt::Debug for MergeExecutor {
@@ -198,6 +213,7 @@ impl MergeExecutor {
         pk_indices: PkIndices,
         actor_id: u32,
         inputs: Vec<Receiver<Message>>,
+        op_info: String,
     ) -> Self {
         Self {
             schema,
@@ -208,6 +224,7 @@ impl MergeExecutor {
             terminated: 0,
             next_barrier: None,
             actor_id,
+            op_info,
         }
     }
 }
@@ -276,6 +293,10 @@ impl Executor for MergeExecutor {
     fn identity(&self) -> &'static str {
         "MergeExecutor"
     }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
+    }
 }
 
 #[cfg(test)]
@@ -317,7 +338,13 @@ mod tests {
             txs.push(tx);
             rxs.push(rx);
         }
-        let mut merger = MergeExecutor::new(Schema::default(), vec![], 0, rxs);
+        let mut merger = MergeExecutor::new(
+            Schema::default(),
+            vec![],
+            0,
+            rxs,
+            "MergerExecutor".to_string(),
+        );
 
         let mut handles = Vec::with_capacity(CHANNEL_NUMBER);
 

--- a/rust/stream/src/executor/mod.rs
+++ b/rust/stream/src/executor/mod.rs
@@ -286,6 +286,9 @@ pub trait Executor: Send + Debug + 'static {
     /// Identity string of the executor.
     fn identity(&self) -> &str;
 
+    /// Logical Operator Information of the executor
+    fn logical_operator_info(&self) -> &str;
+
     /// Clears the in-memory cache of the executor. It's no-op by default.
     fn clear_cache(&mut self) -> Result<()> {
         Ok(())

--- a/rust/stream/src/executor/mview/materialize.rs
+++ b/rust/stream/src/executor/mview/materialize.rs
@@ -20,6 +20,9 @@ pub struct MaterializeExecutor<S: StateStore> {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore> MaterializeExecutor<S> {
@@ -30,7 +33,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
         pk_columns: Vec<usize>,
         orderings: Vec<OrderType>,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         Self {
             input,
@@ -42,7 +45,8 @@ impl<S: StateStore> MaterializeExecutor<S> {
             ),
             schema,
             pk_columns,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("MaterializeExecutor {:X}", executor_id),
+            op_info,
         }
     }
 
@@ -74,6 +78,10 @@ impl<S: StateStore> Executor for MaterializeExecutor<S> {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/project.rs
+++ b/rust/stream/src/executor/project.rs
@@ -23,6 +23,9 @@ pub struct ProjectExecutor {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl std::fmt::Debug for ProjectExecutor {
@@ -42,7 +45,7 @@ impl ProjectExecutor {
         pk_indices: PkIndices,
         exprs: Vec<BoxedExpression>,
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         let schema = Schema {
             fields: exprs
@@ -55,7 +58,8 @@ impl ProjectExecutor {
             pk_indices,
             input,
             exprs,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("ProjectExecutor {:X}", executor_id),
+            op_info,
         }
     }
 }
@@ -76,6 +80,10 @@ impl Executor for ProjectExecutor {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/stream_source.rs
+++ b/rust/stream/src/executor/stream_source.rs
@@ -33,6 +33,9 @@ pub struct StreamSourceExecutor {
     /// Identity string
     identity: String,
 
+    /// Logical Operator Info
+    op_info: String,
+
     // monitor
     /// attributes of the OpenTelemetry monitor
     attributes: Vec<KeyValue>,
@@ -50,7 +53,7 @@ impl StreamSourceExecutor {
         barrier_receiver: UnboundedReceiver<Message>,
         executor_id: u64,
         operator_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Result<Self> {
         let source = source_desc.clone().source;
         let reader: Box<dyn StreamSourceReader> = match source.as_ref() {
@@ -82,12 +85,13 @@ impl StreamSourceExecutor {
             barrier_receiver,
             next_row_id: AtomicU64::from(0u64),
             first_execution: true,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("StreamSourceExecutor {:X}", executor_id),
             attributes: vec![KeyValue::new("source_id", source_identify)],
             source_output_row_count: meter
                 .u64_counter("stream_source_output_rows_counts")
                 .with_description("")
                 .init(),
+            op_info,
         })
     }
 
@@ -162,6 +166,10 @@ impl Executor for StreamSourceExecutor {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 }
 

--- a/rust/stream/src/executor/test_utils.rs
+++ b/rust/stream/src/executor/test_utils.rs
@@ -100,6 +100,10 @@ impl Executor for MockSource {
     fn identity(&self) -> &'static str {
         "MockSource"
     }
+
+    fn logical_operator_info(&self) -> &str {
+        self.identity()
+    }
 }
 
 /// This source takes message from users asynchronously
@@ -183,6 +187,10 @@ impl Executor for MockAsyncSource {
 
     fn identity(&self) -> &'static str {
         "MockAsyncSource"
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        self.identity()
     }
 }
 

--- a/rust/stream/src/executor/top_n.rs
+++ b/rust/stream/src/executor/top_n.rs
@@ -41,6 +41,9 @@ pub struct TopNExecutor<S: StateStore> {
 
     /// Identity string.
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore> std::fmt::Debug for TopNExecutor<S> {
@@ -66,7 +69,7 @@ impl<S: StateStore> TopNExecutor<S> {
         cache_size: Option<usize>,
         total_count: (usize, usize, usize),
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         let pk_data_types = pk_indices
             .iter()
@@ -116,7 +119,8 @@ impl<S: StateStore> TopNExecutor<S> {
             managed_highest_state,
             pk_indices,
             first_execution: true,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("TopNExecutor {:X}", executor_id),
+            op_info,
         }
     }
 
@@ -142,7 +146,11 @@ impl<S: StateStore> Executor for TopNExecutor<S> {
     }
 
     fn identity(&self) -> &str {
-        self.identity.as_str()
+        &self.identity
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 
     fn clear_cache(&mut self) -> Result<()> {

--- a/rust/stream/src/executor/top_n_appendonly.rs
+++ b/rust/stream/src/executor/top_n_appendonly.rs
@@ -74,6 +74,9 @@ pub struct AppendOnlyTopNExecutor<S: StateStore> {
 
     /// Identity string
     identity: String,
+
+    /// Logical Operator Info
+    op_info: String,
 }
 
 impl<S: StateStore> std::fmt::Debug for AppendOnlyTopNExecutor<S> {
@@ -99,7 +102,7 @@ impl<S: StateStore> AppendOnlyTopNExecutor<S> {
         cache_size: Option<usize>,
         total_count: (usize, usize),
         executor_id: u64,
-        identity: String,
+        op_info: String,
     ) -> Self {
         let pk_data_types = pk_indices
             .iter()
@@ -138,7 +141,8 @@ impl<S: StateStore> AppendOnlyTopNExecutor<S> {
             ),
             pk_indices,
             first_execution: true,
-            identity: format!("{} {:X}", identity, executor_id),
+            identity: format!("TopNAppendonlyExecutor {:X}", executor_id),
+            op_info,
         }
     }
 
@@ -164,6 +168,10 @@ impl<S: StateStore> Executor for AppendOnlyTopNExecutor<S> {
 
     fn identity(&self) -> &str {
         self.identity.as_str()
+    }
+
+    fn logical_operator_info(&self) -> &str {
+        &self.op_info
     }
 
     fn clear_cache(&mut self) -> Result<()> {


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

As the title suggests, we should keep identity as the simple name with its executor id. This is used in span name.

We also have logical operator info for all the executors. This info gets logged by the schema check executor when the error occurs.

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Refer to a related PR or issue link (optional)
