### PR TITLE
fix: kafka read dulpliction when recovery

### DIFF
--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -82,6 +82,7 @@ impl SplitReader for KafkaSplitReader {
             for split in splits {
                 if let SplitImpl::Kafka(k) = split {
                     if let Some(offset) = k.start_offset {
+                        let offset = if offset == 0 { 0 } else { offset + 1 };
                         tpl.add_partition_offset(
                             k.topic.as_str(),
                             k.partition,


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, kafka always starts with offset `Some(0)` and the state store keeps the latest success offset, eg. `Some(3)`. when recovery, kafka connector will read from the 3rd element, which has been read before. 

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

part of #5192 