### PR TITLE
chore: changelog ignore PRs with label "no-release-log"

### DIFF
--- a/.github/changelog.json
+++ b/.github/changelog.json
@@ -33,7 +33,7 @@
     }
   ],
   "ignore_labels": [
-    "ignore"
+    "no-release-log"
   ],
   "sort": "ASC",
   "template": "${{CHANGELOG}}\n\n<details>\n<summary>Uncategorized</summary>\n\n${{UNCATEGORIZED}}\n</details>",


### PR DESCRIPTION
## What's changed and what's your intention?

As title, we need a special label "no-release-log" to represent the PR should be ignored in changelog generator bot, and "ignore" is too general.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
