### PR TITLE
style: disallow dbg_macro in our code base

### DIFF
--- a/rust/batch/src/lib.rs
+++ b/rust/batch/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/compute/src/lib.rs
+++ b/rust/compute/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/connector/src/lib.rs
+++ b/rust/connector/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/meta/src/lib.rs
+++ b/rust/meta/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/meta/src/manager/hash_dispatch.rs
+++ b/rust/meta/src/manager/hash_dispatch.rs
@@ -163,8 +163,6 @@ where
 
         self.key_mapping.insert(&*self.meta_store_ref).await?;
 
-        dbg!(&self.load_balancer);
-
         Ok(())
     }
 
@@ -237,8 +235,6 @@ where
 
         // Persist mapping
         self.key_mapping.insert(&*self.meta_store_ref).await?;
-
-        dbg!(&self.load_balancer);
 
         Ok(())
     }

--- a/rust/rpc_client/src/lib.rs
+++ b/rust/rpc_client/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/source/src/lib.rs
+++ b/rust/source/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/stream/src/lib.rs
+++ b/rust/stream/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]

--- a/rust/tests/regress/src/lib.rs
+++ b/rust/tests/regress/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(dead_code)]
+#![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]
 #![warn(clippy::doc_markdown)]
 #![warn(clippy::explicit_into_iter_loop)]


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

dbg is used for debugging.

1. remove `dbg!`
2. add clippy warnings `dbg_macro`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
