### PR TITLE
refactor: replace Bytes with Vec<u8> for object store to avoid buffer copy when decoding block without compression

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use bytes::{Buf, Bytes};
+use bytes::Buf;
 use risingwave_common::types::DataType;
 use risingwave_common::util::value_encoding::deserialize_cell;
 use risingwave_frontend::TableCatalog;
@@ -147,10 +147,10 @@ async fn print_blocks(
 }
 
 /// Prints the data of KV-Pairs of a given block out to the terminal.
-fn print_kv_pairs(block_data: Bytes, table_data: &TableData) -> anyhow::Result<()> {
+fn print_kv_pairs(block_data: Vec<u8>, table_data: &TableData) -> anyhow::Result<()> {
     println!("\tKV-Pairs:");
 
-    let block = Box::new(Block::decode(&block_data).unwrap());
+    let block = Box::new(Block::decode(block_data).unwrap());
     let holder = BlockHolder::from_owned_block(block);
     let mut block_iter = BlockIterator::new(holder);
     block_iter.seek_to_first();

--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -13,12 +13,13 @@
 // limitations under the License.
 
 use aws_sdk_s3::{Client, Endpoint, Region};
+use bytes::Buf;
 use fail::fail_point;
 use futures::future::try_join_all;
 use itertools::Itertools;
 
 use super::{BlockLocation, ObjectError, ObjectMetadata};
-use crate::object::{Bytes, ObjectResult, ObjectStore};
+use crate::object::{ObjectResult, ObjectStore};
 
 /// Object store with S3 backend
 pub struct S3ObjectStore {
@@ -28,7 +29,7 @@ pub struct S3ObjectStore {
 
 #[async_trait::async_trait]
 impl ObjectStore for S3ObjectStore {
-    async fn upload(&self, path: &str, obj: Bytes) -> ObjectResult<()> {
+    async fn upload(&self, path: &str, obj: Vec<u8>) -> ObjectResult<()> {
         fail_point!("s3_upload_err", |_| Err(ObjectError::internal(
             "s3 upload error"
         )));
@@ -43,7 +44,7 @@ impl ObjectStore for S3ObjectStore {
     }
 
     /// Amazon S3 doesn't support retrieving multiple ranges of data per GET request.
-    async fn read(&self, path: &str, block_loc: Option<BlockLocation>) -> ObjectResult<Bytes> {
+    async fn read(&self, path: &str, block_loc: Option<BlockLocation>) -> ObjectResult<Vec<u8>> {
         fail_point!("s3_read_err", |_| Err(ObjectError::internal(
             "s3 read error"
         )));
@@ -61,7 +62,9 @@ impl ObjectStore for S3ObjectStore {
         };
 
         let resp = req.send().await?;
-        let val = resp.body.collect().await?.into_bytes();
+        let mut body = resp.body.collect().await?;
+        let mut val = vec![0; body.remaining()];
+        body.copy_to_slice(&mut val);
 
         if block_loc.is_some() && block_loc.as_ref().unwrap().size != val.len() {
             return Err(ObjectError::internal(format!(
@@ -75,7 +78,7 @@ impl ObjectStore for S3ObjectStore {
         Ok(val)
     }
 
-    async fn readv(&self, path: &str, block_locs: &[BlockLocation]) -> ObjectResult<Vec<Bytes>> {
+    async fn readv(&self, path: &str, block_locs: &[BlockLocation]) -> ObjectResult<Vec<Vec<u8>>> {
         let futures = block_locs
             .iter()
             .map(|block_loc| self.read(path, Some(*block_loc)))

--- a/src/storage/benches/bench_block_iter.rs
+++ b/src/storage/benches/bench_block_iter.rs
@@ -55,7 +55,8 @@ fn bench_block_iter(c: &mut Criterion) {
         &data,
         |b, data| {
             b.iter(|| {
-                let block = BlockHolder::from_owned_block(Box::new(Block::decode(data).unwrap()));
+                let block =
+                    BlockHolder::from_owned_block(Box::new(Block::decode(data.to_vec()).unwrap()));
                 block_iter_next(block)
             });
         },
@@ -72,13 +73,14 @@ fn bench_block_iter(c: &mut Criterion) {
         &data,
         |b, data| {
             b.iter(|| {
-                let block = BlockHolder::from_owned_block(Box::new(Block::decode(data).unwrap()));
+                let block =
+                    BlockHolder::from_owned_block(Box::new(Block::decode(data.to_vec()).unwrap()));
                 block_iter_prev(block)
             });
         },
     );
 
-    let block = BlockHolder::from_owned_block(Box::new(Block::decode(&data).unwrap()));
+    let block = BlockHolder::from_owned_block(Box::new(Block::decode(data).unwrap()));
     let mut iter = BlockIterator::new(block);
     iter.seek_to_first();
     for t in 1..=TABLES_PER_SSTABLE {
@@ -94,7 +96,7 @@ fn bench_block_iter(c: &mut Criterion) {
 criterion_group!(benches, bench_block_iter);
 criterion_main!(benches);
 
-fn build_block_data(t: u32, i: u64) -> Bytes {
+fn build_block_data(t: u32, i: u64) -> Vec<u8> {
     let options = BlockBuilderOptions {
         capacity: BLOCK_CAPACITY,
         compression_algorithm: CompressionAlgorithm::None,
@@ -106,7 +108,7 @@ fn build_block_data(t: u32, i: u64) -> Bytes {
             builder.add(&key(tt, ii), &value(ii));
         }
     }
-    Bytes::from(builder.build().to_vec())
+    builder.build().to_vec()
 }
 
 fn key(t: u32, i: u64) -> Bytes {

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -16,7 +16,6 @@ use std::ops::Range;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use bytes::Bytes;
 use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use itertools::Itertools;
@@ -60,7 +59,7 @@ pub fn test_key_of(idx: usize, epoch: u64) -> Vec<u8> {
 
 const MAX_KEY_COUNT: usize = 128 * 1024;
 
-fn build_table(sstable_id: u64, range: Range<u64>, epoch: u64) -> (Bytes, SstableMeta) {
+fn build_table(sstable_id: u64, range: Range<u64>, epoch: u64) -> (Vec<u8>, SstableMeta) {
     let mut builder = SstableBuilder::new(
         sstable_id,
         SstableBuilderOptions {

--- a/src/storage/src/hummock/sstable/block_iterator.rs
+++ b/src/storage/src/hummock/sstable/block_iterator.rs
@@ -226,7 +226,7 @@ mod tests {
         builder.add(&full_key(b"k05", 5), b"v05");
         let buf = builder.build().to_vec();
         BlockIterator::new(BlockHolder::from_owned_block(Box::new(
-            Block::decode(&buf).unwrap(),
+            Block::decode(buf).unwrap(),
         )))
     }
 

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -268,7 +268,7 @@ mod tests {
         let kv_iter =
             (0..TEST_KEYS_COUNT).map(|i| (test_key_of(i), HummockValue::put(test_value_of(i))));
         let (data, meta, _) = gen_test_sstable_data(default_builder_opt_for_test(), kv_iter);
-        let sstable = Sstable::new_with_data(0, meta, data).unwrap();
+        let sstable = Sstable::new_with_data(0, meta, &data).unwrap();
         let handle = cache.insert(0, 0, 1, Box::new(sstable));
         inner_test_forward_iterator(sstable_store, handle).await;
     }

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -29,7 +29,7 @@ pub mod builder;
 pub use builder::*;
 mod forward_sstable_iterator;
 pub mod multi_builder;
-use bytes::{Buf, BufMut, Bytes};
+use bytes::{Buf, BufMut};
 use fail::fail_point;
 pub use forward_sstable_iterator::*;
 mod backward_sstable_iterator;
@@ -79,12 +79,12 @@ impl Sstable {
     pub fn new_with_data(
         id: HummockSstableId,
         meta: SstableMeta,
-        data: Bytes,
+        data: &[u8],
     ) -> HummockResult<Self> {
         let mut blocks = vec![];
         for block_meta in &meta.block_metas {
             let end_offset = (block_meta.offset + block_meta.len) as usize;
-            let block = Block::decode(&data[block_meta.offset as usize..end_offset])?;
+            let block = Block::decode(data[block_meta.offset as usize..end_offset].to_vec())?;
             blocks.push(Arc::new(block));
         }
         Ok(Self { id, meta, blocks })

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -102,7 +102,7 @@ pub fn default_builder_opt_for_test() -> SstableBuilderOptions {
 pub fn gen_test_sstable_data(
     opts: SstableBuilderOptions,
     kv_iter: impl Iterator<Item = (Vec<u8>, HummockValue<Vec<u8>>)>,
-) -> (Bytes, SstableMeta, Vec<u32>) {
+) -> (Vec<u8>, SstableMeta, Vec<u32>) {
     let mut b = SstableBuilder::new(0, opts);
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After #4484 , we use `Vec<u8>` as underlying buffer storage for `Block` to control memory usage. But with `Bytes` returned by object store, there is always a buffer copy when decoding even if there is no compression.

This PR refactored object store interface and replace `Bytes` with `Vec<u8>`.

Pros:
- Avoid buffer copy when decoding `Block` if there's no compression.
- No extra cost on object store side.

Cons:
- There is an extra buffer copy in `Sstable::new_with_data()`, which is unavoidable.

TODO:
- [ ] Benchmarks to compare the cost.

## Checklist

- [x] I have written necessary rustdoc comments
- [x]  I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#4484 
#4259 