### PR TITLE
fix(frontend): fix unpin_snapshot_before in HummockSnapshotManager

### DIFF
--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -293,7 +293,7 @@ impl HummockSnapshotManagerCore {
         };
 
         let last_unpin_snapshot = self.last_unpin_snapshot.load(Ordering::Acquire);
-        tracing::info!(
+        tracing::trace!(
             "Try unpin snapshot: min_epoch {}, last_unpin_snapshot: {}",
             min_epoch,
             last_unpin_snapshot

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -247,6 +247,9 @@ impl HummockSnapshotManagerCore {
         snapshot: &HummockSnapshot,
         batches: &mut Vec<(QueryId, Callback<SchedulerResult<HummockSnapshot>>)>,
     ) {
+        if batches.is_empty() {
+            return;
+        }
         let committed_epoch = snapshot.committed_epoch;
         let queries = match self.epoch_to_query_ids.get_mut(&committed_epoch) {
             None => {
@@ -278,11 +281,25 @@ impl HummockSnapshotManagerCore {
         // Check the min epoch which still exists running query. If there is no running query,
         // we shall unpin snapshot with the last committed epoch.
         let min_epoch = match self.epoch_to_query_ids.first_key_value() {
-            Some((epoch, _)) => *epoch,
+            Some((epoch, query_ids)) => {
+                assert!(
+                    !query_ids.is_empty(),
+                    "No query is associated with epoch {}",
+                    epoch
+                );
+                *epoch
+            }
             None => last_committed_epoch,
         };
 
-        if min_epoch <= self.last_unpin_snapshot.load(Ordering::Acquire) {
+        let last_unpin_snapshot = self.last_unpin_snapshot.load(Ordering::Acquire);
+        tracing::info!(
+            "Try unpin snapshot: min_epoch {}, last_unpin_snapshot: {}",
+            min_epoch,
+            last_unpin_snapshot
+        );
+
+        if min_epoch <= last_unpin_snapshot {
             return;
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Prior to this PR, frontend will never unpin snapshot after `notify_epoch_assigned_for_queries` is called on empty batches, which causes compaction to fail to delete any stale key-value entries.

This PR fixes #5418.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/pull/5533