### PR TITLE
fix(mem-state-store): `sync` of mem state store should be no-op

### DIFF
--- a/rust/storage/src/memory.rs
+++ b/rust/storage/src/memory.rs
@@ -193,7 +193,8 @@ impl StateStore for MemoryStateStore {
     }
 
     async fn sync(&self, _epoch: Option<u64>) -> Result<()> {
-        unimplemented!()
+        // memory backend doesn't support push to S3, so this is a no-op
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?
Now the server runs by IDE is using mem state store. It will crash cuz `sync` of mem state store is unimplemented.


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
