### PR TITLE
chore(doc): remind people to install rosetta on macOs with Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ brew install protobuf
 brew install openssl
 ```
 
+If one is running on macOS with Apple Silicon, please be sure that:
+```shell
+softwareupdate --install-rosetta 
+```
+Rosetta has been installed.
+
 Note that we only tested our code against Java 11. So please use the specific version!
 
 ## Development


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
As #1323 says, building java requires `softwareupdate --install-rosetta`, otherwise it errs:
>java.io.IOException: Cannot run program "/Users/XXX/.gradle/caches/modules-2/files-2.1/com.google.protobuf/protoc/3.0.0/31a580cdff228f572e27920c0abcfa71cd3d95e4/protoc-3.0.0-osx-x86_64.exe": error=86, Bad CPU type in executable`

## Refer to a related PR or issue link (optional)
closes #1323 