### PR TITLE
feat(frontend): Add e2e test for primary index scan

### DIFF
--- a/e2e_test/batch/order/test_order_requirers_index.part
+++ b/e2e_test/batch/order/test_order_requirers_index.part
@@ -1,0 +1,41 @@
+# description: Test lookup joins with order
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t1 (a int, b int, c int);
+
+statement ok
+INSERT INTO t1 VALUES (10, 0, 35), (10, -2, 28), (-2, 1, 81), (6, -5, 29), (-2, -5, 51), (8, 2, 17), (1, 4, 54), (10, 5, 53), (-1, 3, 96), (10, -1, 70), (5, 2, 50), (-10, 3, 55), (9, -2, 32), (-8, 1, 91), (-2, -1, 75), (9, 4, 13);
+
+statement ok
+create index idx1 on t1(a, b, c);
+
+# Index on all required columns
+query I rowsort
+select * from t1 order by a;
+----
+-1 3 96
+-10 3 55
+-2 -1 75
+-2 -5 51
+-2 1 81
+-8 1 91
+1 4 54
+10 -1 70
+10 -2 28
+10 0 35
+10 5 53
+5 2 50
+6 -5 29
+8 2 17
+9 -2 32
+9 4 13
+
+
+statement ok
+drop index idx1;
+
+statement ok
+drop table t1;

--- a/src/frontend/planner_test/tests/testdata/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/index_selection.yaml
@@ -7,14 +7,6 @@
     BatchExchange { order: [], dist: Single }
       BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
-    /* Use index if it provides required order */
-    create table t1 (a int, b int, c int);
-    create index idx1 on t1(a, b) include(c);
-    select * from t1 order by a, b
-  batch_plan: |
-    BatchExchange { order: [idx1.a ASC, idx1.b ASC], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.a, idx1.b) }
-- sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = 1 or a = 2
@@ -60,6 +52,31 @@
     BatchExchange { order: [], dist: Single }
       BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
         BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(1))], distribution: SomeShard }
+- sql: |
+    /* Index on all required columns */
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(a, b, c);
+    select * from t1 order by a
+  batch_plan: |
+    BatchExchange { order: [idx1.a ASC], dist: Single }
+      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.a, idx1.b, idx1.c) }
+- sql: |
+    /* Index includes all required columns I */
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(b) include(c, a);
+    select * from t1 order by b
+  batch_plan: |
+    BatchExchange { order: [idx1.b ASC], dist: Single }
+      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.b) }
+- sql: |
+    /* Index includes all required columns II */
+    create table t1 (a int, b int, c int);
+    create index idx1 on t1(c, b) include(a);
+    select b, c, a from t1 order by c, b
+  batch_plan: |
+    BatchExchange { order: [idx1.c ASC, idx1.b ASC], dist: Single }
+      BatchProject { exprs: [idx1.b, idx1.c, idx1.a] }
+        BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.c, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
@@ -495,32 +512,3 @@
     BatchExchange { order: [], dist: Single }
       BatchFilter { predicate: (t1.a > 1:Int32) AND (t1.b > 1:Int32) }
         BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
-- sql: |
-    CREATE TABLE lineitem (
-            l_orderkey BIGINT,
-            l_partkey INTEGER,
-            l_suppkey INTEGER,
-            l_linenumber INTEGER,
-            l_quantity NUMERIC,
-            l_extendedprice NUMERIC,
-            l_discount NUMERIC,
-            l_tax NUMERIC,
-            l_returnflag VARCHAR,
-            l_linestatus VARCHAR,
-            l_shipdate DATE,
-            l_commitdate DATE,
-            l_receiptdate DATE,
-            l_shipinstruct VARCHAR,
-            l_shipmode VARCHAR,
-            l_comment VARCHAR
-    );
-    create index non_covered_index on lineitem(l_orderkey);
-    create index covered_index on lineitem(l_orderkey) include(l_orderkey, l_partkey, l_suppkey, l_linenumber, l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate, l_commitdate, l_receiptdate, l_shipinstruct, l_shipmode, l_comment);
-    /* it should choose covered_index */
-    select * from lineitem where l_orderkey = 1
-  batch_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }
-  batch_local_plan: |
-    BatchExchange { order: [], dist: Single }
-      BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }


### PR DESCRIPTION
Update planner tests

Signed-off-by: Georg Kreuzmayr <g.kreuzmayr@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Showing that there is a problem with sorting on index scan

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

