### PR TITLE
refactor(fragmenter): remove unneeded struct, prepare for rewrite

### DIFF
--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -37,7 +37,6 @@ use paste::paste;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::batch_plan::PlanNode as BatchPlanProst;
-use risingwave_pb::stream_plan::StreamNode as StreamPlanProst;
 use serde::Serialize;
 
 use super::property::{Distribution, FunctionalDependencySet, Order};
@@ -150,36 +149,6 @@ impl dyn PlanNode {
                 "".into()
             },
             node_body,
-        }
-    }
-
-    /// Serialize the plan node and its children to a stream plan proto.
-    ///
-    /// Note that [`StreamTableScan`] has its own implementation of `to_stream_prost`. We have a
-    /// hook inside to do some ad-hoc thing for [`StreamTableScan`].
-    pub fn to_stream_prost(&self) -> StreamPlanProst {
-        if let Some(stream_table_scan) = self.as_stream_table_scan() {
-            return stream_table_scan.adhoc_to_stream_prost();
-        }
-        if let Some(stream_index_scan) = self.as_stream_index_scan() {
-            return stream_index_scan.adhoc_to_stream_prost();
-        }
-
-        let node = Some(self.to_stream_prost_body());
-        let input = self
-            .inputs()
-            .into_iter()
-            .map(|plan| plan.to_stream_prost())
-            .collect();
-        // TODO: support pk_indices and operator_id
-        StreamPlanProst {
-            input,
-            identity: format!("{}", self),
-            node_body: node,
-            operator_id: self.id().0 as u64,
-            stream_key: self.logical_pk().iter().map(|x| *x as u32).collect(),
-            fields: self.schema().to_prost(),
-            append_only: self.append_only(),
         }
     }
 }
@@ -431,7 +400,7 @@ macro_rules! for_logical_plan_nodes {
             , { Logical, ProjectSet }
             , { Logical, Union }
             // , { Logical, Sort} not sure if we will support Order by clause in subquery/view/MV
-            // if we dont support that, we don't need LogicalSort, just require the Order at the top of query
+            // if we don't support that, we don't need LogicalSort, just require the Order at the top of query
         }
     };
 }

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -20,7 +20,6 @@ mod rewrite;
 use std::collections::HashSet;
 
 use derivative::Derivative;
-use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
 use risingwave_pb::plan_common::JoinType;
@@ -29,6 +28,8 @@ use risingwave_pb::stream_plan::{
     StreamFragmentGraph as StreamFragmentGraphProto, StreamNode,
 };
 
+use self::rewrite::build_delta_join_without_arrange;
+use crate::optimizer::plan_node::PlanNode;
 use crate::optimizer::PlanRef;
 
 /// The mutable state when building fragment graph.
@@ -74,281 +75,294 @@ impl BuildFragmentGraphState {
     }
 }
 
