### PR TITLE
fix: delete not null of first query demo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ psql -h localhost -p 4566 -d dev -U root
 
 ```sql
 /* create a table */
-create table t1(v1 int not null);
+create table t1(v1 int);
 
 /* create a materialized view based on the previous table */
 create materialized view mv1 as select sum(v1) as sum_v1 from t1;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

I'm trying out the first query from README.md but it failed. It turns out NOT NULL constraint is deleted (https://github.com/RisingWaveLabs/risingwave/issues/4513). So I delete NOT NULL constraint too in README.md.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/RisingWaveLabs/risingwave/issues/4513