### PR TITLE
chore: enable tiered cache on CI and 3 node compose

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -265,18 +265,21 @@ risedev:
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-0}
       enable-async-stack-trace: true
+      enable-tiered-cache: true
 
     - use: compute-node
       id: compute-node-1
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-1}
       enable-async-stack-trace: true
+      enable-tiered-cache: true
 
     - use: compute-node
       id: compute-node-2
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-2}
       enable-async-stack-trace: true
+      enable-tiered-cache: true
 
     - use: frontend
       id: frontend-node-0
@@ -315,6 +318,7 @@ risedev:
       unsafe-disable-recovery: true
       enable-committed-sst-sanity-check: true
     - use: compute-node
+      enable-tiered-cache: true
     - use: frontend
     - use: compactor
 
@@ -328,12 +332,15 @@ risedev:
     - use: compute-node
       port: 5687
       exporter-port: 1222
+      enable-tiered-cache: true
     - use: compute-node
       port: 5688
       exporter-port: 1223
+      enable-tiered-cache: true
     - use: compute-node
       port: 5689
       exporter-port: 1224
+      enable-tiered-cache: true
     - use: frontend
     - use: compactor
 
@@ -347,12 +354,15 @@ risedev:
     - use: compute-node
       port: 5687
       exporter-port: 1222
+      enable-tiered-cache: true
     - use: compute-node
       port: 5688
       exporter-port: 1223
+      enable-tiered-cache: true
     - use: compute-node
       port: 5689
       exporter-port: 1224
+      enable-tiered-cache: true
     - use: frontend
       port: 4565
     - use: frontend
@@ -370,6 +380,7 @@ risedev:
     - use: compute-node
     - use: frontend
     - use: compactor
+      enable-tiered-cache: true
     - use: zookeeper
       persist-data: true
     - use: kafka
@@ -382,6 +393,7 @@ risedev:
     - use: meta-node
       unsafe-disable-recovery: true
     - use: compute-node
+      enable-tiered-cache: true
     - use: frontend
     - use: compactor
     - use: redis

--- a/risedev.yml
+++ b/risedev.yml
@@ -378,9 +378,9 @@ risedev:
     - use: meta-node
       unsafe-disable-recovery: true
     - use: compute-node
+      enable-tiered-cache: true
     - use: frontend
     - use: compactor
-      enable-tiered-cache: true
     - use: zookeeper
       persist-data: true
     - use: kafka


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Since #5009 and #5035 are fixed, we can restore tiered cache on CI and 3 node benchmark compose.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#5009 #5035 #5036 #5039