### PR TITLE
feat(BTreeMapTransaction): delete data both in staging and original `…

### DIFF
--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -445,7 +445,10 @@ impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransaction<'a, K, V> {
             return match op {
                 BTreeMapOp::Delete => None,
                 BTreeMapOp::Insert(_) => match self.staging.remove(&key).unwrap() {
-                    BTreeMapOp::Insert(v) => Some(v),
+                    BTreeMapOp::Insert(v) => {
+                        self.staging.insert(key, BTreeMapOp::Delete);
+                        Some(v)
+                    }
                     BTreeMapOp::Delete => {
                         unreachable!("we have checked that the op of the key is `Insert`, so it's impossible to be Delete")
                     }


### PR DESCRIPTION
…BTreeMap` when `remove` is called in transaction

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

delete data both in staging and original `BTreeMap` when `remove` is called in transaction

if current design is intentional, we can retain current method and add a new method

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
