### PR TITLE
feat(storage) return err instead of panic in `s3.rs/read`

### DIFF
--- a/rust/storage/src/object/s3.rs
+++ b/rust/storage/src/object/s3.rs
@@ -65,7 +65,7 @@ impl ObjectStore for S3ObjectStore {
 
         let val = resp.body.collect().await.map_err(err)?.into_bytes();
 
-        if !block_loc.is_none() && block_loc.as_ref().unwrap().size != val.len() {
+        if block_loc.is_some() && block_loc.as_ref().unwrap().size != val.len() {
             return Err(RwError::from(InternalError(format!(
                 "mismatched size: expected {}, found {} when reading {} at {:?}",
                 block_loc.as_ref().unwrap().size,


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Motivations are described in issue https://github.com/singularity-data/risingwave/issues/1233.

we return err instead of panic in `s3.rs/read`

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
