### PR TITLE
fix(storage): use AtomicCell in atomic operation in conflict detector

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1124,12 +1124,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae5588f6b3c3cb05239e90bd110f257254aecd01e4635400391aeae07497845"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-epoch 0.9.8",
+ "crossbeam-queue",
+ "crossbeam-utils 0.8.7",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.7",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch 0.9.8",
  "crossbeam-utils 0.8.7",
 ]
 
@@ -1146,6 +1171,30 @@ dependencies = [
  "maybe-uninit",
  "memoffset 0.5.6",
  "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.7",
+ "lazy_static",
+ "memoffset 0.6.5",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f25d8400f4a7a5778f0e4e52384a48cbd9b5c495d110786187fc750075277a2"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-utils 0.8.7",
 ]
 
 [[package]]
@@ -2486,7 +2535,7 @@ dependencies = [
  "async-io",
  "async-lock",
  "crossbeam-channel",
- "crossbeam-epoch",
+ "crossbeam-epoch 0.8.2",
  "crossbeam-utils 0.8.7",
  "futures-util",
  "num_cpus",
@@ -4117,6 +4166,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc32fast",
+ "crossbeam",
  "dashmap",
  "either",
  "farmhash",

--- a/rust/storage/Cargo.toml
+++ b/rust/storage/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = "1"
 bytes = { version = "1", features = ["serde"] }
 chrono = "0.4"
 crc32fast = "1"
+crossbeam = "0.8.1"
 dashmap = "5"
 either = "1"
 farmhash = "1"


### PR DESCRIPTION
## What's changed and what's your intention?
The current atomic operation in the hummock conflict detector use `Ordering::Relaxed` as the memory order. 

As suggested by @twocode , it is better to use `Ordering::SeqCst`, but seems that such ordering to too restricted under current use case. An easier tool to use is the `crossbean::AtomicCell`, which does not require specifying the ordering when calling its methods, so we have changed to use `AtomicCell`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
Suggestion is in the comments in #968 