### PR TITLE
feat: flush after write, also fixed some avg problems

### DIFF
--- a/e2e_test/v2/batch/aggregate/avg.slt
+++ b/e2e_test/v2/batch/aggregate/avg.slt
@@ -1,0 +1,13 @@
+statement ok
+create table t(v1 smallint, v2 int, v3 bigint, v4 numeric, v5 real, v6 double precision)
+
+statement ok
+insert into t values (1, 1, 1, 1, 1, 1), (2, 2, 2, 2, 2, 2)
+
+query RRRRRR
+select round(avg(v1), 1), round(avg(v2), 1), round(avg(v3), 1), round(avg(v4), 1), avg(v5), avg(v6) from t
+----
+1.5 1.5 1.5 1.5 1.5 1.5
+
+statement ok
+drop table t

--- a/e2e_test/v2/batch/aggregate/count.slt
+++ b/e2e_test/v2/batch/aggregate/count.slt
@@ -1,0 +1,13 @@
+statement ok
+create table t (v1 int not null, v2 int not null, v3 int not null)
+
+statement ok
+insert into t values (1,4,2), (2,3,3), (3,4,4), (4,3,5)
+
+query I
+select count(*) from t
+----
+4
+
+statement ok
+drop table t

--- a/e2e_test/v2/batch/decimal.slt
+++ b/e2e_test/v2/batch/decimal.slt
@@ -4,9 +4,6 @@ create table t (v1 numeric, v2 numeric)
 statement ok
 insert into t values (1.1987, 4.6543), (2.22, 3.3), (1.165, 1.15)
 
-statement ok
-flush;
-
 query RRR
 select round(v1, 2), round(v2, 1), round(v1, -1) from t
 ----

--- a/e2e_test/v2/batch/insert_expr.slt
+++ b/e2e_test/v2/batch/insert_expr.slt
@@ -1,0 +1,67 @@
+statement ok
+create table t (v1 int not null);
+
+statement ok
+insert into t values (3);
+
+query I rowsort
+select * from t;
+----
+3
+
+statement ok
+insert into t values (2+2);
+
+query I rowsort
+select * from t;
+----
+3
+4
+
+statement ok
+insert into t values (7), (8), (9);
+
+query I rowsort
+select * from t;
+----
+3
+4
+7
+8
+9
+
+statement ok
+insert into t values (2+3), (2+4), (3+4);
+
+query I rowsort
+select * from t;
+----
+3
+4
+5
+6
+7
+7
+8
+9
+
+statement ok
+insert into t values (12), (6+7), (44);
+
+query I rowsort
+select * from t;
+----
+3
+4
+5
+6
+7
+7
+8
+9
+12
+13
+44
+
+statement ok
+drop table t;

--- a/e2e_test/v2/batch/modify.slt
+++ b/e2e_test/v2/batch/modify.slt
@@ -6,9 +6,6 @@ create table t (v1 real not null, v2 int not null);
 statement ok
 insert into t values (114, 10), (514, 20);
 
-statement ok
-flush;
-
 query RI
 select v1, v2 from t order by v2;
 ----
@@ -17,9 +14,6 @@ select v1, v2 from t order by v2;
 
 statement ok
 insert into t values (810, 40), (1919, 30);
-
-statement ok
-flush;
 
 query RI
 select v1, v2 from t order by v2;
@@ -33,9 +27,6 @@ select v1, v2 from t order by v2;
 
 statement ok
 delete from t where v1 = 1919;
-
-statement ok
-flush;
 
 query RI
 select v1, v2 from t order by v2;
@@ -56,12 +47,8 @@ select count(*), v1 from t group by v1;
 1 514
 1 114
 
-
 statement ok
 delete from t;
-
-statement ok
-flush;
 
 query RI
 select v1, v2 from t order by v2;
@@ -71,7 +58,6 @@ query I
 select count(*) from t;
 ----
 0
-
 
 statement ok
 drop table t;

--- a/rust/frontend/src/binder/expr/mod.rs
+++ b/rust/frontend/src/binder/expr/mod.rs
@@ -249,10 +249,10 @@ impl Binder {
                 None => condition,
             };
             inputs.push(self.bind_expr(condition)?);
