### PR TITLE
refactor(meta): support batch unpin version/snapshot.

### DIFF
--- a/java/planner/src/main/java/com/risingwave/execution/handler/cache/HummockSnapshotManagerImpl.java
+++ b/java/planner/src/main/java/com/risingwave/execution/handler/cache/HummockSnapshotManagerImpl.java
@@ -77,7 +77,7 @@ public class HummockSnapshotManagerImpl implements HummockSnapshotManager {
               this.unpinWorker.submit(
                   () -> {
                     var snapshot = HummockSnapshot.newBuilder().setEpoch(keyEpoch).build();
-                    var request = UnpinSnapshotRequest.newBuilder().setSnapshot(snapshot).build();
+                    var request = UnpinSnapshotRequest.newBuilder().addSnapshots(snapshot).build();
                     this.metaClient.unpinSnapshot(request);
                   });
               return null;

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -116,7 +116,7 @@ message PinVersionResponse {
 
 message UnpinVersionRequest {
   uint32 context_id = 1;
-  uint64 pinned_version_id = 2;
+  repeated uint64 pinned_version_ids = 2;
 }
 
 message UnpinVersionResponse {
@@ -135,7 +135,7 @@ message PinSnapshotResponse {
 
 message UnpinSnapshotRequest {
   uint32 context_id = 1;
-  HummockSnapshot snapshot = 2;
+  repeated HummockSnapshot snapshots = 2;
 }
 
 message UnpinSnapshotResponse {

--- a/rust/ctl/src/cmd_impl/hummock/list_version.rs
+++ b/rust/ctl/src/cmd_impl/hummock/list_version.rs
@@ -21,6 +21,6 @@ pub async fn list_version() -> anyhow::Result<()> {
     let (_, hummock_client) = meta_opts.create_hummock_meta_client().await?;
     let version = hummock_client.pin_version(u64::MAX).await?;
     println!("{:#?}", version);
-    hummock_client.unpin_version(version.id).await?;
+    hummock_client.unpin_version(&[version.id]).await?;
     Ok(())
 }

--- a/rust/frontend/src/meta_client.rs
+++ b/rust/frontend/src/meta_client.rs
@@ -44,7 +44,7 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
             .inner
             .unpin_snapshot(UnpinSnapshotRequest {
                 context_id: 0,
-                snapshot: Some(HummockSnapshot { epoch }),
+                snapshots: vec![HummockSnapshot { epoch }],
             })
             .await
             .to_rw_result()?;

--- a/rust/meta/src/hummock/hummock_manager.rs
+++ b/rust/meta/src/hummock/hummock_manager.rs
@@ -345,7 +345,7 @@ where
     pub async fn unpin_version(
         &self,
         context_id: HummockContextId,
-        pinned_version_id: HummockVersionId,
+        pinned_version_ids: impl AsRef<[HummockVersionId]>,
     ) -> Result<()> {
         let mut versioning_guard = self.versioning.write().await;
         let mut pinned_versions =
@@ -356,7 +356,9 @@ where
             }
             Some(context_pinned_version) => context_pinned_version,
         };
-        context_pinned_version.unpin_version(pinned_version_id);
+        for pinned_version_id in pinned_version_ids.as_ref() {
+            context_pinned_version.unpin_version(*pinned_version_id);
+        }
         commit_multi_var!(self, Some(context_id), context_pinned_version)?;
 
         #[cfg(test)]
@@ -658,7 +660,7 @@ where
     pub async fn unpin_snapshot(
         &self,
         context_id: HummockContextId,
-        hummock_snapshot: HummockSnapshot,
+        hummock_snapshots: impl AsRef<[HummockSnapshot]>,
     ) -> Result<()> {
         let mut versioning_guard = self.versioning.write().await;
         let mut pinned_snapshots =
@@ -670,7 +672,9 @@ where
             }
             Some(context_pinned_snapshot) => context_pinned_snapshot,
         };
-        context_pinned_snapshot.unpin_snapshot(hummock_snapshot.epoch);
+        for hummock_snapshot in hummock_snapshots.as_ref() {
+            context_pinned_snapshot.unpin_snapshot(hummock_snapshot.epoch);
+        }
         commit_multi_var!(self, Some(context_id), context_pinned_snapshot)?;
 
         #[cfg(test)]

--- a/rust/meta/src/hummock/hummock_manager_tests.rs
+++ b/rust/meta/src/hummock/hummock_manager_tests.rs
@@ -67,7 +67,7 @@ async fn test_hummock_pin_unpin() -> Result<()> {
     // unpin nonexistent target will not return error
     for _ in 0..3 {
         hummock_manager
-            .unpin_version(context_id, version_id)
+            .unpin_version(context_id, vec![version_id])
             .await
             .unwrap();
         assert_eq!(
@@ -95,7 +95,7 @@ async fn test_hummock_pin_unpin() -> Result<()> {
     // unpin nonexistent target will not return error
     for _ in 0..3 {
         hummock_manager
-            .unpin_snapshot(context_id, HummockSnapshot { epoch })
+            .unpin_snapshot(context_id, vec![HummockSnapshot { epoch }])
             .await
             .unwrap();
         assert_eq!(
@@ -296,7 +296,7 @@ async fn test_hummock_transaction() -> Result<()> {
         assert!(get_sorted_committed_sstable_ids(&pinned_version).is_empty());
 
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
 
         // Commit epoch1
@@ -313,7 +313,7 @@ async fn test_hummock_transaction() -> Result<()> {
         );
 
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
     }
 
@@ -345,7 +345,7 @@ async fn test_hummock_transaction() -> Result<()> {
             get_sorted_committed_sstable_ids(&pinned_version)
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
 
         // Commit epoch2
@@ -362,7 +362,7 @@ async fn test_hummock_transaction() -> Result<()> {
             get_sorted_committed_sstable_ids(&pinned_version)
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
     }
 
@@ -411,7 +411,7 @@ async fn test_hummock_transaction() -> Result<()> {
             get_sorted_committed_sstable_ids(&pinned_version)
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
 
         // Abort epoch3
@@ -437,7 +437,7 @@ async fn test_hummock_transaction() -> Result<()> {
             get_sorted_committed_sstable_ids(&pinned_version)
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
 
         // Commit epoch4
@@ -454,7 +454,7 @@ async fn test_hummock_transaction() -> Result<()> {
             get_sorted_committed_sstable_ids(&pinned_version)
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await?;
     }
     Ok(())

--- a/rust/meta/src/hummock/vacuum.rs
+++ b/rust/meta/src/hummock/vacuum.rs
@@ -293,7 +293,7 @@ mod tests {
             0
         );
         hummock_manager
-            .unpin_version(context_id, pinned_version.id)
+            .unpin_version(context_id, vec![pinned_version.id])
             .await
             .unwrap();
 

--- a/rust/meta/src/rpc/service/hummock_service.rs
+++ b/rust/meta/src/rpc/service/hummock_service.rs
@@ -78,7 +78,7 @@ where
         let req = request.into_inner();
         let result = self
             .hummock_manager
-            .unpin_version(req.context_id, req.pinned_version_id)
+            .unpin_version(req.context_id, req.pinned_version_ids)
             .await;
         match result {
             Ok(_) => Ok(Response::new(UnpinVersionResponse { status: None })),
@@ -151,14 +151,12 @@ where
         request: Request<UnpinSnapshotRequest>,
     ) -> Result<Response<UnpinSnapshotResponse>, Status> {
         let req = request.into_inner();
-        if let Some(snapshot) = req.snapshot {
-            if let Err(e) = self
-                .hummock_manager
-                .unpin_snapshot(req.context_id, snapshot)
-                .await
-            {
-                return Err(e.to_grpc_status());
-            }
+        if let Err(e) = self
+            .hummock_manager
+            .unpin_snapshot(req.context_id, req.snapshots)
+            .await
+        {
+            return Err(e.to_grpc_status());
         }
         Ok(Response::new(UnpinSnapshotResponse { status: None }))
     }

--- a/rust/storage/src/hummock/local_version_manager.rs
+++ b/rust/storage/src/hummock/local_version_manager.rs
@@ -247,7 +247,10 @@ impl LocalVersionManager {
                 }
                 Some(version) => {
                     // TODO: #93 retry instead of unwrap
-                    hummock_meta_client.unpin_version(version.id).await.unwrap();
+                    hummock_meta_client
+                        .unpin_version(&[version.id])
+                        .await
+                        .unwrap();
                     if let Some(local_version_manager) = local_version_manager.upgrade() {
                         local_version_manager.unref_committed_epoch(
                             version.max_committed_epoch,


### PR DESCRIPTION
## What's changed and what's your intention?
This PR makes `unpin_version` RPC able to unpin multiple versions in one call, so as the `unpin_snapshot` RPC.
It helps to reduce the number of RPC calls.

## Checklist

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave/issues/510