### PR TITLE
refactor(frontend): QueryContextRef should be Send.

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -74,6 +74,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 
 [[package]]
+name = "assert-impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3464313de0c867016e3e69d7e1e9ae3499bcc4c18e12283d381359ed38b5b9e"
+
+[[package]]
 name = "assert-json-diff"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3667,6 +3673,7 @@ dependencies = [
 name = "risingwave_frontend"
 version = "0.1.3"
 dependencies = [
+ "assert-impl",
  "async-trait",
  "byteorder",
  "bytes",

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+assert-impl = "0.1"
 async-trait = "0.1"
 byteorder = "1.4"
 bytes = "1"

--- a/rust/frontend/src/handler/create_mv.rs
+++ b/rust/frontend/src/handler/create_mv.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
-use std::rc::Rc;
 
 use itertools::Itertools;
 use pgwire::pg_response::PgResponse;
@@ -197,7 +195,7 @@ pub async fn handle_create_mv(
     let session = context.session_ctx.clone();
 
     let (table, plan) = {
-        let mut planner = Planner::new(Rc::new(RefCell::new(context)));
+        let mut planner = Planner::new(context.into());
 
         let (schema_name, table_name) = Binder::resolve_table_name(name.clone())?;
         let (database_id, schema_id) = session

--- a/rust/frontend/src/handler/create_table.rs
+++ b/rust/frontend/src/handler/create_table.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::rc::Rc;
 
 use itertools::Itertools;
@@ -31,7 +30,7 @@ use crate::binder::Binder;
 use crate::optimizer::plan_node::{LogicalScan, StreamExchange, StreamMaterialize, StreamSource};
 use crate::optimizer::property::{Direction, Distribution, FieldOrder};
 use crate::optimizer::PlanRef;
-use crate::session::QueryContext;
+use crate::session::{QueryContext, QueryContextRef};
 
 pub const ROWID_NAME: &str = "_row_id";
 
@@ -71,7 +70,7 @@ pub async fn handle_create_table(
     };
 
     let plan = {
-        let context = Rc::new(RefCell::new(context));
+        let context: QueryContextRef = context.into();
 
         let source_node = {
             let (columns, fields) = column_descs

--- a/rust/frontend/src/handler/explain.rs
+++ b/rust/frontend/src/handler/explain.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use pgwire::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
 use pgwire::pg_response::{PgResponse, StatementType};
 use pgwire::types::Row;
@@ -31,10 +28,9 @@ pub(super) fn handle_explain(
     stmt: Statement,
     _verbose: bool,
 ) -> Result<PgResponse> {
-    let context = Rc::new(RefCell::new(context));
-    let session = context.borrow().session_ctx.clone();
+    let session = context.session_ctx.clone();
     // bind, plan, optimize, and serialize here
-    let mut planner = Planner::new(context);
+    let mut planner = Planner::new(context.into());
 
     let plan = match stmt {
         Statement::CreateView {

--- a/rust/frontend/src/handler/query.rs
+++ b/rust/frontend/src/handler/query.rs
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
-use std::rc::Rc;
-
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError};
@@ -42,7 +39,7 @@ pub async fn handle_query(context: QueryContext, stmt: Statement) -> Result<PgRe
 
     let (plan, pg_descs) = {
         // Subblock to make sure PlanRef (an Rc) is dropped before `await` below.
-        let plan = Planner::new(Rc::new(RefCell::new(context)))
+        let plan = Planner::new(context.into())
             .plan(bound)?
             .gen_batch_query_plan();
 

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![feature(map_try_insert)]
 #![feature(let_chains)]
+#![feature(negative_impls)]
 
 #[macro_use]
 pub mod catalog;

--- a/rust/frontend/src/optimizer/mod.rs
+++ b/rust/frontend/src/optimizer/mod.rs
@@ -189,8 +189,6 @@ impl PlanRoot {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     use risingwave_common::catalog::Field;
     use risingwave_common::types::DataType;
@@ -202,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_as_subplan() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let scan = LogicalScan::create(
             "test_table".into(),
             TableId::new(3),

--- a/rust/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -479,7 +479,7 @@ impl ToStream for LogicalAgg {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
+
     use std::rc::Rc;
 
     use risingwave_common::catalog::{Field, TableId};
@@ -496,7 +496,7 @@ mod tests {
     #[tokio::test]
     async fn test_create() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = vec![
             Field {
                 data_type: ty.clone(),
@@ -636,7 +636,7 @@ mod tests {
     ///  TableScan(v2, v3)
     async fn test_prune_all() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = vec![
             Field {
                 data_type: ty.clone(),
@@ -705,7 +705,7 @@ mod tests {
     ///   Agg(max(input_ref(1))) group by (input_ref(0))
     ///     TableScan(v2, v3)
     async fn test_prune_group_key() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
             Field {
@@ -784,7 +784,7 @@ mod tests {
     ///     TableScan(v2, v3)
     async fn test_prune_agg() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = vec![
             Field {
                 data_type: ty.clone(),

--- a/rust/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -141,8 +141,6 @@ impl ToStream for LogicalFilter {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     use risingwave_common::catalog::{Field, Schema, TableId};
     use risingwave_common::types::DataType;
@@ -167,7 +165,7 @@ mod tests {
     ///     TableScan(v2, v3)
     /// ```
     async fn test_prune_filter() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = vec![
             Field::with_name(DataType::Int32, "v1"),
             Field::with_name(DataType::Int32, "v2"),
@@ -236,7 +234,7 @@ mod tests {
     ///     TableScan(v2, v3)
     /// ```
     async fn test_prune_filter_no_project() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let ty = DataType::Int32;
         let fields: Vec<Field> = vec![
             Field {

--- a/rust/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_join.rs
@@ -400,8 +400,6 @@ impl ToStream for LogicalJoin {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     use risingwave_common::catalog::{Field, TableId};
     use risingwave_common::types::{DataType, Datum};
@@ -429,7 +427,7 @@ mod tests {
     #[tokio::test]
     async fn test_prune_join() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = (1..7)
             .map(|i| Field {
                 data_type: ty.clone(),
@@ -519,7 +517,7 @@ mod tests {
     #[tokio::test]
     async fn test_prune_join_no_project() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = (1..7)
             .map(|i| Field {
                 data_type: ty.clone(),
@@ -604,7 +602,7 @@ mod tests {
     /// ```
     #[tokio::test]
     async fn test_join_to_batch() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = (1..7)
             .map(|i| Field {
                 data_type: DataType::Int32,
@@ -692,7 +690,7 @@ mod tests {
     /// ```
     #[tokio::test]
     async fn test_join_to_stream() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = (1..7)
             .map(|i| Field {
                 data_type: DataType::Int32,

--- a/rust/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_project.rs
@@ -289,8 +289,6 @@ impl ToStream for LogicalProject {
 }
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     use risingwave_common::catalog::{Field, TableId};
     use risingwave_common::types::DataType;
@@ -314,7 +312,7 @@ mod tests {
     /// ```
     async fn test_prune_project() {
         let ty = DataType::Int32;
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields: Vec<Field> = vec![
             Field {
                 data_type: ty.clone(),

--- a/rust/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/rust/frontend/src/optimizer/plan_node/logical_values.rs
@@ -103,8 +103,6 @@ impl ToStream for LogicalValues {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
 
     use risingwave_common::catalog::Field;
     use risingwave_common::types::{DataType, Datum};
@@ -127,7 +125,7 @@ mod tests {
     /// ```
     #[tokio::test]
     async fn test_prune_filter() {
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let schema = Schema::new(vec![
             Field::with_name(DataType::Int32, "v1"),
             Field::with_name(DataType::Int32, "v2"),

--- a/rust/frontend/src/optimizer/plan_node/plan_base.rs
+++ b/rust/frontend/src/optimizer/plan_node/plan_base.rs
@@ -39,7 +39,7 @@ pub struct PlanBase {
 }
 impl PlanBase {
     pub fn new_logical(ctx: QueryContextRef, schema: Schema, pk_indices: Vec<usize>) -> Self {
-        let id = ctx.borrow_mut().get_id();
+        let id = ctx.next_plan_node_id();
         Self {
             id,
             ctx,
@@ -59,7 +59,7 @@ impl PlanBase {
         append_only: bool,
     ) -> Self {
         // assert!(!pk_indices.is_empty()); TODO: reopen it when ensure the pk for stream op
-        let id = ctx.borrow_mut().get_id();
+        let id = ctx.next_plan_node_id();
         Self {
             id,
             ctx,
@@ -76,7 +76,7 @@ impl PlanBase {
         dist: Distribution,
         order: Order,
     ) -> Self {
-        let id = ctx.borrow_mut().get_id();
+        let id = ctx.next_plan_node_id();
         Self {
             id,
             ctx,

--- a/rust/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/rust/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -38,11 +38,7 @@ impl StreamTableScan {
     pub fn new(logical: LogicalScan) -> Self {
         let ctx = logical.base.ctx.clone();
 
-        let batch_plan_id;
-        {
-            let mut ctx = ctx.borrow_mut();
-            batch_plan_id = ctx.get_id();
-        }
+        let batch_plan_id = ctx.next_plan_node_id();
         // TODO: derive from input
         let base = PlanBase::new_stream(
             ctx,

--- a/rust/frontend/src/scheduler/plan_fragmenter.rs
+++ b/rust/frontend/src/scheduler/plan_fragmenter.rs
@@ -236,8 +236,7 @@ impl BatchPlanFragmenter {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+
     use std::sync::Arc;
 
     use risingwave_common::catalog::{Field, Schema, TableId};
@@ -268,7 +267,7 @@ mod tests {
         //     /    \
         //   Scan  Scan
         //
-        let ctx = Rc::new(RefCell::new(QueryContext::mock().await));
+        let ctx = QueryContext::mock().await;
         let fields = vec![
             Field::unnamed(DataType::Int32),
             Field::unnamed(DataType::Float64),

--- a/rust/frontend/src/session.rs
+++ b/rust/frontend/src/session.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::error::Error;
 use std::fmt::Formatter;
+use std::marker::Sync;
 use std::path::PathBuf;
-use std::rc::Rc;
+use std::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -43,39 +43,64 @@ use crate::FrontendOpts;
 
 pub struct QueryContext {
     pub session_ctx: Arc<SessionImpl>,
-    pub next_id: i32,
+    // We use `AtomicI32` here because  `Arc<T>` implements `Send` only when `T: Send + Sync`.
+    pub next_id: AtomicI32,
 }
-/// The reference of `QueryContext`, our system assumes that frontend will not parallel for a query,
-/// so we use `RefCell` here.
-pub type QueryContextRef = Rc<RefCell<QueryContext>>;
+
+#[derive(Clone, Debug)]
+pub struct QueryContextRef {
+    inner: Arc<QueryContext>,
+}
+
+impl !Sync for QueryContextRef {}
+
+impl From<QueryContext> for QueryContextRef {
+    fn from(inner: QueryContext) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl QueryContextRef {
+    pub fn inner(&self) -> &QueryContext {
+        &self.inner
+    }
+
+    pub fn next_plan_node_id(&self) -> PlanNodeId {
+        // It's safe to use `fetch_add` and `Relaxed` ordering since we have marked
+        // `QueryContextRef` not `Sync`.
+        let next_id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        PlanNodeId(next_id)
+    }
+}
 
 impl QueryContext {
     pub fn new(session_ctx: Arc<SessionImpl>) -> Self {
         Self {
             session_ctx,
-            next_id: 0,
+            next_id: AtomicI32::new(0),
         }
-    }
-
-    pub fn get_id(&mut self) -> PlanNodeId {
-        let ret = PlanNodeId(self.next_id);
-        self.next_id += 1;
-        ret
     }
 
     // TODO(TaoWu): Remove the async.
     #[cfg(test)]
-    pub async fn mock() -> Self {
+    pub async fn mock() -> QueryContextRef {
         Self {
             session_ctx: Arc::new(SessionImpl::mock()),
-            next_id: 0,
+            next_id: AtomicI32::new(0),
         }
+        .into()
     }
 }
 
 impl std::fmt::Debug for QueryContext {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "QueryContext {{ current id = {} }}", self.next_id)
+        write!(
+            f,
+            "QueryContext {{ current id = {} }}",
+            self.next_id.load(Ordering::Relaxed)
+        )
     }
 }
 
@@ -313,3 +338,16 @@ impl Session for SessionImpl {
 //         meta.stop().await;
 //     }
 // }
+
+#[cfg(test)]
+mod tests {
+    use assert_impl::assert_impl;
+
+    use crate::session::QueryContextRef;
+
+    #[test]
+    fn check_query_context_ref() {
+        assert_impl!(Send: QueryContextRef);
+        assert_impl!(!Sync: QueryContextRef);
+    }
+}

--- a/rust/frontend/src/test_utils.rs
+++ b/rust/frontend/src/test_utils.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::error::Error;
-use std::rc::Rc;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
@@ -86,12 +84,10 @@ impl LocalFrontend {
                 );
                 binder.bind(Statement::Query(query.clone()))?
             };
-            Ok(
-                Planner::new(Rc::new(RefCell::new(QueryContext::new(session))))
-                    .plan(bound)
-                    .unwrap()
-                    .gen_batch_query_plan(),
-            )
+            Ok(Planner::new(QueryContext::new(session).into())
+                .plan(bound)
+                .unwrap()
+                .gen_batch_query_plan())
         } else {
             unreachable!()
         }

--- a/rust/frontend/test_runner/src/lib.rs
+++ b/rust/frontend/test_runner/src/lib.rs
@@ -16,8 +16,6 @@
 #![feature(let_chains)]
 
 mod resolve_id;
-use std::cell::RefCell;
-use std::rc::Rc;
 
 use anyhow::{anyhow, Result};
 pub use resolve_id::*;
@@ -156,7 +154,7 @@ impl TestCase {
                         if result.is_some() {
                             panic!("two queries in one test case");
                         }
-                        let ret = self.apply_query(&stmt, Rc::new(RefCell::new(context)))?;
+                        let ret = self.apply_query(&stmt, context.into())?;
                         if do_check_result {
                             check_result(self, &ret)?;
                         }
@@ -178,7 +176,7 @@ impl TestCase {
     }
 
     fn apply_query(&self, stmt: &Statement, context: QueryContextRef) -> Result<TestCaseResult> {
-        let session = context.borrow().session_ctx.clone();
+        let session = context.inner().session_ctx.clone();
         let mut ret = TestCaseResult::default();
 
         let bound = {


### PR DESCRIPTION
## What's changed and what's your intention?

Refactor `QueryContextRef` so that it's `Send`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
