### PR TITLE
refactor: serialize a single row in OrderedRowsSerializer

### DIFF
--- a/rust/common/src/util/ordered/serde.rs
+++ b/rust/common/src/util/ordered/serde.rs
@@ -29,11 +29,7 @@ impl OrderedArraysSerializer {
         Self { order_pairs }
     }
 
-    pub fn order_based_scehmaed_serialize(
-        &self,
-        data: &[&ArrayImpl],
-        append_to: &mut Vec<Vec<u8>>,
-    ) {
+    pub fn serialize(&self, data: &[&ArrayImpl], append_to: &mut Vec<Vec<u8>>) {
         for row_idx in 0..data[0].len() {
             let mut serializer = memcomparable::Serializer::new(vec![]);
             for order_pair in &self.order_pairs {
@@ -48,29 +44,25 @@ impl OrderedArraysSerializer {
     }
 }
 
-pub struct OrderedRowsSerializer {
+pub struct OrderedRowSerializer {
     order_pairs: Vec<OrderPair>,
 }
 
-impl OrderedRowsSerializer {
+impl OrderedRowSerializer {
     pub fn new(order_pairs: Vec<OrderPair>) -> Self {
         Self { order_pairs }
     }
 
-    pub fn serialize(&self, data: &[&Row], append_to: &mut Vec<Vec<u8>>) {
-        for row in data {
-            let mut row_bytes = vec![];
-            for OrderPair {
-                order_type,
-                column_idx,
-            } in &self.order_pairs
-            {
-                let mut serializer = memcomparable::Serializer::new(vec![]);
-                serializer.set_reverse(*order_type == OrderType::Descending);
-                serialize_datum_into(&row.0[*column_idx], &mut serializer).unwrap();
-                row_bytes.extend(serializer.into_inner());
-            }
-            append_to.push(row_bytes);
+    pub fn serialize(&self, row: &Row, append_to: &mut Vec<u8>) {
+        for OrderPair {
+            order_type,
+            column_idx,
+        } in &self.order_pairs
+        {
+            let mut serializer = memcomparable::Serializer::new(vec![]);
+            serializer.set_reverse(*order_type == OrderType::Descending);
+            serialize_datum_into(&row.0[*column_idx], &mut serializer).unwrap();
+            append_to.extend(serializer.into_inner());
         }
     }
 }
@@ -107,10 +99,10 @@ impl OrderedRowDeserializer {
     }
 }
 
-pub fn serialize_pk(pk: &Row, serializer: &OrderedRowsSerializer) -> Result<Vec<u8>> {
+pub fn serialize_pk(pk: &Row, serializer: &OrderedRowSerializer) -> Result<Vec<u8>> {
     let mut result = vec![];
-    serializer.serialize(&[pk], &mut result);
-    Ok(std::mem::take(&mut result[0]))
+    serializer.serialize(pk, &mut result);
+    Ok(result)
 }
 
 // TODO(eric): deprecated. Remove when possible
@@ -214,12 +206,17 @@ mod tests {
             OrderPair::new(0, OrderType::Descending),
             OrderPair::new(1, OrderType::Ascending),
         ];
-        let serializer = OrderedRowsSerializer::new(orders);
+        let serializer = OrderedRowSerializer::new(orders);
         let row1 = Row(vec![Some(Int16(5)), Some(Utf8("abc".to_string()))]);
         let row2 = Row(vec![Some(Int16(5)), Some(Utf8("abd".to_string()))]);
         let row3 = Row(vec![Some(Int16(6)), Some(Utf8("abc".to_string()))]);
+        let rows = vec![row1, row2, row3];
         let mut array = vec![];
-        serializer.serialize(&[&row1, &row2, &row3], &mut array);
+        for row in &rows {
+            let mut row_bytes = vec![];
+            serializer.serialize(row, &mut row_bytes);
+            array.push(row_bytes);
+        }
         array.sort();
         // option 1 byte || number 2 bytes
         assert_eq!(array[0][2], !6i16.to_be_bytes()[1]);
@@ -238,7 +235,7 @@ mod tests {
         let array1 = array_nonnull! { I16Array, [1i16,2,3] }.into();
         let input_arrays = vec![&array0, &array1];
         let mut array = vec![];
-        serializer.order_based_scehmaed_serialize(&input_arrays, &mut array);
+        serializer.serialize(&input_arrays, &mut array);
         array.sort();
         // option 1 byte || number 2 bytes
         assert_eq!(array[0][2], !3i16.to_be_bytes()[1]);
@@ -250,7 +247,7 @@ mod tests {
         let array1 = array_nonnull! { I16Array, [-2i16, -1, -1] }.into();
         let input_arrays = vec![&array0, &array1];
         let mut array = vec![];
-        serializer.order_based_scehmaed_serialize(&input_arrays, &mut array);
+        serializer.serialize(&input_arrays, &mut array);
         array.sort();
         // option 1 byte || number 2 bytes
         assert_eq!(array[0][2], !(-32767i16).to_be_bytes()[1]);
@@ -262,7 +259,7 @@ mod tests {
         let array1 = array_nonnull! { Utf8Array, ["jmz", "mjz", "mzj"] }.into();
         let input_arrays = vec![&array0, &array1];
         let mut array = vec![];
-        serializer.order_based_scehmaed_serialize(&input_arrays, &mut array);
+        serializer.serialize(&input_arrays, &mut array);
         array.sort();
         // option 1 bytes || string 10 bytes
         assert_eq!(
@@ -292,14 +289,19 @@ mod tests {
             OrderPair::new(1, OrderType::Ascending),
         ];
         let order_types = order_pairs.iter().map(|o| o.order_type).collect_vec();
-        let serializer = OrderedRowsSerializer::new(order_pairs);
+        let serializer = OrderedRowSerializer::new(order_pairs);
         let schema = vec![DataType::Varchar, DataType::Int16];
         let row1 = Row(vec![Some(Utf8("abc".to_string())), Some(Int16(5))]);
         let row2 = Row(vec![Some(Utf8("abd".to_string())), Some(Int16(5))]);
         let row3 = Row(vec![Some(Utf8("abc".to_string())), Some(Int16(6))]);
+        let rows = vec![row1.clone(), row2.clone(), row3.clone()];
         let deserializer = OrderedRowDeserializer::new(schema, order_types.clone());
         let mut array = vec![];
-        serializer.serialize(&[&row1, &row2, &row3], &mut array);
+        for row in &rows {
+            let mut row_bytes = vec![];
+            serializer.serialize(row, &mut row_bytes);
+            array.push(row_bytes);
+        }
         assert_eq!(
             deserializer.deserialize(&array[0]).unwrap(),
             OrderedRow::new(row1, &order_types)

--- a/rust/storage/src/table/mview.rs
+++ b/rust/storage/src/table/mview.rs
@@ -25,7 +25,7 @@ pub struct MViewTable<S: StateStore> {
 
     pk_columns: Vec<usize>,
 
-    sort_key_serializer: OrderedRowsSerializer,
+    sort_key_serializer: OrderedRowSerializer,
 }
 
 impl<S: StateStore> std::fmt::Debug for MViewTable<S> {
@@ -67,7 +67,7 @@ impl<S: StateStore> MViewTable<S> {
             schema,
             column_descs,
             pk_columns,
-            sort_key_serializer: OrderedRowsSerializer::new(order_pairs),
+            sort_key_serializer: OrderedRowSerializer::new(order_pairs),
         }
     }
 
@@ -91,7 +91,7 @@ impl<S: StateStore> MViewTable<S> {
             schema,
             column_descs,
             pk_columns,
-            sort_key_serializer: OrderedRowsSerializer::new(order_pairs),
+            sort_key_serializer: OrderedRowSerializer::new(order_pairs),
         }
     }
 

--- a/rust/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/rust/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -163,8 +163,7 @@ impl<S: StateStore> ManagedExtremeState<S> for ManagedStringAggState<S> {
         }
 
         let mut row_keys = vec![];
-        self.sorted_arrays_serializer
-            .order_based_scehmaed_serialize(data, &mut row_keys);
+        self.sorted_arrays_serializer.serialize(data, &mut row_keys);
 
         for (row_idx, (op, key_bytes)) in ops.iter().zip_eq(row_keys.into_iter()).enumerate() {
             let visible = visibility

--- a/rust/stream/src/executor/mview/state.rs
+++ b/rust/stream/src/executor/mview/state.rs
@@ -21,7 +21,7 @@ pub struct ManagedMViewState<S: StateStore> {
     keys: Vec<OrderPair>,
 
     /// Serializer to serialize keys from input rows
-    key_serializer: OrderedRowsSerializer,
+    key_serializer: OrderedRowSerializer,
 
     /// Cached key/values
     cache: HashMap<Row, FlushStatus<Row>>,
@@ -41,7 +41,7 @@ impl<S: StateStore> ManagedMViewState<S> {
             column_ids,
             cache: HashMap::new(),
             keys,
-            key_serializer: OrderedRowsSerializer::new(keys_for_serializer),
+            key_serializer: OrderedRowSerializer::new(keys_for_serializer),
         }
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Serialize a single row instead of a slice of rows in `OrderedRowsSerializer`.

## Refer to a related PR or issue link (optional)
#532 