### PR TITLE
fix(streaming): remove `is_stop_mutation`

### DIFF
--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -176,10 +176,6 @@ impl Barrier {
         Self { span, ..self }
     }
 
-    pub fn is_stop_mutation(&self) -> bool {
-        self.mutation.as_ref().map(|m| m.is_stop()).unwrap_or(false)
-    }
-
     pub fn is_to_stop_actor(&self, actor_id: ActorId) -> bool {
         matches!(self.mutation.as_deref(), Some(Mutation::Stop(actors)) if actors.contains(&actor_id))
     }
@@ -193,13 +189,11 @@ impl PartialEq for Barrier {
 
 impl Mutation {
     /// Return true if the mutation is stop.
+    ///
+    /// Note that this does not mean we will stop the current actor.
+    #[cfg(test)]
     pub fn is_stop(&self) -> bool {
         matches!(self, Mutation::Stop(_))
-    }
-
-    /// Return true if the mutation is add output.
-    pub fn is_add_output(&self) -> bool {
-        matches!(self, Mutation::AddOutput(_))
     }
 }
 
@@ -310,13 +304,16 @@ impl<'a> TryFrom<&'a Message> for &'a Barrier {
 impl Message {
     /// Return true if the message is a stop barrier, meaning the stream
     /// will not continue, false otherwise.
-    pub fn is_terminate(&self) -> bool {
+    ///
+    /// Note that this does not mean we will stop the current actor.
+    #[cfg(test)]
+    pub fn is_stop(&self) -> bool {
         matches!(
             self,
             Message::Barrier(Barrier {
                 mutation,
                 ..
-            }) if mutation.as_deref().unwrap().is_stop()
+            }) if mutation.as_ref().unwrap().is_stop()
         )
     }
 

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -252,6 +252,6 @@ mod tests {
             unreachable!();
         }
 
-        assert!(project.next().await.unwrap().is_terminate());
+        assert!(project.next().await.unwrap().is_stop());
     }
 }

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -59,7 +59,6 @@ pub(super) async fn top_n_executor_next<E: TopNExecutorBase>(executor: &mut E) -
     }
     let res = match msg {
         Message::Chunk(chunk) => Ok(Message::Chunk(executor.apply_chunk(chunk).await?)),
-        Message::Barrier(barrier) if barrier.is_stop_mutation() => Ok(Message::Barrier(barrier)),
         Message::Barrier(barrier) => {
             executor.flush_data().await?;
             executor.update_executor_state(ExecutorState::Active(barrier.epoch.curr));

--- a/src/stream/src/executor_v2/agg.rs
+++ b/src/stream/src/executor_v2/agg.rs
@@ -100,12 +100,6 @@ where
             let msg = msg?;
             match msg {
                 Message::Chunk(chunk) => self.inner.apply_chunk(chunk, epoch).await?,
-                Message::Barrier(barrier) if barrier.is_stop_mutation() => {
-                    yield Message::Barrier(barrier);
-                    // FIXME: `break` should be added here after stopping mutation. But, current
-                    // actors does not stop correctly.
-                    // break;
-                }
                 Message::Barrier(barrier) => {
                     let next_epoch = barrier.epoch.curr;
                     if let Some(chunk) = self.inner.flush_data(epoch).await? {

--- a/src/stream/src/executor_v2/filter.rs
+++ b/src/stream/src/executor_v2/filter.rs
@@ -273,6 +273,6 @@ mod tests {
             unreachable!();
         }
 
-        assert!(filter.next().await.unwrap().unwrap().is_terminate());
+        assert!(filter.next().await.unwrap().unwrap().is_stop());
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

After receiving a barrier with `StopMutation`, we'll do these things...
- The merge executor **checks the `actor_ids`** and finds that the belonged actor was asked to be stopped. Then it closes the stream and there'll be no more new messages.
- The actor **checks the `actor_ids`** and finds that it was asked to be stopped. Then it breaks the loop.

For other executors, they should not specifically handle the stop messages, especially without checking the actor ids. So in this PR, we remove `is_stop_mutation` and some misuses.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
- #1617 