### PR TITLE
refactor(storage): refactor get_from_table

### DIFF
--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -189,7 +189,7 @@ impl HummockStorage {
         // Iterator gets us the key, we tell if it's the key we want
         // or key next to it.
         let value = match key::user_key(iter.key()) == ukey {
-            true => Some(iter.value().to_owned_bytes_value()),
+            true => Some(iter.value().to_bytes()),
             false => None,
         };
         iter.collect_local_statistic(stats);

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -66,9 +66,12 @@ use self::key::user_key;
 pub use self::sstable_store::*;
 pub use self::state_store::HummockStateStoreIter;
 use super::monitor::StateStoreMetrics;
+use crate::error::StorageResult;
 use crate::hummock::compaction_group_client::{CompactionGroupClient, DummyCompactionGroupClient};
 use crate::hummock::conflict_detector::ConflictDetector;
 use crate::hummock::local_version_manager::LocalVersionManager;
+use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
+use crate::hummock::shared_buffer::{OrderSortedUncommittedData, UncommittedData};
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::{SstableStoreRef, TableHolder};
 use crate::monitor::StoreLocalStatistic;
@@ -162,11 +165,11 @@ impl HummockStorage {
         &self,
         sstable: TableHolder,
         internal_key: &[u8],
-        key: &[u8],
         check_bloom_filter: bool,
         stats: &mut StoreLocalStatistic,
     ) -> HummockResult<Option<Option<Bytes>>> {
-        if check_bloom_filter && !Self::hit_sstable_bloom_filter(sstable.value(), key, stats) {
+        let ukey = user_key(internal_key);
+        if check_bloom_filter && !Self::hit_sstable_bloom_filter(sstable.value(), ukey, stats) {
             return Ok(None);
         }
 
@@ -185,7 +188,7 @@ impl HummockStorage {
 
         // Iterator gets us the key, we tell if it's the key we want
         // or key next to it.
-        let value = match user_key(iter.key()) == key {
+        let value = match key::user_key(iter.key()) == ukey {
             true => Some(iter.value().into_user_value().map(Bytes::copy_from_slice)),
             false => None,
         };
@@ -232,5 +235,51 @@ impl HummockStorage {
         }
 
         !surely_not_have
+    }
+
+    /// Get `user_value` from `OrderSortedUncommittedData`. If not get successful, return None.
+    async fn get_from_order_sorted_uncommitted_data(
+        &self,
+        order_sorted_uncommitted_data: OrderSortedUncommittedData,
+        internal_key: &[u8],
+        stats: &mut StoreLocalStatistic,
+        key: &[u8],
+        check_bloom_filter: bool,
+    ) -> StorageResult<(Option<Option<Bytes>>, i32)> {
+        let mut table_counts = 0;
+        let epoch = key::get_epoch(internal_key);
+        for data_list in order_sorted_uncommitted_data {
+            for data in data_list {
+                match data {
+                    UncommittedData::Batch(batch) => {
+                        assert!(batch.epoch() <= epoch, "batch'epoch greater than epoch");
+                        let data = self.get_from_batch(&batch, key);
+                        if data.is_some() {
+                            return Ok((data, table_counts));
+                        }
+                    }
+                    UncommittedData::Sst((_, table_info)) => {
+                        let table = self.sstable_store.sstable(table_info.id, stats).await?;
+                        table_counts += 1;
+
+                        let data = self
+                            .get_from_table(table, internal_key, check_bloom_filter, stats)
+                            .await?;
+                        if data.is_some() {
+                            return Ok((data, table_counts));
+                        }
+                    }
+                }
+            }
+        }
+        Ok((None, table_counts))
+    }
+
+    /// Get `user_value` from `SharedBufferBatch` Return `Some(None)` means the key is deleted.
+    fn get_from_batch(&self, batch: &SharedBufferBatch, key: &[u8]) -> Option<Option<Bytes>> {
+        batch.get(key).map(|v| {
+            self.stats.get_shared_buffer_hit_counts.inc();
+            v.into_user_value().map(|v| v.into())
+        })
     }
 }

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -384,7 +384,7 @@ mod tests {
         iter.rewind().await.unwrap();
         let mut output = vec![];
         while iter.is_valid() {
-            output.push((iter.key().to_owned(), iter.value().to_owned_bytes_value()));
+            output.push((iter.key().to_owned(), iter.value().to_bytes()));
             iter.next().await.unwrap();
         }
         assert_eq!(output, shared_buffer_items);
@@ -396,7 +396,7 @@ mod tests {
         while backward_iter.is_valid() {
             output.push((
                 backward_iter.key().to_owned(),
-                backward_iter.value().to_owned_bytes_value(),
+                backward_iter.value().to_bytes(),
             ));
             backward_iter.next().await.unwrap();
         }

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -306,7 +306,7 @@ impl HummockStorage {
         for epoch_replicated_batches in replicated_batches {
             for batch in epoch_replicated_batches {
                 if let Some(v) = self.get_from_batch(&batch, key) {
-                    return Ok(v);
+                    return Ok(v.into_user_value());
                 }
             }
         }
@@ -324,7 +324,7 @@ impl HummockStorage {
                 )
                 .await?;
             if let Some(v) = value {
-                return Ok(v);
+                return Ok(v.into_user_value());
             }
             table_counts += table_count;
         }
@@ -339,7 +339,7 @@ impl HummockStorage {
                 )
                 .await?;
             if let Some(v) = value {
-                return Ok(v);
+                return Ok(v.into_user_value());
             }
             table_counts += table_count;
         }
@@ -368,7 +368,7 @@ impl HummockStorage {
                             )
                             .await?
                         {
-                            return Ok(v);
+                            return Ok(v.into_user_value());
                         }
                     }
                 }
@@ -404,7 +404,7 @@ impl HummockStorage {
                         .get_from_table(table, &internal_key, check_bloom_filter, &mut local_stats)
                         .await?
                     {
-                        return Ok(v);
+                        return Ok(v.into_user_value());
                     }
                 }
             }

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use minitrace::future::FutureExt;
 use minitrace::Span;
 use risingwave_hummock_sdk::key::{key_with_epoch, next_key, user_key};
-use risingwave_hummock_sdk::{can_concat, key, HummockReadEpoch};
+use risingwave_hummock_sdk::{can_concat, HummockReadEpoch};
 use risingwave_pb::hummock::LevelType;
 
 use super::iterator::{
@@ -37,10 +37,7 @@ use crate::hummock::iterator::{
     HummockIteratorUnion,
 };
 use crate::hummock::local_version::ReadVersion;
-use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
-use crate::hummock::shared_buffer::{
-    build_ordered_merge_iter, OrderSortedUncommittedData, UncommittedData,
-};
+use crate::hummock::shared_buffer::build_ordered_merge_iter;
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::utils::prune_ssts;
 use crate::hummock::HummockResult;
@@ -366,7 +363,6 @@ impl HummockStorage {
                             .get_from_table(
                                 table,
                                 &internal_key,
-                                key,
                                 check_bloom_filter,
                                 &mut local_stats,
                             )
@@ -405,13 +401,7 @@ impl HummockStorage {
                         .await?;
                     table_counts += 1;
                     if let Some(v) = self
-                        .get_from_table(
-                            table,
-                            &internal_key,
-                            key,
-                            check_bloom_filter,
-                            &mut local_stats,
-                        )
+                        .get_from_table(table, &internal_key, check_bloom_filter, &mut local_stats)
                         .await?
                     {
                         return Ok(v);
@@ -426,52 +416,6 @@ impl HummockStorage {
             .with_label_values(&["sub-iter"])
             .observe(table_counts as f64);
         Ok(None)
-    }
-
-    /// Get from `OrderSortedUncommittedData`. If not get successful, return None.
-    async fn get_from_order_sorted_uncommitted_data(
-        &self,
-        order_sorted_uncommitted_data: OrderSortedUncommittedData,
-        internal_key: &[u8],
-        stats: &mut StoreLocalStatistic,
-        key: &[u8],
-        check_bloom_filter: bool,
-    ) -> StorageResult<(Option<Option<Bytes>>, i32)> {
-        let mut table_counts = 0;
-        let epoch = key::get_epoch(internal_key);
-        for data_list in order_sorted_uncommitted_data {
-            for data in data_list {
-                match data {
-                    UncommittedData::Batch(batch) => {
-                        assert!(batch.epoch() <= epoch, "batch'epoch greater than epoch");
-                        let data = self.get_from_batch(&batch, key);
-                        if data.is_some() {
-                            return Ok((data, table_counts));
-                        }
-                    }
-                    UncommittedData::Sst((_, table_info)) => {
-                        let table = self.sstable_store.sstable(table_info.id, stats).await?;
-                        table_counts += 1;
-
-                        let data = self
-                            .get_from_table(table, internal_key, key, check_bloom_filter, stats)
-                            .await?;
-                        if data.is_some() {
-                            return Ok((data, table_counts));
-                        }
-                    }
-                }
-            }
-        }
-        Ok((None, table_counts))
-    }
-
-    /// Return `Some(None)` means the key is deleted.
-    fn get_from_batch(&self, batch: &SharedBufferBatch, key: &[u8]) -> Option<Option<Bytes>> {
-        batch.get(key).map(|v| {
-            self.stats.get_shared_buffer_hit_counts.inc();
-            v.into_user_value().map(|v| v.into())
-        })
     }
 
     fn read_filter<R, B>(

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -52,10 +52,13 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
                 continue;
             }
         };
+
+        // TODO: to use `prefetch: false` after `prefetch` be supported by
+        // SstableIteratorReadOptions
         let mut iter = SstableIterator::new(
             holder,
             sstable_store.clone(),
-            Arc::new(SstableIteratorReadOptions { prefetch: false }),
+            Arc::new(SstableIteratorReadOptions::default()),
         );
         let mut previous_key: Option<Vec<u8>> = None;
         if let Err(err) = iter.rewind().await {

--- a/src/storage/src/hummock/value.rs
+++ b/src/storage/src/hummock/value.rs
@@ -127,7 +127,7 @@ impl<'a> HummockValue<&'a [u8]> {
     }
 
     /// Copies `self` into [`HummockValue<Bytes>`].
-    pub fn to_owned_bytes_value(&self) -> HummockValue<Bytes> {
+    pub fn to_bytes(&self) -> HummockValue<Bytes> {
         match self {
             HummockValue::Put(value) => HummockValue::Put(Bytes::copy_from_slice(value)),
             HummockValue::Delete => HummockValue::Delete,

--- a/src/storage/src/hummock/value.rs
+++ b/src/storage/src/hummock/value.rs
@@ -126,10 +126,10 @@ impl<'a> HummockValue<&'a [u8]> {
         }
     }
 
-    /// Copies `self` into [`HummockValue<Vec<u8>>`].
-    pub fn to_owned_value(&self) -> HummockValue<Vec<u8>> {
+    /// Copies `self` into [`HummockValue<Bytes>`].
+    pub fn to_owned_bytes_value(&self) -> HummockValue<Bytes> {
         match self {
-            HummockValue::Put(value) => HummockValue::Put(value.to_vec()),
+            HummockValue::Put(value) => HummockValue::Put(Bytes::copy_from_slice(value)),
             HummockValue::Delete => HummockValue::Delete,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

refactor get_from_table

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- extract `user_key` in `get_from_table`
- remove duplicated parameter `key` 

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)