### PR TITLE
refactor(storage): shared_buffer_batch support Option notifier

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -167,7 +167,7 @@ pub(crate) use start_measure_real_process_timer;
 
 use super::Compactor;
 
-static CACEL_STATUS_SET: LazyLock<HashSet<TaskStatus>> = LazyLock::new(|| {
+static CANCEL_STATUS_SET: LazyLock<HashSet<TaskStatus>> = LazyLock::new(|| {
     [
         TaskStatus::ManualCanceled,
         TaskStatus::NoAvailCanceled,
@@ -764,7 +764,7 @@ where
     }
 
     pub async fn cancel_compact_task_impl(&self, compact_task: &CompactTask) -> Result<bool> {
-        assert!(CACEL_STATUS_SET.contains(&compact_task.task_status()));
+        assert!(CANCEL_STATUS_SET.contains(&compact_task.task_status()));
         self.report_compact_task_impl(None, compact_task, None)
             .await
     }

--- a/src/storage/benches/bench_merge_iter.rs
+++ b/src/storage/benches/bench_merge_iter.rs
@@ -41,7 +41,7 @@ fn gen_interleave_shared_buffer_batch_iter(
                 HummockValue::put(Bytes::copy_from_slice("value".as_bytes())),
             ));
         }
-        let batch = SharedBufferBatch::new(
+        let batch = SharedBufferBatch::new_with_notifier(
             batch_data,
             2333,
             mpsc::unbounded_channel().0,
@@ -75,7 +75,7 @@ fn gen_interleave_shared_buffer_batch_enum_iter(
                 HummockValue::put(Bytes::copy_from_slice("value".as_bytes())),
             ));
         }
-        let batch = SharedBufferBatch::new(
+        let batch = SharedBufferBatch::new_with_notifier(
             batch_data,
             2333,
             mpsc::unbounded_channel().0,

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -500,7 +500,7 @@ mod tests {
             ));
         }
         shared_buffer_items.sort_by(|l, r| user_key(&l.0).cmp(&r.0));
-        let batch = SharedBufferBatch::new(
+        let batch = SharedBufferBatch::new_with_notifier(
             shared_buffer_items,
             epoch,
             mpsc::unbounded_channel().0,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- shared_buffer_batch support Option notifier, in new `ReadVersion` struct , we gonna to use `SharedBufferBatch` as `Imm` at first, and double write SharedBufferBatch to `ReadVersion` staging_data and `SharedBuffer` for upload. So `ReadVersion`  no need to release buffer

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
