### PR TITLE
refactor(frontend): refactor expr visitor and plan visitor

### DIFF
--- a/src/frontend/src/expr/expr_visitor.rs
+++ b/src/frontend/src/expr/expr_visitor.rs
@@ -26,9 +26,9 @@ use super::{
 /// Note: The default implementation for `visit_subquery` is a no-op, i.e., expressions inside
 /// subqueries are not traversed.
 pub trait ExprVisitor<R: Default> {
-    // This merge function is used to reduce results of expr inputs.
-    // In order to always remind users to implement themselves, we don't provide an default
-    // implementation.
+    /// This merge function is used to reduce results of expr inputs.
+    /// In order to always remind users to implement themselves, we don't provide an default
+    /// implementation.
     fn merge(a: R, b: R) -> R;
 
     fn visit_expr(&mut self, expr: &ExprImpl) -> R {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -193,21 +193,21 @@ macro_rules! impl_has_variant {
             impl ExprImpl {
                 $(
                     pub fn [<has_ $variant:snake>](&self) -> bool {
-                        struct Has {
-                            has: bool,
-                        }
+                        struct Has {}
 
-                        impl ExprVisitor<()> for Has {
-                            fn [<visit_ $variant:snake>](&mut self, _: &$variant) {
-                                self.has = true;
+                        impl ExprVisitor<bool> for Has {
+
+                            fn merge(a: bool, b: bool) -> bool {
+                                a | b
+                            }
+
+                            fn [<visit_ $variant:snake>](&mut self, _: &$variant) -> bool {
+                                true
                             }
                         }
 
-                        let mut visitor = Has {
-                            has: false,
-                        };
-                        visitor.visit_expr(self);
-                        visitor.has
+                        let mut visitor = Has {};
+                        visitor.visit_expr(self)
                     }
                 )*
             }
@@ -239,73 +239,80 @@ impl ExprImpl {
     // We need to traverse inside subqueries.
     pub fn has_correlated_input_ref_by_depth(&self) -> bool {
         struct Has {
-            has: bool,
             depth: usize,
         }
 
-        impl ExprVisitor<()> for Has {
-            fn visit_correlated_input_ref(&mut self, correlated_input_ref: &CorrelatedInputRef) {
-                if correlated_input_ref.depth() >= self.depth {
-                    self.has = true;
-                }
+        impl ExprVisitor<bool> for Has {
+            fn merge(a: bool, b: bool) -> bool {
+                a | b
             }
 
-            fn visit_subquery(&mut self, subquery: &Subquery) {
+            fn visit_correlated_input_ref(
+                &mut self,
+                correlated_input_ref: &CorrelatedInputRef,
+            ) -> bool {
+                correlated_input_ref.depth() >= self.depth
+            }
+
+            fn visit_subquery(&mut self, subquery: &Subquery) -> bool {
                 use crate::binder::BoundSetExpr;
 
+                let mut has = false;
                 self.depth += 1;
                 match &subquery.query.body {
                     BoundSetExpr::Select(select) => {
-                        select.exprs().for_each(|expr| self.visit_expr(expr))
+                        select.exprs().for_each(|expr| has |= self.visit_expr(expr))
                     }
                     BoundSetExpr::Values(values) => {
-                        values.exprs().for_each(|expr| self.visit_expr(expr))
+                        values.exprs().for_each(|expr| has |= self.visit_expr(expr))
                     }
                 }
                 self.depth -= 1;
+
+                has
             }
         }
 
-        let mut visitor = Has {
-            has: false,
-            depth: 1,
-        };
-        visitor.visit_expr(self);
-        visitor.has
+        let mut visitor = Has { depth: 1 };
+        visitor.visit_expr(self)
     }
 
     pub fn has_correlated_input_ref_by_correlated_id(&self, correlated_id: CorrelatedId) -> bool {
         struct Has {
-            has: bool,
             correlated_id: CorrelatedId,
         }
 
-        impl ExprVisitor<()> for Has {
-            fn visit_correlated_input_ref(&mut self, correlated_input_ref: &CorrelatedInputRef) {
-                if correlated_input_ref.correlated_id() == self.correlated_id {
-                    self.has = true;
-                }
+        impl ExprVisitor<bool> for Has {
+            fn merge(a: bool, b: bool) -> bool {
+                a | b
             }
 
-            fn visit_subquery(&mut self, subquery: &Subquery) {
+            fn visit_correlated_input_ref(
+                &mut self,
+                correlated_input_ref: &CorrelatedInputRef,
+            ) -> bool {
+                correlated_input_ref.correlated_id() == self.correlated_id
+            }
+
+            fn visit_subquery(&mut self, subquery: &Subquery) -> bool {
                 use crate::binder::BoundSetExpr;
                 match &subquery.query.body {
-                    BoundSetExpr::Select(select) => {
-                        select.exprs().for_each(|expr| self.visit_expr(expr))
-                    }
-                    BoundSetExpr::Values(values) => {
-                        values.exprs().for_each(|expr| self.visit_expr(expr))
-                    }
+                    BoundSetExpr::Select(select) => select
+                        .exprs()
+                        .map(|expr| self.visit_expr(expr))
+                        .reduce(Self::merge)
+                        .unwrap_or_default(),
+                    BoundSetExpr::Values(values) => values
+                        .exprs()
+                        .map(|expr| self.visit_expr(expr))
+                        .reduce(Self::merge)
+                        .unwrap_or_default(),
                 }
             }
         }
 
-        let mut visitor = Has {
-            has: false,
-            correlated_id,
-        };
-        visitor.visit_expr(self);
-        visitor.has
+        let mut visitor = Has { correlated_id };
+        visitor.visit_expr(self)
     }
 
     /// Collect `CorrelatedInputRef`s in `ExprImpl` by relative `depth`, return their indices, and
@@ -365,6 +372,8 @@ impl ExprImpl {
             has: bool,
         }
         impl ExprVisitor<()> for Has {
+            fn merge(_: (), _: ()) {}
+
             fn visit_expr(&mut self, expr: &ExprImpl) {
                 match expr {
                     ExprImpl::Literal(_inner) => {}

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -354,6 +354,8 @@ pub struct CollectInputRef {
 }
 
 impl ExprVisitor<()> for CollectInputRef {
+    fn merge(_: (), _: ()) {}
+
     fn visit_input_ref(&mut self, expr: &InputRef) {
         self.input_bits.insert(expr.index());
     }

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -295,6 +295,10 @@ impl PlanRoot {
 
         struct HasExchange;
         impl PlanVisitor<bool> for HasExchange {
+            fn merge(a: bool, b: bool) -> bool {
+                a | b
+            }
+
             fn visit_batch_exchange(&mut self, _: &BatchExchange) -> bool {
                 true
             }

--- a/src/frontend/src/optimizer/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_correlated_id_finder.rs
@@ -40,6 +40,8 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter` and
     /// `LogicalJoin` now.
 
+    fn merge(_: (), _: ()) {}
+
     fn visit_logical_join(&mut self, plan: &LogicalJoin) {
         let mut finder = ExprCorrelatedIdFinder::default();
         plan.on().visit_expr(&mut finder);
@@ -83,6 +85,8 @@ impl ExprCorrelatedIdFinder {
 }
 
 impl ExprVisitor<()> for ExprCorrelatedIdFinder {
+    fn merge(_: (), _: ()) {}
+
     fn visit_correlated_input_ref(&mut self, correlated_input_ref: &CorrelatedInputRef) {
         self.correlated_id_set
             .insert(correlated_input_ref.correlated_id());

--- a/src/frontend/src/optimizer/plan_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor.rs
@@ -27,8 +27,8 @@ macro_rules! def_visitor {
                 return true;
             }
 
-            // This merge function is used to reduce results of plan inputs.
-            // In order to always remind users to implement themselves, we don't provide an default implementation.
+            /// This merge function is used to reduce results of plan inputs.
+            /// In order to always remind users to implement themselves, we don't provide an default implementation.
             fn merge(a: R, b: R) -> R;
 
             paste! {

--- a/src/frontend/src/optimizer/rule/index_selection.rs
+++ b/src/frontend/src/optimizer/rule/index_selection.rs
@@ -830,6 +830,10 @@ impl ExprVisitor<IndexCost> for TableScanIoEstimator<'_> {
             }
         }
     }
+
+    fn merge(a: IndexCost, b: IndexCost) -> IndexCost {
+        a.add(&b)
+    }
 }
 
 #[derive(Default)]
@@ -838,6 +842,8 @@ struct ExprInputRefFinder {
 }
 
 impl ExprVisitor<()> for ExprInputRefFinder {
+    fn merge(_: (), _: ()) {}
+
     fn visit_input_ref(&mut self, input_ref: &InputRef) {
         self.input_ref_index_set.insert(input_ref.index);
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- `ExprVisitor` and `PlanVisitor` provide a default return value `R` but with an easy misuse default merge function which returns the first visit value of its inputs.
- This PR enforces users to implement their `merge` function to merge the return value.
- The most mistaken use case of this kind of visitor is to implement the `Has` visitors. `Has` visitors should provide a merge function like `|a, b| -> a | b`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
