### PR TITLE
feat(frontend): derive primary key for anti and semi join

### DIFF
--- a/java/planner/src/test/java/com/risingwave/planner/planner/streaming/StreamJoinPlanTest.java
+++ b/java/planner/src/test/java/com/risingwave/planner/planner/streaming/StreamJoinPlanTest.java
@@ -1,5 +1,6 @@
 package com.risingwave.planner.planner.streaming;
 
+import com.risingwave.common.config.StreamPlannerConfigurations;
 import com.risingwave.planner.util.PlanTestCaseLoader;
 import com.risingwave.planner.util.PlannerTestCase;
 import com.risingwave.planner.util.ToPlannerTestCase;
@@ -19,6 +20,9 @@ public class StreamJoinPlanTest extends StreamPlanTestBase {
   @BeforeAll
   public void initAll() {
     super.init();
+    executionContext
+        .getSessionConfiguration()
+        .setByString(StreamPlannerConfigurations.ENABLE_NEW_SUBQUERY_PLANNER.getKey(), "true");
   }
 
   @ParameterizedTest(name = "{index} => {0}")

--- a/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamJoinPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamJoinPlanTest.xml
@@ -47,4 +47,56 @@ RwStreamMaterialize(name=[mv2])
 ]]>
         </Resource>
     </TestCase>
+    <TestCase name="query 3 semi join">
+        <Resource name="sql">
+            <![CDATA[
+create materialized view mv3 as select * from t where exists (select * from t3 where t.v1 = t3.v1);
+            ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+RwStreamMaterialize(name=[mv3])
+  RwStreamHashJoin(condition=[=($0, $4)], joinType=[semi])
+    RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[3]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.2, 0.0.1.3]])
+        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[3]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.2, 0.0.1.3]])
+    RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+      RwStreamFilter(condition=[true])
+        RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+          RwStreamChain(all=[true], tableId=[0.0.5], primaryKeyIndices=[[1]], columnIds=[[0.0.5.0, 0.0.5.1]])
+            RwStreamBatchPlan(table=[[test_schema, t3]], tableId=[0.0.5], primaryKeyIndices=[[1]], columnIds=[[0.0.5.0, 0.0.5.1]])
+]]>
+        </Resource>
+        <Resource name="primaryKey">
+            <![CDATA[
+[3]
+]]>
+        </Resource>
+    </TestCase>
+    <TestCase name="query 4 anti join">
+        <Resource name="sql">
+            <![CDATA[
+create materialized view mv4 as select * from t where not exists (select * from t3 where t.v1 = t3.v1);
+            ]]>
+        </Resource>
+        <Resource name="plan">
+            <![CDATA[
+RwStreamMaterialize(name=[mv4])
+  RwStreamHashJoin(condition=[=($0, $4)], joinType=[anti])
+    RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[3]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.2, 0.0.1.3]])
+        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[3]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.2, 0.0.1.3]])
+    RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+      RwStreamFilter(condition=[true])
+        RwStreamExchange(distribution=[RwDistributionTrait{type=HASH_DISTRIBUTED, keys=[0]}], collation=[[]])
+          RwStreamChain(all=[true], tableId=[0.0.5], primaryKeyIndices=[[1]], columnIds=[[0.0.5.0, 0.0.5.1]])
+            RwStreamBatchPlan(table=[[test_schema, t3]], tableId=[0.0.5], primaryKeyIndices=[[1]], columnIds=[[0.0.5.0, 0.0.5.1]])
+]]>
+        </Resource>
+        <Resource name="primaryKey">
+            <![CDATA[
+[3]
+]]>
+        </Resource>
+    </TestCase>
 </Root>


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Derive primary key for anti and semi join.
Both join outputs only records from its left child.
Therefore the output primary key indices simply inherit from the primary key indices of its left child.

Fixed some comments in primary key derivation.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests