### PR TITLE
fix(notification service): call `pin_snapshot` only when worker is fr…

### DIFF
--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -75,7 +75,9 @@ where
     ) -> Result<Response<Self::SubscribeStream>, Status> {
         let req = request.into_inner();
         let worker_type = req.get_worker_type()?;
-        self.hummock_manager.pin_snapshot(req.worker_id).await?;
+        if worker_type == WorkerType::Frontend {
+            self.hummock_manager.pin_snapshot(req.worker_id).await?;
+        }
         let host_address = req.get_host()?.clone();
 
         let (tx, rx) = mpsc::unbounded_channel();


### PR DESCRIPTION
…ontend

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

call `pin_snapshot` only when worker is frontend

## Checklist

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
