### PR TITLE
feat(streaming): support configuration change on simple dispatcher

### DIFF
--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -787,11 +787,8 @@ impl Dispatcher for SimpleDispatcher {
     }
 
     fn remove_outputs(&mut self, actor_ids: &HashSet<ActorId>) {
-        let actor_id = actor_ids
-            .iter()
-            .exactly_one()
-            .expect("expect exactly one to remove");
-        self.output.retain(|output| output.actor_id() != *actor_id);
+        self.output
+            .retain(|output| !actor_ids.contains(&output.actor_id()));
     }
 
     fn dispatcher_id(&self) -> DispatcherId {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

When testing migration in #4956, we find that simple dispatcher does not support updating now. According to our design, the `Update` barrier should be forwarded to all outputs, including the to-be-removed ones and to-be-added ones. Therefore, the simple dispatcher need to hold 2 outputs temporarily. The old one will be dropped before we finish processing the `Update` mutation, so we assert the data chunk should always be dispatched to exactly one actor.

Note: `Update` on the receiver executor (a special version of merge executor with only 1 receiver) is still not implemented yet. I'm considering whether to replace all receiver executors with merge executors in our system.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #4956