### PR TITLE
style: fix incorrect indents in macros

### DIFF
--- a/rust/batch/src/executor/join/hash_join.rs
+++ b/rust/batch/src/executor/join/hash_join.rs
@@ -551,8 +551,8 @@ mod tests {
                 ));
 
                 let column2 = Column::new(Arc::new(
-          array! {F64Array, [Some(5.7f64), None, Some(9.6f64), None, Some(8.18f64), None]}.into(),
-        ));
+                array! {F64Array, [Some(5.7f64), None, Some(9.6f64), None, Some(8.18f64), None]}.into(),
+                ));
 
                 let chunk =
                     DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
@@ -705,9 +705,8 @@ mod tests {
         ));
 
         let column2 = Column::new(Arc::new(
-      array! {F64Array, [None, None, None, Some(5.7f64), None, None, Some(7.5f64), Some(5.7f64),
-      None, None, None, None]}
-      .into(),
+            array! {F64Array, [None, None, None, Some(5.7f64), None, None, Some(7.5f64), Some(5.7f64),
+                None, None, None, None]}.into(),
     ));
 
         let expected_chunk =
@@ -726,10 +725,10 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F32Array, [
-              None, Some(3.9f32), Some(3.9f32), Some(6.6), None,
-              None, None, None, None, None,
-              None, None, None, None, None,
-              None, None, None, None, None
+                None, Some(3.9f32), Some(3.9f32), Some(6.6), None,
+                None, None, None, None, None,
+                None, None, None, None, None,
+                None, None, None, None, None
             ]}
             .into(),
         ));
@@ -758,24 +757,24 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F32Array, [
-              Some(6.1f32), None, Some(8.4f32), Some(3.9f32), Some(3.9f32),
-              None, Some(6.6f32), None, None, Some(0.7f32),
-              None, Some(5.5f32), None, None, None,
-              None, None, None, None, None,
-              None, None, None, None, None,
-              None
+                Some(6.1f32), None, Some(8.4f32), Some(3.9f32), Some(3.9f32),
+                None, Some(6.6f32), None, None, Some(0.7f32),
+                None, Some(5.5f32), None, None, None,
+                None, None, None, None, None,
+                None, None, None, None, None,
+                None
             ]}
             .into(),
         ));
 
         let column2 = Column::new(Arc::new(
             array! {F64Array, [
-              None, None, None, Some(5.7f64), None,
-              None, Some(7.5f64), Some(5.7f64), None, None,
-              None, None, Some(6.1f64), Some(8.9f64), Some(3.5f64),
-              None, None, Some(8.0f64), None, Some(9.1f64),
-              None, None, Some(9.6f64), None, Some(8.18f64),
-              None
+                None, None, None, Some(5.7f64), None,
+                None, Some(7.5f64), Some(5.7f64), None, None,
+                None, None, Some(6.1f64), Some(8.9f64), Some(3.5f64),
+                None, None, Some(8.0f64), None, Some(9.1f64),
+                None, None, Some(9.6f64), None, Some(8.18f64),
+                None
             ]}
             .into(),
         ));
@@ -792,7 +791,7 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F32Array, [
-              Some(6.1f32), Some(8.4f32), None, Some(0.7f32), None, Some(5.5f32)
+                Some(6.1f32), Some(8.4f32), None, Some(0.7f32), None, Some(5.5f32)
             ]}
             .into(),
         ));
@@ -808,7 +807,7 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F32Array, [
-              None, Some(3.9f32), Some(6.6f32), None
+                None, Some(3.9f32), Some(6.6f32), None
             ]}
             .into(),
         ));
@@ -824,9 +823,9 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F64Array, [
-              Some(6.1f64), Some(8.9f64), Some(3.5f64), None, None,
-              Some(8.0f64), None, Some(9.1f64), None, None,
-              Some(9.6f64), None, Some(8.18f64), None
+                Some(6.1f64), Some(8.9f64), Some(3.5f64), None, None,
+                Some(8.0f64), None, Some(9.1f64), None, None,
+                Some(9.6f64), None, Some(8.18f64), None
             ]}
             .into(),
         ));
