### PR TITLE
feat(frontend): support creating empty arrays

### DIFF
--- a/e2e_test/batch/types/array_ty.slt.part
+++ b/e2e_test/batch/types/array_ty.slt.part
@@ -16,7 +16,7 @@ select ARRAY[null];
 ----
 {NULL}
 
-statement error
+statement ok
 select ARRAY[];
 
 statement ok

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -87,6 +87,25 @@ impl From<&CastContext> for String {
     }
 }
 
+/// Check whether casting from array `source` to array `target` is ok.
+///
+/// NOTE: for now we can cast an unknown array with nesting depth `a` to any other array types with
+/// nesting depth `b` such that `b` >= `a`.
+pub fn array_cast_ok(source: &DataType, target: &DataType) -> bool {
+    match (source, target) {
+        (
+            &DataType::List {
+                datatype: ref child_source,
+            },
+            &DataType::List {
+                datatype: ref child_target,
+            },
+        ) => array_cast_ok(child_source, child_target),
+        (&DataType::List { .. }, target) if !matches!(target, &DataType::List { .. }) => false,
+        _ => true,
+    }
+}
+
 /// Checks whether casting from `source` to `target` is ok in `allows` context.
 pub fn cast_ok(source: &DataType, target: &DataType, allows: CastContext) -> bool {
     cast_ok_base(source.into(), target.into(), allows)

--- a/src/frontend/src/expr/type_inference/mod.rs
+++ b/src/frontend/src/expr/type_inference/mod.rs
@@ -21,8 +21,8 @@ mod cast;
 mod func;
 pub use agg::{agg_func_sigs, AggFuncSig};
 pub use cast::{
-    align_types, cast_map_array, cast_ok, cast_ok_base, cast_sigs, least_restrictive, CastContext,
-    CastSig,
+    align_types, array_cast_ok, cast_map_array, cast_ok, cast_ok_base, cast_sigs,
+    least_restrictive, CastContext, CastSig,
 };
 pub use func::{func_sigs, infer_type, FuncSign};
 /// `DataTypeName` is designed for type derivation here. In other scenarios,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Now we can create empty arrays as follows:
```
dev=> select {};
 ?column? 
----------
 {}
(1 row)
dev=> create table t (a int[]);
CREATE_TABLE
dev=> insert into t values ({});
INSERT 0 1
dev=> select * from t;
 a  
----
 {}
(1 row)
```

This PR may violate pg's behavior. For example, in pg:
```
postgres=# create table t (a int[]);
CREATE TABLE
postgres=# insert into t values (array[]);
ERROR:  cannot determine type of empty array
LINE 1: insert into t values (array[]);
                              ^
HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].
```

I think inserting an empty array without explicit casting is reasonable, because the array type can be inferred according to the table schema. Similarly, we can insert array[NULL] without explicit casting and this is not allowed in pg (https://github.com/singularity-data/risingwave/issues/4612).

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests (WIP)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
