### PR TITLE
fix(doc): eliminate all the warnings of cargo doc --document-private-items

### DIFF
--- a/rust/meta/src/barrier/command.rs
+++ b/rust/meta/src/barrier/command.rs
@@ -31,8 +31,9 @@ use crate::model::{ActorId, TableFragments};
 use crate::storage::MetaStore;
 use crate::stream::FragmentManagerRef;
 
-/// [`Command`] is the action of [`GlobalBarrierManager`]. For different commands, we'll build
-/// different barriers to send, and may do different stuffs after the barrier is collected.
+/// [`Command`] is the action of [`crate::barrier::GlobalBarrierManager`]. For different commands,
+/// we'll build different barriers to send, and may do different stuffs after the barrier is
+/// collected.
 #[derive(Debug, Clone)]
 pub enum Command {
     /// `Plain` command generates a barrier with the mutation it carries.

--- a/rust/meta/src/barrier/info.rs
+++ b/rust/meta/src/barrier/info.rs
@@ -20,7 +20,8 @@ use crate::cluster::WorkerId;
 use crate::model::ActorId;
 use crate::stream::ActorInfos;
 
-/// [`BarrierActorInfo`] resolves the actor info read from meta store for [`GlobalBarrierManager`].
+/// [`BarrierActorInfo`] resolves the actor info read from meta store for
+/// [`crate::barrier::GlobalBarrierManager`].
 pub struct BarrierActorInfo {
     /// node_id => node
     pub node_map: HashMap<WorkerId, WorkerNode>,

--- a/rust/meta/src/barrier/mod.rs
+++ b/rust/meta/src/barrier/mod.rs
@@ -123,15 +123,15 @@ impl ScheduledBarriers {
     }
 }
 
-/// [`GlobalBarrierManager`] sends barriers to all registered compute nodes and collect them, with
-/// monotonic increasing epoch numbers. On compute nodes, [`LocalBarrierManager`] will serve these
-/// requests and dispatch them to source actors.
+/// [`crate::barrier::GlobalBarrierManager`] sends barriers to all registered compute nodes and
+/// collect them, with monotonic increasing epoch numbers. On compute nodes, `LocalBarrierManager`
+/// in `risingwave_stream` crate will serve these requests and dispatch them to source actors.
 ///
 /// Configuration change in our system is achieved by the mutation in the barrier. Thus,
-/// [`GlobalBarrierManager`] provides a set of interfaces like a state machine, accepting
-/// [`Command`] that carries info to build [`Mutation`]. To keep the consistency between barrier
-/// manager and meta store, some actions like "drop materialized view" or "create mv on mv" must be
-/// done in barrier manager transactional using [`Command`].
+/// [`crate::barrier::GlobalBarrierManager`] provides a set of interfaces like a state machine,
+/// accepting [`Command`] that carries info to build `Mutation`. To keep the consistency between
+/// barrier manager and meta store, some actions like "drop materialized view" or "create mv on mv"
+/// must be done in barrier manager transactional using [`Command`].
 pub struct GlobalBarrierManager<S: MetaStore> {
     /// The maximal interval for sending a barrier.
     interval: Duration,
@@ -158,7 +158,7 @@ where
 {
     const RECOVERY_RETRY_INTERVAL: Duration = Duration::from_millis(500);
 
-    /// Create a new [`GlobalBarrierManager`].
+    /// Create a new [`crate::barrier::GlobalBarrierManager`].
     pub fn new(
         env: MetaSrvEnv<S>,
         cluster_manager: ClusterManagerRef<S>,

--- a/rust/meta/src/stream/graph/stream_graph.rs
+++ b/rust/meta/src/stream/graph/stream_graph.rs
@@ -217,11 +217,11 @@ where
     }
 
     /// Build stream actor inside, two works will be done:
-    /// 1. replace node's input with [`MergeNode`] if it is [`ExchangeNode`], and swallow
+    /// 1. replace node's input with [`MergeNode`] if it is `ExchangeNode`, and swallow
     /// mergeNode's input.
-    /// 2. ignore root node when it's [`ExchangeNode`].
-    /// 3. replace node's [`ExchangeNode`] input with [`MergeNode`] and resolve its upstream actor
-    /// ids if it is a [`ChainNode`].
+    /// 2. ignore root node when it's `ExchangeNode`.
+    /// 3. replace node's `ExchangeNode` input with [`MergeNode`] and resolve its upstream actor
+    /// ids if it is a `ChainNode`.
     pub fn build_inner(
         &self,
         table_sink_map: &mut HashMap<TableId, Vec<ActorId>>,

--- a/rust/meta/src/stream/scheduler.rs
+++ b/rust/meta/src/stream/scheduler.rs
@@ -47,7 +47,7 @@ impl ScheduledLocations {
         }
     }
 
-    /// [`node_actors`] returns all actors for every node.
+    /// [`Self::node_actors`] returns all actors for every node.
     pub fn node_actors(&self) -> HashMap<WorkerId, Vec<ActorId>> {
         let mut node_actors = HashMap::new();
         self.actor_locations
@@ -62,7 +62,7 @@ impl ScheduledLocations {
         node_actors
     }
 
-    /// [`actor_info_map`] returns the `ActorInfo` map for every actor.
+    /// [`Self::actor_info_map`] returns the `ActorInfo` map for every actor.
     pub fn actor_info_map(&self) -> HashMap<ActorId, ActorInfo> {
         self.actor_locations
             .iter()
@@ -80,7 +80,7 @@ impl ScheduledLocations {
             .collect::<HashMap<_, _>>()
     }
 
-    /// [`actor_infos`] returns the `ActorInfo` slice.
+    /// [`Self::actor_infos`] returns the `ActorInfo` slice.
     pub fn actor_infos(&self) -> Vec<ActorInfo> {
         self.actor_locations
             .iter()
@@ -105,7 +105,7 @@ where
         }
     }
 
-    /// [`schedule`] schedules input fragments to different parallel units (workers).
+    /// [`Self::schedule`] schedules input fragments to different parallel units (workers).
     /// The schedule procedure is two-fold:
     /// (1) For normal fragments, we schedule them to all the hash parallel units in the cluster.
     /// (2) For singleton fragments, we apply the round robin strategy. One single parallel unit in

--- a/rust/meta/src/stream/stream_manager.rs
+++ b/rust/meta/src/stream/stream_manager.rs
@@ -39,7 +39,7 @@ use crate::stream::{FragmentManagerRef, Scheduler};
 
 pub type GlobalStreamManagerRef<S> = Arc<GlobalStreamManager<S>>;
 
-/// [`Context`] carries one-time infos.
+/// [`CreateMaterializedViewContext`] carries one-time infos.
 #[derive(Default)]
 pub struct CreateMaterializedViewContext {
     /// New dispatches to add from upstream actors to downstream actors.

--- a/rust/stream/src/executor/lookup/impl_.rs
+++ b/rust/stream/src/executor/lookup/impl_.rs
@@ -28,15 +28,15 @@ use crate::common::StreamChunkBuilder;
 /// Parameters for [`LookupExecutor`].
 pub struct LookupExecutorParams<S: StateStore> {
     /// The side for arrangement. Currently, it should be a
-    /// [`MaterializeExecutor`].
+    /// `MaterializeExecutor`.
     ///
-    /// [`MaterializeExecutor`]: crate::executor::mview::MaterializeExecutor
+    /// `MaterializeExecutor`
     pub arrangement: Box<dyn Executor>,
 
     /// The side for stream. It can be any stream, but it will generally be a
-    /// [`MaterializeExecutor`].
+    /// `MaterializeExecutor`.
     ///
-    /// [`MaterializeExecutor`]: crate::executor::mview::MaterializeExecutor
+    /// `MaterializeExecutor`
     pub stream: Box<dyn Executor>,
 
     /// The keyspace for arrangement. [`LookupExecutor`] will use this keyspace to read the state
@@ -46,11 +46,11 @@ pub struct LookupExecutorParams<S: StateStore> {
     /// Should be the same as [`ColumnDesc`] in the arrangement.
     ///
     /// From the perspective of arrangements, `arrangement_col_descs` include all columns of the
-    /// [`MaterializeExecutor`]. For example, if we already have a table with 3 columns: `a, b,
+    /// `MaterializeExecutor`. For example, if we already have a table with 3 columns: `a, b,
     /// _row_id`, and we create an arrangement with join key `a` on it. `arrangement_col_descs`
     /// should contain all 3 columns.
     ///
-    /// [`MaterializeExecutor`]: crate::executor::mview::MaterializeExecutor
+    /// `MaterializeExecutor`
     pub arrangement_col_descs: Vec<ColumnDesc>,
 
     /// Should be the same as [`OrderPair`] in the arrangement.

--- a/rust/stream/src/executor/lookup/sides.rs
+++ b/rust/stream/src/executor/lookup/sides.rs
@@ -77,7 +77,7 @@ pub(crate) struct ArrangeJoinSide<S: StateStore> {
     pub deserializer: CellBasedRowDeserializer,
 }
 
-/// Message from the [`arrange_join_stream`].
+/// Message from the `arrange_join_stream`.
 pub enum ArrangeMessage {
     /// Arrangement sides' update in this epoch. There will be only one arrange batch message
     /// within epoch. Once the executor receives an arrange batch message, it will replicate batch
@@ -134,12 +134,12 @@ pub async fn stream_lookup_arrange_prev_epoch(
 /// For example, the executor will receive the following message sequence from
 /// `stream_lookup_arrange_this_epoch`:
 ///
-/// * [Msg] Barrier (prev = [1], current = [2])
-/// * [Msg] Arrangement (batch)
-/// * [Do] replicate batch with epoch [2]
-/// * [Msg] Stream (key = a)
-/// * [Do] lookup `a` in arrangement of epoch [2] (current epoch)
-/// * Barrier (prev = [2], current = [3])
+/// * `[Msg`] Barrier (prev = `[1`], current = `[2`])
+/// * `[Msg`] Arrangement (batch)
+/// * `[Do`] replicate batch with epoch `[2`]
+/// * `[Msg`] Stream (key = a)
+/// * `[Do`] lookup `a` in arrangement of epoch `[2`] (current epoch)
+/// * Barrier (prev = `[2`], current = `[3`])
 #[try_stream(ok = ArrangeMessage, error = RwError)]
 pub async fn stream_lookup_arrange_this_epoch(
     stream: Box<dyn Executor>,

--- a/rust/stream/src/executor_v2/error.rs
+++ b/rust/stream/src/executor_v2/error.rs
@@ -75,7 +75,7 @@ impl std::fmt::Debug for TracedStreamExecutorError {
     }
 }
 
-/// Always convert [`TracedStreamExecutorError`] to internal error of [`RwResult`].
+/// Always convert [`TracedStreamExecutorError`] to internal error of `RwResult`.
 impl From<TracedStreamExecutorError> for RwError {
     fn from(h: TracedStreamExecutorError) -> Self {
         ErrorCode::InternalError(h.to_string()).into()

--- a/rust/stream/src/lib.rs
+++ b/rust/stream/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(rustdoc::private_intra_doc_links)]
 #![feature(backtrace)]
 #![warn(clippy::dbg_macro)]
 #![warn(clippy::disallowed_methods)]

--- a/rust/tests/regress/src/file.rs
+++ b/rust/tests/regress/src/file.rs
@@ -46,7 +46,7 @@ impl FileManager {
         Ok(())
     }
 
-    /// Try to find the input file of [`test_name`].
+    /// Try to find the input file of `test_name`.
     pub(crate) fn source_of(&self, test_name: &str) -> anyhow::Result<PathBuf> {
         let mut path = self
             .opts
@@ -71,7 +71,7 @@ impl FileManager {
         bail!("Can't find source of test case: {}", test_name)
     }
 
-    /// Try to find the output file of [`test_name`].
+    /// Try to find the output file of `test_name`.
     pub(crate) fn output_of(&self, test_name: &str) -> anyhow::Result<PathBuf> {
         Ok(self
             .opts
@@ -80,7 +80,7 @@ impl FileManager {
             .join(format!("{}.out", test_name)))
     }
 
-    /// Try to find the expected output file of [`test_name`].
+    /// Try to find the expected output file of `test_name`.
     pub(crate) fn expected_output_of(&self, test_name: &str) -> anyhow::Result<PathBuf> {
         let mut path = self
             .opts
@@ -105,18 +105,18 @@ impl FileManager {
         bail!("Can't find expected output of test case: {}", test_name)
     }
 
-    /// Convert source files in input dir, use [`replace_placeholder`].
+    /// Convert source files in input dir, use [`Self::replace_placeholder`].
     pub(crate) fn convert_source_files(&self) -> anyhow::Result<()> {
         self.convert_source_files_internal("input", "sql", "sql")?;
         self.convert_source_files_internal("output", "expected", "out")?;
         Ok(())
     }
 
-    /// Converts files ends with ".source" suffix in [`input_subdir`] and output them to
-    /// [`dest_subdir`] with filename ends with [`suffix`]
+    /// Converts files ends with ".source" suffix in `input_subdir` and output them to
+    /// `dest_subdir` with filename ends with `suffix`
     ///
-    /// The [`input_subdir`] is relative to [`Opts::input_dir`], and [`output_subdir`] is relative
-    /// to [`Opts::output_dir`].
+    /// The `input_subdir` is relative to [`crate::Opts::input_dir`], and `output_subdir` is
+    /// relative to [`crate::Opts::output_dir`].
     fn convert_source_files_internal(
         &self,
         input_subdir: &str,
@@ -149,8 +149,8 @@ impl FileManager {
         Ok(())
     }
 
-    /// Replace predefined placeholders in [`input`] with correct values and output them to
-    /// [`output`].
+    /// Replace predefined placeholders in `input` with correct values and output them to
+    /// `output`.
     ///
     /// ## Placeholders
     /// * `@abs_srcdir@`: Absolute path of input directory.
@@ -199,12 +199,12 @@ impl FileManager {
     }
 }
 
-/// Check [`dir`] not exists or is empty.
+/// Check `dir` not exists or is empty.
 ///
 /// # Return
 ///
-/// * If [`dir`] doesn't exist, create it and all its parents.
-/// * If [`dir`] exits, return error if not empty.
+/// * If `dir` doesn't exist, create it and all its parents.
+/// * If `dir` exits, return error if not empty.
 fn ensure_dir<P: AsRef<Path>>(dir: P) -> anyhow::Result<()> {
     let dir = dir.as_ref();
     if !dir.exists() {


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
As the title.

Shall we now make cargo doc a part of CI and let it fail on warnings?

## Refer to a related PR or issue link (optional)
#1437 