### PR TITLE
feat: add upstream_fragment_ids to Fragment

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -60,6 +60,10 @@ message TableFragments {
     // Vnode mapping (which should be set in upstream dispatcher) of the fragment.
     common.ParallelUnitMapping vnode_mapping = 5;
     repeated uint32 state_table_ids = 6;
+    // Note that this can be derived backwards from the upstream actors of the Actor held by the Fragment,
+    // but in some scenarios (e.g. Scaling) it will lead to a lot of duplicate code,
+    // so we pre-generate and store it here, this member will only be initialized when creating the Fragment
+    // and modified when and modified when creating the mv-on-mv
     repeated uint32 upstream_fragment_ids = 7;
   }
   uint32 table_id = 1;

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -60,6 +60,7 @@ message TableFragments {
     // Vnode mapping (which should be set in upstream dispatcher) of the fragment.
     common.ParallelUnitMapping vnode_mapping = 5;
     repeated uint32 state_table_ids = 6;
+    repeated uint32 upstream_fragment_ids = 7;
   }
   uint32 table_id = 1;
   map<uint32, Fragment> fragments = 2;

--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -303,10 +303,12 @@ mod tests {
     use assert_matches::assert_matches;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::CompactionGroupId;
+    use risingwave_pb::hummock::compact_task::TaskStatus;
 
     use crate::hummock::compaction_scheduler::{CompactionRequestChannel, ScheduleStatus};
     use crate::hummock::test_utils::{add_ssts, setup_compute_env};
     use crate::hummock::CompactionScheduler;
+    use crate::manager::LocalNotification;
 
     #[tokio::test]
     async fn test_pick_and_assign() {

--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -303,12 +303,10 @@ mod tests {
     use assert_matches::assert_matches;
     use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
     use risingwave_hummock_sdk::CompactionGroupId;
-    use risingwave_pb::hummock::compact_task::TaskStatus;
 
     use crate::hummock::compaction_scheduler::{CompactionRequestChannel, ScheduleStatus};
     use crate::hummock::test_utils::{add_ssts, setup_compute_env};
     use crate::hummock::CompactionScheduler;
-    use crate::manager::LocalNotification;
 
     #[tokio::test]
     async fn test_pick_and_assign() {

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -158,11 +158,10 @@ where
     async fn notify_fragment_mapping(&self, table_fragment: &TableFragments, operation: Operation) {
         for fragment in table_fragment.fragments.values() {
             if !fragment.state_table_ids.is_empty() {
-                let mut mapping = fragment
+                let mapping = fragment
                     .vnode_mapping
                     .clone()
                     .expect("no data distribution found");
-                mapping.fragment_id = fragment.fragment_id;
                 self.env
                     .notification_manager()
                     .notify_frontend(operation, Info::ParallelUnitMapping(mapping))

--- a/src/meta/src/stream/scheduler.rs
+++ b/src/meta/src/stream/scheduler.rs
@@ -254,7 +254,7 @@ impl Scheduler {
         fragment.vnode_mapping = Some(ParallelUnitMapping {
             original_indices,
             data,
-            ..Default::default()
+            fragment_id: fragment.fragment_id,
         });
 
         Ok(vnode_mapping)

--- a/src/meta/src/stream/stream_graph.rs
+++ b/src/meta/src/stream/stream_graph.rs
@@ -899,6 +899,12 @@ impl ActorGraphBuilder {
                         vnode_mapping: None,
                         // Will be filled in `record_internal_state_tables` later.
                         state_table_ids: vec![],
+                        upstream_fragment_ids: self
+                            .fragment_graph
+                            .get_upstreams(GlobalFragmentId(fragment_id))
+                            .keys()
+                            .map(|id| id.as_global_id())
+                            .collect(),
                     },
                 )
             })

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -317,12 +317,24 @@ where
             let upstream_table_id = chain_fragment_upstream_table_map
                 .get(&fragment.fragment_id)
                 .unwrap();
-            fragment.vnode_mapping = env
+
+            let upstream_fragment_vnode_info = env
                 .upstream_fragment_vnode_info
                 .get(upstream_table_id)
-                .unwrap()
+                .unwrap();
+
+            let upstream_fragment_id = upstream_fragment_vnode_info
                 .vnode_mapping
-                .clone();
+                .as_ref()
+                .unwrap()
+                .fragment_id;
+
+            assert!(fragment.upstream_fragment_ids.is_empty());
+            fragment
+                .upstream_fragment_ids
+                .push(upstream_fragment_id as FragmentId);
+
+            fragment.vnode_mapping = upstream_fragment_vnode_info.vnode_mapping.clone();
         }
         Ok(())
     }
@@ -418,7 +430,6 @@ where
             chain_fragment_upstream_table_map,
         )
         .await?;
-
         let dispatchers = &*dispatchers;
         let upstream_worker_actors = &*upstream_worker_actors;
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -334,7 +334,14 @@ where
                 .upstream_fragment_ids
                 .push(upstream_fragment_id as FragmentId);
 
-            fragment.vnode_mapping = upstream_fragment_vnode_info.vnode_mapping.clone();
+            let mut vnode_mapping = upstream_fragment_vnode_info.vnode_mapping.clone();
+            // The upstream vnode_mapping is cloned here,
+            // so the fragment id in the mapping needs to be changed to the id of this fragment
+            if let Some(mapping) = vnode_mapping.as_mut() {
+                assert_ne!(mapping.fragment_id, fragment.fragment_id);
+                mapping.fragment_id = fragment.fragment_id;
+            }
+            fragment.vnode_mapping = vnode_mapping;
         }
         Ok(())
     }

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -371,6 +371,16 @@ async fn test_fragmenter() -> MetaResult<()> {
     assert_eq!(sink_actor_ids, vec![1]);
     assert_eq!(4, internal_table_ids.len());
 
+    let fragment_upstreams: HashMap<_, _> = table_fragments
+        .fragments
+        .iter()
+        .map(|(fragment_id, fragment)| (*fragment_id, fragment.upstream_fragment_ids.clone()))
+        .collect();
+
+    assert_eq!(fragment_upstreams.get(&1).unwrap(), &vec![2]);
+    assert_eq!(fragment_upstreams.get(&2).unwrap(), &vec![3]);
+    assert!(fragment_upstreams.get(&3).unwrap().is_empty());
+
     let mut expected_downstream = HashMap::new();
     expected_downstream.insert(1, vec![]);
     expected_downstream.insert(2, vec![1]);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR introduces `upstream_fragment_ids` to `Fragment` to reduce the cost of maintaining the index when scaling, as there are many places to use, this field is currently modified in these two places

1. Creating Fragment
2. Creating mv on mv for chain node modification

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
