### PR TITLE
refactor: S3FileReader adapts to the new SourceReader trait

### DIFF
--- a/src/connector/src/filesystem/mod.rs
+++ b/src/connector/src/filesystem/mod.rs
@@ -11,6 +11,5 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-
 mod file_common;
 mod s3;


### PR DESCRIPTION
## What's changed and what's your intention?

remote the assign_split method. The overall behavior of the method remains unchanged.  

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

