### PR TITLE
feat(streaming): add single value aggregation for streaming

### DIFF
--- a/rust/stream/src/executor/aggregation/mod.rs
+++ b/rust/stream/src/executor/aggregation/mod.rs
@@ -10,6 +10,8 @@ mod foldable;
 pub use foldable::*;
 
 mod row_count;
+mod single_value;
+
 use dyn_clone::{self, DynClone};
 use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::{
@@ -22,6 +24,8 @@ use risingwave_common::expr::AggKind;
 use risingwave_common::types::{DataType, Datum};
 use risingwave_common::*;
 pub use row_count::*;
+
+use crate::executor::aggregation::single_value::StreamingSingleValueAgg;
 
 /// `StreamingSumAgg` sums data of the same type.
 pub type StreamingSumAgg<R, I> =
@@ -172,6 +176,60 @@ pub fn create_streaming_agg_state(
                     (Max, decimal, decimal, StreamingMaxAgg::<DecimalArray>),
                     (Max, float32, float32, StreamingMaxAgg::<F32Array>),
                     (Max, float64, float64, StreamingMaxAgg::<F64Array>),
+                    (
+                        SingleValue,
+                        int16,
+                        int16,
+                        StreamingSingleValueAgg::<I16Array>
+                    ),
+                    (
+                        SingleValue,
+                        int32,
+                        int32,
+                        StreamingSingleValueAgg::<I32Array>
+                    ),
+                    (
+                        SingleValue,
+                        int64,
+                        int64,
+                        StreamingSingleValueAgg::<I64Array>
+                    ),
+                    (
+                        SingleValue,
+                        float32,
+                        float32,
+                        StreamingSingleValueAgg::<F32Array>
+                    ),
+                    (
+                        SingleValue,
+                        float64,
+                        float64,
+                        StreamingSingleValueAgg::<F64Array>
+                    ),
+                    (
+                        SingleValue,
+                        boolean,
+                        boolean,
+                        StreamingSingleValueAgg::<BoolArray>
+                    ),
+                    (
+                        SingleValue,
+                        decimal,
+                        decimal,
+                        StreamingSingleValueAgg::<DecimalArray>
+                    ),
+                    (
+                        SingleValue,
+                        char,
+                        char,
+                        StreamingSingleValueAgg::<Utf8Array>
+                    ),
+                    (
+                        SingleValue,
+                        varchar,
+                        varchar,
+                        StreamingSingleValueAgg::<Utf8Array>
+                    )
                 ]
             )
         }

