### PR TITLE
chore(optimizer): separate logical optimization

### DIFF
--- a/rust/frontend/src/optimizer/mod.rs
+++ b/rust/frontend/src/optimizer/mod.rs
@@ -87,8 +87,8 @@ impl PlanRoot {
         LogicalProject::create(self.logical_plan, exprs, expr_aliases)
     }
 
-    /// optimize and generate a batch query plan
-    pub fn gen_batch_query_plan(&self) -> PlanRef {
+    /// Apply logical optimization to the plan.
+    pub fn gen_optimized_logical_plan(&self) -> PlanRef {
         let mut plan = self.logical_plan.clone();
 
         // Predicate Push-down
@@ -100,6 +100,13 @@ impl PlanRoot {
 
         // Prune Columns
         plan = plan.prune_col(&self.out_fields);
+
+        plan
+    }
+
+    /// optimize and generate a batch query plan
+    pub fn gen_batch_query_plan(&self) -> PlanRef {
+        let mut plan = self.gen_optimized_logical_plan();
 
         // Convert to physical plan node
         plan = plan.to_batch_with_order_required(&self.required_order);
@@ -124,17 +131,7 @@ impl PlanRoot {
 
     /// optimize and generate a create materialize view plan
     pub fn gen_create_mv_plan(&self) -> PlanRef {
-        let mut plan = self.logical_plan.clone();
-
-        // Predicate Push-down
-        plan = {
-            let rules = vec![FilterJoinRule::create(), FilterProjectRule::create()];
-            let heuristic_optimizer = HeuristicOptimizer::new(ApplyOrder::TopDown, rules);
-            heuristic_optimizer.optimize(plan)
-        };
-
-        // Prune Columns
-        plan = plan.prune_col(&self.out_fields);
+        let mut plan = self.gen_optimized_logical_plan();
 
         // Convert to physical plan node
         plan = plan.to_stream_with_dist_required(&self.required_dist);

--- a/rust/frontend/test_runner/src/lib.rs
+++ b/rust/frontend/test_runner/src/lib.rs
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
 pub struct TestCase {
     pub sql: String,
     pub logical_plan: Option<String>,
+    pub optimized_logical_plan: Option<String>,
     pub batch_plan: Option<String>,
     pub stream_plan: Option<String>,
     pub binder_error: Option<String>,
@@ -34,6 +35,7 @@ pub struct TestCase {
 #[serde(deny_unknown_fields)]
 pub struct TestCaseResult {
     pub logical_plan: Option<String>,
+    pub optimized_logical_plan: Option<String>,
     pub batch_plan: Option<String>,
     pub stream_plan: Option<String>,
     pub binder_error: Option<String>,
@@ -47,6 +49,7 @@ impl TestCaseResult {
         TestCase {
             sql: sql.to_string(),
             logical_plan: self.logical_plan,
+            optimized_logical_plan: self.optimized_logical_plan,
             batch_plan: self.batch_plan,
             stream_plan: self.stream_plan,
             planner_error: self.planner_error,
@@ -123,6 +126,12 @@ impl TestCase {
             }
         };
 
+        // Only generate optimized_logical_plan if it is specified in test case
+        if self.optimized_logical_plan.is_some() {
+            ret.optimized_logical_plan =
+                Some(explain_plan(&logical_plan.gen_optimized_logical_plan()));
+        }
+
         // Only generate batch_plan if it is specified in test case
         if self.batch_plan.is_some() {
             ret.batch_plan = Some(explain_plan(&logical_plan.gen_dist_batch_query_plan()));
@@ -150,6 +159,11 @@ fn check_result(expected: &TestCase, actual: &TestCaseResult) -> Result<()> {
         &actual.optimizer_error,
     )?;
     check_logical_plan("logical_plan", &expected.logical_plan, &actual.logical_plan)?;
+    check_logical_plan(
+        "optimized_logical_plan",
+        &expected.optimized_logical_plan,
+        &actual.optimized_logical_plan,
+    )?;
     check_logical_plan("batch_plan", &expected.batch_plan, &actual.batch_plan)?;
     check_logical_plan("stream_plan", &expected.stream_plan, &actual.stream_plan)?;
 

--- a/rust/frontend/test_runner/tests/testdata/column_pruning.yaml
+++ b/rust/frontend/test_runner/tests/testdata/column_pruning.yaml
@@ -4,10 +4,9 @@
   logical_plan: |
     LogicalProject { exprs: [$1], expr_alias: [Some("v1")] }
       LogicalScan { table: "t", columns: ["_row_id", "v1", "v2"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [Some("v1")] }
-        BatchScan { table: "t", columns: ["v1"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0], expr_alias: [Some("v1")] }
+      LogicalScan { table: "t", columns: ["v1"] }
 # filter
 - sql: |
     create table t (v1 bigint, v2 double precision, v3 int);
@@ -16,11 +15,10 @@
     LogicalProject { exprs: [$1], expr_alias: [Some("v1")] }
       LogicalFilter { predicate: Condition { conjunctions: [($2 > 2:Int32)] } }
         LogicalScan { table: "t", columns: ["_row_id", "v1", "v2", "v3"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [Some("v1")] }
-        BatchFilter { predicate: Condition { conjunctions: [($1 > 2:Int32)] } }
-          BatchScan { table: "t", columns: ["v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0], expr_alias: [Some("v1")] }
+      LogicalFilter { predicate: Condition { conjunctions: [($1 > 2:Int32)] } }
+        LogicalScan { table: "t", columns: ["v1", "v2"] }
 # join
 - sql: |
     create table t1 (v1 int not null, v2 int not null, v3 int);
@@ -31,14 +29,11 @@
       LogicalJoin { type: Inner, on: Condition { conjunctions: [($2 = $6)] } }
         LogicalScan { table: "t1", columns: ["_row_id", "v1", "v2", "v3"] }
         LogicalScan { table: "t2", columns: ["_row_id", "v1", "v2", "v3"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0, $2], expr_alias: [Some("v1"), Some("v1")] }
-        BatchHashJoin(predicate: $1 = $3)
-          BatchExchange { order: Order { field_order: [] }, dist: HashShard([1]) }
-            BatchScan { table: "t1", columns: ["v1", "v2"] }
-          BatchExchange { order: Order { field_order: [] }, dist: HashShard([3]) }
-            BatchScan { table: "t2", columns: ["v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0, $2], expr_alias: [Some("v1"), Some("v1")] }
+      LogicalJoin { type: Inner, on: Condition { conjunctions: [($1 = $3)] } }
+        LogicalScan { table: "t1", columns: ["v1", "v2"] }
+        LogicalScan { table: "t2", columns: ["v1", "v2"] }
 # agg
 - sql: |
     create table t (v1 bigint, v2 double precision, v3 int);
@@ -47,8 +42,7 @@
     LogicalProject { exprs: [Count($1)], expr_alias: [None] }
       LogicalFilter { predicate: Condition { conjunctions: [($2 > 2:Int32)] } }
         LogicalScan { table: "t", columns: ["_row_id", "v1", "v2", "v3"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [Count($0)], expr_alias: [None] }
-        BatchFilter { predicate: Condition { conjunctions: [($1 > 2:Int32)] } }
-          BatchScan { table: "t", columns: ["v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [Count($0)], expr_alias: [None] }
+      LogicalFilter { predicate: Condition { conjunctions: [($1 > 2:Int32)] } }
+        LogicalScan { table: "t", columns: ["v1", "v2"] }

--- a/rust/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
+++ b/rust/frontend/test_runner/tests/testdata/predicate_pushdown.yaml
@@ -3,16 +3,19 @@
     create table t1 (v1 int, v2 int, v3 int);
     create table t2 (v1 int, v2 int, v3 int);
     select * from t1 join t2 on t1.v1=t2.v2 and t1.v1>1 where t2.v2>2;
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7], expr_alias: [Some("_row_id"), Some("v1"), Some("v2"), Some("v3"), Some("_row_id"), Some("v1"), Some("v2"), Some("v3")] }
-        BatchHashJoin(predicate: $1 = $6)
-          BatchExchange { order: Order { field_order: [] }, dist: HashShard([1]) }
-            BatchFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
-              BatchScan { table: "t1", columns: ["_row_id", "v1", "v2", "v3"] }
-          BatchExchange { order: Order { field_order: [] }, dist: HashShard([6]) }
-            BatchFilter { predicate: Condition { conjunctions: [($2 > 2:Int32)] } }
-              BatchScan { table: "t2", columns: ["_row_id", "v1", "v2", "v3"] }
+  logical_plan: |
+    LogicalProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7], expr_alias: [Some("_row_id"), Some("v1"), Some("v2"), Some("v3"), Some("_row_id"), Some("v1"), Some("v2"), Some("v3")] }
+      LogicalFilter { predicate: Condition { conjunctions: [($6 > 2:Int32)] } }
+        LogicalJoin { type: Inner, on: Condition { conjunctions: [($1 = $6), ($1 > 1:Int32)] } }
+          LogicalScan { table: "t1", columns: ["_row_id", "v1", "v2", "v3"] }
+          LogicalScan { table: "t2", columns: ["_row_id", "v1", "v2", "v3"] }
+  optimized_logical_plan: |
+      LogicalProject { exprs: [$0, $1, $2, $3, $4, $5, $6, $7], expr_alias: [Some("_row_id"), Some("v1"), Some("v2"), Some("v3"), Some("_row_id"), Some("v1"), Some("v2"), Some("v3")] }
+        LogicalJoin { type: Inner, on: Condition { conjunctions: [($1 = $6)] } }
+          LogicalFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
+            LogicalScan { table: "t1", columns: ["_row_id", "v1", "v2", "v3"] }
+          LogicalFilter { predicate: Condition { conjunctions: [($2 > 2:Int32)] } }
+            LogicalScan { table: "t2", columns: ["_row_id", "v1", "v2", "v3"] }
 # filter project
 - sql: |
     create table t (v1 bigint, v2 double precision);
@@ -22,11 +25,10 @@
       LogicalFilter { predicate: Condition { conjunctions: [($2 > 1:Int32)] } }
         LogicalProject { exprs: [$0, $1, $2], expr_alias: [Some("_row_id"), Some("v1"), Some("v2")] }
           LogicalScan { table: "t", columns: ["_row_id", "v1", "v2"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0, $1, $2], expr_alias: [Some("_row_id"), Some("v1"), Some("v2")] }
-        BatchFilter { predicate: Condition { conjunctions: [($2 > 1:Int32)] } }
-          BatchScan { table: "t", columns: ["_row_id", "v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0, $1, $2], expr_alias: [Some("_row_id"), Some("v1"), Some("v2")] }
+      LogicalFilter { predicate: Condition { conjunctions: [($2 > 1:Int32)] } }
+        LogicalScan { table: "t", columns: ["_row_id", "v1", "v2"] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2, v1 from t) where v2 > 1;
@@ -35,11 +37,10 @@
       LogicalFilter { predicate: Condition { conjunctions: [($0 > 1:Int32)] } }
         LogicalProject { exprs: [$2, $1], expr_alias: [Some("v2"), Some("v1")] }
           LogicalScan { table: "t", columns: ["_row_id", "v1", "v2"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [Some("v1")] }
-        BatchFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
-          BatchScan { table: "t", columns: ["v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0], expr_alias: [Some("v1")] }
+      LogicalFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
+        LogicalScan { table: "t", columns: ["v1", "v2"] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1 from (select v2 as a2, v1 from t where v1 > 2) where a2 > 1;
@@ -49,9 +50,8 @@
         LogicalProject { exprs: [$2, $1], expr_alias: [Some("a2"), Some("v1")] }
           LogicalFilter { predicate: Condition { conjunctions: [($1 > 2:Int32)] } }
             LogicalScan { table: "t", columns: ["_row_id", "v1", "v2"] }
-  batch_plan: |
-    BatchExchange { order: Order { field_order: [] }, dist: Single }
-      BatchProject { exprs: [$0], expr_alias: [Some("v1")] }
-        BatchFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
-          BatchFilter { predicate: Condition { conjunctions: [($0 > 2:Int32)] } }
-            BatchScan { table: "t", columns: ["v1", "v2"] }
+  optimized_logical_plan: |
+    LogicalProject { exprs: [$0], expr_alias: [Some("v1")] }
+      LogicalFilter { predicate: Condition { conjunctions: [($1 > 1:Int32)] } }
+        LogicalFilter { predicate: Condition { conjunctions: [($0 > 2:Int32)] } }
+          LogicalScan { table: "t", columns: ["v1", "v2"] }


### PR DESCRIPTION
## What's changed and what's your intention?

- separate logical optimization into a method.
- add `optimized_logical_plan` in plan tests, and use it to replace `batch_plan` in `column_pruning`&`predicate_pushdown`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave-dev/issues/1042