### PR TITLE
feat: Set tcp no delay for compute nodes

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -251,6 +251,7 @@ pub async fn compute_node_serve(
     let join_handle = tokio::spawn(async move {
         tonic::transport::Server::builder()
             .initial_connection_window_size(MAX_CONNECTION_WINDOW_SIZE)
+            .tcp_nodelay(true)
             .layer(StackTraceMiddlewareLayer::new_optional(
                 opts.enable_async_stack_trace
                     .then_some(grpc_stack_trace_mgr),

--- a/src/rpc_client/src/compute_client.rs
+++ b/src/rpc_client/src/compute_client.rs
@@ -47,6 +47,7 @@ impl ComputeClient {
     pub async fn new(addr: HostAddr) -> Result<Self> {
         let channel = Endpoint::from_shared(format!("http://{}", &addr))?
             .initial_connection_window_size(MAX_CONNECTION_WINDOW_SIZE)
+            .tcp_nodelay(true)
             .connect_timeout(Duration::from_secs(5))
             .connect()
             .await?;

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -98,6 +98,7 @@ pub async fn pg_serve(addr: &str, session_mgr: Arc<impl SessionManager>) -> io::
         match conn_ret {
             Ok((stream, peer_addr)) => {
                 tracing::info!("New connection: {}", peer_addr);
+                stream.set_nodelay(true)?;
                 tokio::spawn(async move {
                     // connection succeeded
                     let mut pg_proto = PgProtocol::new(stream, session_mgr);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Set tcp no_delay option to reduce latency.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

