### PR TITLE
feat(frontend): pull common factors from OR's operands in join

### DIFF
--- a/java/planner/src/main/java/com/risingwave/planner/rules/logical/NormalizeJoinConditionRule.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rules/logical/NormalizeJoinConditionRule.java
@@ -1,0 +1,51 @@
+package com.risingwave.planner.rules.logical;
+
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlKind;
+
+/** NormalizeJoinConditionRule pulls common factors from OR's operands in join condition. */
+public class NormalizeJoinConditionRule extends RelRule<NormalizeJoinConditionRule.Config> {
+
+  public NormalizeJoinConditionRule(Config config) {
+    super(config);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    LogicalJoin join = call.rel(0);
+    var condition = join.getCondition();
+    return condition.getKind() == SqlKind.OR;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    LogicalJoin join = call.rel(0);
+    var condition = join.getCondition();
+    // Pull the common factors from OR's operands.
+    var newCondition = RexUtil.pullFactors(join.getCluster().getRexBuilder(), condition);
+    call.transformTo(
+        join.copy(
+            join.getTraitSet(),
+            newCondition,
+            join.getLeft(),
+            join.getRight(),
+            join.getJoinType(),
+            join.isSemiJoinDone()));
+  }
+
+  /** Default Config */
+  public interface Config extends RelRule.Config {
+    NormalizeJoinConditionRule.Config DEFAULT =
+        NormalizeJoinConditionRule.Config.EMPTY
+            .withDescription("Extract Equal Join Condition")
+            .withOperandSupplier(s -> s.operand(LogicalJoin.class).anyInputs())
+            .as(NormalizeJoinConditionRule.Config.class);
+
+    default NormalizeJoinConditionRule toRule() {
+      return new NormalizeJoinConditionRule(this);
+    }
+  }
+}

--- a/java/planner/src/main/java/com/risingwave/planner/rules/streaming/StreamingRuleSets.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rules/streaming/StreamingRuleSets.java
@@ -15,6 +15,7 @@ import com.risingwave.planner.rel.streaming.RwStreamProject;
 import com.risingwave.planner.rel.streaming.RwStreamSort;
 import com.risingwave.planner.rel.streaming.RwStreamTableSource;
 import com.risingwave.planner.rel.streaming.join.RwStreamHashJoin;
+import com.risingwave.planner.rules.logical.NormalizeJoinConditionRule;
 import com.risingwave.planner.rules.streaming.aggregate.StreamingShuffleAggRule;
 import com.risingwave.planner.rules.streaming.aggregate.StreamingSingleModeAggRule;
 import com.risingwave.planner.rules.streaming.aggregate.StreamingTwoPhaseAggRule;
@@ -34,7 +35,8 @@ public class StreamingRuleSets {
           RwLogicalValues.RwValuesConverterRule.INSTANCE,
           RwLogicalScan.RwLogicalScanConverterRule.INSTANCE,
           RwLogicalSort.RwLogicalSortConverterRule.INSTANCE,
-          RwLogicalJoin.RwLogicalJoinConverterRule.INSTANCE);
+          RwLogicalJoin.RwLogicalJoinConverterRule.INSTANCE,
+          NormalizeJoinConditionRule.Config.DEFAULT.toRule());
 
   public static final RuleSet STREAMING_CONVERTER_RULES =
       RuleSets.ofList(


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
This rule does one thing and one thing only, pulling the common factors from OR's operands.

Particularly, for streaming tpch q19, the equal join condition is pulled out and the logical join now can be transformed into hash join.

This blocks streaming tpch q19.

## Checklist

- [x] I have written necessary docs and comments

## Refer to a related PR or issue link (optional)
#497 