### PR TITLE
feat(batch): support is null for scan range

### DIFF
--- a/e2e_test/batch/basic/range_scan.slt.part
+++ b/e2e_test/batch/basic/range_scan.slt.part
@@ -26,7 +26,9 @@ insert into orders values
     (8, 2147483648, 2222),
     (9, 2147483648, 3333),
     (10, 2147483649, 1111),
-    (NULL, NULL, NULL);
+    (11, NULL, NULL),
+    (NULL, 9999, NULL),
+    (NULL, NULL, 8888);
 
 query III rowsort
 SELECT * FROM orders_count_by_user WHERE user_id = 42;
@@ -92,9 +94,34 @@ SELECT * FROM orders_count_by_user WHERE date > 1111 AND user_id = 42 AND 5<6 AN
 42 3333 1
 
 query III rowsort
-SELECT * FROM orders_count_by_user WHERE user_id is null;
+SELECT * FROM orders_count_by_user WHERE user_id is null order by user_id, date, orders_count;
 ----
+NULL 8888 1
 NULL NULL 1
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id = 9999 and date is null;
+----
+9999 NULL 1
+
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id = 9999 or user_id is null order by user_id, date, orders_count;
+----
+9999 NULL 1
+NULL 8888 1
+NULL NULL 1
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id = 9999 or (user_id is null and date is null) order by user_id, date, orders_count;
+----
+9999 NULL 1
+NULL NULL 1
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id = 9999 or (user_id = 9999 and date is null) order by user_id, date, orders_count;
+----
+9999 NULL 1
 
 statement ok
 drop materialized view orders_count_by_user;

--- a/e2e_test/batch/basic/range_scan.slt.part
+++ b/e2e_test/batch/basic/range_scan.slt.part
@@ -25,7 +25,8 @@ insert into orders values
     (7, 2147483648, 1111),
     (8, 2147483648, 2222),
     (9, 2147483648, 3333),
-    (10, 2147483649, 1111);
+    (10, 2147483649, 1111),
+    (NULL, NULL, NULL);
 
 query III rowsort
 SELECT * FROM orders_count_by_user WHERE user_id = 42;
@@ -89,6 +90,11 @@ SELECT * FROM orders_count_by_user WHERE date > 1111 AND user_id = 42 AND 5<6 AN
 ----
 42 2222 2
 42 3333 1
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id is null;
+----
+NULL NULL 1
 
 statement ok
 drop materialized view orders_count_by_user;

