### PR TITLE
fix: ignore unstable test

### DIFF
--- a/rust/meta/src/cluster/mod.rs
+++ b/rust/meta/src/cluster/mod.rs
@@ -351,6 +351,7 @@ mod tests {
 
     // This test takes seconds because the TTL is measured in seconds.
     #[tokio::test]
+    #[ignore]
     async fn test_heartbeat() {
         let (_env, _hummock_manager, cluster_manager, worker_node) = setup_compute_env(1).await;
         let context_id_1 = worker_node.id;


### PR DESCRIPTION
Temporarily disable a test added in https://github.com/singularity-data/risingwave-dev/pull/830, which is time sensitive.

## Checklist

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave-dev/pull/830