### PR TITLE
refactor: make all unit tests can be run concurrently

### DIFF
--- a/rust/frontend/src/catalog/catalog_service.rs
+++ b/rust/frontend/src/catalog/catalog_service.rs
@@ -354,11 +354,10 @@ mod tests {
     use crate::catalog::table_catalog::ROWID_NAME;
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_create_and_drop_table() {
         // Init meta and catalog.
-        let meta = LocalMeta::start().await;
-        let mut meta_client = LocalMeta::create_client().await;
+        let meta = LocalMeta::start(12000).await;
+        let mut meta_client = meta.create_client().await;
         let catalog_mgr = CatalogConnector::new(meta_client.clone());
 
         // Create db and schema.

--- a/rust/frontend/src/handler/create_source.rs
+++ b/rust/frontend/src/handler/create_source.rs
@@ -82,16 +82,16 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn handle_create_source() {
-        let meta = LocalMeta::start().await;
+        let meta = LocalMeta::start(12001).await;
 
         let proto_file = create_proto_file();
         let sql = format!(
             r#"CREATE SOURCE t
-    WITH ('kafka.topic' = 'abc', 'kafka.servers' = 'localhost:1001') 
+    WITH ('kafka.topic' = 'abc', 'kafka.servers' = 'localhost:1001')
     ROW FORMAT PROTOBUF MESSAGE '.test.TestRecord' ROW SCHEMA LOCATION 'file://{}'"#,
             proto_file.path().to_str().unwrap()
         );
-        let frontend = LocalFrontend::new().await;
+        let frontend = LocalFrontend::new(&meta).await;
         frontend.run_sql(sql).await.unwrap();
 
         let catalog_manager = frontend.session().env().catalog_mgr();

--- a/rust/frontend/src/handler/create_table.rs
+++ b/rust/frontend/src/handler/create_table.rs
@@ -72,11 +72,10 @@ mod tests {
     use crate::test_utils::LocalFrontend;
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_create_table_handler() {
-        let meta = LocalMeta::start().await;
+        let meta = LocalMeta::start(12002).await;
         let sql = "create table t (v1 smallint, v2 int, v3 bigint, v4 float, v5 double);";
-        let frontend = LocalFrontend::new().await;
+        let frontend = LocalFrontend::new(&meta).await;
         frontend.run_sql(sql).await.unwrap();
 
         let catalog_manager = frontend.session().env().catalog_mgr();

--- a/rust/frontend/src/handler/drop_table.rs
+++ b/rust/frontend/src/handler/drop_table.rs
@@ -32,12 +32,11 @@ mod tests {
     use crate::test_utils::LocalFrontend;
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_drop_table_handler() {
-        let meta = LocalMeta::start().await;
+        let meta = LocalMeta::start(12003).await;
         let sql_create_table = "create table t (v1 smallint);";
         let sql_drop_table = "drop table t;";
-        let frontend = LocalFrontend::new().await;
+        let frontend = LocalFrontend::new(&meta).await;
         frontend.run_sql(sql_create_table).await.unwrap();
         frontend.run_sql(sql_drop_table).await.unwrap();
 

--- a/rust/frontend/src/handler/explain.rs
+++ b/rust/frontend/src/handler/explain.rs
@@ -47,10 +47,9 @@ mod tests {
     use risingwave_sqlparser::parser::Parser;
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_handle_explain() {
-        let meta = risingwave_meta::test_utils::LocalMeta::start().await;
-        let frontend = crate::test_utils::LocalFrontend::new().await;
+        let meta = risingwave_meta::test_utils::LocalMeta::start(12004).await;
+        let frontend = crate::test_utils::LocalFrontend::new(&meta).await;
 
         let sql = "values (11, 22), (33+(1+2), 44);";
         let stmt = Parser::parse_sql(sql).unwrap().into_iter().next().unwrap();
@@ -66,10 +65,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_handle_explain_scan() {
-        let meta = risingwave_meta::test_utils::LocalMeta::start().await;
-        let frontend = crate::test_utils::LocalFrontend::new().await;
+        let meta = risingwave_meta::test_utils::LocalMeta::start(12005).await;
+        let frontend = crate::test_utils::LocalFrontend::new(&meta).await;
 
         let sql_scan = "explain select * from t";
 
@@ -93,10 +91,9 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial_test::serial]
     async fn test_handle_explain_insert() {
-        let meta = risingwave_meta::test_utils::LocalMeta::start().await;
-        let frontend = crate::test_utils::LocalFrontend::new().await;
+        let meta = risingwave_meta::test_utils::LocalMeta::start(12006).await;
+        let frontend = crate::test_utils::LocalFrontend::new(&meta).await;
 
         frontend
             .run_sql("create table t (v1 int, v2 int)")

--- a/rust/frontend/src/session.rs
+++ b/rust/frontend/src/session.rs
@@ -42,6 +42,26 @@ impl FrontendEnv {
         })
     }
 
+    pub async fn with_meta_client(meta_client: MetaClient, opts: &FrontendOpts) -> Result<Self> {
+        meta_client
+            .register(opts.host.parse().unwrap(), WorkerType::Frontend)
+            .await
+            .unwrap();
+
+        // Create default database when env init.
+        let catalog_manager = CatalogConnector::new(meta_client.clone());
+        catalog_manager
+            .create_database(DEFAULT_DATABASE_NAME)
+            .await?;
+        catalog_manager
+            .create_schema(DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME)
+            .await?;
+        Ok(Self {
+            meta_client,
+            catalog_manager,
+        })
+    }
+
     pub fn meta_client(&self) -> &MetaClient {
         &self.meta_client
     }
@@ -121,10 +141,10 @@ mod tests {
 
         use super::*;
 
-        let meta = LocalMeta::start().await;
+        let meta = LocalMeta::start(12008).await;
         let args: [OsString; 0] = []; // No argument.
         let mut opts = FrontendOpts::parse_from(args);
-        opts.meta_addr = format!("http://{}", LocalMeta::meta_addr());
+        opts.meta_addr = format!("http://{}", meta.meta_addr());
         let mgr = RwSessionManager::new(&opts).await.unwrap();
         // Check default database is created.
         assert!(mgr

--- a/rust/frontend/src/test_utils.rs
+++ b/rust/frontend/src/test_utils.rs
@@ -14,12 +14,13 @@ pub struct LocalFrontend {
 }
 
 impl LocalFrontend {
-    pub async fn new() -> Self {
+    pub async fn new(meta: &LocalMeta) -> Self {
         let args: [OsString; 0] = []; // No argument.
         let mut opts: FrontendOpts = FrontendOpts::parse_from(args);
         opts.host = "127.0.0.1:45666".to_string();
-        opts.meta_addr = format!("http://{}", LocalMeta::meta_addr());
-        let env = FrontendEnv::init(&opts).await.unwrap();
+        let env = FrontendEnv::with_meta_client(meta.create_client().await, &opts)
+            .await
+            .unwrap();
         let session = RwSession::new(env, "dev".to_string());
         Self { opts, session }
     }

--- a/rust/meta/src/stream/stream_manager.rs
+++ b/rust/meta/src/stream/stream_manager.rs
@@ -435,7 +435,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_create_materialized_view() -> Result<()> {
-        let services = MockServices::start("127.0.0.1", 12345).await?;
+        let services = MockServices::start("127.0.0.1", 12333).await?;
 
         let table_ref_id = TableRefId {
             schema_ref_id: None,
@@ -508,7 +508,7 @@ mod tests {
                     .unwrap(),
                 HostAddress {
                     host: "127.0.0.1".to_string(),
-                    port: 12345,
+                    port: 12333,
                 }
             );
         }

--- a/rust/meta/src/test_utils.rs
+++ b/rust/meta/src/test_utils.rs
@@ -5,17 +5,23 @@ use tokio::task::JoinHandle;
 use crate::rpc::server::MetaStoreBackend;
 
 pub struct LocalMeta {
+    port: u16,
     join_handle: JoinHandle<()>,
     shutdown_sender: UnboundedSender<()>,
 }
 
 impl LocalMeta {
+    fn meta_addr_inner(port: u16) -> String {
+        format!("127.0.0.1:{}", port)
+    }
+
     /// Start a local meta node in the background.
-    pub async fn start() -> Self {
-        let addr = Self::meta_addr().parse().unwrap();
+    pub async fn start(port: u16) -> Self {
+        let addr = Self::meta_addr_inner(port).parse().unwrap();
         let (join_handle, shutdown_sender) =
             crate::rpc::server::rpc_serve(addr, None, None, MetaStoreBackend::Mem).await;
         Self {
+            port,
             join_handle,
             shutdown_sender,
         }
@@ -26,13 +32,13 @@ impl LocalMeta {
         self.join_handle.await.unwrap();
     }
 
-    pub async fn create_client() -> MetaClient {
-        MetaClient::new(&format!("http://{}", Self::meta_addr()))
+    pub async fn create_client(&self) -> MetaClient {
+        MetaClient::new(&format!("http://{}", self.meta_addr()))
             .await
             .unwrap()
     }
 
-    pub fn meta_addr() -> &'static str {
-        "127.0.0.1:56901"
+    pub fn meta_addr(&self) -> String {
+        Self::meta_addr_inner(self.port)
     }
 }

--- a/rust/server/src/server.rs
+++ b/rust/server/src/server.rs
@@ -159,10 +159,10 @@ mod tests {
     use crate::server::compute_node_serve;
     use crate::ComputeNodeOpts;
 
-    async fn start_compute_node() -> (JoinHandle<()>, UnboundedSender<()>) {
+    async fn start_compute_node(meta: &LocalMeta) -> (JoinHandle<()>, UnboundedSender<()>) {
         let args: [OsString; 0] = []; // No argument.
         let mut opts = ComputeNodeOpts::parse_from(args);
-        opts.meta_address = format!("http://{}", LocalMeta::meta_addr());
+        opts.meta_address = format!("http://{}", meta.meta_addr());
         let addr = opts.host.parse().unwrap();
         compute_node_serve(addr, opts).await
     }
@@ -170,8 +170,8 @@ mod tests {
     #[tokio::test]
     #[serial_test::serial]
     async fn test_server_shutdown() {
-        let meta = LocalMeta::start().await;
-        let (join, shutdown) = start_compute_node().await;
+        let meta = LocalMeta::start(12313).await;
+        let (join, shutdown) = start_compute_node(&meta).await;
         shutdown.send(()).unwrap();
         join.await.unwrap();
         meta.stop().await;

--- a/rust/stream/src/executor/merge.rs
+++ b/rust/stream/src/executor/merge.rs
@@ -455,7 +455,7 @@ mod tests {
     async fn test_stream_exchange_client() {
         let rpc_called = Arc::new(AtomicBool::new(false));
         let server_run = Arc::new(AtomicBool::new(false));
-        let addr = "127.0.0.1:12346".parse().unwrap();
+        let addr = "127.0.0.1:12348".parse().unwrap();
 
         // Start a server.
         let (shutdown_send, mut shutdown_recv) = tokio::sync::mpsc::unbounded_channel();


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

There are many dirty hacks in our unit tests, e.g., bind ports and run services.

The PR bind all tests to different ports, so all tests can be run concurrently. This is a hack, and we will eventually remove all these tests, using e2e or mock instead.

Currently, we can run all tests using `cargo nextest run` in 5 seconds!

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
