### PR TITLE
feat: improve error message when state table sanity check fails

### DIFF
--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -594,7 +594,7 @@ impl<S: StateStore> StateTable<S> {
                             storage_row.is_none(),
                             "overwriting an existing row:\nin-storage: {:?}\nto-be-written: {:?}",
                             storage_row.unwrap(),
-                            row
+                            streaming_deserialize(&self.data_types, row.as_ref())
                         );
                     }
                     local.put(pk, StorageValue::new_put(row));
@@ -614,7 +614,7 @@ impl<S: StateStore> StateTable<S> {
                             storage_row.as_ref().unwrap() == &old_row,
                             "inconsistent deletion:\nin-storage: {:?}\nold-value: {:?}",
                             storage_row.as_ref().unwrap(),
-                            old_row
+                            streaming_deserialize(&self.data_types, old_row.as_ref())
                         );
                     }
                     local.delete(pk);
@@ -633,13 +633,13 @@ impl<S: StateStore> StateTable<S> {
                         assert!(
                             storage_row.is_some(),
                             "update a non-existing row: {:?}",
-                            old_row
+                            streaming_deserialize(&self.data_types, old_row.as_ref())
                         );
                         assert!(
                             storage_row.as_ref().unwrap() == &old_row,
                             "value mismatch when updating row: {:?} != {:?}",
                             storage_row,
-                            old_row
+                            streaming_deserialize(&self.data_types, old_row.as_ref())
                         );
                     }
                     local.put(pk, StorageValue::new_put(new_row));

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -594,7 +594,7 @@ impl<S: StateStore> StateTable<S> {
                             storage_row.is_none(),
                             "overwriting an existing row:\nin-storage: {:?}\nto-be-written: {:?}",
                             storage_row.unwrap(),
-                            streaming_deserialize(&self.data_types, row.as_ref())
+                            streaming_deserialize(&self.data_types, row.as_ref()).unwrap()
                         );
                     }
                     local.put(pk, StorageValue::new_put(row));
@@ -614,7 +614,7 @@ impl<S: StateStore> StateTable<S> {
                             storage_row.as_ref().unwrap() == &old_row,
                             "inconsistent deletion:\nin-storage: {:?}\nold-value: {:?}",
                             storage_row.as_ref().unwrap(),
-                            streaming_deserialize(&self.data_types, old_row.as_ref())
+                            streaming_deserialize(&self.data_types, old_row.as_ref()).unwrap()
                         );
                     }
                     local.delete(pk);
@@ -633,13 +633,13 @@ impl<S: StateStore> StateTable<S> {
                         assert!(
                             storage_row.is_some(),
                             "update a non-existing row: {:?}",
-                            streaming_deserialize(&self.data_types, old_row.as_ref())
+                            streaming_deserialize(&self.data_types, old_row.as_ref()).unwrap()
                         );
                         assert!(
                             storage_row.as_ref().unwrap() == &old_row,
                             "value mismatch when updating row: {:?} != {:?}",
                             storage_row,
-                            streaming_deserialize(&self.data_types, old_row.as_ref())
+                            streaming_deserialize(&self.data_types, old_row.as_ref()).unwrap()
                         );
                     }
                     local.put(pk, StorageValue::new_put(new_row));


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

close #5524 

* make the error message human-readable, by deserializing the raw bytes before printing it out.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

### Release note

None

## Refer to a related PR or issue link (optional)
