### PR TITLE
chore(storage): fix HummockError debug and show error on compaction fail

### DIFF
--- a/rust/storage/src/hummock/compactor.rs
+++ b/rust/storage/src/hummock/compactor.rs
@@ -320,8 +320,9 @@ impl Compactor {
         mut compact_task: CompactTask,
     ) -> HummockResult<()> {
         let result = Compactor::run_compact(context, &mut compact_task).await;
-        if result.is_err() {
+        if let Err(ref e) = result {
             compact_task.sorted_output_ssts.clear();
+            tracing::warn!("compactor error: {}", e);
         }
 
         let is_task_ok = result.is_ok();

--- a/rust/storage/src/hummock/error.rs
+++ b/rust/storage/src/hummock/error.rs
@@ -93,12 +93,18 @@ impl From<prost::DecodeError> for TracedHummockError {
     }
 }
 
-#[derive(Error, Debug)]
-#[error("{source}")]
+#[derive(Error)]
+#[error("{source:?}\n{backtrace:#}")]
 pub struct TracedHummockError {
     #[from]
     source: HummockError,
     backtrace: Backtrace,
+}
+
+impl std::fmt::Debug for TracedHummockError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self)
+    }
 }
 
 impl From<TracedHummockError> for RwError {


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

`TracedHummockError` are more readable now 🤣

Also we will print the source error to console if compaction failed. Previously we don't print the reason why it failed on compute node.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
