### PR TITLE
chore(frontend): hints for pg_catalog

### DIFF
--- a/src/frontend/src/binder/relation.rs
+++ b/src/frontend/src/binder/relation.rs
@@ -209,6 +209,22 @@ impl Binder {
         table_name: &str,
         alias: Option<TableAlias>,
     ) -> Result<Relation> {
+        if schema_name == "pg_catalog" {
+            // TODO: support pg_catalog.
+            return Err(ErrorCode::NotImplemented(
+                // TODO: We can ref the document of `SHOW` commands here if ready.
+                r###"pg_catalog is not supported, please use `SHOW` commands for now.
+`SHOW TABLES`,
+`SHOW MATERIALIZED VIEWS`,
+`DESCRIBE <table>`,
+`SHOW COLUMNS FROM [table]`
+"###
+                .into(),
+                1695.into(),
+            )
+            .into());
+        }
+
         let (ret, columns) = {
             let catalog = &self.catalog;
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

There is no any document about the `SHOW` commands now, as a workaround, we can hint users while they access to `pg_catalog`.

Sorry for that the hint is not friendly enough, but it works now.

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/9161438/162386691-344516ac-87cd-4372-975a-c5b7aa2c7ed5.png">



## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)

Close #1687 
