### PR TITLE
chore(storage): cleanup state store stats

### DIFF
--- a/rust/storage/src/hummock/hummock_meta_client.rs
+++ b/rust/storage/src/hummock/hummock_meta_client.rs
@@ -54,6 +54,8 @@ pub trait HummockMetaClient: Send + Sync + 'static {
 
 pub struct RpcHummockMetaClient {
     meta_client: MetaClient,
+
+    // TODO: should be separated `HummockStats` instead of `StateStoreStats`.
     stats: Arc<StateStoreStats>,
 }
 

--- a/rust/storage/src/hummock/iterator/user.rs
+++ b/rust/storage/src/hummock/iterator/user.rs
@@ -1,12 +1,10 @@
 use std::ops::Bound::{self, *};
-use std::sync::Arc;
 
 use super::{HummockIterator, MergeIterator};
 use crate::hummock::iterator::ReverseUserIterator;
 use crate::hummock::key::{get_epoch, key_with_epoch, user_key as to_user_key, Epoch};
 use crate::hummock::value::HummockValue;
 use crate::hummock::HummockResult;
-use crate::monitor::StateStoreStats;
 
 pub enum DirectedUserIterator<'a> {
     Forward(UserIterator<'a>),
@@ -77,10 +75,6 @@ pub struct UserIterator<'a> {
 
     /// Only read values if `ts <= self.read_epoch`.
     read_epoch: Epoch,
-
-    #[allow(dead_code)]
-    // TODO: separate state store stats with hummock stats
-    stats: Arc<StateStoreStats>,
 }
 
 // TODO: decide wheher this should also impl `HummockIterator`
@@ -91,14 +85,7 @@ impl<'a> UserIterator<'a> {
         iterator: MergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
-        use crate::monitor::DEFAULT_STATE_STORE_STATS;
-
-        Self::new(
-            iterator,
-            key_range,
-            Epoch::MAX,
-            DEFAULT_STATE_STORE_STATS.clone(),
-        )
+        Self::new(iterator, key_range, Epoch::MAX)
     }
 
     /// Create [`UserIterator`] with given `read_epoch`.
@@ -106,7 +93,6 @@ impl<'a> UserIterator<'a> {
         iterator: MergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
-        stats: Arc<StateStoreStats>,
     ) -> Self {
         Self {
             iterator,
@@ -115,7 +101,6 @@ impl<'a> UserIterator<'a> {
             last_key: Vec::new(),
             last_val: Vec::new(),
             read_epoch,
-            stats,
         }
     }
 

--- a/rust/storage/src/hummock/mod.rs
+++ b/rust/storage/src/hummock/mod.rs
@@ -102,9 +102,6 @@ pub struct HummockStorage {
 
     local_version_manager: Arc<LocalVersionManager>,
 
-    /// Statistics.
-    stats: Arc<StateStoreStats>,
-
     hummock_meta_client: Arc<dyn HummockMetaClient>,
 
     sstable_manager: SstableStoreRef,
@@ -138,6 +135,7 @@ impl HummockStorage {
         sstable_manager: SstableStoreRef,
         local_version_manager: Arc<LocalVersionManager>,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
+        // TODO: should be separated `HummockStats` instead of `StateStoreStats`.
         stats: Arc<StateStoreStats>,
     ) -> HummockResult<Self> {
         let options = Arc::new(options);
@@ -161,7 +159,6 @@ impl HummockStorage {
         let instance = Self {
             options,
             local_version_manager,
-            stats,
             hummock_meta_client,
             sstable_manager,
             shared_buffer_manager,
@@ -288,7 +285,6 @@ impl HummockStorage {
                 key_range.end_bound().map(|b| b.as_ref().to_owned()),
             ),
             epoch,
-            self.stats.clone(),
         ))
     }
 

--- a/rust/storage/src/hummock/shared_buffer.rs
+++ b/rust/storage/src/hummock/shared_buffer.rs
@@ -161,7 +161,7 @@ impl SharedBufferManager {
         options: Arc<HummockOptions>,
         local_version_manager: Arc<LocalVersionManager>,
         sstable_manager: SstableStoreRef,
-
+        // TODO: should be separated `HummockStats` instead of `StateStoreStats`.
         stats: Arc<StateStoreStats>,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
     ) -> Self {
@@ -334,6 +334,7 @@ pub struct SharedBufferUploader {
     options: Arc<HummockOptions>,
 
     /// Statistics.
+    // TODO: should be separated `HummockStats` instead of `StateStoreStats`.
     stats: Arc<StateStoreStats>,
     hummock_meta_client: Arc<dyn HummockMetaClient>,
     sstable_manager: SstableStoreRef,


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?
This PR cleans up some unused state store stats in storage code, and adds some comments for replacing `StateStoreStats` with `HummockStats`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)