### PR TITLE
minor: allow passing arguments to risedev test

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -400,9 +400,10 @@ script = """
 #!/bin/bash
 set -e
 
-cargo nextest run
+cargo nextest run "$@"
 """
 description = "Run unit tests"
+
 
 [tasks.check-hakari]
 category = "RiseDev - Check"


### PR DESCRIPTION
It is helpful when we only want to run a specific test. For example:
```
> ./risedev test shared_buffer
Starting 7 tests across 41 binaries (725 skipped)
        PASS [   0.003s]                                risingwave_storage hummock::shared_buffer::shared_buffer_batch::tests::test_shared_buffer_batch_seek
        PASS [   0.004s]                                risingwave_storage hummock::shared_buffer::shared_buffer_batch::tests::test_shared_buffer_batch_basic
        PASS [   1.123s]                                risingwave_storage hummock::shared_buffer::shared_buffer_manager::tests::test_shared_buffer_manager_reset
        PASS [   1.195s]                                risingwave_storage hummock::local_version_manager::tests::test_shared_buffer_cleanup
        PASS [   1.247s]                                risingwave_storage hummock::shared_buffer::shared_buffer_manager::tests::test_shared_buffer_manager_reverse_iter
        PASS [   1.365s]                                risingwave_storage hummock::shared_buffer::shared_buffer_manager::tests::test_shared_buffer_manager_get
        PASS [   1.423s]                                risingwave_storage hummock::shared_buffer::shared_buffer_manager::tests::test_shared_buffer_manager_iter
     Summary [   1.428s] 7 tests run: 7 passed, 725 skipped
[cargo-make] INFO - Build Done in 2.18 seconds.
```
