### PR TITLE
feat(state_table): add `upsert` method for `StateTable`, and use it in managed value state

### DIFF
--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -145,7 +145,6 @@ impl MemTable {
                     e.insert(RowOp::Update((old_val, value)));
                 }
                 RowOp::Update((old_value, _)) => {
-                    // replace the update op
                     let old_val = std::mem::take(old_value);
                     e.insert(RowOp::Update((old_val, value)));
                 }

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -401,6 +401,16 @@ impl<S: StateStore> StateTable<S> {
         Ok(())
     }
 
+    /// Update or insert a row. If the row with the same pk exists, update it. Otherwise, insert it.
+    pub fn upsert(&mut self, value: Row) -> StorageResult<()> {
+        let pk = value.by_indices(self.pk_indices());
+        let key_bytes =
+            serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
+        let value_bytes = value.serialize().map_err(err)?;
+        self.mem_table.upsert(key_bytes, value_bytes);
+        Ok(())
+    }
+
     /// Write batch with a `StreamChunk` which should have the same schema with the table.
     // allow(izip, which use zip instead of zip_eq)
     #[allow(clippy::disallowed_methods)]

--- a/src/stream/src/executor/managed_state/aggregation/mod.rs
+++ b/src/stream/src/executor/managed_state/aggregation/mod.rs
@@ -133,7 +133,7 @@ impl<K: Ord, V> Cache<K, V> {
 /// when they are not dirty.
 pub enum ManagedStateImpl<S: StateStore> {
     /// States as single scalar value e.g. `COUNT`, `SUM`
-    Value(ManagedValueState),
+    Value(ManagedValueState<S>),
 
     /// States as table structure e.g. `MAX`, `STRING_AGG`
     Table(Box<dyn ManagedTableState<S>>),
@@ -149,7 +149,7 @@ impl<S: StateStore> ManagedStateImpl<S> {
         state_table: &mut StateTable<S>,
     ) -> StreamExecutorResult<()> {
         match self {
-            Self::Value(state) => state.apply_chunk(ops, visibility, columns),
+            Self::Value(state) => state.apply_chunk(ops, visibility, columns, epoch, state_table),
             Self::Table(state) => {
                 state
                     .apply_chunk(ops, visibility, columns, epoch, state_table)

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -165,7 +165,8 @@ mod tests {
             ManagedValueState::new(create_test_count_state(), Some(0), None, &state_table)
                 .await
                 .unwrap();
-        assert!(!managed_state.is_dirty());
+
+        let epoch: u64 = 0;
 
         // apply a batch and get the output
         managed_state
@@ -175,13 +176,12 @@ mod tests {
                 &[&I64Array::from_slice(&[Some(0), Some(1), Some(2), None])
                     .unwrap()
                     .into()],
+                epoch,
+                &mut state_table,
             )
             .unwrap();
-        assert!(managed_state.is_dirty());
 
         // write to state store
-        let epoch: u64 = 0;
-        managed_state.flush(&mut state_table).unwrap();
         state_table.commit(epoch).await.unwrap();
 
         // get output
@@ -230,7 +230,8 @@ mod tests {
         )
         .await
         .unwrap();
-        assert!(!managed_state.is_dirty());
+
+        let epoch: u64 = 0;
 
         // apply a batch and get the output
         managed_state
@@ -242,13 +243,12 @@ mod tests {
                         .unwrap()
                         .into(),
                 ],
+                epoch,
+                &mut state_table,
             )
             .unwrap();
-        assert!(managed_state.is_dirty());
 
         // write to state store
-        let epoch: u64 = 0;
-        managed_state.flush(&mut state_table).unwrap();
         state_table.commit(epoch).await.unwrap();
 
         // get output

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -103,7 +103,7 @@ impl<S: StateStore> ManagedValueState<S> {
                 .as_ref()
                 .unwrap_or_else(Row::empty)
                 .values()
-                .map(|v| v.clone())
+                .cloned()
                 .chain(std::iter::once(output))
                 .collect(),
         );


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Managed value state view state table as a one-row table, it update the single row in `flush` previously with `state_table.insert`. However, two problems exist, 1) insertion is not correct in term of semantics, 2) `insert` disallows multiple insertion with the same pk within one epoch, which prevent us from insert the output into state table during `apply_chunk`.

In this PR, `upsert` method is added to solve these problems.

This is a step towards the removal of `is_dirty` and `flush`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#4035