### PR TITLE
fix(meta): recovery use wrong epoch

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -784,12 +784,11 @@ where
             node.notifiers
                 .into_iter()
                 .for_each(|notifier| notifier.notify_collection_failed(err.clone()));
-            new_epoch = node.command_ctx.prev_epoch;
         }
         if self.enable_recovery {
             // If failed, enter recovery mode.
             let (new_epoch, actors_to_track, create_mview_progress) =
-                self.recovery(new_epoch).await;
+                self.recovery(state.in_flight_prev_epoch).await;
             *tracker = CreateMviewProgressTracker::default();
             tracker.add(new_epoch, actors_to_track, vec![]);
             for progress in &create_mview_progress {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
We use the prev_epoch of the latest barrier as the prev_epoch to stop the actor. So we will use this epoch again to write sharedbuffer. 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
