### PR TITLE
fix(frontend): mix START_TRANSACTION and BEGIN

### DIFF
--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 
 use pgwire::pg_response::PgResponse;
-use pgwire::pg_response::StatementType::{ABORT, START_TRANSACTION};
+use pgwire::pg_response::StatementType::{ABORT, BEGIN, START_TRANSACTION};
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{DropStatement, ObjectType, Statement};
 
@@ -202,11 +202,16 @@ pub async fn handle(
         // TODO: Track issues #2595 #2541
         Statement::StartTransaction { .. } => Ok(PgResponse::empty_result_with_notice(
             START_TRANSACTION,
-            "Ignored temporarily.See detail in issue#2541".to_string(),
+            "Ignored temporarily. See detail in issue#2541".to_string(),
+        )),
+        // BEGIN is similar to START TRANSACTION.
+        Statement::BEGIN { .. } => Ok(PgResponse::empty_result_with_notice(
+            BEGIN,
+            "Ignored temporarily. See detail in issue#2541".to_string(),
         )),
         Statement::Abort { .. } => Ok(PgResponse::empty_result_with_notice(
             ABORT,
-            "Ignored temporarily.See detail in issue#2541".to_string(),
+            "Ignored temporarily. See detail in issue#2541".to_string(),
         )),
         _ => {
             Err(ErrorCode::NotImplemented(format!("Unhandled ast: {:?}", stmt), None.into()).into())

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -917,8 +917,10 @@ pub enum Statement {
     ///
     /// Note: this is a PostgreSQL-specific statement.
     ShowVariable { variable: Vec<Ident> },
-    /// `{ BEGIN [ TRANSACTION | WORK ] | START TRANSACTION } ...`
+    /// `START TRANSACTION ...`
     StartTransaction { modes: Vec<TransactionMode> },
+    /// `BEGIN [ TRANSACTION | WORK ]`
+    BEGIN { modes: Vec<TransactionMode> },
     /// ABORT
     Abort,
     /// `SET TRANSACTION ...`
@@ -1370,6 +1372,13 @@ impl fmt::Display for Statement {
             }
             Statement::Flush => {
                 write!(f, "FLUSH")
+            }
+            Statement::BEGIN { modes } => {
+                write!(f, "BEGIN")?;
+                if !modes.is_empty() {
+                    write!(f, " {}", display_comma_separated(modes))?;
+                }
+                Ok(())
             }
         }
     }

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3288,7 +3288,7 @@ impl Parser {
 
     pub fn parse_begin(&mut self) -> Result<Statement, ParserError> {
         let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]);
-        Ok(Statement::StartTransaction {
+        Ok(Statement::BEGIN {
             modes: self.parse_transaction_modes()?,
         })
     }

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -3359,9 +3359,6 @@ fn parse_start_transaction() {
     }
 
     verified_stmt("START TRANSACTION");
-    one_statement_parses_to("BEGIN", "START TRANSACTION");
-    one_statement_parses_to("BEGIN WORK", "START TRANSACTION");
-    one_statement_parses_to("BEGIN TRANSACTION", "START TRANSACTION");
 
     verified_stmt("START TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
     verified_stmt("START TRANSACTION ISOLATION LEVEL READ COMMITTED");
@@ -3396,6 +3393,13 @@ fn parse_start_transaction() {
         ParserError::ParserError("Expected transaction mode, found: EOF".to_string()),
         res.unwrap_err()
     );
+}
+
+#[test]
+fn parse_begin() {
+    one_statement_parses_to("BEGIN", "BEGIN");
+    one_statement_parses_to("BEGIN WORK", "BEGIN");
+    one_statement_parses_to("BEGIN TRANSACTION", "BEGIN");
 }
 
 #[test]

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -435,8 +435,7 @@ where
                 &msg.params,
                 msg.result_format_code,
             )
-            .await
-            .map_err(|_| PsqlError::BindError("Failed to instance statement".into()))?;
+            .await?;
 
         // 3. Insert the Portal.
         if portal_name.is_empty() {
@@ -492,7 +491,6 @@ where
     }
 
     async fn process_describe_msg(&mut self, msg: FeDescribeMessage) -> PsqlResult<()> {
-        // m.kind indicates the Describe type:
         //  b'S' => Statement
         //  b'P' => Portal
         assert!(msg.kind == b'S' || msg.kind == b'P');

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -60,6 +60,7 @@ pub enum StatementType {
     OTHER,
     // EMPTY is used when query statement is empty (e.g. ";").
     EMPTY,
+    BEGIN,
 }
 
 impl std::fmt::Display for StatementType {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

separate BEGIN and START_TRANSACTION.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#5262 