--- a/src/batch/src/executor/join/lookup_join.rs
+++ b/src/batch/src/executor/join/lookup_join.rs
@@ -203,8 +203,8 @@ impl<C: BatchTaskContext> ProbeSideSourceBuilder for ProbeSideSource<C> {
             .zip_eq(self.build_side_key_types.iter())
             .zip_eq(self.probe_side_key_types.iter())
         {
-            let scalar_impl = if probe_type == build_type {
-                datum.as_ref().unwrap().clone()
+            let datum = if probe_type == build_type {
+                datum.clone()
             } else {
                 let cast_expr = new_unary_expr(
                     Type::Cast,
@@ -212,11 +212,10 @@ impl<C: BatchTaskContext> ProbeSideSourceBuilder for ProbeSideSource<C> {
                     Box::new(LiteralExpression::new(build_type.clone(), datum.clone())),
                 )?;
 
-                let datum = cast_expr.eval_row(Row::empty())?;
-                datum.unwrap()
+                cast_expr.eval_row(Row::empty())?
             };
 
-            scan_range.eq_conds.push(scalar_impl);
+            scan_range.eq_conds.push(datum);
         }
 
         let vnode = self.get_virtual_node(&scan_range)?;

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -25,6 +25,7 @@ use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
 use risingwave_common::util::select_all;
 use risingwave_common::util::sort_util::OrderType;
+use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{scan_range, ScanRange};
@@ -92,8 +93,7 @@ fn get_scan_bound(
         .iter()
         .map(|v| {
             let ty = pk_types.next().unwrap();
-            let scalar = ScalarImpl::from_proto_bytes(v, &ty.to_protobuf()).unwrap();
-            Some(scalar)
+            deserialize_datum(v.as_slice(), &ty).expect("fail to deserialize datum")
         })
         .collect_vec());
     if scan_range.lower_bound.is_none() && scan_range.upper_bound.is_none() {

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -19,13 +19,14 @@ use risingwave_pb::batch_plan::scan_range::Bound as BoundProst;
 use risingwave_pb::batch_plan::ScanRange as ScanRangeProst;
 
 use crate::array::Row;
-use crate::types::{ScalarImpl, VirtualNode};
+use crate::types::{Datum, ScalarImpl, VirtualNode};
 use crate::util::hash_util::CRC32FastBuilder;
+use crate::util::value_encoding::serialize_datum;
 
 /// See also [`ScanRangeProst`]
 #[derive(Debug, Clone)]
 pub struct ScanRange {
-    pub eq_conds: Vec<ScalarImpl>,
+    pub eq_conds: Vec<Datum>,
     pub range: (Bound<ScalarImpl>, Bound<ScalarImpl>),
 }
 
@@ -46,7 +47,11 @@ fn bound_to_proto(bound: &Bound<ScalarImpl>) -> Option<BoundProst> {
 impl ScanRange {
     pub fn to_protobuf(&self) -> ScanRangeProst {
         ScanRangeProst {
-            eq_conds: self.eq_conds.iter().map(|lit| lit.to_protobuf()).collect(),
+            eq_conds: self
+                .eq_conds
+                .iter()
+                .map(|datum| serialize_datum(datum).expect("fail to serialize datum"))
+                .collect(),
             lower_bound: bound_to_proto(&self.range.0),
             upper_bound: bound_to_proto(&self.range.1),
         }
@@ -91,11 +96,7 @@ impl ScanRange {
             return None;
         }
 
-        let pk_prefix_value = Row(self
-            .eq_conds
-            .iter()
-            .map(|scalar| Some(scalar.clone()))
-            .collect());
+        let pk_prefix_value = Row(self.eq_conds.clone());
         let vnode = pk_prefix_value
             .hash_by_indices(&dist_key_in_pk_indices, &CRC32FastBuilder {})
             .to_vnode();
@@ -125,10 +126,10 @@ mod tests {
         let mut scan_range = ScanRange::full_table_scan();
         assert!(scan_range.try_compute_vnode(&dist_key, &pk).is_none());
 
-        scan_range.eq_conds.push(ScalarImpl::from(114));
+        scan_range.eq_conds.push(Some(ScalarImpl::from(114)));
         assert!(scan_range.try_compute_vnode(&dist_key, &pk).is_none());
 
-        scan_range.eq_conds.push(ScalarImpl::from(514));
+        scan_range.eq_conds.push(Some(ScalarImpl::from(514)));
         let vnode = Row(vec![
             Some(ScalarImpl::from(114)),
             Some(ScalarImpl::from(514)),
@@ -147,13 +148,13 @@ mod tests {
         let mut scan_range = ScanRange::full_table_scan();
         assert!(scan_range.try_compute_vnode(&dist_key, &pk).is_none());
 
-        scan_range.eq_conds.push(ScalarImpl::from(114));
+        scan_range.eq_conds.push(Some(ScalarImpl::from(114)));
         assert!(scan_range.try_compute_vnode(&dist_key, &pk).is_none());
 
-        scan_range.eq_conds.push(ScalarImpl::from(514));
+        scan_range.eq_conds.push(Some(ScalarImpl::from(514)));
         assert!(scan_range.try_compute_vnode(&dist_key, &pk).is_none());
 
-        scan_range.eq_conds.push(ScalarImpl::from(114514));
+        scan_range.eq_conds.push(Some(ScalarImpl::from(114514)));
         let vnode = Row(vec![
             Some(ScalarImpl::from(114)),
             Some(ScalarImpl::from(514)),

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -458,6 +458,18 @@ impl ExprImpl {
         }
     }
 
+    pub fn as_is_null(&self) -> Option<InputRef> {
+        if let ExprImpl::FunctionCall(function_call) = self &&
+            function_call.get_expr_type() == ExprType::IsNull{
+            match function_call.clone().decompose_as_unary() {
+                (_, ExprImpl::InputRef(x)) => Some(*x),
+                _ => None,
+            }
+        } else {
+            None
+        }
+    }
+
     pub fn as_comparison_const(&self) -> Option<(InputRef, ExprType, ExprImpl)> {
         fn reverse_comparison(comparison: ExprType) -> ExprType {
             match comparison {

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -168,7 +168,10 @@ impl fmt::Display for BatchSeqScan {
                     .eq_conds
                     .iter()
                     .zip(order_names.iter())
-                    .map(|(v, name)| format!("{} = {:?}", name, v))
+                    .map(|(v, name)| match v {
+                        Some(v) => format!("{} = {:?}", name, v),
+                        None => format!("{} IS NULL", name),
+                    })
                     .collect_vec();
                 if !is_full_range(&scan_range.range) {
                     let i = scan_range.eq_conds.len();

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -67,8 +67,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id IS NULL
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: IsNull(orders_count_by_user.user_id) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |

--- a/src/frontend/test_runner/tests/testdata/range_scan.yaml
+++ b/src/frontend/test_runner/tests/testdata/range_scan.yaml
@@ -295,3 +295,44 @@
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: ((orders_count_by_user.user_id > 1:Int32) OR (orders_count_by_user.user_id < 10:Int32)) }
         BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id = 1 or user_id is null
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id = 1 and user_id is null
+  batch_plan: |
+    BatchValues { rows: [] }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id is null and date = 1111)
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date = Int32(1111)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id = 2 and date is null)
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id is null and date is null)
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+- before:
+  - create_table_and_mv
+  sql: |
+    SELECT * FROM orders_count_by_user WHERE user_id is null or (user_id is null and date is null)
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Support `is null` for scan range which is also a preparation for null-safe lookup join.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#4958