### PR TITLE
fix: query result should always be single distribution

### DIFF
--- a/rust/frontend/src/planner/delete.rs
+++ b/rust/frontend/src/planner/delete.rs
@@ -18,7 +18,7 @@ impl Planner {
         let plan: PlanRef = LogicalDelete::create(input, delete.table)?.into();
 
         let order = Order::any().clone();
-        let dist = Distribution::any().clone();
+        let dist = Distribution::Single;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
 

--- a/rust/frontend/src/planner/insert.rs
+++ b/rust/frontend/src/planner/insert.rs
@@ -13,7 +13,7 @@ impl Planner {
         // `columns` not used by backend yet.
         let plan: PlanRef = LogicalInsert::create(input, insert.table, vec![])?.into();
         let order = Order::any().clone();
-        let dist = Distribution::any().clone();
+        let dist = Distribution::Single;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
         let root = PlanRoot::new(plan, dist, order, out_fields);

--- a/rust/frontend/src/planner/query.rs
+++ b/rust/frontend/src/planner/query.rs
@@ -14,7 +14,7 @@ impl Planner {
         let order = Order {
             field_order: query.order,
         };
-        let dist = Distribution::Any;
+        let dist = Distribution::Single;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
         let root = PlanRoot::new(plan, dist, order, out_fields);


### PR DESCRIPTION
## What's changed and what's your intention?

I will add distributed plan in next PR #1004 . This is a small fix.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
