### PR TITLE
feat(storage): split duties of sstable_store `load_table` (load blocks) and `sstable` (meta only), disambiguate `TableHolder::{CachedMeta, Owned}`, do not store blocks in `meta_cache`

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -59,7 +59,7 @@ pub async fn sst_dump() -> anyhow::Result<()> {
             let sstable_cache = sstable_store
                 .sstable(id, &mut StoreLocalStatistic::default())
                 .await?;
-            let sstable = sstable_cache.value().as_ref();
+            let sstable = sstable_cache.value();
             let sstable_meta = &sstable.meta;
 
             let sstable_id_info = id_info_map[&id];

--- a/src/storage/src/hummock/compactor.rs
+++ b/src/storage/src/hummock/compactor.rs
@@ -787,7 +787,7 @@ impl Compactor {
                     let table = self
                         .context
                         .sstable_store
-                        .load_table(table_info.id, true, &mut stats)
+                        .load_table(table_info.id, &mut stats)
                         .await?;
                     table_iters.push(Box::new(SstableIterator::create(
                         table,

--- a/src/storage/src/hummock/iterator/concat_inner.rs
+++ b/src/storage/src/hummock/iterator/concat_inner.rs
@@ -71,7 +71,7 @@ impl<TI: SstableIteratorType> ConcatIteratorInner<TI> {
         } else {
             let table = if self.read_options.prefetch {
                 self.sstable_store
-                    .load_table(self.tables[idx].id, true, &mut self.stats)
+                    .load_table(self.tables[idx].id, &mut self.stats)
                     .await?
             } else {
                 self.sstable_store

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -42,7 +42,8 @@ pub struct BackwardSstableIterator {
 }
 
 impl BackwardSstableIterator {
-    pub fn new(sstable: TableHolder, sstable_store: SstableStoreRef) -> Self {
+    pub fn new(sstable: impl Into<TableHolder>, sstable_store: SstableStoreRef) -> Self {
+        let sstable = sstable.into();
         Self {
             block_iter: None,
             cur_idx: sstable.value().meta.block_metas.len() - 1,
@@ -150,7 +151,11 @@ impl HummockIterator for BackwardSstableIterator {
 }
 
 impl SstableIteratorType for BackwardSstableIterator {
-    fn create(sstable: TableHolder, sstable_store: SstableStoreRef, _: Arc<ReadOptions>) -> Self {
+    fn create(
+        sstable: impl Into<TableHolder>,
+        sstable_store: SstableStoreRef,
+        _: Arc<ReadOptions>,
+    ) -> Self {
         BackwardSstableIterator::new(sstable, sstable_store)
     }
 }

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -25,7 +25,7 @@ use crate::monitor::StoreLocalStatistic;
 
 pub trait SstableIteratorType: HummockIterator + 'static {
     fn create(
-        sstable: TableHolder,
+        sstable: impl Into<TableHolder>,
         sstable_store: SstableStoreRef,
         read_options: Arc<ReadOptions>,
     ) -> Self;
@@ -48,10 +48,11 @@ pub struct SstableIterator {
 
 impl SstableIterator {
     pub fn new(
-        sstable: TableHolder,
+        sstable: impl Into<TableHolder>,
         sstable_store: SstableStoreRef,
         _options: Arc<ReadOptions>,
     ) -> Self {
+        let sstable = sstable.into();
         Self {
             block_iter: None,
             cur_idx: 0,
@@ -171,7 +172,7 @@ impl HummockIterator for SstableIterator {
 
 impl SstableIteratorType for SstableIterator {
     fn create(
-        sstable: TableHolder,
+        sstable: impl Into<TableHolder>,
         sstable_store: SstableStoreRef,
         options: Arc<ReadOptions>,
     ) -> Self {

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -195,7 +195,10 @@ mod tests {
     };
     use crate::hummock::{CachePolicy, Sstable};
 
-    async fn inner_test_forward_iterator(sstable_store: SstableStoreRef, handle: TableHolder) {
+    async fn inner_test_forward_iterator(
+        sstable_store: SstableStoreRef,
+        handle: impl Into<TableHolder>,
+    ) {
         // We should have at least 10 blocks, so that sstable iterator test could cover more code
         // path.
         let mut sstable_iter =


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Remove abuse of sstable_store meta_cache to store data blocks.

Make it slighly less confusing whether `TableHolder` ought to contain blocks.



Todo: 
1. We will validate via bench on S3 whether with this change, we will no longer see high memory usage in compactor. 
  a. (on second thought, I think the high memory usage bug does not really lie here as the meta_cache's capacity is already limited to 1GB. However, note that duplicated requests to the sst_id will result in those requesters holding a reference to a sstable with blocks, despite only requesting for sstable meta. Perhaps this could be a source of memory leak? Answer: no, if CachableEntry is referenced, it will still take up usage in the cache, so such a leak will show up in the compactor cache metrics.)
2. can we get consensus to rename `load_table` and `sstable` to `load_table_with_blocks` and `load_table_meta` respectively?

## Refer to a related PR or issue link (optional)
https://github.com/singularity-data/risingwave/issues/3921
Details: https://github.com/singularity-data/risingwave/issues/3921#issuecomment-1193126155