### PR TITLE
refactor(batch): remove async trait from channels

### DIFF
--- a/rust/batch/src/lib.rs
+++ b/rust/batch/src/lib.rs
@@ -28,6 +28,7 @@
 #![feature(binary_heap_drain_sorted)]
 #![feature(let_chains)]
 #![feature(exact_size_is_empty)]
+#![feature(type_alias_impl_trait)]
 #![cfg_attr(coverage, feature(no_coverage))]
 
 pub mod execution;

--- a/rust/batch/src/task/broadcast_channel.rs
+++ b/rust/batch/src/task/broadcast_channel.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, ToRwResult};
@@ -19,7 +21,7 @@ use risingwave_pb::plan::exchange_info::BroadcastInfo;
 use risingwave_pb::plan::*;
 use tokio::sync::mpsc;
 
-use crate::task::channel::{BoxChanReceiver, BoxChanSender, ChanReceiver, ChanSender};
+use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 
 /// `BroadcastSender` sends the same chunk to a number of `BroadcastReceiver`s.
 pub struct BroadcastSender {
@@ -27,14 +29,16 @@ pub struct BroadcastSender {
     broadcast_info: BroadcastInfo,
 }
 
-#[async_trait::async_trait]
 impl ChanSender for BroadcastSender {
-    async fn send(&mut self, chunk: Option<DataChunk>) -> Result<()> {
-        self.senders.iter().try_for_each(|sender| {
-            sender
-                .send(chunk.clone())
-                .to_rw_result_with("BroadcastSender::send")
-        })
+    type SendFuture<'a> = impl Future<Output = Result<()>>;
+    fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
+        async move {
+            self.senders.iter().try_for_each(|sender| {
+                sender
+                    .send(chunk.clone())
+                    .to_rw_result_with("BroadcastSender::send")
+            })
+        }
     }
 }
 
@@ -43,18 +47,20 @@ pub struct BroadcastReceiver {
     receiver: mpsc::UnboundedReceiver<Option<DataChunk>>,
 }
 
-#[async_trait::async_trait]
 impl ChanReceiver for BroadcastReceiver {
-    async fn recv(&mut self) -> Result<Option<DataChunk>> {
-        match self.receiver.recv().await {
-            Some(data_chunk) => Ok(data_chunk),
-            // Early close should be treated as an error.
-            None => Err(InternalError("broken broadcast_channel".to_string()).into()),
+    type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+    fn recv(&mut self) -> Self::RecvFuture<'_> {
+        async move {
+            match self.receiver.recv().await {
+                Some(data_chunk) => Ok(data_chunk),
+                // Early close should be treated as an error.
+                None => Err(InternalError("broken broadcast_channel".to_string()).into()),
+            }
         }
     }
 }
 
-pub fn new_broadcast_channel(shuffle: &ExchangeInfo) -> (BoxChanSender, Vec<BoxChanReceiver>) {
+pub fn new_broadcast_channel(shuffle: &ExchangeInfo) -> (ChanSenderImpl, Vec<ChanReceiverImpl>) {
     let broadcast_info = match shuffle.distribution {
         Some(exchange_info::Distribution::BroadcastInfo(ref v)) => v.clone(),
         _ => exchange_info::BroadcastInfo::default(),
@@ -68,13 +74,13 @@ pub fn new_broadcast_channel(shuffle: &ExchangeInfo) -> (BoxChanSender, Vec<BoxC
         senders.push(s);
         receivers.push(r);
     }
-    let channel_sender = Box::new(BroadcastSender {
+    let channel_sender = ChanSenderImpl::Broadcast(BroadcastSender {
         senders,
         broadcast_info,
-    }) as BoxChanSender;
+    });
     let channel_receivers = receivers
         .into_iter()
-        .map(|receiver| Box::new(BroadcastReceiver { receiver }) as BoxChanReceiver)
+        .map(|receiver| ChanReceiverImpl::Broadcast(BroadcastReceiver { receiver }))
         .collect::<Vec<_>>();
     (channel_sender, channel_receivers)
 }

--- a/rust/batch/src/task/fifo_channel.rs
+++ b/rust/batch/src/task/fifo_channel.rs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
+
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, ToRwResult};
 use tokio::sync::mpsc;
 
-use crate::task::channel::{BoxChanReceiver, BoxChanSender, ChanReceiver, ChanSender};
+use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 
 pub struct FifoSender {
     sender: mpsc::UnboundedSender<Option<DataChunk>>,
@@ -27,31 +29,35 @@ pub struct FifoReceiver {
     receiver: mpsc::UnboundedReceiver<Option<DataChunk>>,
 }
 
-#[async_trait::async_trait]
 impl ChanSender for FifoSender {
-    async fn send(&mut self, chunk: Option<DataChunk>) -> Result<()> {
-        self.sender
-            .send(chunk)
-            .to_rw_result_with("FifoSender::send")
-    }
-}
-
-#[async_trait::async_trait]
-impl ChanReceiver for FifoReceiver {
-    async fn recv(&mut self) -> Result<Option<DataChunk>> {
-        match self.receiver.recv().await {
-            Some(data_chunk) => Ok(data_chunk),
-            // Early close should be treated as error.
-            None => Err(InternalError("broken fifo_channel".to_string()).into()),
+    type SendFuture<'a> = impl Future<Output = Result<()>>;
+    fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
+        async move {
+            self.sender
+                .send(chunk)
+                .to_rw_result_with("FifoSender::send")
         }
     }
 }
 
-pub fn new_fifo_channel() -> (BoxChanSender, Vec<BoxChanReceiver>) {
+impl ChanReceiver for FifoReceiver {
+    type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+    fn recv(&mut self) -> Self::RecvFuture<'_> {
+        async move {
+            match self.receiver.recv().await {
+                Some(data_chunk) => Ok(data_chunk),
+                // Early close should be treated as error.
+                None => Err(InternalError("broken fifo_channel".to_string()).into()),
+            }
+        }
+    }
+}
+
+pub fn new_fifo_channel() -> (ChanSenderImpl, Vec<ChanReceiverImpl>) {
     let (s, r) = mpsc::unbounded_channel();
     (
-        Box::new(FifoSender { sender: s }),
-        vec![Box::new(FifoReceiver { receiver: r })],
+        ChanSenderImpl::Fifo(FifoSender { sender: s }),
+        vec![ChanReceiverImpl::Fifo(FifoReceiver { receiver: r })],
     )
 }
 

--- a/rust/batch/src/task/hash_shuffle_channel.rs
+++ b/rust/batch/src/task/hash_shuffle_channel.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::future::Future;
 use std::option::Option;
 
 use risingwave_common::array::DataChunk;
@@ -22,7 +23,7 @@ use risingwave_pb::plan::exchange_info::HashInfo;
 use risingwave_pb::plan::*;
 use tokio::sync::mpsc;
 
-use crate::task::channel::{BoxChanReceiver, BoxChanSender, ChanReceiver, ChanSender};
+use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 
 pub struct HashShuffleSender {
     senders: Vec<mpsc::UnboundedSender<Option<DataChunk>>>,
@@ -85,12 +86,14 @@ fn generate_new_data_chunks(
     Ok(res)
 }
 
-#[async_trait::async_trait]
 impl ChanSender for HashShuffleSender {
-    async fn send(&mut self, chunk: Option<DataChunk>) -> Result<()> {
-        match chunk {
-            Some(c) => self.send_chunk(c).await,
-            None => self.send_done().await,
+    type SendFuture<'a> = impl Future<Output = Result<()>>;
+    fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_> {
+        async move {
+            match chunk {
+                Some(c) => self.send_chunk(c).await,
+                None => self.send_done().await,
+            }
         }
     }
 }
@@ -124,18 +127,20 @@ impl HashShuffleSender {
     }
 }
 
-#[async_trait::async_trait]
 impl ChanReceiver for HashShuffleReceiver {
-    async fn recv(&mut self) -> Result<Option<DataChunk>> {
-        match self.receiver.recv().await {
-            Some(data_chunk) => Ok(data_chunk),
-            // Early close should be treated as error.
-            None => Err(InternalError("broken hash_shuffle_channel".to_string()).into()),
+    type RecvFuture<'a> = impl Future<Output = Result<Option<DataChunk>>>;
+    fn recv(&mut self) -> Self::RecvFuture<'_> {
+        async move {
+            match self.receiver.recv().await {
+                Some(data_chunk) => Ok(data_chunk),
+                // Early close should be treated as error.
+                None => Err(InternalError("broken hash_shuffle_channel".to_string()).into()),
+            }
         }
     }
 }
 
-pub fn new_hash_shuffle_channel(shuffle: &ExchangeInfo) -> (BoxChanSender, Vec<BoxChanReceiver>) {
+pub fn new_hash_shuffle_channel(shuffle: &ExchangeInfo) -> (ChanSenderImpl, Vec<ChanReceiverImpl>) {
     let hash_info = match shuffle.distribution {
         Some(exchange_info::Distribution::HashInfo(ref v)) => v.clone(),
         _ => exchange_info::HashInfo::default(),
@@ -149,10 +154,10 @@ pub fn new_hash_shuffle_channel(shuffle: &ExchangeInfo) -> (BoxChanSender, Vec<B
         senders.push(s);
         receivers.push(r);
     }
-    let channel_sender = Box::new(HashShuffleSender { senders, hash_info }) as BoxChanSender;
+    let channel_sender = ChanSenderImpl::HashShuffle(HashShuffleSender { senders, hash_info });
     let channel_receivers = receivers
         .into_iter()
-        .map(|receiver| Box::new(HashShuffleReceiver { receiver }) as BoxChanReceiver)
+        .map(|receiver| ChanReceiverImpl::HashShuffle(HashShuffleReceiver { receiver }))
         .collect::<Vec<_>>();
     (channel_sender, channel_receivers)
 }

--- a/rust/batch/src/task/task_.rs
+++ b/rust/batch/src/task/task_.rs
@@ -25,7 +25,7 @@ use tracing_futures::Instrument;
 
 use crate::executor::{BoxedExecutor, ExecutorBuilder};
 use crate::rpc::service::exchange::ExchangeWriter;
-use crate::task::channel::{create_output_channel, BoxChanReceiver, BoxChanSender};
+use crate::task::channel::{create_output_channel, ChanReceiverImpl, ChanSenderImpl};
 use crate::task::{BatchEnvironment, BatchManager};
 
 #[derive(PartialEq, Eq, Hash, Clone, Debug, Default)]
@@ -100,7 +100,7 @@ impl TaskOutputId {
 
 pub struct TaskOutput {
     task_manager: Arc<BatchManager>,
-    receiver: BoxChanReceiver,
+    receiver: ChanReceiverImpl,
     output_id: TaskOutputId,
 }
 
@@ -166,7 +166,7 @@ pub struct BatchTaskExecution {
     state: Mutex<TaskStatus>,
 
     /// Receivers data of the task.   
-    receivers: Mutex<Vec<Option<BoxChanReceiver>>>,
+    receivers: Mutex<Vec<Option<ChanReceiverImpl>>>,
 
     /// Global environment of task execution.
     env: BatchEnvironment,
@@ -252,7 +252,7 @@ impl BatchTaskExecution {
         Ok(())
     }
 
-    async fn try_execute(mut root: BoxedExecutor, sender: &mut BoxChanSender) -> Result<()> {
+    async fn try_execute(mut root: BoxedExecutor, sender: &mut ChanSenderImpl) -> Result<()> {
         root.open().await?;
         while let Some(chunk) = root.next().await? {
             if chunk.cardinality() > 0 {


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Remove async trait so that there is no overhead of `Boxing` and `dyn`.

Use `pub enum ChanSenderImpl` instead of `BoxChanSender` as the trait after refactoring is not object safe due to its generic associated type.
