### PR TITLE
feat: reschedule interface in risedev 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4485,6 +4485,7 @@ dependencies = [
  "futures",
  "madsim-tokio",
  "parking_lot 0.12.1",
+ "regex",
  "risingwave_common",
  "risingwave_frontend",
  "risingwave_hummock_sdk",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -11,6 +11,7 @@ clap = { version = "3", features = ["derive"] }
 comfy-table = "6"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 parking_lot = "0.12"
+regex = "1.6.0"
 risingwave_common = { path = "../common" }
 risingwave_frontend = { path = "../frontend" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }

--- a/src/ctl/src/cmd_impl/meta.rs
+++ b/src/ctl/src/cmd_impl/meta.rs
@@ -14,6 +14,8 @@
 
 mod cluster_info;
 mod pause_resume;
+mod reschedule;
 
 pub use cluster_info::*;
 pub use pause_resume::*;
+pub use reschedule::*;

--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -13,42 +13,92 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use risingwave_common::bail;
+
+use anyhow::{anyhow, Error, Result};
+use regex::{Match, Regex};
 use risingwave_pb::meta::reschedule_request::Reschedule;
+
 use crate::common::MetaServiceOpts;
 
+const RESCHEDULE_MATCH_REGEXP: &str =
+    r"^(?P<fragment>\d+)(?:-\[(?P<removed>\d+(?:,\d+)*)])?(?:\+\[(?P<added>\d+(?:,\d+)*)])?$";
+const RESCHEDULE_FRAGMENT_KEY: &str = "fragment";
+const RESCHEDULE_REMOVED_KEY: &str = "removed";
+const RESCHEDULE_ADDED_KEY: &str = "added";
 
-pub async fn reschedule(plan: String) -> anyhow::Result<()> {
+pub async fn reschedule(plan: String, dry_run: bool) -> Result<()> {
     let meta_opts = MetaServiceOpts::from_env()?;
     let meta_client = meta_opts.create_meta_client().await?;
 
+    let regex = Regex::new(RESCHEDULE_MATCH_REGEXP)?;
     let mut reschedules = HashMap::new();
+
+    let plan = {
+        let mut plan = plan;
+        plan.retain(|c| !c.is_whitespace());
+        plan
+    };
+
     for fragment_reschedule_plan in plan.split(";") {
-        let slice: Vec<_> = fragment_reschedule_plan.split(",").collect();
+        let captures = regex.captures(fragment_reschedule_plan).ok_or(anyhow!(
+            "plan \"{}\" format illegal",
+            fragment_reschedule_plan
+        ))?;
 
-        if slice.len() != 3 {
-            bail!("should be in format frag_id:removed:added;")
+        let fragment_id = captures
+            .name(RESCHEDULE_FRAGMENT_KEY)
+            .and_then(|mat| mat.as_str().parse::<u32>().ok())
+            .ok_or(anyhow!(
+                "plan \"{}\" does not have a valid fragment id",
+                plan
+            ))?;
+
+        let split_fn = |mat: Match| {
+            mat.as_str()
+                .split(",")
+                .map(|id_str| id_str.parse::<u32>().map_err(Error::msg))
+                .collect::<Result<Vec<_>>>()
+        };
+
+        let removed_parallel_units = captures
+            .name(RESCHEDULE_REMOVED_KEY)
+            .map(split_fn)
+            .transpose()?
+            .unwrap_or_default();
+        let added_parallel_units = captures
+            .name(RESCHEDULE_ADDED_KEY)
+            .map(split_fn)
+            .transpose()?
+            .unwrap_or_default();
+
+        if !(removed_parallel_units.is_empty() && added_parallel_units.is_empty()) {
+            reschedules.insert(
+                fragment_id,
+                Reschedule {
+                    added_parallel_units,
+                    removed_parallel_units,
+                },
+            );
         }
-
-        let fragment_id = slice[0].parse::<u32>()?;
-        let removed_parallel_units = slice[1].split(",").map(|id_str| id_str.parse::<u32>().unwrap()).collect();
-        let added_parallel_units = slice[2].split(",").map(|id_str| id_str.parse::<u32>().unwrap()).collect();
-
-        reschedules.insert(fragment_id, Reschedule {
-            added_parallel_units,
-            removed_parallel_units,
-        });
     }
-
 
     for (fragment_id, reschedule) in &reschedules {
         println!("For fragment #{}", fragment_id);
-        println!("\tRemove: [{:?}]", reschedule.removed_parallel_units);
-        println!("\tAdd:    [{:?}]", reschedule.added_parallel_units);
+        if !reschedule.removed_parallel_units.is_empty() {
+            println!("\tRemove: {:?}", reschedule.removed_parallel_units);
+        }
+
+        if !reschedule.added_parallel_units.is_empty() {
+            println!("\tAdd:    {:?}", reschedule.added_parallel_units);
+        }
     }
 
-    let resp = meta_client.reschedule(reschedules).await?;
-    println!("Response from meta {}", resp);
+
+    if !dry_run {
+        println!("---------------------------");
+        let resp = meta_client.reschedule(reschedules).await?;
+        println!("Response from meta {}", resp);
+    }
 
     Ok(())
 }

--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -1,0 +1,54 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use risingwave_common::bail;
+use risingwave_pb::meta::reschedule_request::Reschedule;
+use crate::common::MetaServiceOpts;
+
+
+pub async fn reschedule(plan: String) -> anyhow::Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta_client = meta_opts.create_meta_client().await?;
+
+    let mut reschedules = HashMap::new();
+    for fragment_reschedule_plan in plan.split(";") {
+        let slice: Vec<_> = fragment_reschedule_plan.split(",").collect();
+
+        if slice.len() != 3 {
+            bail!("should be in format frag_id:removed:added;")
+        }
+
+        let fragment_id = slice[0].parse::<u32>()?;
+        let removed_parallel_units = slice[1].split(",").map(|id_str| id_str.parse::<u32>().unwrap()).collect();
+        let added_parallel_units = slice[2].split(",").map(|id_str| id_str.parse::<u32>().unwrap()).collect();
+
+        reschedules.insert(fragment_id, Reschedule {
+            added_parallel_units,
+            removed_parallel_units,
+        });
+    }
+
+
+    for (fragment_id, reschedule) in &reschedules {
+        println!("For fragment #{}", fragment_id);
+        println!("\tRemove: [{:?}]", reschedule.removed_parallel_units);
+        println!("\tAdd:    [{:?}]", reschedule.added_parallel_units);
+    }
+
+    let resp = meta_client.reschedule(reschedules).await?;
+    println!("Response from meta {}", resp);
+
+    Ok(())
+}

--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -39,23 +39,19 @@ pub async fn reschedule(plan: String, dry_run: bool) -> Result<()> {
         plan
     };
 
-    for fragment_reschedule_plan in plan.split(";") {
-        let captures = regex.captures(fragment_reschedule_plan).ok_or(anyhow!(
-            "plan \"{}\" format illegal",
-            fragment_reschedule_plan
-        ))?;
+    for fragment_reschedule_plan in plan.split(';') {
+        let captures = regex
+            .captures(fragment_reschedule_plan)
+            .ok_or_else(|| anyhow!("plan \"{}\" format illegal", fragment_reschedule_plan))?;
 
         let fragment_id = captures
             .name(RESCHEDULE_FRAGMENT_KEY)
             .and_then(|mat| mat.as_str().parse::<u32>().ok())
-            .ok_or(anyhow!(
-                "plan \"{}\" does not have a valid fragment id",
-                plan
-            ))?;
+            .ok_or_else(|| anyhow!("plan \"{}\" does not have a valid fragment id", plan))?;
 
         let split_fn = |mat: Match| {
             mat.as_str()
-                .split(",")
+                .split(',')
                 .map(|id_str| id_str.parse::<u32>().map_err(Error::msg))
                 .collect::<Result<Vec<_>>>()
         };
@@ -92,7 +88,6 @@ pub async fn reschedule(plan: String, dry_run: bool) -> Result<()> {
             println!("\tAdd:    {:?}", reschedule.added_parallel_units);
         }
     }
-
 
     if !dry_run {
         println!("---------------------------");

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -15,6 +15,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cmd_impl::bench::BenchCommands;
+
 mod cmd_impl;
 pub(crate) mod common;
 
@@ -114,6 +115,20 @@ enum MetaCommands {
     /// get cluster info
     ClusterInfo,
     /// Reschedule the parallel unit in the stream graph
+    ///
+    /// The format is `fragment_id-[removed]+[added]`
+    /// You can provide either `removed` only or `added` only, but `removed` should be preceded by
+    /// `added` when both are provided.
+    ///
+    /// For example, for plan `100-[1,2,3]+[4,5]` the follow request will be generated:
+    /// {
+    ///     100: Reschedule {
+    ///         added_parallel_units: [4,5],
+    ///         removed_parallel_units: [1,2,3],
+    ///     }
+    /// }
+    /// Use ; to separate multiple fragment
+    #[clap(verbatim_doc_comment)]
     Reschedule {
         /// Plan of reschedule
         #[clap(long)]

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -113,6 +113,11 @@ enum MetaCommands {
     Resume,
     /// get cluster info
     ClusterInfo,
+    /// reschedule
+    Reschedule {
+        /// plan of reschedule
+        plan: String
+    },
 }
 
 pub async fn start(opts: CliOpts) -> Result<()> {
@@ -144,6 +149,7 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Meta(MetaCommands::Pause) => cmd_impl::meta::pause().await?,
         Commands::Meta(MetaCommands::Resume) => cmd_impl::meta::resume().await?,
         Commands::Meta(MetaCommands::ClusterInfo) => cmd_impl::meta::cluster_info().await?,
+        Commands::Meta(MetaCommands::Reschedule { plan }) => cmd_impl::meta::reschedule(plan).await?,
         Commands::Trace => cmd_impl::trace::trace().await?,
         Commands::Profile { sleep } => cmd_impl::profile::profile(sleep).await?,
     }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -113,10 +113,14 @@ enum MetaCommands {
     Resume,
     /// get cluster info
     ClusterInfo,
-    /// reschedule
+    /// Reschedule the parallel unit in the stream graph
     Reschedule {
-        /// plan of reschedule
-        plan: String
+        /// Plan of reschedule
+        #[clap(long)]
+        plan: String,
+        /// Show the plan only, no actual operation
+        #[clap(long)]
+        dry_run: bool,
     },
 }
 
@@ -149,7 +153,7 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Meta(MetaCommands::Pause) => cmd_impl::meta::pause().await?,
         Commands::Meta(MetaCommands::Resume) => cmd_impl::meta::resume().await?,
         Commands::Meta(MetaCommands::ClusterInfo) => cmd_impl::meta::cluster_info().await?,
-        Commands::Meta(MetaCommands::Reschedule { plan }) => cmd_impl::meta::reschedule(plan).await?,
+        Commands::Meta(MetaCommands::Reschedule { plan, dry_run }) => cmd_impl::meta::reschedule(plan, dry_run).await?,
         Commands::Trace => cmd_impl::trace::trace().await?,
         Commands::Profile { sleep } => cmd_impl::profile::profile(sleep).await?,
     }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -153,7 +153,9 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Meta(MetaCommands::Pause) => cmd_impl::meta::pause().await?,
         Commands::Meta(MetaCommands::Resume) => cmd_impl::meta::resume().await?,
         Commands::Meta(MetaCommands::ClusterInfo) => cmd_impl::meta::cluster_info().await?,
-        Commands::Meta(MetaCommands::Reschedule { plan, dry_run }) => cmd_impl::meta::reschedule(plan, dry_run).await?,
+        Commands::Meta(MetaCommands::Reschedule { plan, dry_run }) => {
+            cmd_impl::meta::reschedule(plan, dry_run).await?
+        }
         Commands::Trace => cmd_impl::trace::trace().await?,
         Commands::Profile { sleep } => cmd_impl::profile::profile(sleep).await?,
     }

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -673,7 +673,7 @@ where
 
         let applied_reschedules = self
             .fragment_manager
-            .pre_apply_reschedules(fragment_created_actors.clone())
+            .pre_apply_reschedules(fragment_created_actors)
             .await;
 
         let fragment_manager_ref = self.fragment_manager.clone();

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -27,6 +27,7 @@ use risingwave_pb::catalog::{
     Database as ProstDatabase, Index as ProstIndex, Schema as ProstSchema, Sink as ProstSink,
     Source as ProstSource, Table as ProstTable,
 };
+use risingwave_pb::meta::reschedule_request::Reschedule as ProstReschedule;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::ddl_service::ddl_service_client::DdlServiceClient;
 use risingwave_pb::ddl_service::*;
@@ -437,6 +438,12 @@ impl MetaClient {
         let resp = self.inner.get_cluster_info(request).await?;
         Ok(resp)
     }
+
+    pub async fn reschedule(&self, reschedules: HashMap<u32, ProstReschedule>) -> Result<bool> {
+        let request = RescheduleRequest{ reschedules };
+        let resp = self.inner.reschedule(request).await?;
+        Ok(resp.success)
+    }
 }
 
 #[async_trait]
@@ -715,6 +722,7 @@ macro_rules! for_all_meta_rpc {
             ,{ scale_client, pause, PauseRequest, PauseResponse }
             ,{ scale_client, resume, ResumeRequest, ResumeResponse }
             ,{ scale_client, get_cluster_info, GetClusterInfoRequest, GetClusterInfoResponse }
+            ,{ scale_client, reschedule, RescheduleRequest, RescheduleResponse }
             ,{ notification_client, subscribe, SubscribeRequest, Streaming<SubscribeResponse> }
         }
     };

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -27,7 +27,6 @@ use risingwave_pb::catalog::{
     Database as ProstDatabase, Index as ProstIndex, Schema as ProstSchema, Sink as ProstSink,
     Source as ProstSource, Table as ProstTable,
 };
-use risingwave_pb::meta::reschedule_request::Reschedule as ProstReschedule;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::ddl_service::ddl_service_client::DdlServiceClient;
 use risingwave_pb::ddl_service::*;
@@ -38,6 +37,7 @@ use risingwave_pb::meta::heartbeat_request::{extra_info, ExtraInfo};
 use risingwave_pb::meta::heartbeat_service_client::HeartbeatServiceClient;
 use risingwave_pb::meta::list_table_fragments_response::TableFragmentInfo;
 use risingwave_pb::meta::notification_service_client::NotificationServiceClient;
+use risingwave_pb::meta::reschedule_request::Reschedule as ProstReschedule;
 use risingwave_pb::meta::scale_service_client::ScaleServiceClient;
 use risingwave_pb::meta::stream_manager_service_client::StreamManagerServiceClient;
 use risingwave_pb::meta::*;
@@ -440,7 +440,7 @@ impl MetaClient {
     }
 
     pub async fn reschedule(&self, reschedules: HashMap<u32, ProstReschedule>) -> Result<bool> {
-        let request = RescheduleRequest{ reschedules };
+        let request = RescheduleRequest { reschedules };
         let resp = self.inner.reschedule(request).await?;
         Ok(resp.success)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR provides the `risedev ctl meta reschedule` interface, which allows you to call the reschedule api of meta directly from the command line.

Use the `--plan` parameter to provide a reschedule plan, which can provide multiple fragment at the same time  separated by `;`, and the `-dry-run` parameter will only show the parsed results without operation


```
100-[1,2,3]+[4,5];101-[1];102+[3]
```
For fragment 100,  parallel units 1,2,3 will be removed, while parallel units 4,5 will be added. 

You can also provide only the removed parallel unit ids (like fragment 101) or only the added pu ids (like fragment 102), but in the case of both, the removed must precede the added

The parsed result:
```
For fragment #100
	Remove: [1, 2, 3]
	Add:    [4, 5]
For fragment #102
	Add:    [3]
For fragment #101
	Remove: [1]
```

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
