### PR TITLE
feat(binder): bind FETCH

### DIFF
--- a/src/frontend/test_runner/tests/testdata/limit.yaml
+++ b/src/frontend/test_runner/tests/testdata/limit.yaml
@@ -22,3 +22,30 @@
         LogicalLimit { limit: 5, offset: 0 }
           LogicalProject { exprs: [t.v] }
             LogicalScan { table: t, columns: [t.v, t._row_id] }
+- sql: |
+    create table t (v int);
+    select * from t fetch first 4 rows only;
+  logical_plan: |
+    LogicalLimit { limit: 4, offset: 0 }
+      LogicalProject { exprs: [t.v] }
+        LogicalScan { table: t, columns: [t.v, t._row_id] }
+- sql: |
+    create table t (v int);
+    select * from t offset 3 fetch first 4 rows only;
+  logical_plan: |
+    LogicalLimit { limit: 4, offset: 3 }
+      LogicalProject { exprs: [t.v] }
+        LogicalScan { table: t, columns: [t.v, t._row_id] }
+- sql: |
+    create table t (v int);
+    select * from t fetch next rows only;
+  logical_plan: |
+    LogicalLimit { limit: 1, offset: 0 }
+      LogicalProject { exprs: [t.v] }
+        LogicalScan { table: t, columns: [t.v, t._row_id] }
+- sql: |
+    create table t (v int);
+    select * from t fetch next rows with ties;
+  binder_error: |-
+    Feature is not yet implemented: WITH TIES is not supported
+    No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml

--- a/src/frontend/test_runner/tests/testdata/limit.yaml
+++ b/src/frontend/test_runner/tests/testdata/limit.yaml
@@ -45,7 +45,7 @@
         LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
-    select * from t fetch next rows with ties;
+    select * from t order by v fetch next rows with ties;
   binder_error: |-
     Feature is not yet implemented: WITH TIES is not supported
     No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -37,9 +37,8 @@ pub use self::ddl::{
 };
 pub use self::operator::{BinaryOperator, UnaryOperator};
 pub use self::query::{
-    Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, Offset, OffsetRows, OrderByExpr,
-    Query, Select, SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top,
-    Values, With,
+    Cte, Fetch, Join, JoinConstraint, JoinOperator, LateralView, OrderByExpr, Query, Select,
+    SelectItem, SetExpr, SetOperator, TableAlias, TableFactor, TableWithJoins, Top, Values, With,
 };
 pub use self::statement::*;
 pub use self::value::{DateTimeField, TrimWhereField, Value};

--- a/src/sqlparser/src/ast/query.rs
+++ b/src/sqlparser/src/ast/query.rs
@@ -43,22 +43,6 @@ pub struct Query {
     pub fetch: Option<Fetch>,
 }
 
