### PR TITLE
feat(risectl): risectl hummock: add list-version-deltas

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -379,7 +379,7 @@ message GetVersionDeltasRequest {
 }
 
 message GetVersionDeltasResponse {
-    HummockVersionDeltas version_deltas = 1;
+  HummockVersionDeltas version_deltas = 1;
 }
 
 service HummockManagerService {

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -373,9 +373,19 @@ message TriggerFullGCResponse {
   common.Status status = 1;
 }
 
+message GetVersionDeltasRequest {
+  uint64 start_id = 1;
+  uint32 num_epochs = 2;
+}
+
+message GetVersionDeltasResponse {
+    HummockVersionDeltas version_deltas = 1;
+}
+
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);
   rpc GetCurrentVersion(GetCurrentVersionRequest) returns (GetCurrentVersionResponse);
+  rpc GetVersionDeltas(GetVersionDeltasRequest) returns (GetVersionDeltasResponse);
   rpc ReportCompactionTasks(ReportCompactionTasksRequest) returns (ReportCompactionTasksResponse);
   rpc ReportCompactionTaskProgress(ReportCompactionTaskProgressRequest) returns (ReportCompactionTaskProgressResponse);
   rpc PinSnapshot(PinSnapshotRequest) returns (PinSnapshotResponse);

--- a/src/ctl/src/cmd_impl/hummock/list_version_deltas.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_version_deltas.rs
@@ -12,17 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod list_version;
-pub use list_version::*;
-mod list_kv;
-pub use list_kv::*;
-mod sst_dump;
-pub use sst_dump::*;
-mod list_version_deltas;
-pub mod observer;
-mod trigger_full_gc;
-mod trigger_manual_compaction;
+use risingwave_rpc_client::HummockMetaClient;
 
