### PR TITLE
chore: remove src/risedev

### DIFF
--- a/src/risedev
+++ b/src/risedev
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$DIR" || exit 1
-cd .. || exit 1
-
-./risedev "$@"


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

After #1580, most of us use root directory as workdir, it's unnecessary to keep src/risedev.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
