### PR TITLE
fix(hummock): cancel timeout compact task

### DIFF
--- a/rust/meta/src/hummock/compactor_manager.rs
+++ b/rust/meta/src/hummock/compactor_manager.rs
@@ -1,6 +1,7 @@
 use std::ops::Add;
 use std::time::{Duration, Instant};
 
+use itertools::Itertools;
 use risingwave_common::error::Result;
 use risingwave_pb::hummock::{CompactTask, SubscribeCompactTasksResponse, VacuumTask};
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -16,10 +17,9 @@ struct CompactorManagerInner {
 
     // Although we can find all ongoing compact tasks in CompactStatus, this field can help in
     // tracking compact tasks. We don't persist this field because all assigned tasks would be
-    // cancelled at HummockManager initialization. TODO #546: start a worker to handle expired
-    // tasks.
+    // cancelled at HummockManager initialization.
     /// Ongoing compact tasks with instant to expire.
-    assigned_tasks: Vec<(CompactTask, Instant)>,
+    assigned_tasks: Vec<(u64, Instant)>,
 
     /// We use round-robin approach to assign tasks to compactors.
     /// This field indexes the compactor which the next task should be assigned to.
@@ -39,18 +39,20 @@ impl CompactorManagerInner {
 /// `CompactorManager` maintains compactors which can process compact task.
 pub struct CompactorManager {
     inner: RwLock<CompactorManagerInner>,
+    compact_task_timeout: Duration,
 }
 
 impl Default for CompactorManager {
     fn default() -> Self {
-        Self::new()
+        Self::new(COMPACT_TASK_TIMEOUT)
     }
 }
 
 impl CompactorManager {
-    pub fn new() -> Self {
+    pub fn new(compact_task_timeout: Duration) -> Self {
         Self {
             inner: RwLock::new(CompactorManagerInner::new()),
+            compact_task_timeout,
         }
     }
 
@@ -86,10 +88,11 @@ impl CompactorManager {
         }
         guard.next_compactor += 1;
         if let Some(compact_task) = compact_task {
-            // TODO #546: Cancel a task only requires task_id. compact_task.clone() can be avoided.
-            guard
-                .assigned_tasks
-                .push((compact_task, Instant::now().add(COMPACT_TASK_TIMEOUT)));
+            // Track the compact task.
+            guard.assigned_tasks.push((
+                compact_task.task_id,
+                Instant::now().add(self.compact_task_timeout),
+            ));
         }
 
         true
@@ -101,11 +104,31 @@ impl CompactorManager {
         self.inner.write().await.compactors.push(tx);
         rx
     }
+
+    /// Don't track the compact task any more.
+    pub async fn unassign_compact_task(&self, compact_task_id: u64) {
+        let mut guard = self.inner.write().await;
+        guard.assigned_tasks.retain(|e| e.0 != compact_task_id);
+    }
+
+    /// Get timeout compact tasks.
+    pub async fn get_timeout_compact_task(&self) -> Vec<u64> {
+        let now = Instant::now();
+        self.inner
+            .read()
+            .await
+            .assigned_tasks
+            .iter()
+            .filter(|e| now.saturating_duration_since(e.1) > self.compact_task_timeout)
+            .map(|e| e.0)
+            .collect_vec()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::error::Result;
+    use std::time::Duration;
+
     use risingwave_pb::hummock::{CompactTask, SubscribeCompactTasksResponse};
     use tokio::sync::mpsc::error::TryRecvError;
 
@@ -124,8 +147,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_add_compactor() -> Result<()> {
-        let compactor_manager = CompactorManager::new();
+    async fn test_add_compactor() {
+        let compactor_manager = CompactorManager::default();
         // No compactors by default.
         assert_eq!(compactor_manager.inner.read().await.compactors.len(), 0);
 
@@ -163,13 +186,11 @@ mod tests {
             receiver.try_recv().unwrap_err(),
             TryRecvError::Disconnected
         ));
-
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_try_assign_compact_task() -> Result<()> {
-        let compactor_manager = CompactorManager::new();
+    async fn test_try_assign_compact_task() {
+        let compactor_manager = CompactorManager::default();
         let task = dummy_compact_task(123);
         // No compactor available.
         assert!(
@@ -180,6 +201,12 @@ mod tests {
 
         let mut receiver = compactor_manager.add_compactor().await;
         assert_eq!(compactor_manager.inner.read().await.compactors.len(), 1);
+        assert!(compactor_manager
+            .inner
+            .read()
+            .await
+            .assigned_tasks
+            .is_empty());
         assert!(
             compactor_manager
                 .try_assign_compact_task(Some(task.clone()), None)
@@ -189,6 +216,7 @@ mod tests {
             receiver.try_recv().unwrap().unwrap().compact_task.unwrap(),
             task
         );
+        assert_eq!(compactor_manager.inner.read().await.assigned_tasks.len(), 1);
 
         drop(receiver);
         // CompactorManager will find the receiver is dropped when trying to assign a task to it.
@@ -199,13 +227,11 @@ mod tests {
                 .await
         );
         assert_eq!(compactor_manager.inner.read().await.compactors.len(), 0);
-
-        Ok(())
     }
 
     #[tokio::test]
-    async fn test_try_assign_compact_task_round_robin() -> Result<()> {
-        let compactor_manager = CompactorManager::new();
+    async fn test_try_assign_compact_task_round_robin() {
+        let compactor_manager = CompactorManager::default();
         let mut receivers = vec![];
         for _ in 0..5 {
             receivers.push(compactor_manager.add_compactor().await);
@@ -237,6 +263,45 @@ mod tests {
                 }
             }
         }
-        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_cancel_compact_task() {
+        let compact_task_timeout = Duration::from_millis(100);
+        let compactor_manager = CompactorManager::new(compact_task_timeout);
+        let task = dummy_compact_task(123);
+        let _receiver = compactor_manager.add_compactor().await;
+        assert!(
+            compactor_manager
+                .try_assign_compact_task(Some(task.clone()), None)
+                .await
+        );
+        assert_eq!(compactor_manager.inner.read().await.compactors.len(), 1);
+        assert_eq!(compactor_manager.inner.read().await.assigned_tasks.len(), 1);
+
+        // Cancel compact task via report explicitly
+        compactor_manager.unassign_compact_task(task.task_id).await;
+        assert!(compactor_manager
+            .inner
+            .read()
+            .await
+            .assigned_tasks
+            .is_empty());
+
+        // Cancel compact task via timeout checker
+        assert!(
+            compactor_manager
+                .try_assign_compact_task(Some(task.clone()), None)
+                .await
+        );
+        assert_eq!(compactor_manager.inner.read().await.assigned_tasks.len(), 1);
+
+        // Within TTL.
+        tokio::time::sleep(compactor_manager.compact_task_timeout / 2).await;
+        assert_eq!(compactor_manager.get_timeout_compact_task().await.len(), 0);
+
+        // TTL exceeded
+        tokio::time::sleep(compactor_manager.compact_task_timeout * 2).await;
+        assert_eq!(compactor_manager.get_timeout_compact_task().await.len(), 1);
     }
 }

--- a/rust/meta/src/hummock/hummock_manager_tests.rs
+++ b/rust/meta/src/hummock/hummock_manager_tests.rs
@@ -105,12 +105,12 @@ async fn test_hummock_compaction_task() -> Result<()> {
 
     // Cancel the task and succeed.
     assert!(hummock_manager
-        .report_compact_task(compact_task.clone(), false)
+        .cancel_compact_task(compact_task.task_id)
         .await
         .unwrap());
     // Cancel the task and told the task is not found, which may have been processed previously.
     assert!(!hummock_manager
-        .report_compact_task(compact_task.clone(), false)
+        .cancel_compact_task(compact_task.task_id)
         .await
         .unwrap());
 
@@ -119,12 +119,12 @@ async fn test_hummock_compaction_task() -> Result<()> {
     assert_eq!(compact_task.get_task_id(), 2);
     // Finish the task and succeed.
     assert!(hummock_manager
-        .report_compact_task(compact_task.clone(), true)
+        .finish_compact_task(compact_task.clone())
         .await
         .unwrap());
     // Finish the task and told the task is not found, which may have been processed previously.
     assert!(!hummock_manager
-        .report_compact_task(compact_task.clone(), true)
+        .finish_compact_task(compact_task.clone())
         .await
         .unwrap());
 

--- a/rust/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/rust/meta/src/hummock/mock_hummock_meta_client.rs
@@ -89,11 +89,19 @@ impl HummockMetaClient for MockHummockMetaClient {
         compact_task: CompactTask,
         task_result: bool,
     ) -> HummockResult<()> {
-        self.hummock_manager
-            .report_compact_task(compact_task, task_result)
-            .await
-            .map_err(HummockError::meta_error)
-            .map(|_| ())
+        if task_result {
+            self.hummock_manager
+                .finish_compact_task(compact_task)
+                .await
+                .map_err(HummockError::meta_error)
+                .map(|_| ())
+        } else {
+            self.hummock_manager
+                .cancel_compact_task(compact_task.task_id)
+                .await
+                .map_err(HummockError::meta_error)
+                .map(|_| ())
+        }
     }
 
     async fn commit_epoch(&self, epoch: HummockEpoch) -> HummockResult<()> {

--- a/rust/meta/src/hummock/vacuum.rs
+++ b/rust/meta/src/hummock/vacuum.rs
@@ -164,7 +164,7 @@ mod tests {
     #[tokio::test]
     async fn test_shutdown_vacuum() {
         let (_env, hummock_manager, _cluster_manager, _worker_node) = setup_compute_env(80).await;
-        let compactor_manager = Arc::new(CompactorManager::new());
+        let compactor_manager = Arc::new(CompactorManager::default());
         let vacuum = VacuumTrigger::new(hummock_manager, compactor_manager);
         let (join_handle, shutdown_sender) = VacuumTrigger::start_vacuum_trigger(vacuum).await;
         shutdown_sender.send(()).unwrap();

--- a/rust/meta/src/rpc/server.rs
+++ b/rust/meta/src/rpc/server.rs
@@ -83,7 +83,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             .await
             .unwrap(),
     );
-    let compactor_manager = Arc::new(hummock::CompactorManager::new());
+    let compactor_manager = Arc::new(hummock::CompactorManager::default());
     let notification_manager = Arc::new(NotificationManager::new());
     let cluster_manager = Arc::new(
         StoredClusterManager::new(


### PR DESCRIPTION
This PR cancels compact task that is not finished by compactor node and replied to meta node within the specified threshold (60seconds). The timeout can happen for reasons like compactor node failure.

- Timeout detection is performed in the compaction trigger loop in meta node (start_compaction_trigger).
- refactor: CompactStatus::report_compact_task is split into finish_compact_task and cancel_compact_task.

TODO: 
`Compactor` should handle the error where some SSTs to compact have been GCed in s3. The error can happen as follow:
1. Compactor A is assigned a compact task 1 by CompactorManager in meta node.
2. Compactor A cannot finish compact task 1 in time for some reason, for example network delay or heavy calculation.
3. After some time, the CompactorManager marks compact task 1 as timeout and reassigns it to Compactor B.
4. Compactor B finishes compact task 1 and reports to CompactorManager.
5. SSTs compacted by task 1 are removed from S3 by Vacuum.
6. Compactor A continues to process compact task 1, but it may find some SSTs missing in S3.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave-dev/issues/546