### PR TITLE
fix: meta push split assignments down when recovery

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -52,6 +52,7 @@ use crate::manager::{
 use crate::model::{ActorId, BarrierManagerState};
 use crate::rpc::metrics::MetaMetrics;
 use crate::storage::meta_store::MetaStore;
+use crate::stream::SourceManagerRef;
 use crate::{MetaError, MetaResult};
 
 mod command;
@@ -126,6 +127,8 @@ pub struct GlobalBarrierManager<S: MetaStore> {
     fragment_manager: FragmentManagerRef<S>,
 
     hummock_manager: HummockManagerRef<S>,
+
+    source_manager: SourceManagerRef<S>,
 
     metrics: Arc<MetaMetrics>,
 
@@ -455,6 +458,7 @@ where
     S: MetaStore,
 {
     /// Create a new [`crate::barrier::GlobalBarrierManager`].
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         scheduled_barriers: schedule::ScheduledBarriers,
         env: MetaSrvEnv<S>,
@@ -462,6 +466,7 @@ where
         catalog_manager: CatalogManagerRef<S>,
         fragment_manager: FragmentManagerRef<S>,
         hummock_manager: HummockManagerRef<S>,
+        source_manager: SourceManagerRef<S>,
         metrics: Arc<MetaMetrics>,
     ) -> Self {
         let enable_recovery = env.opts.enable_recovery;
@@ -483,6 +488,7 @@ where
             catalog_manager,
             fragment_manager,
             hummock_manager,
+            source_manager,
             metrics,
             env,
         }

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -23,6 +23,8 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::common::worker_node::State;
 use risingwave_pb::common::{ActorInfo, WorkerNode, WorkerType};
 use risingwave_pb::data::Epoch as ProstEpoch;
+use risingwave_pb::stream_plan::barrier::Mutation;
+use risingwave_pb::stream_plan::AddMutation;
 use risingwave_pb::stream_service::barrier_complete_response::CreateMviewProgress;
 use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, ForceStopActorsRequest, SyncSourcesRequest,
@@ -38,6 +40,7 @@ use crate::barrier::{CheckpointControl, Command, GlobalBarrierManager};
 use crate::manager::WorkerId;
 use crate::model::ActorId;
 use crate::storage::MetaStore;
+use crate::stream::build_actor_splits;
 use crate::{MetaError, MetaResult};
 
 pub type RecoveryResult = (Epoch, HashSet<ActorId>, Vec<CreateMviewProgress>);
@@ -109,6 +112,13 @@ where
                 return Err(err);
             }
 
+            // get split assignments for all actors
+            let source_split_assignments = self.source_manager.list_assignments().await;
+            let command = Command::Plain(Some(Mutation::Add(AddMutation {
+                actor_dispatchers: Default::default(),
+                actor_splits: build_actor_splits(&source_split_assignments),
+            })));
+
             let prev_epoch = new_epoch;
             new_epoch = prev_epoch.next();
             // checkpoint, used as init barrier to initialize all executors.
@@ -118,7 +128,7 @@ where
                 info,
                 prev_epoch,
                 new_epoch,
-                Command::checkpoint(),
+                command,
             ));
 
             let (barrier_complete_tx, mut barrier_complete_rx) =

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -352,16 +352,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
     let (barrier_scheduler, scheduled_barriers) =
         BarrierScheduler::new_pair(hummock_manager.clone());
 
-    let barrier_manager = Arc::new(GlobalBarrierManager::new(
-        scheduled_barriers,
-        env.clone(),
-        cluster_manager.clone(),
-        catalog_manager.clone(),
-        fragment_manager.clone(),
-        hummock_manager.clone(),
-        meta_metrics.clone(),
-    ));
-
     let source_manager = Arc::new(
         SourceManager::new(
             env.clone(),
@@ -374,6 +364,17 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         .await
         .unwrap(),
     );
+
+    let barrier_manager = Arc::new(GlobalBarrierManager::new(
+        scheduled_barriers,
+        env.clone(),
+        cluster_manager.clone(),
+        catalog_manager.clone(),
+        fragment_manager.clone(),
+        hummock_manager.clone(),
+        source_manager.clone(),
+        meta_metrics.clone(),
+    ));
 
     {
         let source_manager = source_manager.clone();

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -963,16 +963,6 @@ mod tests {
             let (barrier_scheduler, scheduled_barriers) =
                 BarrierScheduler::new_pair(hummock_manager.clone());
 
-            let barrier_manager = Arc::new(GlobalBarrierManager::new(
-                scheduled_barriers,
-                env.clone(),
-                cluster_manager.clone(),
-                catalog_manager.clone(),
-                fragment_manager.clone(),
-                hummock_manager,
-                meta_metrics.clone(),
-            ));
-
             let compaction_group_manager =
                 Arc::new(CompactionGroupManager::new(env.clone()).await?);
 
@@ -987,6 +977,17 @@ mod tests {
                 )
                 .await?,
             );
+
+            let barrier_manager = Arc::new(GlobalBarrierManager::new(
+                scheduled_barriers,
+                env.clone(),
+                cluster_manager.clone(),
+                catalog_manager.clone(),
+                fragment_manager.clone(),
+                hummock_manager,
+                source_manager.clone(),
+                meta_metrics.clone(),
+            ));
 
             let stream_manager = GlobalStreamManager::new(
                 env.clone(),

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -268,6 +268,12 @@ impl<S: StateStore> SourceExecutor<S> {
         }
 
         let recover_state: ConnectorState = (!boot_state.is_empty()).then_some(boot_state);
+        tracing::debug!(
+            "source {:?} actor {:?} starts with state {:?}",
+            self.source_id,
+            self.ctx.id,
+            recover_state
+        );
 
         // todo: use epoch from msg to restore state from state store
         let source_chunk_reader = self


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, push the assignment to source executor can help restore state. 

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

fix #4918 