### PR TITLE
feat(risedev): support install to cargo home

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -466,3 +466,23 @@ description = "Update CI workflow by applying templates"
 
 [tasks.c]
 alias = "check"
+
+[tasks.install]
+category = "RiseDev - Prepare"
+description = "Install RiseDev to user local"
+script = """
+#!/bin/bash
+set -e
+
+DIR="$(pwd)"
+INSTALL_PATH="$CARGO_HOME/bin/risedev"
+
+cat <<EOF > "${INSTALL_PATH}"
+#!/bin/bash
+set -e
+cd "$DIR"
+./risedev "\\$@"
+EOF
+chmod +x "${INSTALL_PATH}"
+echo RiseDev installed to $(tput setaf 4)${INSTALL_PATH}$(tput sgr0)
+"""

--- a/rust/risedevtool/src/bin/risedev-playground.rs
+++ b/rust/risedevtool/src/bin/risedev-playground.rs
@@ -408,13 +408,18 @@ fn main() -> Result<()> {
             print!("{}", log_buffer);
 
             println!(
-                "* You may find logs using `{}` command",
+                "* You may find logs using {} command",
                 style("./risedev l").blue().bold()
             );
 
             println!(
                 "* Run {} to kill cluster.",
                 style("./risedev k").blue().bold()
+            );
+
+            println!(
+                "* Run {} to run `risedev` anywhere!",
+                style("./risedev install").blue().bold()
             );
 
             Ok(())


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Add `./risedev install`, which installs risedev to cargo home. After that, we can run risedev everywhere.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