@@ -842,7 +841,7 @@ mod tests {
 
         let column1 = Column::new(Arc::new(
             array! {F64Array, [
-              None, Some(5.7f64), None, Some(7.5f64)
+                None, Some(5.7f64), None, Some(7.5f64)
             ]}
             .into(),
         ));

--- a/rust/batch/src/executor/join/nested_loop_join.rs
+++ b/rust/batch/src/executor/join/nested_loop_join.rs
@@ -666,9 +666,8 @@ mod tests {
                     array! {I32Array, [Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
                 ));
                 let column2 = Column::new(Arc::new(
-          array! {F32Array, [Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}
-            .into(),
-        ));
+                    array! {F32Array, [Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into(),
+                ));
 
                 let chunk =
                     DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");
@@ -816,9 +815,8 @@ mod tests {
         let test_fixture = TestFixture::with_join_type(JoinType::LeftOuter);
 
         let column1 = Column::new(Arc::new(
-      array! {I32Array, [Some(1), Some(2), Some(3), Some(3), Some(4), Some(6), Some(6), Some(8)]}
-        .into(),
-    ));
+        array! {I32Array, [Some(1), Some(2), Some(3), Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
+        ));
 
         let column2 = Column::new(Arc::new(array! {F32Array, [Some(6.1f32), Some(8.4f32), Some(3.9f32), Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}.into()));
 

--- a/rust/batch/src/executor/join/sort_merge_join.rs
+++ b/rust/batch/src/executor/join/sort_merge_join.rs
@@ -366,9 +366,11 @@ mod tests {
                     array! {I32Array, [Some(3), Some(4), Some(6), Some(6), Some(8)]}.into(),
                 ));
                 let column2 = Column::new(Arc::new(
-          array! {F32Array, [Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)]}
-            .into(),
-        ));
+                    array! {F32Array, [
+                        Some(6.6f32), Some(0.7f32), Some(5.5f32), Some(5.6f32), Some(7.0f32)
+                    ]}
+                    .into(),
+                ));
 
                 let chunk =
                     DataChunk::try_from(vec![column1, column2]).expect("Failed to create chunk!");

--- a/rust/batch/src/task/task.rs
+++ b/rust/batch/src/task/task.rs
@@ -226,10 +226,10 @@ impl BatchTaskExecution {
                 // close it after task error has been set.
                 if let Err(e) = BatchTaskExecution::try_execute(exec, &mut sender)
                     .instrument(tracing::trace_span!(
-                      "batch_execute",
-                      task_id = ?task_id.task_id,
-                      stage_id = ?task_id.stage_id,
-                      query_id = ?task_id.query_id,
+                        "batch_execute",
+                        task_id = ?task_id.task_id,
+                        stage_id = ?task_id.stage_id,
+                        query_id = ?task_id.query_id,
                     ))
                     .await
                 {

--- a/rust/common/src/array/chrono_array.rs
+++ b/rust/common/src/array/chrono_array.rs
@@ -91,7 +91,7 @@ macro_rules! get_chrono_array {
                 }
             }
 
-             #[derive(Debug)]
+            #[derive(Debug)]
             pub struct $builder {
                 bitmap: BitmapBuilder,
                 data: Vec<$variant_name>

--- a/rust/common/src/array/column_proto_readers.rs
+++ b/rust/common/src/array/column_proto_readers.rs
@@ -88,31 +88,31 @@ fn read_naivedatetime(cursor: &mut Cursor<&[u8]>) -> Result<NaiveDateTimeWrapper
 
 macro_rules! read_one_value_array {
     ($({ $type:ident, $builder:ty }),*) => {
-      paste! {
-        $(
-          pub fn [<read_ $type:lower _array>](array: &ProstArray, cardinality: usize) -> Result<ArrayImpl> {
-            ensure!(
-              array.get_values().len() == 1,
-              "Must have only 1 buffer in a {} array", stringify!($type)
-            );
+        paste! {
+            $(
+            pub fn [<read_ $type:lower _array>](array: &ProstArray, cardinality: usize) -> Result<ArrayImpl> {
+                ensure!(
+                    array.get_values().len() == 1,
+                    "Must have only 1 buffer in a {} array", stringify!($type)
+                );
 
-            let buf = array.get_values()[0].get_body().as_slice();
+                let buf = array.get_values()[0].get_body().as_slice();
 
-            let mut builder = $builder::new(cardinality)?;
-            let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
-            let mut cursor = Cursor::new(buf);
-            for not_null in bitmap.iter() {
-              if not_null {
-                builder.append(Some([<read_ $type:lower>](&mut cursor)?))?;
-              } else {
-                builder.append(None)?;
-              }
+                let mut builder = $builder::new(cardinality)?;
+                let bitmap: Bitmap = array.get_null_bitmap()?.try_into()?;
+                let mut cursor = Cursor::new(buf);
+                for not_null in bitmap.iter() {
+                    if not_null {
+                        builder.append(Some([<read_ $type:lower>](&mut cursor)?))?;
+                    } else {
+                        builder.append(None)?;
+                    }
+                }
+                let arr = builder.finish()?;
+                Ok(arr.into())
             }
-            let arr = builder.finish()?;
-            Ok(arr.into())
-          }
-        )*
-      }
+            )*
+        }
     };
 }
 

--- a/rust/common/src/array/macros.rs
+++ b/rust/common/src/array/macros.rs
@@ -1,7 +1,7 @@
 /// `array` builds an `Array` with `Option`.
 #[macro_export]
 macro_rules! array {
-    ($array:tt, [$( $value:expr ),*]) => {
+    ($array:ident, [$( $value:expr ),*]) => {
         {
             use $crate::array::Array;
             use $crate::array::ArrayBuilder;
@@ -28,7 +28,7 @@ macro_rules! array_nonnull {
                 builder.append(Some(value)).unwrap();
             }
             builder.finish().unwrap()
-          }
+        }
     };
 }
 

--- a/rust/common/src/array/primitive_array.rs
+++ b/rust/common/src/array/primitive_array.rs
@@ -35,38 +35,38 @@ where
 }
 
 macro_rules! impl_primitive_array_item_type {
-  ([], $({ $scalar_type:ty, $variant_type:ident } ),*) => {
-    $(
-      impl PrimitiveArrayItemType for $scalar_type {
-        fn erase_array_type(arr: PrimitiveArray<Self>) -> ArrayImpl {
-          ArrayImpl::$variant_type(arr)
-        }
+    ([], $({ $scalar_type:ty, $variant_type:ident } ),*) => {
+        $(
+        impl PrimitiveArrayItemType for $scalar_type {
+            fn erase_array_type(arr: PrimitiveArray<Self>) -> ArrayImpl {
+                ArrayImpl::$variant_type(arr)
+            }
 
-        fn try_into_array(arr: ArrayImpl) -> Option<PrimitiveArray<Self>> {
-          match arr {
-            ArrayImpl::$variant_type(inner) => Some(inner),
-            _ => None,
-          }
-        }
+            fn try_into_array(arr: ArrayImpl) -> Option<PrimitiveArray<Self>> {
+                match arr {
+                    ArrayImpl::$variant_type(inner) => Some(inner),
+                    _ => None,
+                }
+            }
 
-        fn try_into_array_ref(arr: &ArrayImpl) -> Option<&PrimitiveArray<Self>> {
-          match arr {
-            ArrayImpl::$variant_type(inner) => Some(inner),
-            _ => None,
-          }
-        }
+            fn try_into_array_ref(arr: &ArrayImpl) -> Option<&PrimitiveArray<Self>> {
+                match arr {
+                    ArrayImpl::$variant_type(inner) => Some(inner),
+                    _ => None,
+                }
+            }
 
-        fn array_type() -> ArrayType {
-          ArrayType::$variant_type
-        }
+            fn array_type() -> ArrayType {
+                ArrayType::$variant_type
+            }
 
-        fn create_array_builder(capacity: usize) -> Result<ArrayBuilderImpl> {
-          let array_builder = PrimitiveArrayBuilder::<$scalar_type>::new(capacity)?;
-          Ok(ArrayBuilderImpl::$variant_type(array_builder))
+            fn create_array_builder(capacity: usize) -> Result<ArrayBuilderImpl> {
+                let array_builder = PrimitiveArrayBuilder::<$scalar_type>::new(capacity)?;
+                Ok(ArrayBuilderImpl::$variant_type(array_builder))
+            }
         }
-      }
-    )*
-  };
+        )*
+    };
 }
 
 for_all_native_types! { impl_primitive_array_item_type }

--- a/rust/common/src/expr/expr_unary.rs
+++ b/rust/common/src/expr/expr_unary.rs
@@ -52,50 +52,50 @@ macro_rules! gen_cast_impl {
 }
 
 macro_rules! gen_cast {
-  ($($x:tt, )* ) => {
-    gen_cast_impl! {
-      [$($x),*],
-      { varchar, date, str_to_date},
-      { varchar, timestamp, str_to_timestamp},
-      { varchar, timestampz, str_to_timestampz},
-      { varchar, int16, str_to_i16},
-      { varchar, int32, str_to_i32},
-      { varchar, int64, str_to_i64},
-      { varchar, float32, str_to_real},
-      { varchar, float64, str_to_double},
-      { varchar, decimal, str_to_decimal},
-      { varchar, boolean, str_to_bool},
-      { boolean, varchar, bool_to_str},
-      // TODO: decide whether nullability-cast should be allowed (#2350)
-      { boolean, boolean, |x| Ok(x)},
-      { int16, int32, general_cast },
-      { int16, int64, general_cast },
-      { int16, float32, general_cast },
-      { int16, float64, general_cast },
-      { int16, decimal, general_cast },
-      { int32, int16, general_cast },
-      { int32, int64, general_cast },
-      { int32, float64, general_cast },
-      { int32, decimal, general_cast },
-      { int64, int16, general_cast },
-      { int64, int32, general_cast },
-      { int64, decimal, general_cast },
-      { float32, float64, general_cast },
-      { float32, decimal, general_cast },
-      { float32, int16, to_i16 },
-      { float32, int32, to_i32 },
-      { float32, int64, to_i64 },
-      { float64, decimal, general_cast },
-      { float64, int16, to_i16 },
-      { float64, int32, to_i32 },
-      { float64, int64, to_i64 },
-      { decimal, decimal, dec_to_dec },
-      { decimal, int16, deci_to_i16 },
-      { decimal, int32, deci_to_i32 },
-      { decimal, int64, deci_to_i64 },
-      { date, timestamp, date_to_timestamp }
-    }
-  };
+    ($($x:tt, )* ) => {
+        gen_cast_impl! {
+        [$($x),*],
+        { varchar, date, str_to_date},
+        { varchar, timestamp, str_to_timestamp},
+        { varchar, timestampz, str_to_timestampz},
+        { varchar, int16, str_to_i16},
+        { varchar, int32, str_to_i32},
+        { varchar, int64, str_to_i64},
+        { varchar, float32, str_to_real},
+        { varchar, float64, str_to_double},
+        { varchar, decimal, str_to_decimal},
+        { varchar, boolean, str_to_bool},
+        { boolean, varchar, bool_to_str},
+        // TODO: decide whether nullability-cast should be allowed (#2350)
+        { boolean, boolean, |x| Ok(x)},
+        { int16, int32, general_cast },
+        { int16, int64, general_cast },
+        { int16, float32, general_cast },
+        { int16, float64, general_cast },
+        { int16, decimal, general_cast },
+        { int32, int16, general_cast },
+        { int32, int64, general_cast },
+        { int32, float64, general_cast },
+        { int32, decimal, general_cast },
+        { int64, int16, general_cast },
+        { int64, int32, general_cast },
+        { int64, decimal, general_cast },
+        { float32, float64, general_cast },
+        { float32, decimal, general_cast },
+        { float32, int16, to_i16 },
+        { float32, int32, to_i32 },
+        { float32, int64, to_i64 },
+        { float64, decimal, general_cast },
+        { float64, int16, to_i16 },
+        { float64, int32, to_i32 },
+        { float64, int64, to_i64 },
+        { decimal, decimal, dec_to_dec },
+        { decimal, int16, deci_to_i16 },
+        { decimal, int32, deci_to_i32 },
+        { decimal, int64, deci_to_i64 },
+        { date, timestamp, date_to_timestamp }
+        }
+    };
 }
 
 /// This macro helps to create neg expression.

--- a/rust/common/src/expr/template.rs
+++ b/rust/common/src/expr/template.rs
@@ -183,7 +183,7 @@ macro_rules! gen_expr_bytes {
                         $([<expr_ $arg:lower>], )*
                         return_type,
                         func,
-                         _phantom: std::marker::PhantomData,
+                        _phantom: std::marker::PhantomData,
                     }
                 }
             }

--- a/rust/common/src/test_utils/rand_array.rs
+++ b/rust/common/src/test_utils/rand_array.rs
@@ -143,15 +143,14 @@ mod tests {
     #[test]
     fn test_create_array() {
         macro_rules! gen_rand_array {
-      ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
-        $(
-          {
-            let array = seed_rand_array::<$array>(10, 1024);
-            assert_eq!(10, array.len());
-
-          }
-        )*
-      };
+            ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+            $(
+                {
+                    let array = seed_rand_array::<$array>(10, 1024);
+                    assert_eq!(10, array.len());
+                }
+            )*
+        };
     }
 
         for_all_variants! { gen_rand_array }

--- a/rust/common/src/types/decimal.rs
+++ b/rust/common/src/types/decimal.rs
@@ -52,7 +52,7 @@ macro_rules! impl_from_float {
                 num if num.is_infinite() && num.is_sign_positive() => Some(Decimal::PositiveINF),
                 num if num.is_infinite() && num.is_sign_negative() => Some(Decimal::NegativeINF),
                 num => {
-                  RustDecimal::$from_float(num).map(Decimal::Normalized)
+                    RustDecimal::$from_float(num).map(Decimal::Normalized)
                 },
             }
         })*

