### PR TITLE
feat(frontend): support explain distsql

### DIFF
--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -28,6 +28,7 @@ use super::create_table::gen_create_table_plan;
 use crate::binder::Binder;
 use crate::handler::util::force_local_mode;
 use crate::planner::Planner;
+use crate::scheduler::BatchPlanFragmenter;
 use crate::session::OptimizerContext;
 
 pub(super) fn handle_explain(
@@ -39,19 +40,9 @@ pub(super) fn handle_explain(
     if analyze {
         return Err(ErrorCode::NotImplemented("explain analyze".to_string(), 4856.into()).into());
     }
-    match options.explain_type {
-        ExplainType::Logical => {
-            return Err(
-                ErrorCode::NotImplemented("explain logical".to_string(), 4856.into()).into(),
-            )
-        }
-        ExplainType::Physical => {}
-        ExplainType::DistSQL => {
-            return Err(
-                ErrorCode::NotImplemented("explain distsql".to_string(), 4856.into()).into(),
-            )
-        }
-    };
+    if options.explain_type == ExplainType::Logical {
+        return Err(ErrorCode::NotImplemented("explain logical".to_string(), 4856.into()).into());
+    }
 
     let session = context.session_ctx.clone();
     context
@@ -100,12 +91,43 @@ pub(super) fn handle_explain(
                 session.config().get_query_mode()
             };
             let logical = planner.plan(bound)?;
-            match query_mode {
+            let plan = match query_mode {
                 QueryMode::Local => logical.gen_batch_local_plan()?,
                 QueryMode::Distributed => logical.gen_batch_distributed_plan()?,
+            };
+
+            if options.explain_type == ExplainType::DistSQL {
+                let plan_fragmenter = BatchPlanFragmenter::new(
+                    session.env().worker_node_manager_ref(),
+                    session.env().catalog_reader().clone(),
+                );
+                let query = plan_fragmenter.split(plan)?;
+                let stage_graph_json = serde_json::to_string_pretty(&query.stage_graph).unwrap();
+                let rows = vec![stage_graph_json]
+                    .iter()
+                    .flat_map(|s| s.lines())
+                    .map(|s| Row::new(vec![Some(s.to_string().into())]))
+                    .collect::<Vec<_>>();
+
+                return Ok(PgResponse::new(
+                    StatementType::EXPLAIN,
+                    rows.len() as i32,
+                    rows,
+                    vec![PgFieldDescriptor::new(
+                        "QUERY PLAN".to_owned(),
+                        TypeOid::Varchar,
+                    )],
+                    true,
+                ));
             }
+
+            plan
         }
     };
+
+    if options.explain_type == ExplainType::DistSQL {
+        return Err(ErrorCode::NotImplemented("explain distsql".to_string(), 4856.into()).into());
+    }
 
     let ctx = plan.plan_base().ctx.clone();
     let explain_trace = ctx.is_explain_trace();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Support explain distsql in the handler to output JSON-formatted distributed plan information. Eg. 
```
create table t1(v1 int);
explain (type distsql) select * from t1;

                 QUERY PLAN                 
--------------------------------------------
 {
   "root_stage_id": 0,
   "stages": {
     "1": {
       "root": {
         "plan_node_id": 17,
         "plan_node_type": "BatchSeqScan",
         "schema": [
           {
             "dataType": {
               "typeName": "INT32",
               "isNullable": true
             },
             "name": "t1.v1"
           }
         ],
         "children": [],
         "source_stage_id": null
       },
       "parallelism": 4,
       "exchange_info": {
         "mode": "SINGLE"
       }
     },
     "0": {
       "root": {
         "plan_node_id": 18,
         "plan_node_type": "BatchExchange",
         "schema": [
           {
             "dataType": {
               "typeName": "INT32",
               "isNullable": true
             },
             "name": "t1.v1"
           }
         ],
         "children": [],
         "source_stage_id": 1
       },
       "parallelism": 1,
       "exchange_info": {
         "mode": "SINGLE"
       }
     }
   },
   "child_edges": {
     "1": [],
     "0": [
       1
     ]
   },
   "parent_edges": {
     "0": [],
     "1": [
       0
     ]
   }
 }
(59 rows)
```


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)