### PR TITLE
refactor: cancel running batch query of ctrl-c

### DIFF
--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -104,6 +104,7 @@ pub async fn handle_query(
     if session.config().get_implicit_flush() {
         flush_for_write(&session, stmt_type).await?;
     }
+
     Ok(PgResponse::new(stmt_type, rows_count, rows, pg_descs, true))
 }
 

--- a/src/frontend/src/scheduler/distributed/mod.rs
+++ b/src/frontend/src/scheduler/distributed/mod.rs
@@ -15,7 +15,7 @@
 //! Distributed execution for batch query.
 
 mod query;
-use query::*;
+pub use query::*;
 mod stage;
 use stage::*;
 mod query_manager;

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -12,14 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-
 use std::sync::Arc;
 
 use futures::StreamExt;
 use futures_async_stream::try_stream;
-use parking_lot::Mutex;
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::RwError;
 use risingwave_pb::batch_plan::TaskOutputId;
@@ -33,7 +30,7 @@ use tracing::{debug, error, info};
 // use futures::stream;
 use super::QueryExecution;
 use crate::catalog::catalog_service::CatalogReader;
-use crate::scheduler::plan_fragmenter::{Query, QueryId};
+use crate::scheduler::plan_fragmenter::Query;
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
 use crate::scheduler::{
     DataChunkStream, ExecutionContextRef, HummockSnapshotManagerRef, SchedulerError,
@@ -57,9 +54,9 @@ pub struct QueryManager {
     hummock_snapshot_manager: HummockSnapshotManagerRef,
     compute_client_pool: ComputeClientPoolRef,
     catalog_reader: CatalogReader,
-
-    /// Send cancel request to query when receive ctrl-c.
-    shutdown_receivers_map: Arc<Mutex<HashMap<QueryId, Option<oneshot::Sender<u8>>>>>,
+    // Send cancel request to query when receive ctrl-c.
+    // shutdown_receivers_map: Arc<Mutex<HashMap<QueryId, Option<oneshot::Sender<u8>>>>>,
+    // batch_queries: Arc<Mutex<WeakHashSet<Weak<Query>, >>>
 }
 
 type QueryManagerRef = Arc<QueryManager>;
@@ -76,7 +73,6 @@ impl QueryManager {
             hummock_snapshot_manager,
             compute_client_pool,
             catalog_reader,
-            shutdown_receivers_map: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -121,7 +117,6 @@ impl QueryManager {
 
         Ok(query_result_fetcher.run())
     }
-
 }
 
 impl QueryResultFetcher {

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-use std::mem;
+
 use std::sync::Arc;
 
 use futures::StreamExt;

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -32,9 +32,11 @@ pub enum SchedulerError {
     #[error("Empty workers found")]
     EmptyWorkerNodes,
 
+    /// FIXME: include task error msg in this error.
     #[error("Task fail")]
     TaskExecutionError,
 
+    /// Used when receive cancel request (ctrl-c) from user.
     #[error("Canceled by user")]
     QueryCancelError,
 

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -35,6 +35,9 @@ pub enum SchedulerError {
     #[error("Task fail")]
     TaskExecutionError,
 
+    #[error("Canceled by user")]
+    QueryCancelError,
+
     #[error(transparent)]
     Internal(#[from] anyhow::Error),
 }

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -26,7 +26,7 @@ mod distributed;
 pub use distributed::QueryManager;
 mod hummock_snapshot_manager;
 pub use hummock_snapshot_manager::*;
-mod plan_fragmenter;
+pub mod plan_fragmenter;
 pub use plan_fragmenter::BatchPlanFragmenter;
 mod local;
 pub use local::*;

--- a/src/frontend/src/scheduler/mod.rs
+++ b/src/frontend/src/scheduler/mod.rs
@@ -23,7 +23,7 @@ use risingwave_common::error::Result;
 use crate::session::SessionImpl;
 
 mod distributed;
-pub use distributed::QueryManager;
+pub use distributed::{QueryManager, QueryMessage};
 mod hummock_snapshot_manager;
 pub use hummock_snapshot_manager::*;
 pub mod plan_fragmenter;

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -682,6 +682,10 @@ impl Session for SessionImpl {
     fn user_authenticator(&self) -> &UserAuthenticator {
         &self.user_authenticator
     }
+
+    fn cancel_query(&self) {
+        self.env.query_manager().cancel_running_processes()
+    }
 }
 
 /// Returns row description of the statement

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -73,11 +73,11 @@ impl SessionManager for LocalFrontend {
         Ok(self.session_ref())
     }
 
-    fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+    fn connect_for_cancel(&self, _process_id: i32, _secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
         todo!()
     }
 
-    fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>) {
+    fn insert_session(&self, _process_id: i32, _secret_key: i32, _session: Arc<Self::Session>) {
         todo!()
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -80,10 +80,6 @@ impl SessionManager for LocalFrontend {
     ) -> PsqlResult<Arc<Self::Session>> {
         todo!()
     }
-
-    fn insert_session(&self, _session: Arc<Self::Session>) -> (i32, i32) {
-        todo!()
-    }
 }
 
 impl LocalFrontend {
@@ -160,6 +156,8 @@ impl LocalFrontend {
                 DEFAULT_SUPER_USER_ID,
             )),
             UserAuthenticator::None,
+            // Local Frontend use a non-sense id.
+            (0, 0),
         ))
     }
 
@@ -173,6 +171,8 @@ impl LocalFrontend {
             self.env.clone(),
             Arc::new(AuthContext::new(database, user_name, user_id)),
             UserAuthenticator::None,
+            // Local Frontend use a non-sense id.
+            (0, 0),
         ))
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -40,6 +40,7 @@ use risingwave_rpc_client::error::Result as RpcResult;
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use tempfile::{Builder, NamedTempFile};
+use pgwire::error::PsqlResult;
 
 use crate::binder::Binder;
 use crate::catalog::catalog_service::CatalogWriter;