--- a/rust/common/src/types/mod.rs
+++ b/rust/common/src/types/mod.rs
@@ -259,42 +259,42 @@ pub trait ScalarRef<'a>:
 /// `{ enum variant name, function suffix name, scalar type, scalar ref type }`
 #[macro_export]
 macro_rules! for_all_scalar_variants {
-  ($macro:tt $(, $x:tt)*) => {
-    $macro! {
-      [$($x),*],
-      { Int16, int16, i16, i16 },
-      { Int32, int32, i32, i32 },
-      { Int64, int64, i64, i64 },
-      { Float32, float32, OrderedF32, OrderedF32 },
-      { Float64, float64, OrderedF64, OrderedF64 },
-      { Utf8, utf8, String, &'scalar str },
-      { Bool, bool, bool, bool },
-      { Decimal, decimal, Decimal, Decimal  },
-      { Interval, interval, IntervalUnit, IntervalUnit },
-      { NaiveDate, naivedate, NaiveDateWrapper, NaiveDateWrapper },
-      { NaiveDateTime, naivedatetime, NaiveDateTimeWrapper, NaiveDateTimeWrapper },
-      { NaiveTime, naivetime, NaiveTimeWrapper, NaiveTimeWrapper },
-      { Struct, struct, StructValue, StructRef<'scalar> }
-    }
-  };
+    ($macro:tt $(, $x:tt)*) => {
+        $macro! {
+            [$($x),*],
+            { Int16, int16, i16, i16 },
+            { Int32, int32, i32, i32 },
+            { Int64, int64, i64, i64 },
+            { Float32, float32, OrderedF32, OrderedF32 },
+            { Float64, float64, OrderedF64, OrderedF64 },
+            { Utf8, utf8, String, &'scalar str },
+            { Bool, bool, bool, bool },
+            { Decimal, decimal, Decimal, Decimal  },
+            { Interval, interval, IntervalUnit, IntervalUnit },
+            { NaiveDate, naivedate, NaiveDateWrapper, NaiveDateWrapper },
+            { NaiveDateTime, naivedatetime, NaiveDateTimeWrapper, NaiveDateTimeWrapper },
+            { NaiveTime, naivetime, NaiveTimeWrapper, NaiveTimeWrapper },
+            { Struct, struct, StructValue, StructRef<'scalar> }
+        }
+    };
 }
 
 /// Define `ScalarImpl` and `ScalarRefImpl` with macro.
 macro_rules! scalar_impl_enum {
-  ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-    /// `ScalarImpl` embeds all possible scalars in the evaluation framework.
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    pub enum ScalarImpl {
-      $( $variant_name($scalar) ),*
-    }
+    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+        /// `ScalarImpl` embeds all possible scalars in the evaluation framework.
+        #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub enum ScalarImpl {
+            $( $variant_name($scalar) ),*
+        }
 
-    /// `ScalarRefImpl` embeds all possible scalar references in the evaluation
-    /// framework.
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
-    pub enum ScalarRefImpl<'scalar> {
-      $( $variant_name($scalar_ref) ),*
-    }
-  };
+        /// `ScalarRefImpl` embeds all possible scalar references in the evaluation
+        /// framework.
+        #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+        pub enum ScalarRefImpl<'scalar> {
+            $( $variant_name($scalar_ref) ),*
+        }
+    };
 }
 
 for_all_scalar_variants! { scalar_impl_enum }
@@ -388,16 +388,16 @@ impl ToOwnedDatum for DatumRef<'_> {
 /// `for_all_native_types` includes all native variants of our scalar types.
 #[macro_export]
 macro_rules! for_all_native_types {
-($macro:tt $(, $x:tt)*) => {
-    $macro! {
-      [$($x),*],
-      { i16, Int16 },
-      { i32, Int32 },
-      { i64, Int64 },
-      { $crate::types::OrderedF32, Float32 },
-      { $crate::types::OrderedF64, Float64 }
-    }
-  };
+    ($macro:tt $(, $x:tt)*) => {
+        $macro! {
+            [$($x),*],
+            { i16, Int16 },
+            { i32, Int32 },
+            { i64, Int64 },
+            { $crate::types::OrderedF32, Float32 },
+            { $crate::types::OrderedF64, Float64 }
+        }
+    };
 }
 
 /// `impl_convert` implements several conversions for `Scalar`.
@@ -406,75 +406,75 @@ macro_rules! for_all_native_types {
 /// * `&ScalarImpl -> &Scalar` with `impl.as_int16()`.
 /// * `ScalarImpl -> Scalar` with `impl.into_int16()`.
 macro_rules! impl_convert {
-  ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-    $(
-      impl From<$scalar> for ScalarImpl {
-        fn from(val: $scalar) -> Self {
-          ScalarImpl::$variant_name(val)
-        }
-      }
-
-      impl TryFrom<ScalarImpl> for $scalar {
-        type Error = RwError;
-
-        fn try_from(val: ScalarImpl) -> Result<Self> {
-          match val {
-            ScalarImpl::$variant_name(scalar) => Ok(scalar),
-            other_scalar => Err(ErrorCode::InternalError(
-              format!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
-            ).into())
-          }
-        }
-      }
-
-      impl <'scalar> From<$scalar_ref> for ScalarRefImpl<'scalar> {
-        fn from(val: $scalar_ref) -> Self {
-          ScalarRefImpl::$variant_name(val)
-        }
-      }
-
-      impl <'scalar> TryFrom<ScalarRefImpl<'scalar>> for $scalar_ref {
-        type Error = RwError;
-
-        fn try_from(val: ScalarRefImpl<'scalar>) -> Result<Self> {
-          match val {
-            ScalarRefImpl::$variant_name(scalar_ref) => Ok(scalar_ref),
-            other_scalar => Err(ErrorCode::InternalError(
-              format!("cannot convert ScalarRefImpl::{} to concrete type", other_scalar.get_ident())
-            ).into())
-          }
-        }
-      }
-
-      paste! {
-        impl ScalarImpl {
-          pub fn [<as_ $suffix_name>](&self) -> &$scalar {
-            match self {
-              Self::$variant_name(ref scalar) => scalar,
-              other_scalar => panic!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
+    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+        $(
+            impl From<$scalar> for ScalarImpl {
+                fn from(val: $scalar) -> Self {
+                    ScalarImpl::$variant_name(val)
+                }
             }
-          }
 
-          pub fn [<into_ $suffix_name>](self) -> $scalar {
-            match self {
-              Self::$variant_name(scalar) => scalar,
-              other_scalar =>  panic!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
-            }
-          }
-        }
+            impl TryFrom<ScalarImpl> for $scalar {
+                type Error = RwError;
 
-        impl <'scalar> ScalarRefImpl<'scalar> {
-          // Note that this conversion consume self.
-          pub fn [<into_ $suffix_name>](self) -> $scalar_ref {
-            match self {
-              Self::$variant_name(inner) => inner,
-              other_scalar => panic!("cannot convert ScalarRefImpl::{} to concrete type", other_scalar.get_ident())
+                fn try_from(val: ScalarImpl) -> Result<Self> {
+                    match val {
+                        ScalarImpl::$variant_name(scalar) => Ok(scalar),
+                        other_scalar => Err(ErrorCode::InternalError(
+                            format!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
+                        ).into())
+                    }
+                }
             }
-          }
+
+            impl <'scalar> From<$scalar_ref> for ScalarRefImpl<'scalar> {
+                fn from(val: $scalar_ref) -> Self {
+                    ScalarRefImpl::$variant_name(val)
+                }
+            }
+
+            impl <'scalar> TryFrom<ScalarRefImpl<'scalar>> for $scalar_ref {
+                type Error = RwError;
+
+                fn try_from(val: ScalarRefImpl<'scalar>) -> Result<Self> {
+                    match val {
+                        ScalarRefImpl::$variant_name(scalar_ref) => Ok(scalar_ref),
+                        other_scalar => Err(ErrorCode::InternalError(
+                            format!("cannot convert ScalarRefImpl::{} to concrete type", other_scalar.get_ident())
+                        ).into())
+                    }
+                }
+            }
+
+        paste! {
+            impl ScalarImpl {
+            pub fn [<as_ $suffix_name>](&self) -> &$scalar {
+                match self {
+                Self::$variant_name(ref scalar) => scalar,
+                other_scalar => panic!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
+                }
+            }
+
+            pub fn [<into_ $suffix_name>](self) -> $scalar {
+                match self {
+                Self::$variant_name(scalar) => scalar,
+                other_scalar =>  panic!("cannot convert ScalarImpl::{} to concrete type", other_scalar.get_ident())
+                }
+            }
+            }
+
+            impl <'scalar> ScalarRefImpl<'scalar> {
+            // Note that this conversion consume self.
+            pub fn [<into_ $suffix_name>](self) -> $scalar_ref {
+                match self {
+                Self::$variant_name(inner) => inner,
+                other_scalar => panic!("cannot convert ScalarRefImpl::{} to concrete type", other_scalar.get_ident())
+                }
+            }
+            }
         }
-      }
-    )*
-  };
+        )*
+    };
 }
 
 for_all_scalar_variants! { impl_convert }
@@ -492,29 +492,29 @@ impl From<f64> for ScalarImpl {
 }
 
 macro_rules! impl_scalar_impl_ref_conversion {
- ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-   impl ScalarImpl {
-     /// Converts [`ScalarImpl`] to [`ScalarRefImpl`]
-     pub fn as_scalar_ref_impl(&self) -> ScalarRefImpl<'_> {
-       match self {
-         $(
-           Self::$variant_name(inner) => ScalarRefImpl::<'_>::$variant_name(inner.as_scalar_ref())
-         ), *
-       }
-     }
-   }
+    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+        impl ScalarImpl {
+            /// Converts [`ScalarImpl`] to [`ScalarRefImpl`]
+            pub fn as_scalar_ref_impl(&self) -> ScalarRefImpl<'_> {
+                match self {
+                    $(
+                        Self::$variant_name(inner) => ScalarRefImpl::<'_>::$variant_name(inner.as_scalar_ref())
+                    ), *
+                }
+            }
+        }
 
-   impl<'a> ScalarRefImpl<'a> {
-     /// Converts [`ScalarRefImpl`] to [`ScalarImpl`]
-     pub fn into_scalar_impl(self) -> ScalarImpl {
-       match self {
-         $(
-           Self::$variant_name(inner) => ScalarImpl::$variant_name(inner.to_owned_scalar())
-         ), *
-       }
-     }
-   }
-};
+        impl<'a> ScalarRefImpl<'a> {
+            /// Converts [`ScalarRefImpl`] to [`ScalarImpl`]
+            pub fn into_scalar_impl(self) -> ScalarImpl {
+                match self {
+                    $(
+                        Self::$variant_name(inner) => ScalarImpl::$variant_name(inner.to_owned_scalar())
+                    ), *
+                }
+            }
+        }
+    };
 }
 
 for_all_scalar_variants! { impl_scalar_impl_ref_conversion }
