### PR TITLE
feat(frontend): use new subquery rewriter in stream planner

### DIFF
--- a/e2e_test/batch/tpch/q21.slt.part
+++ b/e2e_test/batch/tpch/q21.slt.part
@@ -1,6 +1,6 @@
 onlyif risingwave
 statement ok
-SET enable_new_subquery_planner TO on
+SET enable_new_subquery_batch_planner TO on
 
 query TI
 select
@@ -48,4 +48,4 @@ Supplier#000000005 15
 
 onlyif risingwave
 statement ok
-SET enable_new_subquery_planner TO off
+SET enable_new_subquery_batch_planner TO off

--- a/java/common/src/main/java/com/risingwave/common/config/BatchPlannerConfigurations.java
+++ b/java/common/src/main/java/com/risingwave/common/config/BatchPlannerConfigurations.java
@@ -49,7 +49,7 @@ public class BatchPlannerConfigurations {
 
   @Config
   public static final ConfigEntry<Boolean> ENABLE_NEW_SUBQUERY_PLANNER =
-      ConfigEntry.<Boolean>builder("enable_new_subquery_planner")
+      ConfigEntry.<Boolean>builder("enable_new_subquery_batch_planner")
           .setOptional(true)
           .withDefaultValue(false)
           .withConverter(BOOLEAN_PARSER)

--- a/java/common/src/main/java/com/risingwave/common/config/Configuration.java
+++ b/java/common/src/main/java/com/risingwave/common/config/Configuration.java
@@ -118,12 +118,17 @@ public class Configuration {
 
   private static ImmutableMap<String, ConfigEntry<?>> loadConfigRegistry() {
     // Load batch planner options.
-    List<ConfigEntry<?>> configEntries = loadConfigEntries(BatchPlannerConfigurations.class);
+    List<List<ConfigEntry<?>>> configEntriesList =
+        List.of(
+            loadConfigEntries(BatchPlannerConfigurations.class),
+            loadConfigEntries(StreamPlannerConfigurations.class));
     var mapBuilder = new ImmutableMap.Builder<String, ConfigEntry<?>>();
-    configEntries.forEach(
-        entry -> {
-          mapBuilder.put(entry.getKey(), entry);
-        });
+    for (var configEntries : configEntriesList) {
+      configEntries.forEach(
+          entry -> {
+            mapBuilder.put(entry.getKey(), entry);
+          });
+    }
     return mapBuilder.build();
   }
 

--- a/java/common/src/main/java/com/risingwave/common/config/StreamPlannerConfigurations.java
+++ b/java/common/src/main/java/com/risingwave/common/config/StreamPlannerConfigurations.java
@@ -1,0 +1,22 @@
+package com.risingwave.common.config;
+
+import static com.risingwave.common.config.Parsers.BOOLEAN_PARSER;
+
+/** Manage all config entry that can be set up in stream planner. */
+public class StreamPlannerConfigurations {
+  private StreamPlannerConfigurations() {}
+
+  /**
+   * The key of config entry should be set exactly the same as the parameter explicitly decalred in
+   * SQL. For example, SET enable_new_subquery_stream_planner to TRUE => the key of
+   * `ENABLE_NEW_SUBQUERY_PLANNER` config should be set to 'enable_new_subquery_stream_planner'.
+   */
+  @Config
+  public static final ConfigEntry<Boolean> ENABLE_NEW_SUBQUERY_PLANNER =
+      ConfigEntry.<Boolean>builder("enable_new_subquery_stream_planner")
+          .setOptional(true)
+          .withDefaultValue(false)
+          .withConverter(BOOLEAN_PARSER)
+          .withDoc("Optimizer config to enable new subquery expand in stream planner")
+          .build();
+}

--- a/java/planner/src/main/java/com/risingwave/planner/planner/batch/BatchPlanner.java
+++ b/java/planner/src/main/java/com/risingwave/planner/planner/batch/BatchPlanner.java
@@ -1,5 +1,6 @@
 package com.risingwave.planner.planner.batch;
 
+import static com.risingwave.common.config.BatchPlannerConfigurations.ENABLE_NEW_SUBQUERY_PLANNER;
 import static com.risingwave.planner.program.ChainedOptimizerProgram.OptimizerPhase;
 import static com.risingwave.planner.program.ChainedOptimizerProgram.OptimizerPhase.DISTRIBUTED;
 import static com.risingwave.planner.program.ChainedOptimizerProgram.OptimizerPhase.JOIN_REORDER;
@@ -56,7 +57,10 @@ public class BatchPlanner implements Planner<BatchPlan> {
       SqlNode ast,
       ExecutionContext context,
       BiFunction<ExecutionContext, RelCollation, OptimizerProgram> optimizerProgramProvider) {
-    SqlConverter sqlConverter = SqlConverter.builder(context).build();
+    SqlConverter sqlConverter =
+        SqlConverter.builder(context)
+            .withExpand(!context.getSessionConfiguration().get(ENABLE_NEW_SUBQUERY_PLANNER))
+            .build();
     RelRoot rawRoot = sqlConverter.toRel(ast);
     OptimizerProgram optimizerProgram = optimizerProgramProvider.apply(context, rawRoot.collation);
     RelNode optimized = optimizerProgram.optimize(rawRoot.rel, context);

--- a/java/planner/src/main/java/com/risingwave/planner/planner/streaming/StreamPlanner.java
+++ b/java/planner/src/main/java/com/risingwave/planner/planner/streaming/StreamPlanner.java
@@ -11,14 +11,10 @@ import static com.risingwave.planner.rules.physical.BatchRuleSets.LOGICAL_REWRIT
 
 import com.google.common.collect.ImmutableList;
 import com.risingwave.catalog.*;
+import com.risingwave.common.config.StreamPlannerConfigurations;
 import com.risingwave.execution.context.ExecutionContext;
 import com.risingwave.planner.planner.Planner;
-import com.risingwave.planner.program.ChainedOptimizerProgram;
-import com.risingwave.planner.program.HepOptimizerProgram;
-import com.risingwave.planner.program.JoinReorderProgram;
-import com.risingwave.planner.program.OptimizerProgram;
-import com.risingwave.planner.program.SubQueryRewriteProgram;
-import com.risingwave.planner.program.VolcanoOptimizerProgram;
+import com.risingwave.planner.program.*;
 import com.risingwave.planner.rel.serialization.ExplainWriter;
 import com.risingwave.planner.rel.streaming.*;
 import com.risingwave.planner.rules.physical.BatchRuleSets;
@@ -62,10 +58,16 @@ public class StreamPlanner implements Planner<StreamingPlan> {
   @Override
   public StreamingPlan plan(SqlNode ast, ExecutionContext context) {
     SqlCreateMaterializedView create = (SqlCreateMaterializedView) ast;
-    SqlConverter sqlConverter = SqlConverter.builder(context).build();
+    SqlConverter sqlConverter =
+        SqlConverter.builder(context)
+            .withExpand(
+                !context
+                    .getSessionConfiguration()
+                    .get(StreamPlannerConfigurations.ENABLE_NEW_SUBQUERY_PLANNER))
+            .build();
     RelNode rawPlan = sqlConverter.toRel(create.query).rel;
     // Logical optimization.
-    OptimizerProgram optimizerProgram = buildLogicalOptimizerProgram();
+    OptimizerProgram optimizerProgram = buildLogicalOptimizerProgram(context);
     RelNode logicalPlan = optimizerProgram.optimize(rawPlan, context);
     log.debug("Logical plan: \n" + ExplainWriter.explainPlan(logicalPlan));
     // Generate Streaming plan from logical plan.
@@ -218,10 +220,18 @@ public class StreamPlanner implements Planner<StreamingPlan> {
     }
   }
 
-  private OptimizerProgram buildLogicalOptimizerProgram() {
+  private OptimizerProgram buildLogicalOptimizerProgram(ExecutionContext context) {
     ChainedOptimizerProgram.Builder builder = ChainedOptimizerProgram.builder(STREAMING);
     // We use partial rules from batch planner until getting a RisingWave logical plan.
-    builder.addLast(SUBQUERY_REWRITE, SubQueryRewriteProgram.INSTANCE);
+    var useNewSubqueryPlanner =
+        context
+            .getSessionConfiguration()
+            .get(StreamPlannerConfigurations.ENABLE_NEW_SUBQUERY_PLANNER);
+    if (useNewSubqueryPlanner) {
+      builder.addLast(SUBQUERY_REWRITE, new SubQueryRewriteProgram2());
+    } else {
+      builder.addLast(SUBQUERY_REWRITE, SubQueryRewriteProgram.INSTANCE);
+    }
 
     builder.addLast(
         LOGICAL_REWRITE, HepOptimizerProgram.builder().addRules(LOGICAL_REWRITE_RULES).build());

--- a/java/planner/src/main/java/com/risingwave/planner/sql/SqlConverter.java
+++ b/java/planner/src/main/java/com/risingwave/planner/sql/SqlConverter.java
@@ -1,6 +1,5 @@
 package com.risingwave.planner.sql;
 
-import static com.risingwave.common.config.BatchPlannerConfigurations.ENABLE_NEW_SUBQUERY_PLANNER;
 import static java.util.Objects.requireNonNull;
 
 import com.risingwave.common.datatype.RisingWaveTypeFactory;
@@ -59,6 +58,8 @@ public class SqlConverter {
     private VolcanoPlanner planner = null;
     private RelOptCluster cluster = null;
 
+    private boolean withExpand = true;
+
     private Builder(ExecutionContext context) {
       this.context = context;
       this.rootSchema = context.getCalciteRootSchema();
@@ -66,6 +67,11 @@ public class SqlConverter {
 
     public Builder withDefaultSchema(List<String> newDefaultSchema) {
       defaultSchema = requireNonNull(newDefaultSchema, "Default schema can't be null!");
+      return this;
+    }
+
+    public Builder withExpand(boolean doExpand) {
+      withExpand = doExpand;
       return this;
     }
 
@@ -85,7 +91,7 @@ public class SqlConverter {
       this.config =
           this.config
               .addRelBuilderConfigTransform(c -> c.withSimplify(false))
-              .withExpand(!context.getSessionConfiguration().get(ENABLE_NEW_SUBQUERY_PLANNER));
+              .withExpand(this.withExpand);
 
       SqlToRelConverter sql2RelConverter =
           new RisingWaveSqlToRelConverter(


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Let the stream planner uses the new subquery rewrite program introduced by @liurenjie1024.

Since some plan still requires the old subquery rewrite, this PR adds a config option similar to the config option for the batch planner, which controls of using which subquery rewriter.

This blocks several streaming tpch query.
