### PR TITLE
refactor(config): eliminate hardcoded cache size

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -238,6 +238,18 @@ pub struct DeveloperConfig {
     /// `SourceExecutor`.
     #[serde(default = "default::developer_connector_message_buffer_size")]
     pub connector_message_buffer_size: usize,
+
+    /// Limit number of cached entries (one per group key)
+    #[serde(default = "default::developer_unsafe_hash_agg_cache_size")]
+    pub unsafe_hash_agg_cache_size: usize,
+
+    /// Limit number of the cached entries (one per join key) on each side.
+    #[serde(default = "default::developer_unsafe_join_cache_size")]
+    pub unsafe_join_cache_size: usize,
+
+    /// Limit number of the cached entries in an extreme aggregation call
+    #[serde(default = "default::developer_unsafe_extreme_cache_size")]
+    pub unsafe_extreme_cache_size: usize,
 }
 
 impl Default for DeveloperConfig {
@@ -368,6 +380,18 @@ mod default {
 
     pub fn developer_connector_message_buffer_size() -> usize {
         16
+    }
+
+    pub fn developer_unsafe_hash_agg_cache_size() -> usize {
+        1 << 16
+    }
+
+    pub fn developer_unsafe_join_cache_size() -> usize {
+        1 << 16
+    }
+
+    pub fn developer_unsafe_extreme_cache_size() -> usize {
+        1 << 10
     }
 }
 

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -28,3 +28,6 @@ cache_meta_fallocate_unit_mb = 16
 [streaming.developer]
 enable_executor_row_count = false
 connector_message_buffer_size = 16
+unsafe_hash_agg_cache_size = 65536
+unsafe_join_cache_size = 65536
+unsafe_extreme_cache_size = 1024

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -331,6 +331,7 @@ pub async fn generate_managed_agg_state<S: StateStore>(
     key: Option<&Row>,
     agg_calls: &[AggCall],
     pk_indices: PkIndices,
+    extreme_cache_size: usize,
     state_tables: &[StateTable<S>],
     state_table_col_mappings: &[Arc<StateTableColumnMapping>],
 ) -> StreamExecutorResult<AggState<S>> {
@@ -347,6 +348,7 @@ pub async fn generate_managed_agg_state<S: StateStore>(
             pk_indices.clone(),
             idx == ROW_COUNT_COLUMN,
             key,
+            extreme_cache_size,
             &state_tables[idx],
             state_table_col_mappings[idx].clone(),
         )

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -42,9 +42,6 @@ use crate::executor::error::StreamExecutorError;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{BoxedMessageStream, Message, PkIndices, PROCESSING_WINDOW_SIZE};
 
-/// Limit number of cached entries (one per group key)
-const HASH_AGG_CACHE_SIZE: usize = 1 << 16;
-
 /// [`HashAggExecutor`] could process large amounts of data using a state backend. It works as
 /// follows:
 ///
@@ -100,6 +97,12 @@ struct HashAggExecutorExtra<S: StateStore> {
     total_lookup_count: AtomicU64,
 
     metrics: Arc<StreamingMetrics>,
+
+    /// Cache size (one per group by key)
+    group_by_key_cache_size: usize,
+
+    /// Extreme state cache size
+    extreme_cache_size: usize,
 }
 
 impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
@@ -129,6 +132,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         pk_indices: PkIndices,
         executor_id: u64,
         key_indices: Vec<usize>,
+        group_by_key_cache_size: usize,
+        extreme_cache_size: usize,
         mut state_tables: Vec<StateTable<S>>,
         state_table_col_mappings: Vec<Vec<usize>>,
         metrics: Arc<StreamingMetrics>,
@@ -152,6 +157,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 _input_schema: input_info.schema,
                 agg_calls,
                 key_indices,
+                group_by_key_cache_size,
+                extreme_cache_size,
                 state_tables,
                 state_table_col_mappings: state_table_col_mappings
                     .into_iter()
@@ -224,6 +231,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             ref key_indices,
             ref agg_calls,
             ref input_pk_indices,
+            group_by_key_cache_size: _,
+            ref extreme_cache_size,
             ref _input_schema,
             ref schema,
             state_tables,
@@ -276,6 +285,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                     Some(&key.clone().deserialize(key_data_types.iter())?),
                                     agg_calls,
                                     input_pk_indices.clone(),
+                                    *extreme_cache_size,
                                     state_tables,
                                     state_table_col_mappings,
                                 )
@@ -447,7 +457,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         } = self;
 
         // The cached states. `HashKey -> (prev_value, value)`.
-        let mut state_map = EvictableHashMap::new(HASH_AGG_CACHE_SIZE);
+        let mut state_map = EvictableHashMap::new(extra.group_by_key_cache_size);
 
         let mut input = input.execute();
         let barrier = expect_first_barrier(&mut input).await?;
