### PR TITLE
fix: single value should only accept at most one value

### DIFF
--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -13,6 +13,7 @@
 #![feature(binary_heap_drain_sorted)]
 #![feature(is_sorted)]
 #![feature(backtrace)]
+#![feature(fn_traits)]
 
 #[macro_use]
 pub mod error;

--- a/rust/common/src/vector_op/agg/aggregator.rs
+++ b/rust/common/src/vector_op/agg/aggregator.rs
@@ -191,15 +191,15 @@ pub fn create_agg_state_unary(
         (Sum, sum, int64, int64),
         // We remark that SingleValue does not produce a runtime error when it receives zero row.
         // Therefore, we do NOT need to change the logic in GeneralAgg::output_concrete.
-        (SingleValue, single_value, int16, int16),
-        (SingleValue, single_value, int32, int32),
-        (SingleValue, single_value, int64, int64),
-        (SingleValue, single_value, float32, float32),
-        (SingleValue, single_value, float64, float64),
-        (SingleValue, single_value, decimal, decimal),
-        (SingleValue, single_value, boolean, boolean),
-        (SingleValue, single_value_str, char, char),
-        (SingleValue, single_value_str, varchar, varchar),
+        (SingleValue, SingleValue::new(), int16, int16),
+        (SingleValue, SingleValue::new(), int32, int32),
+        (SingleValue, SingleValue::new(), int64, int64),
+        (SingleValue, SingleValue::new(), float32, float32),
+        (SingleValue, SingleValue::new(), float64, float64),
+        (SingleValue, SingleValue::new(), decimal, decimal),
+        (SingleValue, SingleValue::new(), boolean, boolean),
+        (SingleValue, SingleValue::new(), char, char),
+        (SingleValue, SingleValue::new(), varchar, varchar),
     ];
     Ok(state)
 }

--- a/rust/common/src/vector_op/agg/general_distinct_agg.rs
+++ b/rust/common/src/vector_op/agg/general_distinct_agg.rs
@@ -49,11 +49,13 @@ where
             .value_at(row_id)
             .map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value());
         if self.exists.insert(value) {
-            let datum = (self.f)(
-                self.result.as_ref().map(|x| x.as_scalar_ref()),
-                input.value_at(row_id),
-            )?
-            .map(|x| x.to_owned_scalar());
+            let datum = self
+                .f
+                .eval(
+                    self.result.as_ref().map(|x| x.as_scalar_ref()),
+                    input.value_at(row_id),
+                )?
+                .map(|x| x.to_owned_scalar());
             self.result = datum;
         }
         Ok(())
@@ -66,7 +68,7 @@ where
         });
         let mut cur = self.result.as_ref().map(|x| x.as_scalar_ref());
         for datum in input {
-            cur = (self.f)(cur, datum)?;
+            cur = self.f.eval(cur, datum)?;
         }
         let r = cur.map(|x| x.to_owned_scalar());
         self.result = r;
@@ -91,7 +93,7 @@ where
             }
             let scalar_impl = v.map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value());
             if self.exists.insert(scalar_impl) {
-                cur = (self.f)(cur, v)?;
+                cur = self.f.eval(cur, v)?;
             }
         }
         self.result = cur.map(|x| x.to_owned_scalar());


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
As detected by @xiangjinwu in #831,
the previous implementation does not treat `null` as a value. However, `single_value` aggregation should accept at most one value no matter the value is null or not. Therefore, we need a struct instead of a function to record the number of inputs as a null of `Option` has already been interpreted as a null value.

This PR partially reverts the changes made in #825 as `RTFn` becomes a trait that needs to be implemented again.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#831 