### PR TITLE
refactor(binder): extract special type infer rules from `FunctionCall:new`

### DIFF
--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -187,9 +187,7 @@ impl FunctionCall {
             _ => {
                 // TODO(xiangjin): move variadic functions above as part of `infer_type`, as its
                 // interface has been enhanced to support mutating (casting) inputs as well.
-                let ret;
-                (inputs, ret) = infer_type(func_type, inputs)?;
-                Ok(ret)
+                infer_type(func_type, &mut inputs)
             }
         }?;
         Ok(Self {

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -24,12 +24,11 @@ use crate::expr::{Expr as _, ExprImpl, ExprType};
 
 /// Infers the return type of a function. Returns `Err` if the function with specified data types
 /// is not supported on backend.
-pub fn infer_type(func_type: ExprType, inputs_mut: &mut Vec<ExprImpl>) -> Result<DataType> {
-    if let Some(res) = infer_type_for_special(func_type, inputs_mut).transpose() {
+pub fn infer_type(func_type: ExprType, inputs: &mut Vec<ExprImpl>) -> Result<DataType> {
+    if let Some(res) = infer_type_for_special(func_type, inputs).transpose() {
         return res;
     }
 
-    let inputs = std::mem::take(inputs_mut);
     let actuals = inputs
         .iter()
         .map(|e| match e.is_unknown() {
@@ -38,7 +37,8 @@ pub fn infer_type(func_type: ExprType, inputs_mut: &mut Vec<ExprImpl>) -> Result
         })
         .collect_vec();
     let sig = infer_type_name(&FUNC_SIG_MAP, func_type, &actuals)?;
-    let inputs = inputs
+    let inputs_owned = std::mem::take(inputs);
+    *inputs = inputs_owned
         .into_iter()
         .zip_eq(&sig.inputs_type)
         .map(|(expr, t)| {
@@ -48,10 +48,7 @@ pub fn infer_type(func_type: ExprType, inputs_mut: &mut Vec<ExprImpl>) -> Result
             Ok(expr)
         })
         .try_collect()?;
-    let ret_type = sig.ret_type.into();
-
-    *inputs_mut = inputs;
-    Ok(ret_type)
+    Ok(sig.ret_type.into())
 }
 
 macro_rules! ensure_arity {
@@ -80,7 +77,11 @@ macro_rules! ensure_arity {
     };
 }
 
-pub fn infer_type_for_special(
+/// Special exprs that cannot be handled by [`infer_type_name`] and [`FuncSigMap`] are handled here.
+/// These include variadic functions, list and struct type, as well as non-implicit cast.
+///
+/// We should aim for enhancing the general inferring framework and reduce the special cases here.
+fn infer_type_for_special(
     func_type: ExprType,
     inputs: &mut Vec<ExprImpl>,
 ) -> Result<Option<DataType>> {

--- a/src/frontend/test_runner/tests/testdata/expr.yaml
+++ b/src/frontend/test_runner/tests/testdata/expr.yaml
@@ -241,7 +241,7 @@
 - sql: |
     create table t (v1 int);
     select coalesce() from t;
-  binder_error: 'Bind error: Function `Coalesce` takes at least 1 arguments (0 given)'
+  binder_error: 'Bind error: Function `coalesce` takes at least 1 arguments (0 given)'
 - sql: |
     create table t (v1 int);
     select coalesce(1,true) from t;
@@ -271,7 +271,7 @@
 - sql: |
     create table t (v1 int);
     select concat_ws() from t;
-  binder_error: 'Bind error: Function `ConcatWs` takes at least 2 arguments (0 given)'
+  binder_error: 'Bind error: Function `concat_ws` takes at least 2 arguments (0 given)'
 - sql: |
     create table t (v1 varchar, v2 int, v3 float);
     select concat(v1, v2, v3, 1) as expr from t;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

They should also be part of `infer_type`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
