### PR TITLE
refactor(stream): SimpleExecutor::map_chunk => map_filter_chunk

### DIFF
--- a/src/stream/src/executor_v2/filter.rs
+++ b/src/stream/src/executor_v2/filter.rs
@@ -16,6 +16,7 @@ use std::fmt::{Debug, Formatter};
 
 use itertools::Itertools;
 use risingwave_common::array::{Array, ArrayImpl, DataChunk, Op, StreamChunk};
+use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
 use risingwave_expr::expr::BoxedExpression;
 
@@ -70,7 +71,10 @@ impl Debug for SimpleFilterExecutor {
 }
 
 impl SimpleExecutor for SimpleFilterExecutor {
-    fn map_chunk(&mut self, chunk: StreamChunk) -> StreamExecutorResult<StreamChunk> {
+    fn map_filter_chunk(
+        &mut self,
+        chunk: StreamChunk,
+    ) -> StreamExecutorResult<Option<StreamChunk>> {
         let chunk = chunk.compact().map_err(StreamExecutorError::eval_error)?;
 
         let (ops, columns, _visibility) = chunk.into_inner();
@@ -144,11 +148,15 @@ impl SimpleExecutor for SimpleFilterExecutor {
             panic!("unmatched type: filter expr returns a non-null array");
         }
 
-        let visibility = new_visibility
+        let visibility: Bitmap = new_visibility
             .try_into()
             .map_err(StreamExecutorError::eval_error)?;
-        let new_chunk = StreamChunk::new(new_ops, columns, Some(visibility));
-        Ok(new_chunk)
+        Ok(if visibility.num_high_bits() > 0 {
+            let new_chunk = StreamChunk::new(new_ops, columns, Some(visibility));
+            Some(new_chunk)
+        } else {
+            None
+        })
     }
 
     fn schema(&self) -> &Schema {

--- a/src/stream/src/executor_v2/simple.rs
+++ b/src/stream/src/executor_v2/simple.rs
@@ -21,9 +21,9 @@ use super::{BoxedExecutor, BoxedMessageStream, Executor, Message, PkIndicesRef, 
 
 /// Executor which can handle [`StreamChunk`]s one by one.
 pub trait SimpleExecutor: Send + 'static {
-    /// convert a single chunk to another chunk.
-    // TODO: How about use `map_filter_chunk` and output chunk optionally?
-    fn map_chunk(&mut self, chunk: StreamChunk) -> StreamExecutorResult<StreamChunk>;
+    /// convert a single chunk to zero or one chunks.
+    fn map_filter_chunk(&mut self, chunk: StreamChunk)
+        -> StreamExecutorResult<Option<StreamChunk>>;
 
     /// See [`super::Executor::schema`].
     fn schema(&self) -> &Schema;
@@ -73,9 +73,12 @@ where
         #[for_await]
         for msg in input {
             let msg = msg?;
-            yield match msg {
-                Message::Chunk(chunk) => Message::Chunk(inner.map_chunk(chunk)?),
-                m => m,
+            match msg {
+                Message::Chunk(chunk) => match inner.map_filter_chunk(chunk)? {
+                    Some(new_chunk) => yield Message::Chunk(new_chunk),
+                    None => continue,
+                },
+                m => yield m,
             }
         }
     }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Some simple executors may produces empty chunk, use `map_filter_chunk` as the interface.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