-impl Query {
-    pub fn get_limit_value(&self) -> Option<usize> {
-        match self.limit {
-            Some(ref limit) => limit.parse().ok(),
-            _ => None,
-        }
-    }
-
-    pub fn get_offset_value(&self) -> Option<usize> {
-        match self.offset {
-            Some(ref offset) => offset.parse().ok(),
-            _ => None,
-        }
-    }
-}
-
 impl fmt::Display for Query {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         if let Some(ref with) = self.with {
@@ -510,16 +494,14 @@ impl fmt::Display for OrderByExpr {
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Fetch {
     pub with_ties: bool,
-    pub percent: bool,
-    pub quantity: Option<Expr>,
+    pub quantity: Option<String>,
 }
 
 impl fmt::Display for Fetch {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let extension = if self.with_ties { "WITH TIES" } else { "ONLY" };
         if let Some(ref quantity) = self.quantity {
-            let percent = if self.percent { " PERCENT" } else { "" };
-            write!(f, "FETCH FIRST {}{} ROWS {}", quantity, percent, extension)
+            write!(f, "FETCH FIRST {} ROWS {}", quantity, extension)
         } else {
             write!(f, "FETCH FIRST ROWS {}", extension)
         }

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -1981,9 +1981,9 @@ impl Parser {
         }
     }
 
-    pub fn parse_number_value(&mut self) -> Result<Value, ParserError> {
+    pub fn parse_number_value(&mut self) -> Result<String, ParserError> {
         match self.parse_value()? {
-            v @ Value::Number(_, _) => Ok(v),
+            Value::Number(v, _) => Ok(v),
             _ => {
                 self.prev_token();
                 self.expected("literal number", self.peek_token())
@@ -3230,25 +3230,19 @@ impl Parser {
     }
 
     /// Parse a LIMIT clause
-    pub fn parse_limit(&mut self) -> Result<Option<Expr>, ParserError> {
+    pub fn parse_limit(&mut self) -> Result<Option<String>, ParserError> {
         if self.parse_keyword(Keyword::ALL) {
             Ok(None)
         } else {
-            Ok(Some(Expr::Value(self.parse_number_value()?)))
+            Ok(Some(self.parse_number_value()?))
         }
     }
 
     /// Parse an OFFSET clause
-    pub fn parse_offset(&mut self) -> Result<Offset, ParserError> {
-        let value = Expr::Value(self.parse_number_value()?);
-        let rows = if self.parse_keyword(Keyword::ROW) {
-            OffsetRows::Row
-        } else if self.parse_keyword(Keyword::ROWS) {
-            OffsetRows::Rows
-        } else {
-            OffsetRows::None
-        };
-        Ok(Offset { value, rows })
+    pub fn parse_offset(&mut self) -> Result<String, ParserError> {
+        let value = self.parse_number_value()?;
+        _ = self.expect_one_of_keywords(&[Keyword::ROW, Keyword::ROWS]);
+        Ok(value)
     }
 
     /// Parse a FETCH clause

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2454,7 +2454,13 @@ impl Parser {
                 if limit.is_some() {
                     return parser_err!("Cannot specify both LIMIT and FETCH".to_string());
                 }
-                Some(self.parse_fetch()?)
+                let fetch = self.parse_fetch()?;
+                if fetch.with_ties && order_by.is_empty() {
+                    return parser_err!(
+                        "WITH TIES cannot be specified without ORDER BY clause".to_string()
+                    );
+                }
+                Some(fetch)
             } else {
                 None
             };

--- a/src/sqlparser/src/test_utils.rs
+++ b/src/sqlparser/src/test_utils.rs
@@ -49,6 +49,7 @@ pub fn parse_sql_statements(sql: &str) -> Result<Vec<Statement>, ParserError> {
 /// additionally asserts that parsing `sql` results in the same parse
 /// tree as parsing `canonical`, and that serializing it back to string
 /// results in the `canonical` representation.
+#[track_caller]
 pub fn one_statement_parses_to(sql: &str, canonical: &str) -> Statement {
     let mut statements = parse_sql_statements(sql).unwrap();
     assert_eq!(statements.len(), 1);
@@ -66,14 +67,24 @@ pub fn one_statement_parses_to(sql: &str, canonical: &str) -> Statement {
 
 /// Ensures that `sql` parses as a single [Statement], and is not modified
 /// after a serialization round-trip.
+#[track_caller]
 pub fn verified_stmt(query: &str) -> Statement {
     one_statement_parses_to(query, query)
 }
 
 /// Ensures that `sql` parses as a single [Query], and is not modified
 /// after a serialization round-trip.
+#[track_caller]
 pub fn verified_query(sql: &str) -> Query {
     match verified_stmt(sql) {
+        Statement::Query(query) => *query,
+        _ => panic!("Expected Query"),
+    }
+}
+
+#[track_caller]
+pub fn query(sql: &str, canonical: &str) -> Query {
+    match one_statement_parses_to(sql, canonical) {
         Statement::Query(query) => *query,
         _ => panic!("Expected Query"),
     }

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3260,12 +3260,12 @@ fn parse_fetch_variations() {
         "SELECT foo FROM bar FETCH FIRST 10 ROWS ONLY",
     );
     one_statement_parses_to(
-        "SELECT foo FROM bar FETCH NEXT 10 ROWS WITH TIES",
-        "SELECT foo FROM bar FETCH FIRST 10 ROWS WITH TIES",
+        "SELECT foo FROM bar ORDER BY baz FETCH NEXT 10 ROWS WITH TIES",
+        "SELECT foo FROM bar ORDER BY baz FETCH FIRST 10 ROWS WITH TIES",
     );
     one_statement_parses_to(
-        "SELECT foo FROM bar FETCH NEXT ROWS WITH TIES",
-        "SELECT foo FROM bar FETCH FIRST ROWS WITH TIES",
+        "SELECT foo FROM bar ORDER BY baz FETCH NEXT ROWS WITH TIES",
+        "SELECT foo FROM bar ORDER BY baz FETCH FIRST ROWS WITH TIES",
     );
     one_statement_parses_to(
         "SELECT foo FROM bar FETCH FIRST ROWS ONLY",

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3187,8 +3187,8 @@ fn parse_offset() {
 fn parse_fetch() {
     let fetch_first_two_rows_only = Some(Fetch {
         with_ties: false,
-        percent: false,
-        quantity: Some(Expr::Value(number("2"))),
+
+        quantity: Some("2".to_string()),
     });
     let ast = verified_query("SELECT foo FROM bar FETCH FIRST 2 ROWS ONLY");
     assert_eq!(ast.fetch, fetch_first_two_rows_only);
@@ -3199,7 +3199,6 @@ fn parse_fetch() {
         ast.fetch,
         Some(Fetch {
             with_ties: false,
-            percent: false,
             quantity: None,
         })
     );
@@ -3214,17 +3213,7 @@ fn parse_fetch() {
         ast.fetch,
         Some(Fetch {
             with_ties: true,
-            percent: false,
-            quantity: Some(Expr::Value(number("2"))),
-        })
-    );
-    let ast = verified_query("SELECT foo FROM bar FETCH FIRST 50 PERCENT ROWS ONLY");
-    assert_eq!(
-        ast.fetch,
-        Some(Fetch {
-            with_ties: false,
-            percent: true,
-            quantity: Some(Expr::Value(number("50"))),
+            quantity: Some("2".to_string()),
         })
     );
     let ast = verified_query(

--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -57,3 +57,6 @@
 
 - input: SELECT id FROM customer WHERE NOT salary = ''
   formatted_sql: SELECT id FROM customer WHERE NOT (salary = '')
+
+- input: SELECT * FROM t LIMIT 1 FETCH FIRST ROWS ONLY
+  error_msg: 'sql parser error: Cannot specify both LIMIT and FETCH'

--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -59,4 +59,7 @@
   formatted_sql: SELECT id FROM customer WHERE NOT (salary = '')
 
 - input: SELECT * FROM t LIMIT 1 FETCH FIRST ROWS ONLY
-  error_msg: 'sql parser error: Cannot specify both LIMIT and FETCH'
+  error_msg: "sql parser error: Cannot specify both LIMIT and FETCH"
+
+- input: SELECT * FROM t FETCH FIRST ROWS WITH TIES
+  error_msg: "sql parser error: WITH TIES cannot be specified without ORDER BY clause"

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -21,7 +21,7 @@ use risingwave_frontend::bind_data_type;
 use risingwave_frontend::expr::DataTypeName;
 use risingwave_sqlparser::ast::{
     BinaryOperator, ColumnDef, Cte, Expr, Ident, Join, JoinConstraint, JoinOperator, ObjectName,
-    OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins, Value, With,
+    OrderByExpr, Query, Select, SelectItem, SetExpr, Statement, TableWithJoins, With,
 };
 use risingwave_sqlparser::parser::Parser;
 
@@ -274,12 +274,9 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         order_by
     }
 
-    fn gen_limit(&mut self) -> Option<Expr> {
+    fn gen_limit(&mut self) -> Option<String> {
         if !self.is_mview && self.rng.gen_bool(0.2) {
-            Some(Expr::Value(Value::Number(
-                self.rng.gen_range(0..=100).to_string(),
-                false,
-            )))
+            Some(self.rng.gen_range(0..=100).to_string())
         } else {
             None
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

When I try `WITH TIES` I found `FETCH` is ignored, which is bad 😕

This PR: 
- Rejects `WITH TIES` and bind `FETCH` to limit. 
- Also did some refactor on sqlparser: simply let `limit/offset/fetch` be `String`, instead of `Expr`, so that unnecessary pattern matching can be avoided.

(Note: I also found that PG supports `OFFSET` after `FETCH`. Not implemented here.

> According to the standard, the OFFSET clause must come before the FETCH clause if both are present; but PostgreSQL is laxer and allows either order.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
