### PR TITLE
fix(meta): don't panic on mock heartbeat

### DIFF
--- a/rust/rpc_client/src/meta_client.rs
+++ b/rust/rpc_client/src/meta_client.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use risingwave_common::catalog::{CatalogVersion, TableId};
-use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::ErrorCode::{self, InternalError};
 use risingwave_common::error::{Result, ToRwResult};
 use risingwave_common::try_match_expand;
 use risingwave_pb::common::{HostAddress, WorkerNode, WorkerType};
@@ -269,7 +269,7 @@ pub trait MetaClientInner: Send + Sync {
     }
 
     async fn heartbeat(&self, _req: HeartbeatRequest) -> Result<HeartbeatResponse> {
-        unimplemented!()
+        Err(ErrorCode::NotImplementedError("heartbeat is not implemented".into()).into())
     }
 
     async fn create(&self, _req: CreateRequest) -> Result<CreateResponse> {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Frontend's `run_all_test_files` will frequently fail because `heartbeat` is not implemented for mock meta client.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
