### PR TITLE
fix(planner): do not reuqire single on insert/delete

### DIFF
--- a/rust/frontend/src/planner/delete.rs
+++ b/rust/frontend/src/planner/delete.rs
@@ -34,7 +34,8 @@ impl Planner {
         let plan: PlanRef = LogicalDelete::create(input, table_name, table_id)?.into();
 
         let order = Order::any().clone();
-        let dist = Distribution::Single;
+        // For delete, frontend will only schedule one task so do not need this to be single.
+        let dist = Distribution::Any;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
 

--- a/rust/frontend/src/planner/insert.rs
+++ b/rust/frontend/src/planner/insert.rs
@@ -28,7 +28,8 @@ impl Planner {
         let plan: PlanRef =
             LogicalInsert::create(input, insert.table.name, insert.table.table_id, vec![])?.into();
         let order = Order::any().clone();
-        let dist = Distribution::Single;
+        // For insert, frontend will only schedule one task so do not need this to be single.
+        let dist = Distribution::Any;
         let mut out_fields = FixedBitSet::with_capacity(plan.schema().len());
         out_fields.insert_range(..);
         let root = PlanRoot::new(plan, dist, order, out_fields);

--- a/rust/frontend/test_runner/tests/testdata/basic_query_1.yaml
+++ b/rust/frontend/test_runner/tests/testdata/basic_query_1.yaml
@@ -89,14 +89,12 @@
     create table t (v1 int, v2 int);
     insert into t values (22, 33), (44, 55);
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchInsert { table_name: "t", columns: [] }
-        BatchValues { rows: [[22:Int32, 33:Int32], [44:Int32, 55:Int32]] }
+    BatchInsert { table_name: "t", columns: [] }
+      BatchValues { rows: [[22:Int32, 33:Int32], [44:Int32, 55:Int32]] }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t where v1 = 1;
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchDelete { table_name: "t" }
-        BatchFilter { predicate: ($1 = 1:Int32) }
-          BatchScan { table: t, columns: [_row_id, v1, v2] }
+    BatchDelete { table_name: "t" }
+      BatchFilter { predicate: ($1 = 1:Int32) }
+        BatchScan { table: t, columns: [_row_id, v1, v2] }

--- a/rust/frontend/test_runner/tests/testdata/basic_query_2.yaml
+++ b/rust/frontend/test_runner/tests/testdata/basic_query_2.yaml
@@ -2,9 +2,8 @@
     create table t (v1 int, v2 int);
     delete from t;
   batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchDelete { table_name: "t" }
-        BatchScan { table: t, columns: [_row_id, v1, v2] }
+    BatchDelete { table_name: "t" }
+      BatchScan { table: t, columns: [_row_id, v1, v2] }
 - sql: |
     create table t (v1 int, v2 int);
     select v1 from t;


### PR DESCRIPTION
## What's changed and what's your intention?

Motivate : #1052 
Two ways to do this
1. change the required dist in handler (this PR).
2. change the defualt dist from any to single in BatchDelete/Insert. But it will insert exchange under BatchDelete/Insert, seems like it's not good so I do not choose this.


## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
