### PR TITLE
chore(frontend): guide user to use VARCHAR

### DIFF
--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -319,7 +319,7 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
         },
         AstDataType::Char(..) => {
             return Err(ErrorCode::NotImplemented(
-                format!("CHAR is not supported, please use VARCHAR instead\n"),
+                "CHAR is not supported, please use VARCHAR instead\n".to_string(),
                 None.into(),
             )
             .into())


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

We removed the `CHAR` support, and we need a hint to guide user to use `VARCHAR` instead.

## Checklist

- [x] I have written necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