-            inputs.push(Binder::ensure_type(result, return_type.clone()));
+            inputs.push(result.ensure_type(return_type.clone()));
         }
         if let Some(expr) = else_result_expr {
-            inputs.push(Binder::ensure_type(expr, return_type.clone()));
+            inputs.push(expr.ensure_type(return_type.clone()));
         }
         Ok(FunctionCall::new_with_return_type(
             ExprType::Case,

--- a/rust/frontend/src/binder/values.rs
+++ b/rust/frontend/src/binder/values.rs
@@ -20,7 +20,7 @@ use risingwave_sqlparser::ast::Values;
 
 use super::bind_context::Clause;
 use crate::binder::Binder;
-use crate::expr::{Expr as _, ExprImpl, ExprType, FunctionCall, Literal};
+use crate::expr::{Expr as _, ExprImpl};
 
 #[derive(Debug)]
 pub struct BoundValues {
@@ -81,7 +81,7 @@ impl Binder {
             .map(|vec| {
                 vec.into_iter()
                     .zip_eq(types.iter().cloned())
-                    .map(|(expr, ty)| Self::ensure_type(expr, ty))
+                    .map(|(expr, ty)| expr.ensure_type(ty))
                     .collect::<Vec<ExprImpl>>()
             })
             .collect::<Vec<Vec<ExprImpl>>>();
@@ -107,22 +107,6 @@ impl Binder {
                 left, right
             ))
             .into())
-        }
-    }
-
-    /// Check if cast needs to be inserted.
-    /// TODO: check castiblility with context.
-    pub fn ensure_type(expr: ExprImpl, ty: DataType) -> ExprImpl {
-        if expr.is_null() {
-            ExprImpl::Literal(Box::new(Literal::new(None, ty)))
-        } else if ty == expr.return_type() {
-            expr
-        } else {
-            ExprImpl::FunctionCall(Box::new(FunctionCall::new_with_return_type(
-                ExprType::Cast,
-                vec![expr],
-                ty,
-            )))
         }
     }
 }

--- a/rust/frontend/src/expr/agg_call.rs
+++ b/rust/frontend/src/expr/agg_call.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use itertools::Itertools;
-use risingwave_common::error::Result;
+use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::expr::AggKind;
 use risingwave_common::types::DataType;
 
