### PR TITLE
fix(doc): use the right path for doc links

### DIFF
--- a/rust/bench/ss_bench/main.rs
+++ b/rust/bench/ss_bench/main.rs
@@ -108,7 +108,7 @@ fn preprocess_options(opts: &mut Opts) {
 }
 
 /// This is used to benchmark the state store performance.
-/// For usage, see: https://github.com/singularity-data/risingwave/blob/main/docs/developer/benchmark_tool/state_store.md
+/// For usage, see: <https://github.com/singularity-data/risingwave/blob/main/docs/developer/benchmark_tool/state_store.md>
 #[tokio::main(flavor = "multi_thread")]
 async fn main() {
     let mut opts = Opts::parse();

--- a/rust/frontend/src/binder/mod.rs
+++ b/rust/frontend/src/binder/mod.rs
@@ -46,7 +46,7 @@ pub struct Binder {
     context: BindContext,
     /// A stack holding contexts of outer queries when binding a subquery.
     ///
-    /// See [`Binder::bind_subquery`] for details.
+    /// See [`Binder::bind_subquery_expr`] for details.
     upper_contexts: Vec<BindContext>,
 
     next_subquery_id: usize,

--- a/rust/meta/src/manager/env.rs
+++ b/rust/meta/src/manager/env.rs
@@ -26,7 +26,7 @@ use crate::manager::{
 use crate::storage::MemStore;
 use crate::storage::MetaStore;
 
-/// [`MetaSrcEnv`] is the global environment in Meta service. The instance will be shared by all
+/// [`MetaSrvEnv`] is the global environment in Meta service. The instance will be shared by all
 /// kind of managers inside Meta.
 #[derive(Clone)]
 pub struct MetaSrvEnv<S>

--- a/rust/meta/src/manager/id.rs
+++ b/rust/meta/src/manager/id.rs
@@ -196,13 +196,13 @@ where
         }
     }
 
-    /// [`generate`] function generates id as `current_id`.
+    /// [`Self::generate`] function generates id as `current_id`.
     pub async fn generate<const C: IdCategoryType>(&self) -> Result<Id> {
         self.get::<C>().generate().await
     }
 
-    /// [`generate_interval`] function generates ids as [`current_id`, `current_id` + interval), the
-    /// next id will be `current_id` + interval.
+    /// [`Self::generate_interval`] function generates ids as [`current_id`, `current_id` +
+    /// interval), the next id will be `current_id` + interval.
     pub async fn generate_interval<const C: IdCategoryType>(&self, interval: i32) -> Result<Id> {
         self.get::<C>().generate_interval(interval).await
     }

--- a/rust/sqlparser/src/ast/ddl.rs
+++ b/rust/sqlparser/src/ast/ddl.rs
@@ -10,7 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! AST types specific to CREATE/ALTER variants of [Statement]
+//! AST types specific to CREATE/ALTER variants of [`crate::ast::Statement`]
 //! (commonly referred to as Data Definition Language, or DDL)
 
 #[cfg(not(feature = "std"))]

--- a/rust/sqlparser/src/ast/mod.rs
+++ b/rust/sqlparser/src/ast/mod.rs
@@ -548,7 +548,7 @@ pub struct WindowFrame {
 impl Default for WindowFrame {
     /// returns default value for window frame
     ///
-    /// see https://www.sqlite.org/windowfunctions.html#frame_specifications
+    /// see <https://www.sqlite.org/windowfunctions.html#frame_specifications>
     fn default() -> Self {
         Self {
             units: WindowFrameUnits::Range,

--- a/rust/sqlparser/src/keywords.rs
+++ b/rust/sqlparser/src/keywords.rs
@@ -12,7 +12,7 @@
 
 //! This module defines
 //! 1) a list of constants for every keyword that
-//! can appear in [Word::keyword]:
+//! can appear in [crate::tokenizer::Word::keyword]:
 //!    pub const KEYWORD = "KEYWORD"
 //! 2) an `ALL_KEYWORDS` array with every keyword in it
 //!     This is not a list of *reserved* keywords: some of these can be

--- a/rust/stream/src/executor/lookup.rs
+++ b/rust/stream/src/executor/lookup.rs
@@ -33,7 +33,7 @@ use super::{Barrier, Executor, Message, PkIndices, PkIndicesRef};
 pub type BoxedArrangeStream = Pin<Box<dyn Stream<Item = Result<ArrangeMessage>> + Send>>;
 
 /// `LookupExecutor` takes one input stream and one arrangement. It joins the input stream with the
-/// arrangement. Currently, it only supports inner join. See [`LookupExecutorParams`] for more
+/// arrangement. Currently, it only supports inner join. See `LookupExecutorParams` for more
 /// information.
 ///
 /// The output schema is `| stream columns | arrangement columns |`.


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
Some of the doc links link to a private item. These cases are not fixed and `cargo doc` would warn this.


#1437 