### PR TITLE
chore(doc): let cargo doc fails on warning due to broken_intra_doc_links

### DIFF
--- a/rust/batch/src/lib.rs
+++ b/rust/batch/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/common/src/lib.rs
+++ b/rust/common/src/lib.rs
@@ -24,6 +24,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/compute/src/lib.rs
+++ b/rust/compute/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/connector/src/lib.rs
+++ b/rust/connector/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(map_try_insert)]
 #![feature(let_chains)]
 #![feature(negative_impls)]

--- a/rust/meta/src/lib.rs
+++ b/rust/meta/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/rpc_client/src/lib.rs
+++ b/rust/rpc_client/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/source/src/lib.rs
+++ b/rust/source/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/storage/src/lib.rs
+++ b/rust/storage/src/lib.rs
@@ -22,6 +22,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(generic_associated_types)]
 #![feature(binary_heap_drain_sorted)]

--- a/rust/stream/src/lib.rs
+++ b/rust/stream/src/lib.rs
@@ -24,6 +24,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(trait_alias)]
 #![feature(type_alias_impl_trait)]
 #![feature(generic_associated_types)]

--- a/rust/tests/regress/src/lib.rs
+++ b/rust/tests/regress/src/lib.rs
@@ -23,6 +23,7 @@
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
 #![deny(unused_must_use)]
+#![deny(rustdoc::broken_intra_doc_links)]
 #![feature(path_file_prefix)]
 
 mod opts;


### PR DESCRIPTION
## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
As the title. So we force it in CI.

## Refer to a related PR or issue link (optional)
closes #1523 