### PR TITLE
fix(meta): expired RiseCtl worker causes meta panics

### DIFF
--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -276,11 +276,18 @@ where
                 for (worker_id, key) in workers_to_delete {
                     match cluster_manager.delete_worker_node(key.clone()).await {
                         Ok(worker_type) => {
-                            cluster_manager
-                                .env
-                                .notification_manager()
-                                .delete_sender(worker_type, WorkerKey(key.clone()))
-                                .await;
+                            match worker_type {
+                                WorkerType::Frontend
+                                | WorkerType::ComputeNode
+                                | WorkerType::Compactor => {
+                                    cluster_manager
+                                        .env
+                                        .notification_manager()
+                                        .delete_sender(worker_type, WorkerKey(key.clone()))
+                                        .await
+                                }
+                                _ => {}
+                            };
                             tracing::warn!(
                                 "Deleted expired worker {} {:#?}, current timestamp {}",
                                 worker_id,

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -151,6 +151,7 @@ impl NotificationManager {
             WorkerType::Frontend => core_guard.compute_senders.remove(&worker_key),
             WorkerType::ComputeNode => core_guard.frontend_senders.remove(&worker_key),
             WorkerType::Compactor => core_guard.compactor_senders.remove(&worker_key),
+            WorkerType::RiseCtl => None,
             _ => unreachable!(),
         };
     }

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -151,7 +151,6 @@ impl NotificationManager {
             WorkerType::Frontend => core_guard.compute_senders.remove(&worker_key),
             WorkerType::ComputeNode => core_guard.frontend_senders.remove(&worker_key),
             WorkerType::Compactor => core_guard.compactor_senders.remove(&worker_key),
-            WorkerType::RiseCtl => None,
             _ => unreachable!(),
         };
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- As title.
- Use any command by risedev ctl. After 60s without any heartbeat, meta will panic.

Log:
```
thread 'risingwave-main' panicked at 'internal error: entered unreachable code', src/meta/src/manager/notification.rs:155:18
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
close #5194 