### PR TITLE
fix(frontend): release hummock snapshot in local execution mode

### DIFF
--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -246,7 +246,7 @@ impl QueryRunner {
                         // So we can now unpin their epoch.
                         tracing::trace!("Query {:?} has scheduled all of its stages that have table scan (iterator creation).", self.query.query_id);
                         self.hummock_snapshot_manager
-                            .unpin_snapshot(self.epoch, self.query.query_id())
+                            .release(self.epoch, self.query.query_id())
                             .await;
                     }
 

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -87,7 +87,7 @@ impl QueryManager {
         let query_id = query.query_id().clone();
         let epoch = self
             .hummock_snapshot_manager
-            .get_epoch(query_id.clone())
+            .acquire(&query_id)
             .await?
             .committed_epoch;
         let query_id = query.query_id.clone();
@@ -114,7 +114,7 @@ impl QueryManager {
             Ok(query_result_fetcher) => query_result_fetcher,
             Err(e) => {
                 self.hummock_snapshot_manager
-                    .unpin_snapshot(epoch, &query_id)
+                    .release(epoch, &query_id)
                     .await;
                 return Err(e);
             }

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -132,7 +132,7 @@ impl HummockSnapshotManager {
         }
     }
 
-    pub async fn get_epoch(&self, query_id: QueryId) -> SchedulerResult<HummockSnapshot> {
+    pub async fn acquire(&self, query_id: &QueryId) -> SchedulerResult<HummockSnapshot> {
         let (sender, rc) = once_channel();
         let msg = EpochOperation::RequestEpoch {
             query_id: query_id.clone(),
@@ -157,7 +157,7 @@ impl HummockSnapshotManager {
             .fetch_max(epoch.current_epoch, Ordering::Relaxed);
     }
 
-    pub async fn unpin_snapshot(&self, epoch: u64, query_id: &QueryId) {
+    pub async fn release(&self, epoch: u64, query_id: &QueryId) {
         let msg = EpochOperation::ReleaseEpoch {
             query_id: query_id.clone(),
             epoch,

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -46,7 +46,7 @@ pub struct LocalQueryExecution {
     sql: String,
     query: Query,
     front_env: FrontendEnv,
-    epoch: Option<u64>,
+    epoch: u64,
 
     auth_context: Arc<AuthContext>,
 }
@@ -56,19 +56,20 @@ impl LocalQueryExecution {
         query: Query,
         front_env: FrontendEnv,
         sql: S,
+        epoch: u64,
         auth_context: Arc<AuthContext>,
     ) -> Self {
         Self {
             sql: sql.into(),
             query,
             front_env,
-            epoch: None,
+            epoch,
             auth_context,
         }
     }
 
     #[try_stream(ok = DataChunk, error = RwError)]
-    pub async fn run_inner(mut self) {
+    pub async fn run_inner(self) {
         debug!(
             "Starting to run query: {:?}, sql: '{}'",
             self.query.query_id, self.sql
@@ -77,24 +78,15 @@ impl LocalQueryExecution {
         let context =
             FrontendBatchTaskContext::new(self.front_env.clone(), self.auth_context.clone());
 
-        let query_id = self.query.query_id().clone();
-
         let task_id = TaskId {
             query_id: self.query.query_id.id.clone(),
             stage_id: 0,
             task_id: 0,
         };
 
-        let epoch = self
-            .front_env
-            .hummock_snapshot_manager()
-            .get_epoch(query_id)
-            .await?
-            .committed_epoch;
-        self.epoch = Some(epoch);
         let plan_fragment = self.create_plan_fragment()?;
         let plan_node = plan_fragment.root.unwrap();
-        let executor = ExecutorBuilder::new(&plan_node, &task_id, context, epoch);
+        let executor = ExecutorBuilder::new(&plan_node, &task_id, context, self.epoch);
         let executor = executor.build().await?;
 
         #[for_await]
@@ -228,9 +220,7 @@ impl LocalQueryExecution {
                         };
                         let local_execute_plan =  LocalExecutePlan {
                             plan: Some(second_stage_plan_fragment),
-                            epoch: self.epoch.expect(
-                                "Local execution mode has not acquired the epoch when generating the plan.",
-                            ),
+                            epoch: self.epoch,
                             };
                         let exchange_source = ExchangeSource {
                             task_output_id: Some(TaskOutputId {
@@ -259,9 +249,7 @@ impl LocalQueryExecution {
 
                     let local_execute_plan = LocalExecutePlan {
                     plan: Some(second_stage_plan_fragment),
-                    epoch: self.epoch.expect(
-                        "Local execution mode has not acquired the epoch when generating the plan.",
-                    ),
+                    epoch: self.epoch,
                     };
 
                     let workers = if second_stage.parallelism == 1 {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Prior to this PR, we will never release the hummock snapshot assigned to batch queries in local execution mode. This PR fixes the issue and does some minor refactoring.

This is yet another bug that causes #5418.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
