### PR TITLE
fix(test): data should be from upstream in `tpch_upstream.slt`

### DIFF
--- a/e2e_test/streaming/nexmark_snapshot.slt
+++ b/e2e_test/streaming/nexmark_snapshot.slt
@@ -1,11 +1,14 @@
 include ../nexmark/create_tables.slt.part
 
+# First, insert the data into the tables
 include ../nexmark/insert_person.slt.part
 include ../nexmark/insert_auction.slt.part
 include ../nexmark/insert_bid.slt.part
 
+# Then, create materialized views based on the historical data (snapshot)
 include ./nexmark/create_views.slt.part
 
+# Test each query
 include ./nexmark/q0.slt.part
 include ./nexmark/q1.slt.part
 include ./nexmark/q2.slt.part

--- a/e2e_test/streaming/nexmark_upstream.slt
+++ b/e2e_test/streaming/nexmark_upstream.slt
@@ -1,14 +1,18 @@
 include ../nexmark/create_tables.slt.part
 
+# First, create materialized views with empty data
 include ./nexmark/create_views.slt.part
 
+# Then, insert the data into the tables
 include ../nexmark/insert_person.slt.part
 include ../nexmark/insert_auction.slt.part
 include ../nexmark/insert_bid.slt.part
 
+# Ensure that the upstream data is fully consumed
 statement ok
 flush;
 
+# Test each query
 include ./nexmark/q0.slt.part
 include ./nexmark/q1.slt.part
 include ./nexmark/q2.slt.part

--- a/e2e_test/streaming/tpch_snapshot.slt
+++ b/e2e_test/streaming/tpch_snapshot.slt
@@ -1,5 +1,6 @@
 include ../tpch/create_tables.slt.part
 
+# First, insert the data into the tables
 include ../tpch/insert_customer.slt.part
 include ../tpch/insert_lineitem.slt.part
 include ../tpch/insert_nation.slt.part
@@ -9,8 +10,10 @@ include ../tpch/insert_partsupp.slt.part
 include ../tpch/insert_region.slt.part
 include ../tpch/insert_supplier.slt.part
 
+# Then, create materialized views based on the historical data (snapshot)
 include ./tpch/create_views.slt.part
 
+# Test each query
 include ./tpch/q1.slt.part
 include ./tpch/q2.slt.part
 include ./tpch/q3.slt.part

--- a/e2e_test/streaming/tpch_upstream.slt
+++ b/e2e_test/streaming/tpch_upstream.slt
@@ -1,5 +1,9 @@
 include ../tpch/create_tables.slt.part
 
+# First, create materialized views with empty data
+include ./tpch/create_views.slt.part
+
+# Then, insert the data into the tables
 include ../tpch/insert_customer.slt.part
 include ../tpch/insert_lineitem.slt.part
 include ../tpch/insert_nation.slt.part
@@ -9,11 +13,11 @@ include ../tpch/insert_partsupp.slt.part
 include ../tpch/insert_region.slt.part
 include ../tpch/insert_supplier.slt.part
 
+# Ensure that the upstream data is fully consumed
 statement ok
 flush;
 
-include ./tpch/create_views.slt.part
-
+# Test each query
 include ./tpch/q1.slt.part
 include ./tpch/q2.slt.part
 include ./tpch/q3.slt.part


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. Previously the `tpch_upstream.slt` is the same as `tpch_snapshot.slt`. 😄

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
