### PR TITLE
fix(risedev-doc): update some deprecated command

### DIFF
--- a/rust/risedevtool/README.md
+++ b/rust/risedevtool/README.md
@@ -35,7 +35,7 @@ RiseDev also provides several other modes:
 Sometimes, you might want to debug a single component, but need to spawn all other components to make that component work. For example, debugging the compute node. In this case, simply run:
 
 ```bash
-./risedev dev-compute-node
+./risedev dev dev-compute-node
 ```
 
 And you will see:


### PR DESCRIPTION
## What's changed and what's your intention?

directly calling ./risedev dev-compute-node has been deprecated. Use ./risedev dev dev-compute-node instead.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
