### PR TITLE
refactor: extract repeated validation into a method

### DIFF
--- a/rust/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -150,12 +150,7 @@ impl WithSchema for LogicalAgg {
 
 impl ColPrunable for LogicalAgg {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let mut child_required_cols =
             FixedBitSet::with_capacity(self.input.schema().fields().len());

--- a/rust/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -71,12 +71,7 @@ impl WithSchema for LogicalFilter {
 
 impl ColPrunable for LogicalFilter {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let mut visitor = CollectRequiredCols {
             required_cols: required_cols.clone(),

--- a/rust/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_join.rs
@@ -101,12 +101,7 @@ impl WithSchema for LogicalJoin {
 
 impl ColPrunable for LogicalJoin {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         match self.join_type {
             JoinType::Inner | JoinType::LeftOuter | JoinType::RightOuter | JoinType::FullOuter => {}

--- a/rust/frontend/src/optimizer/plan_node/logical_limit.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_limit.rs
@@ -59,6 +59,8 @@ impl WithSchema for LogicalLimit {
 
 impl ColPrunable for LogicalLimit {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
+        self.must_contain_columns(required_cols);
+
         let new_input = self.input.prune_col(required_cols);
         self.clone_with_input(new_input).into()
     }

--- a/rust/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_project.rs
@@ -143,12 +143,7 @@ impl WithSchema for LogicalProject {
 
 impl ColPrunable for LogicalProject {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let mut visitor = CollectRequiredCols {
             required_cols: FixedBitSet::with_capacity(self.input.schema().fields().len()),

--- a/rust/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -73,12 +73,7 @@ impl fmt::Display for LogicalScan {
 
 impl ColPrunable for LogicalScan {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let (columns, fields) = required_cols
             .ones()

--- a/rust/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -63,12 +63,7 @@ impl WithSchema for LogicalTopN {
 
 impl ColPrunable for LogicalTopN {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let mut input_required_cols = required_cols.clone();
         self.order

--- a/rust/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_values.rs
@@ -58,12 +58,7 @@ impl fmt::Display for LogicalValues {
 
 impl ColPrunable for LogicalValues {
     fn prune_col(&self, required_cols: &FixedBitSet) -> PlanRef {
-        assert!(
-            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
-            "Invalid required cols: {}, only {} columns available",
-            required_cols,
-            self.schema().fields().len()
-        );
+        self.must_contain_columns(required_cols);
 
         let (rows, fields) = required_cols
             .ones()

--- a/rust/frontend/src/optimizer/property/schema.rs
+++ b/rust/frontend/src/optimizer/property/schema.rs
@@ -1,5 +1,15 @@
+use fixedbitset::FixedBitSet;
 use risingwave_common::catalog::Schema;
 
 pub trait WithSchema {
     fn schema(&self) -> &Schema;
+
+    fn must_contain_columns(&self, required_cols: &FixedBitSet) {
+        assert!(
+            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
+            "Invalid required cols: {}, only {} columns available",
+            required_cols,
+            self.schema().fields().len()
+        );
+    }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

This code piece has been repeated in multiple operators. Try this or do it in another PR.

```
trait WithSchema {
  fn must_contain_columns<T: WithSchema>(t: T, cols : FixedBitSet) {
        assert!(
            required_cols.is_subset(&FixedBitSet::from_iter(0..self.schema().fields().len())),
            "Invalid required cols: {}, only {} columns available",
            required_cols,
            self.schema().fields().len()
        );
  }
} 
```

_Originally posted by @neverchanje in https://github.com/singularity-data/risingwave-dev/pull/733#discussion_r821633650_

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