--- a/rust/stream/src/executor/aggregation/single_value.rs
+++ b/rust/stream/src/executor/aggregation/single_value.rs
@@ -1,0 +1,233 @@
+//! This module implements `StreamingSingleValueAgg`.
+
+use itertools::Itertools;
+use risingwave_common::array::stream_chunk::Ops;
+use risingwave_common::array::*;
+use risingwave_common::buffer::Bitmap;
+use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::types::{option_to_owned_scalar, Datum, Scalar, ScalarImpl};
+
+use crate::executor::StreamingAggStateImpl;
+
+/// `StreamingSingleValueAgg` is a temporary workaround to deal with scalar subquery.
+/// Scalar subquery can at most return one row, otherwise runtime error should be emitted.
+///
+/// When subquery un-nesting becomes more powerful in the future, this should be removed.
+#[derive(Debug, Default)]
+pub struct StreamingSingleValueAgg<T: Array> {
+    /// row count to record how many rows it has accumulated.
+    /// Since this aggregation function would error when it accumulates
+    /// more than one row,
+    row_cnt: i64,
+    result: Option<T::OwnedItem>,
+}
+
+impl<T: Array> Clone for StreamingSingleValueAgg<T> {
+    fn clone(&self) -> Self {
+        Self {
+            row_cnt: self.row_cnt,
+            result: self.result.clone(),
+        }
+    }
+}
+
+impl<T: Array> TryFrom<Datum> for StreamingSingleValueAgg<T> {
+    type Error = RwError;
+
+    /// This function makes the assumption that if this function gets called, then
+    /// we must have row count equal to 1. If the row count is equal to 0,
+    /// then `new` will be called instead of this function.
+    fn try_from(x: Datum) -> Result<Self> {
+        let mut result = None;
+        if let Some(scalar) = x {
+            result = Some(T::OwnedItem::try_from(scalar)?);
+        }
+
+        Ok(Self { row_cnt: 1, result })
+    }
+}
+
+impl<T: Array> StreamingSingleValueAgg<T> {
+    pub fn new() -> Self {
+        Self::with_row_cnt(None)
+    }
+
+    pub fn with_row_cnt(datum: Datum) -> Self {
+        let mut row_cnt = 0;
+        if let Some(cnt) = datum {
+            match cnt {
+        ScalarImpl::Int64(num) => {
+          row_cnt = num;
+        }
+        other => panic!(
+          "type mismatch in streaming aggregator StreamingSingleValueAgg init: expected i64, get {}",
+          other.get_ident()
+        ),
+      }
+        }
+        Self {
+            row_cnt,
+            result: None,
+        }
+    }
+
+    fn accumulate(&mut self, input: Option<T::RefItem<'_>>) -> Result<()> {
+        self.row_cnt += 1;
+        if self.row_cnt > 1 {
+            Err(ErrorCode::InternalError(
+        "SingleValue aggregation can only accept exactly one value. But there is more than one.".to_string(),
+      )
+        .into())
+        } else {
+            self.result = option_to_owned_scalar(&input);
+            Ok(())
+        }
+    }
+
+    fn retract(&mut self, _input: Option<T::RefItem<'_>>) -> Result<()> {
+        if self.row_cnt != 1 {
+            Err(ErrorCode::InternalError(
+        format!("SingleValue aggregation can only retract exactly one value. But there are {} values.", self.row_cnt)
+      )
+        .into())
+        } else {
+            self.row_cnt -= 1;
+            self.result = None;
+            Ok(())
+        }
+    }
+
+    fn apply_batch_concrete(
+        &mut self,
+        ops: Ops<'_>,
+        visibility: Option<&Bitmap>,
+        data: &T,
+    ) -> Result<()> {
+        match visibility {
+            None => {
+                for (op, data) in ops.iter().zip_eq(data.iter()) {
+                    match op {
+                        Op::Insert | Op::UpdateInsert => self.accumulate(data)?,
+                        Op::Delete | Op::UpdateDelete => self.retract(data)?,
+                    }
+                }
+            }
+            Some(visibility) => {
+                for ((visible, op), data) in
+                    visibility.iter().zip_eq(ops.iter()).zip_eq(data.iter())
+                {
+                    if visible {
+                        match op {
+                            Op::Insert | Op::UpdateInsert => self.accumulate(data)?,
+                            Op::Delete | Op::UpdateDelete => self.retract(data)?,
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+macro_rules! impl_single_value_agg {
+    ($array_type:tt, $result_variant:tt) => {
+        impl StreamingAggStateImpl for StreamingSingleValueAgg<$array_type> {
+            fn apply_batch(
+                &mut self,
+                ops: Ops<'_>,
+                visibility: Option<&Bitmap>,
+                data: &[&ArrayImpl],
+            ) -> Result<()> {
+                self.apply_batch_concrete(ops, visibility, data[0].into())
+            }
+
+            fn get_output(&self) -> Result<Datum> {
+                Ok(self.result.clone().map(Scalar::to_scalar_value))
+            }
+
+            fn new_builder(&self) -> ArrayBuilderImpl {
+                ArrayBuilderImpl::$result_variant(<$array_type as Array>::Builder::new(0).unwrap())
+            }
+
+            fn reset(&mut self) {
+                self.row_cnt = 0;
+            }
+        }
+    };
+}
+
+impl_single_value_agg! {I16Array, Int16}
+impl_single_value_agg! {I32Array, Int32}
+impl_single_value_agg! {I64Array, Int64}
+impl_single_value_agg! {F32Array, Float32}
+impl_single_value_agg! {F64Array, Float64}
+impl_single_value_agg! {BoolArray, Bool}
+impl_single_value_agg! {DecimalArray, Decimal}
+impl_single_value_agg! {Utf8Array, Utf8}
+impl_single_value_agg! {IntervalArray, Interval}
+impl_single_value_agg! {NaiveDateArray, NaiveDate}
+impl_single_value_agg! {NaiveDateTimeArray, NaiveDateTime}
+impl_single_value_agg! {NaiveTimeArray, NaiveTime}
+impl_single_value_agg! {StructArray, Struct}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::array_nonnull;
+
+    use super::*;
+
+    #[test]
+    fn test_single_value_agg() {
+        let mut state = StreamingSingleValueAgg::<Utf8Array>::new();
+
+        assert_eq!(state.get_output().unwrap(), None);
+
+        // insert one element to state
+        state
+            .apply_batch(
+                &[Op::Insert],
+                None,
+                &[&ArrayImpl::from(array_nonnull! {Utf8Array, ["abc"]})],
+            )
+            .unwrap();
+
+        assert_eq!(
+            state.get_output().unwrap(),
+            Some(ScalarImpl::Utf8("abc".to_string()))
+        );
+
+        // delete one element from state
+        state
+            .apply_batch(
+                &[Op::UpdateDelete],
+                None,
+                &[&ArrayImpl::from(array_nonnull! {Utf8Array, ["abc"]})],
+            )
+            .unwrap();
+
+        assert_eq!(state.get_output().unwrap(), None);
+
+        // insert one element from state
+        state
+            .apply_batch(
+                &[Op::UpdateInsert],
+                None,
+                &[&ArrayImpl::from(array_nonnull! {Utf8Array, ["xyz"]})],
+            )
+            .unwrap();
+
+        assert_eq!(
+            state.get_output().unwrap(),
+            Some(ScalarImpl::Utf8("xyz".to_string()))
+        );
+
+        // insert another one, leading to error
+        assert!(state
+            .apply_batch(
+                &[Op::UpdateInsert],
+                None,
+                &[&ArrayImpl::from(array_nonnull! {Utf8Array, ["opq"]})],
+            )
+            .is_err());
+    }
+}

--- a/rust/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/rust/stream/src/executor/managed_state/aggregation/mod.rs
@@ -127,7 +127,9 @@ impl<S: StateStore> ManagedStateImpl<S> {
                     ManagedValueState::new(agg_call, keyspace, row_count).await?,
                 ))
             }
-            AggKind::SingleValue => todo!(),
+            AggKind::SingleValue => Ok(Self::Value(
+                ManagedValueState::new(agg_call, keyspace, row_count).await?,
+            )),
         }
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Add `single_value` aggregation for streaming. This is a temporary workaround to deal with scalar subquery. When subquery un-nesting becomes more powerful in the future, this should be removed (together with `single_value` aggregation in `batch`).

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
#831 