### PR TITLE
refactor(expr): simplify gen_binary_expr_atm

### DIFF
--- a/rust/expr/src/expr/expr_binary_nonnull.rs
+++ b/rust/expr/src/expr/expr_binary_nonnull.rs
@@ -49,7 +49,7 @@ pub fn cmp_placeholder<T1, T2, T3>(_l: T1, _r: T2) -> Result<bool> {
 /// * $The scalar function for expression, it's a generic function and specialized by the type of
 ///   `$i1, $i2, $cast`
 macro_rules! gen_atm_impl {
-    ([$l:expr, $r:expr, $ret:expr], $( { $i1:tt, $i2:tt, $cast:tt, $func:ident }, )*) => {
+    ([$l:expr, $r:expr, $ret:expr], $( { $i1:tt, $i2:tt, $cast:tt, $func:ident },)*) => {
         match ($l.return_type(), $r.return_type()) {
             $(
                 ($i1! { type_match_pattern }, $i2! { type_match_pattern }) => {


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

We will add more arithmetic between different types, e.g. Timestamp + Interval, Interval * Int, the original macro is error-prune and not easy to extend.

The PR make the macro more easy to use:

1. Optional argument.
2. Named argument

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