@@ -70,6 +71,14 @@ impl SessionManager for LocalFrontend {
         _user_name: &str,
     ) -> std::result::Result<Arc<Self::Session>, BoxedError> {
         Ok(self.session_ref())
+    }
+
+    fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+        todo!()
+    }
+
+    fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>) {
+        todo!()
     }
 }
 

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -19,6 +19,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use parking_lot::RwLock;
+use pgwire::error::PsqlResult;
 use pgwire::pg_response::PgResponse;
 use pgwire::pg_server::{BoxedError, Session, SessionManager, UserAuthenticator};
 use risingwave_common::catalog::{
@@ -40,7 +41,6 @@ use risingwave_rpc_client::error::Result as RpcResult;
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlparser::parser::Parser;
 use tempfile::{Builder, NamedTempFile};
-use pgwire::error::PsqlResult;
 
 use crate::binder::Binder;
 use crate::catalog::catalog_service::CatalogWriter;
@@ -73,11 +73,15 @@ impl SessionManager for LocalFrontend {
         Ok(self.session_ref())
     }
 
-    fn connect_for_cancel(&self, _process_id: i32, _secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+    fn connect_for_cancel(
+        &self,
+        _process_id: i32,
+        _secret_key: i32,
+    ) -> PsqlResult<Arc<Self::Session>> {
         todo!()
     }
 
-    fn insert_session(&self, _process_id: i32, _secret_key: i32, _session: Arc<Self::Session>) {
+    fn insert_session(&self, _session: Arc<Self::Session>) -> (i32, i32) {
         todo!()
     }
 }

--- a/src/utils/pgwire/src/error.rs
+++ b/src/utils/pgwire/src/error.rs
@@ -59,7 +59,7 @@ pub enum PsqlError {
     IoError(#[from] IoError),
 
     #[error("Cancel Not Found")]
-    CancelNotFound
+    CancelNotFound,
 }
 
 impl PsqlError {

--- a/src/utils/pgwire/src/error.rs
+++ b/src/utils/pgwire/src/error.rs
@@ -57,6 +57,9 @@ pub enum PsqlError {
 
     #[error("{0}")]
     IoError(#[from] IoError),
+
+    #[error("Cancel Not Found")]
+    CancelNotFound
 }
 
 impl PsqlError {

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -66,7 +66,6 @@ impl FeStartupMessage {
         config.chunks(2).for_each(|chunk| {
             map.insert(chunk[0].to_string(), chunk[1].to_string());
         });
-        println!("read start up succesfully");
         Ok(FeStartupMessage { config: map })
     }
 }
@@ -264,7 +263,6 @@ impl FeCloseMessage {
 impl FeMessage {
     /// Read one message from the stream.
     pub async fn read(stream: &mut (impl AsyncRead + Unpin)) -> Result<FeMessage> {
-        println!("Start to read normal message1");
         let val = stream.read_u8().await?;
         let len = stream.read_i32().await?;
 
@@ -274,7 +272,6 @@ impl FeMessage {
             stream.read_exact(&mut payload).await?;
         }
         let sql_bytes = Bytes::from(payload);
-        println!("Start to read normal message {:?}", val);
         match val {
             b'Q' => Ok(FeMessage::Query(FeQueryMessage { sql_bytes })),
             b'P' => FeParseMessage::parse(sql_bytes),
@@ -297,7 +294,6 @@ impl FeStartupMessage {
     /// Read startup message from the stream.
     pub async fn read(stream: &mut (impl AsyncRead + Unpin)) -> Result<FeMessage> {
         let len = stream.read_i32().await?;
-        println!("can not read lenth?");
         let protocol_num = stream.read_i32().await?;
         let payload_len = len - 8;
         let mut payload = vec![0; payload_len as usize];

--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -66,6 +66,7 @@ impl FeStartupMessage {
         config.chunks(2).for_each(|chunk| {
             map.insert(chunk[0].to_string(), chunk[1].to_string());
         });
+        println!("read start up succesfully");
         Ok(FeStartupMessage { config: map })
     }
 }
@@ -129,7 +130,10 @@ impl FeCancelMessage {
     pub fn parse(mut buf: Bytes) -> Result<FeMessage> {
         let target_process_id = buf.get_i32();
         let target_secret_key = buf.get_i32();
-        Ok(FeMessage::CancelQuery(Self {target_process_id,  target_secret_key}))
+        Ok(FeMessage::CancelQuery(Self {
+            target_process_id,
+            target_secret_key,
+        }))
     }
 }
 
@@ -260,6 +264,7 @@ impl FeCloseMessage {
 impl FeMessage {
     /// Read one message from the stream.
     pub async fn read(stream: &mut (impl AsyncRead + Unpin)) -> Result<FeMessage> {
+        println!("Start to read normal message1");
         let val = stream.read_u8().await?;
         let len = stream.read_i32().await?;
 
@@ -269,7 +274,7 @@ impl FeMessage {
             stream.read_exact(&mut payload).await?;
         }
         let sql_bytes = Bytes::from(payload);
-
+        println!("Start to read normal message {:?}", val);
         match val {
             b'Q' => Ok(FeMessage::Query(FeQueryMessage { sql_bytes })),
             b'P' => FeParseMessage::parse(sql_bytes),
@@ -292,6 +297,7 @@ impl FeStartupMessage {
     /// Read startup message from the stream.
     pub async fn read(stream: &mut (impl AsyncRead + Unpin)) -> Result<FeMessage> {
         let len = stream.read_i32().await?;
+        println!("can not read lenth?");
         let protocol_num = stream.read_i32().await?;
         let payload_len = len - 8;
         let mut payload = vec![0; payload_len as usize];

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -234,7 +234,7 @@ where
         }
         // Cancel request need this for identify and verification.
         let id = (0, 0);
-        self.stream.write_no_flush(&BeMessage::BackendKeyData(id));
+        self.stream.write_no_flush(&BeMessage::BackendKeyData(id))?;
         self.session_mgr.insert_session(id.0, id.1, session.clone());
         self.session = Some(session);
         self.state = PgProtocolState::Regular;
@@ -271,7 +271,7 @@ where
         let session = self.session.clone().unwrap();
         session.cancel_query();
         self.session = None;
-        self.stream.write_no_flush(&BeMessage::EmptyQueryResponse);
+        self.stream.write_no_flush(&BeMessage::EmptyQueryResponse)?;
         Ok(())
     }
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -136,6 +136,7 @@ where
                         self.stream
                             .write_for_error(&BeMessage::ErrorResponse(Box::new(e)));
                         self.stream.write_for_error(&BeMessage::ReadyForQuery);
+                        // return true;
                     }
 
                     PsqlError::CloseError(_)
@@ -148,7 +149,9 @@ where
                     }
 
                     // Never reach this.
-                    PsqlError::CancelMsg(_) => todo!(),
+                    PsqlError::CancelMsg(_) => {
+                        todo!("Support processing cancel query")
+                    }
                 }
                 self.stream.flush_for_error().await;
                 tracing::error!("{}", error_msg);
@@ -258,8 +261,9 @@ where
     }
 
     fn process_cancel_msg(&mut self) -> PsqlResult<()> {
-        self.stream
-            .write_no_flush(&BeMessage::ErrorResponse(Box::new(PsqlError::cancel())))?;
+        // TODO: Abort running query in `QueryManager`.
+        let session = self.session.clone().unwrap();
+        session.cancel_query();
         Ok(())
     }
 

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -17,8 +17,8 @@ use std::result::Result;
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
-use crate::error::PsqlResult;
 
+use crate::error::PsqlResult;
 use crate::pg_field_descriptor::PgFieldDescriptor;
 use crate::pg_protocol::PgProtocol;
 use crate::pg_response::PgResponse;
@@ -32,9 +32,13 @@ pub trait SessionManager: Send + Sync + 'static {
 
     fn connect(&self, database: &str, user_name: &str) -> Result<Arc<Self::Session>, BoxedError>;
 
-    fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>);
+    fn insert_session(&self, session: Arc<Self::Session>) -> (i32, i32);
 
-    fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>>;
+    fn connect_for_cancel(
+        &self,
+        process_id: i32,
+        secret_key: i32,
+    ) -> PsqlResult<Arc<Self::Session>>;
 }
 
 /// A psql connection. Each connection binds with a database. Switching database will need to
@@ -117,8 +121,8 @@ mod tests {
     use bytes::Bytes;
     use tokio_postgres::types::*;
     use tokio_postgres::NoTls;
-    use crate::error::PsqlResult;
 
+    use crate::error::PsqlResult;
     use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
     use crate::pg_response::{PgResponse, StatementType};
     use crate::pg_server::{pg_serve, Session, SessionManager, UserAuthenticator};
@@ -137,11 +141,15 @@ mod tests {
             Ok(Arc::new(MockSession {}))
         }
 
-        fn insert_session(&self, _process_id: i32, _secret_key: i32, _session: Arc<Self::Session>) {
+        fn insert_session(&self, _session: Arc<Self::Session>) -> (i32, i32) {
             todo!()
         }
 
-        fn connect_for_cancel(&self, _process_id: i32, _secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+        fn connect_for_cancel(
+            &self,
+            _process_id: i32,
+            _secret_key: i32,
+        ) -> PsqlResult<Arc<Self::Session>> {
             todo!()
         }
     }

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -57,7 +57,7 @@ pub trait Session: Send + Sync {
         sql: &str,
     ) -> Result<Vec<PgFieldDescriptor>, BoxedError>;
     fn user_authenticator(&self) -> &UserAuthenticator;
-    fn cancel_running_queries(&self);
+    async fn cancel_running_queries(&self);
 
     fn id(&self) -> SessionId;
 }
@@ -200,7 +200,7 @@ mod tests {
             ])
         }
 
-        fn cancel_running_queries(&self) {
+        async fn cancel_running_queries(&self) {
             unreachable!("Do not expect mock session to cancel running queries");
         }
 

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -50,6 +50,7 @@ pub trait Session: Send + Sync {
         sql: &str,
     ) -> Result<Vec<PgFieldDescriptor>, BoxedError>;
     fn user_authenticator(&self) -> &UserAuthenticator;
+    fn cancel_query(&self);
 }
 
 #[derive(Debug, Clone)]
@@ -179,6 +180,10 @@ mod tests {
                 PgFieldDescriptor::new("".to_string(), TypeOid::Varchar,);
                 count
             ])
+        }
+
+        fn cancel_query(&self) {
+            todo!()
         }
     }
 

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -17,6 +17,7 @@ use std::result::Result;
 use std::sync::Arc;
 
 use tokio::net::TcpListener;
+use crate::error::PsqlResult;
 
 use crate::pg_field_descriptor::PgFieldDescriptor;
 use crate::pg_protocol::PgProtocol;
@@ -30,6 +31,10 @@ pub trait SessionManager: Send + Sync + 'static {
     type Session: Session;
 
     fn connect(&self, database: &str, user_name: &str) -> Result<Arc<Self::Session>, BoxedError>;
+
+    fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>);
+
+    fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>>;
 }
 
 /// A psql connection. Each connection binds with a database. Switching database will need to
@@ -112,6 +117,7 @@ mod tests {
     use bytes::Bytes;
     use tokio_postgres::types::*;
     use tokio_postgres::NoTls;
+    use crate::error::PsqlResult;
 
     use crate::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
     use crate::pg_response::{PgResponse, StatementType};
@@ -129,6 +135,14 @@ mod tests {
             _user_name: &str,
         ) -> Result<Arc<Self::Session>, Box<dyn Error + Send + Sync>> {
             Ok(Arc::new(MockSession {}))
+        }
+
+        fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>) {
+            todo!()
+        }
+
+        fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+            todo!()
         }
     }
 

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -137,11 +137,11 @@ mod tests {
             Ok(Arc::new(MockSession {}))
         }
 
