### PR TITLE
chore: use XXHash by default.

### DIFF
--- a/rust/common/src/config.rs
+++ b/rust/common/src/config.rs
@@ -209,7 +209,7 @@ mod default {
     }
 
     pub fn checksum_algorithm() -> risingwave_pb::hummock::checksum::Algorithm {
-        risingwave_pb::hummock::checksum::Algorithm::Crc32c
+        risingwave_pb::hummock::checksum::Algorithm::XxHash64
     }
 
     pub fn async_checkpoint_enabled() -> bool {


### PR DESCRIPTION
## What's changed and what's your intention?

Address https://github.com/singularity-data/risingwave/pull/921#discussion_r826633259.

## Checklist

## Refer to a related PR or issue link (optional)
