### PR TITLE
chore(error): remove unnecessary Clone and use Box in RwError

### DIFF
--- a/src/batch/src/executor/join/chunked_data.rs
+++ b/src/batch/src/executor/join/chunked_data.rs
@@ -14,7 +14,6 @@
 
 use std::ops::{Index, IndexMut};
 
-use itertools::repeat_n;
 use risingwave_common::error::{Result, RwError};
 
 /// Id of one row in chunked data.
@@ -155,7 +154,7 @@ impl<V> TryFrom<Vec<Vec<V>>> for ChunkedData<V> {
     type Error = RwError;
 
     fn try_from(value: Vec<Vec<V>>) -> Result<Self> {
-        let chunk_offsets = repeat_n(Ok(0), 1)
+        let chunk_offsets = std::iter::once(Ok(0))
             .chain(value.iter().map(|chunk| -> Result<usize> {
                 ensure!(!chunk.is_empty(), "Chunk size can't be zero!");
                 Ok(chunk.len())

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::iter;
 use std::iter::empty;
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -1385,7 +1386,7 @@ impl DataChunkMutator {
     ) -> Self {
         let mut new_visibility = BitmapBuilder::zeroed(self.0.capacity());
 
-        for (&start_row_id, &end_row_id) in repeat_n(&0, 1)
+        for (&start_row_id, &end_row_id) in iter::once(&0)
             .chain(first_output_row_ids.iter())
             .tuple_windows()
             .filter(|(start_row_id, end_row_id)| start_row_id < end_row_id)
@@ -1428,7 +1429,7 @@ impl DataChunkMutator {
     ) -> Self {
         let mut new_visibility = BitmapBuilder::zeroed(self.0.capacity());
 
-        for (&start_row_id, &end_row_id) in repeat_n(&0, 1)
+        for (&start_row_id, &end_row_id) in iter::once(&0)
             .chain(first_output_row_ids.iter())
             .tuple_windows()
             .filter(|(start_row_id, end_row_id)| start_row_id < end_row_id)
@@ -1521,7 +1522,7 @@ impl DataChunkMutator {
     ) -> Self {
         let mut new_visibility = BitmapBuilder::zeroed(self.0.capacity());
 
-        for (&start_row_id, &end_row_id) in repeat_n(&0, 1)
+        for (&start_row_id, &end_row_id) in iter::once(&0)
             .chain(first_output_row_id.iter())
             .tuple_windows()
             .filter(|(start_row_id, end_row_id)| start_row_id < end_row_id)

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -135,7 +135,7 @@ impl TaskOutput {
                 }
                 // Error happened
                 Err(e) => {
-                    let possible_err = self.failure.lock().clone();
+                    let possible_err = self.failure.lock().take();
                     return if let Some(err) = possible_err {
                         // Task error
                         Err(err)
@@ -444,10 +444,6 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             failure: self.failure.clone(),
         };
         Ok(task_output)
-    }
-
-    pub fn get_error(&self) -> Option<RwError> {
-        self.failure.lock().clone()
     }
 
     pub fn check_if_running(&self) -> Result<()> {

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use parking_lot::Mutex;
 use risingwave_common::error::ErrorCode::{self, TaskNotFound};
-use risingwave_common::error::{Result, RwError};
+use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::{
     PlanFragment, TaskId as ProstTaskId, TaskOutputId as ProstTaskOutputId,
 };
@@ -179,15 +179,6 @@ impl BatchManager {
             }
             tokio::time::sleep(Duration::from_millis(100)).await
         }
-    }
-
-    pub fn get_error(&self, task_id: &TaskId) -> Result<Option<RwError>> {
-        Ok(self
-            .tasks
-            .lock()
-            .get(task_id)
-            .ok_or(TaskNotFound)?
-            .get_error())
     }
 
     /// Return the receivers for streaming RPC.

--- a/src/common/src/error.rs
+++ b/src/common/src/error.rs
@@ -16,7 +16,6 @@ use std::backtrace::Backtrace;
 use std::convert::Infallible;
 use std::fmt::{Debug, Display, Formatter};
 use std::io::Error as IoError;
-use std::sync::Arc;
 
 use memcomparable::Error as MemComparableError;
 use risingwave_pb::ProstFieldNotFound;
@@ -146,10 +145,10 @@ pub fn internal_error(msg: impl Into<String>) -> RwError {
     ErrorCode::InternalError(msg.into()).into()
 }
 
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct RwError {
-    inner: Arc<ErrorCode>,
-    backtrace: Arc<Backtrace>,
+    inner: Box<ErrorCode>,
+    backtrace: Box<Backtrace>,
 }
 
 impl From<RwError> for tonic::Status {
@@ -172,8 +171,8 @@ impl RwError {
 impl From<ErrorCode> for RwError {
     fn from(code: ErrorCode) -> Self {
         Self {
-            inner: Arc::new(code),
-            backtrace: Arc::new(Backtrace::capture()),
+            inner: Box::new(code),
+            backtrace: Box::new(Backtrace::capture()),
         }
     }
 }
@@ -181,8 +180,8 @@ impl From<ErrorCode> for RwError {
 impl From<JoinError> for RwError {
     fn from(join_error: JoinError) -> Self {
         Self {
-            inner: Arc::new(ErrorCode::InternalError(join_error.to_string())),
-            backtrace: Arc::new(Backtrace::capture()),
+            inner: Box::new(ErrorCode::InternalError(join_error.to_string())),
+            backtrace: Box::new(Backtrace::capture()),
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Reviewed the codes and found that we don't really need the `RwError` to implement `Clone`, remove it temporally.

And since we don't need `Clone`, we can also avoid the `Arc`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
