### PR TITLE
fix(streaming): single value cannot be two-phased

### DIFF
--- a/java/planner/src/main/java/com/risingwave/planner/rel/logical/RwLogicalAggregate.java
+++ b/java/planner/src/main/java/com/risingwave/planner/rel/logical/RwLogicalAggregate.java
@@ -51,7 +51,7 @@ public class RwLogicalAggregate extends Aggregate implements RisingWaveLogicalRe
         .allMatch(
             (agg) -> {
               var kind = agg.getAggregation().getKind();
-              return kind == SqlKind.SUM || kind == SqlKind.COUNT || kind == SqlKind.SINGLE_VALUE;
+              return kind == SqlKind.SUM || kind == SqlKind.COUNT;
             });
   }
 

--- a/rust/stream/src/executor/local_simple_agg.rs
+++ b/rust/stream/src/executor/local_simple_agg.rs
@@ -183,7 +183,9 @@ impl AggExecutor for LocalSimpleAggExecutor {
             .iter_mut()
             .zip_eq(builders.iter_mut())
             .try_for_each(|(state, builder)| -> Result<_> {
-                builder.append_datum(&state.get_output()?)?;
+                let data = state.get_output()?;
+                trace!("append_datum: {:?}", data);
+                builder.append_datum(&data)?;
                 state.reset();
                 Ok(())
             })?;


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
Misunderstood the semantics of local simple agg. 

Local simple agg outputs delta instead of total value to the global simple agg.

Now enforce that `SingleValue` aggregation cannot be processed via two-phase aggregation.

Also, log `append_datum` operation in simple aggregation just as in hash aggregation.

## Refer to a related PR or issue link (optional)
#980 