-pub fn build_graph(plan_node: PlanRef) -> StreamFragmentGraphProto {
-    let stream_node = plan_node.to_stream_prost();
-    let BuildFragmentGraphState {
-        fragment_graph,
-        next_local_fragment_id: _,
-        next_operator_id: _,
-        dependent_table_ids,
-        next_table_id,
-    } = {
-        let mut state = BuildFragmentGraphState::default();
-        StreamFragmenter::generate_fragment_graph(&mut state, stream_node).unwrap();
-        state
-    };
+impl dyn PlanNode {
+    /// Serialize the plan node and its children to a stream plan proto.
+    ///
+    /// Note that [`StreamTableScan`] has its own implementation of `to_stream_prost`. We have a
+    /// hook inside to do some ad-hoc thing for [`StreamTableScan`].
+    pub fn to_stream_prost(&self) -> StreamNode {
+        if let Some(stream_table_scan) = self.as_stream_table_scan() {
+            return stream_table_scan.adhoc_to_stream_prost();
+        }
+        if let Some(stream_index_scan) = self.as_stream_index_scan() {
+            return stream_index_scan.adhoc_to_stream_prost();
+        }
 
-    let mut fragment_graph = fragment_graph.to_protobuf();
-    fragment_graph.dependent_table_ids = dependent_table_ids
+        let node = Some(self.to_stream_prost_body());
+        let input = self
+            .inputs()
+            .into_iter()
+            .map(|plan| plan.to_stream_prost())
+            .collect();
+        // TODO: support pk_indices and operator_id
+        StreamNode {
+            input,
+            identity: format!("{}", self),
+            node_body: node,
+            operator_id: self.id().0 as u64,
+            stream_key: self.logical_pk().iter().map(|x| *x as u32).collect(),
+            fields: self.schema().to_prost(),
+            append_only: self.append_only(),
+        }
+    }
+}
+
+pub fn build_graph(plan_node: PlanRef) -> StreamFragmentGraphProto {
+    let mut state = BuildFragmentGraphState::default();
+    let stream_node = plan_node.to_stream_prost();
+    generate_fragment_graph(&mut state, stream_node).unwrap();
+    let mut fragment_graph = state.fragment_graph.to_protobuf();
+    fragment_graph.dependent_table_ids = state
+        .dependent_table_ids
         .into_iter()
         .map(|id| id.table_id)
         .collect();
-    fragment_graph.table_ids_cnt = next_table_id;
+    fragment_graph.table_ids_cnt = state.next_table_id;
     fragment_graph
 }
 
-pub struct StreamFragmenter {}
+fn is_stateful_executor(stream_node: &StreamNode) -> bool {
+    matches!(
+        stream_node.get_node_body().unwrap(),
+        NodeBody::HashAgg(_)
+            | NodeBody::HashJoin(_)
+            | NodeBody::DeltaIndexJoin(_)
+            | NodeBody::Chain(_)
+            | NodeBody::DynamicFilter(_)
+    )
+}
 
-impl StreamFragmenter {
-    fn is_stateful_executor(stream_node: &StreamNode) -> bool {
-        matches!(
-            stream_node.get_node_body().unwrap(),
-            NodeBody::HashAgg(_)
-                | NodeBody::HashJoin(_)
-                | NodeBody::DeltaIndexJoin(_)
-                | NodeBody::Chain(_)
-                | NodeBody::DynamicFilter(_)
-        )
-    }
+/// Do some dirty rewrites on meta. Currently, it will split stateful operators into two
+/// fragments.
+fn rewrite_stream_node(
+    state: &mut BuildFragmentGraphState,
+    stream_node: StreamNode,
+    insert_exchange_flag: bool,
+) -> Result<StreamNode> {
+    let f = |child| {
+        // For stateful operators, set `exchange_flag = true`. If it's already true,
+        // force add an exchange.
+        if is_stateful_executor(&child) {
+            if insert_exchange_flag {
+                let child_node = rewrite_stream_node(state, child, true)?;
 
-    /// Do some dirty rewrites on meta. Currently, it will split stateful operators into two
-    /// fragments.
-    fn rewrite_stream_node(
-        state: &mut BuildFragmentGraphState,
-        stream_node: StreamNode,
-        insert_exchange_flag: bool,
-    ) -> Result<StreamNode> {
-        let f = |child| {
-            // For stateful operators, set `exchange_flag = true`. If it's already true,
-            // force add an exchange.
-            if Self::is_stateful_executor(&child) {
-                if insert_exchange_flag {
-                    let child_node = Self::rewrite_stream_node(state, child, true)?;
-
-                    let strategy = DispatchStrategy {
-                        r#type: DispatcherType::NoShuffle.into(),
-                        column_indices: vec![], // TODO: use distribution key
-                    };
-                    Ok(StreamNode {
-                        stream_key: child_node.stream_key.clone(),
-                        fields: child_node.fields.clone(),
-                        node_body: Some(NodeBody::Exchange(ExchangeNode {
-                            strategy: Some(strategy),
-                        })),
-                        operator_id: state.gen_operator_id() as u64,
-                        append_only: child_node.append_only,
-                        input: vec![child_node],
-                        identity: "Exchange (NoShuffle)".to_string(),
-                    })
-                } else {
-                    Self::rewrite_stream_node(state, child, true)
-                }
+                let strategy = DispatchStrategy {
+                    r#type: DispatcherType::NoShuffle.into(),
+                    column_indices: vec![], // TODO: use distribution key
+                };
+                Ok(StreamNode {
+                    stream_key: child_node.stream_key.clone(),
+                    fields: child_node.fields.clone(),
+                    node_body: Some(NodeBody::Exchange(ExchangeNode {
+                        strategy: Some(strategy),
+                    })),
+                    operator_id: state.gen_operator_id() as u64,
+                    append_only: child_node.append_only,
+                    input: vec![child_node],
+                    identity: "Exchange (NoShuffle)".to_string(),
+                })
             } else {
-                match child.get_node_body()? {
-                    // For exchanges, reset the flag.
-                    NodeBody::Exchange(_) => Self::rewrite_stream_node(state, child, false),
-                    // Otherwise, recursively visit the children.
-                    _ => Self::rewrite_stream_node(state, child, insert_exchange_flag),
-                }
+                rewrite_stream_node(state, child, true)
             }
-        };
-        Ok(StreamNode {
-            input: stream_node
-                .input
-                .into_iter()
-                .map(f)
-                .collect::<Result<_>>()?,
-            ..stream_node
-        })
-    }
-
-    /// Generate fragment DAG from input streaming plan by their dependency.
-    fn generate_fragment_graph(
-        state: &mut BuildFragmentGraphState,
-        stream_node: StreamNode,
-    ) -> Result<()> {
-        let stateful = Self::is_stateful_executor(&stream_node);
-        let stream_node = Self::rewrite_stream_node(state, stream_node, stateful)?;
-        Self::build_and_add_fragment(state, stream_node)?;
-        Ok(())
-    }
-
-    /// Use the given `stream_node` to create a fragment and add it to graph.
-    fn build_and_add_fragment(
-        state: &mut BuildFragmentGraphState,
-        stream_node: StreamNode,
-    ) -> Result<StreamFragment> {
-        let mut fragment = state.new_stream_fragment();
-        let node = Self::build_fragment(state, &mut fragment, stream_node)?;
-
-        assert!(fragment.node.is_none());
-        fragment.node = Some(Box::new(node));
-
-        state.fragment_graph.add_fragment(fragment.clone());
-        Ok(fragment)
-    }
-
-    /// Build new fragment and link dependencies by visiting children recursively, update
-    /// `is_singleton` and `fragment_type` properties for current fragment. While traversing the
-    /// tree, count how many table ids should be allocated in this fragment.
-    // TODO: Should we store the concurrency in StreamFragment directly?
-    fn build_fragment(
-        state: &mut BuildFragmentGraphState,
-        current_fragment: &mut StreamFragment,
-        mut stream_node: StreamNode,
-    ) -> Result<StreamNode> {
-        // Update current fragment based on the node we're visiting.
-        match stream_node.get_node_body()? {
-            NodeBody::Source(_) => current_fragment.fragment_type = FragmentType::Source,
-
-            NodeBody::Materialize(_) => current_fragment.fragment_type = FragmentType::Sink,
-
-            // TODO: Force singleton for TopN as a workaround. We should implement two phase TopN.
-            NodeBody::TopN(_) => current_fragment.is_singleton = true,
-
-            // FIXME: workaround for single-fragment mview on singleton upstream mview.
-            NodeBody::Chain(node) => {
-                // memorize table id for later use
-                state
-                    .dependent_table_ids
-                    .insert(TableId::new(node.table_id));
-                current_fragment.upstream_table_ids.push(node.table_id);
-                current_fragment.is_singleton = node.is_singleton;
-            }
-
-            _ => {}
-        };
-
-        Self::assign_local_table_id_to_stream_node(state, &mut stream_node);
-
-        // handle join logic
-        if let NodeBody::DeltaIndexJoin(delta_index_join) = stream_node.node_body.as_mut().unwrap()
-        {
-            if delta_index_join.get_join_type()? == JoinType::Inner
-                && delta_index_join.condition.is_none()
-            {
-                return Self::build_delta_join_without_arrange(
-                    state,
-                    current_fragment,
-                    stream_node,
-                );
-            } else {
-                panic!("only inner join without non-equal condition is supported for delta joins");
+        } else {
+            match child.get_node_body()? {
+                // For exchanges, reset the flag.
+                NodeBody::Exchange(_) => rewrite_stream_node(state, child, false),
+                // Otherwise, recursively visit the children.
+                _ => rewrite_stream_node(state, child, insert_exchange_flag),
             }
         }
-
-        // Visit plan children.
-        stream_node.input = stream_node
+    };
+    Ok(StreamNode {
+        input: stream_node
             .input
             .into_iter()
-            .map(|mut child_node| -> Result<StreamNode> {
-                match child_node.get_node_body()? {
-                    // When exchange node is generated when doing rewrites, it could be having
-                    // zero input. In this case, we won't recursively visit its children.
-                    NodeBody::Exchange(_) if child_node.input.is_empty() => Ok(child_node),
-                    // Exchange node indicates a new child fragment.
-                    NodeBody::Exchange(exchange_node) => {
-                        let exchange_node_strategy = exchange_node.get_strategy()?.clone();
+            .map(f)
+            .collect::<Result<_>>()?,
+        ..stream_node
+    })
+}
 
-                        let is_simple_dispatcher =
-                            exchange_node_strategy.get_type()? == DispatcherType::Simple;
+/// Generate fragment DAG from input streaming plan by their dependency.
+fn generate_fragment_graph(
+    state: &mut BuildFragmentGraphState,
+    stream_node: StreamNode,
+) -> Result<()> {
+    let stateful = is_stateful_executor(&stream_node);
+    let stream_node = rewrite_stream_node(state, stream_node, stateful)?;
+    build_and_add_fragment(state, stream_node)?;
+    Ok(())
+}
 
-                        assert_eq!(child_node.input.len(), 1);
-                        let child_fragment =
-                            Self::build_and_add_fragment(state, child_node.input.remove(0))?;
-                        state.fragment_graph.add_edge(
-                            child_fragment.fragment_id,
-                            current_fragment.fragment_id,
-                            StreamFragmentEdge {
-                                dispatch_strategy: exchange_node_strategy,
-                                same_worker_node: false,
-                                link_id: child_node.operator_id,
-                            },
-                        );
+/// Use the given `stream_node` to create a fragment and add it to graph.
+pub(self) fn build_and_add_fragment(
+    state: &mut BuildFragmentGraphState,
+    stream_node: StreamNode,
+) -> Result<StreamFragment> {
+    let mut fragment = state.new_stream_fragment();
+    let node = build_fragment(state, &mut fragment, stream_node)?;
 
-                        if is_simple_dispatcher {
-                            current_fragment.is_singleton = true;
-                        }
-                        Ok(child_node)
-                    }
+    assert!(fragment.node.is_none());
+    fragment.node = Some(Box::new(node));
 
-                    // For other children, visit recursively.
-                    _ => Self::build_fragment(state, current_fragment, child_node),
-                }
-            })
-            .try_collect()?;
-        Ok(stream_node)
+    state.fragment_graph.add_fragment(fragment.clone());
+    Ok(fragment)
+}
+
+/// Build new fragment and link dependencies by visiting children recursively, update
+/// `is_singleton` and `fragment_type` properties for current fragment. While traversing the
+/// tree, count how many table ids should be allocated in this fragment.
+// TODO: Should we store the concurrency in StreamFragment directly?
+fn build_fragment(
+    state: &mut BuildFragmentGraphState,
+    current_fragment: &mut StreamFragment,
+    mut stream_node: StreamNode,
+) -> Result<StreamNode> {
+    // Update current fragment based on the node we're visiting.
+    match stream_node.get_node_body()? {
+        NodeBody::Source(_) => current_fragment.fragment_type = FragmentType::Source,
+
+        NodeBody::Materialize(_) => current_fragment.fragment_type = FragmentType::Sink,
+
+        // TODO: Force singleton for TopN as a workaround. We should implement two phase TopN.
+        NodeBody::TopN(_) => current_fragment.is_singleton = true,
+
+        // FIXME: workaround for single-fragment mview on singleton upstream mview.
+        NodeBody::Chain(node) => {
+            // memorize table id for later use
+            state
+                .dependent_table_ids
+                .insert(TableId::new(node.table_id));
+            current_fragment.upstream_table_ids.push(node.table_id);
+            current_fragment.is_singleton = node.is_singleton;
+        }
+
+        _ => {}
+    };
+
+    assign_local_table_id_to_stream_node(state, &mut stream_node);
+
+    // handle join logic
+    if let NodeBody::DeltaIndexJoin(delta_index_join) = stream_node.node_body.as_mut().unwrap() {
+        if delta_index_join.get_join_type()? == JoinType::Inner
+            && delta_index_join.condition.is_none()
+        {
+            return build_delta_join_without_arrange(state, current_fragment, stream_node);
+        } else {
+            panic!("only inner join without non-equal condition is supported for delta joins");
+        }
     }
 
-    /// This function assigns the `table_id` based on the type of `StreamNode`
-    /// Be careful it has side effects and will change the `StreamNode`
-    fn assign_local_table_id_to_stream_node(
-        state: &mut BuildFragmentGraphState,
-        stream_node: &mut StreamNode,
-    ) {
-        match stream_node.node_body.as_mut().unwrap() {
-            // For HashJoin nodes, attempting to rewrite to delta joins only on inner join
-            // with only equal conditions
-            NodeBody::HashJoin(hash_join_node) => {
-                // Allocate local table id. It will be rewrite to global table id after get table id
-                // offset from id generator.
-                if let Some(left_table) = &mut hash_join_node.left_table {
-                    left_table.id = state.gen_table_id();
-                }
-                if let Some(right_table) = &mut hash_join_node.right_table {
-                    right_table.id = state.gen_table_id();
-                }
-            }
+    // Visit plan children.
+    stream_node.input = stream_node
+        .input
+        .into_iter()
+        .map(|mut child_node| {
+            match child_node.get_node_body()? {
+                // When exchange node is generated when doing rewrites, it could be having
+                // zero input. In this case, we won't recursively visit its children.
+                NodeBody::Exchange(_) if child_node.input.is_empty() => Ok(child_node),
+                // Exchange node indicates a new child fragment.
+                NodeBody::Exchange(exchange_node) => {
+                    let exchange_node_strategy = exchange_node.get_strategy()?.clone();
 
-            NodeBody::Source(node) => {
-                node.state_table_id = state.gen_table_id();
-            }
+                    let is_simple_dispatcher =
+                        exchange_node_strategy.get_type()? == DispatcherType::Simple;
 
-            NodeBody::GlobalSimpleAgg(node) => {
-                for table in &mut node.internal_tables {
-                    table.id = state.gen_table_id();
+                    assert_eq!(child_node.input.len(), 1);
+                    let child_fragment = build_and_add_fragment(state, child_node.input.remove(0))?;
+                    state.fragment_graph.add_edge(
+                        child_fragment.fragment_id,
+                        current_fragment.fragment_id,
+                        StreamFragmentEdge {
+                            dispatch_strategy: exchange_node_strategy,
+                            same_worker_node: false,
+                            link_id: child_node.operator_id,
+                        },
+                    );
+
+                    if is_simple_dispatcher {
+                        current_fragment.is_singleton = true;
+                    }
+                    Ok(child_node)
                 }
-            }
 
-            // Rewrite hash agg. One agg call -> one table id.
-            NodeBody::HashAgg(hash_agg_node) => {
-                for table in &mut hash_agg_node.internal_tables {
-                    table.id = state.gen_table_id();
-                }
+                // For other children, visit recursively.
+                _ => build_fragment(state, current_fragment, child_node),
             }
+        })
+        .collect::<Result<_>>()?;
+    Ok(stream_node)
+}
 
-            NodeBody::TopN(top_n_node) => {
-                if let Some(table) = &mut top_n_node.table {
-                    table.id = state.gen_table_id();
-                } else {
-                    panic!("TopNNode's table shouldn't be None");
-                }
+/// This function assigns the `table_id` based on the type of `StreamNode`
+/// Be careful it has side effects and will change the `StreamNode`
+fn assign_local_table_id_to_stream_node(
+    state: &mut BuildFragmentGraphState,
+    stream_node: &mut StreamNode,
+) {
+    match stream_node.node_body.as_mut().unwrap() {
+        // For HashJoin nodes, attempting to rewrite to delta joins only on inner join
+        // with only equal conditions
+        NodeBody::HashJoin(hash_join_node) => {
+            // Allocate local table id. It will be rewrite to global table id after get table id
+            // offset from id generator.
+            if let Some(left_table) = &mut hash_join_node.left_table {
+                left_table.id = state.gen_table_id();
             }
-
-            NodeBody::GroupTopN(group_top_n_node) => {
-                if let Some(table) = &mut group_top_n_node.table {
-                    table.id = state.gen_table_id();
-                } else {
-                    panic!("GroupTopNNode's table shouldn't be None");
-                }
+            if let Some(right_table) = &mut hash_join_node.right_table {
+                right_table.id = state.gen_table_id();
             }
-
-            NodeBody::AppendOnlyTopN(append_only_top_n_node) => {
-                append_only_top_n_node.table_id_l = state.gen_table_id();
-                append_only_top_n_node.table_id_h = state.gen_table_id();
-            }
-
-            NodeBody::DynamicFilter(dynamic_filter_node) => {
-                if let Some(left_table) = &mut dynamic_filter_node.left_table {
-                    left_table.id = state.gen_table_id();
-                }
-                if let Some(right_table) = &mut dynamic_filter_node.right_table {
-                    right_table.id = state.gen_table_id();
-                }
-            }
-
-            _ => {}
         }
+
+        NodeBody::Source(node) => {
+            node.state_table_id = state.gen_table_id();
+        }
+
+        NodeBody::GlobalSimpleAgg(node) => {
+            for table in &mut node.internal_tables {
+                table.id = state.gen_table_id();
+            }
+        }
+
+        // Rewrite hash agg. One agg call -> one table id.
+        NodeBody::HashAgg(hash_agg_node) => {
+            for table in &mut hash_agg_node.internal_tables {
+                table.id = state.gen_table_id();
+            }
+        }
+
+        NodeBody::TopN(top_n_node) => {
+            if let Some(table) = &mut top_n_node.table {
+                table.id = state.gen_table_id();
+            } else {
+                panic!("TopNNode's table shouldn't be None");
+            }
+        }
+
+        NodeBody::GroupTopN(group_top_n_node) => {
+            if let Some(table) = &mut group_top_n_node.table {
+                table.id = state.gen_table_id();
+            } else {
+                panic!("GroupTopNNode's table shouldn't be None");
+            }
+        }
+
+        NodeBody::AppendOnlyTopN(append_only_top_n_node) => {
+            append_only_top_n_node.table_id_l = state.gen_table_id();
+            append_only_top_n_node.table_id_h = state.gen_table_id();
+        }
+
+        NodeBody::DynamicFilter(dynamic_filter_node) => {
+            if let Some(left_table) = &mut dynamic_filter_node.left_table {
+                left_table.id = state.gen_table_id();
+            }
+            if let Some(right_table) = &mut dynamic_filter_node.right_table {
+                right_table.id = state.gen_table_id();
+            }
+        }
+
+        _ => {}
     }
 }
 
@@ -439,7 +453,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
 
             if let NodeBody::HashJoin(hash_join_node) = stream_node.node_body.as_ref().unwrap() {
                 expect_table_id += 1;
@@ -473,7 +487,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
 
             if let NodeBody::GlobalSimpleAgg(global_simple_agg_node) =
                 stream_node.node_body.as_ref().unwrap()
@@ -509,7 +523,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
 
             if let NodeBody::HashAgg(hash_agg_node) = stream_node.node_body.as_ref().unwrap() {
                 assert_eq!(
@@ -535,7 +549,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
             if let NodeBody::TopN(top_n_node) = stream_node.node_body.as_ref().unwrap() {
                 expect_table_id += 1;
                 assert_eq!(expect_table_id, top_n_node.table.as_ref().unwrap().id);
@@ -553,7 +567,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
             if let NodeBody::GroupTopN(node) = stream_node.node_body.as_ref().unwrap() {
                 expect_table_id += 1;
                 assert_eq!(expect_table_id, node.table.as_ref().unwrap().id);
@@ -568,7 +582,7 @@ mod tests {
                 })),
                 ..Default::default()
             };
-            StreamFragmenter::assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
+            assign_local_table_id_to_stream_node(&mut state, &mut stream_node);
 
             if let NodeBody::AppendOnlyTopN(append_only_top_n_node) =
                 stream_node.node_body.as_ref().unwrap()

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -267,7 +267,7 @@ fn build_delta_join_inner(
     Ok(union)
 }
 
-pub(in super::super) fn build_delta_join_without_arrange(
+pub(crate) fn build_delta_join_without_arrange(
     state: &mut BuildFragmentGraphState,
     current_fragment: &mut StreamFragment,
     mut node: StreamNode,

--- a/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/delta_join.rs
@@ -25,311 +25,310 @@ use risingwave_pb::stream_plan::{
     StreamNode,
 };
 
-use super::super::{BuildFragmentGraphState, StreamFragment, StreamFragmentEdge, StreamFragmenter};
+use super::super::{BuildFragmentGraphState, StreamFragment, StreamFragmentEdge};
 use crate::catalog::TableCatalog;
 use crate::optimizer::plan_node::utils::TableCatalogBuilder;
+use crate::stream_fragmenter::build_and_add_fragment;
 
-impl StreamFragmenter {
-    /// All exchanges inside delta join is one-to-one exchange.
-    fn build_exchange_for_delta_join(
-        state: &mut BuildFragmentGraphState,
-        upstream: &StreamNode,
-    ) -> StreamNode {
-        StreamNode {
-            operator_id: state.gen_operator_id() as u64,
-            identity: "Exchange (Lookup and Merge)".into(),
-            fields: upstream.fields.clone(),
-            stream_key: upstream.stream_key.clone(),
-            node_body: Some(NodeBody::Exchange(ExchangeNode {
-                strategy: Some(Self::dispatch_no_shuffle()),
-            })),
-            input: vec![],
-            append_only: upstream.append_only,
-        }
+/// All exchanges inside delta join is one-to-one exchange.
+fn build_exchange_for_delta_join(
+    state: &mut BuildFragmentGraphState,
+    upstream: &StreamNode,
+) -> StreamNode {
+    StreamNode {
+        operator_id: state.gen_operator_id() as u64,
+        identity: "Exchange (Lookup and Merge)".into(),
+        fields: upstream.fields.clone(),
+        stream_key: upstream.stream_key.clone(),
+        node_body: Some(NodeBody::Exchange(ExchangeNode {
+            strategy: Some(dispatch_no_shuffle()),
+        })),
+        input: vec![],
+        append_only: upstream.append_only,
     }
+}
 
-    fn dispatch_no_shuffle() -> DispatchStrategy {
-        DispatchStrategy {
-            r#type: DispatcherType::NoShuffle.into(),
-            column_indices: vec![],
-        }
+fn dispatch_no_shuffle() -> DispatchStrategy {
+    DispatchStrategy {
+        r#type: DispatcherType::NoShuffle.into(),
+        column_indices: vec![],
     }
+}
 
-    fn build_lookup_for_delta_join(
-        state: &mut BuildFragmentGraphState,
-        (exchange_node_arrangement, exchange_node_stream): (&StreamNode, &StreamNode),
-        (output_fields, output_stream_key): (Vec<ProstField>, Vec<u32>),
-        lookup_node: LookupNode,
-    ) -> StreamNode {
-        StreamNode {
-            operator_id: state.gen_operator_id() as u64,
-            identity: "Lookup".into(),
-            fields: output_fields,
-            stream_key: output_stream_key,
-            node_body: Some(NodeBody::Lookup(lookup_node)),
-            input: vec![
-                exchange_node_arrangement.clone(),
-                exchange_node_stream.clone(),
-            ],
-            append_only: exchange_node_stream.append_only,
-        }
+fn build_lookup_for_delta_join(
+    state: &mut BuildFragmentGraphState,
+    (exchange_node_arrangement, exchange_node_stream): (&StreamNode, &StreamNode),
+    (output_fields, output_stream_key): (Vec<ProstField>, Vec<u32>),
+    lookup_node: LookupNode,
+) -> StreamNode {
+    StreamNode {
+        operator_id: state.gen_operator_id() as u64,
+        identity: "Lookup".into(),
+        fields: output_fields,
+        stream_key: output_stream_key,
+        node_body: Some(NodeBody::Lookup(lookup_node)),
+        input: vec![
+            exchange_node_arrangement.clone(),
+            exchange_node_stream.clone(),
+        ],
+        append_only: exchange_node_stream.append_only,
     }
+}
 
-    fn build_delta_join_inner(
-        state: &mut BuildFragmentGraphState,
-        current_fragment: &mut StreamFragment,
-        arrange_0_frag: StreamFragment,
-        arrange_1_frag: StreamFragment,
-        node: &StreamNode,
-        is_local_table_id: bool,
-    ) -> Result<StreamNode> {
-        let delta_join_node = match &node.node_body {
-            Some(NodeBody::DeltaIndexJoin(node)) => node,
-            _ => unreachable!(),
-        };
-        let output_indices = &delta_join_node.output_indices;
+fn build_delta_join_inner(
+    state: &mut BuildFragmentGraphState,
+    current_fragment: &mut StreamFragment,
+    arrange_0_frag: StreamFragment,
+    arrange_1_frag: StreamFragment,
+    node: &StreamNode,
+    is_local_table_id: bool,
+) -> Result<StreamNode> {
+    let delta_join_node = match &node.node_body {
+        Some(NodeBody::DeltaIndexJoin(node)) => node,
+        _ => unreachable!(),
+    };
+    let output_indices = &delta_join_node.output_indices;
 
-        let arrange_0 = arrange_0_frag.node.as_ref().unwrap();
-        let arrange_1 = arrange_1_frag.node.as_ref().unwrap();
-        let exchange_a0l0 = Self::build_exchange_for_delta_join(state, arrange_0);
-        let exchange_a0l1 = Self::build_exchange_for_delta_join(state, arrange_0);
-        let exchange_a1l0 = Self::build_exchange_for_delta_join(state, arrange_1);
-        let exchange_a1l1 = Self::build_exchange_for_delta_join(state, arrange_1);
+    let arrange_0 = arrange_0_frag.node.as_ref().unwrap();
+    let arrange_1 = arrange_1_frag.node.as_ref().unwrap();
+    let exchange_a0l0 = build_exchange_for_delta_join(state, arrange_0);
+    let exchange_a0l1 = build_exchange_for_delta_join(state, arrange_0);
+    let exchange_a1l0 = build_exchange_for_delta_join(state, arrange_1);
+    let exchange_a1l1 = build_exchange_for_delta_join(state, arrange_1);
 
-        let i0_length = arrange_0.fields.len();
-        let i1_length = arrange_1.fields.len();
+    let i0_length = arrange_0.fields.len();
+    let i1_length = arrange_1.fields.len();
 
-        let lookup_0_column_reordering = {
-            let tmp: Vec<i32> = (i1_length..i1_length + i0_length)
-                .chain(0..i1_length)
-                .map(|x| x as _)
-                .collect_vec();
-            output_indices
-                .iter()
-                .map(|&x| tmp[x as usize])
-                .collect_vec()
-        };
-        // lookup left table by right stream
-        let lookup_0 = Self::build_lookup_for_delta_join(
-            state,
-            (&exchange_a1l0, &exchange_a0l0),
-            (node.fields.clone(), node.stream_key.clone()),
-            LookupNode {
-                stream_key: delta_join_node.right_key.clone(),
-                arrange_key: delta_join_node.left_key.clone(),
-                use_current_epoch: false,
-                // will be updated later to a global id
-                arrangement_table_id: if is_local_table_id {
-                    Some(ArrangementTableId::TableId(delta_join_node.left_table_id))
-                } else {
-                    Some(ArrangementTableId::IndexId(delta_join_node.left_table_id))
-                },
-                column_mapping: lookup_0_column_reordering,
-                arrangement_table_info: delta_join_node.left_info.clone(),
-                arrangement_table: Some(
-                    Self::infer_internal_table_catalog(
-                        delta_join_node.left_info.as_ref(),
-                        // Use Arrange node's dist key.
-                        try_match_expand!(arrange_0.get_node_body().unwrap(), NodeBody::Arrange)?
-                            .distribution_key
-                            .clone()
-                            .iter()
-                            .map(|x| *x as usize)
-                            .collect(),
-                        exchange_a0l0.append_only,
-                    )
-                    .to_state_table_prost(),
-                ),
-            },
-        );
-        let lookup_1_column_reordering = {
-            let tmp: Vec<i32> = (0..i0_length + i1_length)
-                .chain(0..i1_length)
-                .map(|x| x as _)
-                .collect_vec();
-            output_indices
-                .iter()
-                .map(|&x| tmp[x as usize])
-                .collect_vec()
-        };
-        // lookup right table by left stream
-        let lookup_1 = Self::build_lookup_for_delta_join(
-            state,
-            (&exchange_a0l1, &exchange_a1l1),
-            (node.fields.clone(), node.stream_key.clone()),
-            LookupNode {
-                stream_key: delta_join_node.left_key.clone(),
-                arrange_key: delta_join_node.right_key.clone(),
-                use_current_epoch: true,
-                // will be updated later to a global id
-                arrangement_table_id: if is_local_table_id {
-                    Some(ArrangementTableId::TableId(delta_join_node.right_table_id))
-                } else {
-                    Some(ArrangementTableId::IndexId(delta_join_node.right_table_id))
-                },
-                column_mapping: lookup_1_column_reordering,
-                arrangement_table_info: delta_join_node.right_info.clone(),
-                arrangement_table: Some(
-                    Self::infer_internal_table_catalog(
-                        delta_join_node.right_info.as_ref(),
-                        // Use Arrange node's dist key.
-                        try_match_expand!(arrange_1.get_node_body().unwrap(), NodeBody::Arrange)?
-                            .distribution_key
-                            .clone()
-                            .iter()
-                            .map(|x| *x as usize)
-                            .collect(),
-                        exchange_a1l1.append_only,
-                    )
-                    .to_state_table_prost(),
-                ),
-            },
-        );
-
-        let lookup_0_frag = Self::build_and_add_fragment(state, lookup_0)?;
-        let lookup_1_frag = Self::build_and_add_fragment(state, lookup_1)?;
-
-        state.fragment_graph.add_edge(
-            arrange_0_frag.fragment_id,
-            lookup_0_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: true,
-                link_id: exchange_a0l0.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_0_frag.fragment_id,
-            lookup_1_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                // stream input doesn't need to be on the same worker node as lookup
-                same_worker_node: false,
-                link_id: exchange_a0l1.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_1_frag.fragment_id,
-            lookup_0_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                // stream input doesn't need to be on the same worker node as lookup
-                same_worker_node: false,
-                link_id: exchange_a1l0.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            arrange_1_frag.fragment_id,
-            lookup_1_frag.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: true,
-                link_id: exchange_a1l1.operator_id,
-            },
-        );
-
-        let exchange_l0m = Self::build_exchange_for_delta_join(state, node);
-        let exchange_l1m = Self::build_exchange_for_delta_join(state, node);
-
-        let union = StreamNode {
-            operator_id: state.gen_operator_id() as u64,
-            identity: "Union".into(),
-            fields: node.fields.clone(),
-            stream_key: node.stream_key.clone(),
-            node_body: Some(NodeBody::LookupUnion(LookupUnionNode { order: vec![1, 0] })),
-            input: vec![exchange_l0m.clone(), exchange_l1m.clone()],
-            append_only: node.append_only,
-        };
-
-        state.fragment_graph.add_edge(
-            lookup_0_frag.fragment_id,
-            current_fragment.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_l0m.operator_id,
-            },
-        );
-
-        state.fragment_graph.add_edge(
-            lookup_1_frag.fragment_id,
-            current_fragment.fragment_id,
-            StreamFragmentEdge {
-                dispatch_strategy: Self::dispatch_no_shuffle(),
-                same_worker_node: false,
-                link_id: exchange_l1m.operator_id,
-            },
-        );
-
-        Ok(union)
-    }
-
-    pub(in super::super) fn build_delta_join_without_arrange(
-        state: &mut BuildFragmentGraphState,
-        current_fragment: &mut StreamFragment,
-        mut node: StreamNode,
-    ) -> Result<StreamNode> {
-        match &node.node_body {
-            Some(NodeBody::DeltaIndexJoin(node)) => node,
-            _ => unreachable!(),
-        };
-
-        let [arrange_0, arrange_1]: [_; 2] = std::mem::take(&mut node.input).try_into().unwrap();
-
-        // TODO: when distribution key is added to catalog, chain and delta join won't have any
-        // exchange in-between. Then we can safely remove this function.
-        fn pass_through_exchange(mut node: StreamNode) -> StreamNode {
-            if let Some(NodeBody::Exchange(exchange)) = node.node_body {
-                if let DispatcherType::NoShuffle =
-                    exchange.strategy.as_ref().unwrap().get_type().unwrap()
-                {
-                    return node.input.remove(0);
-                }
-                panic!("exchange other than no_shuffle not allowed between delta join and arrange");
+    let lookup_0_column_reordering = {
+        let tmp: Vec<i32> = (i1_length..i1_length + i0_length)
+            .chain(0..i1_length)
+            .map(|x| x as _)
+            .collect_vec();
+        output_indices
+            .iter()
+            .map(|&x| tmp[x as usize])
+            .collect_vec()
+    };
+    // lookup left table by right stream
+    let lookup_0 = build_lookup_for_delta_join(
+        state,
+        (&exchange_a1l0, &exchange_a0l0),
+        (node.fields.clone(), node.stream_key.clone()),
+        LookupNode {
+            stream_key: delta_join_node.right_key.clone(),
+            arrange_key: delta_join_node.left_key.clone(),
+            use_current_epoch: false,
+            // will be updated later to a global id
+            arrangement_table_id: if is_local_table_id {
+                Some(ArrangementTableId::TableId(delta_join_node.left_table_id))
             } else {
-                unimplemented!()
+                Some(ArrangementTableId::IndexId(delta_join_node.left_table_id))
+            },
+            column_mapping: lookup_0_column_reordering,
+            arrangement_table_info: delta_join_node.left_info.clone(),
+            arrangement_table: Some(
+                infer_internal_table_catalog(
+                    delta_join_node.left_info.as_ref(),
+                    // Use Arrange node's dist key.
+                    try_match_expand!(arrange_0.get_node_body().unwrap(), NodeBody::Arrange)?
+                        .distribution_key
+                        .clone()
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    exchange_a0l0.append_only,
+                )
+                .to_state_table_prost(),
+            ),
+        },
+    );
+    let lookup_1_column_reordering = {
+        let tmp: Vec<i32> = (0..i0_length + i1_length)
+            .chain(0..i1_length)
+            .map(|x| x as _)
+            .collect_vec();
+        output_indices
+            .iter()
+            .map(|&x| tmp[x as usize])
+            .collect_vec()
+    };
+    // lookup right table by left stream
+    let lookup_1 = build_lookup_for_delta_join(
+        state,
+        (&exchange_a0l1, &exchange_a1l1),
+        (node.fields.clone(), node.stream_key.clone()),
+        LookupNode {
+            stream_key: delta_join_node.left_key.clone(),
+            arrange_key: delta_join_node.right_key.clone(),
+            use_current_epoch: true,
+            // will be updated later to a global id
+            arrangement_table_id: if is_local_table_id {
+                Some(ArrangementTableId::TableId(delta_join_node.right_table_id))
+            } else {
+                Some(ArrangementTableId::IndexId(delta_join_node.right_table_id))
+            },
+            column_mapping: lookup_1_column_reordering,
+            arrangement_table_info: delta_join_node.right_info.clone(),
+            arrangement_table: Some(
+                infer_internal_table_catalog(
+                    delta_join_node.right_info.as_ref(),
+                    // Use Arrange node's dist key.
+                    try_match_expand!(arrange_1.get_node_body().unwrap(), NodeBody::Arrange)?
+                        .distribution_key
+                        .clone()
+                        .iter()
+                        .map(|x| *x as usize)
+                        .collect(),
+                    exchange_a1l1.append_only,
+                )
+                .to_state_table_prost(),
+            ),
+        },
+    );
+
+    let lookup_0_frag = build_and_add_fragment(state, lookup_0)?;
+    let lookup_1_frag = build_and_add_fragment(state, lookup_1)?;
+
+    state.fragment_graph.add_edge(
+        arrange_0_frag.fragment_id,
+        lookup_0_frag.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            same_worker_node: true,
+            link_id: exchange_a0l0.operator_id,
+        },
+    );
+
+    state.fragment_graph.add_edge(
+        arrange_0_frag.fragment_id,
+        lookup_1_frag.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            // stream input doesn't need to be on the same worker node as lookup
+            same_worker_node: false,
+            link_id: exchange_a0l1.operator_id,
+        },
+    );
+
+    state.fragment_graph.add_edge(
+        arrange_1_frag.fragment_id,
+        lookup_0_frag.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            // stream input doesn't need to be on the same worker node as lookup
+            same_worker_node: false,
+            link_id: exchange_a1l0.operator_id,
+        },
+    );
+
+    state.fragment_graph.add_edge(
+        arrange_1_frag.fragment_id,
+        lookup_1_frag.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            same_worker_node: true,
+            link_id: exchange_a1l1.operator_id,
+        },
+    );
+
+    let exchange_l0m = build_exchange_for_delta_join(state, node);
+    let exchange_l1m = build_exchange_for_delta_join(state, node);
+
+    let union = StreamNode {
+        operator_id: state.gen_operator_id() as u64,
+        identity: "Union".into(),
+        fields: node.fields.clone(),
+        stream_key: node.stream_key.clone(),
+        node_body: Some(NodeBody::LookupUnion(LookupUnionNode { order: vec![1, 0] })),
+        input: vec![exchange_l0m.clone(), exchange_l1m.clone()],
+        append_only: node.append_only,
+    };
+
+    state.fragment_graph.add_edge(
+        lookup_0_frag.fragment_id,
+        current_fragment.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            same_worker_node: false,
+            link_id: exchange_l0m.operator_id,
+        },
+    );
+
+    state.fragment_graph.add_edge(
+        lookup_1_frag.fragment_id,
+        current_fragment.fragment_id,
+        StreamFragmentEdge {
+            dispatch_strategy: dispatch_no_shuffle(),
+            same_worker_node: false,
+            link_id: exchange_l1m.operator_id,
+        },
+    );
+
+    Ok(union)
+}
+
+pub(in super::super) fn build_delta_join_without_arrange(
+    state: &mut BuildFragmentGraphState,
+    current_fragment: &mut StreamFragment,
+    mut node: StreamNode,
+) -> Result<StreamNode> {
+    match &node.node_body {
+        Some(NodeBody::DeltaIndexJoin(node)) => node,
+        _ => unreachable!(),
+    };
+
+    let [arrange_0, arrange_1]: [_; 2] = std::mem::take(&mut node.input).try_into().unwrap();
+
+    // TODO: when distribution key is added to catalog, chain and delta join won't have any
+    // exchange in-between. Then we can safely remove this function.
+    fn pass_through_exchange(mut node: StreamNode) -> StreamNode {
+        if let Some(NodeBody::Exchange(exchange)) = node.node_body {
+            if let DispatcherType::NoShuffle =
+                exchange.strategy.as_ref().unwrap().get_type().unwrap()
+            {
+                return node.input.remove(0);
             }
+            panic!("exchange other than no_shuffle not allowed between delta join and arrange");
+        } else {
+            unimplemented!()
         }
-
-        let arrange_0 = pass_through_exchange(arrange_0);
-        let arrange_1 = pass_through_exchange(arrange_1);
-
-        let arrange_0_frag = Self::build_and_add_fragment(state, arrange_0)?;
-        let arrange_1_frag = Self::build_and_add_fragment(state, arrange_1)?;
-
-        let union = Self::build_delta_join_inner(
-            state,
-            current_fragment,
-            arrange_0_frag,
-            arrange_1_frag,
-            &node,
-            false,
-        )?;
-
-        Ok(union)
     }
 
-    fn infer_internal_table_catalog(
-        arrangement_info: Option<&ArrangementInfo>,
-        distribution_key: Vec<usize>,
-        append_only: bool,
-    ) -> TableCatalog {
-        let arrangement_info = arrangement_info.unwrap();
-        let mut internal_table_catalog_builder = TableCatalogBuilder::new();
-        for column_desc in &arrangement_info.column_descs {
-            internal_table_catalog_builder.add_column(&Field::from(&ColumnDesc::from(column_desc)));
-        }
+    let arrange_0 = pass_through_exchange(arrange_0);
+    let arrange_1 = pass_through_exchange(arrange_1);
 
-        for order in &arrangement_info.arrange_key_orders {
-            internal_table_catalog_builder.add_order_column(
-                order.index as usize,
-                OrderType::from_prost(&ProstOrderType::from_i32(order.order_type).unwrap()),
-            );
-        }
+    let arrange_0_frag = build_and_add_fragment(state, arrange_0)?;
+    let arrange_1_frag = build_and_add_fragment(state, arrange_1)?;
 
-        internal_table_catalog_builder.build(distribution_key, append_only)
+    let union = build_delta_join_inner(
+        state,
+        current_fragment,
+        arrange_0_frag,
+        arrange_1_frag,
+        &node,
+        false,
+    )?;
+
+    Ok(union)
+}
+
+fn infer_internal_table_catalog(
+    arrangement_info: Option<&ArrangementInfo>,
+    distribution_key: Vec<usize>,
+    append_only: bool,
+) -> TableCatalog {
+    let arrangement_info = arrangement_info.unwrap();
+    let mut internal_table_catalog_builder = TableCatalogBuilder::new();
+    for column_desc in &arrangement_info.column_descs {
+        internal_table_catalog_builder.add_column(&Field::from(&ColumnDesc::from(column_desc)));
     }
+
+    for order in &arrangement_info.arrange_key_orders {
+        internal_table_catalog_builder.add_order_column(
+            order.index as usize,
+            OrderType::from_prost(&ProstOrderType::from_i32(order.order_type).unwrap()),
+        );
+    }
+
+    internal_table_catalog_builder.build(distribution_key, append_only)
 }

--- a/src/frontend/src/stream_fragmenter/rewrite/mod.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/mod.rs
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 mod delta_join;
-pub(super) use delta_join::build_delta_join_without_arrange;
+pub(crate) use delta_join::build_delta_join_without_arrange;

--- a/src/frontend/src/stream_fragmenter/rewrite/mod.rs
+++ b/src/frontend/src/stream_fragmenter/rewrite/mod.rs
@@ -13,3 +13,4 @@
 // limitations under the License.
 
 mod delta_join;
+pub(super) use delta_join::build_delta_join_without_arrange;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

+ Removed struct `StreamFragmenter`
+ Publicize `BuildFragmentGraphState` at crate level for future refactoring

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

Not really needed -- the change list is pretty much the documentation (and it's just three lines!)

## Refer to a related PR or issue link (optional)

#3684