### PR TITLE
chore(stream): remove reset in executor

### DIFF
--- a/rust/stream/src/executor/batch_query.rs
+++ b/rust/stream/src/executor/batch_query.rs
@@ -138,10 +138,6 @@ impl<S: StateStore> Executor for BatchQueryExecutor<S> {
         }
         Ok(())
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 #[cfg(test)]

--- a/rust/stream/src/executor/chain.rs
+++ b/rust/stream/src/executor/chain.rs
@@ -168,10 +168,6 @@ impl Executor for ChainExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 #[cfg(test)]
@@ -240,10 +236,6 @@ mod test {
 
         fn init(&mut self, _: u64) -> Result<()> {
             Ok(())
-        }
-
-        fn reset(&mut self, _epoch: u64) {
-            // nothing to do
         }
     }
 

--- a/rust/stream/src/executor/debug/mod.rs
+++ b/rust/stream/src/executor/debug/mod.rs
@@ -57,8 +57,4 @@ where
     fn init(&mut self, epoch: u64) -> Result<()> {
         self.input_mut().init(epoch)
     }
-
-    fn reset(&mut self, epoch: u64) {
-        self.input_mut().reset(epoch)
-    }
 }

--- a/rust/stream/src/executor/filter.rs
+++ b/rust/stream/src/executor/filter.rs
@@ -99,10 +99,6 @@ impl Executor for FilterExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 impl SimpleExecutor for FilterExecutor {

--- a/rust/stream/src/executor/global_simple_agg.rs
+++ b/rust/stream/src/executor/global_simple_agg.rs
@@ -270,11 +270,6 @@ impl<S: StateStore> Executor for SimpleAggExecutor<S> {
         self.states.take();
         Ok(())
     }
-
-    fn reset(&mut self, epoch: u64) {
-        self.states.take();
-        self.update_executor_state(ExecutorState::Active(epoch));
-    }
 }
 
 #[cfg(test)]

--- a/rust/stream/src/executor/hash_agg.rs
+++ b/rust/stream/src/executor/hash_agg.rs
@@ -427,11 +427,6 @@ impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, epoch: u64) {
-        self.state_map.clear();
-        self.update_executor_state(ExecutorState::Active(epoch));
-    }
 }
 
 impl<K: HashKey, S: StateStore> StatefulExecutor for HashAggExecutor<K, S> {

--- a/rust/stream/src/executor/hash_join.rs
+++ b/rust/stream/src/executor/hash_join.rs
@@ -217,12 +217,6 @@ impl<S: StateStore, const T: JoinTypePrimitive> Executor for HashJoinExecutor<S,
 
         Ok(())
     }
-
-    fn reset(&mut self, epoch: u64) {
-        self.side_l.ht.clear();
-        self.side_r.ht.clear();
-        self.update_executor_state(ExecutorState::Active(epoch));
-    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/rust/stream/src/executor/local_simple_agg.rs
+++ b/rust/stream/src/executor/local_simple_agg.rs
@@ -134,12 +134,6 @@ impl Executor for LocalSimpleAggExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, epoch: u64) {
-        self.states.iter_mut().for_each(|state| state.reset());
-        self.is_dirty = false;
-        self.update_executor_state(ExecutorState::Active(epoch));
-    }
 }
 
 #[async_trait]

--- a/rust/stream/src/executor/lookup.rs
+++ b/rust/stream/src/executor/lookup.rs
@@ -88,8 +88,4 @@ impl<S: StateStore> Executor for LookupExecutor<S> {
     fn clear_cache(&mut self) -> Result<()> {
         Ok(())
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        self.last_barrier = None;
-    }
 }

--- a/rust/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
+++ b/rust/stream/src/executor/managed_state/top_n/top_n_bottom_n_state.rs
@@ -305,13 +305,12 @@ impl<S: StateStore> ManagedTopNBottomNState<S> {
         Ok(())
     }
 
-    pub fn clear_cache(&mut self, force: bool) {
-        if !force {
-            assert!(
-                !self.is_dirty(),
-                "cannot clear cache while top n bottom n state is dirty"
-            );
-        }
+    pub fn clear_cache(&mut self) {
+        assert!(
+            !self.is_dirty(),
+            "cannot clear cache while top n bottom n state is dirty"
+        );
+
         self.top_n.clear();
         self.bottom_n.clear();
     }

--- a/rust/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/rust/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -359,13 +359,11 @@ impl<S: StateStore, const TOP_N_TYPE: usize> ManagedTopNState<S, TOP_N_TYPE> {
         Ok(())
     }
 
-    pub fn clear_cache(&mut self, force: bool) {
-        if !force {
-            assert!(
-                !self.is_dirty(),
-                "cannot clear cache while top n state is dirty"
-            );
-        }
+    pub fn clear_cache(&mut self) {
+        assert!(
+            !self.is_dirty(),
+            "cannot clear cache while top n state is dirty"
+        );
         self.top_n.clear();
     }
 }

--- a/rust/stream/src/executor/merge.rs
+++ b/rust/stream/src/executor/merge.rs
@@ -159,10 +159,6 @@ impl Executor for ReceiverExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 /// `MergeExecutor` merges data from multiple channels. Dataflow from one channel
@@ -296,10 +292,6 @@ impl Executor for MergeExecutor {
 
     fn logical_operator_info(&self) -> &str {
         &self.op_info
-    }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
     }
 }
 

