### PR TITLE
chore(meta): remove unused notify_all

### DIFF
--- a/src/tests/sync_point/src/test_utils.rs
+++ b/src/tests/sync_point/src/test_utils.rs
@@ -99,7 +99,7 @@ pub async fn get_meta_client() -> MetaClient {
     let meta_addr = std::env::var("RW_META_ADDR").unwrap();
     let mut client = MetaClient::new(&meta_addr).await.unwrap();
     let worker_id = client
-        .register(WorkerType::Generic, &"127.0.0.1:2333".parse().unwrap(), 0)
+        .register(WorkerType::RiseCtl, &"127.0.0.1:2333".parse().unwrap(), 0)
         .await
         .unwrap();
     client.set_worker_id(worker_id);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

remove unused notify_all

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- remove unused notify_all
- remove WorkerType::Generic

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/issues/5238