### PR TITLE
fix(meta): initialize first epoch

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -888,15 +888,13 @@ where
                 // If no checkpoint, we can't notify collection completion
                 if *checkpoint {
                     let mut uncommitted_states = checkpoint_control.get_uncommitted_states();
-                    if prev_epoch != INVALID_EPOCH {
-                        self.hummock_manager
-                            .commit_epoch(
-                                prev_epoch,
-                                uncommitted_states.uncommitted_ssts,
-                                uncommitted_states.uncommitted_work_ids,
-                            )
-                            .await?;
-                    }
+                    self.hummock_manager
+                        .commit_epoch(
+                            prev_epoch,
+                            uncommitted_states.uncommitted_ssts,
+                            uncommitted_states.uncommitted_work_ids,
+                        )
+                        .await?;
                     while let Some((command_ctx, mut notifiers, create_mv_progress)) =
                         uncommitted_states.uncommitted_checkpoint_post.pop_back()
                     {
@@ -913,7 +911,7 @@ where
                             tracker.update(&progress);
                         }
                     }
-                } else if prev_epoch != INVALID_EPOCH {
+                } else {
                     self.hummock_manager
                         .update_current_epoch(prev_epoch)
                         .await?;

--- a/src/meta/src/model/barrier.rs
+++ b/src/meta/src/model/barrier.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::util::epoch::{Epoch, INVALID_EPOCH};
+use risingwave_common::util::epoch::Epoch;
 
 use crate::storage::{MetaStore, MetaStoreError, MetaStoreResult, DEFAULT_COLUMN_FAMILY};
 
@@ -36,7 +36,7 @@ impl BarrierManagerState {
             .await
         {
             Ok(byte_vec) => u64::from_be_bytes(byte_vec.as_slice().try_into().unwrap()).into(),
-            Err(MetaStoreError::ItemNotFound(_)) => INVALID_EPOCH.into(),
+            Err(MetaStoreError::ItemNotFound(_)) => Epoch::now(),
             Err(e) => panic!("{:?}", e),
         };
         Self {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR initializes system's first epoch with Epoch::now.

Before this PR, system's first epoch is 0, which can cause problem if it's used to write shared buffer. 
For example, [here](https://github.com/risingwavelabs/risingwave/blob/0040b3176a9f6c5ca51789c631f61b5746024a58/src/stream/src/executor/source/source_executor.rs) assertion will fail because both epoch and max_sync_epoch are 0. https://github.com/risingwavelabs/risingwave/blob/1291bd044498515b4c4f4509356f90ce45cf6e9f/src/storage/src/hummock/local_version_manager.rs#L443 

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
