### PR TITLE
feat(storage): support read epoch for in-memory state backend

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -109,7 +109,8 @@ condition = { env_set = [ "ENABLE_BUILD_RUST" ] }
 script = '''
 #!/bin/bash
 set -e
-cd rust && cargo build --profile ${RISINGWAVE_BUILD_PROFILE} ${RISEDEV_CARGO_BUILD_FLAGS}
+echo "**Reminder**: risedev will only build risingwave_cmd crate"
+cd rust && cargo build -p risingwave_cmd --profile "${RISINGWAVE_BUILD_PROFILE}" ${RISEDEV_CARGO_BUILD_FLAGS}
 '''
 
 [tasks.build-frontend]

--- a/rust/storage/src/store_impl.rs
+++ b/rust/storage/src/store_impl.rs
@@ -111,7 +111,10 @@ impl StateStoreImpl {
                 StateStoreImpl::HummockStateStore(inner.monitored(stats))
             }
 
-            "in_memory" | "in-memory" => StateStoreImpl::shared_in_memory_store(stats.clone()),
+            "in_memory" | "in-memory" => {
+                tracing::warn!("in-memory state backend should never be used in benchmarks and production environment.");
+                StateStoreImpl::shared_in_memory_store(stats.clone())
+            }
 
             tikv if tikv.starts_with("tikv") => {
                 let inner =

--- a/rust/stream/src/executor/lookup/tests.rs
+++ b/rust/stream/src/executor/lookup/tests.rs
@@ -257,7 +257,6 @@ async fn test_lookup_this_epoch() {
 }
 
 #[tokio::test]
-#[ignore]
 async fn test_lookup_last_epoch() {
     // TODO: memory state store doesn't support read epoch yet, so this test won't pass for now.
     // Will fix later.


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Support read epoch for in-memory state backend. At the same time, enable full lookup executor test.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

close https://github.com/singularity-data/risingwave-dev/issues/852