-        fn insert_session(&self, process_id: i32, secret_key: i32, session: Arc<Self::Session>) {
+        fn insert_session(&self, _process_id: i32, _secret_key: i32, _session: Arc<Self::Session>) {
             todo!()
         }
 
-        fn connect_for_cancel(&self, process_id: i32, secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
+        fn connect_for_cancel(&self, _process_id: i32, _secret_key: i32) -> PsqlResult<Arc<Self::Session>> {
             todo!()
         }
     }

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -34,10 +34,10 @@ fn configure_risingwave_targets_fmt(targets: filter::Targets) -> filter::Targets
         .with_target("risingwave_sqlparser", Level::INFO)
         .with_target("risingwave_source", Level::INFO)
         .with_target("risingwave_connector", Level::INFO)
-        .with_target("risingwave_frontend", Level::INFO)
+        .with_target("risingwave_frontend", Level::TRACE)
         .with_target("risingwave_meta", Level::INFO)
         .with_target("risingwave_tracing", Level::INFO)
-        .with_target("pgwire", Level::ERROR)
+        .with_target("pgwire", Level::TRACE)
         // disable events that are too verbose
         // if you want to enable any of them, find the target name and set it to `TRACE`
         // .with_target("events::stream::mview::scan", Level::TRACE)

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -34,10 +34,10 @@ fn configure_risingwave_targets_fmt(targets: filter::Targets) -> filter::Targets
         .with_target("risingwave_sqlparser", Level::INFO)
         .with_target("risingwave_source", Level::INFO)
         .with_target("risingwave_connector", Level::INFO)
-        .with_target("risingwave_frontend", Level::TRACE)
+        .with_target("risingwave_frontend", Level::INFO)
         .with_target("risingwave_meta", Level::INFO)
         .with_target("risingwave_tracing", Level::INFO)
-        .with_target("pgwire", Level::TRACE)
+        .with_target("pgwire", Level::ERROR)
         // disable events that are too verbose
         // if you want to enable any of them, find the target name and set it to `TRACE`
         // .with_target("events::stream::mview::scan", Level::TRACE)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Abort task when receive ctrl-c signal. Note: this do not mean the query will return immediately.


Code change:
* Add psql protocol related Message: `BackendKeyData`, `CancelRequest`. Used to process cancel request from user.
* Add a shutdown channel for each query and use tokio::select in `QueryRunner`: once received a `()`, shutdown all stages. Should differentiate with #5022: One shutdown message is sent from QueryRunner, one is sent from user. 
* Records the channel for each query in `SessionImpl`: When user cancel a query, first fetch correspoding session using SessionId, then fetch all running queries channel and send shutdown message.


Test:
./risedev p
psql connect

create a lineitem table.
And insert values in insert_lineitem.slt.part

use ctrl-c to send cancel request
get wanted message: "Canceled by user"
<img width="855" alt="image" src="https://user-images.githubusercontent.com/36908971/188414819-bf369866-237e-46fc-8a7a-ec355bf1cf5a.png">


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Close #5027 
