### PR TITLE
refactor(frontend): remove Clone on BoundBaseTable

### DIFF
--- a/rust/frontend/src/binder/relation.rs
+++ b/rust/frontend/src/binder/relation.rs
@@ -43,7 +43,7 @@ pub struct BoundJoin {
     pub cond: ExprImpl,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct BoundBaseTable {
     pub name: String, // explain-only
     pub table_id: TableId,

--- a/rust/frontend/src/optimizer/plan_node/logical_delete.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_delete.rs
@@ -20,7 +20,7 @@ use risingwave_common::error::Result;
 use risingwave_common::types::DataType;
 
 use super::{BatchDelete, ColPrunable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatch, ToStream};
-use crate::binder::BoundBaseTable;
+use crate::catalog::TableId;
 
 /// [`LogicalDelete`] iterates on input relation and delete the data from specified table.
 ///
@@ -28,28 +28,34 @@ use crate::binder::BoundBaseTable;
 #[derive(Debug, Clone)]
 pub struct LogicalDelete {
     pub base: PlanBase,
-    table: BoundBaseTable,
+    table_name: String, // explain-only
+    table_id: TableId,
     input: PlanRef,
 }
 
 impl LogicalDelete {
     /// Create a [`LogicalDelete`] node. Used internally by optimizer.
-    pub fn new(input: PlanRef, table: BoundBaseTable) -> Self {
+    pub fn new(input: PlanRef, table_name: String, table_id: TableId) -> Self {
         let ctx = input.ctx();
         // TODO: support `RETURNING`.
         let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
         let base = PlanBase::new_logical(ctx, schema);
-        Self { base, table, input }
+        Self {
+            base,
+            table_name,
+            table_id,
+            input,
+        }
     }
 
     /// Create a [`LogicalDelete`] node. Used by planner.
-    pub fn create(input: PlanRef, table: BoundBaseTable) -> Result<Self> {
-        Ok(Self::new(input, table))
+    pub fn create(input: PlanRef, table_name: String, table_id: TableId) -> Result<Self> {
+        Ok(Self::new(input, table_name, table_id))
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
         f.debug_struct(name)
-            .field("table_name", &self.table.name)
+            .field("table_name", &self.table_name)
             .finish()
     }
 }
@@ -60,7 +66,7 @@ impl PlanTreeNodeUnary for LogicalDelete {
     }
 
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new(input, self.table.clone())
+        Self::new(input, self.table_name.clone(), self.table_id)
     }
 }
 

--- a/rust/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -20,8 +20,7 @@ use risingwave_common::error::Result;
 use risingwave_common::types::DataType;
 
 use super::{BatchInsert, ColPrunable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatch, ToStream};
-use crate::binder::BoundBaseTable;
-use crate::catalog::ColumnId;
+use crate::catalog::{ColumnId, TableId};
 
 /// `LogicalInsert` iterates on input relation and insert the data into specified table.
 ///
@@ -30,19 +29,26 @@ use crate::catalog::ColumnId;
 #[derive(Debug, Clone)]
 pub struct LogicalInsert {
     pub base: PlanBase,
-    table: BoundBaseTable,
+    table_name: String, // explain-only
+    table_id: TableId,
     columns: Vec<ColumnId>,
     input: PlanRef,
 }
 
 impl LogicalInsert {
     /// Create a [`LogicalInsert`] node. Used internally by optimizer.
-    pub fn new(input: PlanRef, table: BoundBaseTable, columns: Vec<ColumnId>) -> Self {
+    pub fn new(
+        input: PlanRef,
+        table_name: String,
+        table_id: TableId,
+        columns: Vec<ColumnId>,
+    ) -> Self {
         let ctx = input.ctx();
         let schema = Schema::new(vec![Field::unnamed(DataType::Int64)]);
         let base = PlanBase::new_logical(ctx, schema);
         Self {
-            table,
+            table_name,
+            table_id,
             columns,
             input,
             base,
@@ -50,13 +56,18 @@ impl LogicalInsert {
     }
 
     /// Create a [`LogicalInsert`] node. Used by planner.
-    pub fn create(input: PlanRef, table: BoundBaseTable, columns: Vec<ColumnId>) -> Result<Self> {
-        Ok(Self::new(input, table, columns))
+    pub fn create(
+        input: PlanRef,
+        table_name: String,
+        table_id: TableId,
+        columns: Vec<ColumnId>,
+    ) -> Result<Self> {
+        Ok(Self::new(input, table_name, table_id, columns))
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
         f.debug_struct(name)
-            .field("table_name", &self.table.name)
+            .field("table_name", &self.table_name)
             .field("columns", &self.columns)
             .finish()
     }
@@ -67,7 +78,12 @@ impl PlanTreeNodeUnary for LogicalInsert {
         self.input.clone()
     }
     fn clone_with_input(&self, input: PlanRef) -> Self {
-        Self::new(input, self.table.clone(), self.columns.clone())
+        Self::new(
+            input,
+            self.table_name.clone(),
+            self.table_id,
+            self.columns.clone(),
+        )
     }
 }
 impl_plan_tree_node_for_unary! {LogicalInsert}

--- a/rust/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -28,7 +28,7 @@ use crate::session::QueryContextRef;
 #[derive(Debug, Clone)]
 pub struct LogicalScan {
     pub base: PlanBase,
-    table_name: String,
+    table_name: String, // explain-only
     table_id: TableId,
     columns: Vec<ColumnId>,
 }

--- a/rust/frontend/src/planner/delete.rs
+++ b/rust/frontend/src/planner/delete.rs
@@ -23,13 +23,15 @@ use crate::optimizer::{PlanRef, PlanRoot};
 
 impl Planner {
     pub(super) fn plan_delete(&mut self, delete: BoundDelete) -> Result<PlanRoot> {
-        let scan = self.plan_base_table(delete.table.clone())?;
+        let table_name = delete.table.name.clone();
+        let table_id = delete.table.table_id;
+        let scan = self.plan_base_table(delete.table)?;
         let input = if let Some(expr) = delete.selection {
             LogicalFilter::create(scan, expr)?
         } else {
             scan
         };
-        let plan: PlanRef = LogicalDelete::create(input, delete.table)?.into();
+        let plan: PlanRef = LogicalDelete::create(input, table_name, table_id)?.into();
 
         let order = Order::any().clone();
         let dist = Distribution::Single;

--- a/rust/frontend/src/planner/insert.rs
+++ b/rust/frontend/src/planner/insert.rs
@@ -25,7 +25,8 @@ impl Planner {
     pub(super) fn plan_insert(&mut self, insert: BoundInsert) -> Result<PlanRoot> {
         let input = self.plan_query(insert.source)?.as_subplan();
         // `columns` not used by backend yet.
-        let plan: PlanRef = LogicalInsert::create(input, insert.table, vec![])?.into();
+        let plan: PlanRef =
+            LogicalInsert::create(input, insert.table.name, insert.table.table_id, vec![])?.into();
         let order = Order::any().clone();
         let dist = Distribution::Single;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());


### PR DESCRIPTION
## What's changed and what's your intention?

`BoundBaseTable` used to derive `Clone` because it was part of `LogicalInsert` and `LogicalDelete`, and we wanted to avoid the cost of clone via `Rc` (#897). However, these plan nodes only need `table_id` to function properly and an additional `table_name` to have a stable explain output. The column information in `BoundBaseTable` is unnecessary or even misleading for `LogicalScan` and `LogicalInsert`, which maintain their own subset of column ids to work on.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
