### PR TITLE
fix: init catalog version from meta store

### DIFF
--- a/rust/meta/src/manager/catalog.rs
+++ b/rust/meta/src/manager/catalog.rs
@@ -34,8 +34,9 @@ where
         let databases = Database::list(&*meta_store_ref).await?;
         let schemas = Schema::list(&*meta_store_ref).await?;
         let tables = Table::list(&*meta_store_ref).await?;
+        let version = CatalogVersionGenerator::new(&*meta_store_ref).await?;
 
-        let core = Mutex::new(CatalogManagerCore::new(databases, schemas, tables));
+        let core = Mutex::new(CatalogManagerCore::new(databases, schemas, tables, version));
         Ok(Self {
             core,
             meta_store_ref,
@@ -263,7 +264,12 @@ struct CatalogManagerCore {
 }
 
 impl CatalogManagerCore {
-    fn new(databases: Vec<Database>, schemas: Vec<Schema>, tables: Vec<Table>) -> Self {
+    fn new(
+        databases: Vec<Database>,
+        schemas: Vec<Schema>,
+        tables: Vec<Table>,
+        catalog_version: CatalogVersionGenerator,
+    ) -> Self {
         let mut table_ref_count = HashMap::new();
         let databases = HashMap::from_iter(
             databases
@@ -286,7 +292,6 @@ impl CatalogManagerCore {
 
             (TableId::from(&table.table_ref_id), table)
         }));
-        let catalog_version = CatalogVersionGenerator::new();
         Self {
             databases,
             schemas,


### PR DESCRIPTION
## What's changed and what's your intention?

When initing catalog version generator, first `select` from meta store. Create a new CatalogVersionGenerator if version doesn't exist.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
related #749