### PR TITLE
style: refine all constructor namings

### DIFF
--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -253,7 +253,7 @@ mod tests {
     use crate::task::ComputeNodeContext;
     #[tokio::test]
     async fn test_exchange_multiple_sources() {
-        let context = ComputeNodeContext::new_for_test();
+        let context = ComputeNodeContext::for_test();
         let mut sources = vec![];
         for _ in 0..2 {
             let mut rng = rand::thread_rng();

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -271,7 +271,7 @@ mod tests {
             FakeCreateSource,
             ComputeNodeContext,
         > {
-            context: ComputeNodeContext::new_for_test(),
+            context: ComputeNodeContext::for_test(),
             source_inputs: vec![None; proto_sources.len()],
             order_pairs,
             min_heap: BinaryHeap::new(),

--- a/src/batch/src/executor/mod.rs
+++ b/src/batch/src/executor/mod.rs
@@ -230,7 +230,7 @@ mod tests {
         let builder = ExecutorBuilder::new(
             &plan_node,
             task_id,
-            ComputeNodeContext::new_for_test(),
+            ComputeNodeContext::for_test(),
             u64::MAX,
         );
         let child_plan = &PlanNode {

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -121,7 +121,7 @@ impl BatchTaskContext for ComputeNodeContext {
 
 impl ComputeNodeContext {
     #[cfg(test)]
-    pub fn new_for_test() -> Self {
+    pub fn for_test() -> Self {
         Self {
             env: BatchEnvironment::for_test(),
             task_metrics: None,

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -271,7 +271,7 @@ mod tests {
                 distribution: None,
             }),
         };
-        let context = ComputeNodeContext::new_for_test();
+        let context = ComputeNodeContext::for_test();
         let task_id = ProstTaskId {
             query_id: "".to_string(),
             stage_id: 0,
@@ -316,7 +316,7 @@ mod tests {
                 distribution: None,
             }),
         };
-        let context = ComputeNodeContext::new_for_test();
+        let context = ComputeNodeContext::for_test();
         let task_id = ProstTaskId {
             query_id: "".to_string(),
             stage_id: 0,

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -51,7 +51,7 @@ impl ObserverManager<RpcNotificationClient> {
     ) -> Self {
         let client = RpcNotificationClient { meta_client };
         let rx = client.subscribe(&addr, worker_type).await.unwrap();
-        Self::new_with(rx, client, addr, observer_states, worker_type)
+        Self::with_subscriber(rx, client, addr, observer_states, worker_type)
     }
 }
 
@@ -60,7 +60,7 @@ where
     T: NotificationClient<Channel = C> + Send + Sync + 'static,
     C: Channel<SubscribeResponse> + Send + 'static,
 {
-    pub fn new_with(
+    pub fn with_subscriber(
         rx: C,
         client: T,
         addr: HostAddr,

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -162,7 +162,7 @@ async fn test_table_materialize() -> StreamResult<()> {
 
     // Create a `Materialize` to write the changes to storage
 
-    let mut materialize = MaterializeExecutor::new_for_test(
+    let mut materialize = MaterializeExecutor::for_test(
         Box::new(stream_source),
         memory_state_store.clone(),
         source_table_id,
@@ -210,7 +210,7 @@ async fn test_table_materialize() -> StreamResult<()> {
         .collect_vec();
 
     // Since we have not polled `Materialize`, we cannot scan anything from this table
-    let table = StorageTable::new_for_test(
+    let table = StorageTable::for_test(
         memory_state_store.clone(),
         source_table_id,
         column_descs.clone(),
@@ -398,7 +398,7 @@ async fn test_row_seq_scan() -> Result<()> {
         vec![OrderType::Ascending],
         vec![0_usize],
     );
-    let table = StorageTable::new_for_test(
+    let table = StorageTable::for_test(
         memory_state_store.clone(),
         TableId::from(0x42),
         column_descs.clone(),

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -100,10 +100,10 @@ impl LogicalJoin {
     pub(crate) fn new(left: PlanRef, right: PlanRef, join_type: JoinType, on: Condition) -> Self {
         let out_column_num =
             Self::out_column_num(left.schema().len(), right.schema().len(), join_type);
-        Self::new_with_output_indices(left, right, join_type, on, (0..out_column_num).collect())
+        Self::with_output_indices(left, right, join_type, on, (0..out_column_num).collect())
     }
 
-    pub(crate) fn new_with_output_indices(
+    pub(crate) fn with_output_indices(
         left: PlanRef,
         right: PlanRef,
         join_type: JoinType,
@@ -388,7 +388,7 @@ impl LogicalJoin {
 
     /// Clone with new output indices
     pub fn clone_with_output_indices(&self, output_indices: Vec<usize>) -> Self {
-        Self::new_with_output_indices(
+        Self::with_output_indices(
             self.left.clone(),
             self.right.clone(),
             self.join_type,
@@ -399,7 +399,7 @@ impl LogicalJoin {
 
     /// Clone with new `on` condition
     pub fn clone_with_cond(&self, cond: Condition) -> Self {
-        Self::new_with_output_indices(
+        Self::with_output_indices(
             self.left.clone(),
             self.right.clone(),
             self.join_type,
@@ -624,7 +624,7 @@ impl PlanTreeNodeBinary for LogicalJoin {
     }
 
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new_with_output_indices(
+        Self::with_output_indices(
             left,
             right,
             self.join_type,
@@ -659,7 +659,7 @@ impl PlanTreeNodeBinary for LogicalJoin {
             (new_on, new_output_indices)
         };
 
-        let join = Self::new_with_output_indices(
+        let join = Self::with_output_indices(
             left,
             right,
             self.join_type,
@@ -747,7 +747,7 @@ impl ColPrunable for LogicalJoin {
             required_cols.iter().map(|&i| mapping.map(i)).collect_vec()
         };
 
-        LogicalJoin::new_with_output_indices(
+        LogicalJoin::with_output_indices(
             self.left.prune_col(&left_required_cols),
             self.right.prune_col(&right_required_cols),
             self.join_type,
@@ -820,7 +820,7 @@ impl PredicatePushdown for LogicalJoin {
 
         let new_left = self.left.predicate_pushdown(left_predicate);
         let new_right = self.right.predicate_pushdown(right_predicate);
-        let new_join = LogicalJoin::new_with_output_indices(
+        let new_join = LogicalJoin::with_output_indices(
             new_left,
             new_right,
             join_type,

--- a/src/frontend/src/optimizer/rule/push_calculation_of_join.rs
+++ b/src/frontend/src/optimizer/rule/push_calculation_of_join.rs
@@ -94,9 +94,7 @@ impl Rule for PushCalculationOfJoinRule {
             right = new_input(right, right_exprs);
         }
 
-        Some(
-            LogicalJoin::new_with_output_indices(left, right, join_type, on, output_indices).into(),
-        )
+        Some(LogicalJoin::with_output_indices(left, right, join_type, on, output_indices).into())
     }
 }
 

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -63,7 +63,7 @@ impl CompactionConfigBuilder {
         }
     }
 
-    pub fn new_with(config: CompactionConfig) -> Self {
+    pub fn with_config(config: CompactionConfig) -> Self {
         Self { config }
     }
 

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -588,7 +588,7 @@ pub mod tests {
         assert_eq!(compaction.input.target_level, 0);
 
         let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL;
-        let config = CompactionConfigBuilder::new_with(config)
+        let config = CompactionConfigBuilder::with_config(config)
             .max_bytes_for_level_base(100)
             .level0_trigger_file_number(8)
             .compaction_filter_mask(compaction_filter_flag.into())

--- a/src/meta/src/hummock/compaction_group/manager.rs
+++ b/src/meta/src/hummock/compaction_group/manager.rs
@@ -45,10 +45,10 @@ pub struct CompactionGroupManager<S: MetaStore> {
 impl<S: MetaStore> CompactionGroupManager<S> {
     pub async fn new(env: MetaSrvEnv<S>) -> Result<Self> {
         let config = CompactionConfigBuilder::new().build();
-        Self::new_with_config(env, config).await
+        Self::with_config(env, config).await
     }
 
-    pub async fn new_with_config(env: MetaSrvEnv<S>, config: CompactionConfig) -> Result<Self> {
+    pub async fn with_config(env: MetaSrvEnv<S>, config: CompactionConfig) -> Result<Self> {
         let instance = Self {
             env,
             inner: RwLock::new(Default::default()),

--- a/src/meta/src/hummock/compaction_schedule_policy.rs
+++ b/src/meta/src/hummock/compaction_schedule_policy.rs
@@ -222,7 +222,7 @@ impl ScoredPolicy {
     }
 
     #[cfg(test)]
-    fn new_for_test() -> Self {
+    fn for_test() -> Self {
         Self {
             ..Default::default()
         }
@@ -558,7 +558,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_scored_add_pause_remove_compactor() {
-        let mut policy = ScoredPolicy::new_for_test();
+        let mut policy = ScoredPolicy::for_test();
         // No compactors by default.
         assert_eq!(policy.context_id_to_score.len(), 0);
         assert_eq!(policy.score_to_compactor.len(), 0);
@@ -620,7 +620,7 @@ mod tests {
 
     #[test]
     fn test_scored_next_compactor() {
-        let mut policy = ScoredPolicy::new_for_test();
+        let mut policy = ScoredPolicy::for_test();
 
         // No compactor available.
         assert!(policy.next_compactor().is_none());
@@ -680,7 +680,7 @@ mod tests {
 
     #[test]
     fn test_scored_next_idle_compactor() {
-        let mut policy = Box::new(ScoredPolicy::new_for_test());
+        let mut policy = Box::new(ScoredPolicy::for_test());
 
         // Add 2 compactors.
         for context_id in 0..2 {

--- a/src/meta/src/hummock/compaction_schedule_policy.rs
+++ b/src/meta/src/hummock/compaction_schedule_policy.rs
@@ -205,7 +205,7 @@ pub struct ScoredPolicy {
 
 impl ScoredPolicy {
     /// Initialize policy with already assigned tasks.
-    pub fn new_with_task_assignment(task_assignment: &[CompactTaskAssignment]) -> Self {
+    pub fn with_task_assignment(task_assignment: &[CompactTaskAssignment]) -> Self {
         let mut compactor_to_score = HashMap::new();
         task_assignment.iter().for_each(|assignment| {
             let score_delta =
@@ -541,7 +541,7 @@ mod tests {
                 });
             });
 
-        let mut policy = ScoredPolicy::new_with_task_assignment(&existing_assignments);
+        let mut policy = ScoredPolicy::with_task_assignment(&existing_assignments);
         assert_eq!(policy.score_to_compactor.len(), 0);
         assert_eq!(policy.context_id_to_score.len(), existing_tasks.len());
 

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -124,14 +124,14 @@ pub struct CompactorManager {
 }
 
 impl CompactorManager {
-    pub async fn new_with_meta<S: MetaStore>(
+    pub async fn with_meta<S: MetaStore>(
         env: MetaSrvEnv<S>,
         task_expiry_seconds: u64,
     ) -> MetaResult<Self> {
         // Retrieve the existing task assignments from metastore.
         let task_assignment = CompactTaskAssignment::list(env.meta_store()).await?;
         let manager = Self {
-            policy: RwLock::new(Box::new(ScoredPolicy::new_with_task_assignment(
+            policy: RwLock::new(Box::new(ScoredPolicy::with_task_assignment(
                 &task_assignment,
             ))),
             task_expiry_seconds,
@@ -155,7 +155,7 @@ impl CompactorManager {
     }
 
     /// Only used for unit test.
-    pub fn new_with_policy(policy: Box<dyn CompactionSchedulePolicy>) -> Self {
+    pub fn with_policy(policy: Box<dyn CompactionSchedulePolicy>) -> Self {
         Self {
             policy: RwLock::new(policy),
             task_expiry_seconds: 1,
@@ -356,7 +356,7 @@ mod tests {
         };
 
         // Restart. Set task_expiry_seconds to 0 only to speed up test.
-        let compactor_manager = CompactorManager::new_with_meta(env, 0).await.unwrap();
+        let compactor_manager = CompactorManager::with_meta(env, 0).await.unwrap();
         // Because task assignment exists.
         assert_eq!(compactor_manager.task_heartbeats.read().len(), 1);
         // Because compactor gRPC is not established yet.

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -146,7 +146,7 @@ impl CompactorManager {
     }
 
     /// Only used for unit test.
-    pub fn new_for_test() -> Self {
+    pub fn for_test() -> Self {
         Self {
             policy: RwLock::new(Box::new(RoundRobinPolicy::new())),
             task_expiry_seconds: 1,

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -248,7 +248,7 @@ pub async fn setup_compute_env_with_config(
     );
 
     let compaction_group_manager = Arc::new(
-        CompactionGroupManager::new_with_config(env.clone(), config.clone())
+        CompactionGroupManager::with_config(env.clone(), config.clone())
             .await
             .unwrap(),
     );

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -253,7 +253,7 @@ pub async fn setup_compute_env_with_config(
             .unwrap(),
     );
 
-    let compactor_manager = Arc::new(CompactorManager::new_for_test());
+    let compactor_manager = Arc::new(CompactorManager::for_test());
 
     let hummock_manager = Arc::new(
         HummockManager::new(

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -327,7 +327,7 @@ mod tests {
     #[tokio::test]
     async fn test_shutdown_vacuum() {
         let (env, hummock_manager, _cluster_manager, _worker_node) = setup_compute_env(80).await;
-        let compactor_manager = Arc::new(CompactorManager::new_for_test());
+        let compactor_manager = Arc::new(CompactorManager::for_test());
         let vacuum = Arc::new(VacuumManager::new(env, hummock_manager, compactor_manager));
         let (join_handle, shutdown_sender) =
             start_vacuum_scheduler(vacuum, Duration::from_secs(60));

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -315,7 +315,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
     let registry = meta_metrics.registry();
     monitor_process(registry).unwrap();
     let compactor_manager = Arc::new(
-        hummock::CompactorManager::new_with_meta(env.clone(), max_heartbeat_interval.as_secs())
+        hummock::CompactorManager::with_meta(env.clone(), max_heartbeat_interval.as_secs())
             .await
             .unwrap(),
     );

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -944,11 +944,8 @@ mod tests {
 
             // TODO: what should we choose the task heartbeat interval to be? Anyway, we don't run a
             // heartbeat thread here, so it doesn't matter.
-            let compactor_manager = Arc::new(
-                CompactorManager::new_with_meta(env.clone(), 1)
-                    .await
-                    .unwrap(),
-            );
+            let compactor_manager =
+                Arc::new(CompactorManager::with_meta(env.clone(), 1).await.unwrap());
 
             let hummock_manager = Arc::new(
                 HummockManager::new(

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -90,7 +90,7 @@ fn build_table(
             policy: CachePolicy::Fill,
         },
     );
-    let mut builder = SstableBuilder::new_for_test(sstable_id, writer, opt);
+    let mut builder = SstableBuilder::for_test(sstable_id, writer, opt);
     let value = b"1234567890123456789";
     let mut full_key = test_key_of(0, epoch);
     let user_len = full_key.len() - 8;
@@ -163,11 +163,8 @@ async fn compact<I: HummockIterator<Direction = Forward>>(iter: I, sstable_store
         bloom_false_positive: 0.01,
         compression_algorithm: CompressionAlgorithm::None,
     };
-    let mut builder = CapacitySplitTableBuilder::new_for_test(LocalTableBuilderFactory::new(
-        32,
-        sstable_store,
-        opt,
-    ));
+    let mut builder =
+        CapacitySplitTableBuilder::for_test(LocalTableBuilderFactory::new(32, sstable_store, opt));
 
     let task_config = TaskConfig {
         key_range: KeyRange::inf(),

--- a/src/storage/benches/bench_multi_builder.rs
+++ b/src/storage/benches/bench_multi_builder.rs
@@ -74,7 +74,7 @@ impl<F: SstableWriterFactory> TableBuilderFactory for LocalTableBuilderFactory<F
             .create_sst_writer(id, writer_options)
             .await
             .unwrap();
-        let builder = SstableBuilder::new_for_test(id, writer, self.options.clone());
+        let builder = SstableBuilder::for_test(id, writer, self.options.clone());
 
         Ok(builder)
     }
@@ -140,7 +140,7 @@ fn bench_builder(
     if enable_streaming_upload {
         group.bench_function(format!("bench_streaming_upload_{}mb", capacity_mb), |b| {
             b.to_async(&runtime).iter(|| {
-                build_tables(CapacitySplitTableBuilder::new_for_test(
+                build_tables(CapacitySplitTableBuilder::for_test(
                     LocalTableBuilderFactory::new(
                         1,
                         StreamingSstableWriterFactory::new(sstable_store.clone()),
@@ -152,7 +152,7 @@ fn bench_builder(
     } else {
         group.bench_function(format!("bench_batch_upload_{}mb", capacity_mb), |b| {
             b.to_async(&runtime).iter(|| {
-                build_tables(CapacitySplitTableBuilder::new_for_test(
+                build_tables(CapacitySplitTableBuilder::for_test(
                     LocalTableBuilderFactory::new(
                         1,
                         BatchSstableWriterFactory::new(sstable_store.clone()),

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -92,7 +92,7 @@ pub async fn get_test_observer_manager<S: MetaStore>(
     worker_type: WorkerType,
 ) -> ObserverManager<TestNotificationClient<S>> {
     let rx = client.subscribe(&addr, worker_type).await.unwrap();
-    ObserverManager::new_with(rx, client, addr, observer_states, worker_type)
+    ObserverManager::with_subscriber(rx, client, addr, observer_states, worker_type)
 }
 
 pub async fn get_observer_manager(

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -107,7 +107,7 @@ pub struct SstableBuilder<W: SstableWriter> {
 }
 
 impl<W: SstableWriter> SstableBuilder<W> {
-    pub fn new_for_test(sstable_id: u64, writer: W, options: SstableBuilderOptions) -> Self {
+    pub fn for_test(sstable_id: u64, writer: W, options: SstableBuilderOptions) -> Self {
         Self::new(
             sstable_id,
             writer,
@@ -325,7 +325,7 @@ pub(super) mod tests {
             compression_algorithm: CompressionAlgorithm::None,
         };
 
-        let b = SstableBuilder::new_for_test(0, mock_sst_writer(&opt), opt);
+        let b = SstableBuilder::for_test(0, mock_sst_writer(&opt), opt);
 
         b.finish().unwrap();
     }
@@ -333,7 +333,7 @@ pub(super) mod tests {
     #[tokio::test]
     async fn test_basic() {
         let opt = default_builder_opt_for_test();
-        let mut b = SstableBuilder::new_for_test(0, mock_sst_writer(&opt), opt);
+        let mut b = SstableBuilder::for_test(0, mock_sst_writer(&opt), opt);
 
         for i in 0..TEST_KEYS_COUNT {
             b.add(&test_key_of(i), HummockValue::put(&test_value_of(i)))

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -83,7 +83,7 @@ where
         }
     }
 
-    pub fn new_for_test(builder_factory: F) -> Self {
+    pub fn for_test(builder_factory: F) -> Self {
         Self {
             builder_factory,
             sst_outputs: Vec::new(),
@@ -244,7 +244,7 @@ impl TableBuilderFactory for LocalTableBuilderFactory {
             .sstable_store
             .clone()
             .create_sst_writer(id, writer_options);
-        let builder = SstableBuilder::new_for_test(id, writer, self.options.clone());
+        let builder = SstableBuilder::for_test(id, writer, self.options.clone());
 
         Ok(builder)
     }
@@ -270,7 +270,7 @@ mod tests {
             compression_algorithm: CompressionAlgorithm::None,
         };
         let builder_factory = LocalTableBuilderFactory::new(1001, mock_sstable_store(), opts);
-        let builder = CapacitySplitTableBuilder::new_for_test(builder_factory);
+        let builder = CapacitySplitTableBuilder::for_test(builder_factory);
         let results = builder.finish().unwrap();
         assert!(results.is_empty());
     }
@@ -287,7 +287,7 @@ mod tests {
             compression_algorithm: CompressionAlgorithm::None,
         };
         let builder_factory = LocalTableBuilderFactory::new(1001, mock_sstable_store(), opts);
-        let mut builder = CapacitySplitTableBuilder::new_for_test(builder_factory);
+        let mut builder = CapacitySplitTableBuilder::for_test(builder_factory);
 
         for i in 0..table_capacity {
             builder
@@ -307,7 +307,7 @@ mod tests {
     #[tokio::test]
     async fn test_table_seal() {
         let opts = default_builder_opt_for_test();
-        let mut builder = CapacitySplitTableBuilder::new_for_test(LocalTableBuilderFactory::new(
+        let mut builder = CapacitySplitTableBuilder::for_test(LocalTableBuilderFactory::new(
             1001,
             mock_sstable_store(),
             opts,
@@ -347,7 +347,7 @@ mod tests {
     #[tokio::test]
     async fn test_initial_not_allowed_split() {
         let opts = default_builder_opt_for_test();
-        let mut builder = CapacitySplitTableBuilder::new_for_test(LocalTableBuilderFactory::new(
+        let mut builder = CapacitySplitTableBuilder::for_test(LocalTableBuilderFactory::new(
             1001,
             mock_sstable_store(),
             opts,

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -133,7 +133,7 @@ pub fn gen_test_sstable_data(
     opts: SstableBuilderOptions,
     kv_iter: impl Iterator<Item = (Vec<u8>, HummockValue<Vec<u8>>)>,
 ) -> (Bytes, SstableMeta) {
-    let mut b = SstableBuilder::new_for_test(0, mock_sst_writer(&opts), opts);
+    let mut b = SstableBuilder::for_test(0, mock_sst_writer(&opts), opts);
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice()).unwrap();
     }
@@ -187,7 +187,7 @@ pub async fn gen_test_sstable_inner(
         policy,
     };
     let writer = sstable_store.clone().create_sst_writer(sst_id, writer_opts);
-    let mut b = SstableBuilder::new_for_test(sst_id, writer, opts);
+    let mut b = SstableBuilder::for_test(sst_id, writer, opts);
     for (key, value) in kv_iter {
         b.add(&key, value.as_slice()).unwrap();
     }

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -125,7 +125,7 @@ impl<S: StateStore> StorageTable<S> {
         )
     }
 
-    pub fn new_for_test(
+    pub fn for_test(
         store: S,
         table_id: TableId,
         columns: Vec<ColumnDesc>,

--- a/src/storage/src/table/batch_table/test_batch_table.rs
+++ b/src/storage/src/table/batch_table/test_batch_table.rs
@@ -50,7 +50,7 @@ async fn test_storage_table_get_row() -> StorageResult<()> {
         order_types.clone(),
         pk_indices.clone(),
     );
-    let mut table: StorageTable<MemoryStateStore> = StorageTable::new_for_test(
+    let mut table: StorageTable<MemoryStateStore> = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
         column_descs.clone(),
@@ -121,7 +121,7 @@ async fn test_storage_get_row_for_string() {
         order_types.clone(),
         pk_indices.clone(),
     );
-    let mut table: StorageTable<MemoryStateStore> = StorageTable::new_for_test(
+    let mut table: StorageTable<MemoryStateStore> = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
         column_descs.clone(),
@@ -204,7 +204,7 @@ async fn test_shuffled_column_id_for_storage_table_get_row() {
     state.init_epoch(epoch);
     epoch += 1;
 
-    let mut table: StorageTable<MemoryStateStore> = StorageTable::new_for_test(
+    let mut table: StorageTable<MemoryStateStore> = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
         column_descs.clone(),

--- a/src/stream/src/executor/aggregation/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/approx_count_distinct.rs
@@ -197,10 +197,10 @@ pub struct StreamingApproxCountDistinct<const DENSE_BITS: usize> {
 
 impl<const DENSE_BITS: usize> StreamingApproxCountDistinct<DENSE_BITS> {
     pub fn new() -> Self {
-        StreamingApproxCountDistinct::new_with_datum(None)
+        StreamingApproxCountDistinct::with_datum(None)
     }
 
-    pub fn new_with_datum(datum: Datum) -> Self {
+    pub fn with_datum(datum: Datum) -> Self {
         let count = if let Some(c) = datum {
             match c {
                 ScalarImpl::Int64(num) => num,

--- a/src/stream/src/executor/aggregation/foldable.rs
+++ b/src/stream/src/executor/aggregation/foldable.rs
@@ -318,7 +318,7 @@ where
         Self::default()
     }
 
-    pub fn new_with_datum(x: Datum) -> StreamExecutorResult<Self> {
+    pub fn with_datum(x: Datum) -> StreamExecutorResult<Self> {
         let mut result = None;
         if let Some(scalar) = x {
             result = Some(R::OwnedItem::try_from(scalar)?);

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -136,14 +136,14 @@ pub fn create_streaming_agg_state(
             ) {
                 $(
                     (AggKind::$agg_type, $input_type! { type_match_pattern }, $return_type! { type_match_pattern }, Some(datum)) => {
-                        Box::new(<$state_impl>::new_with_datum(datum)?)
+                        Box::new(<$state_impl>::with_datum(datum)?)
                     }
                     (AggKind::$agg_type, $input_type! { type_match_pattern }, $return_type! { type_match_pattern }, None) => {
                         Box::new(<$state_impl>::new())
                     }
                 )*
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, Some(datum)) => {
-                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new_with_datum(datum))
+                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
                     Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())

--- a/src/stream/src/executor/aggregation/single_value.rs
+++ b/src/stream/src/executor/aggregation/single_value.rs
@@ -54,7 +54,7 @@ impl<T: Array> StreamingSingleValueAgg<T> {
     /// This function makes the assumption that if this function gets called, then
     /// we must have row count equal to 1. If the row count is equal to 0,
     /// then `new` will be called instead of this function.
-    pub fn new_with_datum(x: Datum) -> StreamExecutorResult<Self> {
+    pub fn with_datum(x: Datum) -> StreamExecutorResult<Self> {
         let mut result = None;
         if let Some(scalar) = x {
             result = Some(T::OwnedItem::try_from(scalar)?);

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -122,7 +122,7 @@ fn create_arrangement(
         ],
     );
 
-    Box::new(MaterializeExecutor::new_for_test(
+    Box::new(MaterializeExecutor::for_test(
         Box::new(source),
         memory_state_store,
         table_id,

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -73,7 +73,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
     }
 
     /// Create a new `MaterializeExecutor` without distribution info for test purpose.
-    pub fn new_for_test(
+    pub fn for_test(
         input: BoxedExecutor,
         store: S,
         table_id: TableId,
@@ -222,7 +222,7 @@ mod tests {
             ColumnDesc::unnamed(column_ids[1], DataType::Int32),
         ];
 
-        let mut table = StorageTable::new_for_test(
+        let mut table = StorageTable::for_test(
             memory_state_store.clone(),
             table_id,
             column_descs,
@@ -230,7 +230,7 @@ mod tests {
             vec![0],
         );
 
-        let mut materialize_executor = Box::new(MaterializeExecutor::new_for_test(
+        let mut materialize_executor = Box::new(MaterializeExecutor::for_test(
             Box::new(source),
             memory_state_store,
             table_id,

--- a/src/stream/src/executor/mview/test_utils.rs
+++ b/src/stream/src/executor/mview/test_utils.rs
@@ -38,7 +38,7 @@ pub async fn gen_basic_table(row_count: usize) -> StorageTable<MemoryStateStore>
         order_types,
         pk_indices,
     );
-    let table = StorageTable::new_for_test(
+    let table = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
         column_descs.clone(),

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -780,7 +780,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut materialize = MaterializeExecutor::new_for_test(
+        let mut materialize = MaterializeExecutor::for_test(
             Box::new(source_exec),
             mem_state_store.clone(),
             TableId::from(0x2333),


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Follow the Rust API Naming Guide.

https://rust-lang.github.io/api-guidelines/naming.html

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
