### PR TITLE
fix: Close session when UnExpectedEof happens.

### DIFF
--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -14,6 +14,7 @@
 
 use std::error::Error;
 use std::io;
+use std::io::ErrorKind;
 use std::result::Result;
 use std::sync::Arc;
 
@@ -76,6 +77,9 @@ async fn pg_serve_conn(socket: TcpStream, session_mgr: Arc<dyn SessionManager>) 
             Err(e) => {
                 // Execution error should not break current connection.
                 tracing::error!("error {:?}!", e);
+                if matches!(e.kind(), ErrorKind::UnexpectedEof) {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
## What's changed and what's your intention?

When `UnExpectedEof` happens, we should close session. A better handling should identify io error from processing error, but let's fix it first to stop printing too many logs.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
