### PR TITLE
fix(pgwire): return no_data in describe message when encounter non-query statement 

### DIFF
--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -189,6 +189,8 @@ impl PgStatement {
         })
     }
 
+    /// We define the statement start with ("select","values","show","with","describe") is query
+    /// statement. Because these statement will return a result set.
     pub fn is_query(&self) -> bool {
         self.is_query
     }
@@ -267,6 +269,8 @@ impl PgPortal {
         ))
     }
 
+    /// We define the statement start with ("select","values","show","with","describe") is query
+    /// statement. Because these statement will return a result set.
     pub fn is_query(&self) -> bool {
         self.is_query
     }

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -87,6 +87,7 @@ pub struct PgStatement {
     query_string: Bytes,
     type_description: Vec<TypeOid>,
     row_description: Vec<PgFieldDescriptor>,
+    is_query: bool,
 }
 
 impl PgStatement {
@@ -95,12 +96,14 @@ impl PgStatement {
         query_string: Bytes,
         type_description: Vec<TypeOid>,
         row_description: Vec<PgFieldDescriptor>,
+        is_query: bool,
     ) -> Self {
         PgStatement {
             name,
             query_string,
             type_description,
             row_description,
+            is_query,
         }
     }
 
@@ -147,6 +150,7 @@ impl PgStatement {
                 stmt_type: None,
                 row_description: self.row_desc(),
                 result_format,
+                is_query: self.is_query,
             });
         }
 
@@ -181,7 +185,12 @@ impl PgStatement {
             stmt_type: None,
             row_description,
             result_format,
+            is_query: self.is_query,
         })
+    }
+
+    pub fn is_query(&self) -> bool {
+        self.is_query
     }
 }
 
@@ -193,6 +202,7 @@ pub struct PgPortal {
     stmt_type: Option<StatementType>,
     row_description: Vec<PgFieldDescriptor>,
     result_format: bool,
+    is_query: bool,
 }
 
 impl PgPortal {
@@ -255,6 +265,10 @@ impl PgPortal {
             self.row_description.clone(),
             row_end,
         ))
+    }
+
+    pub fn is_query(&self) -> bool {
+        self.is_query
     }
 }
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -493,6 +493,11 @@ where
     async fn process_describe_msg(&mut self, msg: FeDescribeMessage) -> PsqlResult<()> {
         //  b'S' => Statement
         //  b'P' => Portal
+        tracing::trace!(
+            "(extended query)desribe name: {}",
+            cstr_to_str(&msg.name).unwrap()
+        );
+
         assert!(msg.kind == b'S' || msg.kind == b'P');
         if msg.kind == b'S' {
             let name = cstr_to_str(&msg.name).unwrap().to_string();

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -524,6 +524,8 @@ where
                     .write(&BeMessage::RowDescription(&statement.row_desc()))
                     .await?;
             } else {
+                // According https://www.postgresql.org/docs/current/protocol-flow.html#:~:text=The%20response%20is%20a%20RowDescri[…]0a%20query%20that%20will%20return%20rows%3B,
+                // return NoData message if the statement is not a query.
                 self.stream.write(&BeMessage::NoData).await?;
             }
         } else if msg.kind == b'P' {
@@ -545,6 +547,8 @@ where
                     .write(&BeMessage::RowDescription(&portal.row_desc()))
                     .await?;
             } else {
+                // According https://www.postgresql.org/docs/current/protocol-flow.html#:~:text=The%20response%20is%20a%20RowDescri[…]0a%20query%20that%20will%20return%20rows%3B,
+                // return NoData message if the statement is not a query.
                 self.stream.write(&BeMessage::NoData).await?;
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
We missing a behavior in describe phase : [https://www.postgresql.org/docs/current/protocol-flow.html#:~:text=The%20response%20is%20a%20RowDescri[…]0a%20query%20that%20will%20return%20rows%3B](https://www.postgresql.org/docs/current/protocol-flow.html#:~:text=The%20response%20is%20a%20RowDescription%20message%20describing%20the%20rows%20that%20will%20be%20returned%20by%20executing%20the%20portal%3B%20or%20a%20NoData%20message%20if%20the%20portal%20does%20not%20contain%20a%20query%20that%20will%20return%20rows%3B)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
#3675 