### PR TITLE
feat(meta): add gRPC metrics

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -1,5 +1,4 @@
 risedev:
-
   ci-v2:
     - use: minio
     - use: meta-node
@@ -123,7 +122,6 @@ template:
     # If `user-managed` is true, this service will be started by user with the above config
     user-managed: false
 
-
   meta-node:
     # Meta-node listen address
     address: "127.0.0.1"
@@ -136,6 +134,12 @@ template:
 
     # Dashboard listen port
     dashboard-port: 5691
+
+    # Prometheus exporter listen address
+    exporter-address: "127.0.0.1"
+
+    # Prometheus exporter listen port
+    exporter-port: 1250
 
     # Id of this instance
     id: meta-node-${port}
@@ -156,6 +160,9 @@ template:
     # Compute-nodes used by this Prometheus instance
     provide-compute-node: "compute-node*"
 
+    # Meta-nodes used by this Prometheus instance
+    provide-meta-node: "meta-node*"
+
     # Minio instances used by this Prometheus instance
     provide-minio: "minio*"
 
@@ -174,7 +181,7 @@ template:
 
     # If `user-managed` is true, this service will be started by user with the above config
     user-managed: false
-  
+
   frontend-v2:
     # Listen address of frontend
     address: "127.0.0.1"

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3872,6 +3872,7 @@ dependencies = [
  "num-traits",
  "parking_lot 0.12.0",
  "paste",
+ "prometheus 0.13.0",
  "prost 0.9.0",
  "rand 0.8.5",
  "risingwave-pb",

--- a/rust/meta/Cargo.toml
+++ b/rust/meta/Cargo.toml
@@ -29,6 +29,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1"
+prometheus = "0.13"
 prost = "0.9"
 risingwave-pb = { path = "../prost" }
 risingwave_common = { path = "../common" }

--- a/rust/meta/src/bin/meta_node.rs
+++ b/rust/meta/src/bin/meta_node.rs
@@ -11,8 +11,11 @@ struct Opts {
     #[clap(long, default_value = "127.0.0.1:5690")]
     host: String,
 
-    #[clap(long, default_value = "127.0.0.1:5691")]
-    dashboard_host: String,
+    #[clap(long)]
+    dashboard_host: Option<String>,
+
+    #[clap(long)]
+    prometheus_host: Option<String>,
 }
 
 /// Configure log targets for all `RisingWave` crates. When new crates are added and TRACE level
@@ -56,9 +59,11 @@ async fn main() {
     tracing_subscriber::registry().with(fmt_layer).init();
 
     let addr = opts.host.parse().unwrap();
-    let dashboard_addr = opts.dashboard_host.parse().unwrap();
+    let dashboard_addr = opts.dashboard_host.map(|x| x.parse().unwrap());
+    let prometheus_addr = opts.prometheus_host.map(|x| x.parse().unwrap());
+
     info!("Starting meta server at {}", addr);
     let (join_handle, _shutdown_send) =
-        rpc_serve(addr, Some(dashboard_addr), MetaStoreBackend::Mem).await;
+        rpc_serve(addr, prometheus_addr, dashboard_addr, MetaStoreBackend::Mem).await;
     join_handle.await.unwrap();
 }

--- a/rust/meta/src/rpc/intercept.rs
+++ b/rust/meta/src/rpc/intercept.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use hyper::Body;
+use tower::{Layer, Service};
+
+use super::metrics::MetaMetrics;
+
+#[derive(Clone)]
+pub struct MetricsMiddlewareLayer {
+    metrics: Arc<MetaMetrics>,
+}
+
+impl MetricsMiddlewareLayer {
+    pub fn new(metrics: Arc<MetaMetrics>) -> Self {
+        Self { metrics }
+    }
+}
+
+impl<S> Layer<S> for MetricsMiddlewareLayer {
+    type Service = MetricsMiddleware<S>;
+
+    fn layer(&self, service: S) -> Self::Service {
+        MetricsMiddleware {
+            inner: service,
+            metrics: self.metrics.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct MetricsMiddleware<S> {
+    inner: S,
+    metrics: Arc<MetaMetrics>,
+}
+
+impl<S> Service<hyper::Request<Body>> for MetricsMiddleware<S>
+where
+    S: Service<hyper::Request<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = futures::future::BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: hyper::Request<Body>) -> Self::Future {
+        // This is necessary because tonic internally uses `tower::buffer::Buffer`.
+        // See https://github.com/tower-rs/tower/issues/547#issuecomment-767629149
+        // for details on why this is necessary
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+
+        let metrics = self.metrics.clone();
+
+        // TODO: use GAT to avoid static future and Box::pin
+        Box::pin(async move {
+            let path = req.uri().path();
+            let timer = metrics
+                .grpc_latency
+                .with_label_values(&[path])
+                .start_timer();
+
+            let response = inner.call(req).await?;
+
+            timer.observe_duration();
+
+            Ok(response)
+        })
+    }
+}

--- a/rust/meta/src/rpc/metrics.rs
+++ b/rust/meta/src/rpc/metrics.rs
@@ -1,0 +1,71 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use hyper::{Body, Request, Response};
+use itertools::Itertools;
+use prometheus::{
+    histogram_opts, register_histogram_vec_with_registry, Encoder, HistogramVec, Registry,
+    TextEncoder, DEFAULT_BUCKETS,
+};
+use tower::make::Shared;
+use tower::ServiceBuilder;
+use tower_http::add_extension::AddExtensionLayer;
+
+pub struct MetaMetrics {
+    registry: Registry,
+
+    /// gRPC latency of meta services
+    pub grpc_latency: HistogramVec,
+}
+
+impl MetaMetrics {
+    pub fn new() -> Self {
+        let registry = prometheus::Registry::new();
+        let buckets = DEFAULT_BUCKETS;
+        let opts = histogram_opts!(
+            "meta_grpc_duration_seconds",
+            "gRPC latency of meta services",
+            buckets.iter().map(|x| *x * 0.1).collect_vec()
+        );
+        let grpc_latency =
+            register_histogram_vec_with_registry!(opts, &["path"], registry).unwrap();
+        Self {
+            registry,
+            grpc_latency,
+        }
+    }
+
+    pub fn boot_metrics_service(self: &Arc<Self>, listen_addr: SocketAddr) {
+        let meta_metrics = self.clone();
+        tokio::spawn(async move {
+            tracing::info!(
+                "Prometheus listener for Prometheus is set up on http://{}",
+                listen_addr
+            );
+
+            let service = ServiceBuilder::new()
+                .layer(AddExtensionLayer::new(meta_metrics))
+                .service_fn(Self::metrics_service);
+
+            let serve_future = hyper::Server::bind(&listen_addr).serve(Shared::new(service));
+
+            if let Err(err) = serve_future.await {
+                eprintln!("server error: {}", err);
+            }
+        });
+    }
+
+    async fn metrics_service(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+        let meta_metrics = req.extensions().get::<Arc<MetaMetrics>>().unwrap();
+        let encoder = TextEncoder::new();
+        let mut buffer = vec![];
+        let mf = meta_metrics.registry.gather();
+        encoder.encode(&mf, &mut buffer).unwrap();
+        let response = Response::builder()
+            .header(hyper::header::CONTENT_TYPE, encoder.format_type())
+            .body(Body::from(buffer))
+            .unwrap();
+
+        Ok(response)
+    }
+}

--- a/rust/meta/src/rpc/mod.rs
+++ b/rust/meta/src/rpc/mod.rs
@@ -1,2 +1,4 @@
+mod intercept;
+mod metrics;
 pub mod server;
 mod service;

--- a/rust/meta/src/rpc/server.rs
+++ b/rust/meta/src/rpc/server.rs
@@ -11,6 +11,8 @@ use tokio::net::TcpListener;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::task::JoinHandle;
 
+use super::intercept::MetricsMiddlewareLayer;
+use super::metrics::MetaMetrics;
 use crate::barrier::BarrierManager;
 use crate::cluster::StoredClusterManager;
 use crate::dashboard::DashboardService;
@@ -31,6 +33,7 @@ pub enum MetaStoreBackend {
 
 pub async fn rpc_serve(
     addr: SocketAddr,
+    prometheus_addr: Option<SocketAddr>,
     dashboard_addr: Option<SocketAddr>,
     meta_store_backend: MetaStoreBackend,
 ) -> (JoinHandle<()>, UnboundedSender<()>) {
@@ -101,10 +104,16 @@ pub async fn rpc_serve(
         env,
     );
     let hummock_srv = HummockServiceImpl::new(hummock_manager);
+    let meta_metrics = Arc::new(MetaMetrics::new());
+
+    if let Some(prometheus_addr) = prometheus_addr {
+        meta_metrics.boot_metrics_service(prometheus_addr);
+    }
 
     let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::unbounded_channel();
     let join_handle = tokio::spawn(async move {
         tonic::transport::Server::builder()
+            .layer(MetricsMiddlewareLayer::new(meta_metrics.clone()))
             .add_service(EpochServiceServer::new(epoch_srv))
             .add_service(HeartbeatServiceServer::new(heartbeat_srv))
             .add_service(CatalogServiceServer::new(catalog_srv))
@@ -134,7 +143,7 @@ mod tests {
     #[tokio::test]
     async fn test_server_shutdown() {
         let addr = "127.0.0.1:9527".parse().unwrap();
-        let (join_handle, shutdown_send) = rpc_serve(addr, None, MetaStoreBackend::Mem).await;
+        let (join_handle, shutdown_send) = rpc_serve(addr, None, None, MetaStoreBackend::Mem).await;
         shutdown_send.send(()).unwrap();
         join_handle.await.unwrap();
     }

--- a/rust/meta/src/test_utils.rs
+++ b/rust/meta/src/test_utils.rs
@@ -14,7 +14,7 @@ impl LocalMeta {
     pub async fn start() -> Self {
         let addr = Self::meta_addr().parse().unwrap();
         let (join_handle, shutdown_sender) =
-            crate::rpc::server::rpc_serve(addr, None, MetaStoreBackend::Mem).await;
+            crate::rpc::server::rpc_serve(addr, None, None, MetaStoreBackend::Mem).await;
         Self {
             join_handle,
             shutdown_sender,

--- a/rust/risedev/src/config/service_config.rs
+++ b/rust/risedev/src/config/service_config.rs
@@ -22,6 +22,8 @@ pub struct MetaNodeConfig {
     pub port: u16,
     pub dashboard_address: String,
     pub dashboard_port: u16,
+    pub exporter_address: String,
+    pub exporter_port: u16,
     pub user_managed: bool,
 }
 
@@ -58,6 +60,7 @@ pub struct PrometheusConfig {
     pub address: String,
     pub port: u16,
     pub provide_compute_node: Option<Vec<ComputeNodeConfig>>,
+    pub provide_meta_node: Option<Vec<MetaNodeConfig>>,
     pub provide_minio: Option<Vec<MinioConfig>>,
 }
 

--- a/rust/risedev/src/config_gen/prometheus_gen.rs
+++ b/rust/risedev/src/config_gen/prometheus_gen.rs
@@ -15,6 +15,15 @@ impl PrometheusGen {
             .iter()
             .map(|node| format!("\"{}:{}\"", node.exporter_address, node.exporter_port))
             .join(",");
+
+        let meta_node_targets = config
+            .provide_meta_node
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|node| format!("\"{}:{}\"", node.exporter_address, node.exporter_port))
+            .join(",");
+
         let minio_targets = config
             .provide_minio
             .as_ref()
@@ -34,10 +43,14 @@ scrape_configs:
     static_configs:
       - targets: ["{prometheus_host}:{prometheus_port}"]
 
-  - job_name: "hummock_monitor"
+  - job_name: compute-job
     static_configs:
       - targets: [{compute_node_targets}]
 
+  - job_name: meta-job
+    static_configs:
+      - targets: [{meta_node_targets}]
+  
   - job_name: minio-job
     metrics_path: /minio/v2/metrics/cluster
     static_configs:

--- a/rust/risedev/src/task/meta_node_service.rs
+++ b/rust/risedev/src/task/meta_node_service.rs
@@ -36,6 +36,11 @@ impl Task for MetaNodeService {
                 self.config.dashboard_address, self.config.dashboard_port
             ));
 
+        cmd.arg("--prometheus-host").arg(format!(
+            "{}:{}",
+            self.config.exporter_address, self.config.exporter_port
+        ));
+
         if !self.config.user_managed {
             ctx.run_command(ctx.tmux_run(cmd)?)?;
             ctx.pb.set_message("started");


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

This PR adds metrics on meta by using a tonic middleware. Therefore, we don't need to add new histogram objects when adding new gRPC endpoints.

To display the metrics in Grafana, using the follow query:

```
histogram_quantile(0.99, sum(rate(meta_grpc_duration_seconds_bucket{path="/hummock.HummockManagerService/PinVersion"}[5m])) by (le))
```

RiseDev support also added.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave-dev/issues/432