### PR TITLE
fix(meta): prevent panic when all nodes in cluster have been deleted

### DIFF
--- a/rust/meta/src/model/hash_mapping.rs
+++ b/rust/meta/src/model/hash_mapping.rs
@@ -53,7 +53,7 @@ impl From<&Vec<ParallelUnitId>> for ConsistentHashMapping {
 }
 
 impl ConsistentHashMapping {
-    pub fn update(
+    pub fn update_mapping(
         &mut self,
         virtual_key: VirtualKey,
         parallel_unit_id: ParallelUnitId,
@@ -85,5 +85,9 @@ impl ConsistentHashMapping {
             .iter()
             .map(|parallel_unit| parallel_unit.id)
             .collect()
+    }
+
+    pub fn clear_mapping(&mut self) {
+        self.0.parallel_units.clear();
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change 

  - Prevent `HashDispatchManager` from panicking when all nodes in the cluster have been deleted.   
  - Refactor some code.