### PR TITLE
ci: ignore workflow for doc-only pr

### DIFF
--- a/.github/workflow-template/pr-override.yml
+++ b/.github/workflow-template/pr-override.yml
@@ -5,6 +5,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
 
 concurrency:
   group: environment-${{ github.ref }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,8 @@ name: CI
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - '**.md'
 env:
   RUST_TOOLCHAIN: nightly-2022-03-09
   CACHE_KEY_SUFFIX: v20220309


### PR DESCRIPTION
## What's changed and what's your intention?

Ignore workflow if only `.md` files are changed, e.g. #993 

Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-paths

## Checklist

## Refer to a related PR or issue link (optional)
