### PR TITLE
fix(streaming): wait epoch when scaling (Part 2)

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -407,7 +407,7 @@ async fn test_row_seq_scan() -> Result<()> {
     );
 
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
     state.insert(Row(vec![
         Some(1_i32.into()),

--- a/src/ctl/src/cmd_impl/bench.rs
+++ b/src/ctl/src/cmd_impl/bench.rs
@@ -88,7 +88,7 @@ pub async fn do_bench(cmd: BenchCommands) -> Result<()> {
                     tracing::info!(thread = i, "starting scan");
                     let state_table = {
                         let mut tb = make_state_table(hummock, &table);
-                        tb.init_epoch(u64::MAX);
+                        tb.init_epoch(u64::MAX).await;
                         tb
                     };
                     loop {

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -88,7 +88,7 @@ async fn do_scan(
     // We use state table here instead of cell-based table to support iterating with u64::MAX epoch.
     let state_table = {
         let mut tb = make_state_table(hummock.clone(), &table);
-        tb.init_epoch(u64::MAX);
+        tb.init_epoch(u64::MAX).await;
         tb
     };
     let stream = state_table.iter().await?;

--- a/src/storage/src/table/batch_table/test_batch_table.rs
+++ b/src/storage/src/table/batch_table/test_batch_table.rs
@@ -58,7 +58,7 @@ async fn test_storage_table_get_row() -> StorageResult<()> {
         pk_indices,
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     state.insert(Row(vec![Some(1_i32.into()), None, None]));
@@ -129,7 +129,7 @@ async fn test_storage_get_row_for_string() {
         pk_indices,
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     state.insert(Row(vec![
@@ -201,7 +201,7 @@ async fn test_shuffled_column_id_for_storage_table_get_row() {
         pk_indices.clone(),
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     let mut table: StorageTable<MemoryStateStore> = StorageTable::for_test(
@@ -283,7 +283,7 @@ async fn test_row_based_storage_table_point_get_in_batch_mode() {
         value_indices,
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     state.insert(Row(vec![Some(1_i32.into()), None, None]));
@@ -352,7 +352,7 @@ async fn test_row_based_storage_table_scan_in_batch_mode() {
         value_indices,
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     state.insert(Row(vec![

--- a/src/storage/src/table/streaming_table/test_streaming_table.rs
+++ b/src/storage/src/table/streaming_table/test_streaming_table.rs
@@ -42,7 +42,7 @@ async fn test_state_table() -> StorageResult<()> {
     );
 
     let mut epoch = 0;
-    state_table.init_epoch(epoch);
+    state_table.init_epoch(epoch).await;
 
     state_table.insert(Row(vec![
         Some(1_i32.into()),
@@ -167,7 +167,7 @@ async fn test_state_table_update_insert() -> StorageResult<()> {
     );
 
     let mut epoch: u64 = 0;
-    state_table.init_epoch(epoch);
+    state_table.init_epoch(epoch).await;
 
     state_table.insert(Row(vec![
         Some(6_i32.into()),
@@ -336,7 +336,7 @@ async fn test_state_table_iter() {
     );
 
     let mut epoch = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
 
     state.insert(Row(vec![
         Some(1_i32.into()),
@@ -559,7 +559,7 @@ async fn test_state_table_iter_with_prefix() {
     );
 
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
 
     state.insert(Row(vec![
         Some(1_i32.into()),
@@ -672,7 +672,7 @@ async fn test_mem_table_assertion() {
         order_types,
         pk_index,
     );
-    state_table.init_epoch(0);
+    state_table.init_epoch(0).await;
     state_table.insert(Row(vec![
         Some(1_i32.into()),
         Some(11_i32.into()),
@@ -706,7 +706,7 @@ async fn test_state_table_iter_with_value_indices() {
         vec![2],
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
 
     state.insert(Row(vec![
         Some(1_i32.into()),

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -261,8 +261,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
         pin_mut!(aligned_stream);
 
         let barrier = expect_first_barrier_from_aligned_stream(&mut aligned_stream).await?;
-        self.right_table.init_epoch(barrier.epoch.prev);
-        self.range_cache.init(barrier.epoch);
+        self.right_table.init_epoch(barrier.epoch.prev).await;
+        self.range_cache.init(barrier.epoch).await;
 
         // The first barrier message should be propagated.
         yield Message::Barrier(barrier);
@@ -360,7 +360,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
                         self.range_cache
                             .state_table
-                            .update_vnode_bitmap(vnode_bitmap);
+                            .update_vnode_bitmap(vnode_bitmap)
+                            .await;
                     }
 
                     yield Message::Barrier(barrier);

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -258,7 +258,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
 
         let barrier = expect_first_barrier(&mut input).await?;
         for table in &mut state_tables {
-            table.init_epoch(barrier.epoch.prev);
+            table.init_epoch(barrier.epoch.prev).await;
         }
         let mut epoch = barrier.epoch.curr;
 

--- a/src/stream/src/executor/group_top_n.rs
+++ b/src/stream/src/executor/group_top_n.rs
@@ -223,14 +223,15 @@ impl<S: StateStore> TopNExecutorBase for InnerGroupTopNExecutorNew<S> {
         &self.info.identity
     }
 
-    fn update_state_table_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
+    async fn update_state_table_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
         self.managed_state
             .state_table
-            .update_vnode_bitmap(vnode_bitmap);
+            .update_vnode_bitmap(vnode_bitmap)
+            .await;
     }
 
     async fn init(&mut self, epoch: u64) -> StreamExecutorResult<()> {
-        self.managed_state.state_table.init_epoch(epoch);
+        self.managed_state.state_table.init_epoch(epoch).await;
         Ok(())
     }
 }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -462,7 +462,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         let mut input = input.execute();
         let barrier = expect_first_barrier(&mut input).await?;
         for state_table in &mut extra.state_tables {
-            state_table.init_epoch(barrier.epoch.prev);
+            state_table.init_epoch(barrier.epoch.prev).await;
         }
 
         let mut epoch = barrier.epoch.curr;
@@ -487,7 +487,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                     // Update the vnode bitmap for state tables of all agg calls if asked.
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(extra.ctx.id) {
                         for state_table in &mut extra.state_tables {
-                            state_table.update_vnode_bitmap(vnode_bitmap.clone());
+                            state_table.update_vnode_bitmap(vnode_bitmap.clone()).await;
                         }
                     }
 

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -308,7 +308,6 @@ impl<S: StateStore> LookupExecutor<S> {
     }
 
     /// Store the barrier.
-    #[expect(clippy::unused_async)]
     async fn process_barrier(&mut self, barrier: Barrier) -> StreamExecutorResult<()> {
         if self.last_barrier.is_none() {
             assert_ne!(barrier.epoch.prev, 0, "lookup requires prev epoch != 0");
@@ -334,9 +333,12 @@ impl<S: StateStore> LookupExecutor<S> {
                 ..barrier
             });
             if self.arrangement.use_current_epoch {
-                self.arrangement.state_table.init_epoch(barrier.epoch.curr);
+                self.arrangement
+                    .state_table
+                    .init_epoch(barrier.epoch.curr)
+                    .await;
             } else {
-                self.arrangement.state_table.init_epoch(0);
+                self.arrangement.state_table.init_epoch(0).await;
             };
             return Ok(());
         } else {

--- a/src/stream/src/executor/managed_state/aggregation/array_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/array_agg.rs
@@ -264,7 +264,7 @@ mod tests {
             ManagedArrayAggState::new(agg_call, None, input_pk_indices, state_table_col_mapping, 0);
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         let chunk = StreamChunk::from_pretty(
@@ -347,7 +347,7 @@ mod tests {
             ManagedArrayAggState::new(agg_call, None, input_pk_indices, state_table_col_mapping, 0);
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {
@@ -460,7 +460,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {

--- a/src/stream/src/executor/managed_state/aggregation/extreme.rs
+++ b/src/stream/src/executor/managed_state/aggregation/extreme.rs
@@ -348,7 +348,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {
@@ -461,7 +461,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {
@@ -582,8 +582,8 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table_1.init_epoch(epoch);
-        state_table_2.init_epoch(epoch);
+        state_table_1.init_epoch(epoch).await;
+        state_table_2.init_epoch(epoch).await;
         epoch += 1;
 
         let mut managed_state_1 = GenericExtremeState::new(
@@ -683,7 +683,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {
@@ -785,7 +785,7 @@ mod tests {
             vec![0, 1], // [a, _row_id]
         );
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
         let mut managed_state = GenericExtremeState::new(
             agg_call.clone(),
@@ -917,7 +917,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {

--- a/src/stream/src/executor/managed_state/aggregation/string_agg.rs
+++ b/src/stream/src/executor/managed_state/aggregation/string_agg.rs
@@ -301,7 +301,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         let chunk = StreamChunk::from_pretty(
@@ -377,7 +377,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         let chunk = StreamChunk::from_pretty(
@@ -462,7 +462,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         {
@@ -567,7 +567,7 @@ mod tests {
         );
 
         let mut epoch = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
         {
             let chunk = StreamChunk::from_pretty(

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -163,7 +163,7 @@ mod tests {
             vec![],
         );
         let mut epoch: u64 = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         let mut managed_state =
@@ -219,7 +219,7 @@ mod tests {
             pk_index,
         );
         let mut epoch: u64 = 0;
-        state_table.init_epoch(epoch);
+        state_table.init_epoch(epoch).await;
         epoch += 1;
 
         let mut managed_state = ManagedValueState::new(

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -66,8 +66,8 @@ impl<S: StateStore> RangeCache<S> {
         }
     }
 
-    pub fn init(&mut self, epoch: EpochPair) {
-        self.state_table.init_epoch(epoch.prev);
+    pub async fn init(&mut self, epoch: EpochPair) {
+        self.state_table.init_epoch(epoch.prev).await;
         self.current_epoch = epoch.curr;
     }
 

--- a/src/stream/src/executor/managed_state/join/mod.rs
+++ b/src/stream/src/executor/managed_state/join/mod.rs
@@ -325,19 +325,25 @@ impl<K: HashKey, S: StateStore> JoinHashMap<K, S> {
         self.alloc.bytes_in_use()
     }
 
-    pub fn init(&mut self, epoch: EpochPair) {
+    pub async fn init(&mut self, epoch: EpochPair) {
         self.current_epoch = epoch.curr;
-        self.state.table.init_epoch(epoch.prev);
-        self.degree_state.table.init_epoch(epoch.prev);
+        self.state.table.init_epoch(epoch.prev).await;
+        self.degree_state.table.init_epoch(epoch.prev).await;
     }
 
     pub fn update_epoch(&mut self, epoch: u64) {
         self.current_epoch = epoch;
     }
 
-    pub fn update_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
-        self.state.table.update_vnode_bitmap(vnode_bitmap.clone());
-        self.degree_state.table.update_vnode_bitmap(vnode_bitmap);
+    pub async fn update_vnode_bitmap(&mut self, vnode_bitmap: Arc<Bitmap>) {
+        self.state
+            .table
+            .update_vnode_bitmap(vnode_bitmap.clone())
+            .await;
+        self.degree_state
+            .table
+            .update_vnode_bitmap(vnode_bitmap)
+            .await;
     }
 
     /// Returns a mutable reference to the value of the key in the memory, if does not exist, look

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -199,7 +199,7 @@ mod tests {
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
             );
-            tb.init_epoch(0);
+            tb.init_epoch(0).await;
             tb
         };
         let mut managed_state = ManagedTopNState::new(
@@ -268,7 +268,7 @@ mod tests {
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
             );
-            tb.init_epoch(0);
+            tb.init_epoch(0).await;
             tb
         };
         let mut managed_state = ManagedTopNState::new(

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -118,7 +118,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
     async fn execute_inner(mut self) {
         let mut input = self.input.execute();
         let barrier = expect_first_barrier(&mut input).await?;
-        self.state_table.init_epoch(barrier.epoch.prev);
+        self.state_table.init_epoch(barrier.epoch.prev).await;
 
         // The first barrier message should be propagated.
         yield Message::Barrier(barrier);
@@ -137,7 +137,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
 
                     // Update the vnode bitmap for the state table if asked.
                     if let Some(vnode_bitmap) = b.as_update_vnode_bitmap(self.actor_context.id) {
-                        self.state_table.update_vnode_bitmap(vnode_bitmap);
+                        self.state_table.update_vnode_bitmap(vnode_bitmap).await;
                     }
 
                     Message::Barrier(b)

--- a/src/stream/src/executor/mview/test_utils.rs
+++ b/src/stream/src/executor/mview/test_utils.rs
@@ -46,7 +46,7 @@ pub async fn gen_basic_table(row_count: usize) -> StorageTable<MemoryStateStore>
         vec![0],
     );
     let mut epoch: u64 = 0;
-    state.init_epoch(epoch);
+    state.init_epoch(epoch).await;
     epoch += 1;
 
     for idx in 0..row_count {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -71,8 +71,8 @@ pub struct SourceExecutor<S: StateStore> {
 
     state_cache: HashMap<SplitId, SplitImpl>,
 
-    #[expect(dead_code)]
     /// Expected barrier latency
+    #[expect(dead_code)]
     expected_barrier_latency_ms: u64,
 }
 

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -425,7 +425,7 @@ impl<S: StateStore> TopNExecutorBase for InnerTopNExecutorNew<S> {
     }
 
     async fn init(&mut self, epoch: u64) -> StreamExecutorResult<()> {
-        self.managed_state.state_table.init_epoch(epoch);
+        self.managed_state.state_table.init_epoch(epoch).await;
         self.managed_state
             .init_topn_cache(None, &mut self.cache)
             .await

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -216,7 +216,7 @@ impl<S: StateStore> TopNExecutorBase for InnerAppendOnlyTopNExecutor<S> {
     }
 
     async fn init(&mut self, epoch: u64) -> StreamExecutorResult<()> {
-        self.managed_state.state_table.init_epoch(epoch);
+        self.managed_state.state_table.init_epoch(epoch).await;
         self.managed_state
             .init_topn_cache(None, &mut self.cache)
             .await

--- a/src/stream/src/executor/top_n_executor.rs
+++ b/src/stream/src/executor/top_n_executor.rs
@@ -47,7 +47,7 @@ pub trait TopNExecutorBase: Send + 'static {
 
     /// Update the vnode bitmap for the state tables, only used by Group Top-N since it's
     /// distributed.
-    fn update_state_table_vnode_bitmap(&mut self, _vnode_bitmap: Arc<Bitmap>) {}
+    async fn update_state_table_vnode_bitmap(&mut self, _vnode_bitmap: Arc<Bitmap>) {}
 
     async fn init(&mut self, epoch: u64) -> StreamExecutorResult<()>;
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

When scaling, we've ensured that the checkpoint is committed before `Update` (by making `Pause` mutual exclusive to the concurrent checkpoint). However, the version itself is pushed asynchronously, and we may read stale data if we scale a fragment across compute nodes, considering that the shared buffer won't work in this case.

So we add the `wait_epoch` logic in the state table, for the two cases mentioned below.

https://github.com/risingwavelabs/risingwave/blob/ac2537d90c34514cfbc589ad1d27604abb83c59a/src/storage/src/table/streaming_table/state_table.rs#L341-L356

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3750 