@@ -525,22 +525,22 @@ for_all_scalar_variants! { impl_scalar_impl_ref_conversion }
 impl std::hash::Hash for ScalarImpl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         macro_rules! impl_all_hash {
-      ([$self:ident], $({ $variant_type:ty, $scalar_type:ident } ),*) => {
-        match $self {
-          $( Self::$scalar_type(inner) => {
-            inner.hash_wrapper(state);
-          }, )*
-          Self::Bool(b) => b.hash(state),
-          Self::Utf8(s) => s.hash(state),
-          Self::Decimal(decimal) => decimal.hash(state),
-          Self::Interval(interval) => interval.hash(state),
-          Self::NaiveDate(naivedate) => naivedate.hash(state),
-          Self::NaiveDateTime(naivedatetime) => naivedatetime.hash(state),
-          Self::NaiveTime(naivetime) => naivetime.hash(state),
-          Self::Struct(v) => v.hash(state),
+            ([$self:ident], $({ $variant_type:ty, $scalar_type:ident } ),*) => {
+                match $self {
+                    $( Self::$scalar_type(inner) => {
+                        inner.hash_wrapper(state);
+                    }, )*
+                    Self::Bool(b) => b.hash(state),
+                    Self::Utf8(s) => s.hash(state),
+                    Self::Decimal(decimal) => decimal.hash(state),
+                    Self::Interval(interval) => interval.hash(state),
+                    Self::NaiveDate(naivedate) => naivedate.hash(state),
+                    Self::NaiveDateTime(naivedatetime) => naivedatetime.hash(state),
+                    Self::NaiveTime(naivetime) => naivetime.hash(state),
+                    Self::Struct(v) => v.hash(state),
+                }
+            };
         }
-      };
-    }
         for_all_native_types! { impl_all_hash, self }
     }
 }
@@ -548,14 +548,14 @@ impl std::hash::Hash for ScalarImpl {
 impl ToString for ScalarImpl {
     fn to_string(&self) -> String {
         macro_rules! impl_to_string {
-      ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-        match self {
-          $( Self::$variant_name(ref inner) => {
-            inner.to_string()
-          }, )*
+            ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match self {
+                    $( Self::$variant_name(ref inner) => {
+                        inner.to_string()
+                    }, )*
+                }
+            }
         }
-      }
-    }
 
         for_all_scalar_variants! { impl_to_string }
     }
@@ -564,14 +564,14 @@ impl ToString for ScalarImpl {
 impl ToString for ScalarRefImpl<'_> {
     fn to_string(&self) -> String {
         macro_rules! impl_to_string {
-      ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-        match self {
-          $( Self::$variant_name(inner) => {
-            inner.to_string()
-          }, )*
+            ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match self {
+                    $( Self::$variant_name(inner) => {
+                        inner.to_string()
+                    }, )*
+                }
+            }
         }
-      }
-    }
 
         for_all_scalar_variants! { impl_to_string }
     }

--- a/rust/common/src/types/scalar_impl.rs
+++ b/rust/common/src/types/scalar_impl.rs
@@ -12,29 +12,29 @@ pub trait ScalarPartialOrd: Scalar {
 /// Implement `Scalar` and `ScalarRef` for native type.
 /// For `PrimitiveArrayItemType`, clone is trivial, so `T` is both `Scalar` and `ScalarRef`.
 macro_rules! impl_all_native_scalar {
-  ([], $({ $scalar_type:ty, $variant_name:ident } ),*) => {
-    $(
-      impl Scalar for $scalar_type {
-        type ScalarRefType<'a> = Self;
+    ([], $({ $scalar_type:ty, $variant_name:ident } ),*) => {
+        $(
+            impl Scalar for $scalar_type {
+                type ScalarRefType<'a> = Self;
 
-        fn as_scalar_ref(&self) -> Self {
-          *self
-        }
+                fn as_scalar_ref(&self) -> Self {
+                    *self
+                }
 
-        fn to_scalar_value(self) -> ScalarImpl {
-          ScalarImpl::$variant_name(self)
-        }
-      }
+                fn to_scalar_value(self) -> ScalarImpl {
+                    ScalarImpl::$variant_name(self)
+                }
+            }
 
-      impl<'scalar> ScalarRef<'scalar> for $scalar_type {
-        type ScalarType = Self;
+            impl<'scalar> ScalarRef<'scalar> for $scalar_type {
+                type ScalarType = Self;
 
-        fn to_owned_scalar(&self) -> Self {
-          *self
-        }
-      }
-    )*
-  };
+                fn to_owned_scalar(&self) -> Self {
+                    *self
+                }
+            }
+        )*
+    };
 }
 
 for_all_native_types! { impl_all_native_scalar }
@@ -274,12 +274,12 @@ impl<'a> ScalarRef<'a> for StructRef<'a> {
 impl ScalarImpl {
     pub fn get_ident(&self) -> &'static str {
         macro_rules! impl_all_get_ident {
-      ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-        match $self {
-          $( Self::$variant_name(_) => stringify!($variant_name), )*
+            ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match $self {
+                    $( Self::$variant_name(_) => stringify!($variant_name), )*
+                }
+            };
         }
-      };
-    }
         for_all_scalar_variants! { impl_all_get_ident, self }
     }
 }
@@ -287,12 +287,12 @@ impl ScalarImpl {
 impl<'scalar> ScalarRefImpl<'scalar> {
     pub fn get_ident(&self) -> &'static str {
         macro_rules! impl_all_get_ident {
-      ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-        match $self {
-          $( Self::$variant_name(_) => stringify!($variant_name), )*
+            ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match $self {
+                    $( Self::$variant_name(_) => stringify!($variant_name), )*
+                }
+            };
         }
-      };
-    }
         for_all_scalar_variants! { impl_all_get_ident, self }
     }
 }

