### PR TITLE
fix(barriers): recovery use err epoch

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -510,10 +510,6 @@ where
         if self.enable_recovery {
             // handle init, here we simply trigger a recovery process to achieve the consistency. We
             // may need to avoid this when we have more state persisted in meta store.
-            let new_epoch = state.in_flight_prev_epoch.next();
-            assert!(new_epoch > state.in_flight_prev_epoch);
-            state.in_flight_prev_epoch = new_epoch;
-
             let (new_epoch, actors_to_track, create_mview_progress) =
                 self.recovery(state.in_flight_prev_epoch).await;
             tracker.add(new_epoch, actors_to_track, vec![]);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
We skipped one epoch before recovery. So we could't guarantee the continuity of the epochs on the stream. It is wrong.

We save the `state.in_flight_prev_epoch` after the checkpoint is committed, but after https://github.com/risingwavelabs/risingwave/pull/2184, we save the `state.in_flight_prev_epoch` before the checkpoint is injected. So we can't skip one epoch before recovery

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/5393