### PR TITLE
refactor(batch): do not consume data chunk in handler

### DIFF
--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -12,25 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::StreamExt;
-use futures_async_stream::for_await;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::{PgResponse, StatementType};
 use pgwire::types::Row;
-use risingwave_batch::executor::BoxedDataChunkStream;
-use risingwave_common::array::DataChunk;
 use risingwave_common::error::Result;
 use risingwave_common::session_config::QueryMode;
 use risingwave_sqlparser::ast::Statement;
-use tokio::sync::oneshot;
 use tracing::debug;
 
 use crate::binder::{Binder, BoundStatement};
 use crate::handler::privilege::{check_privileges, resolve_privileges};
-use crate::handler::util::{force_local_mode, to_pg_field, to_pg_rows};
+use crate::handler::util::{force_local_mode, to_pg_field};
 use crate::planner::Planner;
 use crate::scheduler::{
-    BatchPlanFragmenter, ExecutionContext, ExecutionContextRef, LocalQueryExecution, SchedulerError,
+    BatchPlanFragmenter, ExecutionContext, ExecutionContextRef, LocalQueryExecution,
 };
 use crate::session::{OptimizerContext, SessionImpl};
 

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -49,3 +49,9 @@ impl From<SchedulerError> for RwError {
         ErrorCode::SchedulerError(Box::new(s)).into()
     }
 }
+
+impl From<RwError> for SchedulerError {
+    fn from(e: RwError) -> Self {
+        Self::Internal(e.into())
+    }
+}

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -16,9 +16,9 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures_async_stream::try_stream;
+use futures_async_stream::{for_await, try_stream};
 use itertools::Itertools;
-use risingwave_batch::executor::ExecutorBuilder;
+use risingwave_batch::executor::{BoxedDataChunkStream, ExecutorBuilder};
 use risingwave_batch::task::TaskId;
 use risingwave_common::array::DataChunk;
 use risingwave_common::bail;
@@ -34,6 +34,8 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::plan_fragmenter::{PartitionInfo, QueryStageRef};
+use crate::handler::query::QueryResultSet;
+use crate::handler::util::to_pg_rows;
 use crate::optimizer::plan_node::PlanNodeType;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query, StageId};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
@@ -99,6 +101,21 @@ impl LocalQueryExecution {
         for chunk in executor.execute() {
             yield chunk?;
         }
+    }
+
+    pub fn run_wrapper(self) -> BoxedDataChunkStream {
+        Box::pin(self.run())
+    }
+
+    pub async fn collect_rows(self, format: bool) -> SchedulerResult<QueryResultSet> {
+        let data_stream = self.run_wrapper();
+        let mut rows = vec![];
+        #[for_await]
+        for chunk in data_stream {
+            rows.extend(to_pg_rows(chunk?, format));
+        }
+
+        Ok(rows)
     }
 
     /// Convert query to plan fragment.

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -68,7 +68,7 @@ impl LocalQueryExecution {
     }
 
     #[try_stream(ok = DataChunk, error = RwError)]
-    pub async fn run(mut self) {
+    pub async fn run_inner(mut self) {
         debug!(
             "Starting to run query: {:?}, sql: '{}'",
             self.query.query_id, self.sql
@@ -103,12 +103,12 @@ impl LocalQueryExecution {
         }
     }
 
-    pub fn run_wrapper(self) -> BoxedDataChunkStream {
-        Box::pin(self.run())
+    pub fn run(self) -> BoxedDataChunkStream {
+        Box::pin(self.run_inner())
     }
 
     pub async fn collect_rows(self, format: bool) -> SchedulerResult<QueryResultSet> {
-        let data_stream = self.run_wrapper();
+        let data_stream = self.run();
         let mut rows = vec![];
         #[for_await]
         for chunk in data_stream {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This makes the code more easy to write for #5027 

Add `collect_rows()` convert Stream<DataChunk> -> Vec<Rows>. Handler do not need to know the detail of data fetch.

Do not consume data chunk in a stream in handler, hide the detail inside ResultFetcher.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
