### PR TITLE
refactor(config): reduce connector_message_buffer_size and make it configurable

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -233,6 +233,10 @@ pub struct DeveloperConfig {
     /// rows data, see `stream_actor_in_record_cnt` and `stream_actor_out_record_cnt` instead.
     #[serde(default = "default::developer_enable_executor_row_count")]
     pub enable_executor_row_count: bool,
+
+    /// The size of channel that connects between `ConnectorSource` and `SourceExecutor`.
+    #[serde(default = "default::developer_connector_message_buffer_size")]
+    pub connector_message_buffer_size: usize,
 }
 
 impl Default for DeveloperConfig {
@@ -359,6 +363,10 @@ mod default {
 
     pub fn developer_enable_executor_row_count() -> bool {
         false
+    }
+
+    pub fn developer_connector_message_buffer_size() -> usize {
+        16
     }
 }
 

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -234,7 +234,8 @@ pub struct DeveloperConfig {
     #[serde(default = "default::developer_enable_executor_row_count")]
     pub enable_executor_row_count: bool,
 
-    /// The size of channel that connects between `ConnectorSource` and `SourceExecutor`.
+    /// The capacity of the chunks in the channel that connects between `ConnectorSource` and
+    /// `SourceExecutor`.
     #[serde(default = "default::developer_connector_message_buffer_size")]
     pub connector_message_buffer_size: usize,
 }

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -27,3 +27,4 @@ cache_meta_fallocate_unit_mb = 16
 
 [streaming.developer]
 enable_executor_row_count = false
+connector_message_buffer_size = 16

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -63,8 +63,6 @@ struct InnerConnectorSourceReaderHandle {
     join_handle: JoinHandle<()>,
 }
 
-const CONNECTOR_MESSAGE_BUFFER_SIZE: usize = 512;
-
 /// [`ConnectorSource`] serves as a bridge between external components and streaming or
 /// batch processing. [`ConnectorSource`] introduces schema at this level while
 /// [`SplitReaderImpl`] simply loads raw content from message queue or file system.
@@ -279,6 +277,7 @@ pub struct ConnectorSource {
     pub config: ConnectorProperties,
     pub columns: Vec<SourceColumnDesc>,
     pub parser: Arc<SourceParserImpl>,
+    pub connector_message_buffer_size: usize,
 }
 
 impl ConnectorSource {
@@ -307,7 +306,7 @@ impl ConnectorSource {
         metrics: Arc<SourceMetrics>,
         context: SourceContext,
     ) -> Result<ConnectorSourceReader> {
-        let (tx, rx) = mpsc::channel(CONNECTOR_MESSAGE_BUFFER_SIZE);
+        let (tx, rx) = mpsc::channel(self.connector_message_buffer_size);
         let mut handles = HashMap::with_capacity(if let Some(split) = &splits {
             split.len()
         } else {

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -126,7 +126,8 @@ pub struct MemSourceManager {
     sources: Mutex<HashMap<TableId, SourceDesc>>,
     /// local source metrics
     metrics: Arc<SourceMetrics>,
-    /// The size of channel that connects between `ConnectorSource` and `SourceExecutor`.
+    /// The capacity of the chunks in the channel that connects between `ConnectorSource` and
+    /// `SourceExecutor`.
     connector_message_buffer_size: usize,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
As per the title, reduce it from 512 to 16.
Also in #5249.

Also suspect that with a faster in-memory data generation source, this unnecessarily large size channel is the cause of OOM.

I mean, without memory management, OOM is expected. But it seems that OOM didn't occur this often before.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* RisingWave cluster configuration changes

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

`connector_message_buffer_size` is now a configurable parameter in `src/config/risingwave.toml` under `[streaming.developer]` subsection.

## Refer to a related PR or issue link (optional)
#5249 