### PR TITLE
refactor: `Row::serialize()` does not need to return `Result`

### DIFF
--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -278,12 +278,12 @@ impl Row {
     /// [`crate::util::ordered::OrderedRow`]
     ///
     /// All values are nullable. Each value will have 1 extra byte to indicate whether it is null.
-    pub fn serialize(&self) -> value_encoding::Result<Vec<u8>> {
+    pub fn serialize(&self) -> Vec<u8> {
         let mut result = vec![];
         for cell in &self.0 {
             serialize_datum(cell, &mut result);
         }
-        Ok(result)
+        result
     }
 
     /// Serialize part of the row into memcomparable bytes.
@@ -394,7 +394,7 @@ mod tests {
             Some(ScalarImpl::Decimal("-233.3".parse().unwrap())),
             Some(ScalarImpl::Interval(IntervalUnit::new(7, 8, 9))),
         ]);
-        let bytes = row.serialize().unwrap();
+        let bytes = row.serialize();
         assert_eq!(bytes.len(), 10 + 1 + 2 + 4 + 8 + 4 + 8 + 16 + 16 + 9);
         let de = RowDeserializer::new(vec![
             Ty::Varchar,

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -410,20 +410,16 @@ async fn test_row_seq_scan() -> Result<()> {
 
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(4_i32.into()),
-            Some(7_i64.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(2_i32.into()),
-            Some(5_i32.into()),
-            Some(8_i64.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(4_i32.into()),
+        Some(7_i64.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(2_i32.into()),
+        Some(5_i32.into()),
+        Some(8_i64.into()),
+    ]));
     state.commit(epoch).await.unwrap();
 
     let executor = Box::new(RowSeqScanExecutor::new(

--- a/src/storage/src/table/batch_table/test_batch_table.rs
+++ b/src/storage/src/table/batch_table/test_batch_table.rs
@@ -59,19 +59,11 @@ async fn test_storage_table_get_row() -> StorageResult<()> {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![Some(1_i32.into()), None, None]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(3_i32.into()), None, None]))
-        .unwrap();
+    state.insert(Row(vec![Some(1_i32.into()), None, None]));
+    state.insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
+    state.insert(Row(vec![Some(3_i32.into()), None, None]));
 
-    state
-        .delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
+    state.delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
     state.commit(epoch).await.unwrap();
 
     let epoch = u64::MAX;
@@ -136,27 +128,21 @@ async fn test_storage_get_row_for_string() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![
-            Some("1".to_string().into()),
-            Some("11".to_string().into()),
-            Some("111".to_string().into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some("4".to_string().into()),
-            Some("44".to_string().into()),
-            Some("444".to_string().into()),
-        ]))
-        .unwrap();
-    state
-        .delete(Row(vec![
-            Some("4".to_string().into()),
-            Some("44".to_string().into()),
-            Some("444".to_string().into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some("1".to_string().into()),
+        Some("11".to_string().into()),
+        Some("111".to_string().into()),
+    ]));
+    state.insert(Row(vec![
+        Some("4".to_string().into()),
+        Some("44".to_string().into()),
+        Some("444".to_string().into()),
+    ]));
+    state.delete(Row(vec![
+        Some("4".to_string().into()),
+        Some("44".to_string().into()),
+        Some("444".to_string().into()),
+    ]));
     state.commit(epoch).await.unwrap();
 
     let epoch = u64::MAX;
@@ -220,19 +206,11 @@ async fn test_shuffled_column_id_for_storage_table_get_row() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![Some(1_i32.into()), None, None]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(3_i32.into()), None, None]))
-        .unwrap();
+    state.insert(Row(vec![Some(1_i32.into()), None, None]));
+    state.insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
+    state.insert(Row(vec![Some(3_i32.into()), None, None]));
 
-    state
-        .delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
+    state.delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
     state.commit(epoch).await.unwrap();
 
     let epoch = u64::MAX;
@@ -300,19 +278,11 @@ async fn test_row_based_storage_table_point_get_in_batch_mode() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![Some(1_i32.into()), None, None]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
-    state
-        .insert(Row(vec![Some(3_i32.into()), None, None]))
-        .unwrap();
+    state.insert(Row(vec![Some(1_i32.into()), None, None]));
+    state.insert(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
+    state.insert(Row(vec![Some(3_i32.into()), None, None]));
 
-    state
-        .delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]))
-        .unwrap();
+    state.delete(Row(vec![Some(2_i32.into()), None, Some(222_i32.into())]));
     state.commit(epoch).await.unwrap();
 
     let epoch = u64::MAX;
