### PR TITLE
fix: remove column index from OrderedRowSerializer

### DIFF
--- a/rust/server/tests/row_seq_scan.rs
+++ b/rust/server/tests/row_seq_scan.rs
@@ -8,7 +8,7 @@ use risingwave_common::array::{Array, Row};
 use risingwave_common::catalog::{ColumnId, Field, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::types::DataType;
-use risingwave_common::util::sort_util::{OrderPair, OrderType};
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::Keyspace;
 use risingwave_stream::executor::{MViewTable, ManagedMViewState};
@@ -27,11 +27,8 @@ async fn test_row_seq_scan() -> Result<()> {
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
     let pk_columns = vec![0];
     let orderings = vec![OrderType::Ascending];
-    let mut state = ManagedMViewState::new(
-        keyspace.clone(),
-        column_ids,
-        vec![OrderPair::new(0, OrderType::Ascending)],
-    );
+    let mut state =
+        ManagedMViewState::new(keyspace.clone(), column_ids, vec![OrderType::Ascending]);
 
     let table = Arc::new(MViewTable::new(
         keyspace.clone(),

--- a/rust/stream/src/executor/mview/materialize.rs
+++ b/rust/stream/src/executor/mview/materialize.rs
@@ -36,9 +36,10 @@ impl<S: StateStore> MaterializeExecutor<S> {
         op_info: String,
     ) -> Self {
         let pk_columns = keys.iter().map(|k| k.column_idx).collect();
+        let pk_order_types = keys.iter().map(|k| k.order_type).collect();
         Self {
             input,
-            local_state: ManagedMViewState::new(keyspace, column_ids, keys),
+            local_state: ManagedMViewState::new(keyspace, column_ids, pk_order_types),
             pk_columns,
             identity: format!("MaterializeExecutor {:X}", executor_id),
             op_info,

--- a/rust/stream/src/executor/mview/table_state_tests.rs
+++ b/rust/stream/src/executor/mview/table_state_tests.rs
@@ -1,6 +1,6 @@
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
-use risingwave_common::util::sort_util::{OrderPair, OrderType};
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::table::mview::MViewTable;
 use risingwave_storage::table::ScannableTable;
@@ -15,14 +15,10 @@ async fn test_mview_table() {
     let schema = schemas::iii();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
     let pk_columns = vec![0, 1];
-    let orderings = vec![OrderType::Ascending, OrderType::Descending];
-    let keys = vec![
-        OrderPair::new(0, OrderType::Ascending),
-        OrderPair::new(1, OrderType::Descending),
-    ];
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
     let keyspace = Keyspace::executor_root(state_store, 0x42);
-    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, keys);
-    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), orderings);
+    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, order_types.clone());
+    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), order_types);
     let epoch: u64 = 0;
 
     state.put(
@@ -86,15 +82,11 @@ async fn test_mview_table_for_string() {
     let state_store = MemoryStateStore::new();
     let schema = schemas::sss();
     let pk_columns = vec![0, 1];
-    let orderings = vec![OrderType::Ascending, OrderType::Descending];
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
     let keyspace = Keyspace::executor_root(state_store, 0x42);
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
-    let keys = vec![
-        OrderPair::new(0, OrderType::Ascending),
-        OrderPair::new(1, OrderType::Descending),
-    ];
-    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, keys);
-    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), orderings);
+    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, order_types.clone());
+    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), order_types);
     let epoch: u64 = 0;
 
     state.put(
@@ -218,16 +210,12 @@ async fn test_mview_table_iter() {
     let state_store = MemoryStateStore::new();
     let schema = schemas::iii();
     let pk_columns = vec![0, 1];
-    let orderings = vec![OrderType::Ascending, OrderType::Descending];
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
     let keyspace = Keyspace::executor_root(state_store, 0x42);
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
-    let keys = vec![
-        OrderPair::new(0, OrderType::Ascending),
-        OrderPair::new(1, OrderType::Descending),
-    ];
 
-    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, keys);
-    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), orderings);
+    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, order_types.clone());
+    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), order_types);
     let epoch: u64 = 0;
 
     state.put(
@@ -273,39 +261,34 @@ async fn test_multi_mview_table_iter() {
     let schema_1 = schemas::iii();
     let schema_2 = schemas::sss();
     let pk_columns = vec![0, 1];
-    let orderings = vec![OrderType::Ascending, OrderType::Descending];
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
 
     let keyspace_1 = Keyspace::executor_root(state_store.clone(), 0x1111);
     let keyspace_2 = Keyspace::executor_root(state_store.clone(), 0x2222);
     let epoch: u64 = 0;
 
-    let keys = vec![
-        OrderPair::new(0, OrderType::Ascending),
-        OrderPair::new(1, OrderType::Descending),
-    ];
-
     let mut state_1 = ManagedMViewState::new(
         keyspace_1.clone(),
         vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)],
-        keys.clone(),
+        order_types.clone(),
     );
     let mut state_2 = ManagedMViewState::new(
         keyspace_2.clone(),
         vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)],
-        keys,
+        order_types.clone(),
     );
 
     let table_1 = MViewTable::new(
         keyspace_1.clone(),
         schema_1.clone(),
         pk_columns.clone(),
-        orderings.clone(),
+        order_types.clone(),
     );
     let table_2 = MViewTable::new(
         keyspace_2.clone(),
         schema_2.clone(),
         pk_columns.clone(),
-        orderings,
+        order_types,
     );
 
     state_1.put(
@@ -392,15 +375,11 @@ async fn test_mview_scan_empty_column_ids_cardinality() {
     let schema = schemas::iii();
     let column_ids = vec![ColumnId::from(0), ColumnId::from(1), ColumnId::from(2)];
     let pk_columns = vec![0, 1];
-    let orderings = vec![OrderType::Ascending, OrderType::Descending];
+    let order_types = vec![OrderType::Ascending, OrderType::Descending];
     let keyspace = Keyspace::executor_root(state_store, 0x42);
-    let keys = vec![
-        OrderPair::new(0, OrderType::Ascending),
-        OrderPair::new(1, OrderType::Descending),
-    ];
 
-    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, keys);
-    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), orderings);
+    let mut state = ManagedMViewState::new(keyspace.clone(), column_ids, order_types.clone());
+    let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), order_types);
     let epoch: u64 = 0;
 
     state.put(

--- a/rust/stream/src/executor/mview/test_utils.rs
+++ b/rust/stream/src/executor/mview/test_utils.rs
@@ -1,5 +1,5 @@
 use risingwave_common::array::Row;
-use risingwave_common::util::sort_util::{OrderPair, OrderType};
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::memory::MemoryStateStore;
 use risingwave_storage::Keyspace;
 
@@ -15,10 +15,7 @@ pub async fn gen_basic_table(row_count: usize) -> MViewTable<MemoryStateStore> {
     let mut state = ManagedMViewState::new(
         keyspace.clone(),
         vec![0.into(), 1.into(), 2.into()],
-        vec![
-            OrderPair::new(0, OrderType::Ascending),
-            OrderPair::new(1, OrderType::Descending),
-        ],
+        vec![OrderType::Ascending, OrderType::Descending],
     );
     let table = MViewTable::new(keyspace.clone(), schema, pk_columns.clone(), orderings);
     let epoch: u64 = 0;


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
As the title suggests, `OrderedRowSerializer` now expects a row that contains exactly the values needed to be serialized.

## Checklist

- [x] I have written necessary docs and comments