### PR TITLE
fix(risedev): ulimit on linux

### DIFF
--- a/src/risedevtool/src/bin/risedev-playground.rs
+++ b/src/risedevtool/src/bin/risedev-playground.rs
@@ -340,7 +340,10 @@ fn preflight_check_proxy() -> Result<()> {
 }
 
 fn preflight_check_ulimit() -> Result<()> {
-    let ulimit = Command::new("ulimit").arg("-n").output()?.stdout;
+    let ulimit = Command::new("sh")
+        .args(["-c", "ulimit -n"])
+        .output()?
+        .stdout;
     let ulimit = String::from_utf8(ulimit)?;
     let ulimit: usize = ulimit.trim().parse()?;
     if ulimit < 8192 {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

`ulimit` is a built-in command in shell. So we may see 
```
[risedev-preflight-check] WARN - failed to run ulimit preflight check: No such file or directory (os error 2)
```
when running risedev on linux.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