@@ -511,12 +521,15 @@ mod tests {
     use crate::executor::test_utils::*;
     use crate::executor::{ActorContext, Executor, HashAggExecutor, Message, PkIndices};
 
+    #[allow(clippy::too_many_arguments)]
     fn new_boxed_hash_agg_executor(
         input: Box<dyn Executor>,
         agg_calls: Vec<AggCall>,
         key_indices: Vec<usize>,
         keyspace_gen: Vec<(MemoryStateStore, TableId)>,
         pk_indices: PkIndices,
+        group_by_cache_size: usize,
+        extreme_cache_size: usize,
         executor_id: u64,
     ) -> Box<dyn Executor> {
         let (state_tables, state_table_col_mappings) = keyspace_gen
@@ -541,6 +554,8 @@ mod tests {
             pk_indices,
             executor_id,
             key_indices,
+            group_by_cache_size,
+            extreme_cache_size,
             state_tables,
             state_table_col_mappings,
             Arc::new(StreamingMetrics::unused()),
@@ -622,8 +637,16 @@ mod tests {
             },
         ];
 
-        let hash_agg =
-            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![], 1);
+        let hash_agg = new_boxed_hash_agg_executor(
+            Box::new(source),
+            agg_calls,
+            keys,
+            keyspace,
+            vec![],
+            1 << 16,
+            1 << 10,
+            1,
+        );
         let mut hash_agg = hash_agg.execute();
 
         // Consume the init barrier
@@ -722,6 +745,8 @@ mod tests {
             key_indices,
             keyspace,
             vec![],
+            1 << 16,
+            1 << 10,
             1,
         );
         let mut hash_agg = hash_agg.execute();
@@ -808,8 +833,16 @@ mod tests {
             },
         ];
 
-        let hash_agg =
-            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![2], 1);
+        let hash_agg = new_boxed_hash_agg_executor(
+            Box::new(source),
+            agg_calls,
+            keys,
+            keyspace,
+            vec![2],
+            1 << 16,
+            1 << 10,
+            1,
+        );
         let mut hash_agg = hash_agg.execute();
 
         // Consume the init barrier
@@ -901,8 +934,16 @@ mod tests {
             },
         ];
 
-        let hash_agg =
-            new_boxed_hash_agg_executor(Box::new(source), agg_calls, keys, keyspace, vec![2], 1);
+        let hash_agg = new_boxed_hash_agg_executor(
+            Box::new(source),
+            agg_calls,
+            keys,
+            keyspace,
+            vec![2],
+            1 << 16,
+            1 << 10,
+            1,
+        );
         let mut hash_agg = hash_agg.execute();
 
         // Consume the init barrier

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -17,8 +17,6 @@ use std::collections::BTreeSet;
 use risingwave_common::array::{Op, Row, StreamChunk};
 use risingwave_common::collection::evictable::EvictableHashMap;
 
-use crate::executor::JOIN_CACHE_CAP;
-
 /// A cache for lookup's arrangement side.
 pub struct LookupCache {
     data: EvictableHashMap<Row, BTreeSet<Row>>,
@@ -59,9 +57,9 @@ impl LookupCache {
         self.data.evict_to_target_cap();
     }
 
-    pub fn new() -> Self {
+    pub fn new(cache_size: usize) -> Self {
         Self {
-            data: EvictableHashMap::new(JOIN_CACHE_CAP),
+            data: EvictableHashMap::new(cache_size),
         }
     }
 }

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -99,6 +99,8 @@ pub struct LookupExecutorParams<S: StateStore> {
     pub arrange_join_key_indices: Vec<usize>,
 
     pub state_table: StateTable<S>,
+
+    pub cache_size: usize,
 }
 
 impl<S: StateStore> LookupExecutor<S> {
@@ -115,6 +117,7 @@ impl<S: StateStore> LookupExecutor<S> {
             schema: output_schema,
             column_mapping,
             state_table,
+            cache_size,
         } = params;
 
         let output_column_length = stream.schema().len() + arrangement.schema().len();
@@ -210,7 +213,7 @@ impl<S: StateStore> LookupExecutor<S> {
             },
             column_mapping,
             key_indices_mapping,
-            lookup_cache: LookupCache::new(),
+            lookup_cache: LookupCache::new(cache_size),
         }
     }
 

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -248,6 +248,7 @@ async fn test_lookup_this_epoch() {
             arrangement_col_arrange_rules(),
             vec![1, 0],
         ),
+        cache_size: 1 << 16,
     }));
     let mut lookup_executor = lookup_executor.execute();
 
