### PR TITLE
fix: Do not compact SSTs in uncommitted epoch

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -75,7 +75,10 @@ message Level {
 
 message UncommittedEpoch {
   uint64 epoch = 1;
-  repeated uint64 table_ids = 2;
+  // We store SstableInfo here because key range information is needed to update
+  // CompactStatus.
+  // TODO: should we combine CompactStatus with HummockVersion?
+  repeated SstableInfo tables = 2;
 }
 
 message HummockVersion {

--- a/rust/meta/src/hummock/compaction.rs
+++ b/rust/meta/src/hummock/compaction.rs
@@ -104,7 +104,7 @@ impl CompactStatus {
         let is_select_level_leveling = matches!(prior, LevelHandler::Nonoverlapping(_, _));
         let target_level = select_level + 1;
         let is_target_level_leveling = matches!(posterior, LevelHandler::Nonoverlapping(_, _));
-        // plan to select and merge table(s) in `select_level` into `target_level`
+        // Try to select and merge table(s) in `select_level` into `target_level`
         match prior {
             LevelHandler::Overlapping(l_n, compacting_key_ranges)
             | LevelHandler::Nonoverlapping(l_n, compacting_key_ranges) => {

--- a/rust/meta/src/hummock/hummock_manager.rs
+++ b/rust/meta/src/hummock/hummock_manager.rs
@@ -86,7 +86,7 @@ where
         Ok(instance)
     }
 
-    /// load state from meta store.
+    /// Load state from meta store.
     async fn load_meta_store_state(&self) -> Result<()> {
         let mut compaction_guard = self.compaction.lock().await;
         compaction_guard.compact_status = CompactStatus::get(self.meta_store_ref.as_ref())
@@ -254,6 +254,19 @@ where
         Ok(())
     }
 
+    fn trigger_commit_stat(&self, current_version: &HummockVersion) {
+        self.metrics
+            .max_committed_epoch
+            .set(current_version.max_committed_epoch as i64);
+        let uncommitted_sst_num = current_version
+            .uncommitted_epochs
+            .iter()
+            .fold(0, |accum, elem| accum + elem.tables.len());
+        self.metrics
+            .uncommitted_sst_num
+            .set(uncommitted_sst_num as i64);
+    }
+
     fn trigger_sst_stat(&self, compact_status: &CompactStatus) {
         let reduce_compact_cnt = |compacting_key_ranges: &Vec<(
             risingwave_storage::hummock::key_range::KeyRange,
@@ -375,29 +388,8 @@ where
         sstables: Vec<SstableInfo>,
         epoch: HummockEpoch,
     ) -> Result<HummockVersion> {
-        let stats = sstables.iter().map(SSTableStat::from).collect_vec();
-
         let mut sst_id_infos_update_vec = vec![];
-        let mut compaction_guard = self.compaction.lock().await;
-        let mut compact_status_copy = compaction_guard.compact_status.clone();
-        match compact_status_copy.level_handlers.first_mut().unwrap() {
-            LevelHandler::Overlapping(vec_tier, _) => {
-                for stat in stats {
-                    let insert_point = vec_tier.partition_point(
-                        |SSTableStat {
-                             key_range: other_key_range,
-                             ..
-                         }| { other_key_range <= &stat.key_range },
-                    );
-                    vec_tier.insert(insert_point, stat);
-                }
-            }
-            LevelHandler::Nonoverlapping(_, _) => {
-                panic!("L0 must be Tiering.");
-            }
-        }
         let mut transaction = Transaction::default();
-        compact_status_copy.update_in_transaction(&mut transaction);
 
         let mut versioning_guard = self.versioning.write().await;
         let mut current_version_id_copy = versioning_guard.current_version_id.clone();
@@ -430,7 +422,7 @@ where
             }
         }
 
-        // check whether the epoch is valid
+        // Check whether the epoch is valid
         // TODO: return error instead of panic
         if epoch <= hummock_version_copy.max_committed_epoch {
             panic!(
@@ -439,22 +431,20 @@ where
             );
         }
 
-        // create new_version by adding tables in UncommittedEpoch
+        // Create new_version by adding tables in UncommittedEpoch
         match hummock_version_copy
             .uncommitted_epochs
             .iter_mut()
             .find(|e| e.epoch == epoch)
         {
             Some(uncommitted_epoch) => {
-                sstables
-                    .iter()
-                    .for_each(|t| uncommitted_epoch.table_ids.push(t.id));
+                uncommitted_epoch.tables.extend(sstables);
             }
             None => hummock_version_copy
                 .uncommitted_epochs
                 .push(UncommittedEpoch {
                     epoch,
-                    table_ids: sstables.iter().map(|t| t.id).collect(),
+                    tables: sstables,
                 }),
         };
         current_version_id_copy.increase();
@@ -462,14 +452,14 @@ where
         hummock_version_copy.id = current_version_id_copy.id();
         hummock_version_copy.upsert_in_transaction(&mut transaction)?;
 
-        // the trx contain update for both tables and compact_status
+        // trx contains update for both tables and compact_status
         self.commit_trx(self.meta_store_ref.as_ref(), transaction, Some(context_id))
             .await?;
 
-        self.trigger_sst_stat(&compact_status_copy);
+        // Update metrics
+        self.trigger_commit_stat(&hummock_version_copy);
 
         // Update in-mem state after transaction succeeds.
-        compaction_guard.compact_status = compact_status_copy;
         versioning_guard.current_version_id = current_version_id_copy;
         versioning_guard
             .hummock_versions
@@ -483,7 +473,6 @@ where
         #[cfg(test)]
         {
             drop(versioning_guard);
-            drop(compaction_guard);
             self.check_state_consistency().await;
         }
 
@@ -575,6 +564,7 @@ where
             None => Ok(None),
             Some(mut compact_task) => {
                 let mut transaction = Transaction::default();
+                // Q: why update?
                 compact_status_copy.update_in_transaction(&mut transaction);
                 self.commit_trx(self.meta_store_ref.as_ref(), transaction, None)
                     .await?;
@@ -766,6 +756,8 @@ where
     }
 
     pub async fn commit_epoch(&self, epoch: HummockEpoch) -> Result<()> {
+        let mut compaction_guard = self.compaction.lock().await;
+        let mut compact_status_copy = compaction_guard.compact_status.clone();
         let mut versioning_guard = self.versioning.write().await;
         let mut transaction = Transaction::default();
         let mut current_version_id_copy = versioning_guard.current_version_id.clone();
@@ -794,21 +786,45 @@ where
         {
             let uncommitted_epoch = &hummock_version_copy.uncommitted_epochs[idx];
 
-            // commit tables by moving them into level0
+            // Commit tables by moving them into level0
             let version_first_level = hummock_version_copy.levels.first_mut().unwrap();
             match version_first_level.get_level_type()? {
                 LevelType::Overlapping => {
                     uncommitted_epoch
-                        .table_ids
+                        .tables
                         .iter()
-                        .for_each(|id| version_first_level.table_ids.push(*id));
+                        .for_each(|t| version_first_level.table_ids.push(t.id));
                 }
                 LevelType::Nonoverlapping => {
                     unimplemented!()
                 }
             };
 
-            // remove the epoch from uncommitted_epochs and update max_committed_epoch
+            // Update compact status so SSTs are eligible for compaction
+            let stats = uncommitted_epoch
+                .tables
+                .iter()
+                .map(SSTableStat::from)
+                .collect_vec();
+            match compact_status_copy.level_handlers.first_mut().unwrap() {
+                LevelHandler::Overlapping(vec_tier, _) => {
+                    for stat in stats {
+                        let insert_point = vec_tier.partition_point(
+                            |SSTableStat {
+                                 key_range: other_key_range,
+                                 ..
+                             }| { other_key_range <= &stat.key_range },
+                        );
+                        vec_tier.insert(insert_point, stat);
+                    }
+                }
+                LevelHandler::Nonoverlapping(_, _) => {
+                    panic!("L0 must be Tiering.");
+                }
+            }
+            compact_status_copy.update_in_transaction(&mut transaction);
+
+            // Remove the epoch from uncommitted_epochs
             hummock_version_copy.uncommitted_epochs.swap_remove(idx);
         }
         // Create a new_version, possibly merely to bump up the version id and max_committed_epoch.
@@ -817,7 +833,13 @@ where
         hummock_version_copy.upsert_in_transaction(&mut transaction)?;
         self.commit_trx(self.meta_store_ref.as_ref(), transaction, None)
             .await?;
+
+        // Update metrics
+        self.trigger_sst_stat(&compact_status_copy);
+        self.trigger_commit_stat(&hummock_version_copy);
+
         // Update in-mem state after transaction succeeds.
+        compaction_guard.compact_status = compact_status_copy;
         versioning_guard.current_version_id = current_version_id_copy;
         versioning_guard
             .hummock_versions
@@ -827,6 +849,7 @@ where
         #[cfg(test)]
         {
             drop(versioning_guard);
+            drop(compaction_guard);
             self.check_state_consistency().await;
         }
 
@@ -847,7 +870,7 @@ where
             .unwrap()
             .clone();
 
-        // get tables in the committing epoch
+        // Get tables in the committing epoch
         let ret = match hummock_version_copy
             .uncommitted_epochs
             .iter()
@@ -856,10 +879,10 @@ where
             Some(idx) => {
                 let uncommitted_epoch = &hummock_version_copy.uncommitted_epochs[idx];
 
-                // remove tables of the aborting epoch
-                for sst_id in &uncommitted_epoch.table_ids {
+                // Remove tables of the aborting epoch
+                for sst in &uncommitted_epoch.tables {
                     if let Some(mut sst_id_info) =
-                        versioning_guard.sstable_id_infos.get(sst_id).cloned()
+                        versioning_guard.sstable_id_infos.get(&sst.id).cloned()
                     {
                         sst_id_info.meta_delete_timestamp = sstable_id_info::get_timestamp_now();
                         sst_id_info.upsert_in_transaction(&mut transaction)?;
@@ -868,7 +891,7 @@ where
                 }
                 hummock_version_copy.uncommitted_epochs.swap_remove(idx);
 
-                // create new_version
+                // Create new_version
                 hummock_version_copy.id = new_version_id;
                 hummock_version_copy.upsert_in_transaction(&mut transaction)?;
 

--- a/rust/meta/src/hummock/hummock_manager_tests.rs
+++ b/rust/meta/src/hummock/hummock_manager_tests.rs
@@ -202,9 +202,8 @@ async fn test_hummock_transaction() -> Result<()> {
         let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
         assert_eq!(epoch1, uncommitted_epoch.epoch);
         assert_eq!(pinned_version.max_committed_epoch, INVALID_EPOCH);
-        uncommitted_epoch.table_ids.sort_unstable();
-        let table_ids_in_epoch1: Vec<u64> = tables_in_epoch1.iter().map(|t| t.id).collect();
-        assert_eq!(table_ids_in_epoch1, uncommitted_epoch.table_ids);
+        uncommitted_epoch.tables.sort_unstable_by_key(|e| e.id);
+        assert_eq!(tables_in_epoch1, uncommitted_epoch.tables);
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
         hummock_manager
@@ -249,9 +248,8 @@ async fn test_hummock_transaction() -> Result<()> {
         let mut pinned_version = hummock_manager.pin_version(context_id).await?;
         let uncommitted_epoch = pinned_version.uncommitted_epochs.first_mut().unwrap();
         assert_eq!(epoch2, uncommitted_epoch.epoch);
-        uncommitted_epoch.table_ids.sort_unstable();
-        let table_ids_in_epoch2: Vec<u64> = tables_in_epoch2.iter().map(|t| t.id).collect();
-        assert_eq!(table_ids_in_epoch2, uncommitted_epoch.table_ids);
+        uncommitted_epoch.tables.sort_unstable_by_key(|e| e.id);
+        assert_eq!(tables_in_epoch2, uncommitted_epoch.tables);
         assert_eq!(pinned_version.max_committed_epoch, epoch1);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -309,17 +307,15 @@ async fn test_hummock_transaction() -> Result<()> {
             .iter_mut()
             .find(|e| e.epoch == epoch3)
             .unwrap();
-        uncommitted_epoch3.table_ids.sort_unstable();
-        let table_ids_in_epoch3: Vec<u64> = tables_in_epoch3.iter().map(|t| t.id).collect();
-        assert_eq!(table_ids_in_epoch3, uncommitted_epoch3.table_ids);
+        uncommitted_epoch3.tables.sort_unstable_by_key(|e| e.id);
+        assert_eq!(tables_in_epoch3, uncommitted_epoch3.tables);
         let uncommitted_epoch4 = pinned_version
             .uncommitted_epochs
             .iter_mut()
             .find(|e| e.epoch == epoch4)
             .unwrap();
-        uncommitted_epoch4.table_ids.sort_unstable();
-        let table_ids_in_epoch4: Vec<u64> = tables_in_epoch4.iter().map(|t| t.id).collect();
-        assert_eq!(table_ids_in_epoch4, uncommitted_epoch4.table_ids);
+        uncommitted_epoch4.tables.sort_unstable_by_key(|e| e.id);
+        assert_eq!(tables_in_epoch4, uncommitted_epoch4.tables);
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),
@@ -344,8 +340,8 @@ async fn test_hummock_transaction() -> Result<()> {
             .iter_mut()
             .find(|e| e.epoch == epoch4)
             .unwrap();
-        uncommitted_epoch4.table_ids.sort_unstable();
-        assert_eq!(table_ids_in_epoch4, uncommitted_epoch4.table_ids);
+        uncommitted_epoch4.tables.sort_unstable_by_key(|e| e.id);
+        assert_eq!(tables_in_epoch4, uncommitted_epoch4.tables);
         assert_eq!(pinned_version.max_committed_epoch, epoch2);
         assert_eq!(
             get_sorted_sstable_ids(&committed_tables),


### PR DESCRIPTION
- Do not update `CompactStatus` during `add_tables` so uncommitted SSTs will be excluded from compaction
- Update `CompactStatus` in `commit_epoch` so newly committed SSTs are eligible for compaction
- Add `max_committed_epoch` and `uncommitted_sst_num` metrics

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close #1018