### PR TITLE
chore: modify default value for no_available_compactor_stall_sec

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -582,6 +582,9 @@ template:
     # Enable sanity check when SSTs are committed. Disabled by default.
     enable-committed-sst-sanity-check: false
 
+    # Seconds compaction scheduler should stall when there is no available compactor.
+    no-available-compactor-stall-sec: 5,
+
   prometheus:
     # Advertise address of Prometheus
     address: "127.0.0.1"

--- a/risedev.yml
+++ b/risedev.yml
@@ -583,7 +583,7 @@ template:
     enable-committed-sst-sanity-check: false
 
     # Seconds compaction scheduler should stall when there is no available compactor.
-    no-available-compactor-stall-sec: 5,
+    no-available-compactor-stall-sec: 5
 
   prometheus:
     # Advertise address of Prometheus

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -152,7 +152,7 @@ pub struct MetaNodeOpts {
     pub periodic_compaction_interval_sec: u64,
 
     /// Seconds compaction scheduler should stall when there is no available compactor.
-    #[clap(long, default_value = "10")]
+    #[clap(long, default_value = "5")]
     pub no_available_compactor_stall_sec: u64,
 
     #[clap(long, default_value = "10")]

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -109,7 +109,7 @@ impl Default for MetaOpts {
             enable_committed_sst_sanity_check: false,
             periodic_compaction_interval_sec: 60,
             node_num_monitor_interval_sec: 10,
-            no_available_compactor_stall_sec: 10,
+            no_available_compactor_stall_sec: 5,
         }
     }
 }

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -66,6 +66,7 @@ pub struct MetaNodeConfig {
     pub collect_gc_watermark_spin_interval_sec: u64,
     pub min_sst_retention_time_sec: u64,
     pub enable_committed_sst_sanity_check: bool,
+    pub no_available_compactor_stall_sec: u64,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -94,6 +94,8 @@ impl MetaNodeService {
             .arg(format!("{}", config.vacuum_interval_sec))
             .arg("--collect-gc-watermark-spin-interval-sec")
             .arg(format!("{}", config.collect_gc_watermark_spin_interval_sec))
+            .arg("--no-available-compactor-stall-sec")
+            .arg(format!("{}", config.no_available_compactor_stall_sec))
             .arg("--min-sst-retention-time-sec")
             .arg(format!("{}", config.min_sst_retention_time_sec));
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Use 5 sec for `no_available_compactor_stall_sec` by default, which is the same as `compactor_selection_retry_interval_sec` removed by https://github.com/risingwavelabs/risingwave/pull/5240, in order to keep compaction behavior close to it.

## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
