### PR TITLE
refactor(frontend): rename Expr::to_expr_impl

### DIFF
--- a/rust/frontend/src/expr/agg_call.rs
+++ b/rust/frontend/src/expr/agg_call.rs
@@ -37,7 +37,7 @@ impl Expr for AggCall {
     fn return_type(&self) -> DataType {
         self.return_type
     }
-    fn bound_expr(self) -> ExprImpl {
+    fn to_expr_impl(self) -> ExprImpl {
         ExprImpl::AggCall(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/expr_rewriter.rs
+++ b/rust/frontend/src/expr/expr_rewriter.rs
@@ -3,10 +3,10 @@ use super::{AggCall, Expr, ExprImpl, FunctionCall, InputRef, Literal};
 pub trait ExprRewriter {
     fn rewrite_expr(&mut self, expr: ExprImpl) -> ExprImpl {
         match expr {
-            ExprImpl::InputRef(inner) => self.rewrite_input_ref(*inner).bound_expr(),
-            ExprImpl::Literal(inner) => self.rewrite_literal(*inner).bound_expr(),
-            ExprImpl::FunctionCall(inner) => self.rewrite_function_call(*inner).bound_expr(),
-            ExprImpl::AggCall(inner) => self.rewrite_agg_call(*inner).bound_expr(),
+            ExprImpl::InputRef(inner) => self.rewrite_input_ref(*inner).to_expr_impl(),
+            ExprImpl::Literal(inner) => self.rewrite_literal(*inner).to_expr_impl(),
+            ExprImpl::FunctionCall(inner) => self.rewrite_function_call(*inner).to_expr_impl(),
+            ExprImpl::AggCall(inner) => self.rewrite_agg_call(*inner).to_expr_impl(),
         }
     }
     fn rewrite_function_call(&mut self, func_call: FunctionCall) -> FunctionCall {

--- a/rust/frontend/src/expr/function_call.rs
+++ b/rust/frontend/src/expr/function_call.rs
@@ -61,7 +61,7 @@ impl Expr for FunctionCall {
     fn return_type(&self) -> DataType {
         self.return_type
     }
-    fn bound_expr(self) -> ExprImpl {
+    fn to_expr_impl(self) -> ExprImpl {
         ExprImpl::FunctionCall(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/input_ref.rs
+++ b/rust/frontend/src/expr/input_ref.rs
@@ -29,7 +29,7 @@ impl Expr for InputRef {
     fn return_type(&self) -> DataType {
         self.data_type
     }
-    fn bound_expr(self) -> ExprImpl {
+    fn to_expr_impl(self) -> ExprImpl {
         ExprImpl::InputRef(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/literal.rs
+++ b/rust/frontend/src/expr/literal.rs
@@ -20,7 +20,7 @@ impl Expr for Literal {
     fn return_type(&self) -> DataType {
         self.data_type
     }
-    fn bound_expr(self) -> ExprImpl {
+    fn to_expr_impl(self) -> ExprImpl {
         ExprImpl::Literal(Box::new(self))
     }
 }

--- a/rust/frontend/src/expr/mod.rs
+++ b/rust/frontend/src/expr/mod.rs
@@ -18,7 +18,7 @@ pub type ExprType = risingwave_pb::expr::expr_node::Type;
 /// the trait of bound exprssions
 pub trait Expr {
     fn return_type(&self) -> DataType;
-    fn bound_expr(self) -> ExprImpl;
+    fn to_expr_impl(self) -> ExprImpl;
 }
 #[derive(Clone, Debug)]
 pub enum ExprImpl {
@@ -37,7 +37,7 @@ impl Expr for ExprImpl {
             ExprImpl::AggCall(expr) => expr.return_type(),
         }
     }
-    fn bound_expr(self) -> ExprImpl {
+    fn to_expr_impl(self) -> ExprImpl {
         self
     }
 }

--- a/rust/frontend/src/optimizer/plan_node/col_pruning.rs
+++ b/rust/frontend/src/optimizer/plan_node/col_pruning.rs
@@ -13,7 +13,7 @@ pub trait ColPrunable: WithSchema + IntoPlanRef {
         let schema = self.schema();
         let exprs: Vec<ExprImpl> = required_cols
             .ones()
-            .map(|i| InputRef::new(i, schema.fields()[i].data_type()).bound_expr())
+            .map(|i| InputRef::new(i, schema.fields()[i].data_type()).to_expr_impl())
             .collect();
         let alias = vec![None; required_cols.len()];
         LogicalProject::create(self.clone_as_plan_ref(), exprs, alias)

--- a/rust/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/rust/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -94,9 +94,9 @@ impl EqJoinPredicate {
                 .iter()
                 .cloned()
                 .map(|(l, r)| {
-                    FunctionCall::new(ExprType::Equal, vec![l.bound_expr(), r.bound_expr()])
+                    FunctionCall::new(ExprType::Equal, vec![l.to_expr_impl(), r.to_expr_impl()])
                         .unwrap()
-                        .bound_expr()
+                        .to_expr_impl()
                 })
                 .collect(),
         }

--- a/rust/frontend/src/utils/condition.rs
+++ b/rust/frontend/src/utils/condition.rs
@@ -29,11 +29,11 @@ impl Condition {
             for expr in iter {
                 ret = FunctionCall::new(ExprType::And, vec![ret, expr])
                     .unwrap()
-                    .bound_expr();
+                    .to_expr_impl();
             }
             ret
         } else {
-            Literal::new(Some(ScalarImpl::Bool(true)), DataType::Boolean).bound_expr()
+            Literal::new(Some(ScalarImpl::Bool(true)), DataType::Boolean).to_expr_impl()
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

historical reason. the name was `bound_expr`, rename it to `to_expr_impl`

