### PR TITLE
fix(state_table): call commit_no_data_expected on state table even with nothing to flush

### DIFF
--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -203,7 +203,13 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
 
         let states = match states.as_mut() {
             Some(states) if states.is_dirty() => states,
-            _ => return Ok(None), // Nothing to flush.
+            _ => {
+                // Call commit on state table to increment the epoch.
+                for state_table in state_tables.iter_mut() {
+                    state_table.commit_no_data_expected(epoch);
+                }
+                return Ok(None);
+            } // Nothing to flush.
         };
 
         for (state, state_table) in states

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -392,6 +392,10 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
         if dirty_cnt == 0 {
             // Nothing to flush.
+            // Call commit on state table to increment the epoch.
+            for state_table in state_tables.iter_mut() {
+                state_table.commit_no_data_expected(epoch);
+            }
             return Ok(());
         } else {
             // Batch commit data.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After fixing the epoch watermark for compaction in #5522, `validate_epoch` can fail due to `safe_epoch > read_epoch`. This is caused by forgetting to update the epoch used for reads in state table when there is nothing to flush in agg executor.

This PR introduces a quick fix by calling `commit_no_data_expected` when there is nothing to flush on seeing a barrier in agg executor. I also checked other stateful executors' implementation and confirmed that the agg executor is the only victim. No changes need to be made to other executors.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
