### PR TITLE
feat(frontend): Use SortAgg when output requires sort 

### DIFF
--- a/e2e_test/batch/aggregate/sort_agg.slt.part
+++ b/e2e_test/batch/aggregate/sort_agg.slt.part
@@ -11,24 +11,25 @@ statement ok
 create materialized view mv as select * from t order by v1 desc
 
 query I rowsort
-select max(v2), v1 from mv group by v1
+select v1, max(v2) from mv group by v1
 ----
-10 100
-20 10
-3 9
-7 4
+-10 100
 1 1
-100 -10
+10 20
+100 10
+4 7
+9 3
+
 
 query II
-select max(v2), v1 from t group by v1 order by v1 desc
+select v1, max(v2) from t group by v1 order by v1 desc
 ----
-10 100
-20 10
-3 9
-7 4
+100 10
+10 20
+9 3
+4 7
 1 1
-100 -10
+-10 100
 
 statement ok
 drop materialized view mv

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -190,25 +190,33 @@
     /* Use BatchSortAgg, when input provides order */
     create table t(v1 int, v2 int);
     create materialized view mv as select * from t order by v1 desc;
-    select max(v2) from mv group by v1;
+    select v1, max(v2) from mv group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(mv.v2)] }
-        BatchSortAgg { group_key: [mv.v1], aggs: [max(mv.v2)] }
-          BatchExchange { order: [mv.v1 DESC], dist: HashShard(mv.v1) }
-            BatchScan { table: mv, columns: [mv.v1, mv.v2], distribution: SomeShard }
+      BatchSortAgg { group_key: [mv.v1], aggs: [max(mv.v2)] }
+        BatchExchange { order: [mv.v1 DESC], dist: HashShard(mv.v1) }
+          BatchScan { table: mv, columns: [mv.v1, mv.v2], distribution: SomeShard }
 - sql: |
     /* Use BatchSortAgg, when output requires order */
     create table t(v1 int, v2 int);
-    select max(v2) from t group by v1 order by v1 desc;
+    select v1, max(v2) from t group by v1 order by v1 desc;
   batch_plan: |
-    BatchProject { exprs: [max(t.v2)] }
-      BatchExchange { order: [t.v1 DESC], dist: Single }
-        BatchSort { order: [t.v1 DESC] }
-          BatchProject { exprs: [max(t.v2), t.v1] }
-            BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-              BatchExchange { order: [], dist: HashShard(t.v1) }
-                BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    BatchExchange { order: [t.v1 DESC], dist: Single }
+      BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+        BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
+          BatchSort { order: [t.v1 DESC] }
+            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+- sql: |
+    /* Use BatchSortAgg, when output requires order with swapped output*/
+    create table t(v1 int, v2 int);
+    select max(v2), v1 from t group by v1 order by v1 desc;
+  batch_plan: |
+    BatchExchange { order: [t.v1 DESC], dist: Single }
+      BatchSort { order: [t.v1 DESC] }
+        BatchProject { exprs: [max(t.v2), t.v1] }
+          BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+            BatchExchange { order: [], dist: HashShard(t.v1) }
+              BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 real);
     select count(*) from t;

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -212,10 +212,10 @@
     select max(v2), v1 from t group by v1 order by v1 desc;
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
-      BatchSort { order: [t.v1 DESC] }
-        BatchProject { exprs: [max(t.v2), t.v1] }
-          BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-            BatchExchange { order: [], dist: HashShard(t.v1) }
+      BatchProject { exprs: [max(t.v2), t.v1] }
+        BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+          BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
+            BatchSort { order: [t.v1 DESC] }
               BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 real);

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -207,6 +207,17 @@
           BatchSort { order: [t.v1 DESC] }
             BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
+    /* Use BatchSortAgg, when required order satisfies input order */
+    create table t(k1 int, k2 int, v1 int);
+    SELECT max(v1), k1, k2 from t group by k1, k2 order by k1;
+  batch_plan: |
+    BatchExchange { order: [t.k1 ASC], dist: Single }
+      BatchProject { exprs: [max(t.v1), t.k1, t.k2] }
+        BatchSortAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
+          BatchExchange { order: [t.k1 ASC, t.k2 ASC], dist: HashShard(t.k1, t.k2) }
+            BatchSort { order: [t.k1 ASC, t.k2 ASC] }
+              BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
+- sql: |
     /* Use BatchSortAgg, when output requires order with swapped output*/
     create table t(v1 int, v2 int);
     select max(v2), v1 from t group by v1 order by v1 desc;

