### PR TITLE
storage: do not fetch all tables during every query.

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -34,7 +34,7 @@ enum LevelType {
 
 message Level {
   LevelType level_type = 1;
-  repeated uint64 table_ids = 2;
+  repeated SstableInfo table_infos = 2;
 }
 
 message UncommittedEpoch {

--- a/src/bench/ss_bench/main.rs
+++ b/src/bench/ss_bench/main.rs
@@ -22,6 +22,7 @@ use operations::*;
 use risingwave_common::config::StorageConfig;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::MockHummockMetaClient;
+use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::{dispatch_state_store, StateStoreImpl};
 
@@ -91,6 +92,10 @@ pub(crate) struct Opts {
 
     #[clap(long)]
     calibrate_histogram: bool,
+
+    // 0 represent do nothing because all files will be synced to L0.
+    #[clap(long, default_value_t = 0)]
+    compact_level_after_write: u32,
 }
 
 fn preprocess_options(opts: &mut Opts) {
@@ -139,15 +144,26 @@ async fn main() {
     ));
     let state_store = StateStoreImpl::new(
         &opts.store,
-        config,
+        config.clone(),
         mock_hummock_meta_client.clone(),
         state_store_stats.clone(),
     )
     .await
     .expect("Failed to get state_store");
+    let mut context = None;
+    if let StateStoreImpl::HummockStateStore(hummock) = state_store.clone() {
+        context = Some(Arc::new(CompactorContext {
+            options: config.clone(),
+            local_version_manager: hummock.inner().local_version_manager().clone(),
+            hummock_meta_client: mock_hummock_meta_client.clone(),
+            sstable_store: hummock.inner().sstable_store(),
+            stats: state_store_stats.clone(),
+            is_share_buffer_compact: false,
+        }));
+    }
 
     dispatch_state_store!(state_store, store, {
-        Operations::run(store, mock_hummock_meta_client, &opts).await
+        Operations::run(store, mock_hummock_meta_client, context, &opts).await
     });
 
     if opts.statistics {

--- a/src/bench/ss_bench/operations/mod.rs
+++ b/src/bench/ss_bench/operations/mod.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use rand::prelude::StdRng;
 use rand::SeedableRng;
 use risingwave_meta::hummock::MockHummockMetaClient;
+use risingwave_storage::hummock::compactor::CompactorContext;
 use risingwave_storage::StateStore;
 
 use crate::utils::display_stats::*;
@@ -50,6 +51,7 @@ impl Operations {
     pub(crate) async fn run(
         store: impl StateStore,
         meta_service: Arc<MockHummockMetaClient>,
+        context: Option<Arc<CompactorContext>>,
         opts: &Opts,
     ) {
         let mut stat_display = DisplayStats::default();
@@ -65,7 +67,7 @@ impl Operations {
             // (Sun Ting) TODO: remove statistics print for each operation
             // after new performance display is ready
             match operation {
-                "writebatch" => runner.write_batch(&store, opts).await,
+                "writebatch" => runner.write_batch(&store, opts, context.clone()).await,
                 "deleterandom" => runner.delete_random(&store, opts).await,
                 "getrandom" => runner.get_random(&store, opts).await,
                 "getseq" => runner.get_seq(&store, opts).await,

--- a/src/bench/ss_bench/operations/write_batch.rs
+++ b/src/bench/ss_bench/operations/write_batch.rs
@@ -22,6 +22,7 @@ use rand::distributions::Uniform;
 use rand::prelude::Distribution;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_rpc_client::HummockMetaClient;
+use risingwave_storage::hummock::compactor::{Compactor, CompactorContext};
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::StateStore;
 
@@ -77,7 +78,12 @@ impl BatchTaskContext {
 }
 
 impl Operations {
-    pub(crate) async fn write_batch(&mut self, store: &impl StateStore, opts: &Opts) {
+    pub(crate) async fn write_batch(
+        &mut self,
+        store: &impl StateStore,
+        opts: &Opts,
+        context: Option<Arc<CompactorContext>>,
+    ) {
         let (prefixes, keys) = Workload::new_random_keys(opts, opts.writes as u64, &mut self.rng);
         let values = Workload::new_values(opts, opts.writes as u64, &mut self.rng);
 
@@ -89,6 +95,13 @@ impl Operations {
         println!("batch size: {}", batches.len());
 
         let perf = self.run_batches(store, opts, batches).await;
+        if opts.compact_level_after_write > 0 {
+            if let Some(context) = context {
+                if let Some(task) = self.meta_client.get_compact_task(1).await {
+                    Compactor::compact(context, task).await;
+                }
+            }
+        }
 
         println!(
             "

--- a/src/meta/src/hummock/compaction.rs
+++ b/src/meta/src/hummock/compaction.rs
@@ -24,7 +24,7 @@ use risingwave_hummock_sdk::key::{user_key, FullKey};
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::{HummockEpoch, HummockSSTableId};
 use risingwave_pb::hummock::{
-    CompactMetrics, CompactTask, Level, LevelEntry, LevelType, TableSetStatistics,
+    CompactMetrics, CompactTask, Level, LevelEntry, LevelType, SstableInfo, TableSetStatistics,
 };
 
 use crate::hummock::level_handler::{LevelHandler, SSTableStat};
@@ -318,12 +318,25 @@ impl CompactStatus {
                             level: if is_select_level_leveling {
                                 Some(Level {
                                     level_type: LevelType::Nonoverlapping as i32,
-                                    table_ids: select_ln_ids,
+                                    table_infos: select_ln_ids
+                                        .into_iter()
+                                        .map(|id| SstableInfo {
+                                            id,
+                                            // compact node will never use key_range in SstableInfo.
+                                            key_range: None,
+                                        })
+                                        .collect_vec(),
                                 })
                             } else {
                                 Some(Level {
                                     level_type: LevelType::Overlapping as i32,
-                                    table_ids: select_ln_ids,
+                                    table_infos: select_ln_ids
+                                        .into_iter()
+                                        .map(|id| SstableInfo {
+                                            id,
+                                            key_range: None,
+                                        })
+                                        .collect_vec(),
                                 })
                             },
                         },
@@ -332,12 +345,24 @@ impl CompactStatus {
                             level: if is_target_level_leveling {
                                 Some(Level {
                                     level_type: LevelType::Nonoverlapping as i32,
-                                    table_ids: select_lnsuc_ids,
+                                    table_infos: select_lnsuc_ids
+                                        .into_iter()
+                                        .map(|id| SstableInfo {
+                                            id,
+                                            key_range: None,
+                                        })
+                                        .collect_vec(),
                                 })
                             } else {
                                 Some(Level {
                                     level_type: LevelType::Overlapping as i32,
-                                    table_ids: select_lnsuc_ids,
+                                    table_infos: select_lnsuc_ids
+                                        .into_iter()
+                                        .map(|id| SstableInfo {
+                                            id,
+                                            key_range: None,
+                                        })
+                                        .collect_vec(),
                                 })
                             },
                         },

--- a/src/meta/src/hummock/hummock_manager.rs
+++ b/src/meta/src/hummock/hummock_manager.rs
@@ -177,11 +177,11 @@ where
                 levels: vec![
                     Level {
                         level_type: LevelType::Overlapping as i32,
-                        table_ids: vec![],
+                        table_infos: vec![],
                     },
                     Level {
                         level_type: LevelType::Nonoverlapping as i32,
-                        table_ids: vec![],
+                        table_infos: vec![],
                     },
                 ],
                 uncommitted_epochs: vec![],
@@ -722,7 +722,15 @@ where
         let input_sst_ids = compact_task
             .input_ssts
             .iter()
-            .flat_map(|v| v.level.as_ref().unwrap().table_ids.clone())
+            .flat_map(|v| {
+                v.level
+                    .as_ref()
+                    .unwrap()
+                    .table_infos
+                    .iter()
+                    .map(|sst| sst.id)
+                    .collect_vec()
+            })
             .collect_vec();
         let output_sst_ids = compact_task
             .sorted_output_ssts
@@ -771,16 +779,38 @@ where
                     .map(|level_handler| match level_handler {
                         LevelHandler::Overlapping(l_n, _) => Level {
                             level_type: LevelType::Overlapping as i32,
-                            table_ids: l_n
+                            table_infos: l_n
                                 .iter()
-                                .map(|SSTableStat { table_id, .. }| *table_id)
+                                .map(
+                                    |SSTableStat {
+                                         table_id,
+                                         key_range,
+                                         ..
+                                     }| {
+                                        SstableInfo {
+                                            id: *table_id,
+                                            key_range: Some(key_range.clone().into()),
+                                        }
+                                    },
+                                )
                                 .collect(),
                         },
                         LevelHandler::Nonoverlapping(l_n, _) => Level {
                             level_type: LevelType::Nonoverlapping as i32,
-                            table_ids: l_n
+                            table_infos: l_n
                                 .iter()
-                                .map(|SSTableStat { table_id, .. }| *table_id)
+                                .map(
+                                    |SSTableStat {
+                                         table_id,
+                                         key_range,
+                                         ..
+                                     }| {
+                                        SstableInfo {
+                                            id: *table_id,
+                                            key_range: Some(key_range.clone().into()),
+                                        }
+                                    },
+                                )
                                 .collect(),
                         },
                     })
@@ -895,7 +925,7 @@ where
                     uncommitted_epoch
                         .tables
                         .iter()
-                        .for_each(|t| version_first_level.table_ids.push(t.id));
+                        .for_each(|t| version_first_level.table_infos.push(t.clone()));
                 }
                 LevelType::Nonoverlapping => {
                     unimplemented!()

--- a/src/meta/src/hummock/hummock_manager_tests.rs
+++ b/src/meta/src/hummock/hummock_manager_tests.rs
@@ -56,8 +56,8 @@ async fn test_hummock_pin_unpin() -> Result<()> {
             .unwrap();
         assert_eq!(version_id, hummock_version.id);
         assert_eq!(2, hummock_version.levels.len());
-        assert_eq!(0, hummock_version.levels[0].table_ids.len());
-        assert_eq!(0, hummock_version.levels[1].table_ids.len());
+        assert_eq!(0, hummock_version.levels[0].table_infos.len());
+        assert_eq!(0, hummock_version.levels[1].table_infos.len());
 
         let pinned_versions = HummockPinnedVersion::list(env.meta_store()).await?;
         assert_eq!(pin_versions_sum(&pinned_versions), 1);
@@ -252,8 +252,8 @@ async fn test_hummock_table() -> Result<()> {
         pinned_version
             .levels
             .iter()
-            .flat_map(|level| level.table_ids.iter())
-            .copied()
+            .flat_map(|level| level.table_infos.iter())
+            .map(|info| info.id)
             .sorted()
             .cmp(original_tables.iter().map(|ot| ot.id).sorted())
     );

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -18,8 +18,8 @@ use async_trait::async_trait;
 use risingwave_common::error::Result;
 use risingwave_hummock_sdk::{HummockContextId, HummockEpoch, HummockSSTableId, HummockVersionId};
 use risingwave_pb::hummock::{
-    CompactTask, HummockSnapshot, HummockVersion, SstableInfo, SubscribeCompactTasksResponse,
-    VacuumTask,
+    CompactTask, HummockSnapshot, HummockVersion, KeyRange, Level, LevelEntry, LevelType,
+    SstableInfo, SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::HummockMetaClient;
 use tonic::Streaming;
@@ -41,6 +41,44 @@ impl MockHummockMetaClient {
             hummock_manager,
             context_id,
         }
+    }
+
+    pub async fn get_compact_task(&self, target_level: u32) -> Option<CompactTask> {
+        let v = self.hummock_manager.get_current_version().await;
+        // `MockHummockMetaClient` only support compact file from L0 to L1.
+        if v.levels.is_empty()
+            || v.levels.first().unwrap().level_type != LevelType::Overlapping as i32
+        {
+            return None;
+        }
+        let select_ln_ids = v.levels.first().unwrap().table_infos.clone();
+        let compact_task = CompactTask {
+            input_ssts: vec![
+                LevelEntry {
+                    level_idx: 0,
+                    level: Some(Level {
+                        level_type: LevelType::Overlapping as i32,
+                        table_infos: select_ln_ids,
+                    }),
+                },
+                LevelEntry {
+                    level_idx: target_level,
+                    level: Some(Level {
+                        level_type: LevelType::Nonoverlapping as i32,
+                        table_infos: vec![],
+                    }),
+                },
+            ],
+            splits: vec![KeyRange::default()],
+            watermark: HummockEpoch::MAX,
+            sorted_output_ssts: vec![],
+            task_id: 1,
+            target_level,
+            is_target_ultimate_and_leveling: target_level as usize + 1 == v.levels.len(),
+            metrics: None,
+            task_status: false,
+        };
+        Some(compact_task)
     }
 }
 

--- a/src/meta/src/hummock/mod.rs
+++ b/src/meta/src/hummock/mod.rs
@@ -157,7 +157,15 @@ where
                     let input_ssts = compact_task
                         .input_ssts
                         .iter()
-                        .flat_map(|v| v.level.as_ref().unwrap().table_ids.clone())
+                        .flat_map(|v| {
+                            v.level
+                                .as_ref()
+                                .unwrap()
+                                .table_infos
+                                .iter()
+                                .map(|sst| sst.id)
+                                .collect_vec()
+                        })
                         .collect_vec();
                     tracing::debug!(
                         "Try to compact SSTs {:?} in worker {}.",

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -117,7 +117,7 @@ pub fn get_sorted_committed_sstable_ids(hummock_version: &HummockVersion) -> Vec
     hummock_version
         .levels
         .iter()
-        .flat_map(|level| level.table_ids.clone())
+        .flat_map(|level| level.table_infos.iter().map(|info| info.id))
         .sorted()
         .collect_vec()
 }

--- a/src/storage/src/hummock/compactor_tests.rs
+++ b/src/storage/src/hummock/compactor_tests.rs
@@ -125,7 +125,7 @@ mod tests {
                 .level
                 .as_ref()
                 .unwrap()
-                .table_ids
+                .table_infos
                 .len(),
             kv_count
         );
@@ -135,13 +135,14 @@ mod tests {
 
         // 4. get the latest version and check
         let version = hummock_manager_ref.get_current_version().await;
-        let output_table_id = *version
+        let output_table_id = version
             .get_levels()
             .last()
             .unwrap()
-            .table_ids
+            .table_infos
             .first()
-            .unwrap();
+            .unwrap()
+            .id;
         let table = storage
             .local_version_manager()
             .pick_few_tables(&[output_table_id])

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -63,10 +63,10 @@ use self::key::{key_with_epoch, user_key, FullKey};
 pub use self::sstable_store::*;
 use self::utils::range_overlap;
 use super::monitor::StateStoreMetrics;
-use crate::hummock::iterator::ReverseUserIterator;
+use crate::hummock::iterator::{ConcatIterator, ReverseConcatIterator, ReverseUserIterator};
 use crate::hummock::local_version_manager::LocalVersionManager;
 use crate::hummock::shared_buffer::shared_buffer_manager::SharedBufferManager;
-use crate::hummock::utils::validate_epoch;
+use crate::hummock::utils::{validate_epoch, validate_table_key_range};
 use crate::storage_value::StorageValue;
 use crate::store::*;
 use crate::{define_state_store_associated_type, StateStore, StateStoreIter};
@@ -227,25 +227,40 @@ impl StateStore for HummockStorage {
             validate_epoch(version.safe_epoch(), epoch)?;
 
             // Query shared buffer. Return the value without iterating SSTs if found
-            if version.max_committed_epoch() < epoch && let Some(v) = self
-                .shared_buffer_manager
-                .get(key, (version.max_committed_epoch() + 1)..=epoch)
-            {
-                self.stats.get_shared_buffer_hit_counts.inc();
-                return Ok(v.into_user_value().map(|v| v.into()));
+            if version.max_committed_epoch() < epoch {
+                if let Some(v) = self
+                    .shared_buffer_manager
+                    .get(key, (version.max_committed_epoch() + 1)..=epoch)
+                {
+                    self.stats.get_shared_buffer_hit_counts.inc();
+                    return Ok(v.into_user_value().map(|v| v.into()));
+                }
             }
             let internal_key = key_with_epoch(key.to_vec(), epoch);
 
             let mut table_counts = 0;
             for level in &version.levels() {
-                let mut tables = self
-                    .local_version_manager
-                    .pick_few_tables(&level.table_ids)
-                    .await?;
+                if level.table_infos.is_empty() {
+                    continue;
+                }
                 match level.level_type() {
                     LevelType::Overlapping => {
-                        tables.reverse();
-                        for table in tables {
+                        let table_infos = level
+                            .table_infos
+                            .iter()
+                            .filter(|info| {
+                                let table_range = info.key_range.as_ref().unwrap();
+                                let table_start = user_key(table_range.left.as_slice());
+                                let table_end = user_key(table_range.right.as_slice());
+                                table_start.le(key) && table_end.ge(key)
+                            })
+                            .map(|info| info.id)
+                            .collect_vec();
+                        let tables = self
+                            .local_version_manager
+                            .pick_few_tables(&table_infos)
+                            .await?;
+                        for table in tables.into_iter().rev() {
                             table_counts += 1;
                             if let Some(v) = self.get_from_table(table, &internal_key, key).await? {
                                 return Ok(Some(v));
@@ -253,25 +268,29 @@ impl StateStore for HummockStorage {
                         }
                     }
                     LevelType::Nonoverlapping => {
-                        let table_idx = tables
+                        let table_idx = level
+                            .table_infos
                             .partition_point(|table| {
                                 let ord = VersionedComparator::compare_key(
-                                    user_key(&table.meta.smallest_key),
+                                    user_key(&table.key_range.as_ref().unwrap().left),
                                     key,
                                 );
                                 ord == Ordering::Less || ord == Ordering::Equal
                             })
                             .saturating_sub(1); // considering the boundary of 0
-                        if table_idx < tables.len() {
-                            table_counts += 1;
-                            // Because we will keep multiple version of one in the same sst file, we
-                            // do not find it in the next adjacent file.
-                            if let Some(v) = self
-                                .get_from_table(tables[table_idx].clone(), &internal_key, key)
-                                .await?
-                            {
-                                return Ok(Some(v));
-                            }
+                        assert!(table_idx < level.table_infos.len());
+                        table_counts += 1;
+                        // Because we will keep multiple version of one in the same sst file, we
+                        // do not find it in the next adjacent file.
+                        let tables = self
+                            .local_version_manager
+                            .pick_few_tables(&[level.table_infos[table_idx].id])
+                            .await?;
+                        if let Some(v) = self
+                            .get_from_table(tables.first().unwrap().clone(), &internal_key, key)
+                            .await?
+                        {
+                            return Ok(Some(v));
                         }
                     }
                 }
@@ -401,23 +420,48 @@ impl StateStore for HummockStorage {
             let version = self.local_version_manager.get_version()?;
             // Check epoch validity
             validate_epoch(version.safe_epoch(), epoch)?;
+            let levels = version.levels();
+            validate_table_key_range(&levels)?;
 
             // Filter out tables that overlap with given `key_range`
-            let tables = self.local_version_manager.tables(&version.levels()).await?;
-            let tables_count = tables.len();
-            let overlapped_sstable_iters = tables
-                .into_iter()
-                .filter(|t| {
-                    let table_start = user_key(t.meta.smallest_key.as_slice());
-                    let table_end = user_key(t.meta.largest_key.as_slice());
-                    range_overlap(&key_range, table_start, table_end, false)
-                })
-                .map(|t| {
-                    Box::new(SSTableIterator::new(t, self.sstable_store.clone()))
-                        as BoxedHummockIterator
-                })
-                .collect_vec();
-
+            let mut overlapped_sstable_iters = vec![];
+            for level in &version.levels() {
+                let table_ids = level
+                    .table_infos
+                    .iter()
+                    .filter(|info| {
+                        let table_range = info.key_range.as_ref().unwrap();
+                        let table_start = user_key(table_range.left.as_slice());
+                        let table_end = user_key(table_range.right.as_slice());
+                        range_overlap(&key_range, table_start, table_end, false)
+                    })
+                    .map(|info| info.id)
+                    .collect_vec();
+                if table_ids.is_empty() {
+                    continue;
+                }
+                let tables = self
+                    .local_version_manager
+                    .pick_few_tables(&table_ids)
+                    .await?;
+                match level.level_type() {
+                    LevelType::Overlapping => {
+                        for table in tables.into_iter().rev() {
+                            overlapped_sstable_iters.push(Box::new(SSTableIterator::new(
+                                table,
+                                self.sstable_store.clone(),
+                            ))
+                                as BoxedHummockIterator);
+                        }
+                    }
+                    LevelType::Nonoverlapping => overlapped_sstable_iters.push(Box::new(
+                        ConcatIterator::new(tables, self.sstable_store.clone()),
+                    )),
+                }
+            }
+            self.stats
+                .iter_merge_sstable_counts
+                .observe(overlapped_sstable_iters.len() as f64);
             let mi = if version.max_committed_epoch() < epoch {
                 // Take shared buffers into consideration if the read epoch is above the max
                 // committed epoch
@@ -431,9 +475,6 @@ impl StateStore for HummockStorage {
                     self.stats.clone(),
                 )
             } else {
-                self.stats
-                    .iter_merge_sstable_counts
-                    .observe(tables_count as f64);
                 MergeIterator::new(overlapped_sstable_iters, self.stats.clone())
             };
 
@@ -464,24 +505,57 @@ impl StateStore for HummockStorage {
             let version = self.local_version_manager.get_version()?;
             // Check epoch validity
             validate_epoch(version.safe_epoch(), epoch)?;
-
             // Filter out tables that overlap with given `key_range`
-            let overlapped_sstable_iters = self
-                .local_version_manager
-                .tables(&version.levels())
-                .await?
-                .into_iter()
-                .filter(|t| {
-                    let table_start = user_key(t.meta.smallest_key.as_slice());
-                    let table_end = user_key(t.meta.largest_key.as_slice());
-                    range_overlap(&key_range, table_start, table_end, true)
-                })
-                .map(|t| {
-                    Box::new(ReverseSSTableIterator::new(t, self.sstable_store.clone()))
-                        as BoxedHummockIterator
-                })
-                .collect_vec();
-
+            let mut overlapped_sstable_iters = vec![];
+            for level in &version.levels() {
+                let table_ids = level
+                    .table_infos
+                    .iter()
+                    .filter(|info| {
+                        let table_range = info.key_range.as_ref().unwrap();
+                        let table_start = user_key(table_range.left.as_slice());
+                        let table_end = user_key(table_range.right.as_slice());
+                        range_overlap(&key_range, table_start, table_end, true)
+                    })
+                    .map(|info| info.id)
+                    .collect_vec();
+                if table_ids.is_empty() {
+                    continue;
+                }
+                let mut tables = self
+                    .local_version_manager
+                    .pick_few_tables(&table_ids)
+                    .await?;
+                match level.level_type() {
+                    LevelType::Overlapping => {
+                        for table in tables.into_iter().rev() {
+                            overlapped_sstable_iters.push(Box::new(ReverseSSTableIterator::new(
+                                table,
+                                self.sstable_store.clone(),
+                            ))
+                                as BoxedHummockIterator);
+                        }
+                    }
+                    LevelType::Nonoverlapping => {
+                        if tables.len() > 1 {
+                            tables.reverse();
+                            overlapped_sstable_iters.push(Box::new(ReverseConcatIterator::new(
+                                tables,
+                                self.sstable_store.clone(),
+                            )))
+                        } else {
+                            overlapped_sstable_iters.push(Box::new(ReverseSSTableIterator::new(
+                                tables.pop().unwrap(),
+                                self.sstable_store.clone(),
+                            ))
+                                as BoxedHummockIterator);
+                        }
+                    }
+                }
+            }
+            self.stats
+                .iter_merge_sstable_counts
+                .observe(overlapped_sstable_iters.len() as f64);
             let reverse_merge_iterator = if version.max_committed_epoch() < epoch {
                 // Take shared buffers into consideration if the read epoch is above the max
                 // committed epoch

--- a/src/storage/src/hummock/snapshot_tests.rs
+++ b/src/storage/src/hummock/snapshot_tests.rs
@@ -211,7 +211,7 @@ async fn test_snapshot_reverse_range_scan() {
     ));
     let hummock_options = Arc::new(default_config_for_test());
     let hummock_storage = HummockStorage::with_default_stats(
-        hummock_options,
+        hummock_options.clone(),
         sstable_store.clone(),
         vm.clone(),
         mock_hummock_meta_client.clone(),
@@ -228,13 +228,33 @@ async fn test_snapshot_reverse_range_scan() {
                 (Bytes::from("2"), StorageValue::new_default_put("test")),
                 (Bytes::from("3"), StorageValue::new_default_put("test")),
                 (Bytes::from("4"), StorageValue::new_default_put("test")),
+                (Bytes::from("5"), StorageValue::new_default_put("test")),
+                (Bytes::from("6"), StorageValue::new_default_put("test")),
             ],
             epoch,
         )
         .await
         .unwrap();
     hummock_storage.sync(Some(epoch)).await.unwrap();
+    mock_hummock_meta_client.commit_epoch(epoch).await.unwrap();
 
+    hummock_storage
+        .ingest_batch(
+            vec![
+                (Bytes::from("5"), StorageValue::new_default_put("test")),
+                (Bytes::from("6"), StorageValue::new_default_put("test")),
+                (Bytes::from("7"), StorageValue::new_default_put("test")),
+                (Bytes::from("8"), StorageValue::new_default_put("test")),
+            ],
+            epoch + 1,
+        )
+        .await
+        .unwrap();
+    hummock_storage.sync(Some(epoch + 1)).await.unwrap();
+    mock_hummock_meta_client
+        .commit_epoch(epoch + 1)
+        .await
+        .unwrap();
     macro_rules! key {
         ($idx:expr) => {
             Bytes::from(stringify!($idx)).to_vec()
@@ -246,5 +266,7 @@ async fn test_snapshot_reverse_range_scan() {
     assert_count_reverse_range_scan!(hummock_storage, key!(3)..key!(1), 2, epoch);
     assert_count_reverse_range_scan!(hummock_storage, key!(3)..=key!(1), 3, epoch);
     assert_count_reverse_range_scan!(hummock_storage, key!(3)..key!(0), 3, epoch);
-    assert_count_reverse_range_scan!(hummock_storage, .., 4, epoch);
+    assert_count_reverse_range_scan!(hummock_storage, .., 6, epoch);
+    assert_count_reverse_range_scan!(hummock_storage, .., 8, epoch + 1);
+    assert_count_reverse_range_scan!(hummock_storage, key!(7)..key!(2), 5, epoch + 1);
 }

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -15,6 +15,8 @@
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::RangeBounds;
 
+use risingwave_pb::hummock::Level;
+
 use super::{HummockError, HummockResult};
 
 pub fn range_overlap<R, B>(
@@ -56,5 +58,19 @@ pub fn validate_epoch(safe_epoch: u64, epoch: u64) -> HummockResult<()> {
         return Err(HummockError::expired_epoch(safe_epoch, epoch));
     }
 
+    Ok(())
+}
+
+pub fn validate_table_key_range(levels: &[Level]) -> HummockResult<()> {
+    for l in levels {
+        for t in &l.table_infos {
+            if t.key_range.is_none() {
+                return Err(HummockError::meta_error(format!(
+                    "key_range in table [{}] is none",
+                    t.id
+                )));
+            }
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

## What's changed and what's your intention?

close https://github.com/singularity-data/risingwave/issues/1507
Although the meta most of tables will be cached, if there are too many files in the whole cluster ,  the bloom-filter-data would cost a lot of memory. In fact, most of request only concerned about a few data in a small range of the current executor , so they do not need to fetch all table from the table-cache.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
