### PR TITLE
fix(hummock): hold reference to hummock version during (Reverse)UserIterator's lifetime

### DIFF
--- a/rust/storage/src/hummock/iterator/reverse_user.rs
+++ b/rust/storage/src/hummock/iterator/reverse_user.rs
@@ -34,7 +34,7 @@ pub struct ReverseUserIterator<'a> {
     read_epoch: Epoch,
 
     /// Ensures the SSTs needed by `iterator` won't be vacuumed.
-    _version: Arc<ScopedLocalVersion>,
+    _version: Option<Arc<ScopedLocalVersion>>,
 }
 
 impl<'a> ReverseUserIterator<'a> {
@@ -44,12 +44,7 @@ impl<'a> ReverseUserIterator<'a> {
         iterator: ReverseMergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
-        Self::new_with_epoch(
-            iterator,
-            key_range,
-            Epoch::MAX,
-            Arc::new(ScopedLocalVersion::for_test()),
-        )
+        Self::new_with_epoch(iterator, key_range, Epoch::MAX, None)
     }
 
     /// Create [`UserIterator`] with given `read_epoch`.
@@ -57,7 +52,7 @@ impl<'a> ReverseUserIterator<'a> {
         iterator: ReverseMergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
-        version: Arc<ScopedLocalVersion>,
+        version: Option<Arc<ScopedLocalVersion>>,
     ) -> Self {
         Self {
             iterator,

--- a/rust/storage/src/hummock/iterator/user.rs
+++ b/rust/storage/src/hummock/iterator/user.rs
@@ -79,7 +79,7 @@ pub struct UserIterator<'a> {
     read_epoch: Epoch,
 
     /// Ensures the SSTs needed by `iterator` won't be vacuumed.
-    _version: Arc<ScopedLocalVersion>,
+    _version: Option<Arc<ScopedLocalVersion>>,
 }
 
 // TODO: decide wheher this should also impl `HummockIterator`
@@ -90,12 +90,7 @@ impl<'a> UserIterator<'a> {
         iterator: MergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
     ) -> Self {
-        Self::new(
-            iterator,
-            key_range,
-            Epoch::MAX,
-            Arc::new(ScopedLocalVersion::for_test()),
-        )
+        Self::new(iterator, key_range, Epoch::MAX, None)
     }
 
     /// Create [`UserIterator`] with given `read_epoch`.
@@ -103,7 +98,7 @@ impl<'a> UserIterator<'a> {
         iterator: MergeIterator<'a>,
         key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
         read_epoch: u64,
-        version: Arc<ScopedLocalVersion>,
+        version: Option<Arc<ScopedLocalVersion>>,
     ) -> Self {
         Self {
             iterator,

--- a/rust/storage/src/hummock/local_version_manager.rs
+++ b/rust/storage/src/hummock/local_version_manager.rs
@@ -40,20 +40,6 @@ impl ScopedLocalVersion {
         }
     }
 
-    #[cfg(test)]
-    pub fn for_test() -> Self {
-        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
-        ScopedLocalVersion {
-            version: Arc::new(HummockVersion {
-                id: 0,
-                levels: vec![],
-                uncommitted_epochs: vec![],
-                max_committed_epoch: 0,
-            }),
-            unpin_worker_tx: tx,
-        }
-    }
-
     pub fn id(&self) -> HummockVersionId {
         self.version.id
     }

--- a/rust/storage/src/hummock/mod.rs
+++ b/rust/storage/src/hummock/mod.rs
@@ -285,7 +285,7 @@ impl HummockStorage {
                 key_range.end_bound().map(|b| b.as_ref().to_owned()),
             ),
             epoch,
-            version,
+            Some(version),
         ))
     }
 
@@ -341,7 +341,7 @@ impl HummockStorage {
                 key_range.start_bound().map(|b| b.as_ref().to_owned()),
             ),
             epoch,
-            version,
+            Some(version),
         ))
     }
 


### PR DESCRIPTION
This PR fixes bug described in https://github.com/singularity-data/risingwave-dev/issues/635 

## Checklist

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave-dev/issues/635