### PR TITLE
feat(bench): introduce read write rate limiter for file cache bench for accuracy

### DIFF
--- a/src/bench/file_cache_bench/main.rs
+++ b/src/bench/file_cache_bench/main.rs
@@ -16,6 +16,7 @@
 mod analyze;
 #[cfg(target_os = "linux")]
 mod bench;
+mod rate;
 #[cfg(target_os = "linux")]
 mod utils;
 

--- a/src/bench/file_cache_bench/rate.rs
+++ b/src/bench/file_cache_bench/rate.rs
@@ -1,0 +1,45 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::{Duration, Instant};
+
+pub struct RateLimiter {
+    capacity: f64,
+    quota: f64,
+
+    last: Instant,
+}
+
+impl RateLimiter {
+    pub fn new(capacity: f64) -> Self {
+        Self {
+            capacity,
+            quota: 0.0,
+            last: Instant::now(),
+        }
+    }
+
+    pub fn consume(&mut self, weight: f64) -> Option<Duration> {
+        let now = Instant::now();
+        let refill = now.duration_since(self.last).as_secs_f64() * self.capacity;
+        self.last = now;
+        self.quota = f64::min(self.quota + refill, self.capacity);
+        self.quota -= weight;
+        if self.quota >= 0.0 {
+            return None;
+        }
+        let wait = Duration::from_secs_f64((-self.quota) / self.capacity);
+        Some(wait)
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Introduce token bucket rate limiter to limit read rate or write rate when benchmarking file cache alone for accuracy. The old strategy was too simple and may contribute tail latency because I/O requests tend to be issued at the same duration.

Usage:

```plain
risingwave_bench

USAGE:
    file-cache-bench [OPTIONS] --path <PATH>

OPTIONS:
        --bs <BS>                                                  (KiB) [default: 1024]
        --cache-file-fallocate-unit <CACHE_FILE_FALLOCATE_UNIT>    (MiB) [default: 512]
        --cache-meta-fallocate-unit <CACHE_META_FALLOCATE_UNIT>    (MiB) [default: 16]
        --capacity <CAPACITY>                                      (MiB) [default: 1024]
        --concurrency <CONCURRENCY>                                [default: 8]
    -h, --help                                                     Print help information
        --look-up-range <LOOK_UP_RANGE>                            [default: 10000]
    -p, --path <PATH>
        --r-rate <R_RATE>                                          (MiB/s), 0 for inf [default: 0]
        --read <READ>                                              [default: 1]
        --report-interval <REPORT_INTERVAL>                        (s) [default: 1]
        --time <TIME>                                              (s) [default: 600]
        --total-buffer-capacity <TOTAL_BUFFER_CAPACITY>            (MiB) [default: 128]
        --w-rate <W_RATE>                                          (MiB/s), 0 for inf [default: 0]
        --write <WRITE>                                            [default: 1]
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