@@ -375,27 +345,21 @@ async fn test_row_based_storage_table_scan_in_batch_mode() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .delete(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
+    state.delete(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
     state.commit(epoch).await.unwrap();
 
     let epoch = u64::MAX;

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -412,7 +412,7 @@ impl<S: StateStore> StateTable<S> {
 
     /// Insert a row into state table. Must provide a full row corresponding to the column desc of
     /// the table.
-    pub fn insert(&mut self, value: Row) -> StorageResult<()> {
+    pub fn insert(&mut self, value: Row) {
         let pk = value.by_indices(self.pk_indices());
 
         let key_bytes =
@@ -421,12 +421,11 @@ impl<S: StateStore> StateTable<S> {
         self.mem_table
             .insert(key_bytes, value_bytes)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
-        Ok(())
     }
 
     /// Delete a row from state table. Must provide a full row of old value corresponding to the
     /// column desc of the table.
-    pub fn delete(&mut self, old_value: Row) -> StorageResult<()> {
+    pub fn delete(&mut self, old_value: Row) {
         let pk = old_value.by_indices(self.pk_indices());
         let key_bytes =
             serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
@@ -434,11 +433,10 @@ impl<S: StateStore> StateTable<S> {
         self.mem_table
             .delete(key_bytes, value_bytes)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
-        Ok(())
     }
 
     /// Update a row. The old and new value should have the same pk.
-    pub fn update(&mut self, old_value: Row, new_value: Row) -> StorageResult<()> {
+    pub fn update(&mut self, old_value: Row, new_value: Row) {
         let old_pk = old_value.by_indices(self.pk_indices());
         let new_pk = new_value.by_indices(self.pk_indices());
         debug_assert_eq!(old_pk, new_pk);
@@ -452,7 +450,6 @@ impl<S: StateStore> StateTable<S> {
         self.mem_table
             .update(new_key_bytes, old_value.serialize(), new_value.serialize())
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
-        Ok(())
     }
 
     /// Write batch with a `StreamChunk` which should have the same schema with the table.

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -417,7 +417,7 @@ impl<S: StateStore> StateTable<S> {
 
         let key_bytes =
             serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
-        let value_bytes = value.serialize().map_err(err)?;
+        let value_bytes = value.serialize();
         self.mem_table
             .insert(key_bytes, value_bytes)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
@@ -430,7 +430,7 @@ impl<S: StateStore> StateTable<S> {
         let pk = old_value.by_indices(self.pk_indices());
         let key_bytes =
             serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode_by_pk(&pk));
-        let value_bytes = old_value.serialize().map_err(err)?;
+        let value_bytes = old_value.serialize();
         self.mem_table
             .delete(key_bytes, value_bytes)
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
@@ -449,10 +449,8 @@ impl<S: StateStore> StateTable<S> {
             self.compute_vnode_by_pk(&new_pk),
         );
 
-        let old_value_bytes = old_value.serialize().map_err(err)?;
-        let new_value_bytes = new_value.serialize().map_err(err)?;
         self.mem_table
-            .update(new_key_bytes, old_value_bytes, new_value_bytes)
+            .update(new_key_bytes, old_value.serialize(), new_value.serialize())
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
         Ok(())
     }

--- a/src/storage/src/table/streaming_table/test_streaming_table.rs
+++ b/src/storage/src/table/streaming_table/test_streaming_table.rs
@@ -41,27 +41,21 @@ async fn test_state_table() -> StorageResult<()> {
         pk_index,
     );
     let mut epoch: u64 = 0;
-    state_table
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
-    state_table
-        .insert(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
-    state_table
-        .insert(Row(vec![
-            Some(3_i32.into()),
-            Some(33_i32.into()),
-            Some(333_i32.into()),
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
+    state_table.insert(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
+    state_table.insert(Row(vec![
+        Some(3_i32.into()),
+        Some(33_i32.into()),
+        Some(333_i32.into()),
+    ]));
 
     // test read visibility
     let row1 = state_table
@@ -90,13 +84,11 @@ async fn test_state_table() -> StorageResult<()> {
         ]))
     );
 
-    state_table
-        .delete(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
+    state_table.delete(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
 
     let row2_delete = state_table
         .get_row(&Row(vec![Some(2_i32.into())]), epoch)
@@ -113,17 +105,13 @@ async fn test_state_table() -> StorageResult<()> {
     assert_eq!(row2_delete_commit, None);
 
     epoch += 1;
-    state_table
-        .delete(Row(vec![
-            Some(3_i32.into()),
-            Some(33_i32.into()),
-            Some(333_i32.into()),
-        ]))
-        .unwrap();
+    state_table.delete(Row(vec![
+        Some(3_i32.into()),
+        Some(33_i32.into()),
+        Some(333_i32.into()),
+    ]));
 
-    state_table
-        .insert(Row(vec![Some(4_i32.into()), None, None]))
-        .unwrap();
+    state_table.insert(Row(vec![Some(4_i32.into()), None, None]));
     let row4 = state_table
         .get_row(&Row(vec![Some(4_i32.into())]), epoch)
         .await
@@ -136,9 +124,7 @@ async fn test_state_table() -> StorageResult<()> {
         .unwrap();
     assert_eq!(non_exist_row, None);
 
-    state_table
-        .delete(Row(vec![Some(4_i32.into()), None, None]))
-        .unwrap();
+    state_table.delete(Row(vec![Some(4_i32.into()), None, None]));
 
     state_table.commit(epoch).await.unwrap();
 
@@ -176,59 +162,47 @@ async fn test_state_table_update_insert() -> StorageResult<()> {
         pk_index,
     );
     let mut epoch: u64 = 0;
-    state_table
-        .insert(Row(vec![
-            Some(6_i32.into()),
-            Some(66_i32.into()),
-            Some(666_i32.into()),
-            Some(6666_i32.into()),
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(6_i32.into()),
+        Some(66_i32.into()),
+        Some(666_i32.into()),
+        Some(6666_i32.into()),
+    ]));
 
-    state_table
-        .insert(Row(vec![
-            Some(7_i32.into()),
-            None,
-            Some(777_i32.into()),
-            None,
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(7_i32.into()),
+        None,
+        Some(777_i32.into()),
+        None,
+    ]));
     state_table.commit(epoch).await.unwrap();
 
     epoch += 1;
-    state_table
-        .delete(Row(vec![
-            Some(6_i32.into()),
-            Some(66_i32.into()),
-            Some(666_i32.into()),
-            Some(6666_i32.into()),
-        ]))
-        .unwrap();
-    state_table
-        .insert(Row(vec![
-            Some(6_i32.into()),
-            None,
-            None,
-            Some(6666_i32.into()),
-        ]))
-        .unwrap();
+    state_table.delete(Row(vec![
+        Some(6_i32.into()),
+        Some(66_i32.into()),
+        Some(666_i32.into()),
+        Some(6666_i32.into()),
+    ]));
+    state_table.insert(Row(vec![
+        Some(6_i32.into()),
+        None,
+        None,
+        Some(6666_i32.into()),
+    ]));
 
-    state_table
-        .delete(Row(vec![
-            Some(7_i32.into()),
-            None,
-            Some(777_i32.into()),
-            None,
-        ]))
-        .unwrap();
-    state_table
-        .insert(Row(vec![
-            Some(7_i32.into()),
-            Some(77_i32.into()),
-            Some(7777_i32.into()),
-            None,
-        ]))
-        .unwrap();
+    state_table.delete(Row(vec![
+        Some(7_i32.into()),
+        None,
+        Some(777_i32.into()),
+        None,
+    ]));
+    state_table.insert(Row(vec![
+        Some(7_i32.into()),
+        Some(77_i32.into()),
+        Some(7777_i32.into()),
+        None,
+    ]));
     let row6 = state_table
         .get_row(&Row(vec![Some(6_i32.into())]), epoch)
         .await
@@ -288,40 +262,32 @@ async fn test_state_table_update_insert() -> StorageResult<()> {
 
     epoch += 1;
 
-    state_table
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(2_i32.into()),
-            Some(3_i32.into()),
-            Some(4_i32.into()),
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(2_i32.into()),
+        Some(3_i32.into()),
+        Some(4_i32.into()),
+    ]));
     state_table.commit(epoch).await.unwrap();
     // one epoch: delete (1, 2, 3, 4), insert (5, 6, 7, None), delete(5, 6, 7, None)
-    state_table
-        .delete(Row(vec![
-            Some(1_i32.into()),
-            Some(2_i32.into()),
-            Some(3_i32.into()),
-            Some(4_i32.into()),
-        ]))
-        .unwrap();
-    state_table
-        .insert(Row(vec![
-            Some(5_i32.into()),
-            Some(6_i32.into()),
-            Some(7_i32.into()),
-            None,
-        ]))
-        .unwrap();
-    state_table
-        .delete(Row(vec![
-            Some(5_i32.into()),
-            Some(6_i32.into()),
-            Some(7_i32.into()),
-            None,
-        ]))
-        .unwrap();
+    state_table.delete(Row(vec![
+        Some(1_i32.into()),
+        Some(2_i32.into()),
+        Some(3_i32.into()),
+        Some(4_i32.into()),
+    ]));
+    state_table.insert(Row(vec![
+        Some(5_i32.into()),
+        Some(6_i32.into()),
+        Some(7_i32.into()),
+        None,
+    ]));
+    state_table.delete(Row(vec![
+        Some(5_i32.into()),
+        Some(6_i32.into()),
+        Some(7_i32.into()),
+        None,
+    ]));
 
     let row1 = state_table
         .get_row(&Row(vec![Some(1_i32.into())]), epoch)
@@ -360,51 +326,39 @@ async fn test_state_table_iter() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .delete(Row(vec![
-            Some(2_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
+    state.delete(Row(vec![
+        Some(2_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(3_i32.into()),
-            Some(33_i32.into()),
-            Some(3333_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(3_i32.into()),
+        Some(33_i32.into()),
+        Some(3333_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(6_i32.into()),
-            Some(66_i32.into()),
-            Some(666_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(6_i32.into()),
+        Some(66_i32.into()),
+        Some(666_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(9_i32.into()),
-            Some(99_i32.into()),
-            Some(999_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(9_i32.into()),
+        Some(99_i32.into()),
+        Some(999_i32.into()),
+    ]));
 
     {
         let iter = state.iter(epoch).await.unwrap();
@@ -450,51 +404,39 @@ async fn test_state_table_iter() {
     // [3, 33, 3333], [6, 66, 666], [9, 99, 999] exists in
     // cell_based_table
 
-    state
-        .delete(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(3_i32.into()),
-            Some(33_i32.into()),
-            Some(333_i32.into()),
-        ]))
-        .unwrap();
+    state.delete(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(3_i32.into()),
+        Some(33_i32.into()),
+        Some(333_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(4_i32.into()),
-            Some(44_i32.into()),
-            Some(444_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(4_i32.into()),
+        Some(44_i32.into()),
+        Some(444_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(5_i32.into()),
-            Some(55_i32.into()),
-            Some(555_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(7_i32.into()),
-            Some(77_i32.into()),
-            Some(777_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(5_i32.into()),
+        Some(55_i32.into()),
+        Some(555_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(7_i32.into()),
+        Some(77_i32.into()),
+        Some(777_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(8_i32.into()),
-            Some(88_i32.into()),
-            Some(888_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(8_i32.into()),
+        Some(88_i32.into()),
+        Some(888_i32.into()),
+    ]));
 
     let iter = state.iter(epoch).await.unwrap();
     pin_mut!(iter);
@@ -607,59 +549,45 @@ async fn test_state_table_iter_with_prefix() {
     );
     let epoch: u64 = 0;
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(4_i32.into()),
-            Some(44_i32.into()),
-            Some(444_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(4_i32.into()),
+        Some(44_i32.into()),
+        Some(444_i32.into()),
+    ]));
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(55_i32.into()),
-            Some(555_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(55_i32.into()),
+        Some(555_i32.into()),
+    ]));
     state.commit(epoch).await.unwrap();
 
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(33_i32.into()),
-            Some(333_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(55_i32.into()),
-            Some(5555_i32.into()),
-        ]))
-        .unwrap();
-    state
-        .insert(Row(vec![
-            Some(6_i32.into()),
-            Some(66_i32.into()),
-            Some(666_i32.into()),
-        ]))
-        .unwrap();
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(33_i32.into()),
+        Some(333_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(55_i32.into()),
+        Some(5555_i32.into()),
+    ]));
+    state.insert(Row(vec![
+        Some(6_i32.into()),
+        Some(66_i32.into()),
+        Some(666_i32.into()),
+    ]));
     let epoch = u64::MAX;
     let pk_prefix = Row(vec![Some(1_i32.into())]);
     let iter = state.iter_with_pk_prefix(&pk_prefix, epoch).await.unwrap();
@@ -730,19 +658,15 @@ async fn test_mem_table_assertion() {
         order_types,
         pk_index,
     );
-    state_table
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(11_i32.into()),
-            Some(111_i32.into()),
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(11_i32.into()),
+        Some(111_i32.into()),
+    ]));
     // duplicate key: 1
-    state_table
-        .insert(Row(vec![
-            Some(1_i32.into()),
-            Some(22_i32.into()),
-            Some(222_i32.into()),
-        ]))
-        .unwrap();
+    state_table.insert(Row(vec![
+        Some(1_i32.into()),
+        Some(22_i32.into()),
+        Some(222_i32.into()),
+    ]));
 }

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -336,7 +336,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                     if self.is_right_table_writer {
                         if let Some(row) = current_epoch_row.take() {
                             assert_eq!(epoch, barrier.epoch.prev);
-                            self.right_table.insert(row)?;
+                            self.right_table.insert(row);
                             self.right_table.commit(epoch).await?;
                         }
                     }

--- a/src/stream/src/executor/group_top_n.rs
+++ b/src/stream/src/executor/group_top_n.rs
@@ -180,11 +180,11 @@ impl<S: StateStore> TopNExecutorBase for InnerGroupTopNExecutorNew<S> {
             match op {
                 Op::Insert | Op::UpdateInsert => {
                     self.managed_state
-                        .insert(ordered_pk_row.clone(), row.clone())?;
+                        .insert(ordered_pk_row.clone(), row.clone());
                 }
 
                 Op::Delete | Op::UpdateDelete => {
-                    self.managed_state.delete(&ordered_pk_row, row.clone())?;
+                    self.managed_state.delete(&ordered_pk_row, row.clone());
                 }
             }
 

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -849,11 +849,11 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                         // Since join key contains pk and pk is unique, there should be only
                         // one row if matched
                         let [row]: [_; 1] = append_only_matched_rows.try_into().unwrap();
-                        side_match.ht.delete(key, row)?;
+                        side_match.ht.delete(key, row);
                     } else if need_update_side_update_degree(T, SIDE) {
-                        side_update.ht.insert(key, JoinRow::new(value, degree))?;
+                        side_update.ht.insert(key, JoinRow::new(value, degree));
                     } else {
-                        side_update.ht.insert_row(key, value)?;
+                        side_update.ht.insert_row(key, value);
                     }
                 }
                 Op::Delete | Op::UpdateDelete => {
@@ -897,9 +897,9 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                         yield Message::Chunk(chunk);
                     }
                     if need_update_side_update_degree(T, SIDE) {
-                        side_update.ht.delete(key, JoinRow::new(value, degree))?;
+                        side_update.ht.delete(key, JoinRow::new(value, degree));
                     } else {
-                        side_update.ht.delete_row(key, value)?;
+                        side_update.ht.delete_row(key, value);
                     };
                 }
             }

--- a/src/stream/src/executor/managed_state/aggregation/array_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/array_agg.rs
@@ -144,13 +144,13 @@ impl<S: StateStore> ManagedArrayAggState<S> {
                     if self.cache_synced {
                         self.cache.insert(cache_key, cache_data);
                     }
-                    state_table.insert(state_row)?;
+                    state_table.insert(state_row);
                 }
                 Delete | UpdateDelete => {
                     if self.cache_synced {
                         self.cache.remove(cache_key);
                     }
-                    state_table.delete(state_row)?;
+                    state_table.delete(state_row);
                 }
             }
         }

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -207,7 +207,7 @@ impl<S: StateStore> GenericExtremeState<S> {
                     {
                         self.cache.insert(cache_key, cache_data);
                     }
-                    state_table.insert(state_row)?;
+                    state_table.insert(state_row);
                     self.total_count += 1;
                 }
                 Op::Delete | Op::UpdateDelete => {
@@ -218,7 +218,7 @@ impl<S: StateStore> GenericExtremeState<S> {
                             self.cache_synced = false;
                         }
                     }
-                    state_table.delete(state_row)?;
+                    state_table.delete(state_row);
                     self.total_count -= 1;
                 }
             }

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -173,13 +173,13 @@ impl<S: StateStore> ManagedStringAggState<S> {
                     if self.cache_synced {
                         self.cache.insert(cache_key, cache_data);
                     }
-                    state_table.insert(state_row)?;
+                    state_table.insert(state_row);
                 }
                 Delete | UpdateDelete => {
                     if self.cache_synced {
                         self.cache.remove(cache_key);
                     }
-                    state_table.delete(state_row)?;
+                    state_table.delete(state_row);
                 }
             }
         }

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -126,7 +126,7 @@ impl ManagedValueState {
         v.extend_from_slice(&self.group_key.as_ref().unwrap_or_else(Row::empty).0);
         v.push(self.state.get_output()?);
 
-        state_table.insert(Row::new(v))?;
+        state_table.insert(Row::new(v));
 
         self.is_dirty = false;
         Ok(())

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -78,6 +78,7 @@ impl<S: StateStore> RangeCache<S> {
 
     /// Delete a row and corresponding scalar value key from cache (if within range) and
     /// `StateTable`.
+    // FIXME: panic instead of returning Err
     pub fn delete(&mut self, k: &ScalarImpl, v: Row) -> StreamExecutorResult<()> {
         if self.range.contains(k) {
             let contains_element = self

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -72,7 +72,7 @@ impl<S: StateStore> RangeCache<S> {
             let entry = self.cache.entry(k).or_insert_with(HashSet::new);
             entry.insert(v.clone());
         }
-        self.state_table.insert(v)?;
+        self.state_table.insert(v);
         Ok(())
     }
 
@@ -92,7 +92,7 @@ impl<S: StateStore> RangeCache<S> {
                 )));
             };
         }
-        self.state_table.delete(v)?;
+        self.state_table.delete(v);
         Ok(())
     }
 

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -138,7 +138,7 @@ mod tests {
             // Pk is only a `i64` here, so encoding method does not matter.
             let pk = Row(pk).serialize();
             let join_row = JoinRow { row, degree: 0 };
-            managed_state.insert(pk, join_row.encode().unwrap());
+            managed_state.insert(pk, join_row.encode());
         }
 
         for ((_, matched_row), (d1, d2)) in managed_state

--- a/src/stream/src/executor/managed_state/join/join_entry_state.rs
+++ b/src/stream/src/executor/managed_state/join/join_entry_state.rs
@@ -136,7 +136,7 @@ mod tests {
             let row: Row = row_ref.into();
             let pk = pk_indices.iter().map(|idx| row[*idx].clone()).collect_vec();
             // Pk is only a `i64` here, so encoding method does not matter.
-            let pk = Row(pk).serialize().unwrap();
+            let pk = Row(pk).serialize();
             let join_row = JoinRow { row, degree: 0 };
             managed_state.insert(pk, join_row.encode().unwrap());
         }

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -456,7 +456,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
     }
 
     /// Insert a join row
-    pub fn insert(&mut self, key: &K, value: JoinRow) -> StreamExecutorResult<()> {
+    pub fn insert(&mut self, key: &K, value: JoinRow) {
         if let Some(entry) = self.inner.get_mut(key) {
             let pk = value
                 .row
@@ -467,12 +467,11 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         let (row, degree) = value.into_table_rows(&self.state.order_key_indices);
         self.state.table.insert(row);
         self.degree_state.table.insert(degree);
-        Ok(())
     }
 
     /// Insert a row.
     /// Used when the side does not need to update degree.
-    pub fn insert_row(&mut self, key: &K, value: Row) -> StreamExecutorResult<()> {
+    pub fn insert_row(&mut self, key: &K, value: Row) {
         let join_row = JoinRow::new(value.clone(), 0);
 
         if let Some(entry) = self.inner.get_mut(key) {
@@ -482,11 +481,10 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         }
         // If no cache maintained, only update the state table.
         self.state.table.insert(value);
-        Ok(())
     }
 
     /// Delete a join row
-    pub fn delete(&mut self, key: &K, value: JoinRow) -> StreamExecutorResult<()> {
+    pub fn delete(&mut self, key: &K, value: JoinRow) {
         if let Some(entry) = self.inner.get_mut(key) {
             let pk = value
                 .row
@@ -498,12 +496,11 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         let (row, degree) = value.into_table_rows(&self.state.order_key_indices);
         self.state.table.delete(row);
         self.degree_state.table.delete(degree);
-        Ok(())
     }
 
     /// Delete a row
     /// Used when the side does not need to update degree.
-    pub fn delete_row(&mut self, key: &K, value: Row) -> StreamExecutorResult<()> {
+    pub fn delete_row(&mut self, key: &K, value: Row) {
         if let Some(entry) = self.inner.get_mut(key) {
             let pk =
                 value.extract_memcomparable_by_indices(&self.pk_serializer, &self.state.pk_indices);
@@ -512,7 +509,6 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
 
         // If no cache maintained, only update the state table.
         self.state.table.delete(value);
-        Ok(())
     }
 
     /// Insert a [`JoinEntryState`]

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -465,8 +465,8 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         }
         // If no cache maintained, only update the flush buffer.
         let (row, degree) = value.into_table_rows(&self.state.order_key_indices);
-        self.state.table.insert(row)?;
-        self.degree_state.table.insert(degree)?;
+        self.state.table.insert(row);
+        self.degree_state.table.insert(degree);
         Ok(())
     }
 
@@ -481,7 +481,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
             entry.insert(pk, join_row.encode());
         }
         // If no cache maintained, only update the state table.
-        self.state.table.insert(value)?;
+        self.state.table.insert(value);
         Ok(())
     }
 
@@ -496,8 +496,8 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
 
         // If no cache maintained, only update the state table.
         let (row, degree) = value.into_table_rows(&self.state.order_key_indices);
-        self.state.table.delete(row)?;
-        self.degree_state.table.delete(degree)?;
+        self.state.table.delete(row);
+        self.degree_state.table.delete(degree);
         Ok(())
     }
 
@@ -511,7 +511,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         }
 
         // If no cache maintained, only update the state table.
-        self.state.table.delete(value)?;
+        self.state.table.delete(value);
         Ok(())
     }
 
@@ -527,7 +527,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         let new_degree = join_row
             .get_schemaed_degree(&self.state.all_data_types, &self.state.order_key_indices)?;
 
-        self.degree_state.table.update(old_degree, new_degree)?;
+        self.degree_state.table.update(old_degree, new_degree);
         Ok(())
     }
 
@@ -538,7 +538,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         let new_degree = join_row
             .get_schemaed_degree(&self.state.all_data_types, &self.state.order_key_indices)?;
 
-        self.degree_state.table.update(old_degree, new_degree)?;
+        self.degree_state.table.update(old_degree, new_degree);
         Ok(())
     }
 

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -102,11 +102,11 @@ impl JoinRow {
         (self.row, degree)
     }
 
-    pub fn encode(&self) -> StreamExecutorResult<EncodedJoinRow> {
-        Ok(EncodedJoinRow {
+    pub fn encode(&self) -> EncodedJoinRow {
+        EncodedJoinRow {
             row: self.row.serialize(),
             degree: self.degree,
-        })
+        }
     }
 }
 
@@ -430,7 +430,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
                     .context("Fail to fetch a degree")?;
                 entry_state.insert(
                     pk,
-                    JoinRow::new(row.into_owned(), *degree_i64.as_int64() as u64).encode()?,
+                    JoinRow::new(row.into_owned(), *degree_i64.as_int64() as u64).encode(),
                 );
             }
         } else {
@@ -441,7 +441,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
                 let row = row?;
                 let pk = row
                     .extract_memcomparable_by_indices(&self.pk_serializer, &self.state.pk_indices);
-                entry_state.insert(pk, JoinRow::new(row.into_owned(), 0).encode()?);
+                entry_state.insert(pk, JoinRow::new(row.into_owned(), 0).encode());
             }
         };
 
