### PR TITLE
fix: new a GeneralSortedGrouper

### DIFF
--- a/rust/common/src/vector_op/agg/general_sorted_grouper.rs
+++ b/rust/common/src/vector_op/agg/general_sorted_grouper.rs
@@ -260,15 +260,9 @@ mod tests {
 
     #[test]
     fn vec_agg_group() -> Result<()> {
-        let mut g0 = GeneralSortedGrouper::<I32Array> {
-            ongoing: false,
-            group_value: None,
-        };
+        let mut g0 = GeneralSortedGrouper::<I32Array>::new(false, None);
         let mut g0_builder = I32ArrayBuilder::new(0)?;
-        let mut g1 = GeneralSortedGrouper::<I32Array> {
-            ongoing: false,
-            group_value: None,
-        };
+        let mut g1 = GeneralSortedGrouper::<I32Array>::new(false, None);
         let mut g1_builder = I32ArrayBuilder::new(0)?;
         let mut a = GeneralAgg::<I32Array, _, I64Array>::new(DataType::Int64, 0, sum);
         let mut a_builder = I64ArrayBuilder::new(0)?;
@@ -313,10 +307,7 @@ mod tests {
 
     #[test]
     fn vec_count_star() {
-        let mut g0 = GeneralSortedGrouper::<I32Array> {
-            ongoing: false,
-            group_value: None,
-        };
+        let mut g0 = GeneralSortedGrouper::<I32Array>::new(false, None);
         let mut g0_builder = I32ArrayBuilder::new(0).unwrap();
         let prost = AggCall {
             r#type: Type::Count as i32,


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Previously, cannot `new` a `GeneralSortedGrouper` due to GAT limitation.