### PR TITLE
refactor: remove HummockOptions which is a duplicate of StorageConfig.

### DIFF
--- a/rust/bench/ss_bench/main.rs
+++ b/rust/bench/ss_bench/main.rs
@@ -5,7 +5,7 @@ mod utils;
 
 use clap::Parser;
 use operations::*;
-use risingwave_common::config::StorageConfig;
+use risingwave_common::config::{parse_checksum_algo, StorageConfig};
 use risingwave_pb::common::WorkerType;
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::monitor::StateStoreMetrics;
@@ -110,7 +110,7 @@ async fn main() {
 
     let config = Arc::new(StorageConfig {
         bloom_false_positive: opts.bloom_false_positive,
-        checksum_algo: opts.checksum_algo.clone(),
+        checksum_algo: parse_checksum_algo(&opts.checksum_algo).unwrap(),
         sstable_size: opts.table_size_mb * (1 << 20),
         block_size: opts.block_size_kb * (1 << 10),
         data_directory: "hummock_001".to_string(),

--- a/rust/common/src/config.rs
+++ b/rust/common/src/config.rs
@@ -1,7 +1,8 @@
 use std::fs;
 use std::path::PathBuf;
 
-use serde::{Deserialize, Serialize};
+use serde::de::Error;
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::error::ErrorCode::InternalError;
 use crate::error::{Result, RwError};
@@ -90,12 +91,41 @@ pub struct StorageConfig {
     pub data_directory: String,
 
     /// Checksum algorithm (Crc32c, XxHash64).
-    #[serde(default = "default::checksum_algorithm")]
-    pub checksum_algo: String,
+    #[serde(
+        default = "default::checksum_algorithm",
+        deserialize_with = "ser_parse_checksum_algo"
+    )]
+    pub checksum_algo: risingwave_pb::hummock::checksum::Algorithm,
 
     /// Whether to enable async checkpoint
     #[serde(default = "default::async_checkpoint_enabled")]
     pub async_checkpoint_enabled: bool,
+}
+
+fn ser_parse_checksum_algo<'de, D>(
+    deserializer: D,
+) -> core::result::Result<risingwave_pb::hummock::checksum::Algorithm, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let checksum_algo = String::deserialize(deserializer)?;
+    match parse_checksum_algo(checksum_algo.as_str()) {
+        Some(algo) => Ok(algo),
+        _ => Err(D::Error::custom(format!(
+            "{} is not supported for Hummock",
+            checksum_algo
+        ))),
+    }
+}
+
+pub fn parse_checksum_algo(
+    checksum_algo: &str,
+) -> Option<risingwave_pb::hummock::checksum::Algorithm> {
+    match checksum_algo {
+        "crc32c" => Some(risingwave_pb::hummock::checksum::Algorithm::Crc32c),
+        "xxhash64" => Some(risingwave_pb::hummock::checksum::Algorithm::XxHash64),
+        _ => None,
+    }
 }
 
 impl Default for StorageConfig {
@@ -160,8 +190,8 @@ mod default {
         "hummock_001".to_string()
     }
 
-    pub fn checksum_algorithm() -> String {
-        "crc32c".to_string()
+    pub fn checksum_algorithm() -> risingwave_pb::hummock::checksum::Algorithm {
+        risingwave_pb::hummock::checksum::Algorithm::Crc32c
     }
 
     pub fn async_checkpoint_enabled() -> bool {

--- a/rust/meta/src/hummock/integration_tests.rs
+++ b/rust/meta/src/hummock/integration_tests.rs
@@ -3,12 +3,13 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
+use risingwave_common::config::StorageConfig;
 use risingwave_pb::common::{HostAddress, WorkerType};
 use risingwave_pb::hummock::checksum::Algorithm as ChecksumAlg;
 use risingwave_storage::hummock::compactor::{Compactor, SubCompactContext};
 use risingwave_storage::hummock::local_version_manager::LocalVersionManager;
 use risingwave_storage::hummock::value::HummockValue;
-use risingwave_storage::hummock::{HummockOptions, HummockStorage, SstableStore};
+use risingwave_storage::hummock::{HummockStorage, SstableStore};
 use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::object::InMemObjectStore;
 
@@ -52,14 +53,14 @@ async fn get_hummock_meta_client() -> MockHummockMetaClient {
 
 async fn get_hummock_storage() -> (HummockStorage, Arc<HummockManager<MemStore>>) {
     let remote_dir = "hummock_001_test".to_string();
-    let options = HummockOptions {
+    let options = Arc::new(StorageConfig {
         sstable_size: 64,
         block_size: 1 << 10,
         bloom_false_positive: 0.1,
         data_directory: remote_dir.clone(),
         checksum_algo: ChecksumAlg::XxHash64,
         async_checkpoint_enabled: true,
-    };
+    });
     let hummock_meta_client = Arc::new(get_hummock_meta_client().await);
     let obj_client = Arc::new(InMemObjectStore::new());
     let sstable_store = Arc::new(SstableStore::new(obj_client.clone(), remote_dir));

--- a/rust/storage/src/hummock/compactor.rs
+++ b/rust/storage/src/hummock/compactor.rs
@@ -4,6 +4,7 @@ use std::time::Duration;
 use bytes::{Bytes, BytesMut};
 use futures::stream::{self, StreamExt};
 use futures::Future;
+use risingwave_common::config::StorageConfig;
 use risingwave_common::error::RwError;
 use risingwave_pb::hummock::{
     CompactMetrics, CompactTask, LevelEntry, LevelType, SstableInfo, SubscribeCompactTasksResponse,
@@ -19,7 +20,7 @@ use super::multi_builder::CapacitySplitTableBuilder;
 use super::sstable_store::SstableStoreRef;
 use super::version_cmp::VersionedComparator;
 use super::{
-    HummockError, HummockMetaClient, HummockOptions, HummockResult, HummockStorage, HummockValue,
+    HummockError, HummockMetaClient, HummockResult, HummockStorage, HummockValue,
     LocalVersionManager, SSTableBuilder, SSTableIterator, Sstable,
 };
 use crate::hummock::vacuum::Vacuum;
@@ -27,7 +28,7 @@ use crate::monitor::StateStoreMetrics;
 
 #[derive(Clone)]
 pub struct SubCompactContext {
-    pub options: Arc<HummockOptions>,
+    pub options: Arc<StorageConfig>,
     pub local_version_manager: Arc<LocalVersionManager>,
     pub hummock_meta_client: Arc<dyn HummockMetaClient>,
     pub sstable_store: SstableStoreRef,
@@ -311,7 +312,7 @@ impl Compactor {
     }
 
     pub fn start_compactor(
-        options: Arc<HummockOptions>,
+        options: Arc<StorageConfig>,
         local_version_manager: Arc<LocalVersionManager>,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
         sstable_store: SstableStoreRef,

--- a/rust/storage/src/hummock/shared_buffer.rs
+++ b/rust/storage/src/hummock/shared_buffer.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use itertools::Itertools;
 use parking_lot::RwLock as PLRwLock;
+use risingwave_common::config::StorageConfig;
 use risingwave_common::error::Result;
 use risingwave_pb::hummock::SstableInfo;
 use tokio::task::JoinHandle;
@@ -18,7 +19,7 @@ use super::key_range::KeyRange;
 use super::local_version_manager::LocalVersionManager;
 use super::utils::range_overlap;
 use super::value::HummockValue;
-use super::{key, HummockError, HummockOptions, HummockResult, SstableStoreRef};
+use super::{key, HummockError, HummockResult, SstableStoreRef};
 use crate::monitor::StateStoreMetrics;
 
 type SharedBufferItem = (Bytes, HummockValue<Bytes>);
@@ -160,7 +161,7 @@ pub struct SharedBufferManager {
 
 impl SharedBufferManager {
     pub fn new(
-        options: Arc<HummockOptions>,
+        options: Arc<StorageConfig>,
         local_version_manager: Arc<LocalVersionManager>,
         sstable_store: SstableStoreRef,
         // TODO: should be separated `HummockStats` instead of `StateStoreMetrics`.
@@ -348,7 +349,7 @@ pub struct SharedBufferUploader {
     /// Batches to upload grouped by epoch
     batches_to_upload: BTreeMap<u64, Vec<SharedBufferBatch>>,
     local_version_manager: Arc<LocalVersionManager>,
-    options: Arc<HummockOptions>,
+    options: Arc<StorageConfig>,
 
     /// Statistics.
     // TODO: should be separated `HummockStats` instead of `StateStoreMetrics`.
@@ -361,7 +362,7 @@ pub struct SharedBufferUploader {
 
 impl SharedBufferUploader {
     pub fn new(
-        options: Arc<HummockOptions>,
+        options: Arc<StorageConfig>,
         local_version_manager: Arc<LocalVersionManager>,
         sstable_store: SstableStoreRef,
         stats: Arc<StateStoreMetrics>,
@@ -517,8 +518,9 @@ mod tests {
     use crate::hummock::local_version_manager::LocalVersionManager;
     use crate::hummock::mock::{MockHummockMetaClient, MockHummockMetaService};
     use crate::hummock::shared_buffer::SharedBufferManager;
+    use crate::hummock::test_utils::default_config_for_test;
     use crate::hummock::value::HummockValue;
-    use crate::hummock::{HummockOptions, SstableStore};
+    use crate::hummock::SstableStore;
     use crate::monitor::StateStoreMetrics;
     use crate::object::{InMemObjectStore, ObjectStore};
 
@@ -672,7 +674,7 @@ mod tests {
             MockHummockMetaService::new(),
         )));
         SharedBufferManager::new(
-            Arc::new(HummockOptions::default_for_test()),
+            Arc::new(default_config_for_test()),
             vm,
             sstable_store,
             Arc::new(StateStoreMetrics::unused()),

--- a/rust/storage/src/hummock/snapshot_tests.rs
+++ b/rust/storage/src/hummock/snapshot_tests.rs
@@ -9,6 +9,7 @@ use crate::hummock::iterator::test_utils::{
 };
 use crate::hummock::local_version_manager::LocalVersionManager;
 use crate::hummock::mock::{MockHummockMetaClient, MockHummockMetaService};
+use crate::hummock::test_utils::default_config_for_test;
 use crate::hummock::value::HummockValue;
 use crate::hummock::SSTableBuilder;
 use crate::object::{InMemObjectStore, ObjectStore};
@@ -152,7 +153,7 @@ async fn test_snapshot() {
         mock_hummock_meta_service.clone(),
     ));
 
-    let hummock_options = HummockOptions::default_for_test();
+    let hummock_options = Arc::new(default_config_for_test());
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,
         sstable_store,
@@ -227,7 +228,7 @@ async fn test_snapshot_range_scan() {
     let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(
         mock_hummock_meta_service.clone(),
     ));
-    let hummock_options = HummockOptions::default_for_test();
+    let hummock_options = Arc::new(default_config_for_test());
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,
         sstable_store,
@@ -282,7 +283,7 @@ async fn test_snapshot_reverse_range_scan() {
     let mock_hummock_meta_client = Arc::new(MockHummockMetaClient::new(
         mock_hummock_meta_service.clone(),
     ));
-    let hummock_options = HummockOptions::default_for_test();
+    let hummock_options = Arc::new(default_config_for_test());
     let hummock_storage = HummockStorage::with_default_stats(
         hummock_options,
         sstable_store.clone(),

--- a/rust/storage/src/hummock/state_store_tests.rs
+++ b/rust/storage/src/hummock/state_store_tests.rs
@@ -3,10 +3,11 @@ use std::sync::Arc;
 use bytes::Bytes;
 
 use super::iterator::UserIterator;
-use super::{HummockOptions, HummockStorage};
+use super::HummockStorage;
 use crate::hummock::iterator::test_utils::mock_sstable_store_with_object_store;
 use crate::hummock::local_version_manager::LocalVersionManager;
 use crate::hummock::mock::{MockHummockMetaClient, MockHummockMetaService};
+use crate::hummock::test_utils::default_config_for_test;
 use crate::monitor::StateStoreMetrics;
 use crate::object::InMemObjectStore;
 
@@ -16,7 +17,7 @@ use crate::object::InMemObjectStore;
 async fn test_basic() {
     let object_client = Arc::new(InMemObjectStore::new());
     let sstable_store = mock_sstable_store_with_object_store(object_client.clone());
-    let hummock_options = HummockOptions::default_for_test();
+    let hummock_options = Arc::new(default_config_for_test());
 
     let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
     let hummock_storage = HummockStorage::with_default_stats(
@@ -159,7 +160,7 @@ async fn count_iter(iter: &mut UserIterator<'_>) -> usize {
 async fn test_reload_storage() {
     let object_store = Arc::new(InMemObjectStore::new());
     let sstable_store = mock_sstable_store_with_object_store(object_store.clone());
-    let hummock_options = HummockOptions::default_for_test();
+    let hummock_options = Arc::new(default_config_for_test());
     let local_version_manager = Arc::new(LocalVersionManager::new(sstable_store.clone()));
     let hummock_meta_client = Arc::new(MockHummockMetaClient::new(Arc::new(
         MockHummockMetaService::new(),
@@ -206,7 +207,7 @@ async fn test_reload_storage() {
     // Mock somthing happened to storage internal, and storage is reloaded.
     drop(hummock_storage);
     let hummock_storage = HummockStorage::with_default_stats(
-        HummockOptions::default_for_test(),
+        Arc::new(default_config_for_test()),
         sstable_store,
         local_version_manager,
         hummock_meta_client,

--- a/rust/storage/src/hummock/test_utils.rs
+++ b/rust/storage/src/hummock/test_utils.rs
@@ -1,0 +1,12 @@
+use risingwave_common::config::StorageConfig;
+
+pub fn default_config_for_test() -> StorageConfig {
+    StorageConfig {
+        sstable_size: 256 * (1 << 20),
+        block_size: 64 * (1 << 10),
+        bloom_false_positive: 0.1,
+        data_directory: "hummock_001".to_string(),
+        checksum_algo: risingwave_pb::hummock::checksum::Algorithm::XxHash64,
+        async_checkpoint_enabled: true,
+    }
+}

--- a/rust/storage/src/store_impl.rs
+++ b/rust/storage/src/store_impl.rs
@@ -78,9 +78,7 @@ impl StateStoreImpl {
     ) -> Result<Self> {
         let store = match s {
             hummock if hummock.starts_with("hummock") => {
-                use risingwave_pb::hummock::checksum::Algorithm as ChecksumAlg;
-
-                use crate::hummock::{HummockOptions, HummockStorage};
+                use crate::hummock::HummockStorage;
 
                 let object_store = match hummock {
                     s3 if s3.starts_with("hummock+s3://") => Arc::new(
@@ -111,20 +109,7 @@ impl StateStoreImpl {
                 ));
                 let inner = HummockStateStore::new(
                     HummockStorage::new(
-                        HummockOptions {
-                            sstable_size: config.sstable_size,
-                            block_size: config.block_size,
-                            bloom_false_positive: config.bloom_false_positive,
-                            data_directory: config.data_directory.to_string(),
-                            checksum_algo: match config.checksum_algo.as_str() {
-                                "crc32c" => ChecksumAlg::Crc32c,
-                                "xxhash64" => ChecksumAlg::XxHash64,
-                                other => {
-                                    unimplemented!("{} is not supported for Hummock", other)
-                                }
-                            },
-                            async_checkpoint_enabled: config.async_checkpoint_enabled,
-                        },
+                        config.clone(),
                         sstable_store.clone(),
                         Arc::new(LocalVersionManager::new(sstable_store)),
                         Arc::new(RpcHummockMetaClient::new(meta_client, stats.clone())),


### PR DESCRIPTION
## What's changed and what's your intention?

Remove HummockOptions which is a duplicate of StorageConfig.

## Checklist

## Refer to a related PR or issue link (optional)
part of https://github.com/singularity-data/risingwave-dev/issues/675