### PR TITLE
refactor: update worker node's TTL more accurately.

### DIFF
--- a/rust/meta/src/lib.rs
+++ b/rust/meta/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(let_chains)]
 #![feature(type_alias_impl_trait)]
 #![feature(map_first_last)]
+#![feature(drain_filter)]
 #![cfg_attr(coverage, feature(no_coverage))]
 
 mod barrier;

--- a/rust/meta/src/storage/meta_store.rs
+++ b/rust/meta/src/storage/meta_store.rs
@@ -39,10 +39,6 @@ pub trait MetaStore: Clone + Sync + Send + 'static {
     async fn delete_cf(&self, cf: &str, key: &[u8]) -> Result<()>;
     async fn txn(&self, trx: Transaction) -> Result<()>;
 
-    /// We will need a proper implementation for `list`, `list_cf` in etcd
-    /// [`MetaStore`]. In a naive implementation, we need to select the latest version for each key
-    /// locally after fetching all versions of it from etcd, which may not meet our
-    /// performance expectation.
     async fn list_cf(&self, cf: &str) -> Result<Vec<Vec<u8>>> {
         self.snapshot().await.list_cf(cf).await
     }

--- a/rust/meta/src/storage/transaction.rs
+++ b/rust/meta/src/storage/transaction.rs
@@ -77,15 +77,12 @@ impl Transaction {
 
 pub enum Operation {
     /// `put` key value pairs.
-    /// If `WithVersion` is not specified, a default global version is used.
     Put {
         cf: ColumnFamily,
         key: Key,
         value: Value,
     },
     /// `delete` key value pairs.
-    /// If `WithVersion` is not specified, all versions of this `Key` are matched and deleted.
-    /// Otherwise, only specific version of this `Key` is deleted.
     Delete { cf: ColumnFamily, key: Key },
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?
We now calculate `expire_at` inside `update_worker_ttl`, to eliminate the delay caused by acquiring `RwLock<StoredClusterManagerCore>`.

## Checklist

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/1197