--- a/rust/stream/src/executor/mod.rs
+++ b/rust/stream/src/executor/mod.rs
@@ -366,9 +366,6 @@ pub trait Executor: Send + Debug + 'static {
     fn init(&mut self, _epoch: u64) -> Result<()> {
         unreachable!()
     }
-
-    /// Clear the executor's in-memory cache and reset to specific epoch.
-    fn reset(&mut self, _epoch: u64);
 }
 
 #[derive(Debug)]

--- a/rust/stream/src/executor/mview/materialize.rs
+++ b/rust/stream/src/executor/mview/materialize.rs
@@ -120,10 +120,6 @@ impl<S: StateStore> Executor for MaterializeExecutor<S> {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        self.local_state.clear_cache();
-    }
 }
 
 impl<S: StateStore> std::fmt::Debug for MaterializeExecutor<S> {

--- a/rust/stream/src/executor/mview/state.rs
+++ b/rust/stream/src/executor/mview/state.rs
@@ -61,10 +61,6 @@ impl<S: StateStore> ManagedMViewState<S> {
         FlushStatus::do_delete(self.cache.entry(pk));
     }
 
-    pub fn clear_cache(&mut self) {
-        self.cache.clear();
-    }
-
     pub async fn flush(&mut self, epoch: u64) -> Result<()> {
         let mut batch = self.keyspace.state_store().start_write_batch();
         batch.reserve(self.cache.len() * self.column_ids.len());

--- a/rust/stream/src/executor/project.rs
+++ b/rust/stream/src/executor/project.rs
@@ -115,10 +115,6 @@ impl Executor for ProjectExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 impl SimpleExecutor for ProjectExecutor {

--- a/rust/stream/src/executor/source.rs
+++ b/rust/stream/src/executor/source.rs
@@ -293,11 +293,6 @@ impl Executor for SourceExecutor {
     fn logical_operator_info(&self) -> &str {
         &self.op_info
     }
-
-    // TODO: implement reset after introduce connector here.
-    fn reset(&mut self, _epoch: u64) {
-        todo!()
-    }
 }
 
 impl Debug for SourceExecutor {

--- a/rust/stream/src/executor/test_utils.rs
+++ b/rust/stream/src/executor/test_utils.rs
@@ -105,10 +105,6 @@ impl Executor for MockSource {
     fn logical_operator_info(&self) -> &str {
         self.identity()
     }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
-    }
 }
 
 /// This source takes message from users asynchronously
@@ -197,10 +193,6 @@ impl Executor for MockAsyncSource {
 
     fn logical_operator_info(&self) -> &str {
         self.identity()
-    }
-
-    fn reset(&mut self, _epoch: u64) {
-        // nothing to do
     }
 }
 

--- a/rust/stream/src/executor/top_n.rs
+++ b/rust/stream/src/executor/top_n.rs
@@ -214,20 +214,12 @@ impl<S: StateStore> Executor for TopNExecutor<S> {
     }
 
     fn clear_cache(&mut self) -> Result<()> {
-        self.managed_lowest_state.clear_cache(false);
-        self.managed_middle_state.clear_cache(false);
-        self.managed_highest_state.clear_cache(false);
+        self.managed_lowest_state.clear_cache();
+        self.managed_middle_state.clear_cache();
+        self.managed_highest_state.clear_cache();
         self.first_execution = true;
 
         Ok(())
-    }
-
-    fn reset(&mut self, epoch: u64) {
-        self.managed_lowest_state.clear_cache(true);
-        self.managed_middle_state.clear_cache(true);
-        self.managed_highest_state.clear_cache(true);
-        self.first_execution = true;
-        self.update_executor_state(ExecutorState::Active(epoch));
     }
 }
 

--- a/rust/stream/src/executor/top_n_appendonly.rs
+++ b/rust/stream/src/executor/top_n_appendonly.rs
@@ -238,18 +238,11 @@ impl<S: StateStore> Executor for AppendOnlyTopNExecutor<S> {
     }
 
     fn clear_cache(&mut self) -> Result<()> {
-        self.managed_lower_state.clear_cache(false);
-        self.managed_higher_state.clear_cache(false);
+        self.managed_lower_state.clear_cache();
+        self.managed_higher_state.clear_cache();
         self.first_execution = true;
 
         Ok(())
-    }
-
-    fn reset(&mut self, epoch: u64) {
-        self.managed_lower_state.clear_cache(true);
-        self.managed_higher_state.clear_cache(true);
-        self.first_execution = true;
-        self.update_executor_state(ExecutorState::Active(epoch));
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

According to offline discussion, the `reset` operation in stream executor is uncontrollable. For failover, we will simply rebuild the entire stream graphs.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
