### PR TITLE
fix(compaction): fix in-correct epoch watermark

### DIFF
--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -40,7 +40,6 @@ use crate::monitor::StoreLocalStatistic;
 pub async fn compact(
     context: Arc<Context>,
     payload: UploadTaskPayload,
-    sst_watermark_epoch: HummockEpoch,
 ) -> HummockResult<Vec<(CompactionGroupId, SstableInfo)>> {
     let mut grouped_payload: HashMap<CompactionGroupId, UploadTaskPayload> = HashMap::new();
     for uncommitted_list in payload {
@@ -65,14 +64,12 @@ pub async fn compact(
     for (id, group_payload) in grouped_payload {
         let id_copy = id;
         futures.push(
-            compact_shared_buffer(context.clone(), group_payload, sst_watermark_epoch).map_ok(
-                move |results| {
-                    results
-                        .into_iter()
-                        .map(move |result| (id_copy, result))
-                        .collect_vec()
-                },
-            ),
+            compact_shared_buffer(context.clone(), group_payload).map_ok(move |results| {
+                results
+                    .into_iter()
+                    .map(move |result| (id_copy, result))
+                    .collect_vec()
+            }),
         );
     }
     // Note that the output is reordered compared with input `payload`.
@@ -88,7 +85,6 @@ pub async fn compact(
 async fn compact_shared_buffer(
     context: Arc<Context>,
     payload: UploadTaskPayload,
-    sst_watermark_epoch: HummockEpoch,
 ) -> HummockResult<Vec<SstableInfo>> {
     let mut start_user_keys = payload
         .iter()
@@ -152,12 +148,7 @@ async fn compact_shared_buffer(
 
     let mut local_stats = StoreLocalStatistic::default();
     for (split_index, key_range) in splits.into_iter().enumerate() {
-        let compactor = SharedBufferCompactRunner::new(
-            split_index,
-            key_range,
-            context.clone(),
-            sst_watermark_epoch,
-        );
+        let compactor = SharedBufferCompactRunner::new(split_index, key_range, context.clone());
         let iter = build_ordered_merge_iter::<ForwardIter>(
             &payload,
             sstable_store.clone(),
@@ -227,21 +218,9 @@ pub struct SharedBufferCompactRunner {
 }
 
 impl SharedBufferCompactRunner {
-    pub fn new(
-        split_index: usize,
-        key_range: KeyRange,
-        context: Arc<Context>,
-        sst_watermark_epoch: HummockEpoch,
-    ) -> Self {
+    pub fn new(split_index: usize, key_range: KeyRange, context: Arc<Context>) -> Self {
         let options = context.options.as_ref().into();
-        let compactor = Compactor::new(
-            context,
-            options,
-            key_range,
-            CachePolicy::Fill,
-            false,
-            sst_watermark_epoch,
-        );
+        let compactor = Compactor::new(context, options, key_range, CachePolicy::Fill, false, 0);
         Self {
             compactor,
             split_index,

--- a/src/storage/src/hummock/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version_manager.rs
@@ -599,7 +599,7 @@ impl LocalVersionManager {
     ) -> HummockResult<Vec<LocalSstableInfo>> {
         let ssts = self
             .shared_buffer_uploader
-            .flush(task_payload, *epochs.last().unwrap(), epoch)
+            .flush(task_payload, epoch)
             .await?;
         self.local_version
             .write()
@@ -613,10 +613,7 @@ impl LocalVersionManager {
         epoch: HummockEpoch,
         task_payload: UploadTaskPayload,
     ) -> HummockResult<()> {
-        let task_result = self
-            .shared_buffer_uploader
-            .flush(task_payload, epoch, epoch)
-            .await;
+        let task_result = self.shared_buffer_uploader.flush(task_payload, epoch).await;
 
         let mut local_version_guard = self.local_version.write();
         let shared_buffer_guard = local_version_guard

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -86,7 +86,6 @@ impl SharedBufferUploader {
     pub async fn flush(
         &self,
         payload: UploadTaskPayload,
-        sst_watermark_epoch: HummockEpoch,
         epoch: HummockEpoch,
     ) -> HummockResult<Vec<LocalSstableInfo>> {
         if payload.is_empty() {
@@ -104,7 +103,7 @@ impl SharedBufferUploader {
             .add_watermark_sst_id(Some(epoch))
             .await?;
 
-        let tables = compact(mem_compactor_ctx, payload, sst_watermark_epoch).await?;
+        let tables = compact(mem_compactor_ctx, payload).await?;
 
         let uploaded_sst_info = tables.into_iter().collect();
 


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

We need to use global-epoch-watermark to recycle multiple-version of the same user-key, which collect from all frontend and record in meta-service. So we can not use local epoch in shared-buffer.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
