### PR TITLE
refactor(common): rename collection/hash_map to hash

### DIFF
--- a/rust/batch/src/executor/hash_agg.rs
+++ b/rust/batch/src/executor/hash_agg.rs
@@ -6,10 +6,10 @@ use itertools::Itertools;
 use risingwave_common::array::column::Column;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
-use risingwave_common::collection::hash_map::{
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::hash::{
     calc_hash_key_kind, HashKey, HashKeyDispatcher, PrecomputedBuildHasher,
 };
-use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
 use risingwave_common::vector_op::agg::{AggStateFactory, BoxedAggState};
 use risingwave_pb::plan::plan_node::NodeBody;

--- a/rust/batch/src/executor/join/hash_join.rs
+++ b/rust/batch/src/executor/join/hash_join.rs
@@ -4,8 +4,8 @@ use std::mem::take;
 use either::Either;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{Field, Schema};
-use risingwave_common::collection::hash_map::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
 use risingwave_common::error::Result;
+use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher};
 use risingwave_common::types::DataType;
 use risingwave_common::util::chunk_coalesce::DEFAULT_CHUNK_BUFFER_SIZE;
 use risingwave_pb::plan::plan_node::NodeBody;
@@ -381,8 +381,8 @@ mod tests {
     use risingwave_common::array::column::Column;
     use risingwave_common::array::{ArrayBuilderImpl, DataChunk, F32Array, F64Array, I32Array};
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::collection::hash_map::Key32;
     use risingwave_common::error::Result;
+    use risingwave_common::hash::Key32;
     use risingwave_common::types::DataType;
 
     use crate::executor::join::hash_join::{EquiJoinParams, HashJoinExecutor};

--- a/rust/batch/src/executor/join/hash_join_state.rs
+++ b/rust/batch/src/executor/join/hash_join_state.rs
@@ -5,9 +5,9 @@ use std::ops::{Deref, DerefMut};
 
 use either::Either;
 use risingwave_common::array::{ArrayImpl, DataChunk};
-use risingwave_common::collection::hash_map::{HashKey, PrecomputedBuildHasher};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError};
+use risingwave_common::hash::{HashKey, PrecomputedBuildHasher};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 
 use crate::executor::join::chunked_data::{ChunkedData, RowId};

--- a/rust/common/src/collection/hash_map/mod.rs
+++ b/rust/common/src/collection/hash_map/mod.rs
@@ -1,4 +1,0 @@
-mod hash_key;
-pub use hash_key::*;
-mod key_dispatcher;
-pub use key_dispatcher::*;

--- a/rust/common/src/collection/mod.rs
+++ b/rust/common/src/collection/mod.rs
@@ -1,2 +1,1 @@
 pub mod evictable;
-pub mod hash_map;

--- a/rust/common/src/hash/dispatcher.rs
+++ b/rust/common/src/hash/dispatcher.rs
@@ -1,5 +1,5 @@
 use super::{HashKey, MAX_FIXED_SIZE_KEY_ELEMENTS};
-use crate::collection::hash_map as hash;
+use crate::hash;
 use crate::types::{DataSize, DataType};
 
 /// An enum to help to dynamically dispatch [`HashKey`] template.
@@ -82,7 +82,7 @@ pub fn calc_hash_key_kind(data_types: &[DataType]) -> HashKeyKind {
 #[cfg(test)]
 mod tests {
 
-    use crate::collection::hash_map::{calc_hash_key_kind, HashKeyKind};
+    use crate::hash::{calc_hash_key_kind, HashKeyKind};
     use crate::types::DataType;
 
     fn all_data_types() -> Vec<DataType> {

--- a/rust/common/src/hash/key.rs
+++ b/rust/common/src/hash/key.rs
@@ -595,7 +595,7 @@ mod tests {
         ArrayRef, BoolArray, DataChunk, DecimalArray, F32Array, F64Array, I16Array, I32Array,
         I32ArrayBuilder, I64Array, NaiveDateArray, NaiveDateTimeArray, NaiveTimeArray, Utf8Array,
     };
-    use crate::collection::hash_map::{
+    use crate::hash::{
         HashKey, Key128, Key16, Key256, Key32, Key64, KeySerialized, PrecomputedBuildHasher,
     };
     use crate::test_utils::rand_array::seed_rand_array_ref;

--- a/rust/common/src/hash/mod.rs
+++ b/rust/common/src/hash/mod.rs
@@ -1,0 +1,4 @@
+mod key;
+pub use key::*;
+mod dispatcher;
+pub use dispatcher::*;

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -26,6 +26,7 @@ pub mod catalog;
 pub mod collection;
 pub mod config;
 pub mod expr;
+pub mod hash;
 #[cfg(test)]
 pub mod test_utils;
 pub mod types;


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

The module is used for all hash infrastructure (including Hash Shuffle, HashMap, HashSet) but not HashMap only, we should extract it from collection.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
