### PR TITLE
feat: improve memtable conflicts error message

### DIFF
--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -15,7 +15,9 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 
-#[derive(Clone)]
+use thiserror::Error;
+
+#[derive(Clone, Debug)]
 pub enum RowOp {
     Insert(Vec<u8>),
     Delete(Vec<u8>),
@@ -29,6 +31,18 @@ pub struct MemTable {
 }
 
 pub type MemTableIter<'a> = impl Iterator<Item = (&'a Vec<u8>, &'a RowOp)>;
+
+#[derive(Error, Debug)]
+pub enum MemTableError {
+    #[error("conflicted row operations on same key")]
+    Conflict {
+        key: Vec<u8>,
+        prev: RowOp,
+        new: RowOp,
+    },
+}
+
+type Result<T> = std::result::Result<T, MemTableError>;
 
 impl Default for MemTable {
     fn default() -> Self {
@@ -53,78 +67,79 @@ impl MemTable {
     }
 
     /// write methods
-    pub fn insert(&mut self, pk: Vec<u8>, value: Vec<u8>) {
+    pub fn insert(&mut self, pk: Vec<u8>, value: Vec<u8>) -> Result<()> {
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
                 e.insert(RowOp::Insert(value));
+                Ok(())
             }
             Entry::Occupied(mut e) => match e.get_mut() {
                 RowOp::Delete(ref mut old_value) => {
                     let old_val = std::mem::take(old_value);
                     e.insert(RowOp::Update((old_val, value)));
+                    Ok(())
                 }
-
-                _ => {
-                    panic!(
-                        "invalid flush status: double insert {:?} -> {:?}",
-                        e.key(),
-                        value
-                    );
-                }
+                _ => Err(MemTableError::Conflict {
+                    key: e.key().clone(),
+                    prev: e.get().clone(),
+                    new: RowOp::Insert(value),
+                }),
             },
         }
     }
 
-    pub fn delete(&mut self, pk: Vec<u8>, old_value: Vec<u8>) {
+    pub fn delete(&mut self, pk: Vec<u8>, before_value: Vec<u8>) -> Result<()> {
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
-                e.insert(RowOp::Delete(old_value));
+                e.insert(RowOp::Delete(before_value));
+                Ok(())
             }
             Entry::Occupied(mut e) => match e.get_mut() {
                 RowOp::Insert(original_value) => {
-                    debug_assert_eq!(original_value, &old_value);
+                    debug_assert_eq!(original_value, &before_value);
                     e.remove();
+                    Ok(())
                 }
-                RowOp::Delete(_) => {
-                    panic!(
-                        "invalid flush status: double delete {:?} -> {:?}",
-                        e.key(),
-                        old_value
-                    );
-                }
+                RowOp::Delete(_) => Err(MemTableError::Conflict {
+                    key: e.key().clone(),
+                    prev: e.get().clone(),
+                    new: RowOp::Delete(before_value),
+                }),
                 RowOp::Update(value) => {
                     let (original_old_value, original_new_value) = std::mem::take(value);
-                    debug_assert_eq!(original_new_value, old_value);
+                    debug_assert_eq!(original_new_value, before_value);
                     e.insert(RowOp::Delete(original_old_value));
+                    Ok(())
                 }
             },
         }
     }
 
-    pub fn update(&mut self, pk: Vec<u8>, old_value: Vec<u8>, new_value: Vec<u8>) {
+    pub fn update(&mut self, pk: Vec<u8>, old_value: Vec<u8>, new_value: Vec<u8>) -> Result<()> {
         let entry = self.buffer.entry(pk);
         match entry {
             Entry::Vacant(e) => {
                 e.insert(RowOp::Update((old_value, new_value)));
+                Ok(())
             }
             Entry::Occupied(mut e) => match e.get_mut() {
                 RowOp::Insert(original_value) => {
                     debug_assert_eq!(original_value, &old_value);
                     e.insert(RowOp::Insert(new_value));
+                    Ok(())
                 }
-                RowOp::Delete(_) => {
-                    panic!(
-                        "invalid flush status: double delete {:?} -> {:?}",
-                        e.key(),
-                        old_value
-                    );
-                }
+                RowOp::Delete(_) => Err(MemTableError::Conflict {
+                    key: e.key().clone(),
+                    prev: e.get().clone(),
+                    new: RowOp::Update((old_value, new_value)),
+                }),
                 RowOp::Update(value) => {
                     let (original_old_value, original_new_value) = std::mem::take(value);
                     debug_assert_eq!(original_new_value, old_value);
                     e.insert(RowOp::Update((original_old_value, new_value)));
+                    Ok(())
                 }
             },
         }

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -27,9 +27,9 @@ use risingwave_common::array::{Op, Row, StreamChunk, Vis};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::{ColumnDesc, TableId, TableOption};
 use risingwave_common::error::RwError;
-use risingwave_common::types::VirtualNode;
+use risingwave_common::types::{DataType, VirtualNode};
 use risingwave_common::util::hash_util::CRC32FastBuilder;
-use risingwave_common::util::ordered::OrderedRowSerializer;
+use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_hummock_sdk::key::{prefixed_range, range_of_prefix};
 use risingwave_pb::catalog::Table;
@@ -43,6 +43,7 @@ use crate::row_serde::row_serde_util::{
 };
 use crate::storage_value::StorageValue;
 use crate::store::{ReadOptions, WriteOptions};
+use crate::table::streaming_table::mem_table::MemTableError;
 use crate::table::{compute_vnode, DataTypes, Distribution};
 use crate::{Keyspace, StateStore, StateStoreIter};
 
@@ -58,6 +59,9 @@ pub struct StateTable<S: StateStore> {
 
     /// Used for serializing the primary key.
     pk_serializer: OrderedRowSerializer,
+
+    /// Used for deserializing the primary key. Debug-only for now.
+    pk_deserializer: OrderedRowDeserializer,
 
     /// Datatypes of each column, used for deserializing the row.
     data_types: DataTypes,
@@ -108,7 +112,7 @@ impl<S: StateStore> StateTable<S> {
             .iter()
             .map(|col| col.column_desc.as_ref().unwrap().into())
             .collect();
-        let order_types = table_catalog
+        let order_types: Vec<OrderType> = table_catalog
             .order_key
             .iter()
             .map(|col_order| {
@@ -145,7 +149,13 @@ impl<S: StateStore> StateTable<S> {
             .collect_vec();
 
         let keyspace = Keyspace::table_root(store, &table_id);
-        let pk_serializer = OrderedRowSerializer::new(order_types);
+        let pk_serializer = OrderedRowSerializer::new(order_types.clone());
+
+        let pk_data_types = pk_indices
+            .iter()
+            .map(|i| table_columns[*i].data_type.clone())
+            .collect();
+        let pk_deserializer = OrderedRowDeserializer::new(pk_data_types, order_types);
 
         let data_types = table_columns.iter().map(|c| c.data_type.clone()).collect();
 
@@ -172,6 +182,7 @@ impl<S: StateStore> StateTable<S> {
             mem_table: MemTable::new(),
             keyspace,
             pk_serializer,
+            pk_deserializer,
             data_types,
             pk_indices: pk_indices.to_vec(),
             dist_key_indices,
@@ -216,7 +227,14 @@ impl<S: StateStore> StateTable<S> {
     ) -> Self {
         let keyspace = Keyspace::table_root(store, &table_id);
 
-        let pk_serializer = OrderedRowSerializer::new(order_types);
+        let pk_serializer = OrderedRowSerializer::new(order_types.clone());
+
+        let pk_data_types = pk_indices
+            .iter()
+            .map(|i| table_columns[*i].data_type.clone())
+            .collect();
+        let pk_deserializer = OrderedRowDeserializer::new(pk_data_types, order_types);
+
         let data_types = table_columns.iter().map(|c| c.data_type.clone()).collect();
         let dist_key_in_pk_indices = dist_key_indices
             .iter()
@@ -236,6 +254,7 @@ impl<S: StateStore> StateTable<S> {
             mem_table: MemTable::new(),
             keyspace,
             pk_serializer,
+            pk_deserializer,
             data_types,
             pk_indices,
             dist_key_indices,
@@ -359,6 +378,38 @@ impl<S: StateStore> StateTable<S> {
 
 // write
 impl<S: StateStore> StateTable<S> {
+    fn pretty_row_op(row_op: &RowOp, data_types: &[DataType]) -> String {
+        match row_op {
+            RowOp::Insert(after) => {
+                let after = streaming_deserialize(data_types, after.as_ref()).unwrap();
+                format!("Insert({:?})", &after)
+            }
+            RowOp::Delete(before) => {
+                let before = streaming_deserialize(data_types, before.as_ref()).unwrap();
+                format!("Delete({:?})", &before)
+            }
+            RowOp::Update((before, after)) => {
+                let before = streaming_deserialize(data_types, before.as_ref()).unwrap();
+                let after = streaming_deserialize(data_types, after.as_ref()).unwrap();
+                format!("Update({:?}, {:?})", &before, &after)
+            }
+        }
+    }
+
+    fn handle_mem_table_error(&self, e: MemTableError) {
+        match e {
+            MemTableError::Conflict { key, prev, new } => {
+                let key = self.pk_deserializer.deserialize(&key).unwrap();
+                panic!(
+                    "mem-table operation conflicts! key: {:?}, prev: {}, new: {}",
+                    &key,
+                    Self::pretty_row_op(&prev, self.data_types.as_ref()),
+                    Self::pretty_row_op(&new, self.data_types.as_ref())
+                )
+            }
+        }
+    }
+
     /// Insert a row into state table. Must provide a full row corresponding to the column desc of
     /// the table.
     pub fn insert(&mut self, value: Row) -> StorageResult<()> {
@@ -367,7 +418,9 @@ impl<S: StateStore> StateTable<S> {
         let key_bytes =
             serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
         let value_bytes = value.serialize().map_err(err)?;
-        self.mem_table.insert(key_bytes, value_bytes);
+        self.mem_table
+            .insert(key_bytes, value_bytes)
+            .unwrap_or_else(|e| self.handle_mem_table_error(e));
         Ok(())
     }
 
@@ -378,7 +431,9 @@ impl<S: StateStore> StateTable<S> {
         let key_bytes =
             serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
         let value_bytes = old_value.serialize().map_err(err)?;
-        self.mem_table.delete(key_bytes, value_bytes);
+        self.mem_table
+            .delete(key_bytes, value_bytes)
+            .unwrap_or_else(|e| self.handle_mem_table_error(e));
         Ok(())
     }
 
@@ -397,7 +452,8 @@ impl<S: StateStore> StateTable<S> {
         let old_value_bytes = old_value.serialize().map_err(err)?;
         let new_value_bytes = new_value.serialize().map_err(err)?;
         self.mem_table
-            .update(new_key_bytes, old_value_bytes, new_value_bytes);
+            .update(new_key_bytes, old_value_bytes, new_value_bytes)
+            .unwrap_or_else(|e| self.handle_mem_table_error(e));
         Ok(())
     }
 
@@ -437,6 +493,7 @@ impl<S: StateStore> StateTable<S> {
                             Op::Insert | Op::UpdateInsert => self.mem_table.insert(key, value),
                             Op::Delete | Op::UpdateDelete => self.mem_table.delete(key, value),
                         }
+                        .unwrap_or_else(|e| self.handle_mem_table_error(e))
                     }
                 }
             }
@@ -446,6 +503,7 @@ impl<S: StateStore> StateTable<S> {
                         Op::Insert | Op::UpdateInsert => self.mem_table.insert(key, value),
                         Op::Delete | Op::UpdateDelete => self.mem_table.delete(key, value),
                     }
+                    .unwrap_or_else(|e| self.handle_mem_table_error(e))
                 }
             }
         }

--- a/src/storage/src/table/streaming_table/test_streaming_table.rs
+++ b/src/storage/src/table/streaming_table/test_streaming_table.rs
@@ -711,3 +711,38 @@ async fn test_state_table_iter_with_prefix() {
     let res = iter.next().await;
     assert!(res.is_none());
 }
+
+#[tokio::test]
+#[should_panic]
+async fn test_mem_table_assertion() {
+    let state_store = MemoryStateStore::new();
+    let column_descs = vec![
+        ColumnDesc::unnamed(ColumnId::from(0), DataType::Int32),
+        ColumnDesc::unnamed(ColumnId::from(1), DataType::Int32),
+        ColumnDesc::unnamed(ColumnId::from(2), DataType::Int32),
+    ];
+    let order_types = vec![OrderType::Ascending];
+    let pk_index = vec![0_usize];
+    let mut state_table = StateTable::new_without_distribution(
+        state_store.clone(),
+        TableId::from(0x42),
+        column_descs,
+        order_types,
+        pk_index,
+    );
+    state_table
+        .insert(Row(vec![
+            Some(1_i32.into()),
+            Some(11_i32.into()),
+            Some(111_i32.into()),
+        ]))
+        .unwrap();
+    // duplicate key: 1
+    state_table
+        .insert(Row(vec![
+            Some(1_i32.into()),
+            Some(22_i32.into()),
+            Some(222_i32.into()),
+        ]))
+        .unwrap();
+}

--- a/src/storage/src/table/streaming_table/test_streaming_table.rs
+++ b/src/storage/src/table/streaming_table/test_streaming_table.rs
@@ -724,7 +724,7 @@ async fn test_mem_table_assertion() {
     let order_types = vec![OrderType::Ascending];
     let pk_index = vec![0_usize];
     let mut state_table = StateTable::new_without_distribution(
-        state_store.clone(),
+        state_store,
         TableId::from(0x42),
         column_descs,
         order_types,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Make the panic message easier to read when conflicts detected by memtable.

Before:

> thread 'risingwave-streaming-actor' panicked at 'invalid flush status: double insert [75, 0, 128, 0, 0, 4, 0, 128, 0, 0, 4] -> [1, 4, 0, 0, 0, 1, 18, 0, 0, 0, 83, 117, 112, 112, 108, 105, 101, 114, 35, 48, 48, 48, 48, 48, 48, 48, 48, 52, 1, 25, 0, 0, 0, 66, 107, 55, 97, 104, 52, 67, 75, 56, 83, 89, 81, 84, 101, 112, 69, 109, 118, 77, 107, 107, 103, 77, 119, 103, 1, 15, 0, 0, 0, 50, 53, 45, 56, 52, 51, 45, 55, 56, 55, 45, 55, 52, 55, 57, 1, 0, 0, 4, 0, 98, 25, 56, 25, 2, 0, 0, 0, 0, 0, 0, 0, 1, 4, 0, 0, 0]'

After:

> thread 'table::streaming_table::test_streaming_table::test_mem_table_assertion' panicked at 'mem-table operation conflicts! key: OrderedRow([NormalOrder(Some(Int32(-2139095040)))]), prev: Insert(Row([Some(Int32(1)), Some(Int32(11)), Some(Int32(111))])), new: Insert(Row([Some(Int32(1)), Some(Int32(22)), Some(Int32(222))]))'


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

not user-facing

## Refer to a related PR or issue link (optional)

None