### PR TITLE
refactor(expr): simplify build of some exprs

### DIFF
--- a/rust/common/src/expr/build_expr_from_prost.rs
+++ b/rust/common/src/expr/build_expr_from_prost.rs
@@ -4,14 +4,13 @@ use risingwave_pb::expr::{expr_node, ExprNode};
 use crate::array::{DataChunk, RwError};
 use crate::error::{ErrorCode, Result};
 use crate::expr::expr_binary_bytes::new_substr_start;
-use crate::expr::expr_binary_nonnull::{new_binary_expr, new_like_default, new_position_expr};
+use crate::expr::expr_binary_nonnull::{new_binary_expr, new_like_default};
 use crate::expr::expr_binary_nullable::new_nullable_binary_expr;
 use crate::expr::expr_case::{CaseExpression, WhenClause};
 use crate::expr::expr_in::InExpression;
 use crate::expr::expr_ternary_bytes::{new_replace_expr, new_substr_start_end, new_translate_expr};
 use crate::expr::expr_unary::{
-    new_ascii_expr, new_length_default, new_ltrim_expr, new_rtrim_expr, new_trim_expr,
-    new_unary_expr,
+    new_length_default, new_ltrim_expr, new_rtrim_expr, new_trim_expr, new_unary_expr,
 };
 use crate::expr::{build_from_prost as expr_build_from_prost, BoxedExpression};
 use crate::types::{DataType, ToOwnedDatum};
@@ -76,14 +75,6 @@ pub fn build_substr_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     }
 }
 
-pub fn build_position_expr(prost: &ExprNode) -> Result<BoxedExpression> {
-    let (children, ret_type) = get_return_type_and_children(prost)?;
-    ensure!(children.len() == 2);
-    let str = expr_build_from_prost(&children[0])?;
-    let sub_str = expr_build_from_prost(&children[1])?;
-    Ok(new_position_expr(str, sub_str, ret_type))
-}
-
 pub fn build_trim_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let (children, ret_type) = get_return_type_and_children(prost)?;
     // TODO: add expr with the delimiter parameter
@@ -131,13 +122,6 @@ pub fn build_like_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let expr_ia1 = expr_build_from_prost(&children[0])?;
     let expr_ia2 = expr_build_from_prost(&children[1])?;
     Ok(new_like_default(expr_ia1, expr_ia2, ret_type))
-}
-
-pub fn build_ascii_expr(prost: &ExprNode) -> Result<BoxedExpression> {
-    let (children, ret_type) = get_return_type_and_children(prost)?;
-    ensure!(children.len() == 1);
-    let child = expr_build_from_prost(&children[0])?;
-    Ok(new_ascii_expr(child, ret_type))
 }
 
 pub fn build_in_expr(prost: &ExprNode) -> Result<BoxedExpression> {

--- a/rust/common/src/expr/expr_binary_nonnull.rs
+++ b/rust/common/src/expr/expr_binary_nonnull.rs
@@ -322,6 +322,9 @@ pub fn new_binary_expr(
             NaiveDateTimeArray,
             _,
         >::new(l, r, ret, tumble_start)),
+        Type::Position => Box::new(BinaryExpression::<Utf8Array, Utf8Array, I32Array, _>::new(
+            l, r, ret, position,
+        )),
         tp => {
             unimplemented!(
                 "The expression {:?} using vectorized expression framework is not supported yet!",
@@ -341,19 +344,6 @@ pub fn new_like_default(
         expr_ia2,
         return_type,
         like_default,
-    ))
-}
-
-pub fn new_position_expr(
-    expr_ia1: BoxedExpression,
-    expr_ia2: BoxedExpression,
-    return_type: DataType,
-) -> BoxedExpression {
-    Box::new(BinaryExpression::<Utf8Array, Utf8Array, I32Array, _>::new(
-        expr_ia1,
-        expr_ia2,
-        return_type,
-        position,
     ))
 }
 

--- a/rust/common/src/expr/expr_unary.rs
+++ b/rust/common/src/expr/expr_unary.rs
@@ -286,6 +286,11 @@ pub fn new_unary_expr(
             return_type,
             lower,
         )),
+        (ProstType::Ascii, _, _) => Box::new(UnaryExpression::<Utf8Array, I32Array, _>::new(
+            child_expr,
+            return_type,
+            ascii,
+        )),
         (ProstType::Neg, _, _) => {
             gen_neg! { child_expr, return_type }
         }
@@ -325,14 +330,6 @@ pub fn new_rtrim_expr(expr_ia1: BoxedExpression, return_type: DataType) -> Boxed
         expr_ia1,
         return_type,
         rtrim,
-    ))
-}
-
-pub fn new_ascii_expr(expr_ia1: BoxedExpression, return_type: DataType) -> BoxedExpression {
-    Box::new(UnaryExpression::<Utf8Array, I32Array, _>::new(
-        expr_ia1,
-        return_type,
-        ascii,
     ))
 }
 

--- a/rust/common/src/expr/mod.rs
+++ b/rust/common/src/expr/mod.rs
@@ -50,12 +50,12 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
 
     match prost.get_expr_type()? {
         Cast | Upper | Lower | Not | PgSleep | IsTrue | IsNotTrue | IsFalse | IsNotFalse
-        | IsNull | IsNotNull | Neg => build_unary_expr_prost(prost),
+        | IsNull | IsNotNull | Neg | Ascii => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual => {
             build_binary_expr_prost(prost)
         }
         Add | Subtract | Multiply | Divide | Modulus => build_binary_expr_prost(prost),
-        Extract | RoundDigit | TumbleStart => build_binary_expr_prost(prost),
+        Extract | RoundDigit | TumbleStart | Position => build_binary_expr_prost(prost),
         StreamNullByRowCount | And | Or => build_nullable_binary_expr_prost(prost),
         Substr => build_substr_expr(prost),
         Length => build_length_expr(prost),
@@ -64,8 +64,6 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         Trim => build_trim_expr(prost),
         Ltrim => build_ltrim_expr(prost),
         Rtrim => build_rtrim_expr(prost),
-        Position => build_position_expr(prost),
-        Ascii => build_ascii_expr(prost),
         ConstantValue => LiteralExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         InputRef => InputRefExpression::try_from(prost).map(|d| Box::new(d) as BoxedExpression),
         Case => build_case_expr(prost),


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

Use `build_unary` and `build_binary` for naive expressions.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
