### PR TITLE
style: introduce some lints

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,6 +25,7 @@ rustflags = [
     "tokio_unstable",
     # lints
     # TODO: use lint configuration in cargo https://github.com/rust-lang/cargo/issues/5034
+    "-Dunused_must_use",
     "-Wclippy::dbg_macro",
     "-Wclippy::disallowed_methods",
     "-Wclippy::disallowed_types",
@@ -36,6 +37,8 @@ rustflags = [
     "-Wclippy::map_flatten",
     "-Wclippy::no_effect_underscore_binding",
     "-Wclippy::await_holding_lock",
-    "-Dunused_must_use",
-    "-Wrustdoc::broken_intra_doc_links"
+    "-Wrustdoc::broken_intra_doc_links",
+    "-Wfuture_incompatible",
+    "-Wnonstandard_style",
+    "-Wrust_2018_idioms",
 ]

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -116,7 +116,7 @@ impl DeleteExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for DeleteExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/expand.rs
+++ b/src/batch/src/executor/expand.rs
@@ -98,7 +98,7 @@ impl ExpandExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ExpandExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let expand_node = try_match_expand!(

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -82,7 +82,7 @@ impl FilterExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for FilterExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [input]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/generic_exchange.rs
+++ b/src/batch/src/executor/generic_exchange.rs
@@ -110,7 +110,7 @@ pub struct GenericExchangeExecutorBuilder {}
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for GenericExchangeExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -122,7 +122,7 @@ impl HashAggExecutorBuilder {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashAggExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -47,7 +47,7 @@ pub struct HopWindowExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HopWindowExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -127,7 +127,7 @@ impl InsertExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for InsertExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -129,7 +129,7 @@ struct RowIdIter<'a> {
 }
 
 impl ChunkedData<Option<RowId>> {
-    fn row_id_iter(&self, begin: Option<RowId>) -> RowIdIter {
+    fn row_id_iter(&self, begin: Option<RowId>) -> RowIdIter<'_> {
         RowIdIter {
             current_row_id: begin,
             next_row_id: self,
@@ -1334,7 +1334,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
 
     fn append_one_row_with_null_build_side(
         chunk_builder: &mut DataChunkBuilder,
-        probe_row_ref: RowRef,
+        probe_row_ref: RowRef<'_>,
         build_column_count: usize,
     ) -> Result<Option<DataChunk>> {
         Ok(chunk_builder.append_one_row_from_datum_refs(
@@ -1346,7 +1346,7 @@ impl<K: HashKey> HashJoinExecutor<K> {
 
     fn append_one_row_with_null_probe_side(
         chunk_builder: &mut DataChunkBuilder,
-        build_row_ref: RowRef,
+        build_row_ref: RowRef<'_>,
         probe_column_count: usize,
     ) -> Result<Option<DataChunk>> {
         Ok(chunk_builder.append_one_row_from_datum_refs(
@@ -1575,7 +1575,7 @@ impl DataChunkMutator {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for HashJoinExecutor<()> {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        context: &ExecutorBuilder<C>,
+        context: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [left_child, right_child]: [_; 2] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/lookup_join.rs
+++ b/src/batch/src/executor/join/lookup_join.rs
@@ -513,7 +513,7 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
     /// evaluated to hide the rows in the join result that don't match the condition.
     fn do_inner_join(
         &self,
-        cur_row: &RowRef,
+        cur_row: &RowRef<'_>,
         probe_side_chunk: DataChunk,
     ) -> Result<Option<DataChunk>> {
         let build_side_chunk = convert_row_to_chunk(
@@ -535,7 +535,7 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
     }
 
     /// Pad the row out with NULLs and return it.
-    fn do_left_outer_join(&self, cur_row: &RowRef) -> Result<Option<DataChunk>> {
+    fn do_left_outer_join(&self, cur_row: &RowRef<'_>) -> Result<Option<DataChunk>> {
         let mut build_datum_refs = cur_row.values().collect_vec();
 
         let builder_data_types = self.chunk_builder.data_types();
@@ -551,7 +551,7 @@ impl<P: 'static + ProbeSideSourceBuilder> LookupJoinExecutor<P> {
     }
 
     /// Converts row to a data chunk
-    fn convert_row_for_builder(&self, cur_row: &RowRef) -> Result<Option<DataChunk>> {
+    fn convert_row_for_builder(&self, cur_row: &RowRef<'_>) -> Result<Option<DataChunk>> {
         Ok(Some(convert_row_to_chunk(
             cur_row,
             1,
@@ -573,7 +573,7 @@ pub struct LookupJoinExecutorBuilder {}
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for LookupJoinExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [build_child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -121,7 +121,7 @@ impl NestedLoopJoinExecutor {
     fn concatenate_and_eval(
         expr: &dyn Expression,
         left_row_types: &[DataType],
-        left_row: RowRef,
+        left_row: RowRef<'_>,
         right_chunk: &DataChunk,
     ) -> Result<DataChunk> {
         let left_chunk = convert_row_to_chunk(&left_row, right_chunk.capacity(), left_row_types)?;
@@ -134,7 +134,7 @@ impl NestedLoopJoinExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for NestedLoopJoinExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [left_child, right_child]: [_; 2] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/join/sort_merge_join.rs
+++ b/src/batch/src/executor/join/sort_merge_join.rs
@@ -221,7 +221,7 @@ impl SortMergeJoinExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortMergeJoinExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> risingwave_common::error::Result<BoxedExecutor> {
         let [left_child, right_child]: [_; 2] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -40,7 +40,7 @@ pub struct LimitExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for LimitExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/merge_sort_exchange.rs
+++ b/src/batch/src/executor/merge_sort_exchange.rs
@@ -184,7 +184,7 @@ pub struct MergeSortExchangeExecutorBuilder {}
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for MergeSortExchangeExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/mod.rs
+++ b/src/batch/src/executor/mod.rs
@@ -105,7 +105,7 @@ impl std::fmt::Debug for BoxedExecutor {
 #[async_trait::async_trait]
 pub trait BoxedExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor>;
 }

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -55,7 +55,7 @@ impl Executor for OrderByExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for OrderByExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/project.rs
+++ b/src/batch/src/executor/project.rs
@@ -69,7 +69,7 @@ impl ProjectExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/project_set.rs
+++ b/src/batch/src/executor/project_set.rs
@@ -144,7 +144,7 @@ impl ProjectSetExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ProjectSetExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -131,7 +131,7 @@ fn get_scan_bound(
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for RowSeqScanExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -52,7 +52,7 @@ pub struct SortAggExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SortAggExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/sys_row_seq_scan.rs
+++ b/src/batch/src/executor/sys_row_seq_scan.rs
@@ -56,7 +56,7 @@ pub struct SysRowSeqScanExecutorBuilder {}
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for SysRowSeqScanExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/table_function.rs
+++ b/src/batch/src/executor/table_function.rs
@@ -74,7 +74,7 @@ impl TableFunctionExecutorBuilder {}
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for TableFunctionExecutorBuilder {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(

--- a/src/batch/src/executor/top_n.rs
+++ b/src/batch/src/executor/top_n.rs
@@ -46,7 +46,7 @@ pub struct TopNExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for TopNExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/union.rs
+++ b/src/batch/src/executor/union.rs
@@ -66,7 +66,7 @@ impl UnionExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for UnionExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let _union_node =

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -162,7 +162,7 @@ impl UpdateExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for UpdateExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         let [child]: [_; 1] = inputs.try_into().unwrap();

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -106,7 +106,7 @@ impl ValuesExecutor {
 #[async_trait::async_trait]
 impl BoxedExecutorBuilder for ValuesExecutor {
     async fn new_boxed_executor<C: BatchTaskContext>(
-        source: &ExecutorBuilder<C>,
+        source: &ExecutorBuilder<'_, C>,
         inputs: Vec<BoxedExecutor>,
     ) -> Result<BoxedExecutor> {
         ensure!(inputs.is_empty(), "ValuesExecutor should have no child!");

--- a/src/bench/s3_bench/main.rs
+++ b/src/bench/s3_bench/main.rs
@@ -563,7 +563,7 @@ where
     impl<'de> serde::de::Visitor<'de> for StringVisitor {
         type Value = ByteSize;
 
-        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             formatter.write_str("ByteSize")
         }
 

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -29,7 +29,7 @@ use crate::util::value_encoding::{deserialize_datum, serialize_datum};
 
 impl DataChunk {
     /// Get an iterator for visible rows.
-    pub fn rows(&self) -> impl Iterator<Item = RowRef> {
+    pub fn rows(&self) -> impl Iterator<Item = RowRef<'_>> {
         DataChunkRefIter {
             chunk: self,
             idx: Some(0),
@@ -37,7 +37,7 @@ impl DataChunk {
     }
 
     /// Get an iterator for all rows in the chunk, and a `None` represents an invisible row.
-    pub fn rows_with_holes(&self) -> impl Iterator<Item = Option<RowRef>> {
+    pub fn rows_with_holes(&self) -> impl Iterator<Item = Option<RowRef<'_>>> {
         DataChunkRefIterWithHoles {
             chunk: self,
             idx: 0,

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -136,7 +136,7 @@ impl ArrayBuilder for ListArrayBuilder {
 }
 
 impl ListArrayBuilder {
-    pub fn append_row_ref(&mut self, row: RowRef) {
+    pub fn append_row_ref(&mut self, row: RowRef<'_>) {
         self.bitmap.append(true);
         let last = *self.offsets.last().unwrap();
         self.offsets.push(last + row.size());
@@ -375,7 +375,7 @@ impl ListValue {
         impl<'a> serde::de::Visitor<'a> for Visitor<'a> {
             type Value = Vec<u8>;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 write!(formatter, "a list of {}", self.0)
             }
 
@@ -533,7 +533,7 @@ impl PartialOrd for ListRef<'_> {
     }
 }
 
-fn cmp_list_value(l: &Option<ScalarRefImpl>, r: &Option<ScalarRefImpl>) -> Ordering {
+fn cmp_list_value(l: &Option<ScalarRefImpl<'_>>, r: &Option<ScalarRefImpl<'_>>) -> Ordering {
     match (l, r) {
         // Comparability check was performed by frontend beforehand.
         (Some(sl), Some(sr)) => sl.partial_cmp(sr).unwrap(),

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -498,7 +498,7 @@ impl PartialOrd for StructRef<'_> {
     }
 }
 
-fn cmp_struct_field(l: &Option<ScalarRefImpl>, r: &Option<ScalarRefImpl>) -> Ordering {
+fn cmp_struct_field(l: &Option<ScalarRefImpl<'_>>, r: &Option<ScalarRefImpl<'_>>) -> Ordering {
     match (l, r) {
         // Comparability check was performed by frontend beforehand.
         (Some(sl), Some(sr)) => sl.partial_cmp(sr).unwrap(),

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -126,7 +126,7 @@ impl From<TableId> for u32 {
 }
 
 impl fmt::Display for TableId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.table_id,)
     }
 }
@@ -217,7 +217,7 @@ impl From<IndexId> for u32 {
 }
 
 impl fmt::Display for IndexId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.index_id,)
     }
 }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -442,7 +442,7 @@ pub fn to_datum_ref(datum: &Datum) -> DatumRef<'_> {
 
 // TODO: specify `NULL FIRST` or `NULL LAST`.
 pub fn serialize_datum_ref_into(
-    datum_ref: &DatumRef,
+    datum_ref: &DatumRef<'_>,
     serializer: &mut memcomparable::Serializer<impl BufMut>,
 ) -> memcomparable::Result<()> {
     // By default, `null` is treated as largest in PostgreSQL.
@@ -456,7 +456,7 @@ pub fn serialize_datum_ref_into(
 }
 
 pub fn serialize_datum_ref_not_null_into(
-    datum_ref: &DatumRef,
+    datum_ref: &DatumRef<'_>,
     serializer: &mut memcomparable::Serializer<impl BufMut>,
 ) -> memcomparable::Result<()> {
     datum_ref

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -195,7 +195,7 @@ impl<T: Float> Hash for OrderedFloat<T> {
 
 impl<T: Float + fmt::Display> fmt::Display for OrderedFloat<T> {
     #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let v = self.0;
         if v.is_nan() {
             return write!(f, "NaN");

--- a/src/common/src/util/encoding_for_comparison.rs
+++ b/src/common/src/util/encoding_for_comparison.rs
@@ -34,7 +34,7 @@ pub fn is_type_encodable(t: DataType) -> bool {
     )
 }
 
-fn encode_value(value: Option<ScalarRefImpl>, order: &OrderType) -> Result<Vec<u8>> {
+fn encode_value(value: Option<ScalarRefImpl<'_>>, order: &OrderType) -> Result<Vec<u8>> {
     let mut serializer = memcomparable::Serializer::new(vec![]);
     serializer.set_reverse(order == &OrderType::Descending);
     serialize_datum_ref_into(&value, &mut serializer)?;

--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -92,7 +92,7 @@ impl From<u64> for Epoch {
 }
 
 impl fmt::Display for Epoch {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -68,7 +68,7 @@ impl OrderedRowSerializer {
     }
 
     #[must_use]
-    pub fn prefix(&self, len: usize) -> Cow<Self> {
+    pub fn prefix(&self, len: usize) -> Cow<'_, Self> {
         if len == self.order_types.len() {
             Cow::Borrowed(self)
         } else {

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -52,7 +52,7 @@ pub fn serialize_datum(cell: &Datum, buf: impl BufMut) {
 }
 
 /// Serialize a datum into bytes (Not order guarantee, used in value encoding).
-pub fn serialize_datum_ref(datum_ref: &DatumRef, mut buf: impl BufMut) {
+pub fn serialize_datum_ref(datum_ref: &DatumRef<'_>, mut buf: impl BufMut) {
     if let Some(d) = datum_ref {
         buf.put_u8(1);
         serialize_value(*d, &mut buf)
@@ -71,7 +71,7 @@ pub fn deserialize_datum(mut data: impl Buf, ty: &DataType) -> Result<Datum> {
     }
 }
 
-fn serialize_value(value: ScalarRefImpl, mut buf: impl BufMut) {
+fn serialize_value(value: ScalarRefImpl<'_>, mut buf: impl BufMut) {
     match value {
         ScalarRefImpl::Int16(v) => buf.put_i16_le(v),
         ScalarRefImpl::Int32(v) => buf.put_i32_le(v),

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -331,7 +331,7 @@ impl Debug for KafkaSink {
     }
 }
 
-fn datum_to_json_object(field: &Field, datum: DatumRef) -> ArrayResult<Value> {
+fn datum_to_json_object(field: &Field, datum: DatumRef<'_>) -> ArrayResult<Value> {
     let scalar_ref = match datum {
         None => return Ok(Value::Null),
         Some(datum) => datum,
@@ -398,7 +398,7 @@ fn datum_to_json_object(field: &Field, datum: DatumRef) -> ArrayResult<Value> {
     Ok(value)
 }
 
-fn record_to_json(row: RowRef, schema: Vec<Field>) -> Result<Map<String, Value>> {
+fn record_to_json(row: RowRef<'_>, schema: Vec<Field>) -> Result<Map<String, Value>> {
     let mut mappings = Map::with_capacity(schema.len());
     for (field, datum_ref) in schema.iter().zip_eq(row.values()) {
         let key = field.name.clone();

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -137,7 +137,7 @@ fn get_builder(cfg: &MySqlConfig) -> OptsBuilder {
 struct MySqlValue(Value);
 
 impl fmt::Display for MySqlValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0.as_sql(true))
     }
 }

--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -71,7 +71,7 @@ pub async fn reschedule(mut plan: String, dry_run: bool) -> Result<()> {
             .and_then(|mat| mat.as_str().parse::<u32>().ok())
             .ok_or_else(|| anyhow!("plan \"{}\" does not have a valid fragment id", plan))?;
 
-        let split_fn = |mat: Match| {
+        let split_fn = |mat: Match<'_>| {
             mat.as_str()
                 .split(',')
                 .map(|id_str| id_str.parse::<u32>().map_err(Error::msg))

--- a/src/expr/src/expr/expr_array_concat.rs
+++ b/src/expr/src/expr/expr_array_concat.rs
@@ -37,7 +37,7 @@ pub struct ArrayConcatExpression {
     left: BoxedExpression,
     right: BoxedExpression,
     op: Operation,
-    op_func: fn(DatumRef, DatumRef) -> Datum,
+    op_func: fn(DatumRef<'_>, DatumRef<'_>) -> Datum,
 }
 
 impl std::fmt::Debug for ArrayConcatExpression {
@@ -94,7 +94,7 @@ impl ArrayConcatExpression {
     /// ----
     /// {123}
     /// ```
-    fn concat_array(left: DatumRef, right: DatumRef) -> Datum {
+    fn concat_array(left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         match (left, right) {
             (None, right) => right.map(ScalarRefImpl::into_scalar_impl),
             (left, None) => left.map(ScalarRefImpl::into_scalar_impl),
@@ -143,7 +143,7 @@ impl ArrayConcatExpression {
     /// ----
     /// NULL
     /// ```
-    fn append_array(left: DatumRef, right: DatumRef) -> Datum {
+    fn append_array(left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         match (left, right) {
             (None, None) => None,
             (None, right) => {
@@ -191,7 +191,7 @@ impl ArrayConcatExpression {
     /// select array_append(null::int[], null::int);
     /// ----
     /// {NULL}
-    fn append_value(left: DatumRef, right: DatumRef) -> Datum {
+    fn append_value(left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         match (left, right) {
             (None, right) => {
                 Some(ListValue::new(vec![right.map(ScalarRefImpl::into_scalar_impl)]).into())
@@ -240,7 +240,7 @@ impl ArrayConcatExpression {
     /// select array_cat(null::int[], null::int[][]);
     /// ----
     /// NULL
-    fn prepend_array(left: DatumRef, right: DatumRef) -> Datum {
+    fn prepend_array(left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         match (left, right) {
             (None, None) => None,
             (left, None) => {
@@ -287,7 +287,7 @@ impl ArrayConcatExpression {
     /// select array_prepend(null::int, null::int[]);
     /// ----
     /// {NULL}
-    fn prepend_value(left: DatumRef, right: DatumRef) -> Datum {
+    fn prepend_value(left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         match (left, right) {
             (left, None) => {
                 Some(ListValue::new(vec![left.map(ScalarRefImpl::into_scalar_impl)]).into())
@@ -307,7 +307,7 @@ impl ArrayConcatExpression {
         }
     }
 
-    fn evaluate(&self, left: DatumRef, right: DatumRef) -> Datum {
+    fn evaluate(&self, left: DatumRef<'_>, right: DatumRef<'_>) -> Datum {
         (self.op_func)(left, right)
     }
 }

--- a/src/expr/src/vector_op/agg/approx_count_distinct.rs
+++ b/src/expr/src/vector_op/agg/approx_count_distinct.rs
@@ -51,7 +51,7 @@ impl ApproxCountDistinct {
 
     /// Adds the count of the datum's hash into the register, if it is greater than the existing
     /// count at the register
-    fn add_datum(&mut self, datum_ref: DatumRef) {
+    fn add_datum(&mut self, datum_ref: DatumRef<'_>) {
         if datum_ref.is_none() {
             return;
         }

--- a/src/expr/src/vector_op/agg/array_agg.rs
+++ b/src/expr/src/vector_op/agg/array_agg.rs
@@ -106,7 +106,7 @@ impl ArrayAggOrdered {
         }
     }
 
-    fn push_row(&mut self, row: RowRef) {
+    fn push_row(&mut self, row: RowRef<'_>) {
         let key = OrderedRow::new(
             row.row_by_indices(&self.order_col_indices),
             &self.order_types,

--- a/src/expr/src/vector_op/agg/string_agg.rs
+++ b/src/expr/src/vector_op/agg/string_agg.rs
@@ -141,7 +141,7 @@ impl StringAggOrdered {
         }
     }
 
-    fn push_row(&mut self, value: &str, delim: &str, row: RowRef) {
+    fn push_row(&mut self, value: &str, delim: &str, row: RowRef<'_>) {
         let key = OrderedRow::new(
             row.row_by_indices(&self.order_col_indices),
             &self.order_types,

--- a/src/expr/src/vector_op/array_access.rs
+++ b/src/expr/src/vector_op/array_access.rs
@@ -18,7 +18,7 @@ use risingwave_common::types::{Scalar, ToOwnedDatum};
 use crate::Result;
 
 #[inline(always)]
-pub fn array_access<T: Scalar>(l: Option<ListRef>, r: Option<i32>) -> Result<Option<T>> {
+pub fn array_access<T: Scalar>(l: Option<ListRef<'_>>, r: Option<i32>) -> Result<Option<T>> {
     match (l, r) {
         // index must be greater than 0 following a one-based numbering convention for arrays
         (Some(list), Some(index)) if index > 0 => {

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -415,7 +415,7 @@ pub fn str_to_list(input: &str, target_elem_type: &DataType) -> Result<ListValue
 ///
 /// TODO: `.map(scalar_cast)` is not a preferred pattern and we should avoid it if possible.
 pub fn list_cast(
-    input: ListRef,
+    input: ListRef<'_>,
     source_elem_type: &DataType,
     target_elem_type: &DataType,
 ) -> Result<ListValue> {
@@ -436,7 +436,7 @@ pub fn list_cast(
 /// mutual recursion with `list_cast` so that we can cast nested lists (e.g., varchar[][] to
 /// int[][]).
 fn scalar_cast(
-    source: ScalarRefImpl,
+    source: ScalarRefImpl<'_>,
     source_type: &DataType,
     target_type: &DataType,
 ) -> Result<ScalarImpl> {

--- a/src/expr/src/vector_op/cmp.rs
+++ b/src/expr/src/vector_op/cmp.rs
@@ -145,13 +145,13 @@ pub(crate) static LE: Comparison = Comparison::Le;
 pub(crate) static GE: Comparison = Comparison::Ge;
 
 #[inline(always)]
-pub fn gen_struct_cmp(op: Comparison) -> fn(StructRef, StructRef) -> Result<bool> {
+pub fn gen_struct_cmp(op: Comparison) -> fn(StructRef<'_>, StructRef<'_>) -> Result<bool> {
     use crate::gen_cmp;
     gen_cmp!(op)
 }
 
 #[inline(always)]
-pub fn gen_list_cmp(op: Comparison) -> fn(ListRef, ListRef) -> Result<bool> {
+pub fn gen_list_cmp(op: Comparison) -> fn(ListRef<'_>, ListRef<'_>) -> Result<bool> {
     use crate::gen_cmp;
     gen_cmp!(op)
 }

--- a/src/frontend/src/catalog/column_catalog.rs
+++ b/src/frontend/src/catalog/column_catalog.rs
@@ -74,7 +74,7 @@ impl From<ProstColumnCatalog> for ColumnCatalog {
 }
 
 impl ColumnCatalog {
-    pub fn name_with_hidden(&self) -> Cow<str> {
+    pub fn name_with_hidden(&self) -> Cow<'_, str> {
         if self.is_hidden {
             Cow::Owned(format!("{}(hidden)", self.column_desc.name))
         } else {

--- a/src/frontend/src/catalog/pg_catalog/pg_cast.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_cast.rs
@@ -25,7 +25,7 @@ use crate::handler::util::data_type_to_type_oid;
 /// The catalog `pg_cast` stores data type conversion paths.
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-cast.html`]
 pub const PG_CAST_TABLE_NAME: &str = "pg_cast";
-pub const PG_CAST_COLUMNS: &[PgCatalogColumnsDef] = &[
+pub const PG_CAST_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "oid"),
     (DataType::Int32, "castsource"),
     (DataType::Int32, "casttarget"),

--- a/src/frontend/src/catalog/pg_catalog/pg_class.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_class.rs
@@ -19,7 +19,7 @@ use crate::catalog::pg_catalog::PgCatalogColumnsDef;
 /// The catalog `pg_class` catalogs tables and most everything else that has columns or is otherwise
 /// similar to a table. Ref: [`https://www.postgresql.org/docs/current/catalog-pg-class.html`]
 pub const PG_CLASS_TABLE_NAME: &str = "pg_class";
-pub const PG_CLASS_COLUMNS: &[PgCatalogColumnsDef] = &[
+pub const PG_CLASS_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "oid"),
     (DataType::Varchar, "relname"),
     (DataType::Int32, "relnamespace"),

--- a/src/frontend/src/catalog/pg_catalog/pg_matviews_info.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_matviews_info.rs
@@ -18,7 +18,7 @@ use crate::catalog::pg_catalog::PgCatalogColumnsDef;
 
 /// The catalog `pg_matviews_info` contains the information about the matviews.
 pub const PG_MATVIEWS_INFO_TABLE_NAME: &str = "pg_matviews_info";
-pub const PG_MATVIEWS_INFO_COLUMNS: &[PgCatalogColumnsDef] = &[
+pub const PG_MATVIEWS_INFO_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "matviewid"),
     (DataType::Varchar, "matviewname"),
     (DataType::Varchar, "matviewschema"),

--- a/src/frontend/src/catalog/pg_catalog/pg_namespace.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_namespace.rs
@@ -20,7 +20,7 @@ use crate::catalog::pg_catalog::PgCatalogColumnsDef;
 /// schemas: each namespace can have a separate collection of relations, types, etc. without name
 /// conflicts. Ref: [`https://www.postgresql.org/docs/current/catalog-pg-namespace.html`]
 pub const PG_NAMESPACE_TABLE_NAME: &str = "pg_namespace";
-pub const PG_NAMESPACE_COLUMNS: &[PgCatalogColumnsDef] = &[
+pub const PG_NAMESPACE_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "oid"),
     (DataType::Varchar, "nspname"),
     (DataType::Int32, "nspowner"),

--- a/src/frontend/src/catalog/pg_catalog/pg_type.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_type.rs
@@ -23,7 +23,7 @@ use crate::catalog::pg_catalog::PgCatalogColumnsDef;
 /// The catalog `pg_type` stores information about data types.
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-type.html`]
 pub const PG_TYPE_TABLE_NAME: &str = "pg_type";
-pub const PG_TYPE_COLUMNS: &[PgCatalogColumnsDef] =
+pub const PG_TYPE_COLUMNS: &[PgCatalogColumnsDef<'_>] =
     &[(DataType::Int32, "oid"), (DataType::Varchar, "typname")];
 
 // TODO: uniform the default data with `TypeOid` under `pg_field_descriptor`.

--- a/src/frontend/src/catalog/pg_catalog/pg_user.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_user.rs
@@ -22,7 +22,7 @@ pub const PG_USER_TABLE_NAME: &str = "pg_user";
 pub const PG_USER_ID_INDEX: usize = 0;
 pub const PG_USER_NAME_INDEX: usize = 1;
 
-pub const PG_USER_COLUMNS: &[PgCatalogColumnsDef] = &[
+pub const PG_USER_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "usesysid"),
     (DataType::Varchar, "name"),
     (DataType::Boolean, "usecreatedb"),

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -23,7 +23,7 @@ use risingwave_common::types::{DataType, ScalarRefImpl};
 use crate::binder::{BoundSetExpr, BoundStatement};
 
 /// Format scalars according to postgres convention.
-fn pg_value_format(d: ScalarRefImpl, format: bool) -> Bytes {
+fn pg_value_format(d: ScalarRefImpl<'_>, format: bool) -> Bytes {
     // format == false means TEXT format
     // format == true means BINARY format
     if !format {

--- a/src/frontend/src/optimizer/plan_node/batch_delete.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_delete.rs
@@ -45,7 +45,7 @@ impl BatchDelete {
 }
 
 impl fmt::Display for BatchDelete {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchDelete")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_exchange.rs
@@ -40,7 +40,7 @@ impl BatchExchange {
 }
 
 impl fmt::Display for BatchExchange {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "BatchExchange {{ order: {}, dist: {} }}",

--- a/src/frontend/src/optimizer/plan_node/batch_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_filter.rs
@@ -49,7 +49,7 @@ impl BatchFilter {
 }
 
 impl fmt::Display for BatchFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchFilter")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -54,7 +54,7 @@ impl BatchHashAgg {
 }
 
 impl fmt::Display for BatchHashAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchHashAgg")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
@@ -98,7 +98,7 @@ impl BatchHashJoin {
 }
 
 impl fmt::Display for BatchHashJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("BatchHashJoin");
         builder.field("type", &format_args!("{:?}", self.logical.join_type()));

--- a/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
@@ -49,7 +49,7 @@ impl BatchHopWindow {
 }
 
 impl fmt::Display for BatchHopWindow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchHopWindow")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_insert.rs
@@ -44,7 +44,7 @@ impl BatchInsert {
 }
 
 impl fmt::Display for BatchInsert {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchInsert")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_limit.rs
@@ -54,7 +54,7 @@ impl BatchLimit {
 }
 
 impl fmt::Display for BatchLimit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "BatchLimit {{ limit: {limit}, offset: {offset} }}",

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -73,7 +73,7 @@ impl BatchLookupJoin {
 }
 
 impl fmt::Display for BatchLookupJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("BatchLookupJoin");
         builder.field("type", &format_args!("{:?}", self.logical.join_type()));

--- a/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
@@ -54,7 +54,7 @@ impl BatchNestedLoopJoin {
 }
 
 impl fmt::Display for BatchNestedLoopJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("BatchNestedLoopJoin");
         builder.field("type", &format_args!("{:?}", self.logical.join_type()));

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -54,7 +54,7 @@ impl BatchProject {
 }
 
 impl fmt::Display for BatchProject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchProject")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -115,7 +115,7 @@ impl BatchSeqScan {
 impl_plan_tree_node_for_leaf! { BatchSeqScan }
 
 impl fmt::Display for BatchSeqScan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn lb_to_string(name: &str, lb: &Bound<ScalarImpl>) -> String {
             let (op, v) = match lb {
                 Bound::Included(v) => (">=", v),

--- a/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
@@ -49,7 +49,7 @@ impl BatchSimpleAgg {
 }
 
 impl fmt::Display for BatchSimpleAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchSimpleAgg")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -41,7 +41,7 @@ impl BatchSort {
 }
 
 impl fmt::Display for BatchSort {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "BatchSort {{ order: {} }}",

--- a/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
@@ -84,7 +84,7 @@ impl BatchSortAgg {
 }
 
 impl fmt::Display for BatchSortAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchSortAgg")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_table_function.rs
@@ -50,7 +50,7 @@ impl BatchTableFunction {
 }
 
 impl fmt::Display for BatchTableFunction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "BatchTableFunction {{ {:?} }}",

--- a/src/frontend/src/optimizer/plan_node/batch_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_topn.rs
@@ -61,7 +61,7 @@ impl BatchTopN {
 }
 
 impl fmt::Display for BatchTopN {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchTopN")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_union.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_union.rs
@@ -49,7 +49,7 @@ impl BatchUnion {
 }
 
 impl fmt::Display for BatchUnion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchUnion")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_update.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_update.rs
@@ -46,7 +46,7 @@ impl BatchUpdate {
 }
 
 impl fmt::Display for BatchUpdate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "BatchUpdate")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/batch_values.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_values.rs
@@ -52,7 +52,7 @@ impl BatchValues {
 }
 
 impl fmt::Display for BatchValues {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("BatchValues")
             .field("rows", &self.logical.rows())
             .finish()

--- a/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -34,7 +34,7 @@ pub struct EqJoinPredicate {
 }
 
 impl fmt::Display for EqJoinPredicate {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         let mut eq_keys = self.eq_keys().iter();
         if let Some((k1, k2, null_safe)) = eq_keys.next() {
             write!(
@@ -208,7 +208,7 @@ pub struct EqJoinPredicateDisplay<'a> {
 }
 
 impl EqJoinPredicateDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         let that = self.eq_join_predicate;
         let mut eq_keys = that.eq_keys().iter();
         if let Some((k1, k2, null_safe)) = eq_keys.next() {
@@ -265,13 +265,13 @@ impl EqJoinPredicateDisplay<'_> {
 }
 
 impl fmt::Display for EqJoinPredicateDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         self.fmt(f)
     }
 }
 
 impl fmt::Debug for EqJoinPredicateDisplay<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
         self.fmt(f)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -1085,7 +1085,7 @@ impl LogicalAgg {
         self.agg_calls.as_ref()
     }
 
-    pub fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay> {
+    pub fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
         self.agg_calls()
             .iter()
             .map(|plan_agg_call| PlanAggCallDisplay {
@@ -1095,7 +1095,7 @@ impl LogicalAgg {
             .collect_vec()
     }
 
-    pub fn group_key_display(&self) -> Vec<FieldDisplay> {
+    pub fn group_key_display(&self) -> Vec<FieldDisplay<'_>> {
         self.group_key()
             .iter()
             .copied()
@@ -1143,7 +1143,7 @@ impl LogicalAgg {
         Self::new(agg_calls, group_key, input)
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let mut builder = f.debug_struct(name);
         if !self.group_key.is_empty() {
             builder.field("group_key", &self.group_key_display());
@@ -1178,7 +1178,7 @@ impl PlanTreeNodeUnary for LogicalAgg {
 impl_plan_tree_node_for_unary! {LogicalAgg}
 
 impl fmt::Display for LogicalAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalAgg")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_apply.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_apply.rs
@@ -46,7 +46,7 @@ pub struct LogicalApply {
 }
 
 impl fmt::Display for LogicalApply {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("LogicalApply");
 
         builder.field("type", &format_args!("{:?}", &self.join_type));

--- a/src/frontend/src/optimizer/plan_node/logical_delete.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_delete.rs
@@ -70,7 +70,7 @@ impl LogicalDelete {
         Ok(Self::new(input, table_source_name, source_id, table_id))
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         write!(f, "{} {{ table: {} }}", name, self.table_source_name)
     }
 

--- a/src/frontend/src/optimizer/plan_node/logical_expand.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_expand.rs
@@ -94,7 +94,7 @@ impl LogicalExpand {
         &self.column_subsets
     }
 
-    pub fn column_subsets_display(&self) -> Vec<Vec<FieldDisplay>> {
+    pub fn column_subsets_display(&self) -> Vec<Vec<FieldDisplay<'_>>> {
         self.column_subsets()
             .iter()
             .map(|subset| {

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -84,7 +84,7 @@ impl LogicalFilter {
         &self.predicate
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let input = self.input();
         let input_schema = input.schema();
         write!(
@@ -122,7 +122,7 @@ impl PlanTreeNodeUnary for LogicalFilter {
 impl_plan_tree_node_for_unary! {LogicalFilter}
 
 impl fmt::Display for LogicalFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalFilter")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -196,7 +196,7 @@ impl LogicalHopWindow {
         )
     }
 
-    pub fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         write!(
             f,
             "{} {{ time_col: {}, slide: {}, size: {}, output: {} }}",
@@ -310,7 +310,7 @@ impl PlanTreeNodeUnary for LogicalHopWindow {
 impl_plan_tree_node_for_unary! {LogicalHopWindow}
 
 impl fmt::Display for LogicalHopWindow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalHopWindow")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -70,7 +70,7 @@ impl LogicalInsert {
         Ok(Self::new(input, table_source_name, source_id, table_id))
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         write!(f, "{} {{ table: {} }}", name, self.table_source_name)
     }
 
@@ -104,7 +104,7 @@ impl PlanTreeNodeUnary for LogicalInsert {
 impl_plan_tree_node_for_unary! {LogicalInsert}
 
 impl fmt::Display for LogicalInsert {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalInsert")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -51,7 +51,7 @@ pub struct LogicalJoin {
 }
 
 impl fmt::Display for LogicalJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("LogicalJoin");
         builder.field("type", &format_args!("{:?}", self.join_type()));

--- a/src/frontend/src/optimizer/plan_node/logical_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_limit.rs
@@ -80,7 +80,7 @@ impl PlanTreeNodeUnary for LogicalLimit {
 }
 impl_plan_tree_node_for_unary! {LogicalLimit}
 impl fmt::Display for LogicalLimit {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "LogicalLimit {{ limit: {}, offset: {} }}",

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -51,7 +51,7 @@ pub struct LogicalMultiJoin {
 }
 
 impl fmt::Display for LogicalMultiJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "LogicalMultiJoin {{ on: {} }}", {
             let fields = self
                 .inputs

--- a/src/frontend/src/optimizer/plan_node/logical_over_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_agg.rs
@@ -244,7 +244,7 @@ impl PlanTreeNodeUnary for LogicalOverAgg {
 impl_plan_tree_node_for_unary! { LogicalOverAgg }
 
 impl fmt::Display for LogicalOverAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("LogicalOverAgg");
         builder.field(
             "window_function",

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -238,7 +238,7 @@ impl LogicalProject {
         &self.exprs
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let mut builder = f.debug_struct(name);
         builder.field(
             "exprs",
@@ -312,7 +312,7 @@ impl PlanTreeNodeUnary for LogicalProject {
 impl_plan_tree_node_for_unary! {LogicalProject}
 
 impl fmt::Display for LogicalProject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalProject")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -231,7 +231,7 @@ impl LogicalProjectSet {
         &self.select_list
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let _verbose = self.base.ctx.is_explain_verbose();
         // TODO: add verbose display like Project
 

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -411,7 +411,7 @@ impl LogicalScan {
 impl_plan_tree_node_for_leaf! {LogicalScan}
 
 impl fmt::Display for LogicalScan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         if self.predicate.always_true() {
             write!(

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -84,7 +84,7 @@ impl LogicalSource {
 impl_plan_tree_node_for_leaf! {LogicalSource}
 
 impl fmt::Display for LogicalSource {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "LogicalSource {{ source: {}, columns: [{}] }}",

--- a/src/frontend/src/optimizer/plan_node/logical_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_table_function.rs
@@ -52,7 +52,7 @@ impl LogicalTableFunction {
 impl_plan_tree_node_for_leaf! { LogicalTableFunction }
 
 impl fmt::Display for LogicalTableFunction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "LogicalTableFunction {{ {:?} }}", self.table_function)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -98,7 +98,7 @@ impl LogicalTopN {
         &self.group_key
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let mut builder = f.debug_struct(name);
         let input = self.input();
         let input_schema = input.schema();
@@ -286,7 +286,7 @@ impl PlanTreeNodeUnary for LogicalTopN {
 }
 impl_plan_tree_node_for_unary! {LogicalTopN}
 impl fmt::Display for LogicalTopN {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalTopN")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_union.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_union.rs
@@ -52,7 +52,7 @@ impl LogicalUnion {
         LogicalUnion::new(all, inputs).into()
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         write!(f, "{} {{ all: {} }}", name, self.all)
     }
 
@@ -74,7 +74,7 @@ impl PlanTreeNode for LogicalUnion {
 }
 
 impl fmt::Display for LogicalUnion {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.fmt_with_name(f, "LogicalUnion")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_update.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_update.rs
@@ -82,7 +82,7 @@ impl LogicalUpdate {
         ))
     }
 
-    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter, name: &str) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         write!(
             f,
             "{} {{ table: {}, exprs: {:?} }}",

--- a/src/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_values.rs
@@ -65,7 +65,7 @@ impl LogicalValues {
 impl_plan_tree_node_for_leaf! { LogicalValues }
 
 impl fmt::Display for LogicalValues {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("LogicalValues")
             .field("rows", &self.rows)
             .field("schema", &self.schema())

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -78,7 +78,7 @@ impl StreamDeltaJoin {
 }
 
 impl fmt::Display for StreamDeltaJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("StreamDeltaJoin");
         builder.field("type", &format_args!("{:?}", self.logical.join_type()));

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -61,7 +61,7 @@ impl StreamDynamicFilter {
 }
 
 impl fmt::Display for StreamDynamicFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut concat_schema = self.left().schema().fields.clone();
         concat_schema.extend(self.right().schema().fields.clone());
         let concat_schema = Schema::new(concat_schema);

--- a/src/frontend/src/optimizer/plan_node/stream_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_exchange.rs
@@ -47,7 +47,7 @@ impl StreamExchange {
 }
 
 impl fmt::Display for StreamExchange {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("StreamExchange");
         builder
             .field(

--- a/src/frontend/src/optimizer/plan_node/stream_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_filter.rs
@@ -54,7 +54,7 @@ impl StreamFilter {
 }
 
 impl fmt::Display for StreamFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "StreamFilter")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
@@ -55,13 +55,13 @@ impl StreamGlobalSimpleAgg {
         self.logical.agg_calls()
     }
 
-    pub fn agg_calls_verbose_display(&self) -> Vec<PlanAggCallDisplay> {
+    pub fn agg_calls_verbose_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
         self.logical.agg_calls_display()
     }
 }
 
 impl fmt::Display for StreamGlobalSimpleAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.input().append_only() {
             self.logical
                 .fmt_with_name(f, "StreamAppendOnlyGlobalSimpleAgg")

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -95,7 +95,7 @@ impl StreamNode for StreamGroupTopN {
 }
 
 impl fmt::Display for StreamGroupTopN {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("StreamGroupTopN");
         let input = self.input();
         let input_schema = input.schema();

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -68,7 +68,7 @@ impl StreamHashAgg {
 }
 
 impl fmt::Display for StreamHashAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.input().append_only() {
             self.logical.fmt_with_name(f, "StreamAppendOnlyHashAgg")
         } else {

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -135,7 +135,7 @@ impl StreamHashJoin {
 }
 
 impl fmt::Display for StreamHashJoin {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = if self.is_append_only {
             f.debug_struct("StreamAppendOnlyHashJoin")
         } else {

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -49,7 +49,7 @@ impl StreamHopWindow {
 }
 
 impl fmt::Display for StreamHopWindow {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "StreamHopWindow")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_index_scan.rs
@@ -68,7 +68,7 @@ impl StreamIndexScan {
 impl_plan_tree_node_for_leaf! { StreamIndexScan }
 
 impl fmt::Display for StreamIndexScan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("StreamIndexScan");
 

--- a/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
@@ -59,7 +59,7 @@ impl StreamLocalSimpleAgg {
 }
 
 impl fmt::Display for StreamLocalSimpleAgg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical
             .fmt_with_name(f, "StreamStatelessLocalSimpleAgg")
     }

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -194,7 +194,7 @@ impl StreamMaterialize {
 }
 
 impl fmt::Display for StreamMaterialize {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let table = self.table();
 
         let column_names = table

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -30,7 +30,7 @@ pub struct StreamProject {
 }
 
 impl fmt::Display for StreamProject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.logical.fmt_with_name(f, "StreamProject")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -72,7 +72,7 @@ impl PlanTreeNodeUnary for StreamSink {
 impl_plan_tree_node_for_unary! { StreamSink }
 
 impl fmt::Display for StreamSink {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("StreamSink");
         builder.finish()
     }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -53,7 +53,7 @@ impl StreamSource {
 impl_plan_tree_node_for_leaf! { StreamSource }
 
 impl fmt::Display for StreamSource {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("StreamSource");
         builder
             .field("source", &self.logical.source_catalog.name)

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -93,7 +93,7 @@ impl StreamTableScan {
 impl_plan_tree_node_for_leaf! { StreamTableScan }
 
 impl fmt::Display for StreamTableScan {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("StreamTableScan");
 

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -61,7 +61,7 @@ impl StreamTopN {
 }
 
 impl fmt::Display for StreamTopN {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.input().append_only() {
             self.logical.fmt_with_name(f, "StreamAppendOnlyTopN")
         } else {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -502,7 +502,7 @@ impl SessionImpl {
         self.auth_context.user_id
     }
 
-    pub fn config(&self) -> RwLockReadGuard<ConfigMap> {
+    pub fn config(&self) -> RwLockReadGuard<'_, ConfigMap> {
         self.config_map.read()
     }
 

--- a/src/meta/src/hummock/manager/compaction.rs
+++ b/src/meta/src/hummock/manager/compaction.rs
@@ -40,8 +40,8 @@ impl Compaction {
         &mut self,
         context_ids: &[HummockContextId],
     ) -> Result<(
-        BTreeMapTransaction<CompactionGroupId, CompactStatus>,
-        BTreeMapTransaction<HummockCompactionTaskId, CompactTaskAssignment>,
+        BTreeMapTransaction<'_, CompactionGroupId, CompactStatus>,
+        BTreeMapTransaction<'_, HummockCompactionTaskId, CompactTaskAssignment>,
     )> {
         let mut compact_statuses = BTreeMapTransaction::new(&mut self.compaction_statuses);
         let mut compact_task_assignment =

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1393,7 +1393,7 @@ where
     }
 
     #[named]
-    pub async fn get_read_guard(&self) -> RwLockReadGuard<Versioning> {
+    pub async fn get_read_guard(&self) -> RwLockReadGuard<'_, Versioning> {
         read_lock!(self, versioning).await
     }
 

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -98,7 +98,7 @@ where
         Ok(())
     }
 
-    pub async fn get_catalog_core_guard(&self) -> MutexGuard<CatalogManagerCore<S>> {
+    pub async fn get_catalog_core_guard(&self) -> MutexGuard<'_, CatalogManagerCore<S>> {
         self.core.lock().await
     }
 }

--- a/src/meta/src/manager/catalog/user.rs
+++ b/src/meta/src/manager/catalog/user.rs
@@ -114,7 +114,7 @@ impl UserManager {
     pub fn get_user_grant_relation_entry(
         &mut self,
         user_id: UserId,
-    ) -> Entry<UserId, HashSet<u32>> {
+    ) -> Entry<'_, UserId, HashSet<u32>> {
         self.user_grant_relation.entry(user_id)
     }
 

--- a/src/meta/src/model/mod.rs
+++ b/src/meta/src/model/mod.rs
@@ -370,7 +370,7 @@ impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransaction<'a, K, V> {
 
     /// Start a `BTreeMapEntryTransaction` when the `key` exists
     #[allow(dead_code)]
-    pub fn new_entry_txn(&mut self, key: K) -> Option<BTreeMapEntryTransaction<K, V>> {
+    pub fn new_entry_txn(&mut self, key: K) -> Option<BTreeMapEntryTransaction<'_, K, V>> {
         BTreeMapEntryTransaction::new(self.tree_ref, key, None)
     }
 
@@ -381,13 +381,13 @@ impl<'a, K: Ord + Debug, V: Clone> BTreeMapTransaction<'a, K, V> {
         &mut self,
         key: K,
         default_val: V,
-    ) -> BTreeMapEntryTransaction<K, V> {
+    ) -> BTreeMapEntryTransaction<'_, K, V> {
         BTreeMapEntryTransaction::new(self.tree_ref, key, Some(default_val))
             .expect("default value is provided and should return `Some`")
     }
 
     /// Start a `BTreeMapEntryTransaction` that inserts the `val` into `key`.
-    pub fn new_entry_insert_txn(&mut self, key: K, val: V) -> BTreeMapEntryTransaction<K, V> {
+    pub fn new_entry_insert_txn(&mut self, key: K, val: V) -> BTreeMapEntryTransaction<'_, K, V> {
         BTreeMapEntryTransaction::new_insert(self.tree_ref, key, val)
     }
 

--- a/src/object_store/src/lib.rs
+++ b/src/object_store/src/lib.rs
@@ -18,6 +18,4 @@
 #![feature(type_alias_impl_trait)]
 #![feature(once_cell)]
 
-extern crate core;
-
 pub mod object;

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -282,7 +282,7 @@ impl MemSourceManager {
         }
     }
 
-    fn get_sources(&self) -> Result<MutexGuard<HashMap<TableId, SourceDesc>>> {
+    fn get_sources(&self) -> Result<MutexGuard<'_, HashMap<TableId, SourceDesc>>> {
         Ok(self.sources.lock())
     }
 }

--- a/src/source/src/parser/avro_parser.rs
+++ b/src/source/src/parser/avro_parser.rs
@@ -260,7 +260,7 @@ pub(crate) fn from_avro_value(column: &SourceColumnDesc, field_value: Value) -> 
 }
 
 impl SourceParser for AvroParser {
-    fn parse(&self, payload: &[u8], writer: SourceStreamChunkRowWriter) -> Result<WriteGuard> {
+    fn parse(&self, payload: &[u8], writer: SourceStreamChunkRowWriter<'_>) -> Result<WriteGuard> {
         match Reader::with_schema(&self.schema, payload) {
             Ok(mut reader) => match reader.next() {
                 Some(Ok(Value::Record(fields))) => writer.insert(|column| {
@@ -603,7 +603,7 @@ mod test {
         ]
     }
 
-    fn build_avro_data(schema: &Schema) -> Record {
+    fn build_avro_data(schema: &Schema) -> Record<'_> {
         let mut record = Record::new(schema).unwrap();
         if let Schema::Record {
             name: _, fields, ..

--- a/src/source/src/parser/common.rs
+++ b/src/source/src/parser/common.rs
@@ -102,7 +102,7 @@ pub(crate) fn json_parse_value(column: &ColumnDesc, value: Option<&Value>) -> Re
     target_feature = "neon",
     target_feature = "simd128"
 ))]
-fn do_parse_simd_json_value(column: &ColumnDesc, v: &BorrowedValue) -> Result<ScalarImpl> {
+fn do_parse_simd_json_value(column: &ColumnDesc, v: &BorrowedValue<'_>) -> Result<ScalarImpl> {
     let v = match column.data_type {
         DataType::Boolean => v.as_bool().ok_or_else(|| anyhow!("expect bool"))?.into(),
         DataType::Int16 => ScalarImpl::Int16(
@@ -149,7 +149,7 @@ fn do_parse_simd_json_value(column: &ColumnDesc, v: &BorrowedValue) -> Result<Sc
 #[inline]
 pub(crate) fn simd_json_parse_value(
     column: &ColumnDesc,
-    value: Option<&BorrowedValue>,
+    value: Option<&BorrowedValue<'_>>,
 ) -> Result<Datum> {
     match value {
         None | Some(BorrowedValue::Static(StaticNode::Null)) => Ok(None),

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -60,7 +60,7 @@ impl SourceParser for JsonParser {
 
         use crate::parser::common::simd_json_parse_value;
         let mut payload_mut = payload.to_vec();
-        let value: BorrowedValue = simd_json::to_borrowed_value(&mut payload_mut)
+        let value: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
         writer.insert(|desc| {

--- a/src/sqlparser/src/ast/data_type.rs
+++ b/src/sqlparser/src/ast/data_type.rs
@@ -81,7 +81,7 @@ pub enum DataType {
 }
 
 impl fmt::Display for DataType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             DataType::Char(size) => format_type_with_optional_length(f, "CHAR", size),
             DataType::Varchar => write!(f, "CHARACTER VARYING"),
@@ -127,7 +127,7 @@ impl fmt::Display for DataType {
 }
 
 fn format_type_with_optional_length(
-    f: &mut fmt::Formatter,
+    f: &mut fmt::Formatter<'_>,
     sql_type: &'static str,
     len: &Option<u64>,
 ) -> fmt::Result {
@@ -146,7 +146,7 @@ pub struct StructField {
 }
 
 impl fmt::Display for StructField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.name, self.data_type)
     }
 }

--- a/src/sqlparser/src/ast/ddl.rs
+++ b/src/sqlparser/src/ast/ddl.rs
@@ -78,7 +78,7 @@ pub enum AlterTableOperation {
 }
 
 impl fmt::Display for AlterTableOperation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AlterTableOperation::AddConstraint(c) => write!(f, "ADD {}", c),
             AlterTableOperation::AddColumn { column_def } => {
@@ -154,7 +154,7 @@ pub enum AlterColumnOperation {
 }
 
 impl fmt::Display for AlterColumnOperation {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AlterColumnOperation::SetNotNull => write!(f, "SET NOT NULL",),
             AlterColumnOperation::DropNotNull => write!(f, "DROP NOT NULL",),
@@ -208,7 +208,7 @@ pub enum TableConstraint {
 }
 
 impl fmt::Display for TableConstraint {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TableConstraint::Unique {
                 name,
@@ -279,7 +279,7 @@ impl ColumnDef {
 }
 
 impl fmt::Display for ColumnDef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} {}", self.name, self.data_type)?;
         for option in &self.options {
             write!(f, " {}", option)?;
@@ -312,7 +312,7 @@ pub struct ColumnOptionDef {
 }
 
 impl fmt::Display for ColumnOptionDef {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}{}", display_constraint_name(&self.name), self.option)
     }
 }
@@ -350,7 +350,7 @@ pub enum ColumnOption {
 }
 
 impl fmt::Display for ColumnOption {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ColumnOption::*;
         match self {
             Null => write!(f, "NULL"),
@@ -386,7 +386,7 @@ impl fmt::Display for ColumnOption {
 fn display_constraint_name(name: &'_ Option<Ident>) -> impl fmt::Display + '_ {
     struct ConstraintName<'a>(&'a Option<Ident>);
     impl<'a> fmt::Display for ConstraintName<'a> {
-        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             if let Some(name) = self.0 {
                 write!(f, "CONSTRAINT {} ", name)?;
             }
@@ -411,7 +411,7 @@ pub enum ReferentialAction {
 }
 
 impl fmt::Display for ReferentialAction {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             ReferentialAction::Restrict => "RESTRICT",
             ReferentialAction::Cascade => "CASCADE",

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -57,7 +57,7 @@ impl<'a, T> fmt::Display for DisplaySeparated<'a, T>
 where
     T: fmt::Display,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut delim = "";
         for t in self.slice {
             write!(f, "{}", delim)?;
@@ -145,7 +145,7 @@ impl ParseTo for Ident {
 }
 
 impl fmt::Display for Ident {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.quote_style {
             Some(q) if q == '"' || q == '\'' || q == '`' => write!(f, "{}{}{}", q, self.value, q),
             Some(q) if q == '[' => write!(f, "[{}]", self.value),
@@ -171,7 +171,7 @@ impl ObjectName {
 }
 
 impl fmt::Display for ObjectName {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", display_separated(&self.0, "."))
     }
 }
@@ -331,7 +331,7 @@ pub enum Expr {
 }
 
 impl fmt::Display for Expr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Expr::Identifier(s) => write!(f, "{}", s),
             Expr::CompoundIdentifier(s) => write!(f, "{}", display_separated(s, ".")),
@@ -560,7 +560,7 @@ pub struct WindowSpec {
 }
 
 impl fmt::Display for WindowSpec {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut delim = "";
         if !self.partition_by.is_empty() {
             delim = " ";
@@ -636,7 +636,7 @@ impl fmt::Display for WindowFrame {
 }
 
 impl fmt::Display for WindowFrameUnits {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             WindowFrameUnits::Rows => "ROWS",
             WindowFrameUnits::Range => "RANGE",
@@ -658,7 +658,7 @@ pub enum WindowFrameBound {
 }
 
 impl fmt::Display for WindowFrameBound {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             WindowFrameBound::CurrentRow => f.write_str("CURRENT ROW"),
             WindowFrameBound::Preceding(None) => f.write_str("UNBOUNDED PRECEDING"),
@@ -678,7 +678,7 @@ pub enum AddDropSync {
 }
 
 impl fmt::Display for AddDropSync {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AddDropSync::SYNC => f.write_str("SYNC PARTITIONS"),
             AddDropSync::DROP => f.write_str("DROP PARTITIONS"),
@@ -701,7 +701,7 @@ pub enum ShowObject {
 }
 
 impl fmt::Display for ShowObject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn fmt_schema(schema: &Option<Ident>) -> String {
             if let Some(schema) = schema {
                 format!(" FROM {}", schema.value)
@@ -737,7 +737,7 @@ pub enum CommentObject {
 }
 
 impl fmt::Display for CommentObject {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             CommentObject::Column => f.write_str("COLUMN"),
             CommentObject::Table => f.write_str("TABLE"),
@@ -754,7 +754,7 @@ pub enum ExplainType {
 }
 
 impl fmt::Display for ExplainType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ExplainType::Logical => f.write_str("Logical"),
             ExplainType::Physical => f.write_str("Physical"),
@@ -783,7 +783,7 @@ impl Default for ExplainOptions {
     }
 }
 impl fmt::Display for ExplainOptions {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let default = Self::default();
         if *self == default {
             Ok(())
@@ -1007,7 +1007,7 @@ impl fmt::Display for Statement {
     // Clippy thinks this function is too complicated, but it is painful to
     // split up without extracting structs for each `Statement` variant.
     #[allow(clippy::cognitive_complexity)]
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Statement::Explain {
                 analyze,
@@ -1393,7 +1393,7 @@ pub enum OnInsert {
 }
 
 impl fmt::Display for OnInsert {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::DuplicateKeyUpdate(expr) => write!(
                 f,
@@ -1418,7 +1418,7 @@ pub enum Privileges {
 }
 
 impl fmt::Display for Privileges {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Privileges::All {
                 with_privileges_keyword,
@@ -1459,7 +1459,7 @@ pub enum Action {
 }
 
 impl fmt::Display for Action {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Action::Connect => f.write_str("CONNECT")?,
             Action::Create => f.write_str("CREATE")?,
@@ -1516,7 +1516,7 @@ pub enum GrantObjects {
 }
 
 impl fmt::Display for GrantObjects {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             GrantObjects::Sequences(sequences) => {
                 write!(f, "SEQUENCE {}", display_comma_separated(sequences))
@@ -1577,7 +1577,7 @@ pub struct Assignment {
 }
 
 impl fmt::Display for Assignment {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} = {}", display_separated(&self.id, "."), self.value)
     }
 }
@@ -1596,7 +1596,7 @@ pub enum FunctionArgExpr {
 }
 
 impl fmt::Display for FunctionArgExpr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FunctionArgExpr::Expr(expr) => write!(f, "{}", expr),
             FunctionArgExpr::ExprQualifiedWildcard(expr, prefix) => {
@@ -1625,7 +1625,7 @@ impl FunctionArg {
 }
 
 impl fmt::Display for FunctionArg {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             FunctionArg::Named { name, arg } => write!(f, "{} => {}", name, arg),
             FunctionArg::Unnamed(unnamed_arg) => write!(f, "{}", unnamed_arg),
@@ -1661,7 +1661,7 @@ impl Function {
 }
 
 impl fmt::Display for Function {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "{}({}{}{}{})",
@@ -1701,7 +1701,7 @@ pub enum ObjectType {
 }
 
 impl fmt::Display for ObjectType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             ObjectType::Table => "TABLE",
             ObjectType::View => "VIEW",
@@ -1757,7 +1757,7 @@ pub struct SqlOption {
 }
 
 impl fmt::Display for SqlOption {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} = {}", self.name, self.value)
     }
 }
@@ -1770,7 +1770,7 @@ pub enum TransactionMode {
 }
 
 impl fmt::Display for TransactionMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TransactionMode::*;
         match self {
             AccessMode(access_mode) => write!(f, "{}", access_mode),
@@ -1787,7 +1787,7 @@ pub enum TransactionAccessMode {
 }
 
 impl fmt::Display for TransactionAccessMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TransactionAccessMode::*;
         f.write_str(match self {
             ReadOnly => "READ ONLY",
@@ -1806,7 +1806,7 @@ pub enum TransactionIsolationLevel {
 }
 
 impl fmt::Display for TransactionIsolationLevel {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TransactionIsolationLevel::*;
         f.write_str(match self {
             ReadUncommitted => "READ UNCOMMITTED",
@@ -1826,7 +1826,7 @@ pub enum ShowStatementFilter {
 }
 
 impl fmt::Display for ShowStatementFilter {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use ShowStatementFilter::*;
         match self {
             Like(pattern) => write!(f, "LIKE '{}'", value::escape_single_quote_string(pattern)),
@@ -1844,7 +1844,7 @@ pub enum SetVariableValue {
 }
 
 impl fmt::Display for SetVariableValue {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use SetVariableValue::*;
         match self {
             Ident(ident) => write!(f, "{}", ident),

--- a/src/sqlparser/src/ast/operator.rs
+++ b/src/sqlparser/src/ast/operator.rs
@@ -37,7 +37,7 @@ pub enum UnaryOperator {
 }
 
 impl fmt::Display for UnaryOperator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             UnaryOperator::Plus => "+",
             UnaryOperator::Minus => "-",
@@ -89,7 +89,7 @@ pub enum BinaryOperator {
 }
 
 impl fmt::Display for BinaryOperator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             BinaryOperator::Plus => "+",
             BinaryOperator::Minus => "-",

--- a/src/sqlparser/src/ast/query.rs
+++ b/src/sqlparser/src/ast/query.rs
@@ -44,7 +44,7 @@ pub struct Query {
 }
 
 impl fmt::Display for Query {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(ref with) = self.with {
             write!(f, "{} ", with)?;
         }
@@ -87,7 +87,7 @@ pub enum SetExpr {
 }
 
 impl fmt::Display for SetExpr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             SetExpr::Select(s) => write!(f, "{}", s),
             SetExpr::Query(q) => write!(f, "({})", q),
@@ -114,7 +114,7 @@ pub enum SetOperator {
 }
 
 impl fmt::Display for SetOperator {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             SetOperator::Union => "UNION",
             SetOperator::Except => "EXCEPT",
@@ -145,7 +145,7 @@ pub struct Select {
 }
 
 impl fmt::Display for Select {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "SELECT{}", if self.distinct { " DISTINCT" } else { "" })?;
         write!(f, " {}", display_comma_separated(&self.projection))?;
         if !self.from.is_empty() {
@@ -184,7 +184,7 @@ pub struct LateralView {
 }
 
 impl fmt::Display for LateralView {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             " LATERAL VIEW{outer} {} {}",
@@ -211,7 +211,7 @@ pub struct With {
 }
 
 impl fmt::Display for With {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "WITH {}{}",
@@ -234,7 +234,7 @@ pub struct Cte {
 }
 
 impl fmt::Display for Cte {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{} AS ({})", self.alias, self.query)?;
         if let Some(ref fr) = self.from {
             write!(f, " FROM {}", fr)?;
@@ -261,7 +261,7 @@ pub enum SelectItem {
 }
 
 impl fmt::Display for SelectItem {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             SelectItem::UnnamedExpr(expr) => write!(f, "{}", expr),
             SelectItem::ExprWithAlias { expr, alias } => write!(f, "{} AS {}", expr, alias),
@@ -280,7 +280,7 @@ pub struct TableWithJoins {
 }
 
 impl fmt::Display for TableWithJoins {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.relation)?;
         for join in &self.joins {
             write!(f, "{}", join)?;
@@ -318,7 +318,7 @@ pub enum TableFactor {
 }
 
 impl fmt::Display for TableFactor {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             TableFactor::Table { name, alias } => {
                 write!(f, "{}", name)?;
@@ -361,7 +361,7 @@ pub struct TableAlias {
 }
 
 impl fmt::Display for TableAlias {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)?;
         if !self.columns.is_empty() {
             write!(f, " ({})", display_comma_separated(&self.columns))?;
@@ -378,7 +378,7 @@ pub struct Join {
 }
 
 impl fmt::Display for Join {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fn prefix(constraint: &JoinConstraint) -> &'static str {
             match constraint {
                 JoinConstraint::Natural => "NATURAL ",
@@ -388,7 +388,7 @@ impl fmt::Display for Join {
         fn suffix(constraint: &'_ JoinConstraint) -> impl fmt::Display + '_ {
             struct Suffix<'a>(&'a JoinConstraint);
             impl<'a> fmt::Display for Suffix<'a> {
-                fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     match self.0 {
                         JoinConstraint::On(expr) => write!(f, " ON {}", expr),
                         JoinConstraint::Using(attrs) => {
@@ -465,7 +465,7 @@ pub struct OrderByExpr {
 }
 
 impl fmt::Display for OrderByExpr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.expr)?;
         match self.asc {
             Some(true) => write!(f, " ASC")?,
@@ -489,7 +489,7 @@ pub struct Fetch {
 }
 
 impl fmt::Display for Fetch {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let extension = if self.with_ties { "WITH TIES" } else { "ONLY" };
         if let Some(ref quantity) = self.quantity {
             write!(f, "FETCH FIRST {} ROWS {}", quantity, extension)
@@ -509,7 +509,7 @@ pub struct Top {
 }
 
 impl fmt::Display for Top {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let extension = if self.with_ties { " WITH TIES" } else { "" };
         if let Some(ref quantity) = self.quantity {
             let percent = if self.percent { " PERCENT" } else { "" };
@@ -525,7 +525,7 @@ impl fmt::Display for Top {
 pub struct Values(pub Vec<Vec<Expr>>);
 
 impl fmt::Display for Values {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VALUES ")?;
         let mut delim = "";
         for row in &self.0 {

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -636,7 +636,7 @@ impl ParseTo for DropMode {
 }
 
 impl fmt::Display for DropMode {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             DropMode::Cascade => "CASCADE",
             DropMode::Restrict => "RESTRICT",

--- a/src/sqlparser/src/ast/value.rs
+++ b/src/sqlparser/src/ast/value.rs
@@ -57,7 +57,7 @@ pub enum Value {
 }
 
 impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Value::Number(v) => write!(f, "{}", v),
             Value::DoubleQuotedString(v) => write!(f, "\"{}\"", v),
@@ -122,7 +122,7 @@ pub enum DateTimeField {
 }
 
 impl fmt::Display for DateTimeField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(match self {
             DateTimeField::Year => "YEAR",
             DateTimeField::Month => "MONTH",
@@ -137,7 +137,7 @@ impl fmt::Display for DateTimeField {
 pub struct EscapeSingleQuoteString<'a>(&'a str);
 
 impl<'a> fmt::Display for EscapeSingleQuoteString<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for c in self.0.chars() {
             if c == '\'' {
                 write!(f, "\'\'")?;
@@ -162,7 +162,7 @@ pub enum TrimWhereField {
 }
 
 impl fmt::Display for TrimWhereField {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use TrimWhereField::*;
         f.write_str(match self {
             Both => "BOTH",

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -94,7 +94,7 @@ impl From<TokenizerError> for ParserError {
 }
 
 impl fmt::Display for ParserError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "sql parser error: {}",

--- a/src/sqlparser/src/tokenizer.rs
+++ b/src/sqlparser/src/tokenizer.rs
@@ -141,7 +141,7 @@ pub enum Token {
 }
 
 impl fmt::Display for Token {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Token::EOF => f.write_str("EOF"),
             Token::Word(ref w) => write!(f, "{}", w),
@@ -234,7 +234,7 @@ pub struct Word {
 }
 
 impl fmt::Display for Word {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.quote_style {
             Some(s) if s == '"' || s == '[' || s == '`' => {
                 write!(f, "{}{}{}", s, self.value, Word::matching_end_quote(s))
@@ -267,7 +267,7 @@ pub enum Whitespace {
 }
 
 impl fmt::Display for Whitespace {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Whitespace::Space => f.write_str(" "),
             Whitespace::Newline => f.write_str("\n"),

--- a/src/storage/benches/bench_fs_operation.rs
+++ b/src/storage/benches/bench_fs_operation.rs
@@ -66,7 +66,7 @@ impl Drop for Timer<'_> {
 }
 
 impl BenchStats {
-    fn start_timer(&mut self) -> Timer {
+    fn start_timer(&mut self) -> Timer<'_> {
         Timer {
             stats: self,
             start_time: SystemTime::now(),

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -693,7 +693,7 @@ impl<S: StateStore> StateTable<S> {
         &'a self,
         pk_prefix: &'a Row,
         epoch: u64,
-    ) -> StorageResult<(MemTableIter, StorageIterInner<S>)> {
+    ) -> StorageResult<(MemTableIter<'_>, StorageIterInner<S>)> {
         let prefix_serializer = self.pk_serializer.prefix(pk_prefix.size());
         let encoded_prefix = serialize_pk(pk_prefix, &prefix_serializer);
         let encoded_key_range = range_of_prefix(&encoded_prefix);

--- a/src/stream/src/executor/aggregation/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/approx_count_distinct.rs
@@ -223,7 +223,7 @@ impl<const DENSE_BITS: usize> StreamingApproxCountDistinct<DENSE_BITS> {
     /// count at the register.
     fn update_registers(
         &mut self,
-        datum_ref: DatumRef,
+        datum_ref: DatumRef<'_>,
         is_insert: bool,
     ) -> StreamExecutorResult<()> {
         if datum_ref.is_none() {

--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -82,7 +82,7 @@ where
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/chain.rs
+++ b/src/stream/src/executor/chain.rs
@@ -124,7 +124,7 @@ impl Executor for ChainExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -379,7 +379,7 @@ impl<S: StateStore> Executor for DynamicFilterExecutor<S> {
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/expand.rs
+++ b/src/stream/src/executor/expand.rs
@@ -91,7 +91,7 @@ impl Executor for ExpandExecutor {
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -173,7 +173,7 @@ impl SimpleExecutor for SimpleFilterExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -81,7 +81,7 @@ impl<S: StateStore> Executor for GlobalSimpleAggExecutor<S> {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/group_top_n.rs
+++ b/src/stream/src/executor/group_top_n.rs
@@ -255,7 +255,7 @@ where
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -114,7 +114,7 @@ impl<K: HashKey, S: StateStore> Executor for HashAggExecutor<K, S> {
         &self.extra.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.extra.pk_indices
     }
 

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -265,7 +265,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> Executor for HashJoi
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 
@@ -281,7 +281,7 @@ struct HashJoinChunkBuilder<const T: JoinTypePrimitive, const SIDE: SideTypePrim
 impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> HashJoinChunkBuilder<T, SIDE> {
     fn with_match_on_insert(
         &mut self,
-        row: &RowRef,
+        row: &RowRef<'_>,
         matched_row: &JoinRow,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         // Left/Right Anti sides
@@ -327,7 +327,7 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> HashJoinChunkBui
 
     fn with_match_on_delete(
         &mut self,
-        row: &RowRef,
+        row: &RowRef<'_>,
         matched_row: &JoinRow,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         Ok(
@@ -377,7 +377,7 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> HashJoinChunkBui
     fn forward_exactly_once_if_matched(
         &mut self,
         op: Op,
-        row: &RowRef,
+        row: &RowRef<'_>,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         // if it's a semi join and the side needs to be maintained.
         Ok(if is_semi(T) && forward_exactly_once(T, SIDE) {
@@ -391,7 +391,7 @@ impl<const T: JoinTypePrimitive, const SIDE: SideTypePrimitive> HashJoinChunkBui
     fn forward_if_not_matched(
         &mut self,
         op: Op,
-        row: &RowRef,
+        row: &RowRef<'_>,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
         // if it's outer join or anti join and the side needs to be maintained.
         Ok(

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -71,7 +71,7 @@ impl Executor for HopWindowExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/local_simple_agg.rs
+++ b/src/stream/src/executor/local_simple_agg.rs
@@ -45,7 +45,7 @@ impl Executor for LocalSimpleAggExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/lookup.rs
+++ b/src/stream/src/executor/lookup.rs
@@ -90,7 +90,7 @@ impl<S: StateStore> Executor for LookupExecutor<S> {
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/lookup_union.rs
+++ b/src/stream/src/executor/lookup_union.rs
@@ -67,7 +67,7 @@ impl Executor for LookupUnionExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -110,7 +110,7 @@ impl<S: StateStore> RangeCache<S> {
         &self,
         range: (Bound<ScalarImpl>, Bound<ScalarImpl>),
         _latest_is_lower: bool,
-    ) -> Range<ScalarImpl, HashSet<Row>> {
+    ) -> Range<'_, ScalarImpl, HashSet<Row>> {
         // TODO (cache behaviour):
         // What we want: At the end of every epoch we will try to read
         // ranges based on the new value. The values in the range may not all be cached.

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -186,7 +186,7 @@ impl Executor for MergeExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -153,7 +153,7 @@ pub trait Executor: Send + 'static {
     /// Return the primary key indices of the OUTPUT of the executor.
     /// Schema is used by both OLAP and streaming, therefore
     /// pk indices are maintained independently.
-    fn pk_indices(&self) -> PkIndicesRef;
+    fn pk_indices(&self) -> PkIndicesRef<'_>;
 
     /// Identity of the executor.
     fn identity(&self) -> &str;

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -156,7 +156,7 @@ impl<S: StateStore> Executor for MaterializeExecutor<S> {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -119,7 +119,7 @@ impl SimpleExecutor for SimpleProjectExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/project_set.rs
+++ b/src/stream/src/executor/project_set.rs
@@ -85,7 +85,7 @@ impl Executor for ProjectSetExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/rearranged_chain.rs
+++ b/src/stream/src/executor/rearranged_chain.rs
@@ -307,7 +307,7 @@ impl Executor for RearrangedChainExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -190,7 +190,7 @@ impl Executor for ReceiverExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/simple.rs
+++ b/src/stream/src/executor/simple.rs
@@ -29,7 +29,7 @@ pub trait SimpleExecutor: Send + 'static {
     fn schema(&self) -> &Schema;
 
     /// See [`super::Executor::pk_indices`].
-    fn pk_indices(&self) -> PkIndicesRef;
+    fn pk_indices(&self) -> PkIndicesRef<'_>;
 
     /// See [`super::Executor::identity`].
     fn identity(&self) -> &str;
@@ -49,7 +49,7 @@ where
         self.inner.schema()
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         self.inner.pk_indices()
     }
 

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -139,7 +139,7 @@ impl<S: StateStore> Executor for SinkExecutor<S> {
         self.input.schema()
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -406,7 +406,7 @@ impl<S: StateStore> Executor for SourceExecutor<S> {
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/subtask.rs
+++ b/src/stream/src/executor/subtask.rs
@@ -39,7 +39,7 @@ impl Executor for SubtaskRxExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -121,7 +121,7 @@ impl Executor for MockSource {
         &self.schema
     }
 
-    fn pk_indices(&self) -> super::PkIndicesRef {
+    fn pk_indices(&self) -> super::PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/top_n.rs
+++ b/src/stream/src/executor/top_n.rs
@@ -564,7 +564,7 @@ impl TopNCacheTrait for TopNCache<true> {
 
 pub fn generate_executor_pk_indices_info(
     order_pairs: &[OrderPair],
-    pk_indices: PkIndicesRef,
+    pk_indices: PkIndicesRef<'_>,
     schema: &Schema,
 ) -> (PkIndices, Vec<DataType>, Vec<OrderType>) {
     let mut internal_key_indices = vec![];
@@ -680,7 +680,7 @@ where
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n_appendonly.rs
@@ -208,7 +208,7 @@ impl<S: StateStore> TopNExecutorBase for InnerAppendOnlyTopNExecutor<S> {
         &self.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.pk_indices
     }
 

--- a/src/stream/src/executor/top_n_executor.rs
+++ b/src/stream/src/executor/top_n_executor.rs
@@ -40,7 +40,7 @@ pub trait TopNExecutorBase: Send + 'static {
     fn schema(&self) -> &Schema;
 
     /// See [`Executor::pk_indices`].
-    fn pk_indices(&self) -> PkIndicesRef;
+    fn pk_indices(&self) -> PkIndicesRef<'_>;
 
     /// See [`Executor::identity`].
     fn identity(&self) -> &str;
@@ -70,7 +70,7 @@ where
         self.inner.schema()
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         self.inner.pk_indices()
     }
 

--- a/src/stream/src/executor/union.rs
+++ b/src/stream/src/executor/union.rs
@@ -60,7 +60,7 @@ impl Executor for UnionExecutor {
         &self.info.schema
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         &self.info.pk_indices
     }
 

--- a/src/stream/src/executor/wrapper.rs
+++ b/src/stream/src/executor/wrapper.rs
@@ -163,7 +163,7 @@ impl Executor for WrapperExecutor {
         self.input.schema()
     }
 
-    fn pk_indices(&self) -> PkIndicesRef {
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
         self.input.pk_indices()
     }
 

--- a/src/stream/src/task/mod.rs
+++ b/src/stream/src/task/mod.rs
@@ -108,11 +108,11 @@ impl SharedContext {
     }
 
     #[inline]
-    fn lock_channel_map(&self) -> MutexGuard<HashMap<UpDownActorIds, ConsumableChannelPair>> {
+    fn lock_channel_map(&self) -> MutexGuard<'_, HashMap<UpDownActorIds, ConsumableChannelPair>> {
         self.channel_map.lock()
     }
 
-    pub fn lock_barrier_manager(&self) -> MutexGuard<LocalBarrierManager> {
+    pub fn lock_barrier_manager(&self) -> MutexGuard<'_, LocalBarrierManager> {
         self.barrier_manager.lock()
     }
 

--- a/src/utils/async_stack_trace/src/manager.rs
+++ b/src/utils/async_stack_trace/src/manager.rs
@@ -147,7 +147,7 @@ where
     /// Note that the reports might not be updated if the traced task is doing some computation
     /// heavy work and never yields, one may check how long the captured time has elapsed to confirm
     /// this.
-    pub fn get_all(&mut self) -> impl Iterator<Item = (&K, watch::Ref<StackTraceReport>)> {
+    pub fn get_all(&mut self) -> impl Iterator<Item = (&K, watch::Ref<'_, StackTraceReport>)> {
         self.rxs.retain(|_, rx| rx.has_changed().is_ok());
         self.rxs.iter_mut().map(|(k, v)| (k, v.borrow_and_update()))
     }

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -110,7 +110,7 @@ pub enum TypeOid {
 pub struct TypeOidError(i32);
 
 impl fmt::Display for TypeOidError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "oid:{} can't be supported", self.0)
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Add
```
    "-Wfuture_incompatible",
    "-Wnonstandard_style",
    "-Wrust_2018_idioms",
```
See https://doc.rust-lang.org/rustc/lints/groups.html for their meanings 

Actually only [`elided_lifetimes_in_paths`](https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html#elided-lifetimes-in-paths) is fixed:

> hidden lifetime parameters in types are deprecated

> Elided lifetime parameters can make it difficult to see at a glance that borrowing is occurring. This lint ensures that lifetime parameters are always explicitly stated, even if it is the '_ [placeholder lifetime](https://doc.rust-lang.org/reference/lifetime-elision.html#lifetime-elision-in-functions).
