### PR TITLE
chore(docs): 'bound' statement instead of 'bounded'

### DIFF
--- a/rust/frontend/src/planner/mod.rs
+++ b/rust/frontend/src/planner/mod.rs
@@ -12,7 +12,7 @@ mod statement;
 mod table_ref;
 mod values;
 
-/// `Planner` converts a bounded statement to a [`crate::optimizer::plan_node::PlanNode`] tree
+/// `Planner` converts a bound statement to a [`crate::optimizer::plan_node::PlanNode`] tree
 pub struct Planner {
     ctx: QueryContextRef,
 }


### PR DESCRIPTION
## What's changed and what's your intention?


_Bound_ is past particle of _bind_.
_Bounded_ means having _bounds_. 
🤔

## Checklist

## Refer to a related PR or issue link (optional)
