### PR TITLE
refactor: simplify FrontendMetaClient

### DIFF
--- a/src/frontend/src/scheduler/query_manager.rs
+++ b/src/frontend/src/scheduler/query_manager.rs
@@ -74,10 +74,14 @@ impl QueryManager {
             output_id: 0,
         };
 
-        // Pin snapshot in meta. Single frontend for now. So context_id is always 0.
-        // TODO: hummock snapshot should maintain as cache instead of RPC each query.
         let meta_client = session.env().meta_client_ref();
-        let epoch = meta_client.pin_snapshot().await?;
+
+        // Pin snapshot in meta.
+        // TODO: Hummock snapshot should maintain as cache instead of RPC each query.
+        // TODO: Use u64::MAX for `last_pinned` so it always return the greatest current epoch. Use
+        // correct `last_pinned` when retrying this RPC.
+        let last_pinned = u64::MAX;
+        let epoch = meta_client.pin_snapshot(last_pinned).await?;
 
         compute_client
             .create_task(task_id.clone(), plan, epoch)
@@ -101,10 +105,14 @@ impl QueryManager {
         // Cheat compiler to resolve type
         let session = context.session();
 
-        // Pin snapshot in meta. Single frontend for now. So context_id is always 0.
-        // TODO: hummock snapshot should maintain as cache instead of RPC each query.
         let meta_client = session.env().meta_client_ref();
-        let epoch = meta_client.pin_snapshot().await?;
+
+        // Pin snapshot in meta.
+        // TODO: Hummock snapshot should maintain as cache instead of RPC each query.
+        // TODO: Use u64::MAX for `last_pinned` so it always return the greatest current epoch. Use
+        // correct `last_pinned` when retrying this RPC.
+        let last_pinned = u64::MAX;
+        let epoch = meta_client.pin_snapshot(last_pinned).await?;
 
         let query_execution = QueryExecution::new(
             query,

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -221,7 +221,7 @@ pub struct MockFrontendMetaClient {}
 
 #[async_trait::async_trait]
 impl FrontendMetaClient for MockFrontendMetaClient {
-    async fn pin_snapshot(&self) -> Result<u64> {
+    async fn pin_snapshot(&self, _last_pinned: u64) -> Result<u64> {
         Ok(0)
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?


Simplify FrontendMetaClient by using MetaClient interfaces directly rather than using the internal GrpcClient interfaces. Since frontend node also registers itself to meta and has its own worker id, FrontendMetaClient now naturally uses the frontend node worker id for `pin_snapshot` and `unpin_snapshot` instead of using a fake one.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
