### PR TITLE
feat(streaming): encode group key in MaterializeExecutor

### DIFF
--- a/rust/stream/src/executor/test_utils.rs
+++ b/rust/stream/src/executor/test_utils.rs
@@ -208,6 +208,7 @@ pub fn create_in_memory_keyspace() -> Keyspace<MemoryStateStore> {
     Keyspace::executor_root(MemoryStateStore::new(), 0x2333)
 }
 
+#[allow(dead_code)]
 pub mod schemas {
     use risingwave_common::catalog::*;
     use risingwave_common::types::DataType;

--- a/rust/stream/src/task/stream_manager.rs
+++ b/rust/stream/src/task/stream_manager.rs
@@ -61,11 +61,23 @@ pub struct StreamManager {
 
 pub struct ExecutorParams {
     pub env: StreamEnvironment,
+
+    /// Indices of primary keys
     pub pk_indices: PkIndices,
+
+    /// Executor id, unique across all actors.
     pub executor_id: u64,
+
+    /// Operator id, unique for each operator in fragment.
     pub operator_id: u64,
+
+    /// Information of the operator from plan node.
     pub op_info: String,
+
+    /// The input executor.
     pub input: Vec<Box<dyn Executor>>,
+
+    /// Id of the actor.
     pub actor_id: u32,
 }
 


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Add group key in MaterializeExecutor, so as to support shared state.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

ref https://github.com/singularity-data/risingwave-dev/issues/719