### PR TITLE
feat(frontend): Use index scan if it satisfies required order

### DIFF
--- a/src/frontend/planner_test/tests/testdata/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/index_selection.yaml
@@ -7,6 +7,14 @@
     BatchExchange { order: [], dist: Single }
       BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
+    /* Use index if it provides required order */
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(a, b) include(c);
+    select * from t1 order by a, b
+  batch_plan: |
+    BatchExchange { order: [idx1.a ASC, idx1.b ASC], dist: Single }
+      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = 1 or a = 2

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -29,6 +29,7 @@ use super::{
 use crate::catalog::{ColumnId, IndexCatalog};
 use crate::expr::{CollectInputRef, Expr, ExprImpl, ExprRewriter, InputRef};
 use crate::optimizer::plan_node::{BatchSeqScan, LogicalFilter, LogicalProject, LogicalValues};
+use crate::optimizer::property::Direction::Asc;
 use crate::optimizer::property::{FieldOrder, FunctionalDependencySet, Order};
 use crate::optimizer::rule::IndexSelectionRule;
 use crate::session::OptimizerContextRef;
@@ -474,9 +475,9 @@ impl PredicatePushdown for LogicalScan {
 }
 
 impl LogicalScan {
-    fn to_batch_inner(&self) -> Result<PlanRef> {
+    fn to_batch_inner_with_required(&self, required_order: &Order) -> Result<PlanRef> {
         if self.predicate.always_true() {
-            Ok(BatchSeqScan::new(self.clone(), vec![]).into())
+            required_order.enforce_if_not_satisfies(BatchSeqScan::new(self.clone(), vec![]).into())
         } else {
             let (scan_ranges, predicate) = self.predicate.clone().split_to_scan_ranges(
                 &self.table_desc.order_column_indices(),
@@ -497,30 +498,85 @@ impl LogicalScan {
                 plan = BatchProject::new(LogicalProject::new(plan, exprs)).into()
             }
             assert_eq!(plan.schema(), self.schema());
-            Ok(plan)
+            required_order.enforce_if_not_satisfies(plan)
         }
+    }
+
+    // For every index, check if the order of the index satisfies the required_order
+    // If yes, use an index scan
+    fn use_index_scan_if_order_is_satisfied(
+        &self,
+        required_order: &Order,
+    ) -> Option<Result<PlanRef>> {
+        let mut satisfying_indices: Vec<(Order, Rc<IndexCatalog>)> = self
+            .indexes()
+            .iter()
+            .map(|idx| {
+                (
+                    Order {
+                        field_order: idx
+                            .index_item
+                            .iter()
+                            .map(|idx_item| FieldOrder {
+                                index: idx_item.index,
+                                direct: Asc,
+                            })
+                            .collect(),
+                    },
+                    idx.clone(),
+                )
+            })
+            .filter(|(order, _)| {
+                !required_order.field_order.is_empty() && order.satisfies(required_order)
+            })
+            .collect();
+        if !satisfying_indices.is_empty() {
+            let (_, index) = satisfying_indices.pop().unwrap();
+            let p2s_mapping = index.primary_to_secondary_mapping();
+            if self
+                .required_col_idx()
+                .iter()
+                .all(|x| p2s_mapping.contains_key(x))
+            {
+                let index_scan = self.to_index_scan(
+                    &index.name,
+                    index.index_table.table_desc().into(),
+                    &index.primary_to_secondary_mapping,
+                );
+                return Some(index_scan.to_batch());
+            }
+        }
+        None
     }
 }
 
 impl ToBatch for LogicalScan {
     fn to_batch(&self) -> Result<PlanRef> {
-        // index selection
+        self.to_batch_with_order_required(&Order::any())
+    }
+
+    fn to_batch_with_order_required(&self, required_order: &Order) -> Result<PlanRef> {
         if !self.indexes().is_empty() {
             let index_selection_rule = IndexSelectionRule::create();
             if let Some(applied) = index_selection_rule.apply(self.clone().into()) {
                 if let Some(scan) = applied.as_logical_scan() {
                     // covering index
-                    return scan.to_batch();
+                    return required_order.enforce_if_not_satisfies(scan.to_batch().unwrap());
                 } else if let Some(join) = applied.as_logical_join() {
                     // index lookup join
-                    return join.to_batch_lookup_join();
+                    return required_order
+                        .enforce_if_not_satisfies(join.to_batch_lookup_join().unwrap());
                 } else {
                     unreachable!();
                 }
+            } else {
+                // Try to make use of index if it satisfies the required order
+                if let Some(plan_ref) = self.use_index_scan_if_order_is_satisfied(required_order) {
+                    return plan_ref;
+                }
             }
         }
-
-        self.to_batch_inner()
+        self.to_batch_inner_with_required(required_order)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Instead of checking if the cost of using an index scan is cheaper than just ripping through all values, the fact that the output requires a specific order is taken into account when choosing scan types.
This PR introduces the usage of covered index, when the output requires an order that is matched by the index.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.
