### PR TITLE
fix(hummock): retry unpin_version RPC.

### DIFF
--- a/rust/compute/src/server.rs
+++ b/rust/compute/src/server.rs
@@ -173,11 +173,11 @@ pub async fn compute_node_serve(
                     _ = shutdown_recv.recv() => {
                         for (join_handle, shutdown_sender) in sub_tasks {
                             if let Err(err) = shutdown_sender.send(()) {
-                                tracing::warn!("Failed to send shutdown: {}", err);
+                                tracing::warn!("Failed to send shutdown: {:?}", err);
                                 continue;
                             }
                             if let Err(err) = join_handle.await {
-                                tracing::warn!("Failed to join shutdown: {}", err);
+                                tracing::warn!("Failed to join shutdown: {:?}", err);
                             }
                         }
                     },

--- a/rust/meta/src/rpc/server.rs
+++ b/rust/meta/src/rpc/server.rs
@@ -257,11 +257,11 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
                         _ = shutdown_recv.recv() => {
                             for (join_handle, shutdown_sender) in sub_tasks {
                                 if let Err(err) = shutdown_sender.send(()) {
-                                    tracing::warn!("Failed to send shutdown: {}", err);
+                                    tracing::warn!("Failed to send shutdown: {:?}", err);
                                     continue;
                                 }
                                 if let Err(err) = join_handle.await {
-                                    tracing::warn!("Failed to join shutdown: {}", err);
+                                    tracing::warn!("Failed to join shutdown: {:?}", err);
                                 }
                             }
                         },

--- a/rust/storage/src/hummock/local_version_manager.rs
+++ b/rust/storage/src/hummock/local_version_manager.rs
@@ -250,7 +250,7 @@ impl LocalVersionManager {
                 Err(err) => {
                     let retry_after = retry_backoff.next().unwrap_or(max_retry_interval);
                     tracing::warn!(
-                        "Failed to pin version {}. Will retry after about {} milliseconds",
+                        "Failed to pin version {:?}. Will retry after about {} milliseconds",
                         err,
                         retry_after.as_millis()
                     );
@@ -324,7 +324,7 @@ impl LocalVersionManager {
                 Err(err) => {
                     let retry_after = retry_backoff.next().unwrap_or(max_retry_interval);
                     tracing::warn!(
-                        "Failed to unpin version {}. Will retry after about {} milliseconds",
+                        "Failed to unpin version {:?}. Will retry after about {} milliseconds",
                         err,
                         retry_after.as_millis()
                     );


### PR DESCRIPTION
## What's changed and what's your intention?
In `start_unpin_worker`
- Batch unpin hummock versions in one RPC.
- Retry with ExponentialBackoff.
- There will be at most one inflight unpin RPC (even before this PR).

## Checklist

## Refer to a related PR or issue link (optional)
close https://github.com/singularity-data/risingwave/issues/1112