### PR TITLE
fix(streaming): add vnode check for state table `write_chunk`

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -20,7 +20,6 @@ risedev:
       enable-dashboard-v2: false
       unsafe-disable-recovery: true
     - use: compute-node
-      enable-in-memory-kv-state-backend: true
     - use: frontend
 
     # If you want to enable compactor, uncomment the following line, and enable either minio or aws-s3 as well.

--- a/src/batch/src/task/hash_shuffle_channel.rs
+++ b/src/batch/src/task/hash_shuffle_channel.rs
@@ -21,12 +21,12 @@ use risingwave_common::array::DataChunk;
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::error::ErrorCode::InternalError;
 use risingwave_common::error::Result;
-use risingwave_common::util::hash_util::CRC32FastBuilder;
+use risingwave_common::util::hash_util::Crc32FastBuilder;
 use risingwave_pb::batch_plan::exchange_info::HashInfo;
 use risingwave_pb::batch_plan::*;
 use tokio::sync::mpsc;
 
-use crate::error::BatchError::{Array, SenderError};
+use crate::error::BatchError::SenderError;
 use crate::error::Result as BatchResult;
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 use crate::task::data_chunk_in_channel::DataChunkInChannel;
@@ -52,7 +52,7 @@ pub struct HashShuffleReceiver {
 fn generate_hash_values(chunk: &DataChunk, hash_info: &HashInfo) -> BatchResult<Vec<usize>> {
     let output_count = hash_info.output_count as usize;
 
-    let hasher_builder = CRC32FastBuilder {};
+    let hasher_builder = Crc32FastBuilder {};
 
     let hash_values = chunk
         .get_hash_values(
@@ -63,7 +63,6 @@ fn generate_hash_values(chunk: &DataChunk, hash_info: &HashInfo) -> BatchResult<
                 .collect::<Vec<_>>(),
             hasher_builder,
         )
-        .map_err(Array)?
         .iter_mut()
         .map(|hash_value| hash_value.hash_code() as usize % output_count)
         .collect::<Vec<_>>();

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -365,17 +365,17 @@ impl DataChunk {
         &self,
         column_idxes: &[usize],
         hasher_builder: H,
-    ) -> ArrayResult<Vec<HashCode>> {
+    ) -> Vec<HashCode> {
         let mut states = Vec::with_capacity(self.capacity());
         states.resize_with(self.capacity(), || hasher_builder.build_hasher());
         for column_idx in column_idxes {
             let array = self.column_at(*column_idx).array();
             array.hash_vec(&mut states[..]);
         }
-        Ok(finalize_hashers(&mut states[..])
+        finalize_hashers(&mut states[..])
             .into_iter()
             .map(|hash_code| hash_code.into())
-            .collect_vec())
+            .collect_vec()
     }
 
     /// Random access a tuple in a data chunk. Return in a row format.

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -381,7 +381,7 @@ impl RowDeserializer {
 mod tests {
     use super::*;
     use crate::types::{DataType as Ty, IntervalUnit, ScalarImpl};
-    use crate::util::hash_util::CRC32FastBuilder;
+    use crate::util::hash_util::Crc32FastBuilder;
 
     #[test]
     fn row_value_encode_decode() {
@@ -416,7 +416,7 @@ mod tests {
 
     #[test]
     fn test_hash_row() {
-        let hash_builder = CRC32FastBuilder {};
+        let hash_builder = Crc32FastBuilder {};
 
         let row1 = Row(vec![
             Some(ScalarImpl::Utf8("string".into())),

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -32,7 +32,7 @@ use crate::types::{
     NaiveTimeWrapper, OrderedF32, OrderedF64, ScalarRef, ToOwnedDatum, VirtualNode,
     VIRTUAL_NODE_COUNT,
 };
-use crate::util::hash_util::CRC32FastBuilder;
+use crate::util::hash_util::Crc32FastBuilder;
 
 /// This file contains implementation for hash key serialization for
 /// hash-agg, hash-join, and perhaps other hash-based operators.
@@ -101,7 +101,7 @@ pub trait HashKey:
     type S: HashKeySerializer<K = Self>;
 
     fn build(column_idxes: &[usize], data_chunk: &DataChunk) -> ArrayResult<Vec<Self>> {
-        let hash_codes = data_chunk.get_hash_values(column_idxes, CRC32FastBuilder)?;
+        let hash_codes = data_chunk.get_hash_values(column_idxes, Crc32FastBuilder);
         Ok(Self::build_from_hash_code(
             column_idxes,
             data_chunk,

--- a/src/common/src/util/hash_util.rs
+++ b/src/common/src/util/hash_util.rs
@@ -21,8 +21,8 @@ pub fn finalize_hashers<H: Hasher>(hashers: &mut [H]) -> Vec<u64> {
         .collect::<Vec<u64>>();
 }
 
-pub struct CRC32FastBuilder;
-impl BuildHasher for CRC32FastBuilder {
+pub struct Crc32FastBuilder;
+impl BuildHasher for Crc32FastBuilder {
     type Hasher = crc32fast::Hasher;
 
     fn build_hasher(&self) -> Self::Hasher {

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -20,7 +20,7 @@ use risingwave_pb::batch_plan::ScanRange as ScanRangeProst;
 
 use crate::array::Row;
 use crate::types::{Datum, ScalarImpl, VirtualNode};
-use crate::util::hash_util::CRC32FastBuilder;
+use crate::util::hash_util::Crc32FastBuilder;
 use crate::util::value_encoding::serialize_datum;
 
 /// See also [`ScanRangeProst`]
@@ -102,7 +102,7 @@ impl ScanRange {
 
         let pk_prefix_value = Row(self.eq_conds.clone());
         let vnode = pk_prefix_value
-            .hash_by_indices(&dist_key_in_pk_indices, &CRC32FastBuilder {})
+            .hash_by_indices(&dist_key_in_pk_indices, &Crc32FastBuilder {})
             .to_vnode();
         Some(vnode)
     }
@@ -138,7 +138,7 @@ mod tests {
             Some(ScalarImpl::from(114)),
             Some(ScalarImpl::from(514)),
         ])
-        .hash_by_indices(&[0, 1], &CRC32FastBuilder {})
+        .hash_by_indices(&[0, 1], &Crc32FastBuilder {})
         .to_vnode();
         assert_eq!(scan_range.try_compute_vnode(&dist_key, &pk), Some(vnode));
     }
@@ -164,7 +164,7 @@ mod tests {
             Some(ScalarImpl::from(514)),
             Some(ScalarImpl::from(114514)),
         ])
-        .hash_by_indices(&[2, 1], &CRC32FastBuilder {})
+        .hash_by_indices(&[2, 1], &Crc32FastBuilder {})
         .to_vnode();
         assert_eq!(scan_range.try_compute_vnode(&dist_key, &pk), Some(vnode));
     }

--- a/src/expr/src/expr/expr_vnode.rs
+++ b/src/expr/src/expr/expr_vnode.rs
@@ -18,7 +18,7 @@ use risingwave_common::array::{
     ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, I16ArrayBuilder, Row,
 };
 use risingwave_common::types::{DataType, Datum};
-use risingwave_common::util::hash_util::CRC32FastBuilder;
+use risingwave_common::util::hash_util::Crc32FastBuilder;
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
 
@@ -69,7 +69,7 @@ impl Expression for VnodeExpression {
     }
 
     fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
-        let hash_values = input.get_hash_values(&self.dist_key_indices, CRC32FastBuilder {})?;
+        let hash_values = input.get_hash_values(&self.dist_key_indices, Crc32FastBuilder {});
         let mut builder = I16ArrayBuilder::new(input.capacity());
         hash_values
             .into_iter()
@@ -81,7 +81,7 @@ impl Expression for VnodeExpression {
         let dist_key_row = input.by_indices(&self.dist_key_indices);
         // FIXME: currently the implementation of the hash function in Row::hash_row differs from
         // Array::hash_at, so their result might be different. #3457
-        let vnode = dist_key_row.hash_row(&CRC32FastBuilder {}).to_vnode() as i16;
+        let vnode = dist_key_row.hash_row(&Crc32FastBuilder {}).to_vnode() as i16;
         Ok(Some(vnode.into()))
     }
 }

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -131,9 +131,13 @@ fn compute_chunk_vnode(chunk: &DataChunk, indices: &[usize], vnodes: &Bitmap) ->
         chunk
             .get_hash_values(indices, Crc32FastBuilder {})
             .into_iter()
-            .map(|h| {
+            .zip_eq(chunk.vis().iter())
+            .map(|(h, vis)| {
                 let vnode = h.to_vnode();
-                check_vnode_is_set(vnode, vnodes);
+                // Ignore the invisible rows.
+                if vis {
+                    check_vnode_is_set(vnode, vnodes);
+                }
                 vnode
             })
             .collect()

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -119,7 +119,10 @@ fn compute_vnode(row: &Row, indices: &[usize], vnodes: &Bitmap) -> VirtualNode {
 
     tracing::trace!(target: "events::storage::storage_table", "compute vnode: {:?} key {:?} => {}", row, indices, vnode);
 
-    check_vnode_is_set(vnode, vnodes);
+    // FIXME: temporary workaround for local agg
+    if !indices.is_empty() {
+        check_vnode_is_set(vnode, vnodes);
+    }
     vnode
 }
 
@@ -135,7 +138,8 @@ fn compute_chunk_vnode(chunk: &DataChunk, indices: &[usize], vnodes: &Bitmap) ->
             .map(|(h, vis)| {
                 let vnode = h.to_vnode();
                 // Ignore the invisible rows.
-                if vis {
+                // FIXME: temporary workaround for local agg
+                if vis && !indices.is_empty() {
                     check_vnode_is_set(vnode, vnodes);
                 }
                 vnode

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -28,7 +28,6 @@ use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::{ColumnDesc, TableId, TableOption};
 use risingwave_common::error::RwError;
 use risingwave_common::types::VirtualNode;
-use risingwave_common::util::hash_util::CRC32FastBuilder;
 use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_hummock_sdk::key::{prefixed_range, range_of_prefix};
@@ -44,7 +43,7 @@ use crate::row_serde::row_serde_util::{
 use crate::storage_value::StorageValue;
 use crate::store::{ReadOptions, WriteOptions};
 use crate::table::streaming_table::mem_table::MemTableError;
-use crate::table::{compute_vnode, DataTypes, Distribution};
+use crate::table::{compute_chunk_vnode, compute_vnode, DataTypes, Distribution};
 use crate::{Keyspace, StateStore, StateStoreIter};
 
 /// `StateTable` is the interface accessing relational data in KV(`StateStore`) with
@@ -498,17 +497,16 @@ impl<S: StateStore> StateTable<S> {
     // allow(izip, which use zip instead of zip_eq)
     #[allow(clippy::disallowed_methods)]
     pub fn write_chunk(&mut self, chunk: StreamChunk) {
+        tracing::warn!("write chunk: {chunk:?}");
+
         let (chunk, op) = chunk.into_parts();
-        let hash_builder = CRC32FastBuilder {};
 
         let mut vnode_and_pks = vec![vec![]; chunk.capacity()];
 
-        chunk
-            .get_hash_values(&self.dist_key_indices, hash_builder)
-            .unwrap()
+        compute_chunk_vnode(&chunk, &self.dist_key_indices, &self.vnodes)
             .into_iter()
             .zip_eq(vnode_and_pks.iter_mut())
-            .for_each(|(h, vnode_and_pk)| vnode_and_pk.extend(h.to_vnode().to_be_bytes()));
+            .for_each(|(vnode, vnode_and_pk)| vnode_and_pk.extend(vnode.to_be_bytes()));
         let values = chunk.serialize();
 
         let chunk = chunk.reorder_columns(self.pk_indices());

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -497,8 +497,6 @@ impl<S: StateStore> StateTable<S> {
     // allow(izip, which use zip instead of zip_eq)
     #[allow(clippy::disallowed_methods)]
     pub fn write_chunk(&mut self, chunk: StreamChunk) {
-        tracing::warn!("write chunk: {chunk:?}");
-
         let (chunk, op) = chunk.into_parts();
 
         let mut vnode_and_pks = vec![vec![]; chunk.capacity()];

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -25,7 +25,7 @@ use itertools::Itertools;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::util::compress::decompress_data;
-use risingwave_common::util::hash_util::CRC32FastBuilder;
+use risingwave_common::util::hash_util::Crc32FastBuilder;
 use risingwave_pb::stream_plan::update_mutation::DispatcherUpdate as ProstDispatcherUpdate;
 use risingwave_pb::stream_plan::Dispatcher as ProstDispatcher;
 use smallvec::{smallvec, SmallVec};
@@ -543,11 +543,10 @@ impl Dispatcher for HashDataDispatcher {
             let num_outputs = self.outputs.len();
 
             // get hash value of every line by its key
-            let hash_builder = CRC32FastBuilder {};
+            let hash_builder = Crc32FastBuilder {};
             let vnodes = chunk
                 .data_chunk()
                 .get_hash_values(&self.keys, hash_builder)
-                .unwrap()
                 .into_iter()
                 .map(|hash| hash.to_vnode())
                 .collect_vec();
@@ -1126,7 +1125,7 @@ mod tests {
         let mut output_cols = vec![vec![vec![]; dimension]; num_outputs];
         let mut output_ops = vec![vec![]; num_outputs];
         for op in &ops {
-            let hash_builder = CRC32FastBuilder {};
+            let hash_builder = Crc32FastBuilder {};
             let mut hasher = hash_builder.build_hasher();
             let one_row = (0..dimension).map(|_| start.next().unwrap()).collect_vec();
             for key_idx in key_indices.iter() {

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -26,7 +26,7 @@ use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
 use risingwave_common::collection::evictable::EvictableHashMap;
 use risingwave_common::hash::{HashCode, HashKey};
-use risingwave_common::util::hash_util::CRC32FastBuilder;
+use risingwave_common::util::hash_util::Crc32FastBuilder;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
@@ -223,7 +223,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         let (data_chunk, ops) = chunk.into_parts();
 
         // Compute hash code here before serializing keys to avoid duplicate hash code computation.
-        let hash_codes = data_chunk.get_hash_values(key_indices, CRC32FastBuilder)?;
+        let hash_codes = data_chunk.get_hash_values(key_indices, Crc32FastBuilder);
         let keys = K::build_from_hash_code(key_indices, &data_chunk, hash_codes.clone());
         let capacity = data_chunk.capacity();
         let (columns, vis) = data_chunk.into_parts();


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds the vnode checking for the `write_chunk` interface of the state table. So that we can check whether the distribution of records written with `write_chunk` is correct.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #5151 
- #5344 
- #5322 