### PR TITLE
docs: fix description of types

### DIFF
--- a/docs/data-model-and-encoding.md
+++ b/docs/data-model-and-encoding.md
@@ -19,13 +19,12 @@ Tables created by users have an implicit, auto-generated row-id column as their 
 
 Primitive data types:
 
-- Integers: `SMALLINT` (16-bit), `INT` (32-bit), `BIGINT` (64-bit)
 - Booleans: `BOOLEAN`
+- Integers: `SMALLINT` (16-bit), `INT` (32-bit), `BIGINT` (64-bit)
 - Decimals: `NUMERIC`
-- Floating-point numbers: `FLOAT`, `DOUBLE`
-- Date & Time: `DATE`, `TIME`, `TIMESTAMP`, `TIMESTAMPZ` (timestamp without timezone)
-- Time Interval: `INTERVAL` 
-- Strings: `VARCHAR`, `CHAR`
+- Floating-point numbers: `REAL`, `DOUBLE`
+- Strings: `VARCHAR`
+- Temporals: `DATE`, `TIMESTAMP`, `TIMESTAMP WITH TIME ZONE`, `TIME`, `INTERVAL`
 
 Composite data types (WIP):
 


### PR DESCRIPTION
## What's changed and what's your intention?

* `float` -> `real`
* `timestampz` -> `timestamp with time zone`
* `time` has a closer relationship with `interval`, and `date`, `timestamp`, `timestamp with time zone` are closer.

## Checklist

~~- [ ] I have written necessary docs and comments~~
~~- [ ] I have added necessary unit tests and integration tests~~

## Refer to a related PR or issue link (optional)
