### PR TITLE
refactor(optimizer): some refactor on stream topn

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -122,11 +122,7 @@ impl LogicalTopN {
     }
 
     /// Infers the state table catalog for [`StreamTopN`] and [`StreamGroupTopN`].
-    pub fn infer_internal_table_catalog(
-        &self,
-        group_key: Option<&[usize]>,
-        vnode_col_idx: Option<usize>,
-    ) -> TableCatalog {
+    pub fn infer_internal_table_catalog(&self, vnode_col_idx: Option<usize>) -> TableCatalog {
         let schema = &self.base.schema;
         let pk_indices = &self.base.logical_pk;
         let columns_fields = schema.fields().to_vec();
@@ -141,17 +137,15 @@ impl LogicalTopN {
         });
         let mut order_cols = HashSet::new();
 
-        if let Some(group_key) = group_key {
-            // Here we want the state table to store the states in the order we want, fisrtly in
-            // ascending order by the columns specified by the group key, then by the columns
-            // specified by `order`. If we do that, when the later group topN operator
-            // does a prefix scannimg with the group key, we can fetch the data in the
-            // desired order.
-            group_key.iter().for_each(|idx| {
-                internal_table_catalog_builder.add_order_column(*idx, OrderType::Ascending);
-                order_cols.insert(*idx);
-            });
-        }
+        // Here we want the state table to store the states in the order we want, fisrtly in
+        // ascending order by the columns specified by the group key, then by the columns
+        // specified by `order`. If we do that, when the later group topN operator
+        // does a prefix scannimg with the group key, we can fetch the data in the
+        // desired order.
+        self.group_key().iter().for_each(|idx| {
+            internal_table_catalog_builder.add_order_column(*idx, OrderType::Ascending);
+            order_cols.insert(*idx);
+        });
 
         field_order.iter().for_each(|field_order| {
             if !order_cols.contains(&field_order.index) {

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -65,11 +65,11 @@ impl StreamGroupTopN {
     }
 
     pub fn topn_order(&self) -> &Order {
-        &self.logical.topn_order()
+        self.logical.topn_order()
     }
 
     pub fn group_key(&self) -> &[usize] {
-        &self.logical.group_key()
+        self.logical.group_key()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::{LogicalTopN, PlanBase, PlanTreeNodeUnary, StreamNode};
-use crate::optimizer::property::{Distribution, OrderDisplay};
+use crate::optimizer::property::{Distribution, Order, OrderDisplay};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::PlanRef;
 
@@ -55,23 +55,38 @@ impl StreamGroupTopN {
             vnode_col_idx,
         }
     }
+
+    pub fn limit(&self) -> usize {
+        self.logical.limit()
+    }
+
+    pub fn offset(&self) -> usize {
+        self.logical.offset()
+    }
+
+    pub fn topn_order(&self) -> &Order {
+        &self.logical.topn_order()
+    }
+
+    pub fn group_key(&self) -> &[usize] {
+        &self.logical.group_key()
+    }
 }
 
 impl StreamNode for StreamGroupTopN {
     fn to_stream_prost_body(&self, state: &mut BuildFragmentGraphState) -> ProstStreamNode {
         use risingwave_pb::stream_plan::*;
-        let group_key = self.logical.group_key();
-        if self.logical.limit() == 0 {
+        if self.limit() == 0 {
             panic!("topN's limit shouldn't be 0.");
         }
         let table = self
             .logical
-            .infer_internal_table_catalog(Some(group_key), self.vnode_col_idx)
+            .infer_internal_table_catalog(self.vnode_col_idx)
             .with_id(state.gen_table_id_wrapped());
         let group_topn_node = GroupTopNNode {
-            limit: self.logical.limit() as u64,
-            offset: self.logical.offset() as u64,
-            group_key: group_key.iter().map(|idx| *idx as u32).collect(),
+            limit: self.limit() as u64,
+            offset: self.offset() as u64,
+            group_key: self.group_key().iter().map(|idx| *idx as u32).collect(),
             table: Some(table.to_internal_table_prost()),
         };
 
@@ -89,15 +104,15 @@ impl fmt::Display for StreamGroupTopN {
             &format!(
                 "{}",
                 OrderDisplay {
-                    order: self.logical.topn_order(),
+                    order: self.topn_order(),
                     input_schema
                 }
             ),
         );
         builder
-            .field("limit", &format_args!("{}", self.logical.limit()))
-            .field("offset", &format_args!("{}", self.logical.offset()))
-            .field("group_key", &format_args!("{:?}", self.logical.group_key()))
+            .field("limit", &format_args!("{}", self.limit()))
+            .field("offset", &format_args!("{}", self.offset()))
+            .field("group_key", &format_args!("{:?}", self.group_key()))
             .finish()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::{LogicalTopN, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
-use crate::optimizer::property::Distribution;
+use crate::optimizer::property::{Distribution, Order};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 /// `StreamTopN` implements [`super::LogicalTopN`] to find the top N elements with a heap
@@ -45,6 +45,18 @@ impl StreamTopN {
             false,
         );
         StreamTopN { base, logical }
+    }
+
+    pub fn limit(&self) -> usize {
+        self.logical.limit()
+    }
+
+    pub fn offset(&self) -> usize {
+        self.logical.offset()
+    }
+
+    pub fn topn_order(&self) -> &Order {
+        &self.logical.topn_order()
     }
 }
 
@@ -74,11 +86,11 @@ impl StreamNode for StreamTopN {
     fn to_stream_prost_body(&self, state: &mut BuildFragmentGraphState) -> ProstStreamNode {
         use risingwave_pb::stream_plan::*;
         let topn_node = TopNNode {
-            limit: self.logical.limit() as u64,
-            offset: self.logical.offset() as u64,
+            limit: self.limit() as u64,
+            offset: self.offset() as u64,
             table: Some(
                 self.logical
-                    .infer_internal_table_catalog(None, None)
+                    .infer_internal_table_catalog(None)
                     .with_id(state.gen_table_id_wrapped())
                     .to_internal_table_prost(),
             ),

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -56,7 +56,7 @@ impl StreamTopN {
     }
 
     pub fn topn_order(&self) -> &Order {
-        &self.logical.topn_order()
+        self.logical.topn_order()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
- remove useless parameter `group key` in `infer_catalog`
- more wrapper function instead of `self.logical.xxx()`


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
