### PR TITLE
chore(risedev): remove riselab

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -292,6 +292,9 @@ set -e
 
 cd rust
 echo "Use \`./risedev d\` instead if you want to start a full cluster."
+
+set -ex
+
 RUST_BACKTRACE=1 RW_NODE=playground cargo run --bin risingwave --features=all-in-one --profile "${RISINGWAVE_BUILD_PROFILE}"
 '''
 
@@ -511,8 +514,17 @@ script = """
 #!/bin/bash
 set -e
 
+
 DIR="$(pwd)"
-INSTALL_PATH="$CARGO_HOME/bin/risedev"
+NAME="${1:-risedev}"
+INSTALL_PATH="$CARGO_HOME/bin/${NAME}"
+
+read -p "Install to ${INSTALL_PATH}? [y/N] " -r
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]
+then
+    exit 1
+fi
 
 cat <<EOF > "${INSTALL_PATH}"
 #!/bin/bash

--- a/riselab
+++ b/riselab
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo "riselab script will be deprecated soon -- please use risedev instead."
-
-./risedev "$@"


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

## What's changed and what's your intention?

Time to say goodbye to the original riselab! If someone still prefers the original riselab command, simply call `./risedev install riselab`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
