### PR TITLE
fix(metrics): set batch_write latency to a more realistic value

### DIFF
--- a/rust/storage/src/monitor/state_store_stats.rs
+++ b/rust/storage/src/monitor/state_store_stats.rs
@@ -205,7 +205,9 @@ impl StateStoreStats {
         let batch_write_build_table_latency =
             register_histogram_with_registry!(opts, registry).unwrap();
 
-        let buckets = DEFAULT_BUCKETS.map(|x| x * BATCH_WRITE_ADD_L0_LATENCT_SCALE).to_vec();
+        let buckets = DEFAULT_BUCKETS
+            .map(|x| x * BATCH_WRITE_ADD_L0_LATENCT_SCALE)
+            .to_vec();
         let opts = histogram_opts!(
             "state_store_batch_write_add_l0_ssts_latency",
             "Total time of add_l0_ssts that have been issued to state store",


### PR DESCRIPTION
## What's changed and what's your intention?
It seems that the scale for batch_write latency is a little small, so I adjust it by my personal experience. （Also some trivial code clean.）

Examples are generated by ss-bench.
Before:
```
state_store_batched_write_latency P50 : 0 P95 : 0 P99 : 0 P100 : 0 COUNT : 100 SUM : 0.9601834430000001
```
After:
```
state_store_batched_write_latency P50 : 0.007790697674418606 P95 : 0.018750000000000003 P99 : 0.02375 P100 : 0.025 COUNT : 100 SUM : 0.9132175259999997
```

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
