### PR TITLE
chore(risedev): better error message with context and root cause

### DIFF
--- a/rust/risedevtool/src/bin/risedev-playground.rs
+++ b/rust/risedevtool/src/bin/risedev-playground.rs
@@ -441,8 +441,9 @@ fn main() -> Result<()> {
         }
         Err(err) => {
             println!(
-                "{} - Failed to start: {}",
+                "{} - Failed to start: {}\nCaused by:\n\t{}",
                 style("ERROR").red().bold(),
+                err,
                 err.root_cause().to_string().trim(),
             );
             println!(

--- a/rust/risedevtool/src/task/configure_tmux_service.rs
+++ b/rust/risedevtool/src/task/configure_tmux_service.rs
@@ -16,7 +16,8 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
+use console::style;
 
 use crate::{ExecuteContext, Task};
 
@@ -45,7 +46,12 @@ impl Task for ConfigureTmuxTask {
 
         let mut cmd = self.tmux();
         cmd.arg("-V");
-        ctx.run_command(cmd)?;
+        ctx.run_command(cmd).with_context(|| {
+            format!(
+                "Failed to execute {} command. Did you install tmux?",
+                style("tmux").blue().bold()
+            )
+        })?;
 
         // List previous windows and kill them
         let mut cmd = self.tmux();


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
Use similar style as 

https://docs.rs/anyhow/latest/anyhow/#:~:text=config)%3F%3B%0A%20%20%20%20Ok(map)%0A%7D-,Attach,-context%20to%20help

to show the context and the root cause.


<img width="1000" alt="Screenshot 2022-03-28 at 1 27 38 PM" src="https://user-images.githubusercontent.com/5791930/160332025-9d553139-affe-46ef-b076-afbac1118124.png">

## Refer to a related PR or issue link (optional)
closes #1322 
