### PR TITLE
chore(ci): disable etcd temporarily

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -9,7 +9,7 @@ risedev:
   # The CI-3node configuration will start 3 compute nodes, 1 meta node, 1 frontend and 1 MinIO.
   ci-3node:
     - use: minio
-    - use: etcd
+    # - use: etcd
     - use: meta-node
     - use: compute-node
       port: 5687
@@ -25,7 +25,7 @@ risedev:
   # The CI-1node configuration will start 1 compute node, 1 meta node, 1 frontend and 1 MinIO.
   ci-1node:
     - use: minio
-    - use: etcd
+    # - use: etcd
     - use: meta-node
     - use: compute-node
     - use: frontend


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

There are several places where dash map's reference will be held across await point, which is quite dangerous:

```rust
    pub async fn update_table_fragments(&self, table_fragment: TableFragments) -> Result<()> {
        match self.table_fragments.entry(table_fragment.table_id()) {
            Entry::Occupied(mut entry) => {
                table_fragment.insert(&*self.meta_store_ref).await?;
                entry.insert(table_fragment);

                Ok(())
            }
            Entry::Vacant(_) => Err(RwError::from(InternalError(
                "table_fragment not exist!".to_string(),
            ))),
        }
    }
```

To mitigate the issue, we temporarily disable etcd meta backend, so as to reduce yield points.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

ref https://github.com/singularity-data/risingwave/issues/1144