### PR TITLE
feat(compaction group): add new compaction group when registering sou…

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -40,6 +40,7 @@ message Source {
     TableSourceInfo table_source = 6;
   }
   uint32 owner = 7;
+  uint32 independent_compaction_group_type = 8;
 }
 
 message Sink {

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -79,6 +79,7 @@ pub(crate) fn make_prost_source(
         name,
         info: Some(source_info),
         owner: session.user_id(),
+        independent_compaction_group_type: 0,
     })
 }
 

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -144,6 +144,7 @@ impl<S: MetaStore> CompactionGroupManager<S> {
         &self,
         source_id: u32,
         table_properties: &HashMap<String, String>,
+        independent_compaction_group_type: u32,
     ) -> Result<Vec<StateTableId>> {
         let table_option = TableOption::build_table_option(table_properties);
         self.inner
@@ -152,7 +153,12 @@ impl<S: MetaStore> CompactionGroupManager<S> {
             .register(
                 &mut [(
                     source_id,
-                    StaticCompactionGroupId::StateDefault.into(),
+                    (if independent_compaction_group_type == 1 {
+                        StaticCompactionGroupId::NewCompactionGroup
+                    } else {
+                        StaticCompactionGroupId::StateDefault
+                    })
+                    .into(),
                     table_option,
                 )],
                 self.env.meta_store(),
@@ -604,22 +610,22 @@ mod tests {
 
         // Test register_source
         compaction_group_manager
-            .register_source(source_1, &table_properties)
+            .register_source(source_1, &table_properties, 0)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 1);
         compaction_group_manager
-            .register_source(source_2, &table_properties)
+            .register_source(source_2, &table_properties, 0)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 2);
         compaction_group_manager
-            .register_source(source_2, &table_properties)
+            .register_source(source_2, &table_properties, 0)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 2);
         compaction_group_manager
-            .register_source(source_3, &table_properties)
+            .register_source(source_3, &table_properties, 0)
             .await
             .unwrap();
         assert_eq!(registered_number().await, 3);

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -605,7 +605,11 @@ where
         // Register beforehand and is safeguarded by CompactionGroupManager::purge_stale_members.
         let registered_table_ids = self
             .compaction_group_manager
-            .register_source(source.id, &HashMap::new())
+            .register_source(
+                source.id,
+                &HashMap::new(),
+                source.independent_compaction_group_type,
+            )
             .await?;
         let compaction_group_manager_ref = self.compaction_group_manager.clone();
         revert_funcs.push(Box::pin(async move {


### PR DESCRIPTION
…rce if required

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

add new compaction group when registering source if required
this PR follows #5265 , which does same work on table fragments

background:

Discussions on compaction group:
- Plan to introduce more compaction groups into our system. Experiments WIP.
- Prefer using separate HummockVersion for different compaction groups even when we have more compaction groups after considering using shared L0, which introduces excessive complexity in compaction and is error-prone.
- Discuss about optimizations to handle increasing IOPS and small objects issue.

design:

Create new compaction groups on source creation if properties of source hint that this source should have separate compaction groups.

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
