### PR TITLE
fix(frontend): enforce singleton distribution on input in single mode aggregation rule

### DIFF
--- a/java/planner/src/main/java/com/risingwave/planner/rules/streaming/aggregate/StreamingSingleModeAggRule.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rules/streaming/aggregate/StreamingSingleModeAggRule.java
@@ -4,6 +4,7 @@ import static com.risingwave.execution.context.ExecutionContext.contextOf;
 import static com.risingwave.planner.planner.PlannerUtils.isSingleMode;
 import static com.risingwave.planner.rel.streaming.RisingWaveStreamingRel.STREAMING;
 
+import com.risingwave.planner.rel.common.dist.RwDistributions;
 import com.risingwave.planner.rel.logical.RwLogicalAggregate;
 import com.risingwave.planner.rel.streaming.RwStreamAgg;
 import org.apache.calcite.plan.RelOptRule;
@@ -30,7 +31,8 @@ public class StreamingSingleModeAggRule extends RelRule<StreamingSingleModeAggRu
   @Override
   public void onMatch(RelOptRuleCall call) {
     RwLogicalAggregate logicalAgg = call.rel(0);
-    var requiredInputTraitSet = logicalAgg.getInput().getTraitSet().plus(STREAMING);
+    var requiredInputTraitSet =
+        logicalAgg.getInput().getTraitSet().plus(STREAMING).plus(RwDistributions.SINGLETON);
     var aggTraits = logicalAgg.getTraitSet().plus(STREAMING);
     var newInput = RelOptRule.convert(logicalAgg.getInput(), requiredInputTraitSet);
 

--- a/java/planner/src/test/java/com/risingwave/planner/planner/streaming/MaterializedViewPlanTest.java
+++ b/java/planner/src/test/java/com/risingwave/planner/planner/streaming/MaterializedViewPlanTest.java
@@ -63,9 +63,11 @@ public class MaterializedViewPlanTest extends StreamPlanTestBase {
         "RwStreamMaterialize(name=[t_test])\n"
             + "  RwStreamProject(v=[+($STREAM_NULL_BY_ROW_COUNT($0, $1), 1)], $f0=[$0], $f1=[$1])\n"
             + "    RwStreamAgg(group=[{}], agg#0=[COUNT()], agg#1=[SUM($0)])\n"
-            + "      RwStreamFilter(condition=[>($0, $1)])\n"
-            + "        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])\n"
-            + "          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])";
+            + "      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])\n"
+            + "        RwStreamFilter(condition=[>($0, $1)])\n"
+            + "          RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])\n"
+            + "            RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])";
+
     Assertions.assertEquals(expectedPlan, resultPlan);
 
     CreateMaterializedViewHandler handler = new CreateMaterializedViewHandler();

--- a/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/MaterializedViewOnMaterializedViewPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/MaterializedViewOnMaterializedViewPlanTest.xml
@@ -52,8 +52,10 @@ create materialized view m3 as select sum(M1.v1) as sum_m1_v1, sum(m1.v2) as sum
 RwStreamMaterialize(name=[m3])
   RwStreamProject(sum_m1_v1=[$STREAM_NULL_BY_ROW_COUNT($0, $1)], sum_m1_v2=[$STREAM_NULL_BY_ROW_COUNT($0, $2)], $f0=[$0], sum_m1_v1_copy=[$1], sum_m1_v2_copy=[$2])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], sum_m1_v1=[SUM($0)], sum_m1_v2=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.4], primaryKeyIndices=[[2]], columnIds=[[0.0.4.0, 0.0.4.1, 0.0.4.2]])
-        RwStreamBatchPlan(table=[[test_schema, m1]], tableId=[0.0.4], primaryKeyIndices=[[2]], columnIds=[[0.0.4.0, 0.0.4.1, 0.0.4.2]])]]>
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.4], primaryKeyIndices=[[2]], columnIds=[[0.0.4.0, 0.0.4.1, 0.0.4.2]])
+          RwStreamBatchPlan(table=[[test_schema, m1]], tableId=[0.0.4], primaryKeyIndices=[[2]], columnIds=[[0.0.4.0, 0.0.4.1, 0.0.4.2]])
+]]>
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
@@ -114,8 +116,10 @@ create materialized view m6 as select sum(v1) as sum_v1, avg(v3) as avg_v3 from 
 RwStreamMaterialize(name=[m6])
   RwStreamProject(sum_v1=[$2], avg_v3=[/(CAST($3):DOUBLE NOT NULL, $4)], v1=[$0])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], sum_v1=[SUM($0)], agg#2=[SUM($1)], agg#3=[COUNT($1)])
-      RwStreamChain(all=[true], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.2, 0.0.8.1, 0.0.8.3]])
-        RwStreamBatchPlan(table=[[test_schema, m5]], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.2, 0.0.8.1, 0.0.8.3]])]]>
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.2, 0.0.8.1, 0.0.8.3]])
+          RwStreamBatchPlan(table=[[test_schema, m5]], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.2, 0.0.8.1, 0.0.8.3]])
+]]>
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
@@ -134,8 +138,10 @@ create materialized view m7 as select sum(v1) as sum_v1 from m5 group by v2;
 RwStreamMaterialize(name=[m7])
   RwStreamProject(sum_v1=[$2], v2=[$0])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], sum_v1=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.0, 0.0.8.2, 0.0.8.3]])
-        RwStreamBatchPlan(table=[[test_schema, m5]], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.0, 0.0.8.2, 0.0.8.3]])]]>
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.0, 0.0.8.2, 0.0.8.3]])
+          RwStreamBatchPlan(table=[[test_schema, m5]], tableId=[0.0.8], primaryKeyIndices=[[2]], columnIds=[[0.0.8.0, 0.0.8.2, 0.0.8.3]])
+]]>
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[
@@ -172,8 +178,10 @@ create materialized view m9 as select round(avg(v1), 1) as avg_v1, sum(v2) as su
 RwStreamMaterialize(name=[m9])
   RwStreamProject(avg_v1=[ROUND($STREAM_NULL_BY_ROW_COUNT($0, /(CAST($1):DOUBLE, $2)), 1)], sum_v2=[$STREAM_NULL_BY_ROW_COUNT($0, $3)], count_v3=[$0], $f1=[$1], $f2=[$2], sum_v2_copy=[$3])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], agg#1=[SUM($0)], agg#2=[COUNT($0)], sum_v2=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.11], primaryKeyIndices=[[2]], columnIds=[[0.0.11.0, 0.0.11.1, 0.0.11.3]])
-        RwStreamBatchPlan(table=[[test_schema, m8]], tableId=[0.0.11], primaryKeyIndices=[[2]], columnIds=[[0.0.11.0, 0.0.11.1, 0.0.11.3]])]]>
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.11], primaryKeyIndices=[[2]], columnIds=[[0.0.11.0, 0.0.11.1, 0.0.11.3]])
+          RwStreamBatchPlan(table=[[test_schema, m8]], tableId=[0.0.11], primaryKeyIndices=[[2]], columnIds=[[0.0.11.0, 0.0.11.1, 0.0.11.3]])
+]]>
         </Resource>
         <Resource name="primaryKey">
             <![CDATA[

--- a/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/MaterializedViewPlanTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/MaterializedViewPlanTest.xml
@@ -10,9 +10,10 @@ create materialized view T1 as select sum(v2) as V from t where v1>1
 RwStreamMaterialize(name=[t1])
   RwStreamProject(v=[$STREAM_NULL_BY_ROW_COUNT($0, $1)], $f0=[$0], v_copy=[$1])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], v=[SUM($1)])
-      RwStreamFilter(condition=[>($0, 1)])
-        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
-          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamFilter(condition=[>($0, 1)])
+          RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+            RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -51,8 +52,9 @@ create materialized view T3 as select v2, sum(v1) as V from t group by v2
 RwStreamMaterialize(name=[t3])
   RwStreamProject(v2=[$0], v=[$2])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], v=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -68,8 +70,9 @@ create materialized view T4 as select sum(v1)+sum(v2) as V from t
 RwStreamMaterialize(name=[t4])
   RwStreamProject(v=[+($STREAM_NULL_BY_ROW_COUNT($0, $1), $STREAM_NULL_BY_ROW_COUNT($0, $2))], $f0=[$0], $f1=[$1], $f2=[$2])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], agg#1=[SUM($0)], agg#2=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -85,9 +88,10 @@ create materialized view T5 as select sum(v1+v2) as V from t
 RwStreamMaterialize(name=[t5])
   RwStreamProject(v=[$STREAM_NULL_BY_ROW_COUNT($0, $1)], $f0=[$0], v_copy=[$1])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], v=[SUM($0)])