@@ -311,6 +312,7 @@ async fn test_lookup_last_epoch() {
             arrangement_col_arrange_rules(),
             vec![1, 0],
         ),
+        cache_size: 1 << 16,
     }));
     let mut lookup_executor = lookup_executor.execute();
 

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -270,6 +270,7 @@ pub mod agg_executor {
                 agg_calls,
                 pk_indices,
                 executor_id,
+                1 << 10,
                 state_tables,
                 state_table_col_mappings,
             )

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -26,7 +26,7 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
-        _stream: &mut LocalStreamManagerCore,
+        stream: &mut LocalStreamManagerCore,
     ) -> StreamResult<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::GlobalSimpleAgg)?;
         let [input]: [_; 1] = params.input.try_into().unwrap();
@@ -49,6 +49,7 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
             agg_calls,
             params.pk_indices,
             params.executor_id,
+            stream.config.developer.unsafe_extreme_cache_size,
             state_tables,
             state_table_col_mappings,
         )?

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -34,6 +34,8 @@ pub struct HashAggExecutorDispatcherArgs<S: StateStore> {
     agg_calls: Vec<AggCall>,
     key_indices: Vec<usize>,
     pk_indices: PkIndices,
+    group_by_cache_size: usize,
+    extreme_cache_size: usize,
     executor_id: u64,
     state_tables: Vec<StateTable<S>>,
     state_table_col_mappings: Vec<Vec<usize>>,
@@ -52,6 +54,8 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcher<S> {
             args.pk_indices,
             args.executor_id,
             args.key_indices,
+            args.group_by_cache_size,
+            args.extreme_cache_size,
             args.state_tables,
             args.state_table_col_mappings,
             args.metrics,
@@ -67,7 +71,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
-        _stream: &mut LocalStreamManagerCore,
+        stream: &mut LocalStreamManagerCore,
     ) -> StreamResult<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::HashAgg)?;
         let key_indices = node
@@ -102,6 +106,8 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             agg_calls,
             key_indices,
             pk_indices: params.pk_indices,
+            group_by_cache_size: stream.config.developer.unsafe_hash_agg_cache_size,
+            extreme_cache_size: stream.config.developer.unsafe_extreme_cache_size,
             executor_id: params.executor_id,
             state_tables,
             state_table_col_mappings,

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -32,7 +32,7 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
-        _stream: &mut LocalStreamManagerCore,
+        stream: &mut LocalStreamManagerCore,
     ) -> StreamResult<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::HashJoin)?;
         let is_append_only = node.is_append_only;
@@ -141,6 +141,7 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
             executor_id: params.executor_id,
             cond: condition,
             op_info: params.op_info,
+            cache_size: stream.config.developer.unsafe_join_cache_size,
             state_table_l,
             degree_state_table_l,
             state_table_r,
@@ -169,6 +170,7 @@ struct HashJoinExecutorDispatcherArgs<S: StateStore> {
     executor_id: u64,
     cond: Option<BoxedExpression>,
     op_info: String,
+    cache_size: usize,
     state_table_l: StateTable<S>,
     degree_state_table_l: StateTable<S>,
     state_table_r: StateTable<S>,
@@ -196,6 +198,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> HashKeyDispatcher
             args.executor_id,
             args.cond,
             args.op_info,
+            args.cache_size,
             args.state_table_l,
             args.degree_state_table_l,
             args.state_table_r,

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -28,7 +28,7 @@ impl ExecutorBuilder for LookupExecutorBuilder {
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
-        _stream: &mut LocalStreamManagerCore,
+        stream_manager: &mut LocalStreamManagerCore,
     ) -> StreamResult<BoxedExecutor> {
         let lookup = try_match_expand!(node.get_node_body().unwrap(), NodeBody::Lookup)?;
 
@@ -65,6 +65,7 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             arrange_join_key_indices: lookup.arrange_key.iter().map(|x| *x as usize).collect(),
             column_mapping: lookup.column_mapping.iter().map(|x| *x as usize).collect(),
             state_table,
+            cache_size: stream_manager.config.developer.unsafe_join_cache_size,
         })))
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
#5249 wants to eliminate hardcoded values.

This PR moves
`HASH_AGG_CACHE_SIZE`,
`JOIN_CACHE_CAP`,
`EXTREME_CACHE_SIZE`,
to the configuration file.

Makes #5080  easier to enable the no-cache test.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* RisingWave cluster configuration changes

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.
`HASH_AGG_CACHE_SIZE`, `JOIN_CACHE_CAP`, and `EXTREME_CACHE_SIZE` can be specified via `src/config/risingwave.toml` in the `[streaming.developer]` subsection.


## Refer to a related PR or issue link (optional)
#5249 