@@ -461,7 +461,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
             let pk = value
                 .row
                 .extract_memcomparable_by_indices(&self.pk_serializer, &self.state.pk_indices);
-            entry.insert(pk, value.encode()?);
+            entry.insert(pk, value.encode());
         }
         // If no cache maintained, only update the flush buffer.
         let (row, degree) = value.into_table_rows(&self.state.order_key_indices);
@@ -478,7 +478,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         if let Some(entry) = self.inner.get_mut(key) {
             let pk =
                 value.extract_memcomparable_by_indices(&self.pk_serializer, &self.state.pk_indices);
-            entry.insert(pk, join_row.encode()?);
+            entry.insert(pk, join_row.encode());
         }
         // If no cache maintained, only update the state table.
         self.state.table.insert(value)?;

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -104,7 +104,7 @@ impl JoinRow {
 
     pub fn encode(&self) -> StreamExecutorResult<EncodedJoinRow> {
         Ok(EncodedJoinRow {
-            row: self.row.serialize()?,
+            row: self.row.serialize(),
             degree: self.degree,
         })
     }

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -54,14 +54,12 @@ impl<S: StateStore> ManagedTopNState<S> {
         }
     }
 
-    pub fn insert(&mut self, _key: OrderedRow, value: Row) -> StreamExecutorResult<()> {
+    pub fn insert(&mut self, _key: OrderedRow, value: Row) {
         self.state_table.insert(value);
-        Ok(())
     }
 
-    pub fn delete(&mut self, _key: &OrderedRow, value: Row) -> StreamExecutorResult<()> {
+    pub fn delete(&mut self, _key: &OrderedRow, value: Row) {
         self.state_table.delete(value);
-        Ok(())
     }
 
     fn get_topn_row(&self, row: Row) -> TopNStateRow {

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -218,9 +218,7 @@ mod tests {
             .collect::<Vec<_>>();
 
         let epoch = 1;
-        managed_state
-            .insert(ordered_rows[3].clone(), rows[3].clone())
-            .unwrap();
+        managed_state.insert(ordered_rows[3].clone(), rows[3].clone());
 
         // now ("ab", 4)
         let valid_rows = managed_state
@@ -231,9 +229,7 @@ mod tests {
         assert_eq!(valid_rows.len(), 1);
         assert_eq!(valid_rows[0].ordered_key, ordered_rows[3].clone());
 
-        managed_state
-            .insert(ordered_rows[2].clone(), rows[2].clone())
-            .unwrap();
+        managed_state.insert(ordered_rows[2].clone(), rows[2].clone());
         let valid_rows = managed_state
             .find_range(None, 1, Some(1), epoch)
             .await
@@ -241,9 +237,7 @@ mod tests {
         assert_eq!(valid_rows.len(), 1);
         assert_eq!(valid_rows[0].ordered_key, ordered_rows[2].clone());
 
-        managed_state
-            .insert(ordered_rows[1].clone(), rows[1].clone())
-            .unwrap();
+        managed_state.insert(ordered_rows[1].clone(), rows[1].clone());
 
         let valid_rows = managed_state
             .find_range(None, 1, Some(2), epoch)
@@ -260,14 +254,10 @@ mod tests {
         );
 
         // delete ("abc", 3)
-        managed_state
-            .delete(&ordered_rows[1].clone(), rows[1].clone())
-            .unwrap();
+        managed_state.delete(&ordered_rows[1].clone(), rows[1].clone());
 
         // insert ("abc", 2)
-        managed_state
-            .insert(ordered_rows[0].clone(), rows[0].clone())
-            .unwrap();
+        managed_state.insert(ordered_rows[0].clone(), rows[0].clone());
 
         let valid_rows = managed_state
             .find_range(None, 0, Some(3), epoch)
@@ -309,18 +299,10 @@ mod tests {
             .collect::<Vec<_>>();
 
         let epoch = 1;
-        managed_state
-            .insert(ordered_rows[3].clone(), rows[3].clone())
-            .unwrap();
-        managed_state
-            .insert(ordered_rows[1].clone(), rows[1].clone())
-            .unwrap();
-        managed_state
-            .insert(ordered_rows[2].clone(), rows[2].clone())
-            .unwrap();
-        managed_state
-            .insert(ordered_rows[4].clone(), rows[4].clone())
-            .unwrap();
+        managed_state.insert(ordered_rows[3].clone(), rows[3].clone());
+        managed_state.insert(ordered_rows[1].clone(), rows[1].clone());
+        managed_state.insert(ordered_rows[2].clone(), rows[2].clone());
+        managed_state.insert(ordered_rows[4].clone(), rows[4].clone());
 
         managed_state
             .fill_cache(None, &mut cache, &ordered_rows[3], 2, epoch)

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -55,12 +55,12 @@ impl<S: StateStore> ManagedTopNState<S> {
     }
 
     pub fn insert(&mut self, _key: OrderedRow, value: Row) -> StreamExecutorResult<()> {
-        self.state_table.insert(value)?;
+        self.state_table.insert(value);
         Ok(())
     }
 
     pub fn delete(&mut self, _key: &OrderedRow, value: Row) -> StreamExecutorResult<()> {
-        self.state_table.delete(value)?;
+        self.state_table.delete(value);
         Ok(())
     }
 

--- a/src/stream/src/executor/mview/test_utils.rs
+++ b/src/stream/src/executor/mview/test_utils.rs
@@ -49,13 +49,11 @@ pub async fn gen_basic_table(row_count: usize) -> StorageTable<MemoryStateStore>
 
     for idx in 0..row_count {
         let idx = idx as i32;
-        state
-            .insert(Row(vec![
-                Some(idx.into()),
-                Some(idx.into()),
-                Some(idx.into()),
-            ]))
-            .unwrap();
+        state.insert(Row(vec![
+            Some(idx.into()),
+            Some(idx.into()),
+            Some(idx.into()),
+        ]));
     }
     state.commit(epoch).await.unwrap();
 

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -359,12 +359,12 @@ impl<S: StateStore> TopNExecutorBase for InnerTopNExecutorNew<S> {
                 Op::Insert | Op::UpdateInsert => {
                     // First insert input row to state store
                     self.managed_state
-                        .insert(ordered_pk_row.clone(), row.clone())?;
+                        .insert(ordered_pk_row.clone(), row.clone());
                 }
 
                 Op::Delete | Op::UpdateDelete => {
                     // First remove the row from state store
-                    self.managed_state.delete(&ordered_pk_row, row.clone())?;
+                    self.managed_state.delete(&ordered_pk_row, row.clone());
                 }
             }
             self.cache

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -151,7 +151,7 @@ impl<S: StateStore> TopNExecutorBase for InnerAppendOnlyTopNExecutor<S> {
                 continue;
             }
             self.managed_state
-                .insert(ordered_pk_row.clone(), row.clone())?;
+                .insert(ordered_pk_row.clone(), row.clone());
 
             // Then insert input row to corresponding cache range according to its order key
             if self.cache.low.len() < self.cache.offset {
@@ -189,7 +189,7 @@ impl<S: StateStore> TopNExecutorBase for InnerAppendOnlyTopNExecutor<S> {
             let res = self.cache.middle.pop_last().unwrap();
             res_ops.push(Op::Delete);
             res_rows.push(res.1.clone());
-            self.managed_state.delete(&res.0, res.1)?;
+            self.managed_state.delete(&res.0, res.1);
 
             res_ops.push(Op::Insert);
             res_rows.push(elem_to_compare_with_middle.1.clone());


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title:

```diff
-    pub fn serialize(&self) -> value_encoding::Result<Vec<u8>> {
+    pub fn serialize(&self) -> Vec<u8> {
```

Other changes are consequent. 😇

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

None