### PR TITLE
chore(ci): start cluster only once in e2e test

### DIFF
--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -39,22 +39,16 @@ echo "--- Prepare RiseDev playground"
 cargo make pre-start-playground
 cargo make link-all-in-one-binaries
 
-echo "--- e2e, ci-3cn-1fe, streaming"
+ehoc "--- Start cluster"
 cargo make ci-start ci-3cn-1fe
+
+echo "--- e2e, ci-3cn-1fe, streaming"
 timeout 5m sqllogictest -p 4566 -d dev  './e2e_test/streaming/**/*.slt' -j 16 --junit "parallel-streaming-${profile}"
 
-echo "--- Kill cluster"
-cargo make ci-kill
-
 echo "--- e2e, ci-3cn-1fe, delta join"
-cargo make ci-start ci-3cn-1fe
 timeout 3m sqllogictest -p 4566 -d dev  './e2e_test/streaming_delta_join/**/*.slt' --junit "parallel-streaming-delta-join-${profile}"
 
-echo "--- Kill cluster"
-cargo make ci-kill
-
 echo "--- e2e, ci-3cn-1fe, batch distributed"
-cargo make ci-start ci-3cn-1fe
 timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/ddl/**/*.slt' --junit "parallel-batch-ddl-${profile}"
 timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/batch/**/*.slt' -j 16 --junit "parallel-batch-${profile}"
 

--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -49,7 +49,6 @@ echo "--- e2e, ci-3cn-1fe, delta join"
 timeout 3m sqllogictest -p 4566 -d dev  './e2e_test/streaming_delta_join/**/*.slt' --junit "parallel-streaming-delta-join-${profile}"
 
 echo "--- e2e, ci-3cn-1fe, batch distributed"
-timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/ddl/**/*.slt' --junit "parallel-batch-ddl-${profile}"
 timeout 2m sqllogictest -p 4566 -d dev  './e2e_test/batch/**/*.slt' -j 16 --junit "parallel-batch-${profile}"
 
 echo "--- Kill cluster"

--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -39,7 +39,7 @@ echo "--- Prepare RiseDev playground"
 cargo make pre-start-playground
 cargo make link-all-in-one-binaries
 
-ehoc "--- Start cluster"
+echo "--- Start cluster"
 cargo make ci-start ci-3cn-1fe
 
 echo "--- e2e, ci-3cn-1fe, streaming"

--- a/ci/scripts/e2e-test.sh
+++ b/ci/scripts/e2e-test.sh
@@ -39,22 +39,16 @@ echo "--- Prepare RiseDev playground"
 cargo make pre-start-playground
 cargo make link-all-in-one-binaries
 
-echo "--- e2e, ci-3cn-1fe, streaming"
+ehoc "--- Start cluster"
 cargo make ci-start ci-3cn-1fe
+
+echo "--- e2e, ci-3cn-1fe, streaming"
 timeout 5m sqllogictest -p 4566 -d dev './e2e_test/streaming/**/*.slt' --junit "streaming-${profile}"
 
-echo "--- Kill cluster"
-cargo make ci-kill
-
 echo "--- e2e, ci-3cn-1fe, delta join"
-cargo make ci-start ci-3cn-1fe
 timeout 3m sqllogictest -p 4566 -d dev './e2e_test/streaming_delta_join/**/*.slt' --junit "streaming-delta-join-${profile}"
 
-echo "--- Kill cluster"
-cargo make ci-kill
-
 echo "--- e2e, ci-3cn-1fe, batch distributed"
-cargo make ci-start ci-3cn-1fe
 timeout 2m sqllogictest -p 4566 -d dev './e2e_test/ddl/**/*.slt' --junit "batch-ddl-${profile}"
 timeout 2m sqllogictest -p 4566 -d dev './e2e_test/batch/**/*.slt' --junit "batch-${profile}"
 timeout 2m sqllogictest -p 4566 -d dev './e2e_test/database/prepare.slt'

--- a/ci/scripts/e2e-test.sh
+++ b/ci/scripts/e2e-test.sh
@@ -39,7 +39,7 @@ echo "--- Prepare RiseDev playground"
 cargo make pre-start-playground
 cargo make link-all-in-one-binaries
 
-ehoc "--- Start cluster"
+echo "--- Start cluster"
 cargo make ci-start ci-3cn-1fe
 
 echo "--- e2e, ci-3cn-1fe, streaming"


### PR DESCRIPTION
Signed-off-by: Alex Chi <iskyzh@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
