### PR TITLE
chore(risedev): append log instead of overwrite

### DIFF
--- a/src/risedevtool/run_command.sh
+++ b/src/risedevtool/run_command.sh
@@ -5,7 +5,7 @@
 echo "${@:3}"
 echo "logging to $1, and status to $2"
 
-"${@:3}" 2>&1 | tee "$1"
+"${@:3}" 2>&1 | tee -a "$1"
 
 RET_STATUS="${PIPESTATUS[0]}"
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title

To see historical metrics, I started Prometheus via `d full` and my logs are rewritten. 😭

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None
## Refer to a related PR or issue link (optional)
None