### PR TITLE
refactor: support null key for extreme state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ Currently, we use [sqllogictest-rs](https://github.com/singularity-data/sqllogic
 To install sqllogictest:
 
 ```shell
-make sqllogictest
+cargo install --git https://github.com/risinglightdb/sqllogictest-rs --features bin
 ```
 
 To run end-to-end tests with multiple compute-nodes, run the script:

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ ss_bench_build:
 	cd rust && cargo build --workspace --bin ss-bench
 
 sqllogictest:
-	cargo install sqllogictest --version 0.2.0 --features bin
+	cargo install --git https://github.com/risinglightdb/sqllogictest-rs --features bin
 
 export DOCKER_GROUP_NAME ?= risingwave
 export DOCKER_IMAGE_TAG ?= latest

--- a/e2e_test/streaming/extreme_null.slt
+++ b/e2e_test/streaming/extreme_null.slt
@@ -1,0 +1,75 @@
+statement ok
+create table t1 (v1 int, v2 int, v3 int);
+
+statement ok
+create table t4 (v1 real, v2 int, v3 real);
+
+statement ok
+insert into t1 values (1,4,2), (2,3,3);
+
+statement ok
+insert into t4 values (1,1,4), (NULL,1,4), (2,9,1), (NULL,8,1), (0,2,3);
+
+statement ok
+create materialized view mv1 as select * from t1;
+
+statement ok
+create materialized view mv2 as select round(avg(v1), 1) as avg_v1, sum(v2) as sum_v2, count(v3) as count_v3 from t1;
+
+statement ok
+create materialized view mv3 as select sum(v1) as sum_v1, min(v1) as min_v1, max(v1) as max_v1 from t4 group by v3;
+
+statement ok
+flush;
+
+query III
+select v1, v2, v3 from mv1;
+----
+1 4 2
+2 3 3
+
+query RII
+select avg_v1, sum_v2, count_v3 from mv2;
+----
+1.5 7 2
+
+statement ok
+insert into t1 values (3,4,4), (4,3,5);
+
+statement ok
+flush;
+
+query III
+select v1, v2, v3 from mv1;
+----
+1 4 2
+2 3 3
+3 4 4
+4 3 5
+
+query RII
+select avg_v1, sum_v2, count_v3 from mv2;
+----
+2.5 14 4
+
+query RRRR
+select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
+----
+0 0 0 3
+1 NULL 1 4
+2 NULL 2 1
+
+statement ok
+drop materialized view mv1
+
+statement ok
+drop materialized view mv2
+
+statement ok
+drop materialized view mv3
+
+statement ok
+drop table t1
+
+statement ok
+drop table t4


### PR DESCRIPTION
## What's changed and what's your intention?

Support null key for managed extreme states.

Refactor the key-value pair of the `top_n` cache to be (`Option<T>`, pk) => `Datum`.
Update the related serialize and deserialize logics.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close #28