### PR TITLE
refactor(storage/object/s3): Remove not needed check on ranged request

### DIFF
--- a/rust/storage/src/object/s3.rs
+++ b/rust/storage/src/object/s3.rs
@@ -16,7 +16,6 @@ use aws_sdk_s3::{Client, Endpoint, Region};
 use aws_smithy_http::body::SdkBody;
 use futures::future::try_join_all;
 use itertools::Itertools;
-use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{BoxedError, ErrorCode, Result, RwError};
 
 use super::{BlockLocation, ObjectMetadata};
@@ -65,15 +64,6 @@ impl ObjectStore for S3ObjectStore {
 
         let val = resp.body.collect().await.map_err(err)?.into_bytes();
 
-        if block_loc.is_some() && block_loc.as_ref().unwrap().size != val.len() {
-            return Err(RwError::from(InternalError(format!(
-                "mismatched size: expected {}, found {} when reading {} at {:?}",
-                block_loc.as_ref().unwrap().size,
-                val.len(),
-                path,
-                block_loc.as_ref().unwrap()
-            ))));
-        }
         Ok(val)
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: [s9y-cla](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb)

Signed-off-by: Xuanwo <github@xuanwo.io>

## What's changed and what's your intention?

Returning the correct bytes that are specified in the `Range` header is a part of HTTP standards and S3 API. So there is no need to check the returning bytes size, instead, we need to check the input `Range` is correct or not.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