-      RwStreamProject($f0=[+($0, $1)], _row_id=[$2])
-        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
-          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamProject($f0=[+($0, $1)], _row_id=[$2])
+          RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+            RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -103,8 +107,9 @@ create materialized view T6 as select sum(v1) as V from t group by v2
 RwStreamMaterialize(name=[t6])
   RwStreamProject(v=[$2], v2=[$0])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], v=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
         <Resource name="primaryKey">
@@ -125,8 +130,9 @@ create materialized view T7 as select sum(v1)+1 as V from t group by v2
 RwStreamMaterialize(name=[t7])
   RwStreamProject(v=[+($2, 1)], v2=[$0])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], agg#1=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
         <Resource name="primaryKey">
@@ -146,10 +152,11 @@ create materialized view T8 as select sum(v1)+1 as V from t where v1>v2
 RwStreamMaterialize(name=[t8])
   RwStreamProject(v=[+($STREAM_NULL_BY_ROW_COUNT($0, $1), 1)], $f0=[$0], $f1=[$1])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], agg#1=[SUM($0)])
-      RwStreamFilter(condition=[>($0, $1)])
-        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
-          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
-            ]]>
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamFilter(condition=[>($0, $1)])
+          RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+            RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.0, 0.0.1.1, 0.0.1.3]])
+]]>
         </Resource>
     </TestCase>>
 

--- a/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamAggPlannerSingleModeTest.xml
+++ b/java/planner/src/test/resources/com/risingwave/planner/planner/streaming/StreamAggPlannerSingleModeTest.xml
@@ -10,8 +10,9 @@ create materialized view T_no_group_no_count_single as select sum(v1) as V from 
 RwStreamMaterialize(name=[t_no_group_no_count_single])
   RwStreamProject(v=[$STREAM_NULL_BY_ROW_COUNT($0, $1)], $f0=[$0], v_copy=[$1])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], v=[SUM($0)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -26,8 +27,9 @@ create materialized view T_no_group_has_count_single as select Count(*), Sum(v1)
 RwStreamMaterialize(name=[t_no_group_has_count_single])
   RwStreamProject(EXPR$0=[$0], v=[$STREAM_NULL_BY_ROW_COUNT($0, $1)], v_copy=[$1])
     RwStreamAgg(group=[{}], agg#0=[COUNT()], v=[SUM($0)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[1]], columnIds=[[0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -41,8 +43,9 @@ create materialized view T_has_group_has_count_single as select v2, Count(*), Su
             <![CDATA[
 RwStreamMaterialize(name=[t_has_group_has_count_single])
   RwStreamAgg(group=[{0}], agg#0=[COUNT()], v=[SUM($1)])
-    RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
-      RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+    RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>
@@ -57,8 +60,9 @@ create materialized view T_has_group_no_count_single as select v2, Sum(v1) as V 
 RwStreamMaterialize(name=[t_has_group_no_count_single])
   RwStreamProject(v2=[$0], v=[$2])
     RwStreamAgg(group=[{0}], agg#0=[COUNT()], v=[SUM($1)])
-      RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
-        RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+      RwStreamExchange(distribution=[RwDistributionTrait{type=SINGLETON, keys=[]}], collation=[[]])
+        RwStreamChain(all=[true], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
+          RwStreamBatchPlan(table=[[test_schema, t]], tableId=[0.0.1], primaryKeyIndices=[[2]], columnIds=[[0.0.1.1, 0.0.1.0, 0.0.1.3]])
 ]]>
         </Resource>
     </TestCase>


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

For simple aggregation with an aggregation function that cannot be two-phased, e.g. max, the aggregator is converted by `SingleModeAggRule`. 

Currently, the input is not enforced by `singleton distribution`. 

We need to enforce this as our plan is actually running in distributed mode and we cannot be sure about the distribution of input.

Haven't changed the java test cases yet.

## Refer to a related PR or issue link (optional)
#917 