### PR TITLE
fix:disable collecting executor metrics in local execution mode 

### DIFF
--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -111,7 +111,7 @@ impl TaskService for BatchServiceImpl {
         } = req.into_inner();
         let task_id = task_id.expect("no task id found");
         let plan = plan.expect("no plan found").clone();
-        let context = ComputeNodeContext::new(self.env.clone(), TaskId::from(&task_id));
+        let context = ComputeNodeContext::new_for_local(self.env.clone());
         trace!(
             "local execute request: plan:{:?} with task id:{:?}",
             plan,

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -79,7 +79,8 @@ pub trait BatchTaskContext: Clone + Send + Sync + 'static {
 #[derive(Clone)]
 pub struct ComputeNodeContext {
     env: BatchEnvironment,
-    task_metrics: BatchTaskMetrics,
+    // None: Local mode don't record mertics.
+    task_metrics: Option<BatchTaskMetrics>,
 }
 
 impl BatchTaskContext for ComputeNodeContext {
@@ -110,7 +111,7 @@ impl BatchTaskContext for ComputeNodeContext {
     }
 
     fn get_task_metrics(&self) -> Option<BatchTaskMetrics> {
-        Some(self.task_metrics.clone())
+        self.task_metrics.clone()
     }
 
     fn client_pool(&self) -> ComputeClientPoolRef {
@@ -123,12 +124,22 @@ impl ComputeNodeContext {
     pub fn new_for_test() -> Self {
         Self {
             env: BatchEnvironment::for_test(),
-            task_metrics: BatchTaskMetrics::for_test(),
+            task_metrics: None,
         }
     }
 
     pub fn new(env: BatchEnvironment, task_id: TaskId) -> Self {
         let task_metrics = env.create_task_metrics(task_id);
-        Self { env, task_metrics }
+        Self {
+            env,
+            task_metrics: Some(task_metrics),
+        }
+    }
+
+    pub fn new_for_local(env: BatchEnvironment) -> Self {
+        Self {
+            env,
+            task_metrics: None,
+        }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

disable collecting executor metrics in local execution mode 

this pr can fix #5320 . After disable collecting executor metrics, the zero QPS didn't occur. So I guess that prometheus will not be OOM.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#5013 