@@ -45,18 +45,29 @@ impl std::fmt::Debug for AggCall {
 }
 
 impl AggCall {
-    pub fn infer_return_type(agg_kind: &AggKind, inputs: &[DataType]) -> DataType {
-        match (&agg_kind, inputs) {
+    pub fn infer_return_type(agg_kind: &AggKind, inputs: &[DataType]) -> Option<DataType> {
+        // The function signatures are aligned with postgres, see
+        // https://www.postgresql.org/docs/current/functions-aggregate.html.
+        let return_type = match (&agg_kind, inputs) {
             (AggKind::Min, [input]) => input.clone(),
             (AggKind::Max, [input]) => input.clone(),
-            (AggKind::Avg, [input]) => input.clone(),
+            (AggKind::Avg, [input]) => match input {
+                DataType::Int16 | DataType::Int32 | DataType::Int64 | DataType::Decimal => {
+                    DataType::Decimal
+                }
+                DataType::Float32 | DataType::Float64 => DataType::Float64,
+                DataType::Interval => DataType::Interval,
+                _ => return None,
+            },
             (AggKind::Sum, [input]) => match input {
                 DataType::Int16 => DataType::Int64,
                 DataType::Int32 => DataType::Int64,
                 DataType::Int64 => DataType::Decimal,
-                DataType::Float32 => DataType::Float64,
+                DataType::Decimal => DataType::Decimal,
+                DataType::Float32 => DataType::Float32,
                 DataType::Float64 => DataType::Float64,
-                other_type => other_type.clone(),
+                DataType::Interval => DataType::Interval,
+                _ => return None,
             },
             (AggKind::Count, _) => DataType::Int64,
             (other_kind, other_inputs) => {
@@ -66,14 +77,22 @@ impl AggCall {
                     other_inputs.len()
                 )
             }
-        }
+        };
+        Some(return_type)
     }
+
     /// Returns error if the function name matches with an existing function
     /// but with illegal arguments.
     pub fn new(agg_kind: AggKind, inputs: Vec<ExprImpl>) -> Result<Self> {
         // TODO(TaoWu): Add arguments validator.
         let data_types = inputs.iter().map(ExprImpl::return_type).collect_vec();
-        let return_type = Self::infer_return_type(&agg_kind, &data_types);
+        let return_type = Self::infer_return_type(&agg_kind, &data_types).ok_or_else(|| {
+            let args = data_types.iter().map(|t| format!("{:?}", t)).join(", ");
+            RwError::from(ErrorCode::NotImplementedError(format!(
+                "No function matches to {}({})",
+                agg_kind, args
+            )))
+        })?;
         Ok(AggCall {
             agg_kind,
             return_type,

--- a/rust/frontend/src/expr/mod.rs
+++ b/rust/frontend/src/expr/mod.rs
@@ -90,6 +90,22 @@ impl ExprImpl {
     pub fn is_null(&self) -> bool {
         matches!(self, ExprImpl::Literal(literal) if literal.get_data().is_none())
     }
+
+    /// Check if cast needs to be inserted.
+    /// TODO: check castiblility with context.
+    pub fn ensure_type(self, ty: DataType) -> ExprImpl {
+        if self.is_null() {
+            ExprImpl::Literal(Box::new(Literal::new(None, ty)))
+        } else if ty == self.return_type() {
+            self
+        } else {
+            ExprImpl::FunctionCall(Box::new(FunctionCall::new_with_return_type(
+                ExprType::Cast,
+                vec![self],
+                ty,
+            )))
+        }
+    }
 }
 
 /// Implement downcast functions, e.g., `as_subquery(self) -> Option<Subquery>`

--- a/rust/frontend/test_runner/tests/testdata/basic_query_2.yaml
+++ b/rust/frontend/test_runner/tests/testdata/basic_query_2.yaml
@@ -134,14 +134,14 @@
     select v3, min(v1) * avg(v1+v2) from t group by v3;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [$0, ($1 * ($2 / $3))], expr_alias: [v3,  ] }
+      BatchProject { exprs: [$0, ($1 * ($2::Decimal / $3))], expr_alias: [v3,  ] }
         BatchHashAgg { group_keys: [$0], aggs: [min($1), sum($2), count($2)] }
           BatchProject { exprs: [$2, $0, ($0 + $1)], expr_alias: [ ,  ,  ] }
             BatchExchange { order: [], dist: HashShard([2]) }
               BatchScan { table: t, columns: [v1, v2, v3] }
   stream_plan: |
     StreamMaterialize { columns: [v3, expr#1], pk_columns: [v3] }
-      StreamProject { exprs: [$0, ($2 * ($3 / $4))], expr_alias: [v3,  ] }
+      StreamProject { exprs: [$0, ($2 * ($3::Decimal / $4))], expr_alias: [v3,  ] }
         StreamHashAgg { group_keys: [$0], aggs: [count, min($1), sum($2), count($2)] }
           StreamProject { exprs: [$2, $0, ($0 + $1), $3], expr_alias: [ ,  ,  ,  ] }
             StreamExchange { dist: HashShard([2]) }


### PR DESCRIPTION
## What's changed and what's your intention?

"flush after write" is to make updates visible for later reads, so that the system can behave like a traditional RDBMS. This is extremely useful for testing and borrowing tests from other DBMSs. This feature is configurable via the env var `RW_IMPLICIT_FLUSH`.
Close https://github.com/singularity-data/risingwave/issues/1445.

This pr also resolved some AVG issues, specifically, since AVG(int) was rewritten to SUM(int) / COUNT, the result would be incorrectly rounded to INT.

```sql
create table t (v1 int);
insert into t values (1) (2);
select avg(t.v1) from t;
```

The correct answer is 1.5, but as the behavior stated above, the result was unexpectedly calculated to `(1+2)::int/2 = 1`. I fixed by rewriting AVG as `CAST(SUM() AS typeof(AVG)) / COUNT`.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

