### PR TITLE
feat(risedev): support risedev frontend-v2 debug mode

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -87,6 +87,13 @@ risedev:
     - use: compute-node
     - use: frontend
 
+  dev-frontend-v2:
+    - use: minio
+    - use: meta-node
+    - use: compute-node
+    - use: frontend-v2
+      user-managed: true
+    
 # The `use` field specified in the above `risedev` section will refer to the templates below.
 template:
   minio:


### PR DESCRIPTION
## What's changed and what's your intention?

Test locally,
`./risedev dev dev-frontend-v2` will wait for user managed frontend v2 start up. Allow debug frontend v2 in IDE.

A problem is, every time debug start fe-v2 server, it will log `Connection closed by error!`. However, the connection is not closed and it works well in e2e. I may improve this in next PRs (use tracing log instead of directly println)

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
