### PR TITLE
feat(frontend): Derive order property from input 

### DIFF
--- a/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
@@ -38,8 +38,12 @@ impl BatchHopWindow {
         let distribution = logical
             .i2o_col_mapping()
             .rewrite_provided_distribution(logical.input().distribution());
-        // TODO: Derive order from input
-        let base = PlanBase::new_batch(ctx, logical.schema().clone(), distribution, Order::any());
+        let base = PlanBase::new_batch(
+            ctx,
+            logical.schema().clone(),
+            distribution,
+            logical.get_out_column_index_order(),
+        );
         BatchHopWindow { base, logical }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -24,7 +24,6 @@ use super::{
 };
 use crate::expr::Expr;
 use crate::optimizer::plan_node::ToLocalBatch;
-use crate::optimizer::property::Order;
 
 /// `BatchProject` implements [`super::LogicalProject`] to evaluate specified expressions on input
 /// rows
@@ -40,9 +39,12 @@ impl BatchProject {
         let distribution = logical
             .i2o_col_mapping()
             .rewrite_provided_distribution(logical.input().distribution());
-
-        // TODO: Derive order from input
-        let base = PlanBase::new_batch(ctx, logical.schema().clone(), distribution, Order::any());
+        let base = PlanBase::new_batch(
+            ctx,
+            logical.schema().clone(),
+            distribution,
+            logical.get_out_column_index_order(),
+        );
         BatchProject { base, logical }
     }
 

--- a/src/frontend/src/optimizer/plan_node/batch_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project_set.rs
@@ -22,7 +22,6 @@ use risingwave_pb::batch_plan::ProjectSetNode;
 use crate::optimizer::plan_node::{
     LogicalProjectSet, PlanBase, PlanTreeNodeUnary, ToBatchProst, ToDistributedBatch, ToLocalBatch,
 };
-use crate::optimizer::property::Order;
 use crate::optimizer::PlanRef;
 
 #[derive(Debug, Clone)]
@@ -38,8 +37,12 @@ impl BatchProjectSet {
             .i2o_col_mapping()
             .rewrite_provided_distribution(logical.input().distribution());
 
-        // TODO: Derive order from input
-        let base = PlanBase::new_batch(ctx, logical.schema().clone(), distribution, Order::any());
+        let base = PlanBase::new_batch(
+            ctx,
+            logical.schema().clone(),
+            distribution,
+            logical.get_out_column_index_order(),
+        );
         BatchProjectSet { base, logical }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -26,6 +26,7 @@ use super::{
 };
 use crate::expr::{InputRef, InputRefDisplay};
 use crate::optimizer::plan_node::utils::IndicesDisplay;
+use crate::optimizer::property::Order;
 use crate::utils::{ColIndexMapping, Condition};
 
 /// `LogicalHopWindow` implements Hop Table Function.
@@ -230,6 +231,12 @@ impl LogicalHopWindow {
                 )
             },
         )
+    }
+
+    /// Map the order of the input to use the updated indices
+    pub fn get_out_column_index_order(&self) -> Order {
+        self.i2o_col_mapping()
+            .rewrite_provided_order(self.input.order())
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -132,6 +132,12 @@ impl LogicalProject {
         Self::new(input, exprs).into()
     }
 
+    /// Map the order of the input to use the updated indices
+    pub fn get_out_column_index_order(&self) -> Order {
+        self.i2o_col_mapping()
+            .rewrite_provided_order(self.input.order())
+    }
+
     /// Creates a `LogicalProject` which select some columns from the input.
     ///
     /// `mapping` should maps from `(0..input_fields.len())` to a consecutive range starting from 0.

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -25,7 +25,7 @@ use super::{
 use crate::expr::{
     Expr, ExprDisplay, ExprImpl, ExprRewriter, FunctionCall, InputRef, TableFunction,
 };
-use crate::optimizer::property::FunctionalDependencySet;
+use crate::optimizer::property::{FunctionalDependencySet, Order};
 use crate::utils::{ColIndexMapping, Condition};
 
 /// `LogicalProjectSet` projects one row multiple times according to `select_list`.
@@ -266,6 +266,12 @@ impl LogicalProjectSet {
 
     pub fn i2o_col_mapping(&self) -> ColIndexMapping {
         Self::i2o_col_mapping_inner(self.input.schema().len(), self.select_list())
+    }
+
+    /// Map the order of the input to use the updated indices
+    pub fn get_out_column_index_order(&self) -> Order {
+        self.i2o_col_mapping()
+            .rewrite_provided_order(self.input.order())
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR introduces deriving the order property for query optimization from the respective input, if the order does not change due to the operator.


## Checklist

- [ x] I have written necessary rustdoc comments
- [ x] I have added necessary unit tests and integration tests
- [ x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.
