### PR TITLE
feat(sqlsmith): enable general `FROM` for mview

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -345,7 +345,11 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         )
     }
 
+    /// Generate `FROM` component of a query.
+    /// NOTE: There is no stream values executor,
+    /// so tables must be non-empty so we can choose from there.
     fn gen_from(&mut self, with_tables: Vec<Table>) -> Vec<TableWithJoins> {
+        assert!(!self.tables.is_empty());
         let mut from = if !with_tables.is_empty() {
             let with_table = with_tables
                 .choose(&mut self.rng)
@@ -357,12 +361,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             vec![rel]
         };
 
-        if self.is_mview {
-            // TODO: These constraints are workarounds required by mview.
-            // Tracked by: <https://github.com/risingwavelabs/risingwave/issues/4024>.
-            assert!(!self.tables.is_empty());
-            return from;
-        }
         let mut lateral_contexts = vec![];
         for _ in 0..self.tables.len() {
             if self.flip_coin() {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As per title. Try enable.

## Checklist

- [ ] Cleanup function `gen_from`
- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #4024 