### PR TITLE
feat(risedev): create .bin and link risingwave

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ rust/log/
 log/
 
 .risingwave/
+.bin/
 
 # generated files
 risedev-components.user.env

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -81,16 +81,25 @@ set -e
 rm -f "${PREFIX_BIN}/compute-node"
 rm -f "${PREFIX_BIN}/meta-node"
 rm -f "${PREFIX_BIN}/frontend-v2"
-rm -rf "${PREFIX_BIN}/risingwave"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/compute-node" "${PREFIX_BIN}/compute-node"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/meta-node" "${PREFIX_BIN}/meta-node"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/frontend-v2" "${PREFIX_BIN}/frontend-v2"
+
+rm -rf "${PREFIX_BIN}/risingwave"
 mkdir -p "${PREFIX_BIN}/risingwave"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_BIN}/risingwave/meta-node"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_BIN}/risingwave/compute-node"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_BIN}/risingwave/frontend-node"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_BIN}/risingwave/risectl"
 ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_BIN}/risingwave/playground"
+
+rm -rf "${PREFIX_USR_BIN}"
+mkdir -p "${PREFIX_USR_BIN}"
+ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_USR_BIN}/meta-node"
+ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_USR_BIN}/compute-node"
+ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_USR_BIN}/frontend-node"
+ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_USR_BIN}/risectl"
+ln -s "$(pwd)/rust/target/${BUILD_MODE_DIR}/risingwave" "${PREFIX_USR_BIN}/playground"
 '''
 
 [tasks.build-risingwave]

--- a/rust/risedev/common.toml
+++ b/rust/risedev/common.toml
@@ -4,6 +4,7 @@ ARCH = { source = "${CARGO_MAKE_RUST_TARGET_ARCH}", mapping = { x86_64 = "amd64"
 SYSTEM = "${OS}-${ARCH}"
 SYSTEM_AMD64 = "${OS}-amd64" # some components do not support darwin-arm64 for now, use amd64 for fallback
 PREFIX = "${PWD}/.risingwave"
+PREFIX_USR_BIN = "${PWD}/.bin"
 PREFIX_BIN = "${PREFIX}/bin"
 PREFIX_CONFIG = "${PREFIX}/config"
 PREFIX_DATA = "${PREFIX}/data"

--- a/rust/risedev/src/task/frontend_service_v2.rs
+++ b/rust/risedev/src/task/frontend_service_v2.rs
@@ -20,7 +20,7 @@ impl FrontendServiceV2 {
         let prefix_bin = env::var("PREFIX_BIN")?;
 
         if let Ok(x) = env::var("ENABLE_ALL_IN_ONE") && x == "true" {
-            Ok(Command::new(Path::new(&prefix_bin).join("risingwave").join("frontend-v2")))
+            Ok(Command::new(Path::new(&prefix_bin).join("risingwave").join("frontend-node")))
         } else {
             Ok(Command::new(Path::new(&prefix_bin).join("frontend-v2")))
         }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

With `all-in-one` binary mode enabled, we can now call:

```
.bin/risectl
```

to use risectl.

This PR also fixes the bug that frontend-v2 cannot be started in all-in-one mode.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
