### PR TITLE
chore(stream): FilterExecutor uses BitmapBuilder

### DIFF
--- a/src/stream/src/executor_v2/filter.rs
+++ b/src/stream/src/executor_v2/filter.rs
@@ -17,7 +17,7 @@ use std::fmt::{Debug, Formatter};
 use async_trait::async_trait;
 use itertools::Itertools;
 use risingwave_common::array::{Array, ArrayImpl, DataChunk, Op, StreamChunk};
-use risingwave_common::buffer::{Bitmap, BitmapBuilder};
+use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::catalog::Schema;
 use risingwave_expr::expr::BoxedExpression;
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Avoid an unnecessary `Vec<bool>`

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