--- a/src/frontend/planner_test/tests/testdata/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/order_by.yaml
@@ -196,3 +196,13 @@
     BatchExchange { order: [mv.v ASC], dist: Single }
       BatchSort { order: [mv.v ASC] }
         BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+- sql: |
+    CREATE TABLE test (a INTEGER, b INTEGER);
+    SELECT b % 2 AS f, SUM(a) FROM test GROUP BY b % 2 ORDER BY f;
+  batch_plan: |
+    BatchExchange { order: [(test.b % 2:Int32) ASC], dist: Single }
+      BatchSortAgg { group_key: [(test.b % 2:Int32)], aggs: [sum(test.a)] }
+        BatchExchange { order: [(test.b % 2:Int32) ASC], dist: HashShard((test.b % 2:Int32)) }
+          BatchSort { order: [(test.b % 2:Int32) ASC] }
+            BatchProject { exprs: [(test.b % 2:Int32), test.a] }
+              BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/order_by.yaml
@@ -23,8 +23,8 @@
     select v1, v1+1 from t order by v1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
-      BatchSort { order: [t.v1 ASC] }
-        BatchProject { exprs: [t.v1, (t.v1 + 1:Int32)] }
+      BatchProject { exprs: [t.v1, (t.v1 + 1:Int32)] }
+        BatchSort { order: [t.v1 ASC] }
           BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);

--- a/src/frontend/planner_test/tests/testdata/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch.yaml
@@ -131,8 +131,8 @@
           LogicalScan { table: lineitem, output_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus], required_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], dist: Single }
-      BatchSort { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC] }
-        BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
+      BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
+        BatchSort { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC] }
           BatchHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
             BatchExchange { order: [], dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
               BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
@@ -883,8 +883,8 @@
             LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'ASIA':Varchar) }
   batch_plan: |
     BatchExchange { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC], dist: Single }
-      BatchSort { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC] }
-        BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
+      BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
+        BatchSort { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC] }
           BatchHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
             BatchExchange { order: [], dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
               BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
@@ -1034,8 +1034,8 @@
             LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |
     BatchExchange { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC], dist: Single }
-      BatchSort { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC] }
-        BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
+      BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
+        BatchSort { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC] }
           BatchHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
             BatchExchange { order: [], dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
               BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }

--- a/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
@@ -44,12 +44,8 @@ impl BatchSortAgg {
                 .rewrite_provided_distribution(input_dist),
             d => d.clone(),
         };
-        let base =
-            PlanBase::new_batch(ctx, logical.schema().clone(), dist, logical.order().clone());
-
         let input_order = Order {
-            field_order: logical
-                .input()
+            field_order: input
                 .order()
                 .field_order
                 .iter()
@@ -64,6 +60,12 @@ impl BatchSortAgg {
         };
 
         assert_eq!(input_order.field_order.len(), logical.group_key().len());
+
+        let order = logical
+            .i2o_col_mapping()
+            .rewrite_provided_order(&input_order);
+
+        let base = PlanBase::new_batch(ctx, logical.schema().clone(), dist, order);
 
         BatchSortAgg {
             base,

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -603,10 +603,9 @@ impl LogicalAgg {
             .any(|call| matches!(call.agg_kind, AggKind::StringAgg | AggKind::ArrayAgg))
     }
 
-    // Check if the output of the aggregation needs to be sorted and return ordering for group keys
-    // If so, push down the sort below the aggregation and use sort merge aggregation
-    // The required order of the output must be satisfied by the order of the group key
-    // The data type of the columns need to be int32
+    // Check if the output of the aggregation needs to be sorted and return ordering req by group
+    // keys If group key order satisfies required order, push down the sort below the
+    // aggregation and use sort aggregation. The data type of the columns need to be int32
     fn output_requires_order_on_group_keys(&self, required_order: &Order) -> (bool, Order) {
         let group_key_order = Order {
             field_order: self


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR makes use of Sort Aggregation, when a sort order is required by the output

## Checklist

- [ x] I have written necessary rustdoc comments
- [x ] I have added necessary unit tests and integration tests
- [x ] All checks passed in `./risedev check` (or alias, `./risedev c`)