### PR TITLE
feat(batch): remove lookup join backtrace

### DIFF
--- a/src/batch/src/executor/join/lookup_join.rs
+++ b/src/batch/src/executor/join/lookup_join.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use risingwave_common::array::{Array, DataChunk, Row, RowRef};
 use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::catalog::{ColumnDesc, Field, Schema};
-use risingwave_common::error::{internal_error, ErrorCode, Result, RwError};
+use risingwave_common::error::{internal_error, Result, RwError};
 use risingwave_common::types::{
     DataType, Datum, ParallelUnitId, ToOwnedDatum, VirtualNode, VnodeMapping,
 };
@@ -319,14 +319,6 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
     async fn do_execute(mut self: Box<Self>) {
         let mut build_side_stream = self.build_child.take().unwrap().execute();
 
-        let invalid_join_error = RwError::from(ErrorCode::NotImplemented(
-            format!(
-                "Lookup Join does not support join type {:?}",
-                self.join_type
-            ),
-            None.into(),
-        ));
-
         while let Some(build_chunk) = build_side_stream.next().await {
             let build_chunk = build_chunk?.compact()?;
 
@@ -415,7 +407,7 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
                                 | JoinType::LeftOuter
                                 | JoinType::LeftSemi
                                 | JoinType::LeftAnti => self.do_inner_join(cur_row, chunk),
-                                _ => Err(invalid_join_error.clone()),
+                                _ => unimplemented!(),
                             }
                         } else {
                             match self.join_type {
@@ -432,7 +424,7 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
                                 JoinType::LeftAnti if !has_match[i][j] => {
                                     self.convert_row_for_builder(cur_row)
                                 }
-                                _ => Err(invalid_join_error.clone()),
+                                _ => unimplemented!(),
                             }
                         }?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- After investigation, I found the bottleneck of lookup join is the `Backtrace::capture()`.
- Previously, for each lookup join we have created a default `RwError` which will call `Backtrace::capture()`, while capture a backtrace need to acquire a global lock. This global lock is the performance killer for high concurrent batch query and hard to discover. 
- After this PR, we can improve our sysbench index lookup QPS from 26,000 to 43,000 and CPU utilization from 40% to 90% using 128 threads on a single c5.12xlarge EC2.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

