### PR TITLE
fix(frontend): fix window_start type

### DIFF
--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -391,7 +391,7 @@ fn new_tumble_start(
         DataType::Date => Box::new(BinaryExpression::<
             NaiveDateArray,
             IntervalArray,
-            NaiveDateArray,
+            NaiveDateTimeArray,
             _,
         >::new(
             expr_ia1, expr_ia2, return_type, tumble_start_date

--- a/src/expr/src/vector_op/tumble.rs
+++ b/src/expr/src/vector_op/tumble.rs
@@ -12,29 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use chrono::{NaiveDateTime, NaiveTime};
+use chrono::NaiveDateTime;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::{IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper};
 
-// FIXME: This implementation is very crude and likely wrong. fix it later.
-#[inline(always)]
-pub fn tumble_start_date(time: NaiveDateWrapper, window: IntervalUnit) -> Result<NaiveDateWrapper> {
-    let diff = NaiveDateTime::new(time.0, NaiveTime::from_hms(0, 0, 0)).timestamp();
-    if window.get_months() != 0 {
-        return Err(RwError::from(InternalError(
-            "unimplemented: tumble_start only support days".to_string(),
-        )));
-    }
-    let window = window.get_days() as i64 * 24 * 60 * 60 + window.get_ms() / 1000;
-    let offset = diff / window;
-    let window_start = window * offset;
+use super::cast::date_to_timestamp;
 
-    Ok(NaiveDateWrapper(
-        NaiveDateTime::from_timestamp(window_start, 0).date(),
-    ))
+#[inline(always)]
+pub fn tumble_start_date(
+    time: NaiveDateWrapper,
+    window: IntervalUnit,
+) -> Result<NaiveDateTimeWrapper> {
+    tumble_start_date_time(date_to_timestamp(time)?, window)
 }
 
+// FIXME: This implementation is very crude and likely wrong. fix it later.
 #[inline(always)]
 pub fn tumble_start_date_time(
     time: NaiveDateTimeWrapper,

--- a/src/frontend/src/binder/window_table_function.rs
+++ b/src/frontend/src/binder/window_table_function.rs
@@ -2,10 +2,11 @@ use std::str::FromStr;
 
 use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, RwError};
+use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{Expr, FunctionArg, FunctionArgExpr, ObjectName};
 
 use super::{Binder, BoundBaseTable, Result};
-use crate::expr::{Expr as _, ExprImpl, InputRef};
+use crate::expr::{ExprImpl, InputRef};
 
 #[derive(Copy, Clone, Debug)]
 pub enum WindowTableFunctionKind {
@@ -76,8 +77,6 @@ impl Binder {
             .into());
         };
 
-        let time_col_data_type = time_col.return_type();
-
         self.pop_context();
 
         let (schema_name, table_name) = Self::resolve_table_name(table_name)?;
@@ -107,12 +106,8 @@ impl Binder {
             })
             .chain(
                 [
-                    (
-                        "window_start".to_string(),
-                        time_col_data_type.clone(),
-                        false,
-                    ),
-                    ("window_end".to_string(), time_col_data_type, false),
+                    ("window_start".to_string(), DataType::Timestamp, false),
+                    ("window_end".to_string(), DataType::Timestamp, false),
                 ]
                 .into_iter(),
             );

--- a/src/frontend/src/expr/type_inference.rs
+++ b/src/frontend/src/expr/type_inference.rs
@@ -342,6 +342,13 @@ fn build_type_derive_map() -> HashMap<FuncSign, DataTypeName> {
         &[T::Timestamp, T::Time, T::Date],
         T::Decimal,
     );
+    build_binary_funcs(
+        &mut map,
+        &[E::TumbleStart],
+        &[T::Date, T::Timestamp],
+        &[T::Interval],
+        T::Timestamp,
+    );
     map
 }
 lazy_static::lazy_static! {


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

1. fix the return type of `tumble_start_date`.
2. fix the type in binder and planner.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Close #1600 