### PR TITLE
feat(frontend tests): return error string when generating stream/batch plan and proto returns error

### DIFF
--- a/src/frontend/test_runner/src/lib.rs
+++ b/src/frontend/test_runner/src/lib.rs
@@ -363,7 +363,7 @@ impl TestCase {
                             &batch_plan.to_batch_prost_identity(false),
                         )?);
                     }
-                },
+                }
                 Err(err) => {
                     if self.batch_plan.is_some() {
                         ret.batch_plan = Some(err.to_string());
@@ -411,7 +411,7 @@ impl TestCase {
                                 + &serde_yaml::to_string(&table)?,
                         );
                     }
-                },
+                }
                 Err(err) => {
                     if self.stream_plan.is_some() {
                         ret.stream_plan = Some(err.to_string());
@@ -421,7 +421,6 @@ impl TestCase {
                     }
                 }
             }
-
         }
 
         Ok(ret)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Return error string when generating stream/batch plan and proto to be checked against the desired output in the .yaml files. 

We may want to check certain error behaviour of stream and batch plan. For instance, we may want to see the error when we try to convert our plan to proto with a correlated input ref.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
