### PR TITLE
feat(compaction group): lifecycle of new created compaction groups

### DIFF
--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -450,8 +450,9 @@ impl TestCase {
                     context,
                     q,
                     ObjectName(vec!["test".into()]),
+                    false,
                 ) {
-                    Ok((stream_plan, _table)) => stream_plan,
+                    Ok((stream_plan, _)) => stream_plan,
                     Err(err) => {
                         ret.stream_error = Some(err.to_string());
                         break 'stream;

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -119,6 +119,8 @@ pub async fn handle_create_mv(
         {
             let catalog_reader = session.env().catalog_reader().read_guard();
             let (schema_name, table_name) = Binder::resolve_table_name(name.clone())?;
+            // This is temporary. MVs whose name ends with "_al" will have dedicate dedicated
+            // compaction groups, respectively.
             is_independent_compaction_group = table_name.ends_with("_al");
             catalog_reader.check_relation_name_duplicated(
                 session.database(),

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -64,7 +64,7 @@ pub(super) fn handle_explain(
             query,
             name,
             ..
-        } => gen_create_mv_plan(&session, planner.ctx(), *query, name)?.0,
+        } => gen_create_mv_plan(&session, planner.ctx(), *query, name, false)?.0,
 
         Statement::CreateSink { stmt } => gen_sink_plan(&session, planner.ctx(), stmt)?.0,
 

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -672,5 +672,13 @@ mod tests {
             .unwrap();
         assert_eq!(registered_number().await, 5);
         assert_eq!(group_number().await, 6);
+
+        // Test `StaticCompactionGroupId::NewCompactionGroup` in `unregister_table_fragments`
+        compaction_group_manager
+            .unregister_table_fragments(&table_fragment_1)
+            .await
+            .unwrap();
+        assert_eq!(registered_number().await, 1);
+        assert_eq!(group_number().await, 2);
     }
 }

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -360,6 +360,9 @@ impl CompactionGroupManagerInner {
             if compaction_group_id > StaticCompactionGroupId::END as CompactionGroupId
                 && compaction_group.member_table_ids.is_empty()
             {
+                // remove staging
+                compaction_groups.remove(compaction_group_id);
+                // remove original
                 compaction_groups.remove(compaction_group_id);
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

lifecycle of new created compaction groups: when mv is created, dropped or compaction groups are purged
this PR is successor of #5265 

background:

Discussions on compaction group:

* Plan to introduce more compaction groups into our system. Experiments WIP.
* Prefer using separate HummockVersion for different compaction groups even when we have more compaction groups after considering using shared L0, which introduces excessive complexity in compaction and is error-prone.
* Discuss about optimizations to handle increasing IOPS and small objects issue.

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
