### PR TITLE
chore(legacy): bump proto & grpc version

### DIFF
--- a/legacy/bom/build.gradle.kts
+++ b/legacy/bom/build.gradle.kts
@@ -4,10 +4,10 @@ plugins {
 
 val junit5Version = "5.7.2"
 val calciteVersion = "1.27.0"
-val grpcVersion = "1.39.0"
+val grpcVersion = "1.43.2"
 val annotationVersion = "1.3.2"
 var guiceVersion = "5.0.1"
-val protobufVersion = "3.17.2"
+val protobufVersion = "3.18.2"
 val akkaVersion = "2.6.15"
 val scalaBinaryVersion = "2.13"
 val mockitoVersion = "3.11.2"

--- a/legacy/proto/build.gradle.kts
+++ b/legacy/proto/build.gradle.kts
@@ -30,13 +30,7 @@ sourceSets {
 
 protobuf {
     protoc {
-        // Since `protoc` does not provide pre-built binary for arm64 architecture, we use this
-        // trick to force download x86_64 binary on apple silicon machine.
-        if (osdetector.os == "osx") {
-            artifact = "com.google.protobuf:protoc:3.0.0:osx-x86_64"
-        } else {
-            artifact = "com.google.protobuf:protoc:3.0.0"
-        }
+        artifact = "com.google.protobuf:protoc:3.18.2"
     }
 
     plugins {
@@ -44,12 +38,7 @@ protobuf {
         // the identifier, which can be referred to in the "plugins"
         // container of the "generateProtoTasks" closure.
         id("grpc") {
-            // Ditto. This trick is for aplle silicon users.
-            if (osdetector.os == "osx") {
-                artifact = "io.grpc:protoc-gen-grpc-java:1.15.1:osx-x86_64"
-            } else {
-                artifact = "io.grpc:protoc-gen-grpc-java:1.15.1"
-            }
+            artifact = "io.grpc:protoc-gen-grpc-java:1.43.2"
         }
         id("grpckt") {
             artifact = "io.grpc:protoc-gen-grpc-kotlin:1.1.0:jdk7@jar"


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

## What's changed and what's your intention?

This PR bumps version of protoc/protobuf/grpc for the legacy frontend, so that we are able to build it on linux-aarch64 and on darwin-aarch64 without Rosetta.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
