### PR TITLE
refactor(session): run statement use Arc and remove SessionContext

### DIFF
--- a/rust/frontend/src/handler/create_source.rs
+++ b/rust/frontend/src/handler/create_source.rs
@@ -102,7 +102,7 @@ mod tests {
         let frontend = LocalFrontend::new().await;
         frontend.run_sql(sql).await.unwrap();
 
-        let catalog_manager = frontend.session().ctx.env().catalog_mgr();
+        let catalog_manager = frontend.session().env().catalog_mgr();
         let table = catalog_manager.get_table("dev", "dev", "t").unwrap();
         let columns = table
             .columns()

--- a/rust/frontend/src/handler/create_table.rs
+++ b/rust/frontend/src/handler/create_table.rs
@@ -67,7 +67,7 @@ mod tests {
         let frontend = LocalFrontend::new().await;
         frontend.run_sql(sql).await.unwrap();
 
-        let catalog_manager = frontend.session().ctx.env().catalog_mgr();
+        let catalog_manager = frontend.session().env().catalog_mgr();
         let table = catalog_manager
             .get_table(DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, "t")
             .unwrap();

--- a/rust/frontend/src/handler/drop_table.rs
+++ b/rust/frontend/src/handler/drop_table.rs
@@ -39,7 +39,7 @@ mod tests {
         frontend.run_sql(sql_create_table).await.unwrap();
         frontend.run_sql(sql_drop_table).await.unwrap();
 
-        let catalog_manager = frontend.session().ctx.env().catalog_mgr();
+        let catalog_manager = frontend.session().env().catalog_mgr();
 
         assert!(catalog_manager
             .get_table(DEFAULT_DATABASE_NAME, DEFAULT_SCHEMA_NAME, "t")

--- a/rust/frontend/src/handler/mod.rs
+++ b/rust/frontend/src/handler/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use pgwire::pg_response::PgResponse;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{ObjectName, Statement};
@@ -11,8 +13,8 @@ mod explain;
 mod query;
 pub mod util;
 
-pub(super) async fn handle(session: &SessionImpl, stmt: Statement) -> Result<PgResponse> {
-    let context = QueryContext::new(session.ctx.clone());
+pub(super) async fn handle(session: Arc<SessionImpl>, stmt: Statement) -> Result<PgResponse> {
+    let context = QueryContext::new(session.clone());
     match stmt {
         Statement::Explain {
             statement, verbose, ..

--- a/rust/frontend/src/session.rs
+++ b/rust/frontend/src/session.rs
@@ -26,7 +26,7 @@ use crate::scheduler::schedule::WorkerNodeManager;
 use crate::FrontendOpts;
 
 pub struct QueryContext {
-    pub session_ctx: Arc<SessionContext>,
+    pub session_ctx: Arc<SessionImpl>,
     pub next_id: i32,
 }
 /// The reference of `QueryContext`, our system assumes that frontend will not parallel for a query,
@@ -34,7 +34,7 @@ pub struct QueryContext {
 pub type QueryContextRef = Rc<RefCell<QueryContext>>;
 
 impl QueryContext {
-    pub fn new(session_ctx: Arc<SessionContext>) -> Self {
+    pub fn new(session_ctx: Arc<SessionImpl>) -> Self {
         Self {
             session_ctx,
             next_id: 0,
@@ -50,7 +50,7 @@ impl QueryContext {
     #[cfg(test)]
     pub async fn mock() -> Self {
         Self {
-            session_ctx: Arc::new(SessionContext::mock().await),
+            session_ctx: Arc::new(SessionImpl::mock().await),
             next_id: 0,
         }
     }
@@ -173,15 +173,11 @@ impl FrontendEnv {
 }
 
 pub struct SessionImpl {
-    pub ctx: Arc<SessionContext>,
-}
-
-pub struct SessionContext {
     env: FrontendEnv,
     database: String,
 }
 
-impl SessionContext {
+impl SessionImpl {
     pub fn new(env: FrontendEnv, database: String) -> Self {
         Self { env, database }
     }
@@ -203,15 +199,6 @@ impl SessionContext {
     }
 }
 
-impl SessionImpl {
-    pub fn new(env: FrontendEnv, database: String) -> Self {
-        let context = SessionContext { env, database };
-        Self {
-            ctx: Arc::new(context),
-        }
-    }
-}
-
 pub struct SessionManagerImpl {
     env: FrontendEnv,
     observer_join_handle: JoinHandle<()>,
@@ -220,10 +207,8 @@ pub struct SessionManagerImpl {
 }
 
 impl SessionManager for SessionManagerImpl {
-    fn connect(&self) -> Box<dyn Session> {
-        Box::new(SessionImpl {
-            ctx: Arc::new(SessionContext::new(self.env.clone(), "dev".to_string())),
-        })
+    fn connect(&self) -> Arc<dyn Session> {
+        Arc::new(SessionImpl::new(self.env.clone(), "dev".to_string()))
     }
 }
 
@@ -249,7 +234,7 @@ impl SessionManagerImpl {
 #[async_trait::async_trait]
 impl Session for SessionImpl {
     async fn run_statement(
-        &self,
+        self: Arc<Self>,
         sql: &str,
     ) -> std::result::Result<PgResponse, Box<dyn std::error::Error + Send + Sync>> {
         // Parse sql.

--- a/rust/frontend/test_runner/src/lib.rs
+++ b/rust/frontend/test_runner/src/lib.rs
@@ -60,13 +60,13 @@ impl TestCase {
     /// Run the test case, and return the expected output.
     pub async fn run(&self, do_check_result: bool) -> Result<TestCaseResult> {
         let frontend = LocalFrontend::new().await;
-        let session = frontend.session();
+        let session = frontend.session_ref();
         let statements = Parser::parse_sql(&self.sql).unwrap();
 
         let mut result = None;
 
         for stmt in statements {
-            let context = QueryContext::new(session.ctx.clone());
+            let context = QueryContext::new(session.clone());
             match stmt.clone() {
                 Statement::Query(_) | Statement::Insert { .. } | Statement::Delete { .. } => {
                     if result.is_some() {

--- a/rust/utils/pgwire/src/pg_protocol.rs
+++ b/rust/utils/pgwire/src/pg_protocol.rs
@@ -27,7 +27,7 @@ where
     is_terminate: bool,
 
     session_mgr: Arc<dyn SessionManager>,
-    session: Option<Box<dyn Session>>,
+    session: Option<Arc<dyn Session>>,
 }
 
 /// States flow happened from top to down.
@@ -107,7 +107,7 @@ where
 
     async fn process_query_msg(&mut self, query: FeQueryMessage) -> Result<()> {
         info!("receive query: {}", query.get_sql());
-        let session = self.session.as_ref().unwrap();
+        let session = self.session.clone().unwrap();
 
         // execute query
         let process_res = session.run_statement(query.get_sql()).await;


### PR DESCRIPTION
## What's changed and what's your intention?

Resolve #826 

* Remove `SessionContext`. Only have `SessionImpl` now. 
* `run_statement` do not use &self, but Arc\<self\>.
## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
