### PR TITLE
feat(ctl): list pinned hummock versions and snapshots

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -399,15 +399,15 @@ message PinnedSnapshotsSummary {
   map<uint32, common.WorkerNode> workers = 2;
 }
 
-message GetPinnedVersionsSummaryRequest {}
+message RiseCtlGetPinnedVersionsSummaryRequest {}
 
-message GetPinnedVersionsSummaryResponse {
+message RiseCtlGetPinnedVersionsSummaryResponse {
   PinnedVersionsSummary summary = 1;
 }
 
-message GetPinnedSnapshotsSummaryRequest {}
+message RiseCtlGetPinnedSnapshotsSummaryRequest {}
 
-message GetPinnedSnapshotsSummaryResponse {
+message RiseCtlGetPinnedSnapshotsSummaryResponse {
   PinnedSnapshotsSummary summary = 1;
 }
 
@@ -428,8 +428,8 @@ service HummockManagerService {
   rpc TriggerManualCompaction(TriggerManualCompactionRequest) returns (TriggerManualCompactionResponse);
   rpc ReportFullScanTask(ReportFullScanTaskRequest) returns (ReportFullScanTaskResponse);
   rpc TriggerFullGC(TriggerFullGCRequest) returns (TriggerFullGCResponse);
-  rpc GetPinnedVersionsSummary(GetPinnedVersionsSummaryRequest) returns (GetPinnedVersionsSummaryResponse);
-  rpc GetPinnedSnapshotsSummary(GetPinnedSnapshotsSummaryRequest) returns (GetPinnedSnapshotsSummaryResponse);
+  rpc RiseCtlGetPinnedVersionsSummary(RiseCtlGetPinnedVersionsSummaryRequest) returns (RiseCtlGetPinnedVersionsSummaryResponse);
+  rpc RiseCtlGetPinnedSnapshotsSummary(RiseCtlGetPinnedSnapshotsSummaryRequest) returns (RiseCtlGetPinnedSnapshotsSummaryResponse);
 }
 
 service CompactorService {}

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -389,6 +389,28 @@ message GetVersionDeltasResponse {
   HummockVersionDeltas version_deltas = 1;
 }
 
+message PinnedVersionsSummary {
+  repeated HummockPinnedVersion pinned_versions = 1;
+  map<uint32, common.WorkerNode> workers = 2;
+}
+
+message PinnedSnapshotsSummary {
+  repeated HummockPinnedSnapshot pinned_snapshots = 1;
+  map<uint32, common.WorkerNode> workers = 2;
+}
+
+message GetPinnedVersionsSummaryRequest {}
+
+message GetPinnedVersionsSummaryResponse {
+  PinnedVersionsSummary summary = 1;
+}
+
+message GetPinnedSnapshotsSummaryRequest {}
+
+message GetPinnedSnapshotsSummaryResponse {
+  PinnedSnapshotsSummary summary = 1;
+}
+
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);
   rpc GetCurrentVersion(GetCurrentVersionRequest) returns (GetCurrentVersionResponse);
@@ -406,6 +428,8 @@ service HummockManagerService {
   rpc TriggerManualCompaction(TriggerManualCompactionRequest) returns (TriggerManualCompactionResponse);
   rpc ReportFullScanTask(ReportFullScanTaskRequest) returns (ReportFullScanTaskResponse);
   rpc TriggerFullGC(TriggerFullGCRequest) returns (TriggerFullGCResponse);
+  rpc GetPinnedVersionsSummary(GetPinnedVersionsSummaryRequest) returns (GetPinnedVersionsSummaryResponse);
+  rpc GetPinnedSnapshotsSummary(GetPinnedSnapshotsSummaryRequest) returns (GetPinnedSnapshotsSummaryResponse);
 }
 
 service CompactorService {}

--- a/src/ctl/src/cmd_impl/hummock/list_version.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_version.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_pb::hummock::{PinnedSnapshotsSummary, PinnedVersionsSummary};
 use risingwave_rpc_client::HummockMetaClient;
 
 use crate::common::MetaServiceOpts;
@@ -21,5 +22,69 @@ pub async fn list_version() -> anyhow::Result<()> {
     let meta_client = meta_opts.create_meta_client().await?;
     let version = meta_client.get_current_version().await?;
     println!("{:#?}", version);
+    Ok(())
+}
+
+pub async fn list_pinned_versions() -> anyhow::Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta_client = meta_opts.create_meta_client().await?;
+    let PinnedVersionsSummary {
+        mut pinned_versions,
+        workers,
+    } = meta_client
+        .get_pinned_versions_summary()
+        .await?
+        .summary
+        .unwrap();
+    pinned_versions.sort_by_key(|v| v.min_pinned_id);
+    for pinned_version in pinned_versions {
+        match workers.get(&pinned_version.context_id) {
+            None => {
+                println!(
+                    "Worker {} may have been dropped, min_pinned_version_id {}",
+                    pinned_version.context_id, pinned_version.min_pinned_id
+                );
+            }
+            Some(worker) => {
+                println!(
+                    "Worker {} type {} min_pinned_version_id {}",
+                    pinned_version.context_id, worker.r#type, pinned_version.min_pinned_id
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+pub async fn list_pinned_snapshots() -> anyhow::Result<()> {
+    let meta_opts = MetaServiceOpts::from_env()?;
+    let meta_client = meta_opts.create_meta_client().await?;
+    let PinnedSnapshotsSummary {
+        mut pinned_snapshots,
+        workers,
+    } = meta_client
+        .get_pinned_snapshots_summary()
+        .await?
+        .summary
+        .unwrap();
+    pinned_snapshots.sort_by_key(|s| s.minimal_pinned_snapshot);
+    for pinned_snapshot in pinned_snapshots {
+        match workers.get(&pinned_snapshot.context_id) {
+            None => {
+                println!(
+                    "Worker {} may have been dropped, min_pinned_snapshot {}",
+                    pinned_snapshot.context_id, pinned_snapshot.minimal_pinned_snapshot
+                );
+            }
+            Some(worker) => {
+                println!(
+                    "Worker {} type {} min_pinned_snapshot {}",
+                    pinned_snapshot.context_id,
+                    worker.r#type,
+                    pinned_snapshot.minimal_pinned_snapshot
+                );
+            }
+        }
+    }
     Ok(())
 }

--- a/src/ctl/src/cmd_impl/hummock/list_version.rs
+++ b/src/ctl/src/cmd_impl/hummock/list_version.rs
@@ -32,7 +32,7 @@ pub async fn list_pinned_versions() -> anyhow::Result<()> {
         mut pinned_versions,
         workers,
     } = meta_client
-        .get_pinned_versions_summary()
+        .risectl_get_pinned_versions_summary()
         .await?
         .summary
         .unwrap();
@@ -63,7 +63,7 @@ pub async fn list_pinned_snapshots() -> anyhow::Result<()> {
         mut pinned_snapshots,
         workers,
     } = meta_client
-        .get_pinned_snapshots_summary()
+        .risectl_get_pinned_snapshots_summary()
         .await?
         .summary
         .unwrap();

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -20,9 +20,9 @@ use risingwave_common::util::value_encoding::deserialize_cell;
 use risingwave_frontend::TableCatalog;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::key::{get_epoch, get_table_id, user_key};
-use risingwave_hummock_sdk::HummockSstableId;
+use risingwave_hummock_sdk::{HummockSstableId, HummockVersionId};
 use risingwave_object_store::object::BlockLocation;
-use risingwave_rpc_client::MetaClient;
+use risingwave_rpc_client::{HummockMetaClient, MetaClient};
 use risingwave_storage::hummock::value::HummockValue;
 use risingwave_storage::hummock::{
     Block, BlockHolder, BlockIterator, CompressionAlgorithm, SstableMeta, SstableStore,
@@ -84,6 +84,9 @@ pub async fn sst_dump() -> anyhow::Result<()> {
         }
     }
 
+    meta_client
+        .unpin_version_before(HummockVersionId::MAX)
+        .await?;
     hummock_opts.shutdown().await;
     Ok(())
 }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -16,6 +16,8 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cmd_impl::bench::BenchCommands;
 
+use crate::cmd_impl::hummock::{list_pinned_snapshots, list_pinned_versions};
+
 mod cmd_impl;
 pub(crate) mod common;
 
@@ -97,6 +99,10 @@ enum HummockCommands {
         #[clap(short, long = "sst_retention_time_sec", default_value_t = 259200)]
         sst_retention_time_sec: u64,
     },
+    /// List pinned versions of each worker.
+    ListPinnedVersions {},
+    /// List pinned snapshots of each worker.
+    ListPinnedSnapshots {},
 }
 
 #[derive(Subcommand)]
@@ -174,6 +180,10 @@ pub async fn start(opts: CliOpts) -> Result<()> {
         Commands::Hummock(HummockCommands::TriggerFullGc {
             sst_retention_time_sec,
         }) => cmd_impl::hummock::trigger_full_gc(sst_retention_time_sec).await?,
+        Commands::Hummock(HummockCommands::ListPinnedVersions {}) => list_pinned_versions().await?,
+        Commands::Hummock(HummockCommands::ListPinnedSnapshots {}) => {
+            list_pinned_snapshots().await?
+        }
         Commands::Table(TableCommands::Scan { mv_name }) => cmd_impl::table::scan(mv_name).await?,
         Commands::Table(TableCommands::ScanById { table_id }) => {
             cmd_impl::table::scan_id(table_id).await?

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -13,14 +13,21 @@
 // limitations under the License.
 
 use std::cmp;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::RangeBounds;
 
+use function_name::named;
+use itertools::Itertools;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionDeltaExt;
 use risingwave_hummock_sdk::{HummockContextId, HummockSstableId, HummockVersionId};
+use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::{
     HummockPinnedSnapshot, HummockPinnedVersion, HummockVersion, HummockVersionDelta,
 };
+
+use crate::hummock::manager::read_lock;
+use crate::hummock::HummockManager;
+use crate::storage::MetaStore;
 
 #[derive(Default)]
 pub struct Versioning {
@@ -81,6 +88,44 @@ impl Versioning {
             // Otherwise, the delta is qualified for deletion after all its sst_to_delete is
             // deleted.
         }
+    }
+}
+
+impl<S> HummockManager<S>
+where
+    S: MetaStore,
+{
+    #[named]
+    pub async fn list_pinned_version(&self) -> Vec<HummockPinnedVersion> {
+        read_lock!(self, versioning)
+            .await
+            .pinned_versions
+            .values()
+            .cloned()
+            .collect_vec()
+    }
+
+    #[named]
+    pub async fn list_pinned_snapshot(&self) -> Vec<HummockPinnedSnapshot> {
+        read_lock!(self, versioning)
+            .await
+            .pinned_snapshots
+            .values()
+            .cloned()
+            .collect_vec()
+    }
+
+    pub async fn list_workers(
+        &self,
+        context_ids: &[HummockContextId],
+    ) -> HashMap<HummockContextId, WorkerNode> {
+        let mut workers = HashMap::new();
+        for context_id in context_ids {
+            if let Some(worker) = self.cluster_manager.get_worker_by_id(*context_id).await {
+                workers.insert(*context_id, worker.worker_node);
+            }
+        }
+        workers
     }
 }
 

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -339,16 +339,16 @@ where
         Ok(Response::new(TriggerFullGcResponse { status: None }))
     }
 
-    async fn get_pinned_versions_summary(
+    async fn rise_ctl_get_pinned_versions_summary(
         &self,
-        _request: Request<GetPinnedVersionsSummaryRequest>,
-    ) -> Result<Response<GetPinnedVersionsSummaryResponse>, Status> {
+        _request: Request<RiseCtlGetPinnedVersionsSummaryRequest>,
+    ) -> Result<Response<RiseCtlGetPinnedVersionsSummaryResponse>, Status> {
         let pinned_versions = self.hummock_manager.list_pinned_version().await;
         let workers = self
             .hummock_manager
             .list_workers(&pinned_versions.iter().map(|v| v.context_id).collect_vec())
             .await;
-        Ok(Response::new(GetPinnedVersionsSummaryResponse {
+        Ok(Response::new(RiseCtlGetPinnedVersionsSummaryResponse {
             summary: Some(PinnedVersionsSummary {
                 pinned_versions,
                 workers,
@@ -356,16 +356,16 @@ where
         }))
     }
 
-    async fn get_pinned_snapshots_summary(
+    async fn rise_ctl_get_pinned_snapshots_summary(
         &self,
-        _request: Request<GetPinnedSnapshotsSummaryRequest>,
-    ) -> Result<Response<GetPinnedSnapshotsSummaryResponse>, Status> {
+        _request: Request<RiseCtlGetPinnedSnapshotsSummaryRequest>,
+    ) -> Result<Response<RiseCtlGetPinnedSnapshotsSummaryResponse>, Status> {
         let pinned_snapshots = self.hummock_manager.list_pinned_snapshot().await;
         let workers = self
             .hummock_manager
             .list_workers(&pinned_snapshots.iter().map(|p| p.context_id).collect_vec())
             .await;
-        Ok(Response::new(GetPinnedSnapshotsSummaryResponse {
+        Ok(Response::new(RiseCtlGetPinnedSnapshotsSummaryResponse {
             summary: Some(PinnedSnapshotsSummary {
                 pinned_snapshots,
                 workers,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -455,14 +455,22 @@ impl MetaClient {
         Ok(resp.success)
     }
 
-    pub async fn get_pinned_versions_summary(&self) -> Result<GetPinnedVersionsSummaryResponse> {
-        let request = GetPinnedVersionsSummaryRequest {};
-        self.inner.get_pinned_versions_summary(request).await
+    pub async fn risectl_get_pinned_versions_summary(
+        &self,
+    ) -> Result<RiseCtlGetPinnedVersionsSummaryResponse> {
+        let request = RiseCtlGetPinnedVersionsSummaryRequest {};
+        self.inner
+            .rise_ctl_get_pinned_versions_summary(request)
+            .await
     }
 
-    pub async fn get_pinned_snapshots_summary(&self) -> Result<GetPinnedSnapshotsSummaryResponse> {
-        let request = GetPinnedSnapshotsSummaryRequest {};
-        self.inner.get_pinned_snapshots_summary(request).await
+    pub async fn risectl_get_pinned_snapshots_summary(
+        &self,
+    ) -> Result<RiseCtlGetPinnedSnapshotsSummaryResponse> {
+        let request = RiseCtlGetPinnedSnapshotsSummaryRequest {};
+        self.inner
+            .rise_ctl_get_pinned_snapshots_summary(request)
+            .await
     }
 }
 
@@ -749,8 +757,8 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, trigger_manual_compaction, TriggerManualCompactionRequest, TriggerManualCompactionResponse }
             ,{ hummock_client, report_full_scan_task, ReportFullScanTaskRequest, ReportFullScanTaskResponse }
             ,{ hummock_client, trigger_full_gc, TriggerFullGcRequest, TriggerFullGcResponse }
-            ,{ hummock_client, get_pinned_versions_summary, GetPinnedVersionsSummaryRequest, GetPinnedVersionsSummaryResponse }
-            ,{ hummock_client, get_pinned_snapshots_summary, GetPinnedSnapshotsSummaryRequest, GetPinnedSnapshotsSummaryResponse }
+            ,{ hummock_client, rise_ctl_get_pinned_versions_summary, RiseCtlGetPinnedVersionsSummaryRequest, RiseCtlGetPinnedVersionsSummaryResponse }
+            ,{ hummock_client, rise_ctl_get_pinned_snapshots_summary, RiseCtlGetPinnedSnapshotsSummaryRequest, RiseCtlGetPinnedSnapshotsSummaryResponse }
             ,{ user_client, create_user, CreateUserRequest, CreateUserResponse }
             ,{ user_client, update_user, UpdateUserRequest, UpdateUserResponse }
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -454,6 +454,16 @@ impl MetaClient {
         let resp = self.inner.reschedule(request).await?;
         Ok(resp.success)
     }
+
+    pub async fn get_pinned_versions_summary(&self) -> Result<GetPinnedVersionsSummaryResponse> {
+        let request = GetPinnedVersionsSummaryRequest {};
+        self.inner.get_pinned_versions_summary(request).await
+    }
+
+    pub async fn get_pinned_snapshots_summary(&self) -> Result<GetPinnedSnapshotsSummaryResponse> {
+        let request = GetPinnedSnapshotsSummaryRequest {};
+        self.inner.get_pinned_snapshots_summary(request).await
+    }
 }
 
 #[async_trait]
@@ -739,6 +749,8 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, trigger_manual_compaction, TriggerManualCompactionRequest, TriggerManualCompactionResponse }
             ,{ hummock_client, report_full_scan_task, ReportFullScanTaskRequest, ReportFullScanTaskResponse }
             ,{ hummock_client, trigger_full_gc, TriggerFullGcRequest, TriggerFullGcResponse }
+            ,{ hummock_client, get_pinned_versions_summary, GetPinnedVersionsSummaryRequest, GetPinnedVersionsSummaryResponse }
+            ,{ hummock_client, get_pinned_snapshots_summary, GetPinnedSnapshotsSummaryRequest, GetPinnedSnapshotsSummaryResponse }
             ,{ user_client, create_user, CreateUserRequest, CreateUserResponse }
             ,{ user_client, update_user, UpdateUserRequest, UpdateUserResponse }
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add list_pinned_versions and list_pinned_snapshots command for risectl.

Sample output

./risedev ctl hummock list-pinned-versions 
```
Worker 1 type 2 min_pinned_version_id 208
Worker 2 type 2 min_pinned_version_id 208
Worker 3 type 2 min_pinned_version_id 208
```


./risedev ctl hummock list-pinned-snapshots
```
Worker 4 type 1 min_pinned_snapshot 3060628331102208
```
## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/5516