--- a/rust/common/src/util/chunk_coalesce.rs
+++ b/rust/common/src/util/chunk_coalesce.rs
@@ -239,11 +239,11 @@ mod tests {
         // Append a chunk with 2 rows
         let input = {
             let column1 = column! {
-              I32Array, [Some(3), None]
+                I32Array, [Some(3), None]
             };
 
             let column2 = column! {
-              I64Array, [None, Some(7i64)]
+                I64Array, [None, Some(7i64)]
             };
 
             let chunk =

--- a/rust/common/src/util/try_match.rs
+++ b/rust/common/src/util/try_match.rs
@@ -1,23 +1,23 @@
 #[macro_export]
 macro_rules! try_match_expand {
-  ($e:expr, $variant:path) => {
-    match $e {
-      $variant(internal) => Ok(internal),
-      _ => Err($crate::error::RwError::from(
-        $crate::error::ErrorCode::InternalError(format!(
-          "unable to match {} with {}",
-          stringify!($e),
-          stringify!($variant),
-        )),
-      )),
-    }
-  };
-  ($e:expr, $variant:path, $($arg:tt)+) => {
-    match $e {
-      $variant(internal) => Ok(internal),
-      _ => Err($crate::error::RwError::from($crate::error::ErrorCode::InternalError(format!($($arg)+)))),
-    }
-  };
+    ($e:expr, $variant:path) => {
+        match $e {
+            $variant(internal) => Ok(internal),
+            _ => Err($crate::error::RwError::from(
+                $crate::error::ErrorCode::InternalError(format!(
+                    "unable to match {} with {}",
+                    stringify!($e),
+                    stringify!($variant),
+                )),
+            )),
+        }
+    };
+    ($e:expr, $variant:path, $($arg:tt)+) => {
+        match $e {
+            $variant(internal) => Ok(internal),
+            _ => Err($crate::error::RwError::from($crate::error::ErrorCode::InternalError(format!($($arg)+)))),
+        }
+    };
 }
 
 mod tests {

--- a/rust/common/src/vector_op/agg/aggregator.rs
+++ b/rust/common/src/vector_op/agg/aggregator.rs
@@ -117,40 +117,40 @@ pub fn create_agg_state_unary(
     use crate::expr::data_types::*;
 
     macro_rules! gen_arms {
-      [$(($agg:ident, $fn:expr, $in:tt, $ret:tt)),* $(,)?] => {
-      match (
-        input_type,
-        agg_type,
-        return_type.clone(),
-        distinct,
-      ) {
-        $(
-        ($in! { type_match_pattern }, AggKind::$agg, $ret! { type_match_pattern }, false) => {
-          Box::new(GeneralAgg::<$in! { type_array }, _, $ret! { type_array }>::new(
-            return_type,
-            input_col_idx,
-            $fn,
-          ))
-        },
-        ($in! { type_match_pattern }, AggKind::$agg, $ret! { type_match_pattern }, true) => {
-          Box::new(GeneralDistinctAgg::<$in! { type_array }, _, $ret! { type_array }>::new(
-            return_type,
-            input_col_idx,
-            $fn,
-          ))
-        },
-        )*
-        (unimpl_input, unimpl_agg, unimpl_ret, distinct) => {
-          return Err(
-            ErrorCode::InternalError(format!(
-              "unsupported aggregator: type={:?} input={:?} output={:?} distinct={}",
-              unimpl_agg, unimpl_input, unimpl_ret, distinct
-            ))
-            .into(),
-          )
-        }
-      }
-    };
+        [$(($agg:ident, $fn:expr, $in:tt, $ret:tt)),* $(,)?] => {
+            match (
+                input_type,
+                agg_type,
+                return_type.clone(),
+                distinct,
+            ) {
+                $(
+                    ($in! { type_match_pattern }, AggKind::$agg, $ret! { type_match_pattern }, false) => {
+                        Box::new(GeneralAgg::<$in! { type_array }, _, $ret! { type_array }>::new(
+                            return_type,
+                            input_col_idx,
+                            $fn,
+                        ))
+                    },
+                    ($in! { type_match_pattern }, AggKind::$agg, $ret! { type_match_pattern }, true) => {
+                        Box::new(GeneralDistinctAgg::<$in! { type_array }, _, $ret! { type_array }>::new(
+                            return_type,
+                            input_col_idx,
+                            $fn,
+                        ))
+                    },
+                )*
+                (unimpl_input, unimpl_agg, unimpl_ret, distinct) => {
+                    return Err(
+                        ErrorCode::InternalError(format!(
+                        "unsupported aggregator: type={:?} input={:?} output={:?} distinct={}",
+                        unimpl_agg, unimpl_input, unimpl_ret, distinct
+                        ))
+                        .into(),
+                    )
+                }
+            }
+        };
     }
 
     let state: Box<dyn Aggregator> = gen_arms![

--- a/rust/compute/src/server.rs
+++ b/rust/compute/src/server.rs
@@ -108,8 +108,8 @@ pub async fn compute_node_serve(
             .add_service(StreamServiceServer::new(stream_srv))
             .serve_with_shutdown(addr, async move {
                 tokio::select! {
-                  _ = tokio::signal::ctrl_c() => {},
-                  _ = shutdown_recv.recv() => {
+                    _ = tokio::signal::ctrl_c() => {},
+                    _ = shutdown_recv.recv() => {
                         // Gracefully shutdown compactor
                         if let Some((compactor_join_handle, compactor_shutdown_sender)) = compactor_handle {
                             if compactor_shutdown_sender.send(()).is_ok() {

--- a/rust/connector/src/pulsar/topic.rs
+++ b/rust/connector/src/pulsar/topic.rs
@@ -97,9 +97,9 @@ pub fn parse_topic(topic: &str) -> Result<ParsedTopic> {
         PERSISTENT_DOMAIN | NON_PERSISTENT_DOMAIN => parts[0],
         _ => {
             return Err(RwError::from(InternalError(format!(
-      "The domain only can be specified as 'persistent' or 'non-persistent'. Input domain is '{}'",
-      parts[0]
-    ))))
+                "The domain only can be specified as 'persistent' or 'non-persistent'. Input domain is '{}'",
+                parts[0]
+            ))))
         }
     };
 

--- a/rust/frontend/src/expr/type_inference.rs
+++ b/rust/frontend/src/expr/type_inference.rs
@@ -227,9 +227,9 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
     map
 }
 lazy_static::lazy_static! {
-  static ref FUNC_SIG_MAP: HashMap<FuncSign, DataTypeName> = {
-    build_type_derive_map()
-  };
+    static ref FUNC_SIG_MAP: HashMap<FuncSign, DataTypeName> = {
+        build_type_derive_map()
+    };
 }
 #[cfg(test)]
 mod tests {

--- a/rust/frontend/src/handler/create_source.rs
+++ b/rust/frontend/src/handler/create_source.rs
@@ -74,10 +74,10 @@ mod tests {
     syntax = "proto3";
     package test;
     message TestRecord {
-      int32 id = 1;
-      string city = 3;
-      int64 zipcode = 4;
-      float rate = 5;
+        int32 id = 1;
+        string city = 3;
+        int64 zipcode = 4;
+        float rate = 5;
     }"#;
         let temp_file = tempfile::Builder::new()
             .prefix("temp")

--- a/rust/frontend/src/optimizer/plan_node/col_pruning.rs
+++ b/rust/frontend/src/optimizer/plan_node/col_pruning.rs
@@ -23,15 +23,15 @@ pub trait ColPrunable {
 
 /// impl ColPrunable for batch and streaming node.
 macro_rules! ban_prune_col {
-  ([], $( { $convention:ident, $name:ident }),*) => {
-    paste!{
-      $(impl ColPrunable for [<$convention $name>] {
-        fn prune_col(&self, _required_cols: &FixedBitSet) -> PlanRef {
-          panic!("column pruning is only allowed on logical plan")
+    ([], $( { $convention:ident, $name:ident }),*) => {
+        paste!{
+            $(impl ColPrunable for [<$convention $name>] {
+                fn prune_col(&self, _required_cols: &FixedBitSet) -> PlanRef {
+                    panic!("column pruning is only allowed on logical plan")
+                }
+            })*
         }
-     })*
     }
-  }
 }
 for_batch_plan_nodes! { ban_prune_col }
 for_stream_plan_nodes! { ban_prune_col }

--- a/rust/frontend/src/optimizer/plan_node/convert.rs
+++ b/rust/frontend/src/optimizer/plan_node/convert.rs
@@ -72,45 +72,45 @@ pub trait ToDistributedBatch {
 
 /// impl ToBatch for batch and streaming node.
 macro_rules! ban_to_batch {
-  ([], $( { $convention:ident, $name:ident }),*) => {
-    paste!{
-      $(impl ToBatch for [<$convention $name>] {
-        fn to_batch(&self) -> PlanRef {
-          panic!("convert into batch is only allowed on logical plan")
+    ([], $( { $convention:ident, $name:ident }),*) => {
+        paste!{
+            $(impl ToBatch for [<$convention $name>] {
+                fn to_batch(&self) -> PlanRef {
+                    panic!("convert into batch is only allowed on logical plan")
+                }
+            })*
         }
-     })*
     }
-  }
 }
 for_batch_plan_nodes! { ban_to_batch }
 for_stream_plan_nodes! { ban_to_batch }
 
 /// impl ToStream for batch and streaming node.
 macro_rules! ban_to_stream {
-  ([], $( { $convention:ident, $name:ident }),*) => {
-    paste!{
-      $(impl ToStream for [<$convention $name>] {
-        fn to_stream(&self) -> PlanRef {
-          panic!("convert into stream is only allowed on logical plan")
+    ([], $( { $convention:ident, $name:ident }),*) => {
+        paste!{
+            $(impl ToStream for [<$convention $name>] {
+                fn to_stream(&self) -> PlanRef {
+                    panic!("convert into stream is only allowed on logical plan")
+                }
+            })*
         }
-     })*
     }
-  }
 }
 for_batch_plan_nodes! { ban_to_stream }
 for_stream_plan_nodes! { ban_to_stream }
 
 /// impl ToDistributedBatch  for logical and streaming node.
 macro_rules! ban_to_distributed {
-  ([], $( { $convention:ident, $name:ident }),*) => {
-    paste!{
-      $(impl ToDistributedBatch for [<$convention $name>] {
-        fn to_distributed(&self) -> PlanRef {
-          panic!("convert into distributed is only allowed on batch plan")
+    ([], $( { $convention:ident, $name:ident }),*) => {
+        paste!{
+            $(impl ToDistributedBatch for [<$convention $name>] {
+                fn to_distributed(&self) -> PlanRef {
+                    panic!("convert into distributed is only allowed on batch plan")
+                }
+            })*
         }
-     })*
     }
-  }
 }
 for_logical_plan_nodes! { ban_to_distributed }
 for_stream_plan_nodes! { ban_to_distributed }

--- a/rust/frontend/src/optimizer/plan_node/mod.rs
+++ b/rust/frontend/src/optimizer/plan_node/mod.rs
@@ -206,32 +206,32 @@ pub use stream_table_source::StreamTableSource;
 /// See the following implementations for example.
 #[macro_export]
 macro_rules! for_all_plan_nodes {
-    ($macro:tt $(, $x:tt)*) => {
-      $macro! {
-          [$($x),*]
-          ,{ Logical, Agg }
-          ,{ Logical, Filter }
-          ,{ Logical, Project }
-          ,{ Logical, Scan }
-          ,{ Logical, Insert }
-          ,{ Logical, Join }
-          ,{ Logical, Values }
-          ,{ Logical, Limit }
-          ,{ Logical, TopN }
-          // ,{ Logical, Sort } we don't need a LogicalSort, just require the Order
-          ,{ Batch, Project }
-          ,{ Batch, SeqScan }
-          ,{ Batch, HashJoin }
-          ,{ Batch, SortMergeJoin }
-          ,{ Batch, Sort }
-          ,{ Batch, Exchange }
-          ,{ Batch, Limit }
-          ,{ Stream, Project }
-          ,{ Stream, TableSource }
-          ,{ Stream, HashJoin }
-          ,{ Stream, Exchange }
-      }
-  };
+    ($macro:ident $(, $x:tt)*) => {
+        $macro! {
+            [$($x),*]
+            ,{ Logical, Agg }
+            ,{ Logical, Filter }
+            ,{ Logical, Project }
+            ,{ Logical, Scan }
+            ,{ Logical, Insert }
+            ,{ Logical, Join }
+            ,{ Logical, Values }
+            ,{ Logical, Limit }
+            ,{ Logical, TopN }
+            // ,{ Logical, Sort } we don't need a LogicalSort, just require the Order
+            ,{ Batch, Project }
+            ,{ Batch, SeqScan }
+            ,{ Batch, HashJoin }
+            ,{ Batch, SortMergeJoin }
+            ,{ Batch, Sort }
+            ,{ Batch, Exchange }
+            ,{ Batch, Limit }
+            ,{ Stream, Project }
+            ,{ Stream, TableSource }
+            ,{ Stream, HashJoin }
+            ,{ Stream, Exchange }
+        }
+    };
 }
 /// `for_logical_plan_nodes` includes all plan nodes with logical convention.
 #[macro_export]
@@ -287,22 +287,21 @@ macro_rules! for_stream_plan_nodes {
 
 /// impl PlanNodeType fn for each node.
 macro_rules! enum_plan_node_type {
-  ([], $( { $convention:ident, $name:ident }),*) => {
-    paste!{
+    ([], $( { $convention:ident, $name:ident }),*) => {
+        paste!{
+            /// each enum value represent a PlanNode struct type, help us to dispatch and downcast
+            #[derive(PartialEq, Debug)]
+            pub enum PlanNodeType{
+                $( [<$convention $name>] ),*
+            }
 
-      /// each enum value represent a PlanNode struct type, help us to dispatch and downcast
-      #[derive(PartialEq, Debug)]
-      pub enum PlanNodeType{
-        $( [<$convention $name>] ),*
-      }
-
-      $(impl PlanNode for [<$convention $name>] {
-          fn node_type(&self) -> PlanNodeType{
-            PlanNodeType::[<$convention $name>]
-          }
-        })*
+            $(impl PlanNode for [<$convention $name>] {
+                fn node_type(&self) -> PlanNodeType{
+                    PlanNodeType::[<$convention $name>]
+                }
+            })*
+        }
     }
-  }
 }
 for_all_plan_nodes! { enum_plan_node_type }
 

--- a/rust/frontend/src/optimizer/plan_node/to_prost.rs
+++ b/rust/frontend/src/optimizer/plan_node/to_prost.rs
@@ -24,22 +24,22 @@ pub trait ToStreamProst {
 /// impl `ToProst` nodes which have impl `ToBatchProst` and `ToStreamProst`.
 macro_rules! impl_to_prost {
     ([], $( { $convention:ident, $name:ident }),*) => {
-      paste!{
-        $(impl ToProst for [<$convention $name>] { })*
-      }
+        paste!{
+            $(impl ToProst for [<$convention $name>] { })*
+        }
     }
 }
 for_all_plan_nodes! { impl_to_prost }
 /// impl a panic `ToBatchProst` for logical and stream node.
 macro_rules! ban_to_batch_prost {
     ([], $( { $convention:ident, $name:ident }),*) => {
-      paste!{
-        $(impl ToBatchProst for [<$convention $name>] {
-            fn to_batch_prost_body(&self) -> pb_batch_node::NodeBody {
-                panic!("convert into distributed is only allowed on batch plan")
-            }
-       })*
-      }
+        paste!{
+            $(impl ToBatchProst for [<$convention $name>] {
+                fn to_batch_prost_body(&self) -> pb_batch_node::NodeBody {
+                    panic!("convert into distributed is only allowed on batch plan")
+                }
+            })*
+        }
     }
 }
 for_logical_plan_nodes! { ban_to_batch_prost }
@@ -47,14 +47,14 @@ for_stream_plan_nodes! { ban_to_batch_prost }
 /// impl a panic `ToStreamProst` for logical and batch node.
 macro_rules! ban_to_stream_prost {
     ([], $( { $convention:ident, $name:ident }),*) => {
-      paste!{
-        $(impl ToStreamProst for [<$convention $name>] {
-            fn to_stream_prost_body(&self) -> pb_stream_node::Node {
-                panic!("convert into distributed is only allowed on stream plan")
-            }
-       })*
-      }
+        paste!{
+            $(impl ToStreamProst for [<$convention $name>] {
+                fn to_stream_prost_body(&self) -> pb_stream_node::Node {
+                    panic!("convert into distributed is only allowed on stream plan")
+                }
+            })*
+        }
     }
-  }
+}
 for_logical_plan_nodes! { ban_to_stream_prost }
 for_batch_plan_nodes! { ban_to_stream_prost }

--- a/rust/meta/src/dashboard/mod.rs
+++ b/rust/meta/src/dashboard/mod.rs
@@ -54,8 +54,8 @@ mod handlers {
     impl IntoResponse for DashboardError {
         fn into_response(self) -> axum::response::Response {
             let mut resp = Json(json!({
-              "error": format!("{}", self.0),
-              "info":  format!("{:?}", self.0),
+                "error": format!("{}", self.0),
+                "info":  format!("{:?}", self.0),
             }))
             .into_response();
             *resp.status_mut() = StatusCode::INTERNAL_SERVER_ERROR;

--- a/rust/meta/src/rpc/server.rs
+++ b/rust/meta/src/rpc/server.rs
@@ -103,8 +103,8 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             meta_store_ref: env.meta_store_ref(),
             has_test_data: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         };
-        tokio::spawn(dashboard_service.serve()); // TODO: join dashboard service back to local
-                                                 // thread
+        // TODO: join dashboard service back to local thread.
+        tokio::spawn(dashboard_service.serve());
     }
     let barrier_manager_ref = Arc::new(BarrierManager::new(
         env.clone(),
@@ -171,8 +171,8 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
                 tokio_stream::wrappers::TcpListenerStream::new(listener),
                 async move {
                     tokio::select! {
-                      _ = tokio::signal::ctrl_c() => {},
-                      _ = shutdown_recv.recv() => {
+                        _ = tokio::signal::ctrl_c() => {},
+                        _ = shutdown_recv.recv() => {
                             if compaction_shutdown_sender.send(()).is_ok() {
                                 compaction_join_handle.await.unwrap();
                             }

--- a/rust/risedev/src/task/compute_node_service.rs
+++ b/rust/risedev/src/task/compute_node_service.rs
@@ -69,13 +69,13 @@ impl Task for ComputeNodeService {
             1 => {
                 let minio = &provide_minio[0];
                 cmd.arg("--state-store").arg(format!(
-          "hummock+minio://{hummock_user}:{hummock_password}@{minio_addr}:{minio_port}/{hummock_bucket}",
-          hummock_user = minio.hummock_user,
-          hummock_password = minio.hummock_password,
-          hummock_bucket = minio.hummock_bucket,
-          minio_addr = minio.address,
-          minio_port = minio.port,
-        ));
+                    "hummock+minio://{hummock_user}:{hummock_password}@{minio_addr}:{minio_port}/{hummock_bucket}",
+                    hummock_user = minio.hummock_user,
+                    hummock_password = minio.hummock_password,
+                    hummock_bucket = minio.hummock_bucket,
+                    minio_addr = minio.address,
+                    minio_port = minio.port,
+                ));
             }
             other_size => {
                 return Err(anyhow!(
@@ -99,9 +99,9 @@ impl Task for ComputeNodeService {
             }
             other_size => {
                 return Err(anyhow!(
-          "Cannot start node: {} meta nodes found in this configuration, but only 1 is needed.",
-          other_size
-        ));
+                    "Cannot start node: {} meta nodes found in this configuration, but only 1 is needed.",
+                    other_size
+                ));
             }
         };
 

--- a/rust/risedev/src/task/frontend_service_v2.rs
+++ b/rust/risedev/src/task/frontend_service_v2.rs
@@ -51,9 +51,9 @@ impl Task for FrontendServiceV2 {
             }
             other_size => {
                 return Err(anyhow!(
-          "Cannot start node: {} meta nodes found in this configuration, but only 1 is needed.",
-          other_size
-        ));
+                    "Cannot start node: {} meta nodes found in this configuration, but only 1 is needed.",
+                    other_size
+                ));
             }
         };
 

--- a/rust/storage/src/hummock/sstable/builder.rs
+++ b/rust/storage/src/hummock/sstable/builder.rs
@@ -228,14 +228,14 @@ impl SSTableBuilder {
     /// Returns true if we roughly reached capacity
     pub fn reach_capacity(&self) -> bool {
         let block_size = self.data_buf.len() as u32 + // actual length of current buffer
-                                 self.entry_offsets.len() as u32 * 4 + // all entry offsets size
-                                 4 + // count of all entry offsets
-                                 8 + // checksum bytes
-                                 4; // checksum length
+            self.entry_offsets.len() as u32 * 4 + // all entry offsets size
+            4 + // count of all entry offsets
+            8 + // checksum bytes
+            4; // checksum length
 
         let estimated_size = block_size +
-                                  4 + // index length
-                                  5 * self.meta.block_metas.len() as u32; // TODO: why 5?
+            4 + // index length
+            5 * self.meta.block_metas.len() as u32; // TODO: why 5?
         estimated_size as u32 > self.options.table_capacity
     }
 

--- a/rust/storage/src/monitor/state_store_stats.rs
+++ b/rust/storage/src/monitor/state_store_stats.rs
@@ -105,8 +105,8 @@ macro_rules! define_state_store_stats {
 for_all_metrics! { define_state_store_stats }
 
 lazy_static::lazy_static! {
-  pub static ref
-  DEFAULT_STATE_STORE_STATS: Arc<StateStoreStats> = Arc::new(StateStoreStats::new(prometheus::default_registry()));
+    pub static ref
+        DEFAULT_STATE_STORE_STATS: Arc<StateStoreStats> = Arc::new(StateStoreStats::new(prometheus::default_registry()));
 }
 
 impl StateStoreStats {

--- a/rust/stream/src/executor/aggregation/row_count.rs
+++ b/rust/stream/src/executor/aggregation/row_count.rs
@@ -31,9 +31,9 @@ impl StreamingRowCountAgg {
                     row_cnt = num;
                 }
                 other => panic!(
-          "type mismatch in streaming aggregator StreamingRowCountAgg init: expected i64, get {}",
-          other.get_ident()
-        ),
+                    "type mismatch in streaming aggregator StreamingRowCountAgg init: expected i64, get {}",
+                    other.get_ident()
+                ),
             }
         }
         Self { row_cnt }

--- a/rust/stream/src/executor/barrier_align.rs
+++ b/rust/stream/src/executor/barrier_align.rs
@@ -44,16 +44,16 @@ impl BarrierAligner {
     pub fn new(mut input_l: Box<dyn Executor>, mut input_r: Box<dyn Executor>) -> Self {
         // Wrap the input executors into streams to ensure cancellation-safety
         let input_l = try_stream! {
-          loop {
-            let message = input_l.next().await?;
-            yield message;
-          }
+            loop {
+                let message = input_l.next().await?;
+                yield message;
+            }
         };
         let input_r = try_stream! {
-          loop {
-            let message = input_r.next().await?;
-            yield message;
-          }
+            loop {
+                let message = input_r.next().await?;
+                yield message;
+            }
         };
         Self {
             input_l: Box::pin(input_l),
@@ -65,44 +65,44 @@ impl BarrierAligner {
     pub async fn next(&mut self) -> AlignedMessage {
         loop {
             select! {
-              message = self.input_l.next(), if self.state != BarrierWaitState::Right => {
+                message = self.input_l.next(), if self.state != BarrierWaitState::Right => {
                 match message.unwrap() {
-                  Ok(message) => match message {
-                    Message::Chunk(chunk) => break AlignedMessage::Left(Ok(chunk)),
-                    Message::Barrier(barrier) => {
-                      match self.state {
-                        BarrierWaitState::Left => {
-                          self.state = BarrierWaitState::Either;
-                          break AlignedMessage::Barrier(barrier);
-                        }
-                        BarrierWaitState::Either => {
-                          self.state = BarrierWaitState::Right;
-                        }
-                        _ => unreachable!("Should not reach this barrier state: {:?}", self.state),
-                      };
-                    },
-                  },
-                  Err(e) => break AlignedMessage::Left(Err(e)),
+                    Ok(message) => match message {
+                        Message::Chunk(chunk) => break AlignedMessage::Left(Ok(chunk)),
+                            Message::Barrier(barrier) => {
+                                match self.state {
+                                    BarrierWaitState::Left => {
+                                        self.state = BarrierWaitState::Either;
+                                        break AlignedMessage::Barrier(barrier);
+                                    }
+                                    BarrierWaitState::Either => {
+                                        self.state = BarrierWaitState::Right;
+                                    }
+                                    _ => unreachable!("Should not reach this barrier state: {:?}", self.state),
+                                };
+                            },
+                        },
+                        Err(e) => break AlignedMessage::Left(Err(e)),
+                    }
+                },
+                message = self.input_r.next(), if self.state != BarrierWaitState::Left => {
+                    match message.unwrap() {
+                        Ok(message) => match message {
+                            Message::Chunk(chunk) => break AlignedMessage::Right(Ok(chunk)),
+                            Message::Barrier(barrier) => match self.state {
+                                BarrierWaitState::Right => {
+                                    self.state = BarrierWaitState::Either;
+                                    break AlignedMessage::Barrier(barrier);
+                                }
+                                BarrierWaitState::Either => {
+                                    self.state = BarrierWaitState::Left;
+                                }
+                                _ => unreachable!("Should not reach this barrier state: {:?}", self.state),
+                            },
+                        },
+                        Err(e) => break AlignedMessage::Right(Err(e)),
+                    }
                 }
-              },
-              message = self.input_r.next(), if self.state != BarrierWaitState::Left => {
-                match message.unwrap() {
-                  Ok(message) => match message {
-                    Message::Chunk(chunk) => break AlignedMessage::Right(Ok(chunk)),
-                    Message::Barrier(barrier) => match self.state {
-                      BarrierWaitState::Right => {
-                        self.state = BarrierWaitState::Either;
-                        break AlignedMessage::Barrier(barrier);
-                      }
-                      BarrierWaitState::Either => {
-                        self.state = BarrierWaitState::Left;
-                      }
-                      _ => unreachable!("Should not reach this barrier state: {:?}", self.state),
-                    },
-                  },
-                  Err(e) => break AlignedMessage::Right(Err(e)),
-                }
-              }
             }
         }
     }

--- a/rust/stream/src/executor/debug/epoch_check.rs
+++ b/rust/stream/src/executor/debug/epoch_check.rs
@@ -37,12 +37,12 @@ impl super::DebugExecutor for EpochCheckExecutor {
 
             if stale {
                 panic!(
-          "epoch check failed on {}: last epoch is {:?}, while the epoch of incoming barrier is {}.\nstale barrier: {:?}",
-          self.input.identity(),
-          self.last_epoch,
-          new_epoch,
-          b
-        );
+                    "epoch check failed on {}: last epoch is {:?}, while the epoch of incoming barrier is {}.\nstale barrier: {:?}",
+                    self.input.identity(),
+                    self.last_epoch,
+                    new_epoch,
+                    b
+                );
             }
             self.last_epoch = Some(new_epoch);
         }

--- a/rust/stream/src/executor/managed_state/flush_status.rs
+++ b/rust/stream/src/executor/managed_state/flush_status.rs
@@ -2,12 +2,12 @@ use std::collections::{btree_map, hash_map};
 
 macro_rules! impl_flush_status {
     ([], $( { $entry_type:ty, $struct_name:ident } ),*) => {
-         /// Represents an entry in the `flush_buffer`. No `FlushStatus` associated with a key means no-op.
-         ///
-         /// ```plain
-         /// No-op --(insert)-> Insert --(delete)-> No-op
-         ///        \------(delete)-> Delete --(insert)-> DeleteInsert --(delete)-> Delete
-         /// ```
+        /// Represents an entry in the `flush_buffer`. No `FlushStatus` associated with a key means no-op.
+        ///
+        /// ```plain
+        /// No-op --(insert)-> Insert --(delete)-> No-op
+        ///        \------(delete)-> Delete --(insert)-> DeleteInsert --(delete)-> Delete
+        /// ```
         $(
             pub enum $struct_name<T> {
                 /// The entry will be deleted.

--- a/rust/stream/src/executor/merge.rs
+++ b/rust/stream/src/executor/merge.rs
@@ -394,20 +394,20 @@ mod tests {
             // expect n chunks
             for _ in 0..CHANNEL_NUMBER {
                 assert_matches!(merger.next().await.unwrap(), Message::Chunk(chunk) => {
-                  assert_eq!(chunk.ops().len() as u64, epoch);
+                    assert_eq!(chunk.ops().len() as u64, epoch);
                 });
             }
             // expect a barrier
             assert_matches!(merger.next().await.unwrap(), Message::Barrier(Barrier{epoch:barrier_epoch,mutation:_,..}) => {
-              assert_eq!(barrier_epoch.curr, epoch);
+                assert_eq!(barrier_epoch.curr, epoch);
             });
         }
         assert_matches!(
-          merger.next().await.unwrap(),
-          Message::Barrier(Barrier {
-            mutation,
-            ..
-          }) if mutation.as_deref().unwrap().is_stop()
+            merger.next().await.unwrap(),
+            Message::Barrier(Barrier {
+                mutation,
+                ..
+            }) if mutation.as_deref().unwrap().is_stop()
         );
 
         for handle in handles {
@@ -498,13 +498,13 @@ mod tests {
             remote_input.run().await
         });
         assert_matches!(rx.next().await.unwrap(), Message::Chunk(chunk) => {
-          let (ops, columns, visibility) = chunk.into_inner();
-          assert_eq!(ops.len() as u64, 0);
-          assert_eq!(columns.len() as u64, 0);
-          assert_eq!(visibility, None);
+            let (ops, columns, visibility) = chunk.into_inner();
+            assert_eq!(ops.len() as u64, 0);
+            assert_eq!(columns.len() as u64, 0);
+            assert_eq!(visibility, None);
         });
         assert_matches!(rx.next().await.unwrap(), Message::Barrier(Barrier { epoch: barrier_epoch, mutation: _, .. }) => {
-          assert_eq!(barrier_epoch.curr, 12345);
+            assert_eq!(barrier_epoch.curr, 12345);
         });
         assert!(rpc_called.load(Ordering::SeqCst));
         input_handle.await.unwrap();

--- a/rust/stream/src/executor/mod.rs
+++ b/rust/stream/src/executor/mod.rs
@@ -281,11 +281,11 @@ impl Message {
     /// will not continue, false otherwise.
     pub fn is_terminate(&self) -> bool {
         matches!(
-          self,
-          Message::Barrier(Barrier {
-            mutation,
-            ..
-          }) if mutation.as_deref().unwrap().is_stop()
+            self,
+            Message::Barrier(Barrier {
+                mutation,
+                ..
+            }) if mutation.as_deref().unwrap().is_stop()
         )
     }
 
@@ -443,10 +443,10 @@ macro_rules! build_executor {
                 },
             )*
             _ => Err(RwError::from(
-              ErrorCode::InternalError(format!(
-                "unsupported node:{:?}",
-                $node.get_node().unwrap()
-              )),
+                ErrorCode::InternalError(format!(
+                    "unsupported node:{:?}",
+                    $node.get_node().unwrap()
+                )),
             )),
         }
     }

--- a/rust/stream/src/executor/monitor/compute_stats.rs
+++ b/rust/stream/src/executor/monitor/compute_stats.rs
@@ -6,8 +6,8 @@ pub struct ComputeStats {
 }
 
 lazy_static::lazy_static! {
-  pub static ref
-  DEFAULT_COMPUTE_STATS: Arc<ComputeStats> = Arc::new(ComputeStats::new());
+    pub static ref
+        DEFAULT_COMPUTE_STATS: Arc<ComputeStats> = Arc::new(ComputeStats::new());
 }
 
 impl Default for ComputeStats {
@@ -15,6 +15,7 @@ impl Default for ComputeStats {
         Self::new()
     }
 }
+
 impl ComputeStats {
     pub fn new() -> Self {
         let prometheus_exporter = opentelemetry_prometheus::exporter()

--- a/rust/stream/src/task/tests.rs
+++ b/rust/stream/src/task/tests.rs
@@ -238,12 +238,12 @@ async fn test_stream_proto() {
         }
         let barrier_epoch = Epoch::new_test_epoch(114514);
         assert!(matches!(
-          sink.next().await.unwrap(),
-          Message::Barrier(Barrier {
-            epoch,
-            mutation,
-            ..
-          }) if mutation.as_deref().unwrap().is_stop() && epoch == barrier_epoch
+            sink.next().await.unwrap(),
+            Message::Barrier(Barrier {
+                epoch,
+                mutation,
+                ..
+            }) if mutation.as_deref().unwrap().is_stop() && epoch == barrier_epoch
         ));
     });
 

--- a/rust/tests/regress/src/schedule.rs
+++ b/rust/tests/regress/src/schedule.rs
@@ -120,13 +120,13 @@ impl Schedule {
 
         if !different_tests.is_empty() {
             info!(
-        "Risingwave regress tests failed, these tests are different from expected output: {:?}",
-        different_tests
-      );
+                "Risingwave regress tests failed, these tests are different from expected output: {:?}",
+                different_tests
+            );
             bail!(
-        "Risingwave regress tests failed, these tests are different from expected output: {:?}",
-        different_tests
-      )
+                "Risingwave regress tests failed, these tests are different from expected output: {:?}",
+                different_tests
+            )
         } else {
             info!("Risingwave regress tests passed.");
             Ok(())


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Found by:

```python
for f in glob("./rust/**/*.rs", recursive=True):
    if (
        "target" in f
        or "sqlparser" in f
        or "ss_bench" in f
        or "expander" in f
        or "config_gen" in f
    ):
        continue
    for (idx, line) in enumerate(open(f).read().split("\n")):
        indents = len(line) - len(line.lstrip())
        if indents % 4 != 0:
            print(f"{f[7:]}:{idx+1}")
```

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
