### PR TITLE
refactor(EpochPair):some refactor epoch pair

### DIFF
--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -97,6 +97,31 @@ impl fmt::Display for Epoch {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EpochPair {
+    pub curr: u64,
+    pub prev: u64,
+}
+
+impl EpochPair {
+    pub fn new(curr: u64, prev: u64) -> Self {
+        assert!(curr > prev);
+        Self { curr, prev }
+    }
+
+    #[cfg(test)]
+    pub fn inc(&self) -> Self {
+        Self {
+            curr: self.curr + 1,
+            prev: self.prev + 1,
+        }
+    }
+
+    pub fn new_test_epoch(curr: u64) -> Self {
+        assert!(curr > 0);
+        Self::new(curr, curr - 1)
+    }
+}
 #[cfg(test)]
 mod tests {
     use chrono::{Local, TimeZone, Utc};

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -22,7 +22,7 @@ use risingwave_pb::catalog::Source;
 use risingwave_pb::stream_service::barrier_complete_response::GroupedSstableInfo;
 use risingwave_pb::stream_service::stream_service_server::StreamService;
 use risingwave_pb::stream_service::*;
-use risingwave_stream::executor::{Barrier, Epoch, Mutation};
+use risingwave_stream::executor::{Barrier, EpochPair, Mutation};
 use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
 use tonic::{Request, Response, Status};
 
@@ -119,7 +119,7 @@ impl StreamService for StreamServiceImpl {
         let epoch = req.epoch.unwrap();
 
         let barrier = &Barrier {
-            epoch: Epoch {
+            epoch: EpochPair {
                 curr: epoch.curr,
                 prev: epoch.prev,
             },

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -18,11 +18,12 @@ use async_stack_trace::StackTrace;
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::error::{tonic_err, Result as RwResult};
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_pb::catalog::Source;
 use risingwave_pb::stream_service::barrier_complete_response::GroupedSstableInfo;
 use risingwave_pb::stream_service::stream_service_server::StreamService;
 use risingwave_pb::stream_service::*;
-use risingwave_stream::executor::{Barrier, EpochPair, Mutation};
+use risingwave_stream::executor::{Barrier, Mutation};
 use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
 use tonic::{Request, Response, Status};
 

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -25,7 +25,7 @@ use tokio_stream::StreamExt;
 use super::monitor::StreamingMetrics;
 use super::StreamConsumer;
 use crate::error::StreamResult;
-use crate::executor::Epoch;
+use crate::executor::EpochPair;
 use crate::task::{ActorId, SharedContext};
 
 /// Shared by all operators of an actor.
@@ -97,7 +97,7 @@ where
             span
         };
 
-        let mut last_epoch: Option<Epoch> = None;
+        let mut last_epoch: Option<EpochPair> = None;
 
         let stream = Box::new(self.consumer).execute();
         pin_mut!(stream);

--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -19,13 +19,13 @@ use async_stack_trace::{SpanValue, StackTrace};
 use futures::pin_mut;
 use minitrace::prelude::*;
 use parking_lot::Mutex;
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_expr::ExprError;
 use tokio_stream::StreamExt;
 
 use super::monitor::StreamingMetrics;
 use super::StreamConsumer;
 use crate::error::StreamResult;
-use crate::executor::EpochPair;
 use crate::task::{ActorId, SharedContext};
 
 /// Shared by all operators of an actor.

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -35,7 +35,7 @@ use super::error::{StreamExecutorError, StreamExecutorResult};
 use super::managed_state::join::*;
 use super::monitor::StreamingMetrics;
 use super::{
-    ActorContextRef, BoxedExecutor, BoxedMessageStream, Epoch, Executor, Message, PkIndices,
+    ActorContextRef, BoxedExecutor, BoxedMessageStream, EpochPair, Executor, Message, PkIndices,
     PkIndicesRef,
 };
 use crate::common::{InfallibleExpression, StreamChunkBuilder};
@@ -199,7 +199,7 @@ impl<K: HashKey, S: StateStore> JoinSide<K, S> {
         // self.ht.clear();
     }
 
-    pub fn init(&mut self, epoch: Epoch) {
+    pub fn init(&mut self, epoch: EpochPair) {
         self.ht.init(epoch);
     }
 }
@@ -935,7 +935,7 @@ mod tests {
 
     use super::*;
     use crate::executor::test_utils::{MessageSender, MockSource};
-    use crate::executor::{ActorContext, Barrier, Epoch, Message};
+    use crate::executor::{ActorContext, Barrier, EpochPair, Message};
 
     fn create_in_memory_state_table(
         mem_state: MemoryStateStore,
@@ -2161,7 +2161,7 @@ mod tests {
         tx_r.push_barrier(2, false);
 
         // get the aligned barrier here
-        let expected_epoch = Epoch::new_test_epoch(2);
+        let expected_epoch = EpochPair::new_test_epoch(2);
         assert!(matches!(
             hash_join.next().await.unwrap().unwrap(),
             Message::Barrier(Barrier {
@@ -2258,7 +2258,7 @@ mod tests {
         tx_r.push_barrier(2, false);
 
         // get the aligned barrier here
-        let expected_epoch = Epoch::new_test_epoch(2);
+        let expected_epoch = EpochPair::new_test_epoch(2);
         assert!(matches!(
             hash_join.next().await.unwrap().unwrap(),
             Message::Barrier(Barrier {

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -25,6 +25,7 @@ use risingwave_common::bail;
 use risingwave_common::catalog::Schema;
 use risingwave_common::hash::HashKey;
 use risingwave_common::types::{DataType, ToOwnedDatum};
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_expr::expr::BoxedExpression;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
@@ -35,8 +36,7 @@ use super::error::{StreamExecutorError, StreamExecutorResult};
 use super::managed_state::join::*;
 use super::monitor::StreamingMetrics;
 use super::{
-    ActorContextRef, BoxedExecutor, BoxedMessageStream, EpochPair, Executor, Message, PkIndices,
-    PkIndicesRef,
+    ActorContextRef, BoxedExecutor, BoxedMessageStream, Executor, Message, PkIndices, PkIndicesRef,
 };
 use crate::common::{InfallibleExpression, StreamChunkBuilder};
 use crate::executor::JoinType::LeftAnti;

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -27,7 +27,7 @@ use crate::executor::error::{StreamExecutorError, StreamExecutorResult};
 use crate::executor::lookup::cache::LookupCache;
 use crate::executor::lookup::sides::{ArrangeJoinSide, ArrangeMessage, StreamJoinSide};
 use crate::executor::lookup::LookupExecutor;
-use crate::executor::{Barrier, Epoch, Executor, Message, PkIndices, PROCESSING_WINDOW_SIZE};
+use crate::executor::{Barrier, EpochPair, Executor, Message, PkIndices, PROCESSING_WINDOW_SIZE};
 /// Parameters for [`LookupExecutor`].
 pub struct LookupExecutorParams<S: StateStore> {
     /// The side for arrangement. Currently, it should be a
@@ -323,7 +323,7 @@ impl<S: StateStore> LookupExecutor<S> {
             // data. Therefore, it is also okay to simply set prev epoch to 0.
 
             self.last_barrier = Some(Barrier {
-                epoch: Epoch {
+                epoch: EpochPair {
                     prev: 0,
                     curr: barrier.epoch.curr,
                 },

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -17,6 +17,7 @@ use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::{Row, RowRef};
 use risingwave_common::catalog::{ColumnDesc, Schema};
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::sort_util::OrderPair;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
@@ -27,7 +28,7 @@ use crate::executor::error::{StreamExecutorError, StreamExecutorResult};
 use crate::executor::lookup::cache::LookupCache;
 use crate::executor::lookup::sides::{ArrangeJoinSide, ArrangeMessage, StreamJoinSide};
 use crate::executor::lookup::LookupExecutor;
-use crate::executor::{Barrier, EpochPair, Executor, Message, PkIndices, PROCESSING_WINDOW_SIZE};
+use crate::executor::{Barrier, Executor, Message, PkIndices, PROCESSING_WINDOW_SIZE};
 /// Parameters for [`LookupExecutor`].
 pub struct LookupExecutorParams<S: StateStore> {
     /// The side for arrangement. Currently, it should be a

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -24,7 +24,7 @@ use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use crate::executor::error::StreamExecutorError;
-use crate::executor::{Epoch, StreamExecutorResult};
+use crate::executor::{EpochPair, StreamExecutorResult};
 
 /// The `RangeCache` caches a given range of `ScalarImpl` keys and corresponding rows.
 /// It will evict keys from memory if it is above capacity and shrink its range.
@@ -65,7 +65,7 @@ impl<S: StateStore> RangeCache<S> {
         }
     }
 
-    pub fn init(&mut self, epoch: Epoch) {
+    pub fn init(&mut self, epoch: EpochPair) {
         self.state_table.init_epoch(epoch.prev);
         self.current_epoch = epoch.curr;
     }

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -20,11 +20,12 @@ use std::ops::RangeBounds;
 use anyhow::anyhow;
 use risingwave_common::array::Row;
 use risingwave_common::types::ScalarImpl;
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use crate::executor::error::StreamExecutorError;
-use crate::executor::{EpochPair, StreamExecutorResult};
+use crate::executor::StreamExecutorResult;
 
 /// The `RangeCache` caches a given range of `ScalarImpl` keys and corresponding rows.
 /// It will evict keys from memory if it is above capacity and shrink its range.

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -41,7 +41,7 @@ use stats_alloc::{SharedStatsAlloc, StatsAlloc};
 use self::iter_utils::zip_by_order_key;
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::Epoch;
+use crate::executor::EpochPair;
 use crate::task::ActorId;
 
 type DegreeType = u64;
@@ -325,7 +325,7 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         self.alloc.bytes_in_use()
     }
 
-    pub fn init(&mut self, epoch: Epoch) {
+    pub fn init(&mut self, epoch: EpochPair) {
         self.current_epoch = epoch.curr;
         self.state.table.init_epoch(epoch.prev);
         self.degree_state.table.init_epoch(epoch.prev);

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -32,6 +32,7 @@ use risingwave_common::collection::estimate_size::EstimateSize;
 use risingwave_common::collection::evictable::EvictableHashMap;
 use risingwave_common::hash::{HashKey, PrecomputedBuildHasher};
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::ordered::OrderedRowSerializer;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
@@ -41,7 +42,6 @@ use stats_alloc::{SharedStatsAlloc, StatsAlloc};
 use self::iter_utils::zip_by_order_key;
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::EpochPair;
 use crate::task::ActorId;
 
 type DegreeType = u64;

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -27,6 +27,7 @@ use risingwave_common::array::{ArrayImpl, StreamChunk};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
+use risingwave_common::util::epoch::EpochPair;
 use risingwave_connector::source::{ConnectorState, SplitImpl};
 use risingwave_pb::data::Epoch as ProstEpoch;
 use risingwave_pb::stream_plan::add_mutation::Dispatchers;
@@ -207,32 +208,6 @@ pub enum Mutation {
     SourceChangeSplit(HashMap<ActorId, ConnectorState>),
     Pause,
     Resume,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq)]
-pub struct EpochPair {
-    pub curr: u64,
-    pub prev: u64,
-}
-
-impl EpochPair {
-    pub fn new(curr: u64, prev: u64) -> Self {
-        assert!(curr > prev);
-        Self { curr, prev }
-    }
-
-    #[cfg(test)]
-    pub fn inc(&self) -> Self {
-        Self {
-            curr: self.curr + 1,
-            prev: self.prev + 1,
-        }
-    }
-
-    pub fn new_test_epoch(curr: u64) -> Self {
-        assert!(curr > 0);
-        Self::new(curr, curr - 1)
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -235,16 +235,7 @@ impl EpochPair {
     }
 }
 
-impl Default for EpochPair {
-    fn default() -> Self {
-        Self {
-            curr: 1,
-            prev: INVALID_EPOCH,
-        }
-    }
-}
-
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Barrier {
     pub epoch: EpochPair,
     pub mutation: Option<Arc<Mutation>>,
@@ -260,7 +251,8 @@ impl Barrier {
         Self {
             epoch: EpochPair::new_test_epoch(epoch),
             checkpoint: true,
-            ..Default::default()
+            mutation: Default::default(),
+            passed_actors: Default::default(),
         }
     }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -210,12 +210,12 @@ pub enum Mutation {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub struct Epoch {
+pub struct EpochPair {
     pub curr: u64,
     pub prev: u64,
 }
 
-impl Epoch {
+impl EpochPair {
     pub fn new(curr: u64, prev: u64) -> Self {
         assert!(curr > prev);
         Self { curr, prev }
@@ -235,7 +235,7 @@ impl Epoch {
     }
 }
 
-impl Default for Epoch {
+impl Default for EpochPair {
     fn default() -> Self {
         Self {
             curr: 1,
@@ -246,7 +246,7 @@ impl Default for Epoch {
 
 #[derive(Debug, Clone, Default)]
 pub struct Barrier {
-    pub epoch: Epoch,
+    pub epoch: EpochPair,
     pub mutation: Option<Arc<Mutation>>,
     pub checkpoint: bool,
 
@@ -258,7 +258,7 @@ impl Barrier {
     /// Create a plain barrier.
     pub fn new_test_barrier(epoch: u64) -> Self {
         Self {
-            epoch: Epoch::new_test_epoch(epoch),
+            epoch: EpochPair::new_test_epoch(epoch),
             checkpoint: true,
             ..Default::default()
         }
@@ -528,7 +528,7 @@ impl Barrier {
         let epoch = prost.get_epoch().unwrap();
         Ok(Barrier {
             checkpoint: prost.checkpoint,
-            epoch: Epoch::new(epoch.curr, epoch.prev),
+            epoch: EpochPair::new(epoch.curr, epoch.prev),
             mutation,
             passed_actors: prost.get_passed_actors().clone(),
         })

--- a/src/stream/src/executor/source/reader.rs
+++ b/src/stream/src/executor/source/reader.rs
@@ -161,14 +161,14 @@ mod tests {
         table_source.write_chunk(StreamChunk::default()).unwrap();
         assert_matches!(next!().unwrap(), Either::Right(_));
         // Write a barrier, and we should receive it.
-        barrier_tx.send(Barrier::default()).unwrap();
+        barrier_tx.send(Barrier::new_test_barrier(1)).unwrap();
         assert_matches!(next!().unwrap(), Either::Left(_));
 
         // Pause the stream.
         stream.pause_source();
 
         // Write a barrier.
-        barrier_tx.send(Barrier::default()).unwrap();
+        barrier_tx.send(Barrier::new_test_barrier(2)).unwrap();
         // Then write a chunk.
         table_source.write_chunk(StreamChunk::default()).unwrap();
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -546,7 +546,10 @@ mod tests {
         barrier_sender.send(Barrier::new_test_barrier(1)).unwrap();
 
         let msg = executor.next().await.unwrap().unwrap();
-        assert_eq!(msg.into_barrier().unwrap().epoch, Epoch::new_test_epoch(1));
+        assert_eq!(
+            msg.into_barrier().unwrap().epoch,
+            EpochPair::new_test_epoch(1)
+        );
 
         // Write 1st chunk
         write_chunk(chunk1);

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -436,6 +436,7 @@ mod tests {
     use risingwave_common::array::StreamChunk;
     use risingwave_common::catalog::{ColumnDesc, Field, Schema};
     use risingwave_common::types::DataType;
+    use risingwave_common::util::epoch::EpochPair;
     use risingwave_common::util::sort_util::{OrderPair, OrderType};
     use risingwave_connector::source::datagen::DatagenSplit;
     use risingwave_pb::catalog::{ColumnIndex as ProstColumnIndex, StreamSourceInfo};

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -237,7 +237,7 @@ mod tests {
     use crate::executor::test_utils::top_n_executor::create_in_memory_state_table;
     use crate::executor::test_utils::MockSource;
     use crate::executor::top_n_appendonly::AppendOnlyTopNExecutor;
-    use crate::executor::{Barrier, Epoch, Executor, Message, PkIndices};
+    use crate::executor::{Barrier, EpochPair, Executor, Message, PkIndices};
 
     fn create_stream_chunks() -> Vec<StreamChunk> {
         let chunk1 = StreamChunk::from_pretty(
@@ -290,17 +290,17 @@ mod tests {
             PkIndices::new(),
             vec![
                 Message::Barrier(Barrier {
-                    epoch: Epoch::new_test_epoch(1),
+                    epoch: EpochPair::new_test_epoch(1),
                     ..Barrier::default()
                 }),
                 Message::Chunk(std::mem::take(&mut chunks[0])),
                 Message::Barrier(Barrier {
-                    epoch: Epoch::new_test_epoch(2),
+                    epoch: EpochPair::new_test_epoch(2),
                     ..Barrier::default()
                 }),
                 Message::Chunk(std::mem::take(&mut chunks[1])),
                 Message::Barrier(Barrier {
-                    epoch: Epoch::new_test_epoch(3),
+                    epoch: EpochPair::new_test_epoch(3),
                     ..Barrier::default()
                 }),
                 Message::Chunk(std::mem::take(&mut chunks[2])),

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -237,7 +237,7 @@ mod tests {
     use crate::executor::test_utils::top_n_executor::create_in_memory_state_table;
     use crate::executor::test_utils::MockSource;
     use crate::executor::top_n_appendonly::AppendOnlyTopNExecutor;
-    use crate::executor::{Barrier, EpochPair, Executor, Message, PkIndices};
+    use crate::executor::{Barrier, Executor, Message, PkIndices};
 
     fn create_stream_chunks() -> Vec<StreamChunk> {
         let chunk1 = StreamChunk::from_pretty(
@@ -289,20 +289,11 @@ mod tests {
             schema,
             PkIndices::new(),
             vec![
-                Message::Barrier(Barrier {
-                    epoch: EpochPair::new_test_epoch(1),
-                    ..Barrier::default()
-                }),
+                Message::Barrier(Barrier::new_test_barrier(1)),
                 Message::Chunk(std::mem::take(&mut chunks[0])),
-                Message::Barrier(Barrier {
-                    epoch: EpochPair::new_test_epoch(2),
-                    ..Barrier::default()
-                }),
+                Message::Barrier(Barrier::new_test_barrier(2)),
                 Message::Chunk(std::mem::take(&mut chunks[1])),
-                Message::Barrier(Barrier {
-                    epoch: EpochPair::new_test_epoch(3),
-                    ..Barrier::default()
-                }),
+                Message::Barrier(Barrier::new_test_barrier(3)),
                 Message::Chunk(std::mem::take(&mut chunks[2])),
             ],
         ))


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
- rename `pub struct Epoch {    pub curr: u64,    pub prev: u64}` to EpochPair
- move EpochPair into common crate
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