-pub use list_version_deltas::*;
-pub use trigger_full_gc::*;
-pub use trigger_manual_compaction::*;
+use crate::common::MetaServiceOpts;
+
+pub async fn list_version_deltas(start_id: u64, num_epochs: u32) -> anyhow::Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta_client = meta_opts.create_meta_client().await?;
+    let resp = meta_client.get_version_deltas(start_id, num_epochs).await?;
+    println!("{:#?}", resp.version_deltas);
+    Ok(())
+}

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -62,6 +62,15 @@ enum Commands {
 enum HummockCommands {
     /// list latest Hummock version on meta node
     ListVersion,
+
+    /// list hummock version deltas in the meta store
+    ListVersionDeltas {
+        #[clap(short, long = "start-version-delta-id", default_value_t = 0)]
+        start_id: u64,
+
+        #[clap(short, long = "num-epochs", default_value_t = 100)]
+        num_epochs: u32,
+    },
     /// list all Hummock key-value pairs
     ListKv {
         #[clap(short, long = "epoch", default_value_t = u64::MAX)]
@@ -143,6 +152,12 @@ pub async fn start(opts: CliOpts) -> Result<()> {
     match opts.command {
         Commands::Hummock(HummockCommands::ListVersion) => {
             cmd_impl::hummock::list_version().await?;
+        }
+        Commands::Hummock(HummockCommands::ListVersionDeltas {
+            start_id,
+            num_epochs,
+        }) => {
+            cmd_impl::hummock::list_version_deltas(start_id, num_epochs).await?;
         }
         Commands::Hummock(HummockCommands::ListKv { epoch, table_id }) => {
             cmd_impl::hummock::list_kv(epoch, table_id).await?;

--- a/src/meta/src/hummock/mock_hummock_meta_client.rs
+++ b/src/meta/src/hummock/mock_hummock_meta_client.rs
@@ -23,7 +23,7 @@ use risingwave_hummock_sdk::{
 };
 use risingwave_pb::hummock::{
     CompactTask, CompactTaskProgress, CompactionGroup, HummockSnapshot, HummockVersion,
-    SubscribeCompactTasksResponse, VacuumTask,
+    HummockVersionDeltas, SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::{Result, RpcError};
 use risingwave_rpc_client::HummockMetaClient;
@@ -71,6 +71,14 @@ impl HummockMetaClient for MockHummockMetaClient {
 
     async fn get_current_version(&self) -> Result<HummockVersion> {
         Ok(self.hummock_manager.get_current_version().await)
+    }
+
+    async fn get_version_deltas(
+        &self,
+        _start_id: u64,
+        _num_epochs: u32,
+    ) -> Result<HummockVersionDeltas> {
+        unimplemented!()
     }
 
     async fn pin_snapshot(&self) -> Result<HummockSnapshot> {

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -90,6 +90,21 @@ where
         }))
     }
 
+    async fn get_version_deltas(
+        &self,
+        request: Request<GetVersionDeltasRequest>,
+    ) -> Result<Response<GetVersionDeltasResponse>, Status> {
+        let req = request.into_inner();
+        let version_deltas = self
+            .hummock_manager
+            .get_version_deltas(req.start_id, req.num_epochs)
+            .await?;
+        let resp = GetVersionDeltasResponse {
+            version_deltas: Some(version_deltas),
+        };
+        Ok(Response::new(resp))
+    }
+
     async fn report_compaction_tasks(
         &self,
         request: Request<ReportCompactionTasksRequest>,

--- a/src/rpc_client/src/hummock_meta_client.rs
+++ b/src/rpc_client/src/hummock_meta_client.rs
@@ -18,7 +18,7 @@ use risingwave_hummock_sdk::{
 };
 use risingwave_pb::hummock::{
     CompactTask, CompactTaskProgress, CompactionGroup, HummockSnapshot, HummockVersion,
-    SubscribeCompactTasksResponse, VacuumTask,
+    HummockVersionDeltas, SubscribeCompactTasksResponse, VacuumTask,
 };
 use tonic::Streaming;
 
@@ -28,6 +28,11 @@ use crate::error::Result;
 pub trait HummockMetaClient: Send + Sync + 'static {
     async fn unpin_version_before(&self, unpin_version_before: HummockVersionId) -> Result<()>;
     async fn get_current_version(&self) -> Result<HummockVersion>;
+    async fn get_version_deltas(
+        &self,
+        start_id: u64,
+        num_epochs: u32,
+    ) -> Result<HummockVersionDeltas>;
     async fn pin_snapshot(&self) -> Result<HummockSnapshot>;
     async fn unpin_snapshot(&self) -> Result<()>;
     async fn unpin_snapshot_before(&self, pinned_epochs: HummockEpoch) -> Result<()>;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -477,6 +477,23 @@ impl HummockMetaClient for MetaClient {
             .unwrap())
     }
 
+    async fn get_version_deltas(
+        &self,
+        start_id: u64,
+        num_epochs: u32,
+    ) -> Result<HummockVersionDeltas> {
+        let req = GetVersionDeltasRequest {
+            start_id,
+            num_epochs,
+        };
+        Ok(self
+            .inner
+            .get_version_deltas(req)
+            .await?
+            .version_deltas
+            .unwrap())
+    }
+
     async fn pin_snapshot(&self) -> Result<HummockSnapshot> {
         let req = PinSnapshotRequest {
             context_id: self.worker_id(),
@@ -700,6 +717,7 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, risectl_list_state_tables, RisectlListStateTablesRequest, RisectlListStateTablesResponse }
             ,{ hummock_client, unpin_version_before, UnpinVersionBeforeRequest, UnpinVersionBeforeResponse }
             ,{ hummock_client, get_current_version, GetCurrentVersionRequest, GetCurrentVersionResponse }
+            ,{ hummock_client, get_version_deltas, GetVersionDeltasRequest, GetVersionDeltasResponse }
             ,{ hummock_client, pin_snapshot, PinSnapshotRequest, PinSnapshotResponse }
             ,{ hummock_client, get_epoch, GetEpochRequest, GetEpochResponse }
             ,{ hummock_client, unpin_snapshot, UnpinSnapshotRequest, UnpinSnapshotResponse }

--- a/src/storage/src/hummock/hummock_meta_client.rs
+++ b/src/storage/src/hummock/hummock_meta_client.rs
@@ -18,7 +18,7 @@ use async_trait::async_trait;
 use risingwave_hummock_sdk::{HummockSstableId, LocalSstableInfo, SstIdRange};
 use risingwave_pb::hummock::{
     CompactTask, CompactTaskProgress, CompactionGroup, HummockSnapshot, HummockVersion,
-    SubscribeCompactTasksResponse, VacuumTask,
+    HummockVersionDeltas, SubscribeCompactTasksResponse, VacuumTask,
 };
 use risingwave_rpc_client::error::Result;
 use risingwave_rpc_client::{HummockMetaClient, MetaClient};
@@ -54,6 +54,16 @@ impl HummockMetaClient for MonitoredHummockMetaClient {
 
     async fn get_current_version(&self) -> Result<HummockVersion> {
         self.meta_client.get_current_version().await
+    }
+
+    async fn get_version_deltas(
+        &self,
+        start_id: u64,
+        num_epochs: u32,
+    ) -> Result<HummockVersionDeltas> {
+        self.meta_client
+            .get_version_deltas(start_id, num_epochs)
+            .await
     }
 
     async fn pin_snapshot(&self) -> Result<HummockSnapshot> {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add a list-version-deltas command to **risectl** to print the version delta logs.
Users can specify the first version delta via `start_id` and the number of epochs to print via `num_epochs`.

```
$ ./risedev ctl hummock list-version-deltas -h
USAGE:
    risectl hummock list-version-deltas [OPTIONS]

OPTIONS:
    -h, --help                                 Print help information
    -n, --num-epochs <NUM_EPOCHS>              [default: 100]
    -s, --start-version-delta-id <START_ID>    [default: 0]
    -V, --version                              Print version information

```

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
