### PR TITLE
refactor(pgwire): Match on char to avoid utf8 convert

### DIFF
--- a/rust/utils/pgwire/src/pg_message.rs
+++ b/rust/utils/pgwire/src/pg_message.rs
@@ -51,8 +51,7 @@ impl FeQueryMessage {
 impl FeMessage {
     /// Read one message from the stream.
     pub async fn read(stream: &mut (impl AsyncRead + Unpin)) -> Result<FeMessage> {
-        let val = &[stream.read_u8().await?];
-        let tag = std::str::from_utf8(val).unwrap();
+        let val = stream.read_u8().await?;
         let len = stream.read_i32().await?;
 
         let payload_len = len - 4;
@@ -62,9 +61,9 @@ impl FeMessage {
         }
         let sql_bytes = Bytes::from(payload);
 
-        match tag {
-            "Q" => Ok(FeMessage::Query(FeQueryMessage { sql_bytes })),
-            "X" => Ok(FeMessage::Terminate),
+        match val {
+            b'Q' => Ok(FeMessage::Query(FeQueryMessage { sql_bytes })),
+            b'X' => Ok(FeMessage::Terminate),
             _ => {
                 unimplemented!("Do not support other tags regular message yet")
             }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [s9y-cla](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb)

Signed-off-by: Xuanwo <github@xuanwo.io>

## What's changed and what's your intention?

The convert from `&[u8]` to `&str` is not needed, as we can match on the char directly.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests
