### PR TITLE
feat(frontend): add no-op create mv handler

### DIFF
--- a/rust/frontend/src/handler/create_mv.rs
+++ b/rust/frontend/src/handler/create_mv.rs
@@ -1,0 +1,38 @@
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pgwire::pg_response::PgResponse;
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_sqlparser::ast::{ObjectName, Query, Statement};
+
+use crate::binder::Binder;
+use crate::planner::Planner;
+use crate::session::QueryContext;
+
+pub async fn handle_create_mv(
+    context: QueryContext,
+    name: ObjectName,
+    query: Box<Query>,
+) -> Result<PgResponse> {
+    let session = context.session_ctx.clone();
+    let catalog_mgr = session.env().catalog_mgr();
+    let catalog = catalog_mgr
+        .get_database_snapshot(session.database())
+        .ok_or_else(|| ErrorCode::InternalError(String::from("catalog not found")))?;
+
+    let mut binder = Binder::new(catalog);
+    let bound = binder.bind(Statement::Query(query))?;
+    let plan = Planner::new(Rc::new(RefCell::new(context)))
+        .plan(bound)?
+        .gen_create_mv_plan()
+        .to_stream_prost();
+
+    tracing::info!(name= ?name, plan = ?plan);
+
+    Ok(PgResponse::new(
+        pgwire::pg_response::StatementType::CREATE_MATERIALIZED_VIEW,
+        0,
+        vec![],
+        vec![],
+    ))
+}

--- a/rust/frontend/src/handler/mod.rs
+++ b/rust/frontend/src/handler/mod.rs
@@ -6,6 +6,7 @@ use risingwave_sqlparser::ast::{ObjectName, Statement};
 
 use crate::session::{QueryContext, SessionImpl};
 
+mod create_mv;
 mod create_source;
 pub mod create_table;
 pub mod drop_table;
@@ -28,6 +29,13 @@ pub(super) async fn handle(session: Arc<SessionImpl>, stmt: Statement) -> Result
             drop_table::handle_drop_table(context, table_object_name).await
         }
         Statement::Query(query) => query::handle_query(context, query).await,
+        Statement::CreateView {
+            materialized: true,
+            or_replace: false,
+            name,
+            query,
+            ..
+        } => create_mv::handle_create_mv(context, name, query).await,
         _ => Err(ErrorCode::NotImplementedError(format!("Unhandled ast: {:?}", stmt)).into()),
     }
 }


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Add a no-op create MV handler which only generates plan, so that we can easily know what's missing.

Currently, `to_stream_prost` will panic, so I think we can separate this task and create a tracking issue for this.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
ref https://github.com/singularity-data/risingwave-dev/issues/878