### PR TITLE
feat(planner): improve explain formatting

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -20,43 +20,43 @@
     select v1, min(v2) + max(v3) * count(v1) as agg from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
-        BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
-          BatchExchange { order: [], dist: HashShard(t.v1) }
-            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
+      └─BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
-      BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1)] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
-      StreamProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
-        StreamHashAgg { group_key: [t.v1], aggs: [count, min(t.v2), max(t.v3), count(t.v1)] }
-          StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1)))] }
+      └─StreamHashAgg { group_key: [t.v1], aggs: [count, min(t.v2), max(t.v3), count(t.v1)] }
+        └─StreamExchange { dist: HashShard(t.v1) }
+          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int, v3 int);
     select min(v1) + max(v2) * count(v3) as agg from t;
   batch_plan: |
     BatchProject { exprs: [(min(min(t.v1)) + (max(max(t.v2)) * sum(count(t.v3))))] }
-      BatchSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v2)), sum(count(t.v3))] }
-        BatchExchange { order: [], dist: Single }
-          BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
-            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v2)), sum(count(t.v3))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [(min(t.v1) + (max(t.v2) * count(t.v3)))] }
-      BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchSimpleAgg { aggs: [min(t.v1), max(t.v2), count(t.v3)] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [] }
-      StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v2)) * sum(count(t.v3))))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), min(min(t.v1)), max(max(t.v2)), sum(count(t.v3))] }
-          StreamExchange { dist: Single }
-            StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, min(t.v1), max(t.v2), count(t.v3)] }
-              StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id)] }
-                StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v2)) * sum(count(t.v3))))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), min(min(t.v1)), max(max(t.v2)), sum(count(t.v3))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, min(t.v1), max(t.v2), count(t.v3)] }
+            └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id)] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v2;
@@ -72,51 +72,51 @@
     select v3, min(v1) * avg(v1+v2) as agg from t group by v3;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
-        BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
-          BatchExchange { order: [], dist: HashShard(t.v3) }
-            BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
-              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
+      └─BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
+        └─BatchExchange { order: [], dist: HashShard(t.v3) }
+          └─BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
-      BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
-            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchProject { exprs: [t.v3, t.v1, (t.v1 + t.v2)] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v3, agg], pk_columns: [v3] }
-      StreamProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
-        StreamHashAgg { group_key: [t.v3], aggs: [count, min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
-          StreamExchange { dist: HashShard(t.v3) }
-            StreamProject { exprs: [t.v3, t.v1, (t.v1 + t.v2), t._row_id] }
-              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v3, (min(t.v1) * (sum((t.v1 + t.v2))::Decimal / count((t.v1 + t.v2))))] }
+      └─StreamHashAgg { group_key: [t.v3], aggs: [count, min(t.v1), sum((t.v1 + t.v2)), count((t.v1 + t.v2))] }
+        └─StreamExchange { dist: HashShard(t.v3) }
+          └─StreamProject { exprs: [t.v3, t.v1, (t.v1 + t.v2), t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
     select min(v1), sum(v1 + v2) from t group by v1 + v2;
   logical_plan: |
     LogicalProject { exprs: [min(t.v1), sum((t.v1 + t.v2))] }
-      LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [min(t.v1), sum((t.v1 + t.v2))] }
-        LogicalProject { exprs: [(t.v1 + t.v2), t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [min(t.v1), sum((t.v1 + t.v2))] }
+      └─LogicalProject { exprs: [(t.v1 + t.v2), t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v1 * v2) as sum from t group by (v1 + v2) / v3, v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, sum((t.v1 * t.v2))] }
-      LogicalAgg { group_key: [((t.v1 + t.v2) / t.v3), t.v1], aggs: [sum((t.v1 * t.v2))] }
-        LogicalProject { exprs: [((t.v1 + t.v2) / t.v3), t.v1, (t.v1 * t.v2)] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { group_key: [((t.v1 + t.v2) / t.v3), t.v1], aggs: [sum((t.v1 * t.v2))] }
+      └─LogicalProject { exprs: [((t.v1 + t.v2) / t.v3), t.v1, (t.v1 * t.v2)] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
 - sql: |
     /* test logical_agg with complex group expression */
     create table t(v1 int, v2 int);
     select v1 + v2 from t group by v1 + v2;
   logical_plan: |
     LogicalProject { exprs: [(t.v1 + t.v2)] }
-      LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [] }
-        LogicalProject { exprs: [(t.v1 + t.v2)] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalAgg { group_key: [(t.v1 + t.v2)], aggs: [] }
+      └─LogicalProject { exprs: [(t.v1 + t.v2)] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* test logical_agg with complex group expression */
     /* should complain about nested agg call */
@@ -131,9 +131,9 @@
     select v1 + v2 from t group by v1, v2;
   logical_plan: |
     LogicalProject { exprs: [(t.v1 + t.v2)] }
-      LogicalAgg { group_key: [t.v1, t.v2], aggs: [] }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalAgg { group_key: [t.v1, t.v2], aggs: [] }
+      └─LogicalProject { exprs: [t.v1, t.v2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     create table t(v1 int, v2 int);
     select v1 from t group by v1 + v2;
@@ -144,48 +144,48 @@
     select count(v1 + v2) as cnt, sum(v1 + v2) as sum from t;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
-          BatchProject { exprs: [(t.v1 + t.v2)] }
-            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
+        └─BatchProject { exprs: [(t.v1 + t.v2)] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [(t.v1 + t.v2)] }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [(t.v1 + t.v2)] }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [cnt, sum], pk_columns: [] }
-      StreamProject { exprs: [sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
-              StreamProject { exprs: [(t.v1 + t.v2), t._row_id] }
-                StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(count((t.v1 + t.v2))), sum(sum((t.v1 + t.v2)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, count((t.v1 + t.v2)), sum((t.v1 + t.v2))] }
+            └─StreamProject { exprs: [(t.v1 + t.v2), t._row_id] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t(v1 int, v2 int, v3 int);
     select v1, sum(v2 + v3) / count(v2 + v3) + max(v1) as agg from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t.v1, ((sum((t.v2 + t.v3)) / count((t.v2 + t.v3))) + max(t.v1))] }
-        BatchHashAgg { group_key: [t.v1], aggs: [sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
-          BatchExchange { order: [], dist: HashShard(t.v1) }
-            BatchProject { exprs: [t.v1, (t.v2 + t.v3)] }
-              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [t.v1, ((sum((t.v2 + t.v3)) / count((t.v2 + t.v3))) + max(t.v1))] }
+      └─BatchHashAgg { group_key: [t.v1], aggs: [sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1) }
+          └─BatchProject { exprs: [t.v1, (t.v2 + t.v3)] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1] }
-      StreamProject { exprs: [t.v1, ((sum((t.v2 + t.v3)) / count((t.v2 + t.v3))) + max(t.v1))] }
-        StreamHashAgg { group_key: [t.v1], aggs: [count, sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
-          StreamExchange { dist: HashShard(t.v1) }
-            StreamProject { exprs: [t.v1, (t.v2 + t.v3), t._row_id] }
-              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, ((sum((t.v2 + t.v3)) / count((t.v2 + t.v3))) + max(t.v1))] }
+      └─StreamHashAgg { group_key: [t.v1], aggs: [count, sum((t.v2 + t.v3)), count((t.v2 + t.v3)), max(t.v1)] }
+        └─StreamExchange { dist: HashShard(t.v1) }
+          └─StreamProject { exprs: [t.v1, (t.v2 + t.v3), t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 real);
     select v1, count(*) from t group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashAgg { group_key: [t.v1], aggs: [count] }
-        BatchExchange { order: [], dist: HashShard(t.v1) }
-          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [t.v1], aggs: [count] }
+      └─BatchExchange { order: [], dist: HashShard(t.v1) }
+        └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* Use BatchSortAgg, when input provides order */
     create table t(v1 int, v2 int);
@@ -193,70 +193,70 @@
     select v1, max(v2) from mv group by v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchSortAgg { group_key: [mv.v1], aggs: [max(mv.v2)] }
-        BatchExchange { order: [mv.v1 DESC], dist: HashShard(mv.v1) }
-          BatchScan { table: mv, columns: [mv.v1, mv.v2], distribution: SomeShard }
+    └─BatchSortAgg { group_key: [mv.v1], aggs: [max(mv.v2)] }
+      └─BatchExchange { order: [mv.v1 DESC], dist: HashShard(mv.v1) }
+        └─BatchScan { table: mv, columns: [mv.v1, mv.v2], distribution: SomeShard }
 - sql: |
     /* Use BatchSortAgg, when output requires order */
     create table t(v1 int, v2 int);
     select v1, max(v2) from t group by v1 order by v1 desc;
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
-      BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-        BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
-          BatchSort { order: [t.v1 DESC] }
-            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+      └─BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
+        └─BatchSort { order: [t.v1 DESC] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     /* Use BatchSortAgg, when required order satisfies input order */
     create table t(k1 int, k2 int, v1 int);
     SELECT max(v1), k1, k2 from t group by k1, k2 order by k1;
   batch_plan: |
     BatchExchange { order: [t.k1 ASC], dist: Single }
-      BatchProject { exprs: [max(t.v1), t.k1, t.k2] }
-        BatchSortAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
-          BatchExchange { order: [t.k1 ASC, t.k2 ASC], dist: HashShard(t.k1, t.k2) }
-            BatchSort { order: [t.k1 ASC, t.k2 ASC] }
-              BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [max(t.v1), t.k1, t.k2] }
+      └─BatchSortAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
+        └─BatchExchange { order: [t.k1 ASC, t.k2 ASC], dist: HashShard(t.k1, t.k2) }
+          └─BatchSort { order: [t.k1 ASC, t.k2 ASC] }
+            └─BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
 - sql: |
     /* Use BatchSortAgg, when output requires order with swapped output*/
     create table t(v1 int, v2 int);
     select max(v2), v1 from t group by v1 order by v1 desc;
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
-      BatchProject { exprs: [max(t.v2), t.v1] }
-        BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-          BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
-            BatchSort { order: [t.v1 DESC] }
-              BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchProject { exprs: [max(t.v2), t.v1] }
+      └─BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+        └─BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
+          └─BatchSort { order: [t.v1 DESC] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 real);
     select count(*) from t;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count)] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count] }
-          BatchScan { table: t, columns: [], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count] }
+        └─BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* having with agg call */
     create table t (v1 real);
     select 1 from t having sum(v1) > 5;
   batch_plan: |
     BatchProject { exprs: [1:Int32] }
-      BatchFilter { predicate: (sum(sum(t.v1)) > 5:Int32) }
-        BatchSimpleAgg { aggs: [sum(sum(t.v1))] }
-          BatchExchange { order: [], dist: Single }
-            BatchSimpleAgg { aggs: [sum(t.v1)] }
-              BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchFilter { predicate: (sum(sum(t.v1)) > 5:Int32) }
+      └─BatchSimpleAgg { aggs: [sum(sum(t.v1))] }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchSimpleAgg { aggs: [sum(t.v1)] }
+            └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* having with group column */
     create table t (v1 real);
     select 1 from t group by v1 having v1 > 5;
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalFilter { predicate: (t.v1 > 5:Int32) }
-        LogicalAgg { group_key: [t.v1], aggs: [] }
-          LogicalProject { exprs: [t.v1] }
-            LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    └─LogicalFilter { predicate: (t.v1 > 5:Int32) }
+      └─LogicalAgg { group_key: [t.v1], aggs: [] }
+        └─LogicalProject { exprs: [t.v1] }
+          └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
 - sql: |
     /* having with non-group column */
     create table t (v1 real, v2 int);
@@ -269,202 +269,202 @@
     select distinct v1 from t;
   logical_plan: |
     LogicalAgg { group_key: [t.v1], aggs: [] }
-      LogicalProject { exprs: [t.v1] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalProject { exprs: [t.v1] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* distinct with agg */
     create table t (v1 int, v2 int);
     select distinct sum(v1) from t group by v2;
   logical_plan: |
     LogicalAgg { group_key: [sum(t.v1)], aggs: [] }
-      LogicalProject { exprs: [sum(t.v1)] }
-        LogicalAgg { group_key: [t.v2], aggs: [sum(t.v1)] }
-          LogicalProject { exprs: [t.v2, t.v1] }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalProject { exprs: [sum(t.v1)] }
+      └─LogicalAgg { group_key: [t.v2], aggs: [sum(t.v1)] }
+        └─LogicalProject { exprs: [t.v2, t.v1] }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* arguments out-of-order */
     create table t(v1 int, v2 int, v3 int);
     select count(v3), min(v2), max(v1) from t;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(t.v3)), min(min(t.v2)), max(max(t.v1))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(t.v3), min(t.v2), max(t.v1)] }
-          BatchProject { exprs: [t.v3, t.v2, t.v1] }
-            BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(t.v3), min(t.v2), max(t.v1)] }
+        └─BatchProject { exprs: [t.v3, t.v2, t.v1] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* simple-agg arguments out-of-order */
     create table t(v1 int, v2 int, v3 int);
     select min(v1) + max(v3) * count(v2) as agg from t;
   batch_plan: |
     BatchProject { exprs: [(min(min(t.v1)) + (max(max(t.v3)) * sum(count(t.v2))))] }
-      BatchSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v3)), sum(count(t.v2))] }
-        BatchExchange { order: [], dist: Single }
-          BatchSimpleAgg { aggs: [min(t.v1), max(t.v3), count(t.v2)] }
-            BatchProject { exprs: [t.v1, t.v3, t.v2] }
-              BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v3)), sum(count(t.v2))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [min(t.v1), max(t.v3), count(t.v2)] }
+          └─BatchProject { exprs: [t.v1, t.v3, t.v2] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [] }
-      StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v3)) * sum(count(t.v2))))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), min(min(t.v1)), max(max(t.v3)), sum(count(t.v2))] }
-          StreamExchange { dist: Single }
-            StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, min(t.v1), max(t.v3), count(t.v2)] }
-              StreamProject { exprs: [t.v1, t.v3, t.v2, t._row_id, Vnode(t._row_id)] }
-                StreamProject { exprs: [t.v1, t.v3, t.v2, t._row_id] }
-                  StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v3)) * sum(count(t.v2))))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), min(min(t.v1)), max(max(t.v3)), sum(count(t.v2))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, min(t.v1), max(t.v3), count(t.v2)] }
+            └─StreamProject { exprs: [t.v1, t.v3, t.v2, t._row_id, Vnode(t._row_id)] }
+              └─StreamProject { exprs: [t.v1, t.v3, t.v2, t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* dup group key */
     create table t(v1 int) with (appendonly = false);
     select v1 from t group by v1, v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    └─LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
-        LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalAgg { group_key: [t.v1, t.v1], aggs: [] }
+      └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t.v1(hidden)], pk_columns: [v1, t.v1] }
-      StreamProject { exprs: [t.v1, t.v1] }
-        StreamHashAgg { group_key: [t.v1, t.v1], aggs: [count] }
-          StreamExchange { dist: HashShard(t.v1) }
-            StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, t.v1] }
+      └─StreamHashAgg { group_key: [t.v1, t.v1], aggs: [count] }
+        └─StreamExchange { dist: HashShard(t.v1) }
+          └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* dup group key */
     create table t(v1 int, v2 int, v3 int) with (appendonly = false);
     select v2, min(v1) as min_v1, v3, max(v1) as max_v1 from t group by v3, v2, v2;
   logical_plan: |
     LogicalProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1)] }
-      LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
-        LogicalProject { exprs: [t.v3, t.v2, t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
+      └─LogicalProject { exprs: [t.v3, t.v2, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1)] }
-      LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
-        LogicalProject { exprs: [t.v3, t.v2, t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
+    └─LogicalAgg { group_key: [t.v3, t.v2, t.v2], aggs: [min(t.v1), max(t.v1)] }
+      └─LogicalProject { exprs: [t.v3, t.v2, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
   stream_plan: |
     StreamMaterialize { columns: [v2, min_v1, v3, max_v1, t.v2(hidden)], pk_columns: [v3, v2, t.v2] }
-      StreamProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1), t.v2] }
-        StreamHashAgg { group_key: [t.v3, t.v2, t.v2], aggs: [count, min(t.v1), max(t.v1)] }
-          StreamExchange { dist: HashShard(t.v3, t.v2) }
-            StreamProject { exprs: [t.v3, t.v2, t.v1, t._row_id] }
-              StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1), t.v2] }
+      └─StreamHashAgg { group_key: [t.v3, t.v2, t.v2], aggs: [count, min(t.v1), max(t.v1)] }
+        └─StreamExchange { dist: HashShard(t.v3, t.v2) }
+          └─StreamProject { exprs: [t.v3, t.v2, t.v1, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by agg input */
     create table t(v1 int);
     select sum(v1 order by v1) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1)] }
-      LogicalAgg { aggs: [sum(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by other columns */
     create table t(v1 int, v2 varchar);
     select sum(v1 order by v2) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1)] }
-      LogicalAgg { aggs: [sum(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by ASC/DESC and default */
     create table t(v1 int, v2 varchar, v3 int);
     select sum(v1 order by v1, v2 ASC, v3 DESC) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1)] }
-      LogicalAgg { aggs: [sum(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by NULLS FIRST/LAST and default */
     create table t(v1 int, v2 varchar, v3 int);
     select sum(v1 order by v1, v2 NULLS FIRST, v3 NULLS LAST) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1)] }
-      LogicalAgg { aggs: [sum(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by complex expressions */
     create table t(v1 int, v2 varchar, v3 int);
     select sum(v1 order by v1 + v3 ASC, length(v2) * v3 DESC NULLS FIRST) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1)] }
-      LogicalAgg { aggs: [sum(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1)] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* filter clause */
     create table t(v1 int);
     select sum(v1) FILTER (WHERE v1 > 0) AS sa from t;
   logical_plan: |
     LogicalProject { exprs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
-      LogicalAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    └─LogicalAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
   stream_plan: |
     StreamMaterialize { columns: [sa], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1) filter((t.v1 > 0:Int32))] }
-              StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1) filter((t.v1 > 0:Int32))] }
+            └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* filter clause */
     /* extra calculation, should reuse result from project */
@@ -472,75 +472,75 @@
     select sum(a * b) filter (where a * b > 0) as sab from t;
   logical_plan: |
     LogicalProject { exprs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
-      LogicalAgg { aggs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
-        LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-          LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+    └─LogicalAgg { aggs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
+      └─LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((t.a * t.b)) filter(((t.a * t.b) > 0:Int32))] }
-      LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-        LogicalScan { table: t, columns: [t.a, t.b] }
+    └─LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
+      └─LogicalScan { table: t, columns: [t.a, t.b] }
 - sql: |
     /* complex filter clause */
     create table t(a int, b int);
     select max(a * b) FILTER (WHERE a < b AND a + b < 100 AND a * b != a + b - 1) AS sab from t;
   logical_plan: |
     LogicalProject { exprs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
-      LogicalAgg { aggs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
-        LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-          LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+    └─LogicalAgg { aggs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
+      └─LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
-      LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
-        LogicalScan { table: t, columns: [t.a, t.b] }
+    └─LogicalProject { exprs: [t.a, t.b, (t.a * t.b)] }
+      └─LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [sab], pk_columns: [] }
-      StreamProject { exprs: [max(max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), max(max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
-          StreamExchange { dist: Single }
-            StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
-              StreamProject { exprs: [t.a, t.b, (t.a * t.b), t._row_id, Vnode(t._row_id)] }
-                StreamProject { exprs: [t.a, t.b, (t.a * t.b), t._row_id] }
-                  StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [max(max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), max(max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max((t.a * t.b)) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
+            └─StreamProject { exprs: [t.a, t.b, (t.a * t.b), t._row_id, Vnode(t._row_id)] }
+              └─StreamProject { exprs: [t.a, t.b, (t.a * t.b), t._row_id] }
+                └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* avg filter clause + group by */
     create table t(a int, b int);
     select avg(a) FILTER (WHERE a > b) AS avga from t group by b ;
   logical_plan: |
     LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b)))] }
-      LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
-        LogicalProject { exprs: [t.b, t.a] }
-          LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+    └─LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
+      └─LogicalProject { exprs: [t.b, t.a] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b)))] }
-      LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
-        LogicalProject { exprs: [t.b, t.a] }
-          LogicalScan { table: t, columns: [t.a, t.b] }
+    └─LogicalAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
+      └─LogicalProject { exprs: [t.b, t.a] }
+        └─LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [avga, t.b(hidden)], pk_columns: [t.b] }
-      StreamProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))), t.b] }
-        StreamHashAgg { group_key: [t.b], aggs: [count, sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
-          StreamExchange { dist: HashShard(t.b) }
-            StreamProject { exprs: [t.b, t.a, t._row_id] }
-              StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))), t.b] }
+      └─StreamHashAgg { group_key: [t.b], aggs: [count, sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
+        └─StreamExchange { dist: HashShard(t.b) }
+          └─StreamProject { exprs: [t.b, t.a, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* count filter clause */
     create table t(a int, b int);
     select count(*) FILTER (WHERE a > b) AS cnt_agb from t;
   logical_plan: |
     LogicalProject { exprs: [count filter((t.a > t.b))] }
-      LogicalAgg { aggs: [count filter((t.a > t.b))] }
-        LogicalProject { exprs: [t.a, t.b] }
-          LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+    └─LogicalAgg { aggs: [count filter((t.a > t.b))] }
+      └─LogicalProject { exprs: [t.a, t.b] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count filter((t.a > t.b))] }
-      LogicalScan { table: t, columns: [t.a, t.b] }
+    └─LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [cnt_agb], pk_columns: [] }
-      StreamProject { exprs: [sum(count filter((t.a > t.b)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(count filter((t.a > t.b)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, count filter((t.a > t.b))] }
-              StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(count filter((t.a > t.b)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(count filter((t.a > t.b)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, count filter((t.a > t.b))] }
+            └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* filter clause + non-boolean function */
     create table t(a int, b int);
@@ -573,80 +573,80 @@
     with sub(a, b) as (select min(v1), sum(v2) filter (where v2 < 5) from t) select b from sub;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum(t.v2) filter((t.v2 < 5:Int32))] }
-          BatchScan { table: t, columns: [t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum(t.v2) filter((t.v2 < 5:Int32))] }
+        └─BatchScan { table: t, columns: [t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [b], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
-              StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
+            └─StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* only distinct agg */
     create table t(a int, b int, c int);
     select a, count(distinct b) as distinct_b_num, sum(distinct c) filter(where c < 100) as distinct_c_sum from t group by a;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((flag = 0:Int64)), sum(t.c) filter((count filter((t.c < 100:Int32)) > 0:Int64) AND (flag = 1:Int64))] }
-      LogicalAgg { group_key: [t.a, t.b, t.c, flag], aggs: [count filter((t.c < 100:Int32))] }
-        LogicalProject { exprs: [t.a, t.b, t.c, t.c, flag] }
-          LogicalExpand { column_subsets: [[t.a, t.b], [t.a, t.c]] }
-            LogicalScan { table: t, columns: [t.a, t.b, t.c] }
+    └─LogicalAgg { group_key: [t.a, t.b, t.c, flag], aggs: [count filter((t.c < 100:Int32))] }
+      └─LogicalProject { exprs: [t.a, t.b, t.c, t.c, flag] }
+        └─LogicalExpand { column_subsets: [[t.a, t.b], [t.a, t.c]] }
+          └─LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* distinct agg and non-disintct agg */
     create table t(a int, b int, c int);
     select a, count(distinct b) as distinct_b_num, sum(c) as sum_c from t group by a;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.a], aggs: [count(t.b), sum(sum(t.c))] }
-      LogicalAgg { group_key: [t.a, t.b], aggs: [sum(t.c)] }
-        LogicalScan { table: t, columns: [t.a, t.b, t.c] }
+    └─LogicalAgg { group_key: [t.a, t.b], aggs: [sum(t.c)] }
+      └─LogicalScan { table: t, columns: [t.a, t.b, t.c] }
   stream_plan: |
     StreamMaterialize { columns: [a, distinct_b_num, sum_c], pk_columns: [a] }
-      StreamProject { exprs: [t.a, count(t.b), sum(sum(t.c))] }
-        StreamHashAgg { group_key: [t.a], aggs: [count, count(t.b), sum(sum(t.c))] }
-          StreamExchange { dist: HashShard(t.a) }
-            StreamProject { exprs: [t.a, t.b, sum(t.c)] }
-              StreamHashAgg { group_key: [t.a, t.b], aggs: [count, sum(t.c)] }
-                StreamExchange { dist: HashShard(t.a, t.b) }
-                  StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.a, count(t.b), sum(sum(t.c))] }
+      └─StreamHashAgg { group_key: [t.a], aggs: [count, count(t.b), sum(sum(t.c))] }
+        └─StreamExchange { dist: HashShard(t.a) }
+          └─StreamProject { exprs: [t.a, t.b, sum(t.c)] }
+            └─StreamHashAgg { group_key: [t.a, t.b], aggs: [count, sum(t.c)] }
+              └─StreamExchange { dist: HashShard(t.a, t.b) }
+                └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* distinct agg with filter */
     create table t(a int, b int, c int);
     select a, count(distinct b) filter(where b < 100), sum(c) from t group by a;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.a], aggs: [count(t.b) filter((count filter((t.b < 100:Int32)) > 0:Int64)), sum(sum(t.c))] }
-      LogicalAgg { group_key: [t.a, t.b], aggs: [count filter((t.b < 100:Int32)), sum(t.c)] }
-        LogicalScan { table: t, columns: [t.a, t.b, t.c] }
+    └─LogicalAgg { group_key: [t.a, t.b], aggs: [count filter((t.b < 100:Int32)), sum(t.c)] }
+      └─LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* non-distinct agg with filter */
     create table t(a int, b int, c int);
     select a, count(distinct b), sum(c) filter(where b < 100) from t group by a;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.a], aggs: [count(t.b), sum(sum(t.c) filter((t.b < 100:Int32)))] }
-      LogicalAgg { group_key: [t.a, t.b], aggs: [sum(t.c) filter((t.b < 100:Int32))] }
-        LogicalScan { table: t, columns: [t.a, t.b, t.c] }
+    └─LogicalAgg { group_key: [t.a, t.b], aggs: [sum(t.c) filter((t.b < 100:Int32))] }
+      └─LogicalScan { table: t, columns: [t.a, t.b, t.c] }
 - sql: |
     /* combined order by & filter clauses */
     create table t(a varchar, b int);
     select sum(length(a) * b order by length(a) + b) filter (where b < 100 AND b * 2 > 10) as s1 from t;
   logical_plan: |
     LogicalProject { exprs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
-      LogicalAgg { aggs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
-        LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
-          LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+    └─LogicalAgg { aggs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
+      └─LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
-      LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
-        LogicalScan { table: t, columns: [t.a, t.b] }
+    └─LogicalProject { exprs: [t.b, (Length(t.a) * t.b)] }
+      └─LogicalScan { table: t, columns: [t.a, t.b] }
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
-              StreamProject { exprs: [t.b, (Length(t.a) * t.b), t._row_id] }
-                StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum((Length(t.a) * t.b)) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
+            └─StreamProject { exprs: [t.b, (Length(t.a) * t.b), t._row_id] }
+              └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t(x int, y varchar);
     select string_agg(y, ',' order by y), count(distinct x) from t;
@@ -661,8 +661,8 @@
     with z(a, b) as (select count(distinct v1), count(v2) from t) select a from z;
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(t.v1)] }
-      LogicalAgg { group_key: [t.v1], aggs: [] }
-        LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalAgg { group_key: [t.v1], aggs: [] }
+      └─LogicalScan { table: t, columns: [t.v1] }
 - sql: |
     /* input is sharded by group key */
     create table t(x int);
@@ -670,40 +670,40 @@
     select count(*) as cnt from i group by x;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [count] }
-        BatchSortAgg { group_key: [i.x], aggs: [count] }
-          BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+    └─BatchProject { exprs: [count] }
+      └─BatchSortAgg { group_key: [i.x], aggs: [count] }
+        └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
   stream_plan: |
     StreamMaterialize { columns: [cnt, i.x(hidden)], pk_columns: [i.x] }
-      StreamProject { exprs: [count, i.x] }
-        StreamHashAgg { group_key: [i.x], aggs: [count, count] }
-          StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+    └─StreamProject { exprs: [count, i.x] }
+      └─StreamHashAgg { group_key: [i.x], aggs: [count, count] }
+        └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
 - sql: |
     /* distinct aggregates only have one distinct argument doesn't need expand */
     create table t(x int, y int);
     select count(x), sum(distinct y), sum(distinct y) from t;
   optimized_logical_plan: |
     LogicalProject { exprs: [Coalesce(sum(count(t.x)), 0:Int64), sum(t.y), sum(t.y)] }
-      LogicalAgg { aggs: [sum(count(t.x)), sum(t.y), sum(t.y)] }
-        LogicalAgg { group_key: [t.y, t.y], aggs: [count(t.x)] }
-          LogicalScan { table: t, columns: [t.x, t.y] }
+    └─LogicalAgg { aggs: [sum(count(t.x)), sum(t.y), sum(t.y)] }
+      └─LogicalAgg { group_key: [t.y, t.y], aggs: [count(t.x)] }
+        └─LogicalScan { table: t, columns: [t.x, t.y] }
 - sql: |
     create table t(x int, y int);
     select count(y), sum(distinct y) from t;
   optimized_logical_plan: |
     LogicalProject { exprs: [Coalesce(sum(count(t.y)), 0:Int64), sum(t.y)] }
-      LogicalAgg { aggs: [sum(count(t.y)), sum(t.y)] }
-        LogicalAgg { group_key: [t.y], aggs: [count(t.y)] }
-          LogicalScan { table: t, columns: [t.y] }
+    └─LogicalAgg { aggs: [sum(count(t.y)), sum(t.y)] }
+      └─LogicalAgg { group_key: [t.y], aggs: [count(t.y)] }
+        └─LogicalScan { table: t, columns: [t.y] }
 - sql: |
     create table t(x int, y int);
     select count(distinct x), sum(distinct y) from t;
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(t.x) filter((flag = 0:Int64)), sum(t.y) filter((flag = 1:Int64))] }
-      LogicalAgg { group_key: [t.x, t.y, flag], aggs: [] }
-        LogicalProject { exprs: [t.x, t.y, flag] }
-          LogicalExpand { column_subsets: [[t.x], [t.y]] }
-            LogicalScan { table: t, columns: [t.x, t.y] }
+    └─LogicalAgg { group_key: [t.x, t.y, flag], aggs: [] }
+      └─LogicalProject { exprs: [t.x, t.y, flag] }
+        └─LogicalExpand { column_subsets: [[t.x], [t.y]] }
+          └─LogicalScan { table: t, columns: [t.x, t.y] }
 - sql: |
     create table t(x varchar, y int);
     select string_agg(x, ','), count(distinct y) from t;
@@ -716,7 +716,7 @@
     select max(distinct x), min(distinct y) from t;
   optimized_logical_plan: |
     LogicalAgg { aggs: [max(t.x), min(t.y)] }
-      LogicalScan { table: t, columns: [t.x, t.y] }
+    └─LogicalScan { table: t, columns: [t.x, t.y] }
 - sql: |
     /* agg filter: subquery */
     /* This case is valid in PostgreSQL */

--- a/src/frontend/planner_test/tests/testdata/append_only.yaml
+++ b/src/frontend/planner_test/tests/testdata/append_only.yaml
@@ -4,36 +4,36 @@
     select v1, max(v2) as mx2 from t1 group by v1;
   stream_plan: |
     StreamMaterialize { columns: [v1, mx2], pk_columns: [v1] }
-      StreamProject { exprs: [t1.v1, max(t1.v2)] }
-        StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [count, max(t1.v2)] }
-          StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamProject { exprs: [t1.v1, max(t1.v2)] }
+      └─StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [count, max(t1.v2)] }
+        └─StreamExchange { dist: HashShard(t1.v1) }
+          └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     create table t2 (v1 int, v3 int) with (appendonly = true);
     select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
   stream_plan: |
     StreamMaterialize { columns: [id, v2, v3, t1._row_id(hidden), t2._row_id(hidden), t2.v1(hidden)], pk_columns: [t1._row_id, t2._row_id, id, t2.v1] }
-      StreamAppendOnlyHashJoin { type: Inner, predicate: t1.v1 = t2.v1, append_only: true, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id, t2.v1] }
-        StreamExchange { dist: HashShard(t1.v1) }
-          StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
-        StreamExchange { dist: HashShard(t2.v1) }
-          StreamTableScan { table: t2, columns: [t2.v1, t2.v3, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+    └─StreamAppendOnlyHashJoin { type: Inner, predicate: t1.v1 = t2.v1, append_only: true, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id, t2.v1] }
+      ├─StreamExchange { dist: HashShard(t1.v1) }
+      | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+      └─StreamExchange { dist: HashShard(t2.v1) }
+        └─StreamTableScan { table: t2, columns: [t2.v1, t2.v3, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     select v1 from t1 order by v1 limit 3 offset 3;
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id], order_descs: [v1, t1._row_id] }
-      StreamAppendOnlyTopN { order: "[t1.v1 ASC]", limit: 3, offset: 3 }
-        StreamExchange { dist: Single }
-          StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamAppendOnlyTopN { order: "[t1.v1 ASC]", limit: 3, offset: 3 }
+      └─StreamExchange { dist: Single }
+        └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int) with (appendonly = true);
     select max(v1) as max_v1 from t1;
   stream_plan: |
     StreamMaterialize { columns: [max_v1], pk_columns: [] }
-      StreamProject { exprs: [max(max(t1.v1))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(t1.v1))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, max(t1.v1)] }
-              StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamProject { exprs: [max(max(t1.v1))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(t1.v1))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(t1.v1)] }
+            └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/array.yaml
@@ -16,16 +16,16 @@
     select (ARRAY[1, v1]) from t;
   logical_plan: |
     LogicalProject { exprs: [Array(1:Int32, t.v1)] }
-      LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Array(1:Int32, t.v1)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Array(1:Int32, t.v1)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     select ARRAY[null];
   logical_plan: |
     LogicalProject { exprs: [Array(null:Varchar)] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[];
   binder_error: |-
@@ -35,12 +35,12 @@
     select ARRAY[]::int[];
   logical_plan: |
     LogicalProject { exprs: [Array::List { datatype: Int32 }] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int[][];
   logical_plan: |
     LogicalProject { exprs: [Array::List { datatype: List { datatype: Int32 } }] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int;
   binder_error: |-
@@ -50,26 +50,26 @@
     select array_cat(array[66], array[123]);
   logical_plan: |
     LogicalProject { exprs: [ArrayCat(Array(66:Int32), Array(123:Int32))] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
     BatchProject { exprs: [ArrayCat(Array(66:Int32), Array(123:Int32))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select array_cat(array[array[66]], array[233]);
   logical_plan: |
     LogicalProject { exprs: [ArrayCat(Array(Array(66:Int32)), Array(233:Int32))] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
     BatchProject { exprs: [ArrayCat(Array(Array(66:Int32)), Array(233:Int32))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select array_cat(array[233], array[array[66]]);
   logical_plan: |
     LogicalProject { exprs: [ArrayCat(Array(233:Int32), Array(Array(66:Int32)))] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
     BatchProject { exprs: [ArrayCat(Array(233:Int32), Array(Array(66:Int32)))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select array_cat(array[233], array[array[array[66]]]);
   binder_error: 'Bind error: Cannot concatenate integer[] and integer[][][]'
@@ -83,10 +83,10 @@
     select array_append(array[66], 123);
   logical_plan: |
     LogicalProject { exprs: [ArrayAppend(Array(66:Int32), 123:Int32)] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
     BatchProject { exprs: [ArrayAppend(Array(66:Int32), 123:Int32)] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select array_append(123, 234);
   binder_error: 'Bind error: Cannot append integer to integer'
@@ -97,10 +97,10 @@
     select array_prepend(123, array[66]);
   logical_plan: |
     LogicalProject { exprs: [ArrayPrepend(123:Int32, Array(66:Int32))] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
     BatchProject { exprs: [ArrayPrepend(123:Int32, Array(66:Int32))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select array_prepend(123, 234);
   binder_error: 'Bind error: Cannot prepend integer to integer'
@@ -122,7 +122,7 @@
     select ('{c,' || 'd}')::varchar[];
   logical_plan: |
     LogicalProject { exprs: [ConcatOp('{c,':Varchar, 'd}':Varchar)::List { datatype: Varchar }] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* unknown to varchar[] in implicit context */
     values (array['a', 'b']), ('{c,d}');
@@ -134,23 +134,23 @@
     insert into t values ('{c,d}');
   logical_plan: |
     LogicalInsert { table: t }
-      LogicalValues { rows: [['{c,d}':Varchar::List { datatype: Varchar }]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Varchar }] } }
+    └─LogicalValues { rows: [['{c,d}':Varchar::List { datatype: Varchar }]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Varchar }] } }
 - sql: |
     /* unknown to varchar[] in explicit context */
     select ('{c,d}')::varchar[];
   logical_plan: |
     LogicalProject { exprs: ['{c,d}':Varchar::List { datatype: Varchar }] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* varchar[] to string in assign context */
     create table t (v1 varchar);
     insert into t values (array['a', 'b']);
   logical_plan: |
     LogicalInsert { table: t }
-      LogicalValues { rows: [[Array('a':Varchar, 'b':Varchar)::Varchar]], schema: Schema { fields: [*VALUES*_0.column_0:Varchar] } }
+    └─LogicalValues { rows: [[Array('a':Varchar, 'b':Varchar)::Varchar]], schema: Schema { fields: [*VALUES*_0.column_0:Varchar] } }
 - sql: |
     /* varchar[] to string in explicit context */
     select array['a', 'b']::varchar;
   logical_plan: |
     LogicalProject { exprs: [Array('a':Varchar, 'b':Varchar)::Varchar] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }

--- a/src/frontend/planner_test/tests/testdata/array_access.yaml
+++ b/src/frontend/planner_test/tests/testdata/array_access.yaml
@@ -3,13 +3,13 @@
     select (ARRAY['foo', 'bar'])[1];
   logical_plan: |
     LogicalProject { exprs: [ArrayAccess(Array('foo':Varchar, 'bar':Varchar), 1:Int32)] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t(i int[]);
     select min(i) from t where i[1]>2;
   batch_plan: |
     BatchSimpleAgg { aggs: [min(min(t.i))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [min(t.i)] }
-          BatchFilter { predicate: (ArrayAccess(t.i, 1:Int32) > 2:Int32) }
-            BatchScan { table: t, columns: [t.i], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [min(t.i)] }
+        └─BatchFilter { predicate: (ArrayAccess(t.i, 1:Int32) > 2:Int32) }
+          └─BatchScan { table: t, columns: [t.i], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/basic_query.yaml
@@ -9,10 +9,10 @@
     select * from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t2.* from t;
@@ -22,107 +22,107 @@
     select * from t where 1>2 and 1=1 and 3<1 and 4<>1 or 1=1 and 2>=1 and 1<=2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
-        BatchScan { table: t, columns: [], distribution: SomeShard }
+    └─BatchFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
+      └─BatchScan { table: t, columns: [], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
-        StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamFilter { predicate: (1:Int32 = 1:Int32) AND ((((1:Int32 > 2:Int32) AND (3:Int32 < 1:Int32)) AND (4:Int32 <> 1:Int32)) OR ((2:Int32 >= 1:Int32) AND (1:Int32 <= 2:Int32))) }
+      └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select * from t where v1<1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (t.v1 < 1:Int32) }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchFilter { predicate: (t.v1 < 1:Int32) }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamFilter { predicate: (t.v1 < 1:Int32) }
-        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamFilter { predicate: (t.v1 < 1:Int32) }
+      └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* test boolean expression common factor extraction */
     create table t (v1 Boolean, v2 Boolean, v3 Boolean);
     select * from t where v1 AND v2 AND ((v1 AND v2) OR (v2 AND v3));
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: t.v1 AND t.v2 AND (t.v1 OR t.v3) }
-        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchFilter { predicate: t.v1 AND t.v2 AND (t.v1 OR t.v3) }
+      └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* test boolean expression simplification */
     create table t (v1 Boolean, v2 Boolean, v3 Boolean);
     select * from t where v1 AND NOT(v1 OR v2 Or NOT(v1 AND v2 AND true));
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: t.v1 AND Not(t.v1) AND Not(t.v2) AND t.v2 }
-        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchFilter { predicate: t.v1 AND Not(t.v1) AND Not(t.v2) AND t.v2 }
+      └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - sql: |
     /* test boolean expression simplification */
     create table t (v1 Boolean, v2 Boolean);
     select * from t where (v1 AND v2) OR (v1 AND v2);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: t.v1 AND t.v2 }
-        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchFilter { predicate: t.v1 AND t.v2 }
+      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     /* constant folding for IS TRUE, IS FALSE, IS NULL*/
     create table t(a Boolean);
     select * from t where (NULL IS NULL) IS TRUE AND FALSE IS FALSE AND a;
   logical_plan: |
     LogicalProject { exprs: [t.a] }
-      LogicalFilter { predicate: t.a }
-        LogicalScan { table: t, columns: [t.a, t._row_id] }
+    └─LogicalFilter { predicate: t.a }
+      └─LogicalScan { table: t, columns: [t.a, t._row_id] }
 - sql: |
     /* constant folding for IS NOT TRUE, IS NOT FALSE */
     create table t(a Boolean);
     select * from t where (NULL IS NOT TRUE) IS NOT FALSE AND a IS NOT TRUE;
   logical_plan: |
     LogicalProject { exprs: [t.a] }
-      LogicalFilter { predicate: IsNotTrue(t.a) }
-        LogicalScan { table: t, columns: [t.a, t._row_id] }
+    └─LogicalFilter { predicate: IsNotTrue(t.a) }
+      └─LogicalScan { table: t, columns: [t.a, t._row_id] }
 - sql: |
     /* constant folding IS NOT NULL */
     create table t(a double precision);
     select * from t where (a IS NOT NULL AND 3.14 IS NOT NULL) OR (NULL IS NOT NULL);
   logical_plan: |
     LogicalProject { exprs: [t.a] }
-      LogicalFilter { predicate: IsNotNull(t.a) }
-        LogicalScan { table: t, columns: [t.a, t._row_id] }
+    └─LogicalFilter { predicate: IsNotNull(t.a) }
+      └─LogicalScan { table: t, columns: [t.a, t._row_id] }
 - sql: |
     create table t (v1 int, v2 int);
     select v1 from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: select 1
   batch_plan: |
     BatchProject { exprs: [1:Int32] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select a from t as t2(a);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchDelete { table: t }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchDelete { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     delete from t where v1 = 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchDelete { table: t }
-        BatchExchange { order: [], dist: Single }
-          BatchFilter { predicate: (t.v1 = 1:Int32) }
-            BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchDelete { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchFilter { predicate: (t.v1 = 1:Int32) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     select * from generate_series('2'::INT,'10'::INT,'2'::INT);
   batch_plan: |
@@ -150,7 +150,7 @@
     select * from t;
   logical_plan: |
     LogicalProject { exprs: [] }
-      LogicalScan { table: t, columns: [t._row_id] }
+    └─LogicalScan { table: t, columns: [t._row_id] }
 - sql: |
     /* disallow subquery in values */
     values(1, (select 1));
@@ -169,14 +169,14 @@
     select * from t limit 1
   batch_plan: |
     BatchLimit { limit: 1, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchLimit { limit: 1, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchLimit { limit: 1, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 limit 1
   batch_plan: |
     BatchTopN { order: "[t.v1 ASC]", limit: 1, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[t.v1 ASC]", limit: 1, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[t.v1 ASC]", limit: 1, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/batch_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/batch_dist_agg.yaml
@@ -12,13 +12,13 @@
     select max(v) as a1 from S;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(s.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(s.v)] }
-          BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(s.v)] }
+        └─BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [max(s.v)] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
 - id: extreme_on_T
   before:
   - create_tables
@@ -26,13 +26,13 @@
     select max(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [max(t.v)] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
 - id: sum_on_T
   before:
   - create_tables
@@ -40,13 +40,13 @@
     select sum(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [sum(t.v)] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
 - id: cnt_on_T
   before:
   - create_tables
@@ -54,13 +54,13 @@
     select count(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [count(t.v)] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
 - id: string_agg_on_T
   before:
   - create_tables
@@ -68,14 +68,14 @@
     select string_agg(s, ',' order by o) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
 - id: extreme_count_on_T
   before:
   - create_tables
@@ -83,13 +83,13 @@
     select max(v) as a1, count(v) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(t.v)), sum(count(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(t.v), count(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(t.v), count(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [max(t.v), count(t.v)] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
 - id: count_string_agg_on_T
   before:
   - create_tables
@@ -97,14 +97,14 @@
     select count(v) as a1, string_agg(s, ',' order by o) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
 - id: extreme_string_agg_on_T
   before:
   - create_tables
@@ -112,14 +112,14 @@
     select max(v) as a1, string_agg(s, ',' order by o) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
   batch_local_plan: |
     BatchSimpleAgg { aggs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
 - id: extreme_on_T_by_k
   before:
   - create_tables
@@ -127,15 +127,15 @@
     select max(v) as a1 from T group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(t.v)] }
-        BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
-          BatchExchange { order: [], dist: HashShard(t.k) }
-            BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
+    └─BatchProject { exprs: [max(t.v)] }
+      └─BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
+        └─BatchExchange { order: [], dist: HashShard(t.k) }
+          └─BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
   batch_local_plan: |
     BatchProject { exprs: [max(t.v)] }
-      BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
 - id: extreme_on_Tk_by_k
   before:
   - create_tables
@@ -143,14 +143,14 @@
     select max(v) as a1 from Tk group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(tk.v)] }
-        BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
-          BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
+    └─BatchProject { exprs: [max(tk.v)] }
+      └─BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
+        └─BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
   batch_local_plan: |
     BatchProject { exprs: [max(tk.v)] }
-      BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
-        BatchExchange { order: [tk.k ASC], dist: Single }
-          BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
+    └─BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
+      └─BatchExchange { order: [tk.k ASC], dist: Single }
+        └─BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
 - id: extreme_on_S_by_k
   before:
   - create_tables
@@ -158,11 +158,11 @@
     select max(v) as a1 from S group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(s.v)] }
-        BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
-          BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
+    └─BatchProject { exprs: [max(s.v)] }
+      └─BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
+        └─BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
   batch_local_plan: |
     BatchProject { exprs: [max(s.v)] }
-      BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
+    └─BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }

--- a/src/frontend/planner_test/tests/testdata/column_pruning.yaml
+++ b/src/frontend/planner_test/tests/testdata/column_pruning.yaml
@@ -4,7 +4,7 @@
     select v1 from t
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [t.v1] }
 - sql: |
@@ -13,8 +13,8 @@
     select v1 from t where v2 > 2
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalFilter { predicate: (t.v2 > 2:Int32) }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 2:Int32) }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
 - sql: |
@@ -24,87 +24,87 @@
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t2.v1] }
-      LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
-        LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
-        LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
+    └─LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
+      ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
+      └─LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: [t1.v1, t2.v1] }
-      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
-      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
+    ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+    └─LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* agg */
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(v1) from t where v2 > 2
   logical_plan: |
     LogicalProject { exprs: [count(t.v1)] }
-      LogicalAgg { aggs: [count(t.v1)] }
-        LogicalProject { exprs: [t.v1] }
-          LogicalFilter { predicate: (t.v2 > 2:Int32) }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [count(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalFilter { predicate: (t.v2 > 2:Int32) }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(t.v1)] }
-      LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
+    └─LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 2:Int32) }
 - sql: |
     /* top n */
     create table t (v1 int, v2 int, v3 int);
     select v3 from (select * from t order by v3, v2 limit 2) as s;
   logical_plan: |
     LogicalProject { exprs: [t.v3] }
-      LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
-        LogicalProject { exprs: [t.v1, t.v2, t.v3] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
+      └─LogicalProject { exprs: [t.v1, t.v2, t.v3] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v3] }
-      LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
-        LogicalScan { table: t, columns: [t.v2, t.v3] }
+    └─LogicalTopN { order: "[t.v3 ASC, t.v2 ASC]", limit: 2, offset: 0 }
+      └─LogicalScan { table: t, columns: [t.v2, t.v3] }
 - sql: |
     /* constant */
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalScan { table: t, columns: [] }
+    └─LogicalScan { table: t, columns: [] }
 - sql: |
     /* constant + filter */
     create table t (v1 bigint, v2 double precision, v3 int);
     select 1 from t where v2>1
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalScan { table: t, output_columns: [], required_columns: [v2], predicate: (t.v2 > 1:Int32) }
+    └─LogicalScan { table: t, output_columns: [], required_columns: [v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     /* constant agg */
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1) from t
   logical_plan: |
     LogicalProject { exprs: [count(1:Int32)] }
-      LogicalAgg { aggs: [count(1:Int32)] }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [count(1:Int32)] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32)] }
-      LogicalProject { exprs: [1:Int32] }
-        LogicalScan { table: t, columns: [] }
+    └─LogicalProject { exprs: [1:Int32] }
+      └─LogicalScan { table: t, columns: [] }
 - sql: |
     /* constant agg + filter */
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1) from t where v2>1
   logical_plan: |
     LogicalProject { exprs: [count(1:Int32)] }
-      LogicalAgg { aggs: [count(1:Int32)] }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalFilter { predicate: (t.v2 > 1:Int32) }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [count(1:Int32)] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32)] }
-      LogicalProject { exprs: [1:Int32] }
-        LogicalScan { table: t, output_columns: [], required_columns: [v2], predicate: (t.v2 > 1:Int32) }
+    └─LogicalProject { exprs: [1:Int32] }
+      └─LogicalScan { table: t, output_columns: [], required_columns: [v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     /* join + filter */
     create table t1 (v1 int, v2 int, v3 int);
@@ -112,44 +112,44 @@
     select t1.v1, t2.v1 from t1 join t2 on t1.v2 = t2.v2 where t1.v3 < 1;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t2.v1] }
-      LogicalFilter { predicate: (t1.v3 < 1:Int32) }
-        LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.v3 < 1:Int32) }
+      └─LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: [t1.v1, t2.v1] }
-      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2, v3], predicate: (t1.v3 < 1:Int32) }
-      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
+    ├─LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2, v3], predicate: (t1.v3 < 1:Int32) }
+    └─LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* mixed */
     create table t (v1 bigint, v2 double precision, v3 int);
     select count(1), count(v1) from t where v2>1
   logical_plan: |
     LogicalProject { exprs: [count(1:Int32), count(t.v1)] }
-      LogicalAgg { aggs: [count(1:Int32), count(t.v1)] }
-        LogicalProject { exprs: [1:Int32, t.v1] }
-          LogicalFilter { predicate: (t.v2 > 1:Int32) }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { aggs: [count(1:Int32), count(t.v1)] }
+      └─LogicalProject { exprs: [1:Int32, t.v1] }
+        └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32), count(t.v1)] }
-      LogicalProject { exprs: [1:Int32, t.v1] }
-        LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
+    └─LogicalProject { exprs: [1:Int32, t.v1] }
+      └─LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
     /* hop window, time_col not selected */
     create table t1 (a int, b int, created_at timestamp);
     select a, window_end from hop(t1, created_at, interval '15' minute, interval '30' minute)
   logical_plan: |
     LogicalProject { exprs: [t1.a, window_end] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-        LogicalScan { table: t1, columns: [t1.a, t1.b, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.a, t1.b, t1.created_at, t1._row_id] }
   optimized_logical_plan: |
     LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end] }
-      LogicalScan { table: t1, columns: [t1.a, t1.created_at] }
+    └─LogicalScan { table: t1, columns: [t1.a, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.a, t1.created_at], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.a, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_end] }
-      StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.a, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.a, window_end, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.a, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/common_table_expressions.yaml
+++ b/src/frontend/planner_test/tests/testdata/common_table_expressions.yaml
@@ -4,60 +4,60 @@
     with cte as (select v1, v2 from t1) select v1 from cte;
   logical_plan: |
     LogicalProject { exprs: [t1.v1] }
-      LogicalProject { exprs: [t1.v1, t1.v2] }
-        LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
+    └─LogicalProject { exprs: [t1.v1, t1.v2] }
+      └─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id] }
-      StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v3 int, v4 int);
     with cte as (select v1 from t1) select * from t2 inner join cte on t2.v3 = cte.v1;
   logical_plan: |
     LogicalProject { exprs: [t2.v3, t2.v4, t1.v1] }
-      LogicalJoin { type: Inner, on: (t2.v3 = t1.v1), output: all }
-        LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
-        LogicalProject { exprs: [t1.v1] }
-          LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
+    └─LogicalJoin { type: Inner, on: (t2.v3 = t1.v1), output: all }
+      ├─LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
+      └─LogicalProject { exprs: [t1.v1] }
+        └─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [v3, v4, v1, t2._row_id(hidden), t1._row_id(hidden)], pk_columns: [t2._row_id, t1._row_id, v3, v1] }
-      StreamHashJoin { type: Inner, predicate: t2.v3 = t1.v1, output: [t2.v3, t2.v4, t1.v1, t2._row_id, t1._row_id] }
-        StreamExchange { dist: HashShard(t2.v3) }
-          StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
-        StreamExchange { dist: HashShard(t1.v1) }
-          StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t2.v3 = t1.v1, output: [t2.v3, t2.v4, t1.v1, t2._row_id, t1._row_id] }
+      ├─StreamExchange { dist: HashShard(t2.v3) }
+      | └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+      └─StreamExchange { dist: HashShard(t1.v1) }
+        └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v3 int, v4 int);
     with cte as (select v1, v2 from t1), cte2 as (select v1 from cte) select * from cte2;
   logical_plan: |
     LogicalProject { exprs: [t1.v1] }
-      LogicalProject { exprs: [t1.v1] }
-        LogicalProject { exprs: [t1.v1, t1.v2] }
-          LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
+    └─LogicalProject { exprs: [t1.v1] }
+      └─LogicalProject { exprs: [t1.v1, t1.v2] }
+        └─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t1._row_id(hidden)], pk_columns: [t1._row_id] }
-      StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (x int);
     with with_0 as (select * from t1 group by x having EXISTS(select 0.1)) select * from with_0;
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalProject { exprs: [t1.x] }
-        LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-          LogicalAgg { group_key: [t1.x], aggs: [] }
-            LogicalProject { exprs: [t1.x] }
-              LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
-          LogicalProject { exprs: [0.1:Decimal] }
-            LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalProject { exprs: [t1.x] }
+      └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+        ├─LogicalAgg { group_key: [t1.x], aggs: [] }
+        | └─LogicalProject { exprs: [t1.x] }
+        |   └─LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
+        └─LogicalProject { exprs: [0.1:Decimal] }
+          └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* Ensure we can bind CTE with aliases in both table name and columns */
     create table t1 (x int, y int);
     with cte (cost) as (select * from t1) select * from cte as t2 (outflow, profit) join cte on (outflow = cost);
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y, t1.x, t1.y] }
-      LogicalJoin { type: Inner, on: (t1.x = t1.x), output: all }
-        LogicalProject { exprs: [t1.x, t1.y] }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t1.x, t1.y] }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+    └─LogicalJoin { type: Inner, on: (t1.x = t1.x), output: all }
+      ├─LogicalProject { exprs: [t1.x, t1.y] }
+      | └─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t1.x, t1.y] }
+        └─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }

--- a/src/frontend/planner_test/tests/testdata/distribution_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/distribution_derive.yaml
@@ -12,34 +12,34 @@
   sql: select A.v, B.v as Bv from A join B using(k1);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [a.v, b.v] }
-        BatchExchange { order: [], dist: HashShard(a.k1) }
-          BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(b.k1) }
-          BatchScan { table: b, columns: [b.k1, b.v], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [a.v, b.v] }
+      ├─BatchExchange { order: [], dist: HashShard(a.k1) }
+      | └─BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(b.k1) }
+        └─BatchScan { table: b, columns: [b.k1, b.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), bk1.b._row_id(hidden), bk1.k1(hidden)], pk_columns: [ak1.a._row_id, bk1.b._row_id, ak1.k1, bk1.k1] }
-      StreamDeltaJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v, ak1.a._row_id, ak1.k1, bk1.b._row_id, bk1.k1] }
-        StreamIndexScan { index: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: HashShard(ak1.k1) }
-        StreamIndexScan { index: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: HashShard(bk1.k1) }
+    └─StreamDeltaJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v, ak1.a._row_id, ak1.k1, bk1.b._row_id, bk1.k1] }
+      ├─StreamIndexScan { index: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: HashShard(ak1.k1) }
+      └─StreamIndexScan { index: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: HashShard(bk1.k1) }
 - id: Ak1_join_B_onk1
   before:
   - create_tables
   sql: select A.v, B.v as Bv from Ak1 as A join B using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: ak1.k1 = b.k1, output: [ak1.v, b.v] }
-        BatchExchange { order: [], dist: HashShard(ak1.k1) }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
-        BatchExchange { order: [], dist: HashShard(b.k1) }
-          BatchScan { table: b, columns: [b.k1, b.v], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: ak1.k1 = b.k1, output: [ak1.v, b.v] }
+      ├─BatchExchange { order: [], dist: HashShard(ak1.k1) }
+      | └─BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+      └─BatchExchange { order: [], dist: HashShard(b.k1) }
+        └─BatchScan { table: b, columns: [b.k1, b.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), b._row_id(hidden), b.k1(hidden)], pk_columns: [ak1.a._row_id, b._row_id, ak1.k1, b.k1] }
-      StreamHashJoin { type: Inner, predicate: ak1.k1 = b.k1, output: [ak1.v, b.v, ak1.a._row_id, ak1.k1, b._row_id, b.k1] }
-        StreamExchange { dist: HashShard(ak1.k1) }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
-        StreamExchange { dist: HashShard(b.k1) }
-          StreamTableScan { table: b, columns: [b.k1, b.v, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: ak1.k1 = b.k1, output: [ak1.v, b.v, ak1.a._row_id, ak1.k1, b._row_id, b.k1] }
+      ├─StreamExchange { dist: HashShard(ak1.k1) }
+      | └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+      └─StreamExchange { dist: HashShard(b.k1) }
+        └─StreamTableScan { table: b, columns: [b.k1, b.v, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), b._row_id(hidden), b.k1(hidden)], pk_columns: [ak1.a._row_id, b._row_id, ak1.k1, b.k1] }
@@ -70,18 +70,18 @@
   sql: select A.v, B.v as Bv from A join Bk1 as B using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: a.k1 = bk1.k1, output: [a.v, bk1.v] }
-        BatchExchange { order: [], dist: HashShard(a.k1) }
-          BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(bk1.k1) }
-          BatchScan { table: bk1, columns: [bk1.k1, bk1.v], distribution: UpstreamHashShard(bk1.k1) }
+    └─BatchHashJoin { type: Inner, predicate: a.k1 = bk1.k1, output: [a.v, bk1.v] }
+      ├─BatchExchange { order: [], dist: HashShard(a.k1) }
+      | └─BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(bk1.k1) }
+        └─BatchScan { table: bk1, columns: [bk1.k1, bk1.v], distribution: UpstreamHashShard(bk1.k1) }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, a._row_id(hidden), a.k1(hidden), bk1.b._row_id(hidden), bk1.k1(hidden)], pk_columns: [a._row_id, bk1.b._row_id, a.k1, bk1.k1] }
-      StreamHashJoin { type: Inner, predicate: a.k1 = bk1.k1, output: [a.v, bk1.v, a._row_id, a.k1, bk1.b._row_id, bk1.k1] }
-        StreamExchange { dist: HashShard(a.k1) }
-          StreamTableScan { table: a, columns: [a.k1, a.v, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
-        StreamExchange { dist: HashShard(bk1.k1) }
-          StreamTableScan { table: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: UpstreamHashShard(bk1.k1) }
+    └─StreamHashJoin { type: Inner, predicate: a.k1 = bk1.k1, output: [a.v, bk1.v, a._row_id, a.k1, bk1.b._row_id, bk1.k1] }
+      ├─StreamExchange { dist: HashShard(a.k1) }
+      | └─StreamTableScan { table: a, columns: [a.k1, a.v, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+      └─StreamExchange { dist: HashShard(bk1.k1) }
+        └─StreamTableScan { table: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: UpstreamHashShard(bk1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [v, bv, a._row_id(hidden), a.k1(hidden), bk1.b._row_id(hidden), bk1.k1(hidden)], pk_columns: [a._row_id, bk1.b._row_id, a.k1, bk1.k1] }
@@ -112,18 +112,18 @@
   sql: select A.v, B.v as Bv from Ak1 as A join Bk1 as B using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v] }
-        BatchExchange { order: [], dist: HashShard(ak1.k1) }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
-        BatchExchange { order: [], dist: HashShard(bk1.k1) }
-          BatchScan { table: bk1, columns: [bk1.k1, bk1.v], distribution: UpstreamHashShard(bk1.k1) }
+    └─BatchHashJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v] }
+      ├─BatchExchange { order: [], dist: HashShard(ak1.k1) }
+      | └─BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+      └─BatchExchange { order: [], dist: HashShard(bk1.k1) }
+        └─BatchScan { table: bk1, columns: [bk1.k1, bk1.v], distribution: UpstreamHashShard(bk1.k1) }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), bk1.b._row_id(hidden), bk1.k1(hidden)], pk_columns: [ak1.a._row_id, bk1.b._row_id, ak1.k1, bk1.k1] }
-      StreamHashJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v, ak1.a._row_id, ak1.k1, bk1.b._row_id, bk1.k1] }
-        StreamExchange { dist: HashShard(ak1.k1) }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
-        StreamExchange { dist: HashShard(bk1.k1) }
-          StreamTableScan { table: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: UpstreamHashShard(bk1.k1) }
+    └─StreamHashJoin { type: Inner, predicate: ak1.k1 = bk1.k1, output: [ak1.v, bk1.v, ak1.a._row_id, ak1.k1, bk1.b._row_id, bk1.k1] }
+      ├─StreamExchange { dist: HashShard(ak1.k1) }
+      | └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+      └─StreamExchange { dist: HashShard(bk1.k1) }
+        └─StreamTableScan { table: bk1, columns: [bk1.k1, bk1.v, bk1.b._row_id], pk: [bk1.b._row_id], distribution: UpstreamHashShard(bk1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), bk1.b._row_id(hidden), bk1.k1(hidden)], pk_columns: [ak1.a._row_id, bk1.b._row_id, ak1.k1, bk1.k1] }
@@ -157,16 +157,16 @@
     group by k1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(a.v)] }
-        BatchHashAgg { group_key: [a.k1], aggs: [max(a.v)] }
-          BatchExchange { order: [], dist: HashShard(a.k1) }
-            BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
+    └─BatchProject { exprs: [max(a.v)] }
+      └─BatchHashAgg { group_key: [a.k1], aggs: [max(a.v)] }
+        └─BatchExchange { order: [], dist: HashShard(a.k1) }
+          └─BatchScan { table: a, columns: [a.k1, a.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_v, a.k1(hidden)], pk_columns: [a.k1] }
-      StreamProject { exprs: [max(a.v), a.k1] }
-        StreamHashAgg { group_key: [a.k1], aggs: [count, max(a.v)] }
-          StreamExchange { dist: HashShard(a.k1) }
-            StreamTableScan { table: a, columns: [a.k1, a.v, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamProject { exprs: [max(a.v), a.k1] }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(a.v)] }
+        └─StreamExchange { dist: HashShard(a.k1) }
+          └─StreamTableScan { table: a, columns: [a.k1, a.v, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_v, a.k1(hidden)], pk_columns: [a.k1] }
@@ -193,14 +193,14 @@
     group by k1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(ak1.v)] }
-        BatchSortAgg { group_key: [ak1.k1], aggs: [max(ak1.v)] }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+    └─BatchProject { exprs: [max(ak1.v)] }
+      └─BatchSortAgg { group_key: [ak1.k1], aggs: [max(ak1.v)] }
+        └─BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1.k1(hidden)], pk_columns: [ak1.k1] }
-      StreamProject { exprs: [max(ak1.v), ak1.k1] }
-        StreamHashAgg { group_key: [ak1.k1], aggs: [count, max(ak1.v)] }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+    └─StreamProject { exprs: [max(ak1.v), ak1.k1] }
+      └─StreamHashAgg { group_key: [ak1.k1], aggs: [count, max(ak1.v)] }
+        └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_v, ak1.k1(hidden)], pk_columns: [ak1.k1] }
@@ -224,16 +224,16 @@
     group by k1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(ak1k2.v)] }
-        BatchSortAgg { group_key: [ak1k2.k1], aggs: [max(ak1k2.v)] }
-          BatchExchange { order: [ak1k2.k1 ASC], dist: HashShard(ak1k2.k1) }
-            BatchScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.v], distribution: SomeShard }
+    └─BatchProject { exprs: [max(ak1k2.v)] }
+      └─BatchSortAgg { group_key: [ak1k2.k1], aggs: [max(ak1k2.v)] }
+        └─BatchExchange { order: [ak1k2.k1 ASC], dist: HashShard(ak1k2.k1) }
+          └─BatchScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1k2.k1(hidden)], pk_columns: [ak1k2.k1] }
-      StreamProject { exprs: [max(ak1k2.v), ak1k2.k1] }
-        StreamHashAgg { group_key: [ak1k2.k1], aggs: [count, max(ak1k2.v)] }
-          StreamExchange { dist: HashShard(ak1k2.k1) }
-            StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.v, ak1k2.k2, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
+    └─StreamProject { exprs: [max(ak1k2.v), ak1k2.k1] }
+      └─StreamHashAgg { group_key: [ak1k2.k1], aggs: [count, max(ak1k2.v)] }
+        └─StreamExchange { dist: HashShard(ak1k2.k1) }
+          └─StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.v, ak1k2.k2, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_v, ak1k2.k1(hidden)], pk_columns: [ak1k2.k1] }
@@ -260,16 +260,16 @@
     group by k2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(ak1k2.v)] }
-        BatchHashAgg { group_key: [ak1k2.k2], aggs: [max(ak1k2.v)] }
-          BatchExchange { order: [], dist: HashShard(ak1k2.k2) }
-            BatchScan { table: ak1k2, columns: [ak1k2.k2, ak1k2.v], distribution: SomeShard }
+    └─BatchProject { exprs: [max(ak1k2.v)] }
+      └─BatchHashAgg { group_key: [ak1k2.k2], aggs: [max(ak1k2.v)] }
+        └─BatchExchange { order: [], dist: HashShard(ak1k2.k2) }
+          └─BatchScan { table: ak1k2, columns: [ak1k2.k2, ak1k2.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1k2.k2(hidden)], pk_columns: [ak1k2.k2] }
-      StreamProject { exprs: [max(ak1k2.v), ak1k2.k2] }
-        StreamHashAgg { group_key: [ak1k2.k2], aggs: [count, max(ak1k2.v)] }
-          StreamExchange { dist: HashShard(ak1k2.k2) }
-            StreamTableScan { table: ak1k2, columns: [ak1k2.k2, ak1k2.v, ak1k2.k1, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
+    └─StreamProject { exprs: [max(ak1k2.v), ak1k2.k2] }
+      └─StreamHashAgg { group_key: [ak1k2.k2], aggs: [count, max(ak1k2.v)] }
+        └─StreamExchange { dist: HashShard(ak1k2.k2) }
+          └─StreamTableScan { table: ak1k2, columns: [ak1k2.k2, ak1k2.v, ak1k2.k1, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_v, ak1k2.k2(hidden)], pk_columns: [ak1k2.k2] }
@@ -296,14 +296,14 @@
     group by k1, k2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [sum(ak1k2.v)] }
-        BatchSortAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [sum(ak1k2.v)] }
-          BatchScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
+    └─BatchProject { exprs: [sum(ak1k2.v)] }
+      └─BatchSortAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [sum(ak1k2.v)] }
+        └─BatchScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_plan: |
     StreamMaterialize { columns: [sum_v, ak1k2.k1(hidden), ak1k2.k2(hidden)], pk_columns: [ak1k2.k1, ak1k2.k2] }
-      StreamProject { exprs: [sum(ak1k2.v), ak1k2.k1, ak1k2.k2] }
-        StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [count, sum(ak1k2.v)] }
-          StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
+    └─StreamProject { exprs: [sum(ak1k2.v), ak1k2.k1, ak1k2.k2] }
+      └─StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [count, sum(ak1k2.v)] }
+        └─StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v, ak1k2.a._row_id], pk: [ak1k2.a._row_id], distribution: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [sum_v, ak1k2.k1(hidden), ak1k2.k2(hidden)], pk_columns: [ak1k2.k1, ak1k2.k2] }
@@ -327,14 +327,14 @@
     group by k1, k2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [sum(ak1.v)] }
-        BatchHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [sum(ak1.v)] }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+    └─BatchProject { exprs: [sum(ak1.v)] }
+      └─BatchHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [sum(ak1.v)] }
+        └─BatchScan { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
   stream_plan: |
     StreamMaterialize { columns: [sum_v, ak1.k1(hidden), ak1.k2(hidden)], pk_columns: [ak1.k1, ak1.k2] }
-      StreamProject { exprs: [sum(ak1.v), ak1.k1, ak1.k2] }
-        StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [count, sum(ak1.v)] }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+    └─StreamProject { exprs: [sum(ak1.v), ak1.k1, ak1.k2] }
+      └─StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [count, sum(ak1.v)] }
+        └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [sum_v, ak1.k1(hidden), ak1.k2(hidden)], pk_columns: [ak1.k1, ak1.k2] }
@@ -364,19 +364,19 @@
     group by k1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(count)] }
-        BatchHashAgg { group_key: [a.k1], aggs: [max(count)] }
-          BatchHashAgg { group_key: [a.k1], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(a.k1) }
-              BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
+    └─BatchProject { exprs: [max(count)] }
+      └─BatchHashAgg { group_key: [a.k1], aggs: [max(count)] }
+        └─BatchHashAgg { group_key: [a.k1], aggs: [count] }
+          └─BatchExchange { order: [], dist: HashShard(a.k1) }
+            └─BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1] }
-      StreamProject { exprs: [max(count), a.k1] }
-        StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
-          StreamProject { exprs: [a.k1, count] }
-            StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-              StreamExchange { dist: HashShard(a.k1) }
-                StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamProject { exprs: [max(count), a.k1] }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
+        └─StreamProject { exprs: [a.k1, count] }
+          └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+            └─StreamExchange { dist: HashShard(a.k1) }
+              └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1] }
@@ -414,22 +414,22 @@
     group by k1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(count)] }
-        BatchHashAgg { group_key: [a.k1], aggs: [max(count)] }
-          BatchExchange { order: [], dist: HashShard(a.k1) }
-            BatchProject { exprs: [a.k1, count] }
-              BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
-                BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
-                  BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
+    └─BatchProject { exprs: [max(count)] }
+      └─BatchHashAgg { group_key: [a.k1], aggs: [max(count)] }
+        └─BatchExchange { order: [], dist: HashShard(a.k1) }
+          └─BatchProject { exprs: [a.k1, count] }
+            └─BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+              └─BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
+                └─BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1] }
-      StreamProject { exprs: [max(count), a.k1] }
-        StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
-          StreamExchange { dist: HashShard(a.k1) }
-            StreamProject { exprs: [a.k1, count, a.k2] }
-              StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-                StreamExchange { dist: HashShard(a.k1, a.k2) }
-                  StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamProject { exprs: [max(count), a.k1] }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
+        └─StreamExchange { dist: HashShard(a.k1) }
+          └─StreamProject { exprs: [a.k1, count, a.k2] }
+            └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
+              └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+                └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1] }
@@ -470,22 +470,22 @@
     group by k2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(count)] }
-        BatchHashAgg { group_key: [a.k2], aggs: [max(count)] }
-          BatchExchange { order: [], dist: HashShard(a.k2) }
-            BatchProject { exprs: [a.k2, count] }
-              BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
-                BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
-                  BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
+    └─BatchProject { exprs: [max(count)] }
+      └─BatchHashAgg { group_key: [a.k2], aggs: [max(count)] }
+        └─BatchExchange { order: [], dist: HashShard(a.k2) }
+          └─BatchProject { exprs: [a.k2, count] }
+            └─BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+              └─BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
+                └─BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k2(hidden)], pk_columns: [a.k2] }
-      StreamProject { exprs: [max(count), a.k2] }
-        StreamHashAgg { group_key: [a.k2], aggs: [count, max(count)] }
-          StreamExchange { dist: HashShard(a.k2) }
-            StreamProject { exprs: [a.k2, count, a.k1] }
-              StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-                StreamExchange { dist: HashShard(a.k1, a.k2) }
-                  StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamProject { exprs: [max(count), a.k2] }
+      └─StreamHashAgg { group_key: [a.k2], aggs: [count, max(count)] }
+        └─StreamExchange { dist: HashShard(a.k2) }
+          └─StreamProject { exprs: [a.k2, count, a.k1] }
+            └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
+              └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+                └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k2(hidden)], pk_columns: [a.k2] }
@@ -526,19 +526,19 @@
     group by k1, k2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(count)] }
-        BatchHashAgg { group_key: [a.k1, a.k2], aggs: [max(count)] }
-          BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
-              BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
+    └─BatchProject { exprs: [max(count)] }
+      └─BatchHashAgg { group_key: [a.k1, a.k2], aggs: [max(count)] }
+        └─BatchHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+          └─BatchExchange { order: [], dist: HashShard(a.k1, a.k2) }
+            └─BatchScan { table: a, columns: [a.k1, a.k2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden), a.k2(hidden)], pk_columns: [a.k1, a.k2] }
-      StreamProject { exprs: [max(count), a.k1, a.k2] }
-        StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, max(count)] }
-          StreamProject { exprs: [a.k1, a.k2, count] }
-            StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-              StreamExchange { dist: HashShard(a.k1, a.k2) }
-                StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamProject { exprs: [max(count), a.k1, a.k2] }
+      └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, max(count)] }
+        └─StreamProject { exprs: [a.k1, a.k2, count] }
+          └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
+            └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+              └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden), a.k2(hidden)], pk_columns: [a.k1, a.k2] }
@@ -574,22 +574,22 @@
     select A.v, B.num as Bv from Ak1 as A join B using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: ak1.k1 = a.k1, output: [ak1.v, count] }
-        BatchExchange { order: [], dist: HashShard(ak1.k1) }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
-        BatchProject { exprs: [count, a.k1] }
-          BatchHashAgg { group_key: [a.k1], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(a.k1) }
-              BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: ak1.k1 = a.k1, output: [ak1.v, count] }
+      ├─BatchExchange { order: [], dist: HashShard(ak1.k1) }
+      | └─BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+      └─BatchProject { exprs: [count, a.k1] }
+        └─BatchHashAgg { group_key: [a.k1], aggs: [count] }
+          └─BatchExchange { order: [], dist: HashShard(a.k1) }
+            └─BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), a.k1(hidden)], pk_columns: [ak1.a._row_id, a.k1, ak1.k1] }
-      StreamHashJoin { type: Inner, predicate: ak1.k1 = a.k1, output: [ak1.v, count, ak1.a._row_id, ak1.k1, a.k1] }
-        StreamExchange { dist: HashShard(ak1.k1) }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
-        StreamProject { exprs: [count, a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-            StreamExchange { dist: HashShard(a.k1) }
-              StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: ak1.k1 = a.k1, output: [ak1.v, count, ak1.a._row_id, ak1.k1, a.k1] }
+      ├─StreamExchange { dist: HashShard(ak1.k1) }
+      | └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+      └─StreamProject { exprs: [count, a.k1] }
+        └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+          └─StreamExchange { dist: HashShard(a.k1) }
+            └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [v, bv, ak1.a._row_id(hidden), ak1.k1(hidden), a.k1(hidden)], pk_columns: [ak1.a._row_id, a.k1, ak1.k1] }
@@ -632,22 +632,22 @@
     select A.v, B.num as Bv from B join Ak1 as A using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count] }
-        BatchProject { exprs: [count, a.k1] }
-          BatchHashAgg { group_key: [a.k1], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(a.k1) }
-              BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(ak1.k1) }
-          BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
+    └─BatchHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count] }
+      ├─BatchProject { exprs: [count, a.k1] }
+      | └─BatchHashAgg { group_key: [a.k1], aggs: [count] }
+      |   └─BatchExchange { order: [], dist: HashShard(a.k1) }
+      |     └─BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(ak1.k1) }
+        └─BatchScan { table: ak1, columns: [ak1.k1, ak1.v], distribution: UpstreamHashShard(ak1.k1) }
   stream_plan: |
     StreamMaterialize { columns: [v, bv, a.k1(hidden), ak1.a._row_id(hidden), ak1.k1(hidden)], pk_columns: [a.k1, ak1.a._row_id, ak1.k1] }
-      StreamHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count, a.k1, ak1.a._row_id, ak1.k1] }
-        StreamProject { exprs: [count, a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-            StreamExchange { dist: HashShard(a.k1) }
-              StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
-        StreamExchange { dist: HashShard(ak1.k1) }
-          StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
+    └─StreamHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count, a.k1, ak1.a._row_id, ak1.k1] }
+      ├─StreamProject { exprs: [count, a.k1] }
+      | └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+      |   └─StreamExchange { dist: HashShard(a.k1) }
+      |     └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+      └─StreamExchange { dist: HashShard(ak1.k1) }
+        └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], distribution: UpstreamHashShard(ak1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [v, bv, a.k1(hidden), ak1.a._row_id(hidden), ak1.k1(hidden)], pk_columns: [a.k1, ak1.a._row_id, ak1.k1] }
@@ -695,26 +695,26 @@
     select A.num, B.num as Bv from A join B using(k1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count] }
-        BatchProject { exprs: [count, a.k1] }
-          BatchHashAgg { group_key: [a.k1], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(a.k1) }
-              BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
-        BatchProject { exprs: [count, b.k1] }
-          BatchHashAgg { group_key: [b.k1], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(b.k1) }
-              BatchScan { table: b, columns: [b.k1], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count] }
+      ├─BatchProject { exprs: [count, a.k1] }
+      | └─BatchHashAgg { group_key: [a.k1], aggs: [count] }
+      |   └─BatchExchange { order: [], dist: HashShard(a.k1) }
+      |     └─BatchScan { table: a, columns: [a.k1], distribution: SomeShard }
+      └─BatchProject { exprs: [count, b.k1] }
+        └─BatchHashAgg { group_key: [b.k1], aggs: [count] }
+          └─BatchExchange { order: [], dist: HashShard(b.k1) }
+            └─BatchScan { table: b, columns: [b.k1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [num, bv, a.k1(hidden), b.k1(hidden)], pk_columns: [a.k1, b.k1] }
-      StreamHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count, a.k1, b.k1] }
-        StreamProject { exprs: [count, a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-            StreamExchange { dist: HashShard(a.k1) }
-              StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
-        StreamProject { exprs: [count, b.k1] }
-          StreamHashAgg { group_key: [b.k1], aggs: [count, count] }
-            StreamExchange { dist: HashShard(b.k1) }
-              StreamTableScan { table: b, columns: [b.k1, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count, a.k1, b.k1] }
+      ├─StreamProject { exprs: [count, a.k1] }
+      | └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+      |   └─StreamExchange { dist: HashShard(a.k1) }
+      |     └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+      └─StreamProject { exprs: [count, b.k1] }
+        └─StreamHashAgg { group_key: [b.k1], aggs: [count, count] }
+          └─StreamExchange { dist: HashShard(b.k1) }
+            └─StreamTableScan { table: b, columns: [b.k1, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [num, bv, a.k1(hidden), b.k1(hidden)], pk_columns: [a.k1, b.k1] }
@@ -754,19 +754,19 @@
     select * from hop(t1, created_at, interval '15' minute, interval '30' minute);
   logical_plan: |
     LogicalProject { exprs: [t1.row_id, t1.uid, t1.v, t1.created_at, window_start, window_end] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-        LogicalScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at, t1._row_id] }
   optimized_logical_plan: |
     LogicalHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-      LogicalScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at] }
+    └─LogicalScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: all }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [row_id, uid, v, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start, window_end] }
-      StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.row_id, t1.uid, t1.v, t1.created_at, window_start, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 00:15:00, size: 00:30:00, output: [t1.row_id, t1.uid, t1.v, t1.created_at, window_start, window_end, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.row_id, t1.uid, t1.v, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [row_id, uid, v, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start, window_end] }

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -4,13 +4,13 @@
     select int '1';
   logical_plan: |
     LogicalProject { exprs: ['1':Varchar::Int32] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* bind typed literal */
     SELECT bool 't'
   logical_plan: |
     LogicalProject { exprs: ['t':Varchar::Boolean] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     values(must_be_unimplemented_func(1));
   binder_error: |-
@@ -29,38 +29,38 @@
     select (((((false is not true) is true) is not false) is false) is not null) is null from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [IsNull(IsNotNull(IsFalse(IsNotFalse(IsTrue(IsNotTrue(false:Boolean))))))] }
-        BatchScan { table: t, columns: [], distribution: SomeShard }
+    └─BatchProject { exprs: [IsNull(IsNotNull(IsFalse(IsNotFalse(IsTrue(IsNotTrue(false:Boolean))))))] }
+      └─BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* bind between */
     SELECT 1 between 2 and 3
   logical_plan: |
     LogicalProject { exprs: [((1:Int32 >= 2:Int32) AND (1:Int32 <= 3:Int32))] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* bind is distinct from */
     SELECT 1 IS DISTINCT FROM 2
   logical_plan: |
     LogicalProject { exprs: [IsDistinctFrom(1:Int32, 2:Int32)] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* bind is not distinct from */
     SELECT 1 IS NOT DISTINCT FROM 2
   logical_plan: |
     LogicalProject { exprs: [IsNotDistinctFrom(1:Int32, 2:Int32)] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     /* in-list with aligned types */
     SELECT 1::real in (3, 1.0, 2);
   batch_plan: |
     BatchProject { exprs: [In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32)] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     /* not in-list with aligned types */
     SELECT 1::real not in (3, 1.0, 2);
   batch_plan: |
     BatchProject { exprs: [Not(In(1:Int32::Float32, 3:Int32::Float32, 1.0:Decimal::Float32, 2:Int32::Float32))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     /* in-list with misaligned types */
     SELECT true in (3, 1.0, 2);
@@ -71,10 +71,10 @@
     SELECT 1 in (3, 0.5*2, min(v1)) from t;
   batch_plan: |
     BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = min(min(t.v1))))] }
-      BatchSimpleAgg { aggs: [min(min(t.v1))] }
-        BatchExchange { order: [], dist: Single }
-          BatchSimpleAgg { aggs: [min(t.v1)] }
-            BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [min(t.v1)] }
+          └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* in-list with non-const: scalar subquery */
     create table t (v1 int);
@@ -82,14 +82,14 @@
     SELECT b2 from b where 1 in (3, 1.0, (select min(v1) from t));
   batch_plan: |
     BatchProject { exprs: [b.b2] }
-      BatchFilter { predicate: (In(1:Int32::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (1:Int32 = min(min(t.v1)))) }
-        BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: b, columns: [b.b2], distribution: SomeShard }
-          BatchSimpleAgg { aggs: [min(min(t.v1))] }
-            BatchExchange { order: [], dist: Single }
-              BatchSimpleAgg { aggs: [min(t.v1)] }
-                BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchFilter { predicate: (In(1:Int32::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (1:Int32 = min(min(t.v1)))) }
+      └─BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: b, columns: [b.b2], distribution: SomeShard }
+        └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
+          └─BatchExchange { order: [], dist: Single }
+            └─BatchSimpleAgg { aggs: [min(t.v1)] }
+              └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* in-list with non-const: correlated ref */
     create table t (v1 int);
@@ -97,16 +97,16 @@
     SELECT b2 from b where exists (select 2 from t where v1 in (3, 1.0, b1));
   batch_plan: |
     BatchNestedLoopJoin { type: LeftSemi, predicate: (In(t.v1::Decimal, 3:Int32::Decimal, 1.0:Decimal) OR (t.v1 = b.b1)), output: [b.b2] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: b, columns: [b.b1, b.b2], distribution: SomeShard }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v1, t.v1] }
-          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    ├─BatchExchange { order: [], dist: Single }
+    | └─BatchScan { table: b, columns: [b.b1, b.b2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v1, t.v1] }
+        └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     select +1.0, -2.0;
   batch_plan: |
     BatchProject { exprs: [1.0:Decimal, -2.0:Decimal] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     values(round(42.4382, 2));
   batch_plan: |
@@ -152,41 +152,41 @@
     select length(trim(trailing '1' from '12'))+length(trim(leading '2' from '23'))+length(trim(both '3' from '34'));
   batch_plan: |
     BatchProject { exprs: [((Length(Rtrim('12':Varchar, '1':Varchar)) + Length(Ltrim('23':Varchar, '2':Varchar))) + Length(Trim('34':Varchar, '3':Varchar)))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select position(replace('1','1','2'),'123') where '12' like '%1';
   batch_plan: |
     BatchProject { exprs: [Position(Replace('1':Varchar, '1':Varchar, '2':Varchar), '123':Varchar)] }
-      BatchFilter { predicate: Like('12':Varchar, '%1':Varchar) }
-        BatchValues { rows: [[]] }
+    └─BatchFilter { predicate: Like('12':Varchar, '%1':Varchar) }
+      └─BatchValues { rows: [[]] }
 - sql: |
     /* case searched form with else */
     create table t (v1 int);
     select (case when v1=1 then 1 when v1=2 then 2 else 0.0 end) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2:Int32::Decimal, 0.0:Decimal), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* case searched form without else */
     create table t (v1 int);
     select (case when v1=1 then 1 when v1=2 then 2.1 end) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2.1:Decimal)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2:Int32), 2.1:Decimal)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* case simple form */
     create table t (v1 int);
     select (case v1 when 1 then 1 when 2.0 then 2 else 0.0 end) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2.0:Decimal), 2:Int32::Decimal, 0.0:Decimal)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Case((t.v1 = 1:Int32), 1:Int32::Decimal, (t.v1 = 2.0:Decimal), 2:Int32::Decimal, 0.0:Decimal)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* case misaligned result types */
     create table t (v1 int);
@@ -204,12 +204,12 @@
     select nullif(v1, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [Case((t.v1 = 1:Int32), null:Int32, t.v1), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select nullif(v1, 1, 2) from t;
@@ -225,19 +225,19 @@
     select coalesce(v1, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Coalesce(t.v1, 1:Int32)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Coalesce(t.v1, 1:Int32)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamProject { exprs: [Coalesce(t.v1, 1:Int32), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [Coalesce(t.v1, 1:Int32), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int);
     select coalesce(v1, 1.2) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Coalesce(t.v1::Decimal, 1.2:Decimal)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [Coalesce(t.v1::Decimal, 1.2:Decimal)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select coalesce() from t;
@@ -251,19 +251,19 @@
     select concat_ws(v1, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [ConcatWs(t.v1, 1:Int32::Varchar), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar);
     select concat_ws(v1, 1.2) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [ConcatWs(t.v1, 1.2:Decimal::Varchar)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [ConcatWs(t.v1, 1.2:Decimal::Varchar)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select concat_ws(v1, 1.2) from t;
@@ -277,19 +277,19 @@
     select concat(v1, v2, v3, 1) as expr from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar)] }
-        BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar)] }
+      └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [expr, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [ConcatWs('':Varchar, t.v1, t.v2::Varchar, t.v3::Varchar, 1:Int32::Varchar), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 float);
     select concat(v1) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [ConcatWs('':Varchar, t.v1::Varchar)] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [ConcatWs('':Varchar, t.v1::Varchar)] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 int);
     select concat() from t;
@@ -298,44 +298,44 @@
     select concat(':', true);
   batch_plan: |
     BatchProject { exprs: [ConcatWs('':Varchar, ':':Varchar, BoolOut(true:Boolean))] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select ':' || true;
   batch_plan: |
     BatchProject { exprs: [ConcatOp(':':Varchar, true:Boolean::Varchar)] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select substr('hello', NULL);
   batch_plan: |
     BatchProject { exprs: [Substr('hello':Varchar, null:Int32)] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select substr(NULL, 1);
   batch_plan: |
     BatchProject { exprs: [Substr(null:Varchar, 1:Int32)] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select pg_typeof('123');
   batch_plan: |
     BatchProject { exprs: ['unknown':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select pg_typeof(round(null));
   batch_plan: |
     BatchProject { exprs: ['double precision':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select pg_typeof(row(true, 1, 'hello'));
   batch_plan: |
     BatchProject { exprs: ['record':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select pg_typeof(array[1, 2]);
   batch_plan: |
     BatchProject { exprs: ['integer[]':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select pg_typeof(array[array[1, 2], array[3, 4]]);
   batch_plan: |
     BatchProject { exprs: ['integer[][]':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }

--- a/src/frontend/planner_test/tests/testdata/index.yaml
+++ b/src/frontend/planner_test/tests/testdata/index.yaml
@@ -8,9 +8,9 @@
     select * from t1, t2 where t1.v1 = t2.v3;
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, t1_v1.t1._row_id(hidden), t2_v3.t2._row_id(hidden)], pk_columns: [t1_v1.t1._row_id, t2_v3.t2._row_id, v1, v3] }
-      StreamDeltaJoin { type: Inner, predicate: t1_v1.v1 = t2_v3.v3, output: [t1_v1.v1, t1_v1.v2, t2_v3.v3, t2_v3.v4, t2_v3.v5, t1_v1.t1._row_id, t2_v3.t2._row_id] }
-        StreamIndexScan { index: t1_v1, columns: [t1_v1.v1, t1_v1.v2, t1_v1.t1._row_id], pk: [t1_v1.t1._row_id], distribution: HashShard(t1_v1.v1) }
-        StreamIndexScan { index: t2_v3, columns: [t2_v3.v3, t2_v3.v4, t2_v3.v5, t2_v3.t2._row_id], pk: [t2_v3.t2._row_id], distribution: HashShard(t2_v3.v3) }
+    └─StreamDeltaJoin { type: Inner, predicate: t1_v1.v1 = t2_v3.v3, output: [t1_v1.v1, t1_v1.v2, t2_v3.v3, t2_v3.v4, t2_v3.v5, t1_v1.t1._row_id, t2_v3.t2._row_id] }
+      ├─StreamIndexScan { index: t1_v1, columns: [t1_v1.v1, t1_v1.v2, t1_v1.t1._row_id], pk: [t1_v1.t1._row_id], distribution: HashShard(t1_v1.v1) }
+      └─StreamIndexScan { index: t2_v3, columns: [t2_v3.v3, t2_v3.v4, t2_v3.v5, t2_v3.t2._row_id], pk: [t2_v3.t2._row_id], distribution: HashShard(t2_v3.v3) }
 - id: index_slt
   sql: |
     create table iii_t1 (v1 int, v2 int);
@@ -25,15 +25,15 @@
     select * from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, v4, iii_index_1.iii_t1._row_id(hidden), iii_index_2.iii_t2._row_id(hidden)], pk_columns: [iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id, v1, v3] }
-      StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output: [iii_index_1.v1, iii_index_1.v2, iii_index_2.v3, iii_index_2.v4, iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id] }
-        StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.v2, iii_index_1.iii_t1._row_id], pk: [iii_index_1.iii_t1._row_id], distribution: HashShard(iii_index_1.v1) }
-        StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk: [iii_index_2.iii_t2._row_id], distribution: HashShard(iii_index_2.v3) }
+    └─StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output: [iii_index_1.v1, iii_index_1.v2, iii_index_2.v3, iii_index_2.v4, iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id] }
+      ├─StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.v2, iii_index_1.iii_t1._row_id], pk: [iii_index_1.iii_t1._row_id], distribution: HashShard(iii_index_1.v1) }
+      └─StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk: [iii_index_2.iii_t2._row_id], distribution: HashShard(iii_index_2.v3) }
 - before:
   - index_slt
   sql: |
     select v4 from iii_t1, iii_t2 where iii_t1.v1 = iii_t2.v3;
   stream_plan: |
     StreamMaterialize { columns: [v4, iii_index_1.iii_t1._row_id(hidden), iii_index_1.v1(hidden), iii_index_2.iii_t2._row_id(hidden), iii_index_2.v3(hidden)], pk_columns: [iii_index_1.iii_t1._row_id, iii_index_2.iii_t2._row_id, iii_index_1.v1, iii_index_2.v3] }
-      StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output: [iii_index_2.v4, iii_index_1.iii_t1._row_id, iii_index_1.v1, iii_index_2.iii_t2._row_id, iii_index_2.v3] }
-        StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.iii_t1._row_id], pk: [iii_index_1.iii_t1._row_id], distribution: HashShard(iii_index_1.v1) }
-        StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk: [iii_index_2.iii_t2._row_id], distribution: HashShard(iii_index_2.v3) }
+    └─StreamDeltaJoin { type: Inner, predicate: iii_index_1.v1 = iii_index_2.v3, output: [iii_index_2.v4, iii_index_1.iii_t1._row_id, iii_index_1.v1, iii_index_2.iii_t2._row_id, iii_index_2.v3] }
+      ├─StreamIndexScan { index: iii_index_1, columns: [iii_index_1.v1, iii_index_1.iii_t1._row_id], pk: [iii_index_1.iii_t1._row_id], distribution: HashShard(iii_index_1.v1) }
+      └─StreamIndexScan { index: iii_index_2, columns: [iii_index_2.v3, iii_index_2.v4, iii_index_2.iii_t2._row_id], pk: [iii_index_2.iii_t2._row_id], distribution: HashShard(iii_index_2.v3) }

--- a/src/frontend/planner_test/tests/testdata/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/index_selection.yaml
@@ -5,7 +5,7 @@
     select * from t1 where a = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     /* Use index if it provides required order */
     create table t1 (a int, b int, c int);
@@ -13,35 +13,35 @@
     select * from t1 order by a, b
   batch_plan: |
     BatchExchange { order: [idx1.a ASC, idx1.b ASC], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = 1 or a = 2
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a in (1,2,3)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2) OR idx1.a = Int32(3)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2) OR idx1.a = Int32(3)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a between 1 and 8
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2) OR idx1.a = Int32(3) OR idx1.a = Int32(4) OR idx1.a = Int32(5) OR idx1.a = Int32(6) OR idx1.a = Int32(7) OR idx1.a = Int32(8)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2) OR idx1.a = Int32(3) OR idx1.a = Int32(4) OR idx1.a = Int32(5) OR idx1.a = Int32(6) OR idx1.a = Int32(7) OR idx1.a = Int32(8)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select * from t1 where a = 1 and b = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1), idx1.b = Decimal(Normalized(1))], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1), idx1.b = Decimal(Normalized(1))], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
@@ -49,7 +49,7 @@
     select * from t1 where b = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(1))], distribution: UpstreamHashShard(idx2.b, idx2.a) }
+    └─BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(1))], distribution: UpstreamHashShard(idx2.b, idx2.a) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b);
@@ -58,8 +58,8 @@
     select * from t1 where b = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(1))], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
+      └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(1))], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
@@ -68,16 +68,16 @@
     select * from t1 where c = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (t1.c = 1:Int32) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], distribution: SomeShard }
+    └─BatchFilter { predicate: (t1.c = 1:Int32) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
     select a,b from t1 where a in (1,2) and b in (2,3)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: In(idx1.b, 2:Int32::Decimal, 3:Int32::Decimal) }
-        BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
+    └─BatchFilter { predicate: In(idx1.b, 2:Int32::Decimal, 3:Int32::Decimal) }
+      └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], scan_ranges: [idx1.a = Int32(1) OR idx1.a = Int32(2)], distribution: UpstreamHashShard(idx1.a, idx1.b) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a, b) include(c);
@@ -85,10 +85,10 @@
     select count(1) from t1;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(1:Int32))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(1:Int32)] }
-          BatchProject { exprs: [1:Int32] }
-            BatchScan { table: idx2, columns: [], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(1:Int32)] }
+        └─BatchProject { exprs: [1:Int32] }
+          └─BatchScan { table: idx2, columns: [], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a) include (b, c);
@@ -97,8 +97,8 @@
     select * from t1 where c = 1 and a < 10;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (idx3.a < 10:Int32) }
-        BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c], scan_ranges: [idx3.c = Int64(1)], distribution: UpstreamHashShard(idx3.c) }
+    └─BatchFilter { predicate: (idx3.a < 10:Int32) }
+      └─BatchScan { table: idx3, columns: [idx3.a, idx3.b, idx3.c], scan_ranges: [idx3.c = Int64(1)], distribution: UpstreamHashShard(idx3.c) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a) include (b, c);
@@ -107,7 +107,7 @@
     select * from t1 where a = 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a) }
+    └─BatchScan { table: idx1, columns: [idx1.a, idx1.b, idx1.c], scan_ranges: [idx1.a = Int32(1)], distribution: UpstreamHashShard(idx1.a) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a) include (b, c);
@@ -116,7 +116,7 @@
     select * from t1 where a = 1 and b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: UpstreamHashShard(idx2.b, idx2.a) }
+    └─BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: UpstreamHashShard(idx2.b, idx2.a) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a) include (b, c);
@@ -125,7 +125,7 @@
     select * from t1 where b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: UpstreamHashShard(idx2.b, idx2.a) }
+    └─BatchScan { table: idx2, columns: [idx2.a, idx2.b, idx2.c], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: UpstreamHashShard(idx2.b, idx2.a) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -134,12 +134,12 @@
     select * from t1 where c = 1 and a < 10;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx3.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.a < 10:Int32), output: [t1.a, t1.b, t1.c] }
-        BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx3.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.a < 10:Int32), output: [t1.a, t1.b, t1.c] }
+      └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx3.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.a < 10:Int32), output: [t1.a, t1.b, t1.c] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -148,12 +148,12 @@
     select * from t1 where a = 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-        BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
+      └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -162,12 +162,12 @@
     select * from t1 where a = 1 and b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
+      └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -176,12 +176,12 @@
     select * from t1 where b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
+      └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -190,15 +190,15 @@
     delete from t1 where b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchDelete { table: t1 }
-        BatchExchange { order: [], dist: Single }
-          BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+    └─BatchDelete { table: t1 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
+          └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
   batch_local_plan: |
     BatchDelete { table: t1 }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -207,15 +207,15 @@
     update t1 set c = 3 where a = 1 and b = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t1, exprs: [$0, $1, 3:Int32::Int64, $3] }
-        BatchExchange { order: [], dist: Single }
-          BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
+    └─BatchUpdate { table: t1, exprs: [$0, $1, 3:Int32::Int64, $3] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
+          └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchUpdate { table: t1, exprs: [$0, $1, 3:Int32::Int64, $3] }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id, output: [t1.a, t1.b, t1.c, t1._row_id] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create materialized view v as select count(*) as cnt, p from t1 group by p;
@@ -223,22 +223,22 @@
     select * from v where cnt = 1 or p = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.v.p IS NOT DISTINCT FROM v.p AND ((v.cnt = 1:Int32) OR (v.p = 2:Int32)), output: [v.cnt, v.p] }
-        BatchHashAgg { group_key: [idx1.v.p], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.v.p) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.v.p], scan_ranges: [idx1.cnt = Int64(1)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: v, columns: [v.p], scan_ranges: [v.p = Int32(2)], distribution: UpstreamHashShard(v.p) }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.v.p IS NOT DISTINCT FROM v.p AND ((v.cnt = 1:Int32) OR (v.p = 2:Int32)), output: [v.cnt, v.p] }
+      └─BatchHashAgg { group_key: [idx1.v.p], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.v.p) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.v.p], scan_ranges: [idx1.cnt = Int64(1)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: v, columns: [v.p], scan_ranges: [v.p = Int32(2)], distribution: UpstreamHashShard(v.p) }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.v.p IS NOT DISTINCT FROM v.p AND ((v.cnt = 1:Int32) OR (v.p = 2:Int32)), output: [v.cnt, v.p] }
-      BatchHashAgg { group_key: [idx1.v.p], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.v.p], scan_ranges: [idx1.cnt = Int64(1)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: v, columns: [v.p], scan_ranges: [v.p = Int32(2)], distribution: UpstreamHashShard(v.p) }
+    └─BatchHashAgg { group_key: [idx1.v.p], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.v.p], scan_ranges: [idx1.cnt = Int64(1)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: v, columns: [v.p], scan_ranges: [v.p = Int32(2)], distribution: UpstreamHashShard(v.p) }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -247,22 +247,22 @@
     select * from t1 where a = 1 or c = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR (t1.c = 1:Int32)), output: [t1.a, t1.b, t1.c] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR (t1.c = 1:Int32)), output: [t1.a, t1.b, t1.c] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR (t1.c = 1:Int32)), output: [t1.a, t1.b, t1.c] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint);
     create index idx1 on t1(a);
@@ -271,22 +271,22 @@
     select * from t1 where c = 1 or (a = 2 and b = 3)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.c = 1:Int32) OR ((t1.a = 2:Int32) AND (t1.b = 3:Int32))), output: [t1.a, t1.b, t1.c] }
-        BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx2.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.c = 1:Int32) OR ((t1.a = 2:Int32) AND (t1.b = 3:Int32))), output: [t1.a, t1.b, t1.c] }
+      └─BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx2.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.c = 1:Int32) OR ((t1.a = 2:Int32) AND (t1.b = 3:Int32))), output: [t1.a, t1.b, t1.c] }
-      BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -296,22 +296,22 @@
     select * from t1 where p = 1 or (a = 2 and b = 3 and c = 4)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.p = 1:Int32) OR (((t1.a = 2:Int32) AND (t1.b = 3:Int32)) AND (t1.c = 4:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx2.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(1)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.p = 1:Int32) OR (((t1.a = 2:Int32) AND (t1.b = 3:Int32)) AND (t1.c = 4:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx2.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(1)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx2.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.p = 1:Int32) OR (((t1.a = 2:Int32) AND (t1.b = 3:Int32)) AND (t1.c = 4:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(1)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx2.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3)), idx2.a = Int32(2)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(1)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -321,30 +321,30 @@
     select * from t1 where a = 1 or b = 2 or c = 3 or p = 4 or a = 5
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((((t1.a = 1:Int32) OR (t1.b = 2:Int32)) OR (t1.c = 3:Int32)) OR (t1.p = 4:Int32)) OR (t1.a = 5:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(5) OR idx1.a = Int32(1)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(4)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((((t1.a = 1:Int32) OR (t1.b = 2:Int32)) OR (t1.c = 3:Int32)) OR (t1.p = 4:Int32)) OR (t1.a = 5:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(5) OR idx1.a = Int32(1)], distribution: SomeShard }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(4)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((((t1.a = 1:Int32) OR (t1.b = 2:Int32)) OR (t1.c = 3:Int32)) OR (t1.p = 4:Int32)) OR (t1.a = 5:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(5) OR idx1.a = Int32(1)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(4)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(5) OR idx1.a = Int32(1)], distribution: SomeShard }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2))], distribution: SomeShard }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx4, columns: [idx4.t1._row_id], scan_ranges: [idx4.p = Int32(4)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -354,22 +354,22 @@
     select * from t1 where (a = 1 or (b = 2 and a = 5)) and (c = 3 or p = 4)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR ((t1.b = 2:Int32) AND (t1.a = 5:Int32))) AND ((t1.c = 3:Int32) OR (t1.p = 4:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(5)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR ((t1.b = 2:Int32) AND (t1.a = 5:Int32))) AND ((t1.c = 3:Int32) OR (t1.p = 4:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(5)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND ((t1.a = 1:Int32) OR ((t1.b = 2:Int32) AND (t1.a = 5:Int32))) AND ((t1.c = 3:Int32) OR (t1.p = 4:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(5)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(1)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(2)), idx2.a = Int32(5)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -379,26 +379,26 @@
     select * from t1 where p != 1 and (c = 3 or (c != 4 and (a = 2 or b = 3)))
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.p <> 1:Int32) AND ((t1.c = 3:Int32) OR ((t1.c <> 4:Int32) AND ((t1.a = 2:Int32) OR (t1.b = 3:Int32)))), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(2)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3))], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.p <> 1:Int32) AND ((t1.c = 3:Int32) OR ((t1.c <> 4:Int32) AND ((t1.a = 2:Int32) OR (t1.b = 3:Int32)))), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(2)], distribution: SomeShard }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3))], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (t1.p <> 1:Int32) AND ((t1.c = 3:Int32) OR ((t1.c <> 4:Int32) AND ((t1.a = 2:Int32) OR (t1.b = 3:Int32)))), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(2)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3))], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a = Int32(2)], distribution: SomeShard }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx2, columns: [idx2.t1._row_id], scan_ranges: [idx2.b = Decimal(Normalized(3))], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(3)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -409,22 +409,22 @@
     select * from t1 where (a > 1 and a < 8) or c between 8 and 9
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR ((t1.c >= 8:Int32) AND (t1.c <= 9:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8) OR idx3.c = Int64(9)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR ((t1.c >= 8:Int32) AND (t1.c <= 9:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8) OR idx3.c = Int64(9)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR ((t1.c >= 8:Int32) AND (t1.c <= 9:Int32))), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8) OR idx3.c = Int64(9)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8) OR idx3.c = Int64(9)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -434,22 +434,22 @@
     select * from t1 where (a > 1 and a < 8) or c = 8
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR (t1.c = 8:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-        BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
-            BatchUnion { all: true }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
-              BatchExchange { order: [], dist: Single }
-                BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8)], distribution: SomeShard }
+    └─BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR (t1.c = 8:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
+      └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(idx1.t1._row_id) }
+          └─BatchUnion { all: true }
+            ├─BatchExchange { order: [], dist: Single }
+            | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8)], distribution: SomeShard }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: idx1.t1._row_id IS NOT DISTINCT FROM t1._row_id AND (((t1.a > 1:Int32) AND (t1.a < 8:Int32)) OR (t1.c = 8:Int32)), output: [t1.a, t1.b, t1.c, t1.p] }
-      BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
-        BatchUnion { all: true }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8)], distribution: SomeShard }
+    └─BatchHashAgg { group_key: [idx1.t1._row_id], aggs: [] }
+      └─BatchUnion { all: true }
+        ├─BatchExchange { order: [], dist: Single }
+        | └─BatchScan { table: idx1, columns: [idx1.t1._row_id], scan_ranges: [idx1.a > Int32(1) AND idx1.a < Int32(8)], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: idx3, columns: [idx3.t1._row_id], scan_ranges: [idx3.c = Int64(8)], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -459,12 +459,12 @@
     select * from t1 where a > 1 or c > 1 or b > 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (((t1.a > 1:Int32) OR (t1.c > 1:Int32)) OR (t1.b > 1:Int32)) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: (((t1.a > 1:Int32) OR (t1.c > 1:Int32)) OR (t1.b > 1:Int32)) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
   batch_local_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (((t1.a > 1:Int32) OR (t1.c > 1:Int32)) OR (t1.b > 1:Int32)) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: (((t1.a > 1:Int32) OR (t1.c > 1:Int32)) OR (t1.b > 1:Int32)) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -474,12 +474,12 @@
     select * from t1 where a between 1 and 8 or b between 1 and 8 or c between 1 and 8;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: ((((t1.a >= 1:Int32) AND (t1.a <= 8:Int32)) OR ((t1.b >= 1:Int32) AND (t1.b <= 8:Int32))) OR ((t1.c >= 1:Int32) AND (t1.c <= 8:Int32))) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: ((((t1.a >= 1:Int32) AND (t1.a <= 8:Int32)) OR ((t1.b >= 1:Int32) AND (t1.b <= 8:Int32))) OR ((t1.c >= 1:Int32) AND (t1.c <= 8:Int32))) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
   batch_local_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: ((((t1.a >= 1:Int32) AND (t1.a <= 8:Int32)) OR ((t1.b >= 1:Int32) AND (t1.b <= 8:Int32))) OR ((t1.c >= 1:Int32) AND (t1.c <= 8:Int32))) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: ((((t1.a >= 1:Int32) AND (t1.a <= 8:Int32)) OR ((t1.b >= 1:Int32) AND (t1.b <= 8:Int32))) OR ((t1.c >= 1:Int32) AND (t1.c <= 8:Int32))) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
 - sql: |
     create table t1 (a int, b numeric, c bigint, p int);
     create index idx1 on t1(a);
@@ -489,12 +489,12 @@
     select * from t1 where a > 1 and b > 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (t1.a > 1:Int32) AND (t1.b > 1:Int32) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: (t1.a > 1:Int32) AND (t1.b > 1:Int32) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
   batch_local_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (t1.a > 1:Int32) AND (t1.b > 1:Int32) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
+    └─BatchFilter { predicate: (t1.a > 1:Int32) AND (t1.b > 1:Int32) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c, t1.p], distribution: SomeShard }
 - sql: |
     CREATE TABLE lineitem (
             l_orderkey BIGINT,
@@ -520,7 +520,7 @@
     select * from lineitem where l_orderkey = 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }
+    └─BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }
   batch_local_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }
+    └─BatchScan { table: covered_index, columns: [covered_index.l_orderkey, covered_index.l_partkey, covered_index.l_suppkey, covered_index.l_linenumber, covered_index.l_quantity, covered_index.l_extendedprice, covered_index.l_discount, covered_index.l_tax, covered_index.l_returnflag, covered_index.l_linestatus, covered_index.l_shipdate, covered_index.l_commitdate, covered_index.l_receiptdate, covered_index.l_shipinstruct, covered_index.l_shipmode, covered_index.l_comment], scan_ranges: [covered_index.l_orderkey = Int64(1)], distribution: UpstreamHashShard(covered_index.l_orderkey) }

--- a/src/frontend/planner_test/tests/testdata/insert.yaml
+++ b/src/frontend/planner_test/tests/testdata/insert.yaml
@@ -5,16 +5,16 @@
     insert into t values (22, 33), (44, 55);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchValues { rows: [[22:Int32, 33:Int32], [44:Int32, 55:Int32]] }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[22:Int32, 33:Int32], [44:Int32, 55:Int32]] }
 - sql: |
     /* insert values on assign-castable types */
     create table t (v1 real, v2 int);
     insert into t values (22.33, '33'), (44, 55.0);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchValues { rows: [[22.33:Decimal::Float32, '33':Varchar::Int32], [44:Int32::Float32, 55.0:Decimal::Int32]] }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[22.33:Decimal::Float32, '33':Varchar::Int32], [44:Int32::Float32, 55.0:Decimal::Int32]] }
 - sql: |
     /* insert values on non-assign-castable types */
     create table t (v1 real, v2 int);
@@ -31,16 +31,16 @@
     insert into t values(NULL);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchValues { rows: [[null:Int32]] }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[null:Int32]] }
 - sql: |
     /* insert values cast each expr rather than whole `VALUES` (compare with below) */
     create table t (v1 time);
     insert into t values (timestamp '2020-01-01 01:02:03'), (time '03:04:05');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchValues { rows: [['2020-01-01 01:02:03':Varchar::Timestamp::Time], ['03:04:05':Varchar::Time]] }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [['2020-01-01 01:02:03':Varchar::Timestamp::Time], ['03:04:05':Varchar::Time]] }
 - sql: |
     /* a `VALUES` without insert context may be invalid on its own (compare with above) */
     create table t (v1 time);
@@ -71,19 +71,19 @@
     insert into t select v1 from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchInsert { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* insert into select with cast */
     create table t (v1 time, v2 int, v3 real);
     insert into t select timestamp '2020-01-01 01:02:03', 11, 4.5 from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t }
-        BatchExchange { order: [], dist: Single }
-          BatchProject { exprs: ['2020-01-01 01:02:03':Varchar::Timestamp::Time, 11:Int32, 4.5:Decimal::Float32] }
-            BatchScan { table: t, columns: [], distribution: SomeShard }
+    └─BatchInsert { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchProject { exprs: ['2020-01-01 01:02:03':Varchar::Timestamp::Time, 11:Int32, 4.5:Decimal::Float32] }
+          └─BatchScan { table: t, columns: [], distribution: SomeShard }
 - sql: |
     /* insert into select with cast error */
     create table t (v1 timestamp, v2 real);
@@ -103,10 +103,10 @@
     insert into t1 select c, e from t2 join t3 on t2.d = t3.f
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchInsert { table: t1 }
-        BatchExchange { order: [], dist: Single }
-          BatchHashJoin { type: Inner, predicate: t2.d = t3.f, output: [t2.c, t3.e] }
-            BatchExchange { order: [], dist: HashShard(t2.d) }
-              BatchScan { table: t2, columns: [t2.c, t2.d], distribution: SomeShard }
-            BatchExchange { order: [], dist: HashShard(t3.f) }
-              BatchScan { table: t3, columns: [t3.e, t3.f], distribution: SomeShard }
+    └─BatchInsert { table: t1 }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchHashJoin { type: Inner, predicate: t2.d = t3.f, output: [t2.c, t3.e] }
+          ├─BatchExchange { order: [], dist: HashShard(t2.d) }
+          | └─BatchScan { table: t2, columns: [t2.c, t2.d], distribution: SomeShard }
+          └─BatchExchange { order: [], dist: HashShard(t3.f) }
+            └─BatchScan { table: t3, columns: [t3.e, t3.f], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/join.yaml
@@ -6,38 +6,38 @@
     select * from t1, t2, t3 where t1.v1 = t2.v3 and t1.v1 = t3.v5;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6] }
-      LogicalFilter { predicate: (t1.v1 = t2.v3) AND (t1.v1 = t3.v5) }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalJoin { type: Inner, on: true, output: all }
-            LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
-            LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
-          LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id] }
+    └─LogicalFilter { predicate: (t1.v1 = t2.v3) AND (t1.v1 = t3.v5) }
+      └─LogicalJoin { type: Inner, on: true, output: all }
+        ├─LogicalJoin { type: Inner, on: true, output: all }
+        | ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
+        | └─LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
+        └─LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3, v4, v5, v6, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id, v1, v3, t3._row_id, v5] }
-      StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5, output: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t1._row_id, t2._row_id, t3._row_id] }
-        StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t1._row_id, t2._row_id] }
-          StreamExchange { dist: HashShard(t1.v1) }
-            StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
-          StreamExchange { dist: HashShard(t2.v3) }
-            StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
-        StreamExchange { dist: HashShard(t3.v5) }
-          StreamTableScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id], pk: [t3._row_id], distribution: UpstreamHashShard(t3._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t1.v1 = t3.v5, output: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t1._row_id, t2._row_id, t3._row_id] }
+      ├─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v3, output: [t1.v1, t1.v2, t2.v3, t2.v4, t1._row_id, t2._row_id] }
+      | ├─StreamExchange { dist: HashShard(t1.v1) }
+      | | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+      | └─StreamExchange { dist: HashShard(t2.v3) }
+      |   └─StreamTableScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+      └─StreamExchange { dist: HashShard(t3.v5) }
+        └─StreamTableScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id], pk: [t3._row_id], distribution: UpstreamHashShard(t3._row_id) }
 - sql: |
     /* self join */
     create table t (v1 int, v2 int);
     select t1.v1 as t1v1, t2.v1 as t2v1 from t t1 join t t2 on t1.v1 = t2.v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v1] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
+      ├─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [t1v1, t2v1, t._row_id(hidden), t._row_id#1(hidden)], pk_columns: [t._row_id, t._row_id#1, t1v1, t2v1] }
-      StreamHashJoin { type: Inner, predicate: t.v1 = t.v1, output: [t.v1, t.v1, t._row_id, t._row_id] }
-        StreamExchange { dist: HashShard(t.v1) }
-          StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
-        StreamExchange { dist: HashShard(t.v1) }
-          StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t.v1 = t.v1, output: [t.v1, t.v1, t._row_id, t._row_id] }
+      ├─StreamExchange { dist: HashShard(t.v1) }
+      | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+      └─StreamExchange { dist: HashShard(t.v1) }
+        └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
@@ -45,88 +45,88 @@
     select t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2, t3.v1 as t3_v1, t3.v2 as t3_v2 from t1 join t2 on (t1.v1 = t2.v1) join t3 on (t2.v2 = t3.v2);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: all }
-        BatchExchange { order: [], dist: HashShard(t2.v2) }
-          BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
-            BatchExchange { order: [], dist: HashShard(t1.v1) }
-              BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-            BatchExchange { order: [], dist: HashShard(t2.v1) }
-              BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(t3.v2) }
-          BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: all }
+      ├─BatchExchange { order: [], dist: HashShard(t2.v2) }
+      | └─BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
+      |   ├─BatchExchange { order: [], dist: HashShard(t1.v1) }
+      |   | └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+      |   └─BatchExchange { order: [], dist: HashShard(t2.v1) }
+      |     └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t3.v2) }
+        └─BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
   batch_local_plan: |
     BatchHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: all }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
+    ├─BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: all }
+    | ├─BatchExchange { order: [], dist: Single }
+    | | └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    | └─BatchExchange { order: [], dist: Single }
+    |   └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t3, columns: [t3.v1, t3.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t1_v1, t1_v2, t2_v1, t2_v2, t3_v1, t3_v2, t1._row_id(hidden), t2._row_id(hidden), t3._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id, t1_v1, t2_v1, t3._row_id, t2_v2, t3_v2] }
-      StreamHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: [t1.v1, t1.v2, t2.v1, t2.v2, t3.v1, t3.v2, t1._row_id, t2._row_id, t3._row_id] }
-        StreamExchange { dist: HashShard(t2.v2) }
-          StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
-            StreamExchange { dist: HashShard(t1.v1) }
-              StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
-            StreamExchange { dist: HashShard(t2.v1) }
-              StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
-        StreamExchange { dist: HashShard(t3.v2) }
-          StreamTableScan { table: t3, columns: [t3.v1, t3.v2, t3._row_id], pk: [t3._row_id], distribution: UpstreamHashShard(t3._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t2.v2 = t3.v2, output: [t1.v1, t1.v2, t2.v1, t2.v2, t3.v1, t3.v2, t1._row_id, t2._row_id, t3._row_id] }
+      ├─StreamExchange { dist: HashShard(t2.v2) }
+      | └─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+      |   ├─StreamExchange { dist: HashShard(t1.v1) }
+      |   | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+      |   └─StreamExchange { dist: HashShard(t2.v1) }
+      |     └─StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+      └─StreamExchange { dist: HashShard(t3.v2) }
+        └─StreamTableScan { table: t3, columns: [t3.v1, t3.v2, t3._row_id], pk: [t3._row_id], distribution: UpstreamHashShard(t3._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 = t2.v1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2] }
-        BatchExchange { order: [], dist: HashShard(t1.v1) }
-          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(t2.v1) }
-          BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2] }
+      ├─BatchExchange { order: [], dist: HashShard(t1.v1) }
+      | └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t2.v1) }
+        └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   batch_local_plan: |
     BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+    ├─BatchExchange { order: [], dist: Single }
+    | └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [t1_v2, t2_v2, t1._row_id(hidden), t1.v1(hidden), t2._row_id(hidden), t2.v1(hidden)], pk_columns: [t1._row_id, t2._row_id, t1.v1, t2.v1] }
-      StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2, t1._row_id, t1.v1, t2._row_id, t2.v1] }
-        StreamExchange { dist: HashShard(t1.v1) }
-          StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
-        StreamExchange { dist: HashShard(t2.v1) }
-          StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v2, t2.v2, t1._row_id, t1.v1, t2._row_id, t2.v1] }
+      ├─StreamExchange { dist: HashShard(t1.v1) }
+      | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+      └─StreamExchange { dist: HashShard(t2.v1) }
+        └─StreamTableScan { table: t2, columns: [t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v2 int);
     select t1.v2 as t1_v2, t2.v2 as t2_v2 from t1 join t2 on t1.v1 > t2.v1 and t1.v2 < 10;
   batch_plan: |
     BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1), output: [t1.v2, t2.v2] }
-      BatchExchange { order: [], dist: Single }
-        BatchFilter { predicate: (t1.v2 < 10:Int32) }
-          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+    ├─BatchExchange { order: [], dist: Single }
+    | └─BatchFilter { predicate: (t1.v2 < 10:Int32) }
+    |   └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
   batch_local_plan: |
     BatchNestedLoopJoin { type: Inner, predicate: (t1.v1 > t2.v1), output: [t1.v2, t2.v2] }
-      BatchExchange { order: [], dist: Single }
-        BatchFilter { predicate: (t1.v2 < 10:Int32) }
-          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
+    ├─BatchExchange { order: [], dist: Single }
+    | └─BatchFilter { predicate: (t1.v2 < 10:Int32) }
+    |   └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t2, columns: [t2.v1, t2.v2], distribution: SomeShard }
 - sql: |
     create table t1 (v1 int, v2 int);
     create table t2 (v1 int, v3 int);
     select * from t1 join t2 using(v1);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3] }
-        BatchExchange { order: [], dist: HashShard(t1.v1) }
-          BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(t2.v1) }
-          BatchScan { table: t2, columns: [t2.v1, t2.v3], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3] }
+      ├─BatchExchange { order: [], dist: HashShard(t1.v1) }
+      | └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(t2.v1) }
+        └─BatchScan { table: t2, columns: [t2.v1, t2.v3], distribution: SomeShard }
 - sql: |
     create table ab (a int, b int);
     create table bc (b int, c int);
@@ -134,15 +134,15 @@
     select * from ab join bc using(b) join ca using(c);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: bc.c = ca.c, output: [bc.c, ab.b, ab.a, ca.a] }
-        BatchExchange { order: [], dist: HashShard(bc.c) }
-          BatchHashJoin { type: Inner, predicate: ab.b = bc.b, output: [ab.a, ab.b, bc.c] }
-            BatchExchange { order: [], dist: HashShard(ab.b) }
-              BatchScan { table: ab, columns: [ab.a, ab.b], distribution: SomeShard }
-            BatchExchange { order: [], dist: HashShard(bc.b) }
-              BatchScan { table: bc, columns: [bc.b, bc.c], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(ca.c) }
-          BatchScan { table: ca, columns: [ca.c, ca.a], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: bc.c = ca.c, output: [bc.c, ab.b, ab.a, ca.a] }
+      ├─BatchExchange { order: [], dist: HashShard(bc.c) }
+      | └─BatchHashJoin { type: Inner, predicate: ab.b = bc.b, output: [ab.a, ab.b, bc.c] }
+      |   ├─BatchExchange { order: [], dist: HashShard(ab.b) }
+      |   | └─BatchScan { table: ab, columns: [ab.a, ab.b], distribution: SomeShard }
+      |   └─BatchExchange { order: [], dist: HashShard(bc.b) }
+      |     └─BatchScan { table: bc, columns: [bc.b, bc.c], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(ca.c) }
+        └─BatchScan { table: ca, columns: [ca.c, ca.a], distribution: SomeShard }
 - sql: |
     /* Only push to left */
     create table t1 (v1 int, v2 int);
@@ -150,8 +150,8 @@
     select * from t1 left join t2 where t1.v2 > 100;
   optimized_logical_plan: |
     LogicalJoin { type: LeftOuter, on: true, output: all }
-      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v2 > 100:Int32) }
-      LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
+    ├─LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v2 > 100:Int32) }
+    └─LogicalScan { table: t2, columns: [t2.v1, t2.v2] }
 - sql: |
     /* Only push to right */
     create table t1 (v1 int, v2 int);
@@ -159,8 +159,8 @@
     select * from t1 right join t2 where t2.v2 > 100;
   optimized_logical_plan: |
     LogicalJoin { type: RightOuter, on: true, output: all }
-      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
-      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v2 > 100:Int32) }
+    ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+    └─LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v2 > 100:Int32) }
 - sql: |
     /* Push to left, right and on */
     create table t1 (v1 int, v2 int);
@@ -168,8 +168,8 @@
     select * from t1, t2 where t1.v1 > 100 and t2.v1 < 1000 and t1.v2 = t2.v2;
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v2 = t2.v2), output: all }
-      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v1 > 100:Int32) }
-      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v1 < 1000:Int32) }
+    ├─LogicalScan { table: t1, output_columns: [t1.v1, t1.v2], required_columns: [v1, v2], predicate: (t1.v1 > 100:Int32) }
+    └─LogicalScan { table: t2, output_columns: [t2.v1, t2.v2], required_columns: [v1, v2], predicate: (t2.v1 < 1000:Int32) }
 - sql: |
     /* Left & right has same SomeShard distribution. There should still be exchanges below hash join */
     create table t(x int);
@@ -177,18 +177,18 @@
     select i.x as ix, ii.x as iix from i join i as ii on i.x=ii.x;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: i.x = i.x, output: all }
-        BatchExchange { order: [], dist: HashShard(i.x) }
-          BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
-        BatchExchange { order: [], dist: HashShard(i.x) }
-          BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+    └─BatchHashJoin { type: Inner, predicate: i.x = i.x, output: all }
+      ├─BatchExchange { order: [], dist: HashShard(i.x) }
+      | └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+      └─BatchExchange { order: [], dist: HashShard(i.x) }
+        └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
   stream_plan: |
     StreamMaterialize { columns: [ix, iix, i.t._row_id(hidden), i.t._row_id#1(hidden)], pk_columns: [i.t._row_id, i.t._row_id#1, ix, iix] }
-      StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.x, i.t._row_id, i.t._row_id] }
-        StreamExchange { dist: HashShard(i.x) }
-          StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
-        StreamExchange { dist: HashShard(i.x) }
-          StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+    └─StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.x, i.t._row_id, i.t._row_id] }
+      ├─StreamExchange { dist: HashShard(i.x) }
+      | └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+      └─StreamExchange { dist: HashShard(i.x) }
+        └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
 - sql: |
     /* Left & right has same SomeShard distribution. There should still be exchanges below hash join */
     create table t(x int);
@@ -196,18 +196,18 @@
     select i.x as ix, t.x as tx from i join t on i.x=t.x;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: i.x = t.x, output: all }
-        BatchExchange { order: [], dist: HashShard(i.x) }
-          BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
-        BatchExchange { order: [], dist: HashShard(t.x) }
-          BatchScan { table: t, columns: [t.x], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: i.x = t.x, output: all }
+      ├─BatchExchange { order: [], dist: HashShard(i.x) }
+      | └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+      └─BatchExchange { order: [], dist: HashShard(t.x) }
+        └─BatchScan { table: t, columns: [t.x], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [ix, tx, i.t._row_id(hidden), t._row_id(hidden)], pk_columns: [i.t._row_id, t._row_id, ix, tx] }
-      StreamHashJoin { type: Inner, predicate: i.x = t.x, output: [i.x, t.x, i.t._row_id, t._row_id] }
-        StreamExchange { dist: HashShard(i.x) }
-          StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
-        StreamExchange { dist: HashShard(t.x) }
-          StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: i.x = t.x, output: [i.x, t.x, i.t._row_id, t._row_id] }
+      ├─StreamExchange { dist: HashShard(i.x) }
+      | └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+      └─StreamExchange { dist: HashShard(t.x) }
+        └─StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* Left & right has same HashShard distribution. There should be no exchange below hash join */
     create table t(x int);
@@ -219,33 +219,33 @@
     using (x);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Coalesce(i.x, i.x)] }
-        BatchHashJoin { type: FullOuter, predicate: i.x = i.x, output: all }
-          BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
-            BatchExchange { order: [], dist: HashShard(i.x) }
-              BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
-            BatchExchange { order: [], dist: HashShard(i.x) }
-              BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
-          BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
-            BatchExchange { order: [], dist: HashShard(i.x) }
-              BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
-            BatchExchange { order: [], dist: HashShard(i.x) }
-              BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+    └─BatchProject { exprs: [Coalesce(i.x, i.x)] }
+      └─BatchHashJoin { type: FullOuter, predicate: i.x = i.x, output: all }
+        ├─BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
+        | ├─BatchExchange { order: [], dist: HashShard(i.x) }
+        | | └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+        | └─BatchExchange { order: [], dist: HashShard(i.x) }
+        |   └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+        └─BatchHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x] }
+          ├─BatchExchange { order: [], dist: HashShard(i.x) }
+          | └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
+          └─BatchExchange { order: [], dist: HashShard(i.x) }
+            └─BatchScan { table: i, columns: [i.x], distribution: UpstreamHashShard(i.x) }
   stream_plan: |
     StreamMaterialize { columns: [x, i.t._row_id(hidden), i.t._row_id#1(hidden), i.x(hidden), i.x#1(hidden), i.t._row_id#2(hidden), i.t._row_id#3(hidden), i.x#2(hidden), i.x#3(hidden)], pk_columns: [i.t._row_id, i.t._row_id#1, i.x, i.x#1, i.t._row_id#2, i.t._row_id#3, i.x#2, i.x#3] }
-      StreamExchange { dist: HashShard(i.t._row_id, i.t._row_id, i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.x) }
-        StreamProject { exprs: [Coalesce(i.x, i.x), i.t._row_id, i.t._row_id, i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.x] }
-          StreamHashJoin { type: FullOuter, predicate: i.x = i.x, output: [i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.t._row_id, i.t._row_id, i.x] }
-            StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.t._row_id, i.t._row_id, i.x] }
-              StreamExchange { dist: HashShard(i.x) }
-                StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
-              StreamExchange { dist: HashShard(i.x) }
-                StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
-            StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.t._row_id, i.t._row_id, i.x] }
-              StreamExchange { dist: HashShard(i.x) }
-                StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
-              StreamExchange { dist: HashShard(i.x) }
-                StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+    └─StreamExchange { dist: HashShard(i.t._row_id, i.t._row_id, i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.x) }
+      └─StreamProject { exprs: [Coalesce(i.x, i.x), i.t._row_id, i.t._row_id, i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.x] }
+        └─StreamHashJoin { type: FullOuter, predicate: i.x = i.x, output: [i.x, i.x, i.t._row_id, i.t._row_id, i.x, i.t._row_id, i.t._row_id, i.x] }
+          ├─StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.t._row_id, i.t._row_id, i.x] }
+          | ├─StreamExchange { dist: HashShard(i.x) }
+          | | └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+          | └─StreamExchange { dist: HashShard(i.x) }
+          |   └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+          └─StreamHashJoin { type: Inner, predicate: i.x = i.x, output: [i.x, i.t._row_id, i.t._row_id, i.x] }
+            ├─StreamExchange { dist: HashShard(i.x) }
+            | └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
+            └─StreamExchange { dist: HashShard(i.x) }
+              └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], distribution: UpstreamHashShard(i.x) }
 - sql: |
     /* Use lookup join */
     create table t1 (v1 int, v2 int);
@@ -254,8 +254,8 @@
     select * from t1 join t3 where t1.v2 = t3.v1;
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: t1.v2 = t3.v1, output: all }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
   with_config_map:
     QUERY_MODE: local
     RW_BATCH_ENABLE_LOOKUP_JOIN: 'true'
@@ -267,11 +267,11 @@
     select * from t3, t1 join t2 using (v1);
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t3.v2] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t3, columns: [t3.v2, t3._row_id] }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v1), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v1, t2._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalScan { table: t3, columns: [t3.v2, t3._row_id] }
+      └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v1), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v1, t2._row_id] }
 - sql: |
     /* Ensure correct binding of join with ON clause */
     create table t1(v1 varchar);
@@ -280,11 +280,11 @@
     select * from t3, t1 join t2 on v1 = v2;
   logical_plan: |
     LogicalProject { exprs: [t3.v3, t1.v1, t2.v2] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t3, columns: [t3.v3, t3._row_id] }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v2, t2._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalScan { table: t3, columns: [t3.v3, t3._row_id] }
+      └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v2, t2._row_id] }
 - sql: |
     /* Ensure correct binding with USING clause with left outer join */
     create table t1(v1 varchar);
@@ -293,11 +293,11 @@
     select * from t3, t1 left join t2 using (v1);
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t3.v2] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t3, columns: [t3.v2, t3._row_id] }
-        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v1), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v1, t2._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalScan { table: t3, columns: [t3.v2, t3._row_id] }
+      └─LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v1), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v1, t2._row_id] }
 - sql: |
     /* Ensure correct binding with ON clause with left outer join */
     create table t1(v1 varchar);
@@ -306,11 +306,11 @@
     select * from t3, t1 left join t2 on v1 = v2;
   logical_plan: |
     LogicalProject { exprs: [t3.v3, t1.v1, t2.v2] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t3, columns: [t3.v3, t3._row_id] }
-        LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v2), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v2, t2._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalScan { table: t3, columns: [t3.v3, t3._row_id] }
+      └─LogicalJoin { type: LeftOuter, on: (t1.v1 = t2.v2), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v2, t2._row_id] }
 - sql: |
     /* Ensure that ON clause cannot reference correlated columns */
     create table a(a1 int);
@@ -333,11 +333,11 @@
     select * from a natural join b natural join c;
   logical_plan: |
     LogicalProject { exprs: [a.x, c.y] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-          LogicalScan { table: a, columns: [a.x, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b._row_id] }
-        LogicalScan { table: c, columns: [c.y, c._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      | ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.y, c._row_id] }
 - sql: |
     /* Ensure that natural joins can disambiguate columns */
     create table a(x int);
@@ -345,9 +345,9 @@
     select x, a.x, b.x from a natural join b;
   logical_plan: |
     LogicalProject { exprs: [a.x, a.x, b.x] }
-      LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -356,11 +356,11 @@
     select * from a natural join b natural join c;
   logical_plan: |
     LogicalProject { exprs: [a.x, c.y] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-          LogicalScan { table: a, columns: [a.x, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b._row_id] }
-        LogicalScan { table: c, columns: [c.y, c._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      | ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.y, c._row_id] }
 - sql: |
     /* Ensure that natural joins can disambiguate columns */
     create table a(x int);
@@ -368,9 +368,9 @@
     select x, a.x, b.x from a natural join b;
   logical_plan: |
     LogicalProject { exprs: [a.x, a.x, b.x] }
-      LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -379,11 +379,11 @@
     select * from a natural join b natural join c;
   logical_plan: |
     LogicalProject { exprs: [a.x, c.y] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-          LogicalScan { table: a, columns: [a.x, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b._row_id] }
-        LogicalScan { table: c, columns: [c.y, c._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      | ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.y, c._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -391,9 +391,9 @@
     select x from a natural join b;
   logical_plan: |
     LogicalProject { exprs: [a.x] }
-      LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -401,9 +401,9 @@
     select x from a natural left join b;
   logical_plan: |
     LogicalProject { exprs: [a.x] }
-      LogicalJoin { type: LeftOuter, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: LeftOuter, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -411,9 +411,9 @@
     select x, a.x, b.x from a natural right join b;
   logical_plan: |
     LogicalProject { exprs: [b.x, a.x, b.x] }
-      LogicalJoin { type: RightOuter, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: RightOuter, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that natural joins bind the correct columns */
     create table a(x int);
@@ -421,9 +421,9 @@
     select x, a.x, b.x from a natural full join b;
   logical_plan: |
     LogicalProject { exprs: [Coalesce(a.x, b.x), a.x, b.x] }
-      LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
-        LogicalScan { table: a, columns: [a.x, a._row_id] }
-        LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
+      ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+      └─LogicalScan { table: b, columns: [b.x, b._row_id] }
 - sql: |
     /* Ensure that nested natural joins bind and disambiguate columns */
     create table a(x int, y int);
@@ -432,11 +432,11 @@
     select x, a.x, b.x, c.x from a natural join b natural join c;
   logical_plan: |
     LogicalProject { exprs: [a.x, a.x, b.x, c.x] }
-      LogicalJoin { type: Inner, on: (a.x = c.x), output: all }
-        LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
-          LogicalScan { table: a, columns: [a.x, a.y, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
-        LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
+    └─LogicalJoin { type: Inner, on: (a.x = c.x), output: all }
+      ├─LogicalJoin { type: Inner, on: (a.x = b.x), output: all }
+      | ├─LogicalScan { table: a, columns: [a.x, a.y, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
 - sql: |
     /* Ensure that nested natural joins bind and disambiguate columns */
     create table a(x int, y int);
@@ -445,20 +445,20 @@
     select x, a.x, b.x, c.x from a natural full join b natural full join c;
   logical_plan: |
     LogicalProject { exprs: [Coalesce(a.x, b.x, c.x), a.x, b.x, c.x] }
-      LogicalJoin { type: FullOuter, on: (Coalesce(a.x, b.x) = c.x), output: all }
-        LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
-          LogicalScan { table: a, columns: [a.x, a.y, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
-        LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
+    └─LogicalJoin { type: FullOuter, on: (Coalesce(a.x, b.x) = c.x), output: all }
+      ├─LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
+      | ├─LogicalScan { table: a, columns: [a.x, a.y, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [Coalesce(a.x, b.x, c.x), a.x, b.x, c.x] }
-      LogicalJoin { type: FullOuter, on: (Coalesce(a.x, b.x) = c.x), output: [a.x, b.x, c.x] }
-        LogicalProject { exprs: [a.x, b.x, Coalesce(a.x, b.x)] }
-          LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
-            LogicalScan { table: a, columns: [a.x] }
-            LogicalScan { table: b, columns: [b.x] }
-        LogicalProject { exprs: [c.x, c.x] }
-          LogicalScan { table: c, columns: [c.x] }
+    └─LogicalJoin { type: FullOuter, on: (Coalesce(a.x, b.x) = c.x), output: [a.x, b.x, c.x] }
+      ├─LogicalProject { exprs: [a.x, b.x, Coalesce(a.x, b.x)] }
+      | └─LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
+      |   ├─LogicalScan { table: a, columns: [a.x] }
+      |   └─LogicalScan { table: b, columns: [b.x] }
+      └─LogicalProject { exprs: [c.x, c.x] }
+        └─LogicalScan { table: c, columns: [c.x] }
 - sql: |
     /* Ensure that nested natural joins bind and disambiguate columns */
     create table a(a int, y int);
@@ -467,11 +467,11 @@
     select a, x, a.a, c.a, b.x, c.x from a natural full join b natural full join c;
   logical_plan: |
     LogicalProject { exprs: [Coalesce(a.a, c.a), Coalesce(b.x, c.x), a.a, c.a, b.x, c.x] }
-      LogicalJoin { type: FullOuter, on: (a.a = c.a) AND (b.x = c.x), output: all }
-        LogicalJoin { type: FullOuter, on: true, output: all }
-          LogicalScan { table: a, columns: [a.a, a.y, a._row_id] }
-          LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
-        LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
+    └─LogicalJoin { type: FullOuter, on: (a.a = c.a) AND (b.x = c.x), output: all }
+      ├─LogicalJoin { type: FullOuter, on: true, output: all }
+      | ├─LogicalScan { table: a, columns: [a.a, a.y, a._row_id] }
+      | └─LogicalScan { table: b, columns: [b.x, b.z, b._row_id] }
+      └─LogicalScan { table: c, columns: [c.x, c.a, c._row_id] }
 - sql: |
     /* Ensure error on non-existent USING col */
     create table t1(v1 int, v2 int);
@@ -495,13 +495,13 @@
     select * from (t1 join t2 on v1=v3) full join (t3 join t4 on v5=v7) on v2=v6 and v4=v8;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t1.v2, t2.v3, t2.v4, t3.v5, t3.v6, t4.v7, t4.v8] }
-      LogicalJoin { type: FullOuter, on: (t1.v2 = t3.v6) AND (t2.v4 = t4.v8), output: all }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v3), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
-        LogicalJoin { type: Inner, on: (t3.v5 = t4.v7), output: all }
-          LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id] }
-          LogicalScan { table: t4, columns: [t4.v7, t4.v8, t4._row_id] }
+    └─LogicalJoin { type: FullOuter, on: (t1.v2 = t3.v6) AND (t2.v4 = t4.v8), output: all }
+      ├─LogicalJoin { type: Inner, on: (t1.v1 = t2.v3), output: all }
+      | ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id] }
+      | └─LogicalScan { table: t2, columns: [t2.v3, t2.v4, t2._row_id] }
+      └─LogicalJoin { type: Inner, on: (t3.v5 = t4.v7), output: all }
+        ├─LogicalScan { table: t3, columns: [t3.v5, t3.v6, t3._row_id] }
+        └─LogicalScan { table: t4, columns: [t4.v7, t4.v8, t4._row_id] }
 - sql: |
     /* Ensure that we can correctly bind nested joins with ambiguous column names */
     create table t1(x int);
@@ -510,11 +510,11 @@
     select *, x, t1.x, t2.x, t3.x from t1 full join (t2 full join t3 using (x)) using (x);
   logical_plan: |
     LogicalProject { exprs: [Coalesce(t1.x, t2.x, t3.x), Coalesce(t1.x, t2.x, t3.x), t1.x, t2.x, t3.x] }
-      LogicalJoin { type: FullOuter, on: (t1.x = Coalesce(t2.x, t3.x)), output: all }
-        LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
-        LogicalJoin { type: FullOuter, on: (t2.x = t3.x), output: all }
-          LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
-          LogicalScan { table: t3, columns: [t3.x, t3._row_id] }
+    └─LogicalJoin { type: FullOuter, on: (t1.x = Coalesce(t2.x, t3.x)), output: all }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
+      └─LogicalJoin { type: FullOuter, on: (t2.x = t3.x), output: all }
+        ├─LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
+        └─LogicalScan { table: t3, columns: [t3.x, t3._row_id] }
 - sql: |
     /* Ensure that non-trivial ambiguous references can be resolved */
     create table a(x int);
@@ -522,58 +522,58 @@
     select 2 * x as Y, x + x as Z from a natural full join b where 2 * x < 10 order by x + x;
   logical_plan: |
     LogicalProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
-      LogicalProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
-        LogicalFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
-          LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
-            LogicalScan { table: a, columns: [a.x, a._row_id] }
-            LogicalScan { table: b, columns: [b.x, b._row_id] }
+    └─LogicalProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
+      └─LogicalFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
+        └─LogicalJoin { type: FullOuter, on: (a.x = b.x), output: all }
+          ├─LogicalScan { table: a, columns: [a.x, a._row_id] }
+          └─LogicalScan { table: b, columns: [b.x, b._row_id] }
   batch_plan: |
     BatchProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
-      BatchExchange { order: [(Coalesce(a.x, b.x) + Coalesce(a.x, b.x)) ASC], dist: Single }
-        BatchSort { order: [(Coalesce(a.x, b.x) + Coalesce(a.x, b.x)) ASC] }
-          BatchProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
-            BatchFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
-              BatchHashJoin { type: FullOuter, predicate: a.x = b.x, output: all }
-                BatchExchange { order: [], dist: HashShard(a.x) }
-                  BatchScan { table: a, columns: [a.x], distribution: SomeShard }
-                BatchExchange { order: [], dist: HashShard(b.x) }
-                  BatchScan { table: b, columns: [b.x], distribution: SomeShard }
+    └─BatchExchange { order: [(Coalesce(a.x, b.x) + Coalesce(a.x, b.x)) ASC], dist: Single }
+      └─BatchSort { order: [(Coalesce(a.x, b.x) + Coalesce(a.x, b.x)) ASC] }
+        └─BatchProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))] }
+          └─BatchFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
+            └─BatchHashJoin { type: FullOuter, predicate: a.x = b.x, output: all }
+              ├─BatchExchange { order: [], dist: HashShard(a.x) }
+              | └─BatchScan { table: a, columns: [a.x], distribution: SomeShard }
+              └─BatchExchange { order: [], dist: HashShard(b.x) }
+                └─BatchScan { table: b, columns: [b.x], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [y, z, (Coalesce(a.x, b.x) + Coalesce(a.x, b.x))(hidden), a._row_id(hidden), b._row_id(hidden), a.x(hidden), b.x(hidden)], pk_columns: [a._row_id, b._row_id, a.x, b.x], order_descs: [(Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), a._row_id, b._row_id, a.x, b.x] }
-      StreamExchange { dist: HashShard(a._row_id, b._row_id, a.x, b.x) }
-        StreamProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), a._row_id, b._row_id, a.x, b.x] }
-          StreamFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
-            StreamHashJoin { type: FullOuter, predicate: a.x = b.x, output: [a.x, b.x, a._row_id, b._row_id] }
-              StreamExchange { dist: HashShard(a.x) }
-                StreamTableScan { table: a, columns: [a.x, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
-              StreamExchange { dist: HashShard(b.x) }
-                StreamTableScan { table: b, columns: [b.x, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
+    └─StreamExchange { dist: HashShard(a._row_id, b._row_id, a.x, b.x) }
+      └─StreamProject { exprs: [(2:Int32 * Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), (Coalesce(a.x, b.x) + Coalesce(a.x, b.x)), a._row_id, b._row_id, a.x, b.x] }
+        └─StreamFilter { predicate: ((2:Int32 * Coalesce(a.x, b.x)) < 10:Int32) }
+          └─StreamHashJoin { type: FullOuter, predicate: a.x = b.x, output: [a.x, b.x, a._row_id, b._row_id] }
+            ├─StreamExchange { dist: HashShard(a.x) }
+            | └─StreamTableScan { table: a, columns: [a.x, a._row_id], pk: [a._row_id], distribution: UpstreamHashShard(a._row_id) }
+            └─StreamExchange { dist: HashShard(b.x) }
+              └─StreamTableScan { table: b, columns: [b.x, b._row_id], pk: [b._row_id], distribution: UpstreamHashShard(b._row_id) }
 - sql: |
     CREATE TABLE test (a INTEGER, b INTEGER);
     CREATE TABLE test2 (a INTEGER, c INTEGER);
     SELECT test.a, b, c FROM test, test2 WHERE test.a = test2.a AND test.b <> test2.c ORDER BY test.a;
   logical_plan: |
     LogicalProject { exprs: [test.a, test.b, test2.c] }
-      LogicalProject { exprs: [test.a, test.b, test2.c, test.a] }
-        LogicalFilter { predicate: (test.a = test2.a) AND (test.b <> test2.c) }
-          LogicalJoin { type: Inner, on: true, output: all }
-            LogicalScan { table: test, columns: [test.a, test.b, test._row_id] }
-            LogicalScan { table: test2, columns: [test2.a, test2.c, test2._row_id] }
+    └─LogicalProject { exprs: [test.a, test.b, test2.c, test.a] }
+      └─LogicalFilter { predicate: (test.a = test2.a) AND (test.b <> test2.c) }
+        └─LogicalJoin { type: Inner, on: true, output: all }
+          ├─LogicalScan { table: test, columns: [test.a, test.b, test._row_id] }
+          └─LogicalScan { table: test2, columns: [test2.a, test2.c, test2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (test.a = test2.a) AND (test.b <> test2.c), output: [test.a, test.b, test2.c, test.a] }
-      LogicalScan { table: test, columns: [test.a, test.b] }
-      LogicalScan { table: test2, columns: [test2.a, test2.c] }
+    ├─LogicalScan { table: test, columns: [test.a, test.b] }
+    └─LogicalScan { table: test2, columns: [test2.a, test2.c] }
   batch_plan: |
     BatchProject { exprs: [test.a, test.b, test2.c] }
-      BatchExchange { order: [test.a ASC], dist: Single }
-        BatchSort { order: [test.a ASC] }
-          BatchProject { exprs: [test.a, test.b, test2.c, test.a] }
-            BatchFilter { predicate: (test.b <> test2.c) }
-              BatchHashJoin { type: Inner, predicate: test.a = test2.a, output: all }
-                BatchExchange { order: [], dist: HashShard(test.a) }
-                  BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }
-                BatchExchange { order: [], dist: HashShard(test2.a) }
-                  BatchScan { table: test2, columns: [test2.a, test2.c], distribution: SomeShard }
+    └─BatchExchange { order: [test.a ASC], dist: Single }
+      └─BatchSort { order: [test.a ASC] }
+        └─BatchProject { exprs: [test.a, test.b, test2.c, test.a] }
+          └─BatchFilter { predicate: (test.b <> test2.c) }
+            └─BatchHashJoin { type: Inner, predicate: test.a = test2.a, output: all }
+              ├─BatchExchange { order: [], dist: HashShard(test.a) }
+              | └─BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }
+              └─BatchExchange { order: [], dist: HashShard(test2.a) }
+                └─BatchScan { table: test2, columns: [test2.a, test2.c], distribution: SomeShard }
 - sql: |
     /* Use lookup join with predicate */
     create table t1 (v1 int, v2 int);
@@ -582,12 +582,12 @@
     select * from t1 join t3 where t1.v2 = t3.v1 and t3.v1 > 1;
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v2 = t3.v1), output: all }
-      LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
-      LogicalScan { table: t3, output_columns: [t3.v1, t3.v2], required_columns: [v1, v2], predicate: (t3.v1 > 1:Int32) }
+    ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2] }
+    └─LogicalScan { table: t3, output_columns: [t3.v1, t3.v2], required_columns: [v1, v2], predicate: (t3.v1 > 1:Int32) }
   batch_local_plan: |
     BatchLookupJoin { type: Inner, predicate: t1.v2 = t3.v1 AND (t3.v1 > 1:Int32), output: all }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.v1, t1.v2], distribution: SomeShard }
   with_config_map:
     QUERY_MODE: local
     RW_BATCH_ENABLE_LOOKUP_JOIN: 'true'
@@ -598,10 +598,10 @@
     select * from t1, t2 where t1.x + t1.y = t2.x + t2.y;
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: ((t1.x + t1.y) = (t2.x + t2.y)), output: [t1.x, t1.y, t2.x, t2.y] }
-      LogicalProject { exprs: [t1.x, t1.y, (t1.x + t1.y)] }
-        LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.x, t2.y, (t2.x + t2.y)] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalProject { exprs: [t1.x, t1.y, (t1.x + t1.y)] }
+    | └─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t2.x, t2.y, (t2.x + t2.y)] }
+      └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     /* Use project to align return types */
     create table t1(x int, y int);
@@ -609,7 +609,7 @@
     select * from t1, t2 where t1.x = t2.y;
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.x::Decimal = t2.y), output: [t1.x, t1.y, t2.x, t2.y] }
-      LogicalProject { exprs: [t1.x, t1.y, t1.x::Decimal] }
-        LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.x, t2.y, t2.y] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalProject { exprs: [t1.x, t1.y, t1.x::Decimal] }
+    | └─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t2.x, t2.y, t2.y] }
+      └─LogicalScan { table: t2, columns: [t2.x, t2.y] }

--- a/src/frontend/planner_test/tests/testdata/limit.yaml
+++ b/src/frontend/planner_test/tests/testdata/limit.yaml
@@ -4,45 +4,45 @@
     select * from t limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from t offset 4;
   logical_plan: |
     LogicalLimit { limit: 9223372036854775807, offset: 4 }
-      LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from ( select * from t limit 5 ) limit 4;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [t.v] }
-        LogicalLimit { limit: 5, offset: 0 }
-          LogicalProject { exprs: [t.v] }
-            LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalLimit { limit: 5, offset: 0 }
+        └─LogicalProject { exprs: [t.v] }
+          └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from t fetch first 4 rows only;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 0 }
-      LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from t offset 3 fetch first 4 rows only;
   logical_plan: |
     LogicalLimit { limit: 4, offset: 3 }
-      LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from t fetch next rows only;
   logical_plan: |
     LogicalLimit { limit: 1, offset: 0 }
-      LogicalProject { exprs: [t.v] }
-        LogicalScan { table: t, columns: [t.v, t._row_id] }
+    └─LogicalProject { exprs: [t.v] }
+      └─LogicalScan { table: t, columns: [t.v, t._row_id] }
 - sql: |
     create table t (v int);
     select * from t order by v fetch next rows with ties;

--- a/src/frontend/planner_test/tests/testdata/mv_on_mv.yaml
+++ b/src/frontend/planner_test/tests/testdata/mv_on_mv.yaml
@@ -12,11 +12,11 @@
     select m1.v1 as m1v1, m1.v2 as m1v2, m2.v1 as m2v1, m2.v2 as m2v2 from m1 join m2 on m1.v1 = m2.v1;
   stream_plan: |
     StreamMaterialize { columns: [m1v1, m1v2, m2v1, m2v2, m1.t1._row_id(hidden), m2.t1._row_id(hidden)], pk_columns: [m1.t1._row_id, m2.t1._row_id, m1v1, m2v1] }
-      StreamHashJoin { type: Inner, predicate: m1.v1 = m2.v1, output: [m1.v1, m1.v2, m2.v1, m2.v2, m1.t1._row_id, m2.t1._row_id] }
-        StreamExchange { dist: HashShard(m1.v1) }
-          StreamTableScan { table: m1, columns: [m1.v1, m1.v2, m1.t1._row_id], pk: [m1.t1._row_id], distribution: UpstreamHashShard(m1.t1._row_id) }
-        StreamExchange { dist: HashShard(m2.v1) }
-          StreamTableScan { table: m2, columns: [m2.v1, m2.v2, m2.t1._row_id], pk: [m2.t1._row_id], distribution: UpstreamHashShard(m2.t1._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: m1.v1 = m2.v1, output: [m1.v1, m1.v2, m2.v1, m2.v2, m1.t1._row_id, m2.t1._row_id] }
+      ├─StreamExchange { dist: HashShard(m1.v1) }
+      | └─StreamTableScan { table: m1, columns: [m1.v1, m1.v2, m1.t1._row_id], pk: [m1.t1._row_id], distribution: UpstreamHashShard(m1.t1._row_id) }
+      └─StreamExchange { dist: HashShard(m2.v1) }
+        └─StreamTableScan { table: m2, columns: [m2.v1, m2.v2, m2.t1._row_id], pk: [m2.t1._row_id], distribution: UpstreamHashShard(m2.t1._row_id) }
 - id: create_singleton_mv
   sql: |
     create table t (v int);
@@ -28,7 +28,7 @@
     select v from mv; -- FIXME: there should not be a `Single` exchange here
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: mv, columns: [mv.v], distribution: UpstreamHashShard() }
+    └─BatchScan { table: mv, columns: [mv.v], distribution: UpstreamHashShard() }
 - id: single_fragment_mv_on_singleton_mv
   before:
   - create_singleton_mv
@@ -36,7 +36,7 @@
     select v from mv;
   stream_plan: |
     StreamMaterialize { columns: [v, mv.t._row_id(hidden)], pk_columns: [mv.t._row_id] }
-      StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
+    └─StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
 - id: mv_on_singleton_mv
   before:
   - create_singleton_mv
@@ -44,8 +44,8 @@
     select mv1.v as v from mv as mv1, mv as mv2 where mv1.v = mv2.v;
   stream_plan: |
     StreamMaterialize { columns: [v, mv.t._row_id(hidden), mv.t._row_id#1(hidden), mv.v(hidden)], pk_columns: [mv.t._row_id, mv.t._row_id#1, v, mv.v] }
-      StreamHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v, mv.t._row_id, mv.t._row_id, mv.v] }
-        StreamExchange { dist: HashShard(mv.v) }
-          StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
-        StreamExchange { dist: HashShard(mv.v) }
-          StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
+    └─StreamHashJoin { type: Inner, predicate: mv.v = mv.v, output: [mv.v, mv.t._row_id, mv.t._row_id, mv.v] }
+      ├─StreamExchange { dist: HashShard(mv.v) }
+      | └─StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }
+      └─StreamExchange { dist: HashShard(mv.v) }
+        └─StreamTableScan { table: mv, columns: [mv.v, mv.t._row_id], pk: [mv.t._row_id], distribution: Single }

--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -48,10 +48,10 @@
     SELECT auction, bidder, price, date_time FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -73,12 +73,12 @@
     FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time] }
-        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time] }
+      └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time, bid._row_id] }
-        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), bid.date_time, bid._row_id] }
+      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -96,12 +96,12 @@
     = 2001 OR auction = 2019 OR auction = 2087;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
-        BatchScan { table: bid, columns: [bid.auction, bid.price], distribution: SomeShard }
+    └─BatchFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
+      └─BatchScan { table: bid, columns: [bid.auction, bid.price], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
-        StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
+      └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -124,24 +124,24 @@
         A.category = 10 and (P.state = 'or' OR P.state = 'id' OR P.state = 'ca');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: auction.seller = person.id, output: [person.name, person.city, person.state, auction.id] }
-        BatchExchange { order: [], dist: HashShard(auction.seller) }
-          BatchProject { exprs: [auction.id, auction.seller] }
-            BatchFilter { predicate: (auction.category = 10:Int32) }
-              BatchScan { table: auction, columns: [auction.id, auction.seller, auction.category], distribution: UpstreamHashShard(auction.id) }
-        BatchExchange { order: [], dist: HashShard(person.id) }
-          BatchFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
-            BatchScan { table: person, columns: [person.id, person.name, person.city, person.state], distribution: UpstreamHashShard(person.id) }
+    └─BatchHashJoin { type: Inner, predicate: auction.seller = person.id, output: [person.name, person.city, person.state, auction.id] }
+      ├─BatchExchange { order: [], dist: HashShard(auction.seller) }
+      | └─BatchProject { exprs: [auction.id, auction.seller] }
+      |   └─BatchFilter { predicate: (auction.category = 10:Int32) }
+      |     └─BatchScan { table: auction, columns: [auction.id, auction.seller, auction.category], distribution: UpstreamHashShard(auction.id) }
+      └─BatchExchange { order: [], dist: HashShard(person.id) }
+        └─BatchFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
+          └─BatchScan { table: person, columns: [person.id, person.name, person.city, person.state], distribution: UpstreamHashShard(person.id) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, auction.seller(hidden), person.id(hidden)], pk_columns: [id, person.id, auction.seller] }
-      StreamHashJoin { type: Inner, predicate: auction.seller = person.id, output: [person.name, person.city, person.state, auction.id, auction.seller, person.id] }
-        StreamExchange { dist: HashShard(auction.seller) }
-          StreamProject { exprs: [auction.id, auction.seller] }
-            StreamFilter { predicate: (auction.category = 10:Int32) }
-              StreamTableScan { table: auction, columns: [auction.id, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
-        StreamExchange { dist: HashShard(person.id) }
-          StreamFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
-            StreamTableScan { table: person, columns: [person.id, person.name, person.city, person.state], pk: [person.id], distribution: UpstreamHashShard(person.id) }
+    └─StreamHashJoin { type: Inner, predicate: auction.seller = person.id, output: [person.name, person.city, person.state, auction.id, auction.seller, person.id] }
+      ├─StreamExchange { dist: HashShard(auction.seller) }
+      | └─StreamProject { exprs: [auction.id, auction.seller] }
+      |   └─StreamFilter { predicate: (auction.category = 10:Int32) }
+      |     └─StreamTableScan { table: auction, columns: [auction.id, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
+      └─StreamExchange { dist: HashShard(person.id) }
+        └─StreamFilter { predicate: (((person.state = 'or':Varchar) OR (person.state = 'id':Varchar)) OR (person.state = 'ca':Varchar)) }
+          └─StreamTableScan { table: person, columns: [person.id, person.name, person.city, person.state], pk: [person.id], distribution: UpstreamHashShard(person.id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [name, city, state, id, auction.seller(hidden), person.id(hidden)], pk_columns: [id, person.id, auction.seller] }
@@ -185,32 +185,32 @@
     GROUP BY Q.category;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price)))] }
-        BatchHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price))] }
-          BatchExchange { order: [], dist: HashShard(auction.category) }
-            BatchProject { exprs: [auction.category, max(bid.price)] }
-              BatchHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price)] }
-                BatchProject { exprs: [auction.id, auction.category, bid.price] }
-                  BatchFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-                    BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                      BatchExchange { order: [], dist: HashShard(auction.id) }
-                        BatchScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category], distribution: UpstreamHashShard(auction.id) }
-                      BatchExchange { order: [], dist: HashShard(bid.auction) }
-                        BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price)))] }
+      └─BatchHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price))] }
+        └─BatchExchange { order: [], dist: HashShard(auction.category) }
+          └─BatchProject { exprs: [auction.category, max(bid.price)] }
+            └─BatchHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price)] }
+              └─BatchProject { exprs: [auction.id, auction.category, bid.price] }
+                └─BatchFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+                  └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                    ├─BatchExchange { order: [], dist: HashShard(auction.id) }
+                    | └─BatchScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category], distribution: UpstreamHashShard(auction.id) }
+                    └─BatchExchange { order: [], dist: HashShard(bid.auction) }
+                      └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category] }
-      StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price)))] }
-        StreamHashAgg { group_key: [auction.category], aggs: [count, sum(max(bid.price)), count(max(bid.price))] }
-          StreamExchange { dist: HashShard(auction.category) }
-            StreamProject { exprs: [auction.category, max(bid.price), auction.id] }
-              StreamHashAgg { group_key: [auction.id, auction.category], aggs: [count, max(bid.price)] }
-                StreamProject { exprs: [auction.id, auction.category, bid.price, bid._row_id, bid.auction] }
-                  StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-                    StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                      StreamExchange { dist: HashShard(auction.id) }
-                        StreamTableScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
-                      StreamExchange { dist: HashShard(bid.auction) }
-                        StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price)))] }
+      └─StreamHashAgg { group_key: [auction.category], aggs: [count, sum(max(bid.price)), count(max(bid.price))] }
+        └─StreamExchange { dist: HashShard(auction.category) }
+          └─StreamProject { exprs: [auction.category, max(bid.price), auction.id] }
+            └─StreamHashAgg { group_key: [auction.id, auction.category], aggs: [count, max(bid.price)] }
+              └─StreamProject { exprs: [auction.id, auction.category, bid.price, bid._row_id, bid.auction] }
+                └─StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+                  └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                    ├─StreamExchange { dist: HashShard(auction.id) }
+                    | └─StreamTableScan { table: auction, columns: [auction.id, auction.date_time, auction.expires, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
+                    └─StreamExchange { dist: HashShard(bid.auction) }
+                      └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [category, avg], pk_columns: [category] }
@@ -285,44 +285,44 @@
     ON AuctionBids.starttime = MaxBids.starttime_c AND AuctionBids.num >= MaxBids.maxn;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, count] }
-        BatchFilter { predicate: (count >= max(count)) }
-          BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
-            BatchExchange { order: [], dist: HashShard(window_start) }
-              BatchProject { exprs: [bid.auction, count, window_start] }
-                BatchHashAgg { group_key: [window_start, bid.auction], aggs: [count] }
-                  BatchExchange { order: [], dist: HashShard(window_start, bid.auction) }
-                    BatchProject { exprs: [window_start, bid.auction] }
-                      BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
-                        BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
-            BatchProject { exprs: [max(count), window_start] }
-              BatchHashAgg { group_key: [window_start], aggs: [max(count)] }
-                BatchExchange { order: [], dist: HashShard(window_start) }
-                  BatchProject { exprs: [window_start, count] }
-                    BatchHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
-                      BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
-                        BatchExchange { order: [], dist: HashShard(bid.auction) }
-                          BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, count] }
+      └─BatchFilter { predicate: (count >= max(count)) }
+        └─BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
+          ├─BatchExchange { order: [], dist: HashShard(window_start) }
+          | └─BatchProject { exprs: [bid.auction, count, window_start] }
+          |   └─BatchHashAgg { group_key: [window_start, bid.auction], aggs: [count] }
+          |     └─BatchExchange { order: [], dist: HashShard(window_start, bid.auction) }
+          |       └─BatchProject { exprs: [window_start, bid.auction] }
+          |         └─BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
+          |           └─BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
+          └─BatchProject { exprs: [max(count), window_start] }
+            └─BatchHashAgg { group_key: [window_start], aggs: [max(count)] }
+              └─BatchExchange { order: [], dist: HashShard(window_start) }
+                └─BatchProject { exprs: [window_start, count] }
+                  └─BatchHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+                    └─BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
+                      └─BatchExchange { order: [], dist: HashShard(bid.auction) }
+                        └─BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1] }
-      StreamProject { exprs: [bid.auction, count, window_start, window_start] }
-        StreamFilter { predicate: (count >= max(count)) }
-          StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
-            StreamExchange { dist: HashShard(window_start) }
-              StreamProject { exprs: [bid.auction, count, window_start] }
-                StreamHashAgg { group_key: [window_start, bid.auction], aggs: [count, count] }
-                  StreamExchange { dist: HashShard(window_start, bid.auction) }
-                    StreamProject { exprs: [window_start, bid.auction, bid._row_id] }
-                      StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-                        StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
-            StreamProject { exprs: [max(count), window_start] }
-              StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
-                StreamExchange { dist: HashShard(window_start) }
-                  StreamProject { exprs: [window_start, count, bid.auction] }
-                    StreamHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-                      StreamExchange { dist: HashShard(bid.auction, window_start) }
-                        StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-                          StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, count, window_start, window_start] }
+      └─StreamFilter { predicate: (count >= max(count)) }
+        └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
+          ├─StreamExchange { dist: HashShard(window_start) }
+          | └─StreamProject { exprs: [bid.auction, count, window_start] }
+          |   └─StreamHashAgg { group_key: [window_start, bid.auction], aggs: [count, count] }
+          |     └─StreamExchange { dist: HashShard(window_start, bid.auction) }
+          |       └─StreamProject { exprs: [window_start, bid.auction, bid._row_id] }
+          |         └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
+          |           └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+          └─StreamProject { exprs: [max(count), window_start] }
+            └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+              └─StreamExchange { dist: HashShard(window_start) }
+                └─StreamProject { exprs: [window_start, count, bid.auction] }
+                  └─StreamHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
+                    └─StreamExchange { dist: HashShard(bid.auction, window_start) }
+                      └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
+                        └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1] }
@@ -416,32 +416,32 @@
       AND B1.date_time;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time] }
-        BatchFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-          BatchHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
-            BatchExchange { order: [], dist: HashShard(bid.price) }
-              BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.date_time] }
-                BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
-            BatchExchange { order: [], dist: HashShard(max(bid.price)) }
-              BatchProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)] }
-                BatchHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [max(bid.price)] }
-                  BatchExchange { order: [], dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-                    BatchProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price] }
-                      BatchScan { table: bid, columns: [bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time] }
+      └─BatchFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+        └─BatchHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
+          ├─BatchExchange { order: [], dist: HashShard(bid.price) }
+          | └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.date_time] }
+          |   └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
+          └─BatchExchange { order: [], dist: HashShard(max(bid.price)) }
+            └─BatchProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)] }
+              └─BatchHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [max(bid.price)] }
+                └─BatchExchange { order: [], dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+                  └─BatchProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price] }
+                    └─BatchScan { table: bid, columns: [bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bidder, date_time, bid._row_id(hidden), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), max(bid.price)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), price, max(bid.price)] }
-      StreamProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time, bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), max(bid.price)] }
-        StreamFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-          StreamHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
-            StreamExchange { dist: HashShard(bid.price) }
-              StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.date_time, bid._row_id] }
-                StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
-            StreamExchange { dist: HashShard(max(bid.price)) }
-              StreamProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)] }
-                StreamHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count, max(bid.price)] }
-                  StreamExchange { dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-                    StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price, bid._row_id] }
-                      StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, bid.price, bid.bidder, bid.date_time, bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), max(bid.price)] }
+      └─StreamFilter { predicate: (bid.date_time >= ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)) AND (bid.date_time <= (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+        └─StreamHashJoin { type: Inner, predicate: bid.price = max(bid.price), output: all }
+          ├─StreamExchange { dist: HashShard(bid.price) }
+          | └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.date_time, bid._row_id] }
+          |   └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+          └─StreamExchange { dist: HashShard(max(bid.price)) }
+            └─StreamProject { exprs: [max(bid.price), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), ((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) - '00:00:10':Interval)] }
+              └─StreamHashAgg { group_key: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count, max(bid.price)] }
+                └─StreamExchange { dist: HashShard((TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+                  └─StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), bid.price, bid._row_id] }
+                    └─StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, bidder, date_time, bid._row_id(hidden), (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), max(bid.price)(hidden)], pk_columns: [bid._row_id, (TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval), price, max(bid.price)] }
@@ -516,28 +516,28 @@
       AND P.endtime = A.endtime;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval)] }
-        BatchExchange { order: [], dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-          BatchHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
-            BatchProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-              BatchScan { table: person, columns: [person.id, person.name, person.date_time], distribution: UpstreamHashShard(person.id) }
-        BatchHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
-          BatchExchange { order: [], dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-            BatchProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-              BatchScan { table: auction, columns: [auction.date_time, auction.seller], distribution: SomeShard }
+    └─BatchHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval)] }
+      ├─BatchExchange { order: [], dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+      | └─BatchHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
+      |   └─BatchProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      |     └─BatchScan { table: person, columns: [person.id, person.name, person.date_time], distribution: UpstreamHashShard(person.id) }
+      └─BatchHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+          └─BatchProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+            └─BatchScan { table: auction, columns: [auction.date_time, auction.seller], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.date_time, '00:00:10':Interval)(hidden), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-      StreamHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: all }
-        StreamExchange { dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-          StreamProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-            StreamHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
-              StreamProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-                StreamTableScan { table: person, columns: [person.id, person.name, person.date_time], pk: [person.id], distribution: UpstreamHashShard(person.id) }
-        StreamProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-          StreamHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
-            StreamExchange { dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
-              StreamProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.id] }
-                StreamTableScan { table: auction, columns: [auction.date_time, auction.seller, auction.id], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
+    └─StreamHashJoin { type: Inner, predicate: person.id = auction.seller AND TumbleStart(person.date_time, '00:00:10':Interval) = TumbleStart(auction.date_time, '00:00:10':Interval) AND (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval) = (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), output: all }
+      ├─StreamExchange { dist: HashShard(person.id, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+      | └─StreamProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      |   └─StreamHashAgg { group_key: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
+      |     └─StreamProject { exprs: [person.id, person.name, TumbleStart(person.date_time, '00:00:10':Interval), (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      |       └─StreamTableScan { table: person, columns: [person.id, person.name, person.date_time], pk: [person.id], distribution: UpstreamHashShard(person.id) }
+      └─StreamProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+        └─StreamHashAgg { group_key: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)], aggs: [count] }
+          └─StreamExchange { dist: HashShard(auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)) }
+            └─StreamProject { exprs: [auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.id] }
+              └─StreamTableScan { table: auction, columns: [auction.date_time, auction.seller, auction.id], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden), auction.seller(hidden), TumbleStart(auction.date_time, '00:00:10':Interval)(hidden), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)(hidden)], pk_columns: [id, name, starttime, (TumbleStart(person.date_time, '00:00:10':Interval) + '00:00:10':Interval), auction.seller, TumbleStart(auction.date_time, '00:00:10':Interval), (TumbleStart(auction.date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
@@ -588,29 +588,29 @@
     WHERE rownum <= 1;
   logical_plan: |
     LogicalProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time] }
-      LogicalFilter { predicate: (ROW_NUMBER <= 1:Int32) }
-        LogicalProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY auction.id ORDER BY bid.price DESC NULLS FIRST, bid.date_time ASC NULLS LAST) }
-            LogicalFilter { predicate: (auction.id = bid.auction) AND (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
-                LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER <= 1:Int32) }
+      └─LogicalProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY auction.id ORDER BY bid.price DESC NULLS FIRST, bid.date_time ASC NULLS LAST) }
+          └─LogicalFilter { predicate: (auction.id = bid.auction) AND (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
+              └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time] }
-      LogicalTopN { order: "[bid.price DESC, bid.date_time ASC]", limit: 1, offset: 0, group_key: [0] }
-        LogicalJoin { type: Inner, on: (auction.id = bid.auction) AND (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires), output: all }
-          LogicalScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
-          LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └─LogicalTopN { order: "[bid.price DESC, bid.date_time ASC]", limit: 1, offset: 0, group_key: [0] }
+      └─LogicalJoin { type: Inner, on: (auction.id = bid.auction) AND (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires), output: all }
+        ├─LogicalScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
+        └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, bid._row_id(hidden)], pk_columns: [id, bid._row_id, auction] }
-      StreamProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id] }
-        StreamGroupTopN { order: "[bid.price DESC, bid.date_time ASC]", limit: 1, offset: 0, group_key: [0] }
-          StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
-            StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-              StreamExchange { dist: HashShard(auction.id) }
-                StreamTableScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
-              StreamExchange { dist: HashShard(bid.auction) }
-                StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id] }
+      └─StreamGroupTopN { order: "[bid.price DESC, bid.date_time ASC]", limit: 1, offset: 0, group_key: [0] }
+        └─StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+          └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+            ├─StreamExchange { dist: HashShard(auction.id) }
+            | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
+            └─StreamExchange { dist: HashShard(bid.auction) }
+              └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, bid._row_id(hidden)], pk_columns: [id, bid._row_id, auction] }
@@ -650,12 +650,12 @@
     SELECT auction, bidder, price, date_time, TO_CHAR(date_time, 'YYYY-MM-DD') as date, TO_CHAR(date_time, 'HH:MI') as time FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar)] }
-        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar)] }
+      └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar), bid._row_id] }
-        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), ToChar(bid.date_time, 'HH:MI':Varchar), bid._row_id] }
+      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -737,14 +737,14 @@
     WHERE 0.908 * price > 1000000 AND 0.908 * price < 50000000;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra] }
-        BatchFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
-          BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra] }
+      └─BatchFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
+        └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra, bid._row_id] }
-        StreamFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
-          StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price), Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar), bid.date_time, bid.extra, bid._row_id] }
+      └─StreamFilter { predicate: ((0.908:Decimal * bid.price) > 1000000:Int32) AND ((0.908:Decimal * bid.price) < 50000000:Int32) }
+        └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -778,27 +778,27 @@
     GROUP BY to_char(date_time, 'yyyy-MM-dd');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-        BatchHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-          BatchExchange { order: [], dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
-            BatchHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-              BatchExchange { order: [], dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
-                BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, bid.price, flag] }
-                  BatchExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
-                    BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction] }
-                      BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+      └─BatchHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+        └─BatchExchange { order: [], dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
+          └─BatchHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+            └─BatchExchange { order: [], dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
+              └─BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, bid.price, flag] }
+                └─BatchExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
+                  └─BatchProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction] }
+                    └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day] }
-      StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-        StreamHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-          StreamExchange { dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
-            StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-              StreamHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-                StreamExchange { dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
-                  StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, bid.price, flag, bid._row_id] }
-                    StreamExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
-                      StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
-                        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+      └─StreamHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+        └─StreamExchange { dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
+          └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+            └─StreamHashAgg { group_key: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+              └─StreamExchange { dist: HashShard(ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
+                └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, bid.price, flag, bid._row_id] }
+                  └─StreamExpand { column_subsets: [[ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
+                    └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
+                      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day] }
@@ -871,27 +871,27 @@
     GROUP BY channel, to_char(date_time, 'yyyy-MM-dd');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-        BatchHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-          BatchExchange { order: [], dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
-            BatchHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-              BatchExchange { order: [], dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
-                BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.bidder, bid.auction, bid.price, flag] }
-                  BatchExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar)], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
-                    BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction] }
-                      BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+      └─BatchHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+        └─BatchExchange { order: [], dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
+          └─BatchHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+            └─BatchExchange { order: [], dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
+              └─BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.bidder, bid.auction, bid.price, flag] }
+                └─BatchExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar)], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
+                  └─BatchProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction] }
+                    └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day] }
-      StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-        StreamHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
-          StreamExchange { dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
-            StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag, max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-              StreamHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
-                StreamExchange { dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
-                  StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.bidder, bid.auction, bid.price, flag, bid._row_id] }
-                    StreamExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar)], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
-                      StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
-                        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), Coalesce(sum(count) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), Coalesce(sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), 0:Int64), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+      └─StreamHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)], aggs: [count, max(max(ToChar(bid.date_time, 'HH:mm':Varchar))) filter((flag = 0:Int64)), sum(count) filter((flag = 0:Int64)), sum(count filter((bid.price < 10000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32))) filter((flag = 0:Int64)), sum(count filter((bid.price >= 1000000:Int32))) filter((flag = 0:Int64)), count(bid.bidder) filter((flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.bidder) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 1:Int64)), count(bid.auction) filter((flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price < 10000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64)), count(bid.auction) filter((count filter((bid.price >= 1000000:Int32)) > 0:Int64) AND (flag = 2:Int64))] }
+        └─StreamExchange { dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar)) }
+          └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag, max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+            └─StreamHashAgg { group_key: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.bidder, bid.bidder, bid.bidder, bid.auction, bid.auction, bid.auction, bid.auction, flag], aggs: [count, max(ToChar(bid.date_time, 'HH:mm':Varchar)), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32))] }
+              └─StreamExchange { dist: HashShard(bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder, bid.auction, flag) }
+                └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.bidder, bid.auction, bid.price, flag, bid._row_id] }
+                  └─StreamExpand { column_subsets: [[bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar)], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.bidder], [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), bid.auction]] }
+                    └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar), ToChar(bid.date_time, 'HH:mm':Varchar), bid.price, bid.bidder, bid.auction, bid._row_id] }
+                      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day] }
@@ -961,18 +961,18 @@
     GROUP BY auction, to_char(date_time, 'YYYY-MM-DD');
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)), sum(bid.price)] }
-        BatchHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
-          BatchExchange { order: [], dist: HashShard(bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)) }
-            BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), bid.price] }
-              BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)), sum(bid.price)] }
+      └─BatchHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
+        └─BatchExchange { order: [], dist: HashShard(bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)) }
+          └─BatchProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), bid.price] }
+            └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day] }
-      StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)), sum(bid.price)] }
-        StreamHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
-          StreamExchange { dist: HashShard(bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)) }
-            StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), bid.price, bid._row_id] }
-              StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)), sum(bid.price)] }
+      └─StreamHashAgg { group_key: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price), sum(bid.price)] }
+        └─StreamExchange { dist: HashShard(bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar)) }
+          └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar), bid.price, bid._row_id] }
+            └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day] }
@@ -1009,17 +1009,17 @@
     WHERE rank_number <= 1;
   logical_plan: |
     LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra] }
-      LogicalFilter { predicate: (ROW_NUMBER <= 1:Int32) }
-        LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.bidder, bid.auction ORDER BY bid.date_time DESC NULLS FIRST) }
-            LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER <= 1:Int32) }
+      └─LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.bidder, bid.auction ORDER BY bid.date_time DESC NULLS FIRST) }
+          └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamExchange { dist: HashShard(bid._row_id) }
-        StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
-          StreamGroupTopN { order: "[bid.date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
-            StreamExchange { dist: HashShard(bid.bidder, bid.auction) }
-              StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamExchange { dist: HashShard(bid._row_id) }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+        └─StreamGroupTopN { order: "[bid.date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
+          └─StreamExchange { dist: HashShard(bid.bidder, bid.auction) }
+            └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, bid._row_id(hidden)], pk_columns: [bid._row_id] }
@@ -1051,16 +1051,16 @@
     WHERE rank_number <= 10;
   logical_plan: |
     LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
-      LogicalFilter { predicate: (ROW_NUMBER <= 10:Int32) }
-        LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.auction ORDER BY bid.price DESC NULLS FIRST) }
-            LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER <= 10:Int32) }
+      └─LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.auction ORDER BY bid.price DESC NULLS FIRST) }
+          └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
   optimizer_error: |
     internal error: OverAgg can not be transformed. Plan:
     LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, ROW_NUMBER] }
-      LogicalFilter { predicate: (ROW_NUMBER <= 10:Int32) }
-        LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.auction ORDER BY bid.price DESC NULLS FIRST) }
-          LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER <= 10:Int32) }
+      └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY bid.auction ORDER BY bid.price DESC NULLS FIRST) }
+        └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
 - id: nexmark_q20
   before:
   - create_tables
@@ -1073,20 +1073,20 @@
     WHERE A.category = 10;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
-        BatchExchange { order: [], dist: HashShard(bid.auction) }
-          BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time], distribution: SomeShard }
-        BatchExchange { order: [], dist: HashShard(auction.id) }
-          BatchFilter { predicate: (auction.category = 10:Int32) }
-            BatchScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], distribution: UpstreamHashShard(auction.id) }
+    └─BatchHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category] }
+      ├─BatchExchange { order: [], dist: HashShard(bid.auction) }
+      | └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time], distribution: SomeShard }
+      └─BatchExchange { order: [], dist: HashShard(auction.id) }
+        └─BatchFilter { predicate: (auction.category = 10:Int32) }
+          └─BatchScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], distribution: UpstreamHashShard(auction.id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, bid._row_id(hidden), auction.id(hidden)], pk_columns: [bid._row_id, auction.id, auction] }
-      StreamHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid._row_id, auction.id] }
-        StreamExchange { dist: HashShard(bid.auction) }
-          StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
-        StreamExchange { dist: HashShard(auction.id) }
-          StreamFilter { predicate: (auction.category = 10:Int32) }
-            StreamTableScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
+    └─StreamHashJoin { type: Inner, predicate: bid.auction = auction.id, output: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category, bid._row_id, auction.id] }
+      ├─StreamExchange { dist: HashShard(bid.auction) }
+      | └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+      └─StreamExchange { dist: HashShard(auction.id) }
+        └─StreamFilter { predicate: (auction.category = 10:Int32) }
+          └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name, auction.description, auction.initial_bid, auction.reserve, auction.date_time, auction.expires, auction.seller, auction.category], pk: [auction.id], distribution: UpstreamHashShard(auction.id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, bid._row_id(hidden), auction.id(hidden)], pk_columns: [bid._row_id, auction.id, auction] }
@@ -1142,12 +1142,12 @@
         SPLIT_PART(url, '/', 6) as dir3 FROM bid;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32)] }
-        BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url], distribution: SomeShard }
+    └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32)] }
+      └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32), bid._row_id] }
-        StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32), SplitPart(bid.url, '/':Varchar, 5:Int32), SplitPart(bid.url, '/':Varchar, 6:Int32), bid._row_id] }
+      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, bid._row_id(hidden)], pk_columns: [bid._row_id] }

--- a/src/frontend/planner_test/tests/testdata/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/order_by.yaml
@@ -5,42 +5,42 @@
     select * from t order by v1 desc;
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
-      BatchSort { order: [t.v1 DESC] }
-        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchSort { order: [t.v1 DESC] }
+      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
-      StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* output names are not qualified after table names */
     create table t (v1 bigint, v2 double precision);
     select t.* from t order by v1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
-      BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchSort { order: [t.v1 ASC] }
+      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select v1, v1+1 from t order by v1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
-      BatchProject { exprs: [t.v1, (t.v1 + 1:Int32)] }
-        BatchSort { order: [t.v1 ASC] }
-          BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchProject { exprs: [t.v1, (t.v1 + 1:Int32)] }
+      └─BatchSort { order: [t.v1 ASC] }
+        └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select t.v1 from t order by v1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
-      BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchSort { order: [t.v1 ASC] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* order by output alias */
     create table t (v1 bigint, v2 double precision);
     select v1 as a1 from t order by a1;
   batch_plan: |
     BatchExchange { order: [t.v1 ASC], dist: Single }
-      BatchSort { order: [t.v1 ASC] }
-        BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    └─BatchSort { order: [t.v1 ASC] }
+      └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
 - sql: |
     /* order by ambiguous */
     create table t (v1 bigint, v2 double precision);
@@ -52,21 +52,21 @@
     select v1 as a, v2 as a from t order by 2;
   batch_plan: |
     BatchExchange { order: [t.v2 ASC], dist: Single }
-      BatchSort { order: [t.v2 ASC] }
-        BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchSort { order: [t.v2 ASC] }
+      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by 1+1;
   batch_plan: |
     BatchProject { exprs: [t.v1, t.v2] }
-      BatchExchange { order: [(1:Int32 + 1:Int32) ASC], dist: Single }
-        BatchSort { order: [(1:Int32 + 1:Int32) ASC] }
-          BatchProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32)] }
-            BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [(1:Int32 + 1:Int32) ASC], dist: Single }
+      └─BatchSort { order: [(1:Int32 + 1:Int32) ASC] }
+        └─BatchProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32)] }
+          └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, (1:Int32 + 1:Int32)(hidden), t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [(1:Int32 + 1:Int32), t._row_id] }
-      StreamProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32), t._row_id] }
-        StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, t.v2, (1:Int32 + 1:Int32), t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by v;
@@ -76,66 +76,66 @@
     select * from t order by v1 desc limit 5;
   batch_plan: |
     BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
-      StreamProject { exprs: [t.v1, t.v2, t._row_id] }
-        StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[t.v1 DESC]", limit: 5, offset: 0, group_key: [3] }
-              StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id)] }
-                StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, t.v2, t._row_id] }
+      └─StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[t.v1 DESC]", limit: 5, offset: 0, group_key: [3] }
+            └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id)] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t limit 3 offset 4;
   batch_plan: |
     BatchLimit { limit: 3, offset: 4 }
-      BatchExchange { order: [], dist: Single }
-        BatchLimit { limit: 7, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchLimit { limit: 7, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t limit 5;
   batch_plan: |
     BatchLimit { limit: 5, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchLimit { limit: 5, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchLimit { limit: 5, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from t order by v1 desc limit 5 offset 7;
   batch_plan: |
     BatchTopN { order: "[t.v1 DESC]", limit: 5, offset: 7 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[t.v1 DESC]", limit: 12, offset: 0 }
-          BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[t.v1 DESC]", limit: 12, offset: 0 }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [v1, t._row_id] }
-      StreamProject { exprs: [t.v1, t.v2, t._row_id] }
-        StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 7 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[t.v1 DESC]", limit: 12, offset: 0, group_key: [3] }
-              StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id)] }
-                StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, t.v2, t._row_id] }
+      └─StreamTopN { order: "[t.v1 DESC]", limit: 5, offset: 7 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[t.v1 DESC]", limit: 12, offset: 0, group_key: [3] }
+            └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id)] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by expression that would be valid in select list */
     create table t (x int, y int, z int);
     select x, y from t order by x + y, z;
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y, (t.x + t.y), t.z] }
-      LogicalScan { table: t, columns: [t.x, t.y, t.z] }
+    └─LogicalScan { table: t, columns: [t.x, t.y, t.z] }
   batch_plan: |
     BatchProject { exprs: [t.x, t.y] }
-      BatchExchange { order: [(t.x + t.y) ASC, t.z ASC], dist: Single }
-        BatchSort { order: [(t.x + t.y) ASC, t.z ASC] }
-          BatchProject { exprs: [t.x, t.y, (t.x + t.y), t.z] }
-            BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
+    └─BatchExchange { order: [(t.x + t.y) ASC, t.z ASC], dist: Single }
+      └─BatchSort { order: [(t.x + t.y) ASC, t.z ASC] }
+        └─BatchProject { exprs: [t.x, t.y, (t.x + t.y), t.z] }
+          └─BatchScan { table: t, columns: [t.x, t.y, t.z], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [x, y, (t.x + t.y)(hidden), t.z(hidden), t._row_id(hidden)], pk_columns: [t._row_id], order_descs: [(t.x + t.y), t.z, t._row_id] }
-      StreamProject { exprs: [t.x, t.y, (t.x + t.y), t.z, t._row_id] }
-        StreamTableScan { table: t, columns: [t.x, t.y, t.z, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.x, t.y, (t.x + t.y), t.z, t._row_id] }
+      └─StreamTableScan { table: t, columns: [t.x, t.y, t.z, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* order by the number of an output column */
     create table t (x int, y int);
@@ -144,8 +144,8 @@
     LogicalScan { table: t, columns: [t.x, t.y] }
   batch_plan: |
     BatchExchange { order: [t.y ASC], dist: Single }
-      BatchSort { order: [t.y ASC] }
-        BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
+    └─BatchSort { order: [t.y ASC] }
+      └─BatchScan { table: t, columns: [t.x, t.y], distribution: SomeShard }
 - sql: |
     /* index exceeds the number of select items */
     create table t (x int, y int);
@@ -169,7 +169,7 @@
     select * from mv order by v asc;
   batch_plan: |
     BatchExchange { order: [mv.v ASC], dist: Single }
-      BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - sql: |
     /* BatchSort needed, when input is sorted in wrong order */
     create table t(v int);
@@ -177,8 +177,8 @@
     select * from mv order by v desc;
   batch_plan: |
     BatchExchange { order: [mv.v DESC], dist: Single }
-      BatchSort { order: [mv.v DESC] }
-        BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    └─BatchSort { order: [mv.v DESC] }
+      └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - sql: |
     /* No BatchSort needed, when input is already sorted */
     create table t(v int);
@@ -186,7 +186,7 @@
     select * from mv order by v desc;
   batch_plan: |
     BatchExchange { order: [mv.v DESC], dist: Single }
-      BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - sql: |
     /* BatchSort needed, when input is sorted in wrong order */
     create table t(v int);
@@ -194,15 +194,15 @@
     select * from mv order by v asc;
   batch_plan: |
     BatchExchange { order: [mv.v ASC], dist: Single }
-      BatchSort { order: [mv.v ASC] }
-        BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+    └─BatchSort { order: [mv.v ASC] }
+      └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
 - sql: |
     CREATE TABLE test (a INTEGER, b INTEGER);
     SELECT b % 2 AS f, SUM(a) FROM test GROUP BY b % 2 ORDER BY f;
   batch_plan: |
     BatchExchange { order: [(test.b % 2:Int32) ASC], dist: Single }
-      BatchSortAgg { group_key: [(test.b % 2:Int32)], aggs: [sum(test.a)] }
-        BatchExchange { order: [(test.b % 2:Int32) ASC], dist: HashShard((test.b % 2:Int32)) }
-          BatchSort { order: [(test.b % 2:Int32) ASC] }
-            BatchProject { exprs: [(test.b % 2:Int32), test.a] }
-              BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }
+    └─BatchSortAgg { group_key: [(test.b % 2:Int32)], aggs: [sum(test.a)] }
+      └─BatchExchange { order: [(test.b % 2:Int32) ASC], dist: HashShard((test.b % 2:Int32)) }
+        └─BatchSort { order: [(test.b % 2:Int32) ASC] }
+          └─BatchProject { exprs: [(test.b % 2:Int32), test.a] }
+            └─BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/over_window_function.yaml
@@ -19,8 +19,8 @@
     select row_number() over(PARTITION BY x ORDER BY x) from t;
   logical_plan: |
     LogicalProject { exprs: [ROW_NUMBER] }
-      LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
+      └─LogicalScan { table: t, columns: [t.x, t._row_id] }
 - sql: |
     create table t(x int);
     select row_number() over(PARTITION BY x ORDER BY x ROWS BETWEEN 10 PRECEDING AND CURRENT ROW) from t;
@@ -44,9 +44,9 @@
     select * from t order by (row_number() over(PARTITION BY x ORDER BY x));
   logical_plan: |
     LogicalProject { exprs: [t.x] }
-      LogicalProject { exprs: [t.x, ROW_NUMBER] }
-        LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalProject { exprs: [t.x, ROW_NUMBER] }
+      └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
 - sql: |
     create table t(x int);
     select x from t group by (row_number(x) over());
@@ -71,16 +71,16 @@
     where rank<3;
   logical_plan: |
     LogicalProject { exprs: [t.x, ROW_NUMBER] }
-      LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) }
-        LogicalProject { exprs: [t.x, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
-            LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) }
+      └─LogicalProject { exprs: [t.x, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
+          └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimizer_error: |
     internal error: OverAgg can not be transformed. Plan:
     LogicalProject { exprs: [t.x, ROW_NUMBER] }
-      LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) }
-        LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) }
+      └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.x ASC NULLS LAST) }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
 - sql: |
     /* TopN without rank output */
     create table t(x int, y int);
@@ -89,22 +89,22 @@
     where rank<3 AND x>y;
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) AND (t.x > t.y) }
-        LogicalProject { exprs: [t.x, t.y, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.y ORDER BY t.x ASC NULLS LAST) }
-            LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER < 3:Int32) AND (t.x > t.y) }
+      └─LogicalProject { exprs: [t.x, t.y, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.y ORDER BY t.x ASC NULLS LAST) }
+          └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalTopN { order: "[t.x ASC]", limit: 2, offset: 0, group_key: [1] }
-        LogicalScan { table: t, output_columns: [t.x, t.y, t._row_id], required_columns: [x, y, _row_id], predicate: (t.x > t.y) }
+    └─LogicalTopN { order: "[t.x ASC]", limit: 2, offset: 0, group_key: [1] }
+      └─LogicalScan { table: t, output_columns: [t.x, t.y, t._row_id], required_columns: [x, y, _row_id], predicate: (t.x > t.y) }
   stream_plan: |
     StreamMaterialize { columns: [x, y, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamExchange { dist: HashShard(t._row_id) }
-        StreamProject { exprs: [t.x, t.y, t._row_id] }
-          StreamGroupTopN { order: "[t.x ASC]", limit: 2, offset: 0, group_key: [1] }
-            StreamExchange { dist: HashShard(t.y) }
-              StreamFilter { predicate: (t.x > t.y) }
-                StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamExchange { dist: HashShard(t._row_id) }
+      └─StreamProject { exprs: [t.x, t.y, t._row_id] }
+        └─StreamGroupTopN { order: "[t.x ASC]", limit: 2, offset: 0, group_key: [1] }
+          └─StreamExchange { dist: HashShard(t.y) }
+            └─StreamFilter { predicate: (t.x > t.y) }
+              └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   batch_error: |-
     Feature is not yet implemented: Group TopN in batch mode
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/4847
@@ -115,8 +115,8 @@
     where rank<=3;
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalTopN { order: "[t.x ASC]", limit: 3, offset: 0, group_key: [1] }
-        LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalTopN { order: "[t.x ASC]", limit: 3, offset: 0, group_key: [1] }
+      └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
 - sql: |
     create table t(x int, y int);
     select x, y from
@@ -124,8 +124,8 @@
     where rank>3;
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalTopN { order: "[t.x ASC]", limit: 9223372036854775807, offset: 3, group_key: [1] }
-        LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalTopN { order: "[t.x ASC]", limit: 9223372036854775807, offset: 3, group_key: [1] }
+      └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   stream_error: 'Invalid input syntax: OFFSET without LIMIT in streaming mode'
 - sql: |
     create table t(x int, y int);
@@ -134,8 +134,8 @@
     where rank>=3;
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalTopN { order: "[t.x ASC]", limit: 9223372036854775807, offset: 2, group_key: [1] }
-        LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalTopN { order: "[t.x ASC]", limit: 9223372036854775807, offset: 2, group_key: [1] }
+      └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
 - sql: |
     create table t(x int, y int);
     select x, y from
@@ -145,9 +145,9 @@
   optimizer_error: |
     internal error: OverAgg can not be transformed. Plan:
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalFilter { predicate: (3:Int32 <= ROW_NUMBER) AND (ROW_NUMBER <= 5:Int32) }
-        LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.y ORDER BY t.x ASC NULLS LAST) }
-          LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalFilter { predicate: (3:Int32 <= ROW_NUMBER) AND (ROW_NUMBER <= 5:Int32) }
+      └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.y ORDER BY t.x ASC NULLS LAST) }
+        └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
 - id: create_bid
   sql: |
     /*
@@ -194,13 +194,13 @@
     ) WHERE rownum <= 3;
   stream_plan: |
     StreamMaterialize { columns: [window_start, window_end, supplier_id, price, cnt], pk_columns: [window_start, window_end, supplier_id] }
-      StreamGroupTopN { order: "[sum(bid.price) DESC]", limit: 3, offset: 0, group_key: [0, 1] }
-        StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)) }
-          StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, sum(bid.price), count] }
-            StreamHashAgg { group_key: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id], aggs: [count, sum(bid.price), count] }
-              StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id) }
-                StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, bid.price, bid._row_id] }
-                  StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamGroupTopN { order: "[sum(bid.price) DESC]", limit: 3, offset: 0, group_key: [0, 1] }
+      └─StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)) }
+        └─StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, sum(bid.price), count] }
+          └─StreamHashAgg { group_key: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id], aggs: [count, sum(bid.price), count] }
+            └─StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id) }
+              └─StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, bid.price, bid._row_id] }
+                └─StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
 - before:
   - create_bid
   sql: |
@@ -214,12 +214,12 @@
     ) WHERE rownum <= 3;
   stream_plan: |
     StreamMaterialize { columns: [window_start, window_end, supplier_id, price, bid._row_id(hidden)], pk_columns: [bid._row_id] }
-      StreamExchange { dist: HashShard(bid._row_id) }
-        StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, bid.price, bid._row_id] }
-          StreamGroupTopN { order: "[bid.price DESC]", limit: 3, offset: 0, group_key: [5, 6] }
-            StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)) }
-              StreamProject { exprs: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id, TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)] }
-                StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+    └─StreamExchange { dist: HashShard(bid._row_id) }
+      └─StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval), bid.supplier_id, bid.price, bid._row_id] }
+        └─StreamGroupTopN { order: "[bid.price DESC]", limit: 3, offset: 0, group_key: [5, 6] }
+          └─StreamExchange { dist: HashShard(TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)) }
+            └─StreamProject { exprs: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id, TumbleStart(bid.bidtime, '00:10:00':Interval), (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval)] }
+              └─StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
 - sql: |
     /* Deduplication */
     create table t(x int, y int);
@@ -228,18 +228,18 @@
     where rank = 1
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalFilter { predicate: (ROW_NUMBER = 1:Int32) }
-        LogicalProject { exprs: [t.x, t.y, ROW_NUMBER] }
-          LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.y ASC NULLS LAST) }
-            LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalFilter { predicate: (ROW_NUMBER = 1:Int32) }
+      └─LogicalProject { exprs: [t.x, t.y, ROW_NUMBER] }
+        └─LogicalOverAgg { window_function: ROW_NUMBER() OVER(PARTITION BY t.x ORDER BY t.y ASC NULLS LAST) }
+          └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, t.y] }
-      LogicalTopN { order: "[t.y ASC]", limit: 1, offset: 0, group_key: [0] }
-        LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+    └─LogicalTopN { order: "[t.y ASC]", limit: 1, offset: 0, group_key: [0] }
+      └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [x, y, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamExchange { dist: HashShard(t._row_id) }
-        StreamProject { exprs: [t.x, t.y, t._row_id] }
-          StreamGroupTopN { order: "[t.y ASC]", limit: 1, offset: 0, group_key: [0] }
-            StreamExchange { dist: HashShard(t.x) }
-              StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamExchange { dist: HashShard(t._row_id) }
+      └─StreamProject { exprs: [t.x, t.y, t._row_id] }
+        └─StreamGroupTopN { order: "[t.y ASC]", limit: 1, offset: 0, group_key: [0] }
+          └─StreamExchange { dist: HashShard(t.x) }
+            └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/pg_catalog.yaml
+++ b/src/frontend/planner_test/tests/testdata/pg_catalog.yaml
@@ -3,35 +3,35 @@
     select * from pg_catalog.pg_type
   logical_plan: |
     LogicalProject { exprs: [pg_type.oid, pg_type.typname] }
-      LogicalScan { table: pg_type, columns: [pg_type.oid, pg_type.typname] }
+    └─LogicalScan { table: pg_type, columns: [pg_type.oid, pg_type.typname] }
   batch_plan: |
     BatchScan { table: pg_type, columns: [pg_type.oid, pg_type.typname], distribution: Single }
 - sql: |
     select * from pg_catalog.pg_namespace
   logical_plan: |
     LogicalProject { exprs: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
-      LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
+    └─LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
   batch_plan: |
     BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl], distribution: Single }
 - sql: |
     select * from pg_catalog.pg_cast
   logical_plan: |
     LogicalProject { exprs: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext] }
-      LogicalScan { table: pg_cast, columns: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext] }
+    └─LogicalScan { table: pg_cast, columns: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext] }
   batch_plan: |
     BatchScan { table: pg_cast, columns: [pg_cast.oid, pg_cast.castsource, pg_cast.casttarget, pg_cast.castcontext], distribution: Single }
 - sql: |
     select pg_catalog.pg_get_userbyid(1)
   logical_plan: |
     LogicalProject { exprs: [pg_user.name] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [pg_user.name] }
-          LogicalFilter { predicate: (1:Int32 = pg_user.usesysid) }
-            LogicalScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name, pg_user.usecreatedb, pg_user.usesuper, pg_user.passwd] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalProject { exprs: [pg_user.name] }
+        └─LogicalFilter { predicate: (1:Int32 = pg_user.usesysid) }
+          └─LogicalScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name, pg_user.usecreatedb, pg_user.usesuper, pg_user.passwd] }
   batch_plan: |
     BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
-      BatchValues { rows: [[]] }
-      BatchProject { exprs: [pg_user.name] }
-        BatchFilter { predicate: (1:Int32 = pg_user.usesysid) }
-          BatchScan { table: pg_user, columns: [pg_user.name, pg_user.usesysid], distribution: Single }
+    ├─BatchValues { rows: [[]] }
+    └─BatchProject { exprs: [pg_user.name] }
+      └─BatchFilter { predicate: (1:Int32 = pg_user.usesysid) }
+        └─BatchScan { table: pg_user, columns: [pg_user.name, pg_user.usesysid], distribution: Single }

--- a/src/frontend/planner_test/tests/testdata/pk_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/pk_derive.yaml
@@ -21,15 +21,15 @@
         Tone.id = Ttwo.id;
   stream_plan: |
     StreamMaterialize { columns: [max_v1, max_v2, t1.id(hidden), t2.id(hidden)], pk_columns: [t1.id, t2.id] }
-      StreamHashJoin { type: Inner, predicate: t1.id = t2.id, output: [max(t1.v1), max(t2.v2), t1.id, t2.id] }
-        StreamProject { exprs: [max(t1.v1), t1.id] }
-          StreamHashAgg { group_key: [t1.id], aggs: [count, max(t1.v1)] }
-            StreamExchange { dist: HashShard(t1.id) }
-              StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
-        StreamProject { exprs: [max(t2.v2), t2.id] }
-          StreamHashAgg { group_key: [t2.id], aggs: [count, max(t2.v2)] }
-            StreamExchange { dist: HashShard(t2.id) }
-              StreamTableScan { table: t2, columns: [t2.id, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t1.id = t2.id, output: [max(t1.v1), max(t2.v2), t1.id, t2.id] }
+      ├─StreamProject { exprs: [max(t1.v1), t1.id] }
+      | └─StreamHashAgg { group_key: [t1.id], aggs: [count, max(t1.v1)] }
+      |   └─StreamExchange { dist: HashShard(t1.id) }
+      |     └─StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+      └─StreamProject { exprs: [max(t2.v2), t2.id] }
+        └─StreamHashAgg { group_key: [t2.id], aggs: [count, max(t2.v2)] }
+          └─StreamExchange { dist: HashShard(t2.id) }
+            └─StreamTableScan { table: t2, columns: [t2.id, t2.v2, t2._row_id], pk: [t2._row_id], distribution: UpstreamHashShard(t2._row_id) }
 - sql: |
     create table t (id int, v int);
     SELECT Tone.max_v, Ttwo.min_v
@@ -51,15 +51,15 @@
         Tone.id = Ttwo.id;
   stream_plan: |
     StreamMaterialize { columns: [max_v, min_v, t.id(hidden), t.id#1(hidden)], pk_columns: [t.id, t.id#1] }
-      StreamHashJoin { type: Inner, predicate: t.id = t.id, output: [max(t.v), min(t.v), t.id, t.id] }
-        StreamProject { exprs: [max(t.v), t.id] }
-          StreamHashAgg { group_key: [t.id], aggs: [count, max(t.v)] }
-            StreamExchange { dist: HashShard(t.id) }
-              StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
-        StreamProject { exprs: [min(t.v), t.id] }
-          StreamHashAgg { group_key: [t.id], aggs: [count, min(t.v)] }
-            StreamExchange { dist: HashShard(t.id) }
-              StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamHashJoin { type: Inner, predicate: t.id = t.id, output: [max(t.v), min(t.v), t.id, t.id] }
+      ├─StreamProject { exprs: [max(t.v), t.id] }
+      | └─StreamHashAgg { group_key: [t.id], aggs: [count, max(t.v)] }
+      |   └─StreamExchange { dist: HashShard(t.id) }
+      |     └─StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+      └─StreamProject { exprs: [min(t.v), t.id] }
+        └─StreamHashAgg { group_key: [t.id], aggs: [count, min(t.v)] }
+          └─StreamExchange { dist: HashShard(t.id) }
+            └─StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar, v2 varchar, v3 varchar);
     select
@@ -72,13 +72,13 @@
         v3;
   optimized_logical_plan: |
     LogicalAgg { group_key: [t.v1, t.v2, t.v3], aggs: [] }
-      LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
+    └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3] }
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, v3], pk_columns: [v1, v2, v3] }
-      StreamProject { exprs: [t.v1, t.v2, t.v3] }
-        StreamHashAgg { group_key: [t.v1, t.v2, t.v3], aggs: [count] }
-          StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
-            StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, t.v2, t.v3] }
+      └─StreamHashAgg { group_key: [t.v1, t.v2, t.v3], aggs: [count] }
+        └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
+          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 varchar, v2 varchar, v3 varchar);
     create materialized view mv as
@@ -100,5 +100,5 @@
     LogicalScan { table: mv, output_columns: [mv.v1], required_columns: [v1, v3], predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
   stream_plan: |
     StreamMaterialize { columns: [v1, mv.v2(hidden), mv.v3(hidden)], pk_columns: [v1, mv.v2, mv.v3] }
-      StreamFilter { predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
-        StreamTableScan { table: mv, columns: [mv.v1, mv.v2, mv.v3], pk: [mv.v1, mv.v2, mv.v3], distribution: UpstreamHashShard(mv.v1, mv.v2, mv.v3) }
+    └─StreamFilter { predicate: ((mv.v3 = 'world':Varchar) OR (mv.v3 = 'hello':Varchar)) }
+      └─StreamTableScan { table: mv, columns: [mv.v1, mv.v2, mv.v3], pk: [mv.v1, mv.v2, mv.v3], distribution: UpstreamHashShard(mv.v1, mv.v2, mv.v3) }

--- a/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
@@ -5,22 +5,22 @@
     select * from t1 join t2 on t1.v1=t2.v2 and t1.v1>1 where t2.v2>2;
   logical_plan: |
     LogicalProject { exprs: [t1.v1, t1.v2, t1.v3, t2.v1, t2.v2, t2.v3] }
-      LogicalFilter { predicate: (t2.v2 > 2:Int32) }
-        LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) AND (t1.v1 > 1:Int32), output: all }
-          LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
-          LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
+    └─LogicalFilter { predicate: (t2.v2 > 2:Int32) }
+      └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) AND (t1.v1 > 1:Int32), output: all }
+        ├─LogicalScan { table: t1, columns: [t1.v1, t1.v2, t1.v3, t1._row_id] }
+        └─LogicalScan { table: t2, columns: [t2.v1, t2.v2, t2.v3, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
-      LogicalScan { table: t1, output_columns: [t1.v1, t1.v2, t1.v3], required_columns: [v1, v2, v3], predicate: (t1.v1 > 1:Int32) }
-      LogicalScan { table: t2, output_columns: [t2.v1, t2.v2, t2.v3], required_columns: [v1, v2, v3], predicate: (t2.v2 > 2:Int32) }
+    ├─LogicalScan { table: t1, output_columns: [t1.v1, t1.v2, t1.v3], required_columns: [v1, v2, v3], predicate: (t1.v1 > 1:Int32) }
+    └─LogicalScan { table: t2, output_columns: [t2.v1, t2.v2, t2.v3], required_columns: [v1, v2, v3], predicate: (t2.v2 > 2:Int32) }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) where v2 > 1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalProject { exprs: [t.v1, t.v2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, output_columns: [t.v1, t.v2], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
@@ -28,9 +28,9 @@
     select v1 from (select v2, v1 from t) where v2 > 1;
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalProject { exprs: [t.v2, t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalProject { exprs: [t.v2, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) }
 - sql: |
@@ -38,10 +38,10 @@
     select v1 from (select v2 as a2, v1 from t where v1 > 2) where a2 > 1;
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalProject { exprs: [t.v2, t.v1] }
-          LogicalFilter { predicate: (t.v1 > 2:Int32) }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalProject { exprs: [t.v2, t.v1] }
+        └─LogicalFilter { predicate: (t.v1 > 2:Int32) }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, output_columns: [t.v1], required_columns: [v1, v2], predicate: (t.v2 > 1:Int32) AND (t.v1 > 2:Int32) }
 - sql: |
@@ -49,20 +49,20 @@
     select * from (select v1, min(v2) as min from t group by v1) where v1 > 1 and min > 1 and 1 > 0 and v1 > min;
   logical_plan: |
     LogicalProject { exprs: [t.v1, min(t.v2)] }
-      LogicalFilter { predicate: (t.v1 > 1:Int32) AND (min(t.v2) > 1:Int32) AND (1:Int32 > 0:Int32) AND (t.v1 > min(t.v2)) }
-        LogicalProject { exprs: [t.v1, min(t.v2)] }
-          LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
-            LogicalProject { exprs: [t.v1, t.v2] }
-              LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t.v4, t._row_id] }
+    └─LogicalFilter { predicate: (t.v1 > 1:Int32) AND (min(t.v2) > 1:Int32) AND (1:Int32 > 0:Int32) AND (t.v1 > min(t.v2)) }
+      └─LogicalProject { exprs: [t.v1, min(t.v2)] }
+        └─LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
+          └─LogicalProject { exprs: [t.v1, t.v2] }
+            └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t.v4, t._row_id] }
   optimized_logical_plan: |
     LogicalFilter { predicate: (min(t.v2) > 1:Int32) AND (t.v1 > min(t.v2)) }
-      LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
-        LogicalScan { table: t, output_columns: [t.v1, t.v2], required_columns: [v1, v2], predicate: (t.v1 > 1:Int32) AND (1:Int32 > 0:Int32) }
+    └─LogicalAgg { group_key: [t.v1], aggs: [min(t.v2)] }
+      └─LogicalScan { table: t, output_columns: [t.v1, t.v2], required_columns: [v1, v2], predicate: (t.v1 > 1:Int32) AND (1:Int32 > 0:Int32) }
 - sql: |
     /* Always false should not be pushed below SimpleAgg */
     create table t(v1 int, v2 int, v3 int, v4 int);
     select min(v1) from t having false;
   optimized_logical_plan: |
     LogicalFilter { predicate: false:Boolean }
-      LogicalAgg { aggs: [min(t.v1)] }
-        LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalAgg { aggs: [min(t.v1)] }
+      └─LogicalScan { table: t, columns: [t.v1] }

--- a/src/frontend/planner_test/tests/testdata/project_set.yaml
+++ b/src/frontend/planner_test/tests/testdata/project_set.yaml
@@ -3,81 +3,81 @@
     select generate_series('2'::INT,'10'::INT,'2'::INT);
   batch_plan: |
     BatchProject { exprs: [Generate('2':Varchar::Int32, '10':Varchar::Int32, '2':Varchar::Int32)] }
-      BatchProjectSet { select_list: [Generate('2':Varchar::Int32, '10':Varchar::Int32, '2':Varchar::Int32)] }
-        BatchValues { rows: [[]] }
+    └─BatchProjectSet { select_list: [Generate('2':Varchar::Int32, '10':Varchar::Int32, '2':Varchar::Int32)] }
+      └─BatchValues { rows: [[]] }
 - sql: |
     select unnest(Array[1,2,3]);
   batch_plan: |
     BatchProject { exprs: [Unnest(Array(1:Int32, 2:Int32, 3:Int32))] }
-      BatchProjectSet { select_list: [Unnest(Array(1:Int32, 2:Int32, 3:Int32))] }
-        BatchValues { rows: [[]] }
+    └─BatchProjectSet { select_list: [Unnest(Array(1:Int32, 2:Int32, 3:Int32))] }
+      └─BatchValues { rows: [[]] }
 - sql: |
     select unnest(Array[Array[1,2,3], Array[4,5,6]]);
   batch_plan: |
     BatchProject { exprs: [Unnest(Array(Array(1:Int32, 2:Int32, 3:Int32), Array(4:Int32, 5:Int32, 6:Int32)))] }
-      BatchProjectSet { select_list: [Unnest(Array(Array(1:Int32, 2:Int32, 3:Int32), Array(4:Int32, 5:Int32, 6:Int32)))] }
-        BatchValues { rows: [[]] }
+    └─BatchProjectSet { select_list: [Unnest(Array(Array(1:Int32, 2:Int32, 3:Int32), Array(4:Int32, 5:Int32, 6:Int32)))] }
+      └─BatchValues { rows: [[]] }
 - sql: |
     create table t(x int[]);
     select unnest(x) as unnest from t;
   batch_plan: |
     BatchProject { exprs: [Unnest($0)] }
-      BatchExchange { order: [], dist: Single }
-        BatchProjectSet { select_list: [Unnest($0)] }
-          BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProjectSet { select_list: [Unnest($0)] }
+        └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), unnest, t._row_id(hidden)], pk_columns: [t._row_id, projected_row_id] }
-      StreamProjectSet { select_list: [Unnest($0), $1] }
-        StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProjectSet { select_list: [Unnest($0), $1] }
+      └─StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* table functions used with usual expressions */
     create table t(x int[]);
     select unnest(x), 1 from t;
   batch_plan: |
     BatchProject { exprs: [Unnest($0), 1:Int32] }
-      BatchExchange { order: [], dist: Single }
-        BatchProjectSet { select_list: [Unnest($0), 1:Int32] }
-          BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProjectSet { select_list: [Unnest($0), 1:Int32] }
+        └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* multiple table functions */
     create table t(x int[]);
     select unnest(x), unnest(Array[1,2]) from t;
   batch_plan: |
     BatchProject { exprs: [Unnest($0), Unnest(Array(1:Int32, 2:Int32))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProjectSet { select_list: [Unnest($0), Unnest(Array(1:Int32, 2:Int32))] }
-          BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProjectSet { select_list: [Unnest($0), Unnest(Array(1:Int32, 2:Int32))] }
+        └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int);
     select -generate_series(x,x,x) from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [Neg(Generate($0, $0, $0))] }
-        BatchProjectSet { select_list: [$0, $1, Generate($0, $0, $0)] }
-          BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchProject { exprs: [Neg(Generate($0, $0, $0))] }
+      └─BatchProjectSet { select_list: [$0, $1, Generate($0, $0, $0)] }
+        └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of usual functions */
     create table t(x int[]);
     select unnest(x) * unnest(x) as a, unnest(x) as b from t;
   batch_plan: |
     BatchProject { exprs: [(Unnest($0) * Unnest($0)), Unnest($1)] }
-      BatchExchange { order: [], dist: Single }
-        BatchProjectSet { select_list: [($3 * $4), Unnest($1)] }
-          BatchProjectSet { select_list: [$0, $1, Unnest($0), Unnest($0)] }
-            BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProjectSet { select_list: [($3 * $4), Unnest($1)] }
+        └─BatchProjectSet { select_list: [$0, $1, Unnest($0), Unnest($0)] }
+          └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [projected_row_id(hidden), a, b, t._row_id(hidden), projected_row_id#1(hidden)], pk_columns: [t._row_id, projected_row_id#1, projected_row_id] }
-      StreamProjectSet { select_list: [($3 * $4), Unnest($1), $2, $0] }
-        StreamProjectSet { select_list: [$0, $1, Unnest($0), Unnest($0)] }
-          StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProjectSet { select_list: [($3 * $4), Unnest($1), $2, $0] }
+      └─StreamProjectSet { select_list: [$0, $1, Unnest($0), Unnest($0)] }
+        └─StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     /* table functions as parameters of table functions */
     create table t(x int[]);
     select generate_series(unnest(x),100,1) from t;
   batch_plan: |
     BatchProject { exprs: [Generate($3, 100:Int32, 1:Int32)] }
-      BatchExchange { order: [], dist: Single }
-        BatchProjectSet { select_list: [Generate($3, 100:Int32, 1:Int32)] }
-          BatchProjectSet { select_list: [$0, $1, Unnest($0)] }
-            BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProjectSet { select_list: [Generate($3, 100:Int32, 1:Int32)] }
+        └─BatchProjectSet { select_list: [$0, $1, Unnest($0)] }
+          └─BatchScan { table: t, columns: [t.x, t._row_id], distribution: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/range_scan.yaml
+++ b/src/frontend/planner_test/tests/testdata/range_scan.yaml
@@ -13,21 +13,21 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id < 43
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id < Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id < Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 + 1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -54,7 +54,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = '42'
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -67,7 +67,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id IS NULL
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -80,37 +80,37 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date = 1111
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(1111)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(1111)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id > 42 AND date = 1111 AND 2>1
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (2:Int32 > 1:Int32) AND (orders_count_by_user.date = 1111:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id > Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: (2:Int32 > 1:Int32) AND (orders_count_by_user.date = 1111:Int32) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id > Int64(42)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE date > 1111 AND user_id = 42 AND 5<6 AND date <= 6666
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (5:Int32 < 6:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date > Int32(1111) AND orders_count_by_user.date <= Int32(6666)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: (5:Int32 < 6:Int32) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date > Int32(1111) AND orders_count_by_user.date <= Int32(6666)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42, 43)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in (42+1, 44-1)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -118,15 +118,15 @@
     SELECT * FROM orders_count_by_user WHERE user_id in (42.0, 43.0)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: In(orders_count_by_user.user_id::Decimal, 42.0:Decimal, 43.0:Decimal) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: In(orders_count_by_user.user_id::Decimal, 42.0:Decimal, 43.0:Decimal) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id in ('42', '43')
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42) OR orders_count_by_user.user_id = Int64(43)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -138,15 +138,15 @@
     SELECT * FROM orders_count_by_user WHERE user_id in (2147483648, 2147483649) AND date = 6666
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (orders_count_by_user.date = 6666:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: (orders_count_by_user.date = 6666:Int32) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222) OR orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222) OR orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -154,7 +154,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 2222)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -162,7 +162,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, NULL)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -177,7 +177,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date in (4444, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -185,7 +185,7 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date in (2222, 3333) AND date = 3333
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(42), orders_count_by_user.date = Int32(3333)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -199,8 +199,8 @@
     SELECT * FROM orders_count_by_user WHERE user_id in (2147483648, 2147483649) AND date in (2222, 3333)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: In(orders_count_by_user.date, 2222:Int32, 3333:Int32) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: In(orders_count_by_user.date, 2222:Int32, 3333:Int32) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(2147483648) OR orders_count_by_user.user_id = Int64(2147483649)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - id: create_table_and_mv_ordered
   sql: |
     CREATE TABLE orders (
@@ -217,22 +217,22 @@
     SELECT * FROM orders_count_by_user_ordered WHERE user_id = 42
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (orders_count_by_user_ordered.user_id = 42:Int32) }
-        BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id = 42:Int32) }
+      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE user_id > 42 AND orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10), orders_count_by_user_ordered.user_id > Int32(42)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10), orders_count_by_user_ordered.user_id > Int32(42)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - before:
   - create_table_and_mv_ordered
   sql: |
     SELECT * FROM orders_count_by_user_ordered WHERE orders_count = 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
 - id: create_small
   sql: |
     CREATE TABLE t(x smallint);
@@ -245,8 +245,8 @@
     SELECT * FROM mv WHERE x = 60000;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (mv.x = 60000:Int32) }
-        BatchScan { table: mv, columns: [mv.x], distribution: UpstreamHashShard(mv.x) }
+    └─BatchFilter { predicate: (mv.x = 60000:Int32) }
+      └─BatchScan { table: mv, columns: [mv.x], distribution: UpstreamHashShard(mv.x) }
 - before:
   - create_small
   sql: |
@@ -254,29 +254,29 @@
     SELECT * FROM mv WHERE x < 60000;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (mv.x < 60000:Int32) }
-        BatchScan { table: mv, columns: [mv.x], distribution: UpstreamHashShard(mv.x) }
+    └─BatchFilter { predicate: (mv.x < 60000:Int32) }
+      └─BatchScan { table: mv, columns: [mv.x], distribution: UpstreamHashShard(mv.x) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 1 or user_id = 2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE (user_id = 1) or (user_id = 2 and date = 2222);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE (user_id = 1) or (user_id = 2 and date in (1111, 2222));
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(1111) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(1111) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date = Int32(2222)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -284,8 +284,8 @@
     SELECT * FROM orders_count_by_user WHERE (user_id = 1) or (user_id = 2 and date in (1111, 2222)) or (user_id != 3);
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (((orders_count_by_user.user_id = 1:Int32) OR ((orders_count_by_user.user_id = 2:Int32) AND In(orders_count_by_user.date, 1111:Int32, 2222:Int32))) OR (orders_count_by_user.user_id <> 3:Int32)) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: (((orders_count_by_user.user_id = 1:Int32) OR ((orders_count_by_user.user_id = 2:Int32) AND In(orders_count_by_user.date, 1111:Int32, 2222:Int32))) OR (orders_count_by_user.user_id <> 3:Int32)) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -293,15 +293,15 @@
     SELECT * FROM orders_count_by_user WHERE user_id > 1 or user_id < 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: ((orders_count_by_user.user_id > 1:Int32) OR (orders_count_by_user.user_id < 10:Int32)) }
-        BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchFilter { predicate: ((orders_count_by_user.user_id > 1:Int32) OR (orders_count_by_user.user_id < 10:Int32)) }
+      └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 1 or user_id is null
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
@@ -314,52 +314,52 @@
     SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id is null and date = 1111)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date = Int32(1111)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date = Int32(1111)], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id = 2 and date is null)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id = Int64(2), orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id = 1 or (user_id is null and date is null)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id = Int64(1) OR orders_count_by_user.user_id IS NULL, orders_count_by_user.date IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - before:
   - create_table_and_mv
   sql: |
     SELECT * FROM orders_count_by_user WHERE user_id is null or (user_id is null and date is null)
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
+    └─BatchScan { table: orders_count_by_user, columns: [orders_count_by_user.user_id, orders_count_by_user.date, orders_count_by_user.orders_count], scan_ranges: [orders_count_by_user.user_id IS NULL], distribution: UpstreamHashShard(orders_count_by_user.user_id, orders_count_by_user.date) }
 - sql: |
     create table sbtest1(id INT, k INT, c VARCHAR, pad VARCHAR);
     create index k1 on sbtest1(k);
     select count(k) from sbtest1 where k between 0 and 5;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(k1.k))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(k1.k)] }
-          BatchScan { table: k1, columns: [k1.k], scan_ranges: [k1.k = Int32(0) OR k1.k = Int32(1) OR k1.k = Int32(2) OR k1.k = Int32(3) OR k1.k = Int32(4) OR k1.k = Int32(5)], distribution: UpstreamHashShard(k1.k) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(k1.k)] }
+        └─BatchScan { table: k1, columns: [k1.k], scan_ranges: [k1.k = Int32(0) OR k1.k = Int32(1) OR k1.k = Int32(2) OR k1.k = Int32(3) OR k1.k = Int32(4) OR k1.k = Int32(5)], distribution: UpstreamHashShard(k1.k) }
 - sql: |
     create table sbtest1(id INT, k INT, c VARCHAR, pad VARCHAR);
     create index k1 on sbtest1(k);
     select count(k) from sbtest1 where k between 0 and 500;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(k1.k))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(k1.k)] }
-          BatchScan { table: k1, columns: [k1.k], scan_ranges: [k1.k >= Int32(0) AND k1.k <= Int32(500)], distribution: UpstreamHashShard(k1.k) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(k1.k)] }
+        └─BatchScan { table: k1, columns: [k1.k], scan_ranges: [k1.k >= Int32(0) AND k1.k <= Int32(500)], distribution: UpstreamHashShard(k1.k) }
 - sql: |
     create table sbtest1(id INT, k INT, c VARCHAR, pad VARCHAR, primary key(id));
     create index k1 on sbtest1(k);
     select count(k) from sbtest1 where id between 0 and 5;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(sbtest1.k))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(sbtest1.k)] }
-          BatchScan { table: sbtest1, columns: [sbtest1.k], scan_ranges: [sbtest1.id = Int32(0) OR sbtest1.id = Int32(1) OR sbtest1.id = Int32(2) OR sbtest1.id = Int32(3) OR sbtest1.id = Int32(4) OR sbtest1.id = Int32(5)], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(sbtest1.k)] }
+        └─BatchScan { table: sbtest1, columns: [sbtest1.k], scan_ranges: [sbtest1.id = Int32(0) OR sbtest1.id = Int32(1) OR sbtest1.id = Int32(2) OR sbtest1.id = Int32(3) OR sbtest1.id = Int32(4) OR sbtest1.id = Int32(5)], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/stream_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/stream_dist_agg.yaml
@@ -13,14 +13,14 @@
     select max(v) as a1 from S;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(s.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(s.v)] }
-          BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(s.v)] }
+        └─BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [max(s.v)] }
-        StreamGlobalSimpleAgg { aggs: [count, max(s.v)] }
-          StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [max(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [count, max(s.v)] }
+        └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -42,14 +42,14 @@
     select sum(v) as a1 from S;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum(s.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum(s.v)] }
-          BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum(s.v)] }
+        └─BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [sum(s.v)] }
-        StreamGlobalSimpleAgg { aggs: [count, sum(s.v)] }
-          StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [sum(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [count, sum(s.v)] }
+        └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -71,14 +71,14 @@
     select count(v) as a1 from S;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(s.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(s.v)] }
-          BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(s.v)] }
+        └─BatchScan { table: s, columns: [s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [count(s.v)] }
-        StreamGlobalSimpleAgg { aggs: [count, count(s.v)] }
-          StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [count(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [count, count(s.v)] }
+        └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -100,15 +100,15 @@
     select string_agg(s, ',' order by v) as a1 from S;
   batch_plan: |
     BatchSimpleAgg { aggs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [s.s, ',':Varchar, s.v] }
-          BatchScan { table: s, columns: [s.v, s.s], distribution: UpstreamHashShard() }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [s.s, ',':Varchar, s.v] }
+        └─BatchScan { table: s, columns: [s.v, s.s], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
-        StreamGlobalSimpleAgg { aggs: [count, string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
-          StreamProject { exprs: [s.s, ',':Varchar, s.v, s.t._row_id] }
-            StreamTableScan { table: s, columns: [s.v, s.s, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
+        └─StreamProject { exprs: [s.s, ',':Varchar, s.v, s.t._row_id] }
+          └─StreamTableScan { table: s, columns: [s.v, s.s, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -131,17 +131,17 @@
     select max(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [max(max(t.v))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), max(max(t.v))] }
-          StreamExchange { dist: Single }
-            StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max(t.v)] }
-              StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id)] }
-                StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [max(max(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), max(max(t.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max(t.v)] }
+            └─StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id)] }
+              └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -171,11 +171,11 @@
     select max(v) as a1 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [max(max(ao.v))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(ao.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v)] }
-              StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [max(max(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(ao.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v)] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -201,16 +201,16 @@
     select sum(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(t.v))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v)] }
-              StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(sum(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(t.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v)] }
+            └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -236,11 +236,11 @@
     select sum(v) as a1 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [sum(sum(ao.v))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), sum(sum(ao.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(ao.v)] }
-              StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [sum(sum(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), sum(sum(ao.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(ao.v)] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -266,16 +266,16 @@
     select count(v) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(count(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [count(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [count(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [sum(count(t.v))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(count(t.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, count(t.v)] }
-              StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(count(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(count(t.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, count(t.v)] }
+            └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -301,11 +301,11 @@
     select count(v) as a1 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [sum(count(ao.v))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), sum(count(ao.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, count(ao.v)] }
-              StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [sum(count(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), sum(count(ao.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, count(ao.v)] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -331,16 +331,16 @@
     select string_agg(s, ',' order by o) as a1 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.o, t.s], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-        StreamGlobalSimpleAgg { aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [t.s, ',':Varchar, t.o, t._row_id] }
-              StreamTableScan { table: t, columns: [t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [t.s, ',':Varchar, t.o, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -366,11 +366,11 @@
     select string_agg(s, ',' order by o) as a1 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [] }
-      StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [ao.s, ',':Varchar, ao.o, ao._row_id] }
-              StreamTableScan { table: ao, columns: [ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [ao.s, ',':Varchar, ao.o, ao._row_id] }
+            └─StreamTableScan { table: ao, columns: [ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [] }
@@ -396,17 +396,17 @@
     select max(v) as a1, count(v) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(max(t.v)), sum(count(t.v))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [max(t.v), count(t.v)] }
-          BatchScan { table: t, columns: [t.v], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [max(t.v), count(t.v)] }
+        └─BatchScan { table: t, columns: [t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [max(max(t.v)), sum(count(t.v))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), max(max(t.v)), sum(count(t.v))] }
-          StreamExchange { dist: Single }
-            StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max(t.v), count(t.v)] }
-              StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id)] }
-                StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [max(max(t.v)), sum(count(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), max(max(t.v)), sum(count(t.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [Vnode(t._row_id)], aggs: [count, max(t.v), count(t.v)] }
+            └─StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id)] }
+              └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -438,11 +438,11 @@
     select max(v) as a1, count(v) as a2 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [max(max(ao.v)), sum(count(ao.v))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(ao.v)), sum(count(ao.v))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v), count(ao.v)] }
-              StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [max(max(ao.v)), sum(count(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(count), max(max(ao.v)), sum(count(ao.v))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v), count(ao.v)] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -469,16 +469,16 @@
     select count(v) as a1, string_agg(s, ',' order by o) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-        StreamGlobalSimpleAgg { aggs: [count, count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
-              StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -505,11 +505,11 @@
     select count(v) as a1, string_agg(s, ',' order by o) as a2 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [count, count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
-              StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -536,16 +536,16 @@
     select max(v) as a1, string_agg(s, ',' order by o) as a2 from T;
   batch_plan: |
     BatchSimpleAgg { aggs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      BatchExchange { order: [], dist: Single }
-        BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
-          BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchProject { exprs: [t.v, t.s, ',':Varchar, t.o] }
+        └─BatchScan { table: t, columns: [t.v, t.o, t.s], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-        StreamGlobalSimpleAgg { aggs: [count, max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
-              StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -572,11 +572,11 @@
     select max(v) as a1, string_agg(s, ',' order by o) as a2 from AO;
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [] }
-      StreamProject { exprs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-        StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamExchange { dist: Single }
-            StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
-              StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: Single }
+          └─StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
+            └─StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [] }
@@ -603,16 +603,16 @@
     select max(v) as a1 from T group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(t.v)] }
-        BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
-          BatchExchange { order: [], dist: HashShard(t.k) }
-            BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
+    └─BatchProject { exprs: [max(t.v)] }
+      └─BatchHashAgg { group_key: [t.k], aggs: [max(t.v)] }
+        └─BatchExchange { order: [], dist: HashShard(t.k) }
+          └─BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
-      StreamProject { exprs: [max(t.v), t.k] }
-        StreamHashAgg { group_key: [t.k], aggs: [count, max(t.v)] }
-          StreamExchange { dist: HashShard(t.k) }
-            StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [max(t.v), t.k] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [count, max(t.v)] }
+        └─StreamExchange { dist: HashShard(t.k) }
+          └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
@@ -637,14 +637,14 @@
     select max(v) as a1 from Tk group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(tk.v)] }
-        BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
-          BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
+    └─BatchProject { exprs: [max(tk.v)] }
+      └─BatchSortAgg { group_key: [tk.k], aggs: [max(tk.v)] }
+        └─BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
-      StreamProject { exprs: [max(tk.v), tk.k] }
-        StreamHashAgg { group_key: [tk.k], aggs: [count, max(tk.v)] }
-          StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
+    └─StreamProject { exprs: [max(tk.v), tk.k] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [count, max(tk.v)] }
+        └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
@@ -666,15 +666,15 @@
     select max(v) as a1 from S group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [max(s.v)] }
-        BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
-          BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
+    └─BatchProject { exprs: [max(s.v)] }
+      └─BatchHashAgg { group_key: [s.k], aggs: [max(s.v)] }
+        └─BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
-      StreamProject { exprs: [max(s.v), s.k] }
-        StreamHashAgg { group_key: [s.k], aggs: [count, max(s.v)] }
-          StreamExchange { dist: HashShard(s.k) }
-            StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [max(s.v), s.k] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [count, max(s.v)] }
+        └─StreamExchange { dist: HashShard(s.k) }
+          └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
@@ -699,10 +699,10 @@
     select max(v) as a1 from AO group by k;
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
-      StreamProject { exprs: [max(ao.v), ao.k] }
-        StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, max(ao.v)] }
-          StreamExchange { dist: HashShard(ao.k) }
-            StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [max(ao.v), ao.k] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, max(ao.v)] }
+        └─StreamExchange { dist: HashShard(ao.k) }
+          └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
@@ -727,16 +727,16 @@
     select sum(v) as a1 from T group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [sum(t.v)] }
-        BatchHashAgg { group_key: [t.k], aggs: [sum(t.v)] }
-          BatchExchange { order: [], dist: HashShard(t.k) }
-            BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
+    └─BatchProject { exprs: [sum(t.v)] }
+      └─BatchHashAgg { group_key: [t.k], aggs: [sum(t.v)] }
+        └─BatchExchange { order: [], dist: HashShard(t.k) }
+          └─BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
-      StreamProject { exprs: [sum(t.v), t.k] }
-        StreamHashAgg { group_key: [t.k], aggs: [count, sum(t.v)] }
-          StreamExchange { dist: HashShard(t.k) }
-            StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [sum(t.v), t.k] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [count, sum(t.v)] }
+        └─StreamExchange { dist: HashShard(t.k) }
+          └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
@@ -761,14 +761,14 @@
     select sum(v) as a1 from Tk group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [sum(tk.v)] }
-        BatchSortAgg { group_key: [tk.k], aggs: [sum(tk.v)] }
-          BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
+    └─BatchProject { exprs: [sum(tk.v)] }
+      └─BatchSortAgg { group_key: [tk.k], aggs: [sum(tk.v)] }
+        └─BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
-      StreamProject { exprs: [sum(tk.v), tk.k] }
-        StreamHashAgg { group_key: [tk.k], aggs: [count, sum(tk.v)] }
-          StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
+    └─StreamProject { exprs: [sum(tk.v), tk.k] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [count, sum(tk.v)] }
+        └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
@@ -790,15 +790,15 @@
     select sum(v) as a1 from S group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [sum(s.v)] }
-        BatchHashAgg { group_key: [s.k], aggs: [sum(s.v)] }
-          BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
+    └─BatchProject { exprs: [sum(s.v)] }
+      └─BatchHashAgg { group_key: [s.k], aggs: [sum(s.v)] }
+        └─BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
-      StreamProject { exprs: [sum(s.v), s.k] }
-        StreamHashAgg { group_key: [s.k], aggs: [count, sum(s.v)] }
-          StreamExchange { dist: HashShard(s.k) }
-            StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [sum(s.v), s.k] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [count, sum(s.v)] }
+        └─StreamExchange { dist: HashShard(s.k) }
+          └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
@@ -823,10 +823,10 @@
     select sum(v) as a1 from AO group by k;
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
-      StreamProject { exprs: [sum(ao.v), ao.k] }
-        StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, sum(ao.v)] }
-          StreamExchange { dist: HashShard(ao.k) }
-            StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [sum(ao.v), ao.k] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, sum(ao.v)] }
+        └─StreamExchange { dist: HashShard(ao.k) }
+          └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
@@ -851,16 +851,16 @@
     select count(v) as a1 from T group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [count(t.v)] }
-        BatchHashAgg { group_key: [t.k], aggs: [count(t.v)] }
-          BatchExchange { order: [], dist: HashShard(t.k) }
-            BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
+    └─BatchProject { exprs: [count(t.v)] }
+      └─BatchHashAgg { group_key: [t.k], aggs: [count(t.v)] }
+        └─BatchExchange { order: [], dist: HashShard(t.k) }
+          └─BatchScan { table: t, columns: [t.k, t.v], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
-      StreamProject { exprs: [count(t.v), t.k] }
-        StreamHashAgg { group_key: [t.k], aggs: [count, count(t.v)] }
-          StreamExchange { dist: HashShard(t.k) }
-            StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [count(t.v), t.k] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [count, count(t.v)] }
+        └─StreamExchange { dist: HashShard(t.k) }
+          └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
@@ -885,14 +885,14 @@
     select count(v) as a1 from Tk group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [count(tk.v)] }
-        BatchSortAgg { group_key: [tk.k], aggs: [count(tk.v)] }
-          BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
+    └─BatchProject { exprs: [count(tk.v)] }
+      └─BatchSortAgg { group_key: [tk.k], aggs: [count(tk.v)] }
+        └─BatchScan { table: tk, columns: [tk.k, tk.v], distribution: UpstreamHashShard(tk.k) }
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
-      StreamProject { exprs: [count(tk.v), tk.k] }
-        StreamHashAgg { group_key: [tk.k], aggs: [count, count(tk.v)] }
-          StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
+    └─StreamProject { exprs: [count(tk.v), tk.k] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [count, count(tk.v)] }
+        └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
@@ -914,15 +914,15 @@
     select count(v) as a1 from S group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [count(s.v)] }
-        BatchHashAgg { group_key: [s.k], aggs: [count(s.v)] }
-          BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
+    └─BatchProject { exprs: [count(s.v)] }
+      └─BatchHashAgg { group_key: [s.k], aggs: [count(s.v)] }
+        └─BatchScan { table: s, columns: [s.k, s.v], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
-      StreamProject { exprs: [count(s.v), s.k] }
-        StreamHashAgg { group_key: [s.k], aggs: [count, count(s.v)] }
-          StreamExchange { dist: HashShard(s.k) }
-            StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [count(s.v), s.k] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [count, count(s.v)] }
+        └─StreamExchange { dist: HashShard(s.k) }
+          └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
@@ -947,10 +947,10 @@
     select count(v) as a1 from AO group by k;
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
-      StreamProject { exprs: [count(ao.v), ao.k] }
-        StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, count(ao.v)] }
-          StreamExchange { dist: HashShard(ao.k) }
-            StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [count(ao.v), ao.k] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, count(ao.v)] }
+        └─StreamExchange { dist: HashShard(ao.k) }
+          └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
@@ -975,18 +975,18 @@
     select string_agg(s, ',' order by o) as a1 from T group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-        BatchHashAgg { group_key: [t.k], aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          BatchExchange { order: [], dist: HashShard(t.k) }
-            BatchProject { exprs: [t.k, t.s, ',':Varchar, t.o] }
-              BatchScan { table: t, columns: [t.k, t.o, t.s], distribution: SomeShard }
+    └─BatchProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─BatchHashAgg { group_key: [t.k], aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+        └─BatchExchange { order: [], dist: HashShard(t.k) }
+          └─BatchProject { exprs: [t.k, t.s, ',':Varchar, t.o] }
+            └─BatchScan { table: t, columns: [t.k, t.o, t.s], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
-      StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), t.k] }
-        StreamHashAgg { group_key: [t.k], aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamExchange { dist: HashShard(t.k) }
-            StreamProject { exprs: [t.k, t.s, ',':Varchar, t.o, t._row_id] }
-              StreamTableScan { table: t, columns: [t.k, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), t.k] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: HashShard(t.k) }
+          └─StreamProject { exprs: [t.k, t.s, ',':Varchar, t.o, t._row_id] }
+            └─StreamTableScan { table: t, columns: [t.k, t.o, t.s, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k] }
@@ -1012,16 +1012,16 @@
     select string_agg(s, ',' order by o) as a1 from Tk group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
-        BatchSortAgg { group_key: [tk.k], aggs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
-          BatchProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o] }
-            BatchScan { table: tk, columns: [tk.k, tk.o, tk.s], distribution: UpstreamHashShard(tk.k) }
+    └─BatchProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
+      └─BatchSortAgg { group_key: [tk.k], aggs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
+        └─BatchProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o] }
+          └─BatchScan { table: tk, columns: [tk.k, tk.o, tk.s], distribution: UpstreamHashShard(tk.k) }
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
-      StreamProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), tk.k] }
-        StreamHashAgg { group_key: [tk.k], aggs: [count, string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
-          StreamProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o, tk.t._row_id] }
-            StreamTableScan { table: tk, columns: [tk.k, tk.o, tk.s, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
+    └─StreamProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), tk.k] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [count, string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
+        └─StreamProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o, tk.t._row_id] }
+          └─StreamTableScan { table: tk, columns: [tk.k, tk.o, tk.s, tk.t._row_id], pk: [tk.t._row_id], distribution: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k] }
@@ -1044,17 +1044,17 @@
     select string_agg(s, ',' order by o) as a1 from S group by k;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
-        BatchHashAgg { group_key: [s.k], aggs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
-          BatchProject { exprs: [s.k, s.s, ',':Varchar, s.o] }
-            BatchScan { table: s, columns: [s.k, s.o, s.s], distribution: UpstreamHashShard() }
+    └─BatchProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
+      └─BatchHashAgg { group_key: [s.k], aggs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
+        └─BatchProject { exprs: [s.k, s.s, ',':Varchar, s.o] }
+          └─BatchScan { table: s, columns: [s.k, s.o, s.s], distribution: UpstreamHashShard() }
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
-      StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), s.k] }
-        StreamHashAgg { group_key: [s.k], aggs: [count, string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
-          StreamExchange { dist: HashShard(s.k) }
-            StreamProject { exprs: [s.k, s.s, ',':Varchar, s.o, s.t._row_id] }
-              StreamTableScan { table: s, columns: [s.k, s.o, s.s, s.t._row_id], pk: [s.t._row_id], distribution: Single }
+    └─StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), s.k] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [count, string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: HashShard(s.k) }
+          └─StreamProject { exprs: [s.k, s.s, ',':Varchar, s.o, s.t._row_id] }
+            └─StreamTableScan { table: s, columns: [s.k, s.o, s.s, s.t._row_id], pk: [s.t._row_id], distribution: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k] }
@@ -1080,11 +1080,11 @@
     select string_agg(s, ',' order by o) as a1 from AO group by k;
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }
-      StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), ao.k] }
-        StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamExchange { dist: HashShard(ao.k) }
-            StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
-              StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
+    └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), ao.k] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+        └─StreamExchange { dist: HashShard(ao.k) }
+          └─StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
+            └─StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], distribution: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k] }

--- a/src/frontend/planner_test/tests/testdata/struct_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/struct_query.yaml
@@ -4,10 +4,10 @@
     select * from t;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t, columns: [t.country], distribution: SomeShard }
+    └─BatchScan { table: t, columns: [t.country], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [country, t._row_id(hidden)], pk_columns: [t._row_id] }
-      StreamTableScan { table: t, columns: [t.country, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamTableScan { table: t, columns: [t.country, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
   create_source:
     row_format: protobuf
     name: s
@@ -34,7 +34,7 @@
     select (t).country.city,(t).country,(country).city.address from t;
   logical_plan: |
     LogicalProject { exprs: [Field(t.country, 1:Int32), t.country, Field(Field(t.country, 1:Int32), 0:Int32)] }
-      LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -69,13 +69,13 @@
     select (t).country.city.*,(t.country).*,(country).city.* from t;
   logical_plan: |
     LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 0:Int32), Field(Field(t.country, 1:Int32), 1:Int32), Field(t.country, 0:Int32), Field(t.country, 1:Int32), Field(t.country, 2:Int32), Field(Field(t.country, 1:Int32), 0:Int32), Field(Field(t.country, 1:Int32), 1:Int32)] }
-      LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
 - sql: |
     create materialized view t as select * from s;
     select (t).country1.city.*,(t.country2).*,(country3).city.* from t;
   logical_plan: |
     LogicalProject { exprs: [Field(Field(t.country1, 1:Int32), 0:Int32), Field(Field(t.country1, 1:Int32), 1:Int32), Field(t.country2, 0:Int32), Field(t.country2, 1:Int32), Field(t.country2, 2:Int32), Field(Field(t.country3, 1:Int32), 0:Int32), Field(Field(t.country3, 1:Int32), 1:Int32)] }
-      LogicalScan { table: t, columns: [t.id, t.country1, t.country2, t.country3, t.zipcode, t.rate, t._row_id] }
+    └─LogicalScan { table: t, columns: [t.id, t.country1, t.country2, t.country3, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -104,8 +104,8 @@
     select (c).zipcode from (select (t).country.city as c from t);
   logical_plan: |
     LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 1:Int32)] }
-      LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-        LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalProject { exprs: [Field(t.country, 1:Int32)] }
+      └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -132,10 +132,10 @@
     select (c).zipcode from (select min((t).country.city) as c from t);
   logical_plan: |
     LogicalProject { exprs: [Field(min(Field(t.country, 1:Int32)), 1:Int32)] }
-      LogicalProject { exprs: [min(Field(t.country, 1:Int32))] }
-        LogicalAgg { aggs: [min(Field(t.country, 1:Int32))] }
-          LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-            LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalProject { exprs: [min(Field(t.country, 1:Int32))] }
+      └─LogicalAgg { aggs: [min(Field(t.country, 1:Int32))] }
+        └─LogicalProject { exprs: [Field(t.country, 1:Int32)] }
+          └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -162,10 +162,10 @@
     select * from (select (country).city as c from t) as vv join t on (c).zipcode=(t.country).zipcode;
   logical_plan: |
     LogicalProject { exprs: [Field(t.country, 1:Int32), t.id, t.country, t.zipcode, t.rate] }
-      LogicalJoin { type: Inner, on: (Field(Field(t.country, 1:Int32), 1:Int32) = Field(t.country, 2:Int32)), output: all }
-        LogicalProject { exprs: [Field(t.country, 1:Int32)] }
-          LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
-        LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalJoin { type: Inner, on: (Field(Field(t.country, 1:Int32), 1:Int32) = Field(t.country, 2:Int32)), output: all }
+      ├─LogicalProject { exprs: [Field(t.country, 1:Int32)] }
+      | └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+      └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -192,9 +192,9 @@
     select min((t.country).city.address) + max((t.country).city.address) * count(zipcode) from t;
   logical_plan: |
     LogicalProject { exprs: [(min(Field(Field(t.country, 1:Int32), 0:Int32)) + (max(Field(Field(t.country, 1:Int32), 0:Int32)) * count(t.zipcode)))] }
-      LogicalAgg { aggs: [min(Field(Field(t.country, 1:Int32), 0:Int32)), max(Field(Field(t.country, 1:Int32), 0:Int32)), count(t.zipcode)] }
-        LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 0:Int32), t.zipcode] }
-          LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalAgg { aggs: [min(Field(Field(t.country, 1:Int32), 0:Int32)), max(Field(Field(t.country, 1:Int32), 0:Int32)), count(t.zipcode)] }
+      └─LogicalProject { exprs: [Field(Field(t.country, 1:Int32), 0:Int32), t.zipcode] }
+        └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -221,10 +221,10 @@
     select count(1), count((country).city.zipcode) from t where (country).city.address>1;
   logical_plan: |
     LogicalProject { exprs: [count(1:Int32), count(Field(Field(t.country, 1:Int32), 1:Int32))] }
-      LogicalAgg { aggs: [count(1:Int32), count(Field(Field(t.country, 1:Int32), 1:Int32))] }
-        LogicalProject { exprs: [1:Int32, Field(Field(t.country, 1:Int32), 1:Int32)] }
-          LogicalFilter { predicate: (Field(Field(t.country, 1:Int32), 0:Int32) > 1:Int32) }
-            LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
+    └─LogicalAgg { aggs: [count(1:Int32), count(Field(Field(t.country, 1:Int32), 1:Int32))] }
+      └─LogicalProject { exprs: [1:Int32, Field(Field(t.country, 1:Int32), 1:Int32)] }
+        └─LogicalFilter { predicate: (Field(Field(t.country, 1:Int32), 0:Int32) > 1:Int32) }
+          └─LogicalScan { table: t, columns: [t.id, t.country, t.zipcode, t.rate, t._row_id] }
   create_source:
     row_format: protobuf
     name: s
@@ -338,7 +338,7 @@
     insert into s values (1,2,(1,2,(1,2,null)));
   logical_plan: |
     LogicalInsert { table: s }
-      LogicalValues { rows: [[1:Int32, 2:Int32, Row(1:Int32, 2:Int32, Row(1:Int32, 2:Int32, null:Int32))]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Struct(StructType { fields: [Int32, Int32, Struct(StructType { fields: [Int32, Int32, Int32], field_names: ["v1", "v2", "v3"] })], field_names: ["v1", "v2", "v3"] })] } }
+    └─LogicalValues { rows: [[1:Int32, 2:Int32, Row(1:Int32, 2:Int32, Row(1:Int32, 2:Int32, null:Int32))]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Struct(StructType { fields: [Int32, Int32, Struct(StructType { fields: [Int32, Int32, Int32], field_names: ["v1", "v2", "v3"] })], field_names: ["v1", "v2", "v3"] })] } }
   create_source:
     row_format: protobuf
     name: s
@@ -365,8 +365,8 @@
     select * from s where s.v3 = (1,2,(1,2,3));
   logical_plan: |
     LogicalProject { exprs: [s.v1, s.v2, s.v3] }
-      LogicalFilter { predicate: (s.v3 = Row(1:Int32, 2:Int32, Row(1:Int32, 2:Int32, 3:Int32))) }
-        LogicalScan { table: s, columns: [s._row_id, s.v1, s.v2, s.v3] }
+    └─LogicalFilter { predicate: (s.v3 = Row(1:Int32, 2:Int32, Row(1:Int32, 2:Int32, 3:Int32))) }
+      └─LogicalScan { table: s, columns: [s._row_id, s.v1, s.v2, s.v3] }
   create_source:
     row_format: protobuf
     name: s

--- a/src/frontend/planner_test/tests/testdata/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery.yaml
@@ -4,17 +4,17 @@
     select v1 from (select * from t) where v2 > 1;
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalProject { exprs: [t.v1, t.v2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* merge and then eliminate */
     create table t (v1 bigint, v2 double precision);
     select a1 as v1, a2 as v2 from (select v1 as a1, v2 as a2 from t);
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
-      LogicalProject { exprs: [t.v1, t.v2] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalProject { exprs: [t.v1, t.v2] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [t.v1, t.v2] }
 - sql: |
@@ -26,27 +26,27 @@
     select v3 from (select v2, v1 as v3 from t) where v2 > 1;
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
-      LogicalFilter { predicate: (t.v2 > 1:Int32) }
-        LogicalProject { exprs: [t.v2, t.v1] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalFilter { predicate: (t.v2 > 1:Int32) }
+      └─LogicalProject { exprs: [t.v2, t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* consecutive projects are merged */
     create table t (v1 bigint, v2 double precision);
     select v1, 2 from (select v1, v2, 1 from t);
   logical_plan: |
     LogicalProject { exprs: [t.v1, 2:Int32] }
-      LogicalProject { exprs: [t.v1, t.v2, 1:Int32] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalProject { exprs: [t.v1, t.v2, 1:Int32] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.v1, 2:Int32] }
-      LogicalScan { table: t, columns: [t.v1] }
+    └─LogicalScan { table: t, columns: [t.v1] }
 - sql: |
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t);
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
-      LogicalProject { exprs: [t.v1, t.v2] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalProject { exprs: [t.v1, t.v2] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan: |
     LogicalScan { table: t, columns: [t.v1, t.v2] }
 - sql: |
@@ -55,30 +55,30 @@
     select * from (select * from t), t;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalProject { exprs: [t.v1, t.v2] }
+      | └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* table alias */
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt join t on tt.v1=t.v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
+      ├─LogicalProject { exprs: [t.v1, t.v2] }
+      | └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* alias less columns than available */
     create table t (v1 bigint, v2 double precision);
     select * from (select * from t) as tt(a) join t on a=v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2, t.v1, t.v2] }
-      LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
-        LogicalProject { exprs: [t.v1, t.v2] }
-          LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
-        LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    └─LogicalJoin { type: Inner, on: (t.v1 = t.v1), output: all }
+      ├─LogicalProject { exprs: [t.v1, t.v2] }
+      | └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - sql: |
     /* alias more columns than available */
     create table t (v1 bigint, v2 double precision);
@@ -108,10 +108,10 @@
     );
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(ab.a, bc.b), output: all }
-      LogicalScan { table: ab, columns: [ab.a, ab.b] }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: bc, columns: [bc.b] }
-        LogicalScan { table: t, output_columns: [], required_columns: [v1], predicate: IsNotNull(t.v1) }
+    ├─LogicalScan { table: ab, columns: [ab.a, ab.b] }
+    └─LogicalJoin { type: Inner, on: true, output: all }
+      ├─LogicalScan { table: bc, columns: [bc.b] }
+      └─LogicalScan { table: t, output_columns: [], required_columns: [v1], predicate: IsNotNull(t.v1) }
 - sql: |
     /* We cannot reference columns in left table if not lateral */
     create table ab (a int, b int);
@@ -140,31 +140,31 @@
     select count(1) from (select sum(distinct 1) from t1), t2;
   logical_plan: |
     LogicalProject { exprs: [count(1:Int32)] }
-      LogicalAgg { aggs: [count(1:Int32)] }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalJoin { type: Inner, on: true, output: all }
-            LogicalProject { exprs: [sum(distinct 1:Int32)] }
-              LogicalAgg { aggs: [sum(distinct 1:Int32)] }
-                LogicalProject { exprs: [1:Int32] }
-                  LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalAgg { aggs: [count(1:Int32)] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalJoin { type: Inner, on: true, output: all }
+          ├─LogicalProject { exprs: [sum(distinct 1:Int32)] }
+          | └─LogicalAgg { aggs: [sum(distinct 1:Int32)] }
+          |   └─LogicalProject { exprs: [1:Int32] }
+          |     └─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+          └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [count(1:Int32)] }
-      LogicalProject { exprs: [1:Int32] }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalAgg { aggs: [] }
-            LogicalScan { table: t1, columns: [] }
-          LogicalScan { table: t2, columns: [] }
+    └─LogicalProject { exprs: [1:Int32] }
+      └─LogicalJoin { type: Inner, on: true, output: all }
+        ├─LogicalAgg { aggs: [] }
+        | └─LogicalScan { table: t1, columns: [] }
+        └─LogicalScan { table: t2, columns: [] }
   batch_plan: |
     BatchSimpleAgg { aggs: [count(1:Int32)] }
-      BatchProject { exprs: [1:Int32] }
-        BatchNestedLoopJoin { type: Inner, predicate: true, output: all }
-          BatchSimpleAgg { aggs: [] }
-            BatchExchange { order: [], dist: Single }
-              BatchSimpleAgg { aggs: [] }
-                BatchScan { table: t1, columns: [], distribution: SomeShard }
-          BatchExchange { order: [], dist: Single }
-            BatchScan { table: t2, columns: [], distribution: SomeShard }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchNestedLoopJoin { type: Inner, predicate: true, output: all }
+        ├─BatchSimpleAgg { aggs: [] }
+        | └─BatchExchange { order: [], dist: Single }
+        |   └─BatchSimpleAgg { aggs: [] }
+        |     └─BatchScan { table: t1, columns: [], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: Single }
+          └─BatchScan { table: t2, columns: [], distribution: SomeShard }
 - sql: |
     SELECT n.nspname as "Schema",
     c.relname as "Name",
@@ -180,27 +180,27 @@
     ORDER BY 1,2;
   logical_plan: |
     LogicalProject { exprs: [pg_namespace.nspname, pg_class.relname, Case((pg_class.relkind = 'r':Varchar), 'table':Varchar, (pg_class.relkind = 'v':Varchar), 'view':Varchar, (pg_class.relkind = 'm':Varchar), 'materialized view':Varchar, (pg_class.relkind = 'i':Varchar), 'index':Varchar, (pg_class.relkind = 'S':Varchar), 'sequence':Varchar, (pg_class.relkind = 's':Varchar), 'special':Varchar, (pg_class.relkind = 't':Varchar), 'TOAST table':Varchar, (pg_class.relkind = 'f':Varchar), 'foreign table':Varchar, (pg_class.relkind = 'p':Varchar), 'partitioned table':Varchar, (pg_class.relkind = 'I':Varchar), 'partitioned index':Varchar), pg_user.name] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) AND (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
-          LogicalJoin { type: LeftOuter, on: (pg_namespace.oid = pg_class.relnamespace), output: all }
-            LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind] }
-            LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
-        LogicalProject { exprs: [pg_user.name] }
-          LogicalFilter { predicate: (CorrelatedInputRef { index: 3, correlated_id: 1 } = pg_user.usesysid) }
-            LogicalScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name, pg_user.usecreatedb, pg_user.usesuper, pg_user.passwd] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) AND (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
+      | └─LogicalJoin { type: LeftOuter, on: (pg_namespace.oid = pg_class.relnamespace), output: all }
+      |   ├─LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind] }
+      |   └─LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
+      └─LogicalProject { exprs: [pg_user.name] }
+        └─LogicalFilter { predicate: (CorrelatedInputRef { index: 3, correlated_id: 1 } = pg_user.usesysid) }
+          └─LogicalScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name, pg_user.usecreatedb, pg_user.usesuper, pg_user.passwd] }
   batch_plan: |
     BatchExchange { order: [pg_namespace.nspname ASC, pg_class.relname ASC], dist: Single }
-      BatchProject { exprs: [pg_namespace.nspname, pg_class.relname, Case((pg_class.relkind = 'r':Varchar), 'table':Varchar, (pg_class.relkind = 'v':Varchar), 'view':Varchar, (pg_class.relkind = 'm':Varchar), 'materialized view':Varchar, (pg_class.relkind = 'i':Varchar), 'index':Varchar, (pg_class.relkind = 'S':Varchar), 'sequence':Varchar, (pg_class.relkind = 's':Varchar), 'special':Varchar, (pg_class.relkind = 't':Varchar), 'TOAST table':Varchar, (pg_class.relkind = 'f':Varchar), 'foreign table':Varchar, (pg_class.relkind = 'p':Varchar), 'partitioned table':Varchar, (pg_class.relkind = 'I':Varchar), 'partitioned index':Varchar), pg_user.name] }
-        BatchSort { order: [pg_namespace.nspname ASC, pg_class.relname ASC] }
-          BatchHashJoin { type: LeftOuter, predicate: pg_class.relowner = pg_user.usesysid, output: [pg_class.relname, pg_class.relkind, pg_namespace.nspname, pg_user.name] }
-            BatchExchange { order: [], dist: HashShard(pg_class.relowner) }
-              BatchHashJoin { type: Inner, predicate: pg_class.relnamespace = pg_namespace.oid, output: [pg_class.relname, pg_class.relowner, pg_class.relkind, pg_namespace.nspname] }
-                BatchExchange { order: [], dist: HashShard(pg_class.relnamespace) }
-                  BatchFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) }
-                    BatchScan { table: pg_class, columns: [pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind], distribution: Single }
-                BatchExchange { order: [], dist: HashShard(pg_namespace.oid) }
-                  BatchFilter { predicate: (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
-                    BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname], distribution: Single }
-            BatchExchange { order: [], dist: HashShard(pg_user.usesysid) }
-              BatchProject { exprs: [pg_user.name, pg_user.usesysid] }
-                BatchScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name], distribution: Single }
+    └─BatchProject { exprs: [pg_namespace.nspname, pg_class.relname, Case((pg_class.relkind = 'r':Varchar), 'table':Varchar, (pg_class.relkind = 'v':Varchar), 'view':Varchar, (pg_class.relkind = 'm':Varchar), 'materialized view':Varchar, (pg_class.relkind = 'i':Varchar), 'index':Varchar, (pg_class.relkind = 'S':Varchar), 'sequence':Varchar, (pg_class.relkind = 's':Varchar), 'special':Varchar, (pg_class.relkind = 't':Varchar), 'TOAST table':Varchar, (pg_class.relkind = 'f':Varchar), 'foreign table':Varchar, (pg_class.relkind = 'p':Varchar), 'partitioned table':Varchar, (pg_class.relkind = 'I':Varchar), 'partitioned index':Varchar), pg_user.name] }
+      └─BatchSort { order: [pg_namespace.nspname ASC, pg_class.relname ASC] }
+        └─BatchHashJoin { type: LeftOuter, predicate: pg_class.relowner = pg_user.usesysid, output: [pg_class.relname, pg_class.relkind, pg_namespace.nspname, pg_user.name] }
+          ├─BatchExchange { order: [], dist: HashShard(pg_class.relowner) }
+          | └─BatchHashJoin { type: Inner, predicate: pg_class.relnamespace = pg_namespace.oid, output: [pg_class.relname, pg_class.relowner, pg_class.relkind, pg_namespace.nspname] }
+          |   ├─BatchExchange { order: [], dist: HashShard(pg_class.relnamespace) }
+          |   | └─BatchFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) }
+          |   |   └─BatchScan { table: pg_class, columns: [pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind], distribution: Single }
+          |   └─BatchExchange { order: [], dist: HashShard(pg_namespace.oid) }
+          |     └─BatchFilter { predicate: (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
+          |       └─BatchScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname], distribution: Single }
+          └─BatchExchange { order: [], dist: HashShard(pg_user.usesysid) }
+            └─BatchProject { exprs: [pg_user.name, pg_user.usesysid] }
+              └─BatchScan { table: pg_user, columns: [pg_user.usesysid, pg_user.name], distribution: Single }

--- a/src/frontend/planner_test/tests/testdata/subquery_expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery_expr.yaml
@@ -3,76 +3,76 @@
     select (select 1);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   optimized_logical_plan: |
     LogicalJoin { type: LeftOuter, on: true, output: all }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-      LogicalProject { exprs: [1:Int32] }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalProject { exprs: [1:Int32] }
+      └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t(x int);
     select (select x from t), 1 from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [t.x] }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimizer_error: 'internal error: Scalar subquery might produce more than one row.'
 - sql: |
     create table t(x int);
     select (select x from t limit 1), 1 from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalLimit { limit: 1, offset: 0 }
-          LogicalProject { exprs: [t.x] }
-            LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalLimit { limit: 1, offset: 0 }
+        └─LogicalProject { exprs: [t.x] }
+          └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalJoin { type: LeftOuter, on: true, output: all }
-        LogicalScan { table: t, columns: [] }
-        LogicalLimit { limit: 1, offset: 0 }
-          LogicalScan { table: t, columns: [t.x] }
+    └─LogicalJoin { type: LeftOuter, on: true, output: all }
+      ├─LogicalScan { table: t, columns: [] }
+      └─LogicalLimit { limit: 1, offset: 0 }
+        └─LogicalScan { table: t, columns: [t.x] }
 - sql: |
     create table t(x int);
     select (select x from t) + 1 from t;
   logical_plan: |
     LogicalProject { exprs: [(t.x + 1:Int32)] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [t.x] }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimizer_error: 'internal error: Scalar subquery might produce more than one row.'
 - sql: |
     create table t(x int);
     select (select x from t), (select 1);
   logical_plan: |
     LogicalProject { exprs: [t.x, 1:Int32] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-          LogicalProject { exprs: [t.x] }
-            LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      | ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      | └─LogicalProject { exprs: [t.x] }
+      |   └─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   optimizer_error: 'internal error: Scalar subquery might produce more than one row.'
 - sql: |
     create table t(x int);
     select x + (select x + (select x as v1 from t) as v2 from t) as v3 from t;
   logical_plan: |
     LogicalProject { exprs: [(t.x + (t.x + t.x))] }
-      LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalProject { exprs: [(t.x + t.x)] }
-          LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-            LogicalScan { table: t, columns: [t.x, t._row_id] }
-            LogicalProject { exprs: [t.x] }
-              LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+      ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [(t.x + t.x)] }
+        └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+          ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+          └─LogicalProject { exprs: [t.x] }
+            └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimizer_error: 'internal error: Scalar subquery might produce more than one row.'
 - sql: |
     create table t1 (x int, y int);
@@ -80,10 +80,10 @@
     select t1.x, (select y from (select y from t2 order by y desc limit 1 offset 3) t2 limit 2) from t1;
   optimized_logical_plan: |
     LogicalJoin { type: LeftOuter, on: true, output: all }
-      LogicalScan { table: t1, columns: [t1.x] }
-      LogicalLimit { limit: 2, offset: 0 }
-        LogicalTopN { order: "[t2.y DESC]", limit: 1, offset: 3 }
-          LogicalScan { table: t2, columns: [t2.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x] }
+    └─LogicalLimit { limit: 2, offset: 0 }
+      └─LogicalTopN { order: "[t2.y DESC]", limit: 1, offset: 3 }
+        └─LogicalScan { table: t2, columns: [t2.y] }
 - sql: |
     select (select 1, 2);
   binder_error: 'Bind error: Subquery must return only one column'
@@ -92,91 +92,91 @@
     select 1 where exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalProject { exprs: [t.x] }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftSemi, on: true, output: all }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalScan { table: t, columns: [] }
+    └─LogicalJoin { type: LeftSemi, on: true, output: all }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalScan { table: t, columns: [] }
 - sql: |
     create table t(x int);
     select 1 where not exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalProject { exprs: [t.x] }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   optimized_logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalJoin { type: LeftAnti, on: true, output: all }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-        LogicalScan { table: t, columns: [] }
+    └─LogicalJoin { type: LeftAnti, on: true, output: all }
+      ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+      └─LogicalScan { table: t, columns: [] }
 - sql: |
     create table t1(x int);
     create table t2(x int);
     select x from t1 where exists (select x from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
-        LogicalProject { exprs: [t2.x] }
-          LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
+      └─LogicalProject { exprs: [t2.x] }
+        └─LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
 - sql: |
     create table t(x int);
     select x from t where exists (select * from t);
   logical_plan: |
     LogicalProject { exprs: [t.x] }
-      LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalScan { table: t, columns: [t.x, t._row_id] }
-        LogicalProject { exprs: [t.x] }
-          LogicalScan { table: t, columns: [t.x, t._row_id] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalScan { table: t, columns: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [t.x] }
+        └─LogicalScan { table: t, columns: [t.x, t._row_id] }
 - sql: |
     create table t1(x int);
     create table t2(x int);
     select x from t1 where x > (select x from t2)
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalFilter { predicate: (t1.x > t2.x) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
-          LogicalProject { exprs: [t2.x] }
-            LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.x > t2.x) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
+        └─LogicalProject { exprs: [t2.x] }
+          └─LogicalScan { table: t2, columns: [t2.x, t2._row_id] }
 - sql: |
     select 1 where 1>0 and exists (values (1))
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalFilter { predicate: (1:Int32 > 0:Int32) }
-        LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-          LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-          LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
+    └─LogicalFilter { predicate: (1:Int32 > 0:Int32) }
+      └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+        ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+        └─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
 - sql: |
     select 1 where (not exists (values (1))) and (1>0 or exists (values (1)))
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalFilter { predicate: ((1:Int32 > 0:Int32) OR (count >= 1:Int32)) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-          LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
-            LogicalValues { rows: [[]], schema: Schema { fields: [] } }
-            LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
-          LogicalProject { exprs: [(count >= 1:Int32)] }
-            LogicalAgg { aggs: [count] }
-              LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_1.column_0:Int32] } }
+    └─LogicalFilter { predicate: ((1:Int32 > 0:Int32) OR (count >= 1:Int32)) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+        ├─LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
+        | ├─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+        | └─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
+        └─LogicalProject { exprs: [(count >= 1:Int32)] }
+          └─LogicalAgg { aggs: [count] }
+            └─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_1.column_0:Int32] } }
 - sql: |
     select a + 1, b::varchar, c from (values (1, 2, 3), (4, 5, 6)) t(a, b, c);
   logical_plan: |
     LogicalProject { exprs: [(*VALUES*_0.column_0 + 1:Int32), *VALUES*_0.column_1::Varchar, *VALUES*_0.column_2] }
-      LogicalValues { rows: [[1:Int32, 2:Int32, 3:Int32], [4:Int32, 5:Int32, 6:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Int32] } }
+    └─LogicalValues { rows: [[1:Int32, 2:Int32, 3:Int32], [4:Int32, 5:Int32, 6:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Int32] } }
 - sql: |
     select sum(a), max(b + c + 10), string_agg(c::varchar || '~', ',') from (values (1, 2, 3), (4, 5, 6)) as t(a, b, c);
   logical_plan: |
     LogicalProject { exprs: [sum(*VALUES*_0.column_0), max(((*VALUES*_0.column_1 + *VALUES*_0.column_2) + 10:Int32)), string_agg(ConcatOp(*VALUES*_0.column_2::Varchar, '~':Varchar), ',':Varchar)] }
-      LogicalAgg { aggs: [sum(*VALUES*_0.column_0), max(((*VALUES*_0.column_1 + *VALUES*_0.column_2) + 10:Int32)), string_agg(ConcatOp(*VALUES*_0.column_2::Varchar, '~':Varchar), ',':Varchar)] }
-        LogicalProject { exprs: [*VALUES*_0.column_0, ((*VALUES*_0.column_1 + *VALUES*_0.column_2) + 10:Int32), ConcatOp(*VALUES*_0.column_2::Varchar, '~':Varchar), ',':Varchar] }
-          LogicalValues { rows: [[1:Int32, 2:Int32, 3:Int32], [4:Int32, 5:Int32, 6:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Int32] } }
+    └─LogicalAgg { aggs: [sum(*VALUES*_0.column_0), max(((*VALUES*_0.column_1 + *VALUES*_0.column_2) + 10:Int32)), string_agg(ConcatOp(*VALUES*_0.column_2::Varchar, '~':Varchar), ',':Varchar)] }
+      └─LogicalProject { exprs: [*VALUES*_0.column_0, ((*VALUES*_0.column_1 + *VALUES*_0.column_2) + 10:Int32), ConcatOp(*VALUES*_0.column_2::Varchar, '~':Varchar), ',':Varchar] }
+        └─LogicalValues { rows: [[1:Int32, 2:Int32, 3:Int32], [4:Int32, 5:Int32, 6:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32, *VALUES*_0.column_2:Int32] } }
 - sql: |
     select 1 + (select 2 from t);
   binder_error: 'Catalog error: table or source not found: t'
@@ -186,17 +186,17 @@
     select x from t1 where y in (select y from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.y] }
+        └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y not in (select y from t2);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftAnti, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftAnti, on: (t1.y = t2.y), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.y] }
+        └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }

--- a/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
@@ -5,41 +5,41 @@
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y=t2.y and t2.y = 1000)
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
-            LogicalAgg { aggs: [min(t2.x)] }
-              LogicalProject { exprs: [t2.x] }
-                LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) AND (t2.y = 1000:Int32) }
-                  LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
+          └─LogicalAgg { aggs: [min(t2.x)] }
+            └─LogicalProject { exprs: [t2.x] }
+              └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) AND (t2.y = 1000:Int32) }
+                └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: IsNotDistinctFrom(t1.y, t1.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
-        LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, t2.x] }
-            LogicalAgg { group_key: [t1.y], aggs: [] }
-              LogicalScan { table: t1, columns: [t1.y] }
-            LogicalProject { exprs: [t2.y, t2.x] }
-              LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) AND IsNotNull(t2.y) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
+      └─LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, t2.x] }
+          ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+          | └─LogicalScan { table: t1, columns: [t1.y] }
+          └─LogicalProject { exprs: [t2.y, t2.x] }
+            └─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 1000:Int32) AND IsNotNull(t2.y) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x>(select min(x) from t2 where t2.y = (select t1.y))
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > min(t2.x)) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [min(t2.x)] }
-            LogicalAgg { aggs: [min(t2.x)] }
-              LogicalProject { exprs: [t2.x] }
-                LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
-                  LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-                    LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
-                    LogicalProject { exprs: [CorrelatedInputRef { index: 1, correlated_id: 1 }] }
-                      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalFilter { predicate: (t1.x > min(t2.x)) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [min(t2.x)] }
+          └─LogicalAgg { aggs: [min(t2.x)] }
+            └─LogicalProject { exprs: [t2.x] }
+              └─LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
+                └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+                  ├─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+                  └─LogicalProject { exprs: [CorrelatedInputRef { index: 1, correlated_id: 1 }] }
+                    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -47,125 +47,125 @@
     select * from t1 where x>(select min(x) from t2 where t1.y=t2.y and t1.x=(select max(x) from t3, (select 1) as dummy where t3.y=t1.y))
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > min(t2.x)) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [min(t2.x)] }
-            LogicalAgg { aggs: [min(t2.x)] }
-              LogicalProject { exprs: [t2.x] }
-                LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) AND (CorrelatedInputRef { index: 0, correlated_id: 1 } = max(t3.x)) }
-                  LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-                    LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
-                    LogicalProject { exprs: [max(t3.x)] }
-                      LogicalAgg { aggs: [max(t3.x)] }
-                        LogicalProject { exprs: [t3.x] }
-                          LogicalFilter { predicate: (t3.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
-                            LogicalJoin { type: Inner, on: true, output: all }
-                              LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
-                              LogicalProject { exprs: [1:Int32] }
-                                LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalFilter { predicate: (t1.x > min(t2.x)) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [min(t2.x)] }
+          └─LogicalAgg { aggs: [min(t2.x)] }
+            └─LogicalProject { exprs: [t2.x] }
+              └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) AND (CorrelatedInputRef { index: 0, correlated_id: 1 } = max(t3.x)) }
+                └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+                  ├─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+                  └─LogicalProject { exprs: [max(t3.x)] }
+                    └─LogicalAgg { aggs: [max(t3.x)] }
+                      └─LogicalProject { exprs: [t3.x] }
+                        └─LogicalFilter { predicate: (t3.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) }
+                          └─LogicalJoin { type: Inner, on: true, output: all }
+                            ├─LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
+                            └─LogicalProject { exprs: [1:Int32] }
+                              └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where exists(select * from t2 where y = 100 and t1.x = t2.x and x = 1000 and t1.y = t2.y);
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.x, t2.y] }
-          LogicalFilter { predicate: (t2.y = 100:Int32) AND (CorrelatedInputRef { index: 0, correlated_id: 1 } = t2.x) AND (t2.x = 1000:Int32) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.x, t2.y] }
+        └─LogicalFilter { predicate: (t2.y = 100:Int32) AND (CorrelatedInputRef { index: 0, correlated_id: 1 } = t2.x) AND (t2.x = 1000:Int32) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
+          └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 100:Int32) AND (t2.x = 1000:Int32) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: (t2.y = 100:Int32) AND (t2.x = 1000:Int32) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x > (select 1.5 * min(x) from t2 where t1.y = t2.y);
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
-            LogicalAgg { aggs: [min(t2.x)] }
-              LogicalProject { exprs: [t2.x] }
-                LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.x > (1.5:Decimal * min(t2.x))) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [(1.5:Decimal * min(t2.x))] }
+          └─LogicalAgg { aggs: [min(t2.x)] }
+            └─LogicalProject { exprs: [t2.x] }
+              └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
+                └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: IsNotDistinctFrom(t1.y, t1.y) AND (t1.x > (1.5:Decimal * min(t2.x))), output: [t1.x, t1.y] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
-        LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, t2.x] }
-            LogicalAgg { group_key: [t1.y], aggs: [] }
-              LogicalScan { table: t1, columns: [t1.y] }
-            LogicalProject { exprs: [t2.y, t2.x] }
-              LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.y) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t1.y, (1.5:Decimal * min(t2.x))] }
+      └─LogicalAgg { group_key: [t1.y], aggs: [min(t2.x)] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, t2.x] }
+          ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+          | └─LogicalScan { table: t1, columns: [t1.y] }
+          └─LogicalProject { exprs: [t2.y, t2.x] }
+            └─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.y) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) from t2 where t1.y = t2.y);
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > count) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [count] }
-            LogicalAgg { aggs: [count] }
-              LogicalProject { exprs: [] }
-                LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.x > count) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [count] }
+          └─LogicalAgg { aggs: [count] }
+            └─LogicalProject { exprs: [] }
+              └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
+                └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: IsNotDistinctFrom(t1.y, t1.y) AND (t1.x > count(1:Int32)), output: [t1.x, t1.y] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32)] }
-        LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, 1:Int32] }
-          LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [t1.y] }
-          LogicalProject { exprs: [t2.y, 1:Int32] }
-            LogicalScan { table: t2, output_columns: [t2.y], required_columns: [y], predicate: IsNotNull(t2.y) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32)] }
+      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, 1:Int32] }
+        ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+        | └─LogicalScan { table: t1, columns: [t1.y] }
+        └─LogicalProject { exprs: [t2.y, 1:Int32] }
+          └─LogicalScan { table: t2, output_columns: [t2.y], required_columns: [y], predicate: IsNotNull(t2.y) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where x > (select count(*) + count(*) from t2 where t1.y = t2.y);
   logical_plan: |
     LogicalProject { exprs: [t1.x, t1.y] }
-      LogicalFilter { predicate: (t1.x > (count + count)) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-          LogicalProject { exprs: [(count + count)] }
-            LogicalAgg { aggs: [count, count] }
-              LogicalProject { exprs: [] }
-                LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
-                  LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalFilter { predicate: (t1.x > (count + count)) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+        └─LogicalProject { exprs: [(count + count)] }
+          └─LogicalAgg { aggs: [count, count] }
+            └─LogicalProject { exprs: [] }
+              └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t2.y) }
+                └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: IsNotDistinctFrom(t1.y, t1.y) AND (t1.x > (count(1:Int32) + count(1:Int32))), output: [t1.x, t1.y] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t1.y, (count(1:Int32) + count(1:Int32))] }
-        LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32), count(1:Int32)] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, 1:Int32] }
-            LogicalAgg { group_key: [t1.y], aggs: [] }
-              LogicalScan { table: t1, columns: [t1.y] }
-            LogicalProject { exprs: [t2.y, 1:Int32] }
-              LogicalScan { table: t2, output_columns: [t2.y], required_columns: [y], predicate: IsNotNull(t2.y) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t1.y, (count(1:Int32) + count(1:Int32))] }
+      └─LogicalAgg { group_key: [t1.y], aggs: [count(1:Int32), count(1:Int32)] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.y, t2.y), output: [t1.y, 1:Int32] }
+          ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+          | └─LogicalScan { table: t1, columns: [t1.y] }
+          └─LogicalProject { exprs: [t2.y, 1:Int32] }
+            └─LogicalScan { table: t2, output_columns: [t2.y], required_columns: [y], predicate: IsNotNull(t2.y) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x = t2.x);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.y] }
-          LogicalFilter { predicate: (CorrelatedInputRef { index: 0, correlated_id: 1 } = t2.x) }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.y] }
+        └─LogicalFilter { predicate: (CorrelatedInputRef { index: 0, correlated_id: 1 } = t2.x) }
+          └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x = t2.x), output: [t1.x] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.y, t2.x] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t2.y, t2.x] }
+      └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -176,33 +176,33 @@
     select x from t1 where y in (select y from t2 where t1.x + t2.x = 100 and t1.y = 1000);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.y] }
-          LogicalFilter { predicate: ((CorrelatedInputRef { index: 0, correlated_id: 1 } + t2.x) = 100:Int32) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = 1000:Int32) }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.y] }
+        └─LogicalFilter { predicate: ((CorrelatedInputRef { index: 0, correlated_id: 1 } + t2.x) = 100:Int32) AND (CorrelatedInputRef { index: 1, correlated_id: 1 } = 1000:Int32) }
+          └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND ((t1.x + t2.x) = 100:Int32), output: [t1.x] }
-      LogicalScan { table: t1, output_columns: [t1.x, t1.y], required_columns: [x, y], predicate: (t1.y = 1000:Int32) }
-      LogicalProject { exprs: [t2.y, t2.x] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalScan { table: t1, output_columns: [t1.x, t1.y], required_columns: [x, y], predicate: (t1.y = 1000:Int32) }
+    └─LogicalProject { exprs: [t2.y, t2.x] }
+      └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select x from t1 where y in (select y from t2 where t1.x > t2.x + 1000);
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.y] }
-          LogicalFilter { predicate: (CorrelatedInputRef { index: 0, correlated_id: 1 } > (t2.x + 1000:Int32)) }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.y), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.y] }
+        └─LogicalFilter { predicate: (CorrelatedInputRef { index: 0, correlated_id: 1 } > (t2.x + 1000:Int32)) }
+          └─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t2.y) AND (t1.x > (t2.x + 1000:Int32)), output: [t1.x] }
-      LogicalProject { exprs: [t1.x, t1.y, t1.x] }
-        LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalProject { exprs: [t2.y, (t2.x + 1000:Int32)] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalProject { exprs: [t1.x, t1.y, t1.x] }
+    | └─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalProject { exprs: [t2.y, (t2.x + 1000:Int32)] }
+      └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -216,23 +216,23 @@
     select x from t1 where y in (select x from t2 where t2.y = t1.y and x > (select min(x) from t3));
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.x] }
-          LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) AND (t2.x > min(t3.x)) }
-            LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-              LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
-              LogicalProject { exprs: [min(t3.x)] }
-                LogicalAgg { aggs: [min(t3.x)] }
-                  LogicalProject { exprs: [t3.x] }
-                    LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.x] }
+        └─LogicalFilter { predicate: (t2.y = CorrelatedInputRef { index: 1, correlated_id: 1 }) AND (t2.x > min(t3.x)) }
+          └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+            ├─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+            └─LogicalProject { exprs: [min(t3.x)] }
+              └─LogicalAgg { aggs: [min(t3.x)] }
+                └─LogicalProject { exprs: [t3.x] }
+                  └─LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t2.x) AND (t2.y = t1.y), output: [t1.x] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: Inner, on: (t2.x > min(t3.x)), output: [t2.x, t2.y] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalAgg { aggs: [min(t3.x)] }
-          LogicalScan { table: t3, columns: [t3.x] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: Inner, on: (t2.x > min(t3.x)), output: [t2.x, t2.y] }
+      ├─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      └─LogicalAgg { aggs: [min(t3.x)] }
+        └─LogicalScan { table: t3, columns: [t3.x] }
 - sql: |
     /* correlated inner subquery with depth = 2 */
     create table t1(x int, y int);
@@ -241,14 +241,14 @@
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t1.y = t3.y));
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.x] }
-          LogicalApply { type: LeftSemi, on: (t2.y = t3.y), correlated_id: 2 }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
-            LogicalProject { exprs: [t3.y] }
-              LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t3.y) }
-                LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.x] }
+        └─LogicalApply { type: LeftSemi, on: (t2.y = t3.y), correlated_id: 2 }
+          ├─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+          └─LogicalProject { exprs: [t3.y] }
+            └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 1 } = t3.y) }
+              └─LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
 - sql: |
     /* uncorrelated outer subquery with a correlated inner subquery */
     create table t1(x int, y int);
@@ -257,21 +257,21 @@
     select x from t1 where y in (select x from t2 where y in (select y from t3 where t2.y = t3.y));
   logical_plan: |
     LogicalProject { exprs: [t1.x] }
-      LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
-        LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
-        LogicalProject { exprs: [t2.x] }
-          LogicalApply { type: LeftSemi, on: (t2.y = t3.y), correlated_id: 2 }
-            LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
-            LogicalProject { exprs: [t3.y] }
-              LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 2 } = t3.y) }
-                LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
+    └─LogicalApply { type: LeftSemi, on: (t1.y = t2.x), correlated_id: 1 }
+      ├─LogicalScan { table: t1, columns: [t1.x, t1.y, t1._row_id] }
+      └─LogicalProject { exprs: [t2.x] }
+        └─LogicalApply { type: LeftSemi, on: (t2.y = t3.y), correlated_id: 2 }
+          ├─LogicalScan { table: t2, columns: [t2.x, t2.y, t2._row_id] }
+          └─LogicalProject { exprs: [t3.y] }
+            └─LogicalFilter { predicate: (CorrelatedInputRef { index: 1, correlated_id: 2 } = t3.y) }
+              └─LogicalScan { table: t3, columns: [t3.x, t3.y, t3._row_id] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t2.x), output: [t1.x] }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.y = t3.y), output: [t2.x] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalProject { exprs: [t3.y, t3.y] }
-          LogicalScan { table: t3, columns: [t3.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND (t2.y = t3.y), output: [t2.x] }
+      ├─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      └─LogicalProject { exprs: [t3.y, t3.y] }
+        └─LogicalScan { table: t3, columns: [t3.y] }
 - sql: |
     /* correlated agg column in SELECT */
     create table t (v1 int, v2 int);
@@ -337,15 +337,15 @@
     );
   logical_plan: |
     LogicalProject { exprs: [1:Int32] }
-      LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-        LogicalAgg { aggs: [] }
-          LogicalProject { exprs: [] }
-            LogicalScan { table: a, columns: [a.a1, a.a2, a._row_id] }
-        LogicalProject { exprs: [1:Int32] }
-          LogicalApply { type: LeftSemi, on: true, correlated_id: 2 }
-            LogicalScan { table: b, columns: [b.b1, b.b2, b._row_id] }
-            LogicalProject { exprs: [CorrelatedInputRef { index: 0, correlated_id: 2 }] }
-              LogicalScan { table: c, columns: [c.c1, c.c2, c._row_id] }
+    └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+      ├─LogicalAgg { aggs: [] }
+      | └─LogicalProject { exprs: [] }
+      |   └─LogicalScan { table: a, columns: [a.a1, a.a2, a._row_id] }
+      └─LogicalProject { exprs: [1:Int32] }
+        └─LogicalApply { type: LeftSemi, on: true, correlated_id: 2 }
+          ├─LogicalScan { table: b, columns: [b.b1, b.b2, b._row_id] }
+          └─LogicalProject { exprs: [CorrelatedInputRef { index: 0, correlated_id: 2 }] }
+            └─LogicalScan { table: c, columns: [c.c1, c.c2, c._row_id] }
 - sql: |
     /* correlated column with depth=2 in HAVING */
     create table a (a1 int, a2 int);
@@ -383,8 +383,8 @@
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t1.y = t2.y)
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.x = t2.x) AND (t1.y = t2.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -392,10 +392,10 @@
     select * from t1, t2 where exists(select x from t3 where t3.x = t1.x and t3.y <> t2.y);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t3.x = t1.x) AND (t3.y <> t2.y), output: all }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t1, columns: [t1.x, t1.y] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
-      LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalJoin { type: Inner, on: true, output: all }
+    | ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -403,10 +403,10 @@
     select * from t1, t2 where exists(select x from t3 where t3.x = t2.y and t3.y = t1.x);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t3.x = t2.y) AND (t3.y = t1.x), output: all }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalScan { table: t1, columns: [t1.x, t1.y] }
-        LogicalScan { table: t2, columns: [t2.x, t2.y] }
-      LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalJoin { type: Inner, on: true, output: all }
+    | ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -415,12 +415,12 @@
     select * from t1, t2, t3 where exists(select x from t4 where t4.x = t2.y and t4.y = t1.x and t4.z = t3.x);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t4.x = t2.y) AND (t4.y = t1.x) AND (t4.z = t3.x), output: all }
-      LogicalJoin { type: Inner, on: true, output: all }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalScan { table: t1, columns: [t1.x, t1.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalScan { table: t3, columns: [t3.x, t3.y] }
-      LogicalScan { table: t4, columns: [t4.x, t4.y, t4.z] }
+    ├─LogicalJoin { type: Inner, on: true, output: all }
+    | ├─LogicalJoin { type: Inner, on: true, output: all }
+    | | ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    | | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+    | └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    └─LogicalScan { table: t4, columns: [t4.x, t4.y, t4.z] }
 - sql: |
     create table a(a1 int, a2 int, a3 int);
     create table b(b1 int, b2 int, b3 int);
@@ -428,98 +428,98 @@
     select count(*) from a, b where a3 = b2 and 3 = (select count(*) from c where b2 = c2 and a3 = c3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.a3, a.a3) AND IsNotDistinctFrom(b.b2, b.b2), output: [] }
-        LogicalJoin { type: Inner, on: (a.a3 = b.b2), output: all }
-          LogicalScan { table: a, columns: [a.a3] }
-          LogicalScan { table: b, columns: [b.b2] }
-        LogicalProject { exprs: [a.a3, b.b2] }
-          LogicalFilter { predicate: (3:Int32 = count(1:Int32)) }
-            LogicalAgg { group_key: [a.a3, b.b2], aggs: [count(1:Int32)] }
-              LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.a3, c.c3) AND IsNotDistinctFrom(b.b2, c.c2), output: [a.a3, b.b2, 1:Int32] }
-                LogicalAgg { group_key: [a.a3, b.b2], aggs: [] }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalScan { table: a, columns: [a.a3] }
-                    LogicalScan { table: b, columns: [b.b2] }
-                LogicalProject { exprs: [c.c3, c.c2, 1:Int32] }
-                  LogicalScan { table: c, output_columns: [c.c2, c.c3], required_columns: [c2, c3], predicate: IsNotNull(c.c3) AND IsNotNull(c.c2) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.a3, a.a3) AND IsNotDistinctFrom(b.b2, b.b2), output: [] }
+      ├─LogicalJoin { type: Inner, on: (a.a3 = b.b2), output: all }
+      | ├─LogicalScan { table: a, columns: [a.a3] }
+      | └─LogicalScan { table: b, columns: [b.b2] }
+      └─LogicalProject { exprs: [a.a3, b.b2] }
+        └─LogicalFilter { predicate: (3:Int32 = count(1:Int32)) }
+          └─LogicalAgg { group_key: [a.a3, b.b2], aggs: [count(1:Int32)] }
+            └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.a3, c.c3) AND IsNotDistinctFrom(b.b2, c.c2), output: [a.a3, b.b2, 1:Int32] }
+              ├─LogicalAgg { group_key: [a.a3, b.b2], aggs: [] }
+              | └─LogicalJoin { type: Inner, on: true, output: all }
+              |   ├─LogicalScan { table: a, columns: [a.a3] }
+              |   └─LogicalScan { table: b, columns: [b.b2] }
+              └─LogicalProject { exprs: [c.c3, c.c2, 1:Int32] }
+                └─LogicalScan { table: c, output_columns: [c.c2, c.c3], required_columns: [c2, c3], predicate: IsNotNull(c.c3) AND IsNotNull(c.c2) }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z and a.x = 3);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.x, a.x) AND IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
-        LogicalProject { exprs: [a.x, a.z, a.y::Int64] }
-          LogicalScan { table: a, output_columns: [a.x, a.y, a.z], required_columns: [x, y, z], predicate: (a.x = 3:Int32) }
-        LogicalAgg { group_key: [a.x, a.z], aggs: [count(1:Int32)] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.x, a.x) AND IsNotDistinctFrom(a.z, a.z), output: [a.x, a.z, 1:Int32] }
-            LogicalAgg { group_key: [a.x, a.z], aggs: [] }
-              LogicalScan { table: a, columns: [a.x, a.z] }
-            LogicalProject { exprs: [a.x, a.z, 1:Int32] }
-              LogicalJoin { type: Inner, on: (b.z = a.z), output: [a.x, a.z] }
-                LogicalAgg { group_key: [a.x, a.z], aggs: [] }
-                  LogicalScan { table: a, output_columns: [a.x, a.z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
-                LogicalScan { table: b, columns: [b.z] }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.x, a.x) AND IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
+      ├─LogicalProject { exprs: [a.x, a.z, a.y::Int64] }
+      | └─LogicalScan { table: a, output_columns: [a.x, a.y, a.z], required_columns: [x, y, z], predicate: (a.x = 3:Int32) }
+      └─LogicalAgg { group_key: [a.x, a.z], aggs: [count(1:Int32)] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.x, a.x) AND IsNotDistinctFrom(a.z, a.z), output: [a.x, a.z, 1:Int32] }
+          ├─LogicalAgg { group_key: [a.x, a.z], aggs: [] }
+          | └─LogicalScan { table: a, columns: [a.x, a.z] }
+          └─LogicalProject { exprs: [a.x, a.z, 1:Int32] }
+            └─LogicalJoin { type: Inner, on: (b.z = a.z), output: [a.x, a.z] }
+              ├─LogicalAgg { group_key: [a.x, a.z], aggs: [] }
+              | └─LogicalScan { table: a, output_columns: [a.x, a.z], required_columns: [x, z], predicate: (a.x = 3:Int32) }
+              └─LogicalScan { table: b, columns: [b.z] }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.x=3 and a.y = (select count(*) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
-        LogicalProject { exprs: [a.z, a.y::Int64] }
-          LogicalScan { table: a, output_columns: [a.y, a.z], required_columns: [y, z, x], predicate: (a.x = 3:Int32) }
-        LogicalAgg { group_key: [a.z], aggs: [count(1:Int32)] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, 1:Int32] }
-            LogicalAgg { group_key: [a.z], aggs: [] }
-              LogicalScan { table: a, columns: [a.z] }
-            LogicalProject { exprs: [b.z, 1:Int32] }
-              LogicalScan { table: b, output_columns: [b.z], required_columns: [z], predicate: IsNotNull(b.z) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(1:Int32)), output: [] }
+      ├─LogicalProject { exprs: [a.z, a.y::Int64] }
+      | └─LogicalScan { table: a, output_columns: [a.y, a.z], required_columns: [y, z, x], predicate: (a.x = 3:Int32) }
+      └─LogicalAgg { group_key: [a.z], aggs: [count(1:Int32)] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, 1:Int32] }
+          ├─LogicalAgg { group_key: [a.z], aggs: [] }
+          | └─LogicalScan { table: a, columns: [a.z] }
+          └─LogicalProject { exprs: [b.z, 1:Int32] }
+            └─LogicalScan { table: b, output_columns: [b.z], required_columns: [z], predicate: IsNotNull(b.z) }
 - sql: |
     create table a(x int, y varchar, z int);
     create table b(x varchar, y int, z int);
     select count(*) from a where a.y = (select string_agg(x, ',' order by x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y = string_agg(b.x, ',':Varchar order_by(b.x ASC NULLS LAST))), output: [] }
-        LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [a.z], aggs: [string_agg(b.x, ',':Varchar order_by(b.x ASC NULLS LAST))] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x, ',':Varchar] }
-            LogicalAgg { group_key: [a.z], aggs: [] }
-              LogicalScan { table: a, columns: [a.z] }
-            LogicalProject { exprs: [b.z, b.x, ',':Varchar] }
-              LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y = string_agg(b.x, ',':Varchar order_by(b.x ASC NULLS LAST))), output: [] }
+      ├─LogicalScan { table: a, columns: [a.y, a.z] }
+      └─LogicalAgg { group_key: [a.z], aggs: [string_agg(b.x, ',':Varchar order_by(b.x ASC NULLS LAST))] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x, ',':Varchar] }
+          ├─LogicalAgg { group_key: [a.z], aggs: [] }
+          | └─LogicalScan { table: a, columns: [a.z] }
+          └─LogicalProject { exprs: [b.z, b.x, ',':Varchar] }
+            └─LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(distinct x) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(b.x)), output: [] }
-        LogicalProject { exprs: [a.z, a.y::Int64] }
-          LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [a.z], aggs: [count(b.x)] }
-          LogicalAgg { group_key: [a.z, b.x], aggs: [] }
-            LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x] }
-              LogicalAgg { group_key: [a.z], aggs: [] }
-                LogicalScan { table: a, columns: [a.z] }
-              LogicalProject { exprs: [b.z, b.x] }
-                LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(b.x)), output: [] }
+      ├─LogicalProject { exprs: [a.z, a.y::Int64] }
+      | └─LogicalScan { table: a, columns: [a.y, a.z] }
+      └─LogicalAgg { group_key: [a.z], aggs: [count(b.x)] }
+        └─LogicalAgg { group_key: [a.z, b.x], aggs: [] }
+          └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x] }
+            ├─LogicalAgg { group_key: [a.z], aggs: [] }
+            | └─LogicalScan { table: a, columns: [a.z] }
+            └─LogicalProject { exprs: [b.z, b.x] }
+              └─LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
 - sql: |
     create table a(x int, y int, z int);
     create table b(x int, y int, z int);
     select count(*) from a where a.y = (select count(x) filter(where x < 100) from b where b.z = a.z);
   optimized_logical_plan: |
     LogicalAgg { aggs: [count] }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(b.x) filter((b.x < 100:Int32))), output: [] }
-        LogicalProject { exprs: [a.z, a.y::Int64] }
-          LogicalScan { table: a, columns: [a.y, a.z] }
-        LogicalAgg { group_key: [a.z], aggs: [count(b.x) filter((b.x < 100:Int32))] }
-          LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x] }
-            LogicalAgg { group_key: [a.z], aggs: [] }
-              LogicalScan { table: a, columns: [a.z] }
-            LogicalProject { exprs: [b.z, b.x] }
-              LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.z, a.z) AND (a.y::Int64 = count(b.x) filter((b.x < 100:Int32))), output: [] }
+      ├─LogicalProject { exprs: [a.z, a.y::Int64] }
+      | └─LogicalScan { table: a, columns: [a.y, a.z] }
+      └─LogicalAgg { group_key: [a.z], aggs: [count(b.x) filter((b.x < 100:Int32))] }
+        └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.z, b.z), output: [a.z, b.x] }
+          ├─LogicalAgg { group_key: [a.z], aggs: [] }
+          | └─LogicalScan { table: a, columns: [a.z] }
+          └─LogicalProject { exprs: [b.z, b.x] }
+            └─LogicalScan { table: b, output_columns: [b.x, b.z], required_columns: [x, z], predicate: IsNotNull(b.z) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -527,10 +527,10 @@
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.x, t2.x), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
-        LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
-        LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: LeftSemi, on: (t2.y = t3.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
+      ├─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
+      └─LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -538,24 +538,24 @@
     select * from t1 where exists(select t2.x from t2 join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.y, t1.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: Inner, on: (t2.x = t3.x) AND (t1.y = t3.y), output: [t1.y] }
-        LogicalJoin { type: Inner, on: (t1.y = t2.y), output: [t1.y, t2.x] }
-          LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [t1.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: Inner, on: (t2.x = t3.x) AND (t1.y = t3.y), output: [t1.y] }
+      ├─LogicalJoin { type: Inner, on: (t1.y = t2.y), output: [t1.y, t2.x] }
+      | ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+      | | └─LogicalScan { table: t1, columns: [t1.y] }
+      | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
     select * from t1 where t1.y in (select t1.y from t2 where t1.x = t2.x);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (t1.y = t1.y) AND IsNotDistinctFrom(t1.x, t1.x) AND IsNotDistinctFrom(t1.y, t1.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: Inner, on: (t1.x = t2.x), output: [t1.x, t1.y, t1.y] }
-        LogicalAgg { group_key: [t1.x, t1.y], aggs: [] }
-          LogicalScan { table: t1, columns: [t1.x, t1.y] }
-        LogicalScan { table: t2, columns: [t2.x] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: Inner, on: (t1.x = t2.x), output: [t1.x, t1.y, t1.y] }
+      ├─LogicalAgg { group_key: [t1.x, t1.y], aggs: [] }
+      | └─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+      └─LogicalScan { table: t2, columns: [t2.x] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -563,10 +563,10 @@
     select * from t1 where not exists(select x from t2 where t1.x = t2.x and t2.y not in (select t3.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
     LogicalJoin { type: LeftAnti, on: IsNotDistinctFrom(t1.x, t2.x), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: LeftAnti, on: (t2.y = t3.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
-        LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
-        LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: LeftAnti, on: (t2.y = t3.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
+      ├─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
+      └─LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -574,13 +574,13 @@
     select * from t1 where exists(select t2.x from t2 left join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.y, t1.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: LeftOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y), output: [t1.y] }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [t1.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: LeftOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y), output: [t1.y] }
+      ├─LogicalJoin { type: Inner, on: true, output: all }
+      | ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+      | | └─LogicalScan { table: t1, columns: [t1.y] }
+      | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -588,14 +588,14 @@
     select * from t1 where exists(select t2.x from t2 right join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.y, t2.x), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: RightOuter, on: (t2.x = t3.x) AND (t2.x = t3.y), output: [t2.x] }
-        LogicalScan { table: t2, output_columns: [t2.x], required_columns: [x, y], predicate: (t2.x = t2.y) }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalProject { exprs: [] }
-            LogicalAgg { group_key: [t1.y], aggs: [] }
-              LogicalScan { table: t1, columns: [t1.y] }
-          LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: RightOuter, on: (t2.x = t3.x) AND (t2.x = t3.y), output: [t2.x] }
+      ├─LogicalScan { table: t2, output_columns: [t2.x], required_columns: [x, y], predicate: (t2.x = t2.y) }
+      └─LogicalJoin { type: Inner, on: true, output: all }
+        ├─LogicalProject { exprs: [] }
+        | └─LogicalAgg { group_key: [t1.y], aggs: [] }
+        |   └─LogicalScan { table: t1, columns: [t1.y] }
+        └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -603,16 +603,16 @@
     select * from t1 where exists(select t2.x from t2 full join t3 on t2.x = t3.x and t1.y = t2.y and t1.y = t3.y);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.y, t1.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: FullOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND IsNotDistinctFrom(t1.y, t1.y), output: [t1.y] }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [t1.y] }
-          LogicalScan { table: t2, columns: [t2.x, t2.y] }
-        LogicalJoin { type: Inner, on: true, output: all }
-          LogicalAgg { group_key: [t1.y], aggs: [] }
-            LogicalScan { table: t1, columns: [t1.y] }
-          LogicalScan { table: t3, columns: [t3.x, t3.y] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: FullOuter, on: (t1.y = t2.y) AND (t2.x = t3.x) AND (t1.y = t3.y) AND IsNotDistinctFrom(t1.y, t1.y), output: [t1.y] }
+      ├─LogicalJoin { type: Inner, on: true, output: all }
+      | ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+      | | └─LogicalScan { table: t1, columns: [t1.y] }
+      | └─LogicalScan { table: t2, columns: [t2.x, t2.y] }
+      └─LogicalJoin { type: Inner, on: true, output: all }
+        ├─LogicalAgg { group_key: [t1.y], aggs: [] }
+        | └─LogicalScan { table: t1, columns: [t1.y] }
+        └─LogicalScan { table: t3, columns: [t3.x, t3.y] }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -620,27 +620,27 @@
     select * from t1 where exists(select x from t2 where t1.x = t2.x and t2.y in (select t3.y + t2.y from t3 where t1.x = t3.x));
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.x, t2.x), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND IsNotDistinctFrom(t2.y, t2.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
-        LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
-        LogicalProject { exprs: [t3.x, t2.y, (t3.y + t2.y)] }
-          LogicalJoin { type: Inner, on: true, output: [t3.x, t2.y, t3.y] }
-            LogicalAgg { group_key: [t2.y], aggs: [] }
-              LogicalScan { table: t2, columns: [t2.y] }
-            LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: LeftSemi, on: (t2.y = (t3.y + t2.y)) AND IsNotDistinctFrom(t2.y, t2.y) AND IsNotDistinctFrom(t2.x, t3.x), output: [t2.x] }
+      ├─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.x) }
+      └─LogicalProject { exprs: [t3.x, t2.y, (t3.y + t2.y)] }
+        └─LogicalJoin { type: Inner, on: true, output: [t3.x, t2.y, t3.y] }
+          ├─LogicalAgg { group_key: [t2.y], aggs: [] }
+          | └─LogicalScan { table: t2, columns: [t2.y] }
+          └─LogicalScan { table: t3, output_columns: [t3.x, t3.y], required_columns: [x, y], predicate: IsNotNull(t3.x) }
 - sql: |
     create table t1 (a int, b int);
     create table t2 (b int, c int);
     select a, (select t1.a), c from t1, t2 where t1.b = t2.b order by c;
   optimized_logical_plan: |
     LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(t1.a, t1.a), output: [t1.a, t1.a, t2.c] }
-      LogicalJoin { type: Inner, on: (t1.b = t2.b), output: [t1.a, t2.c] }
-        LogicalScan { table: t1, columns: [t1.a, t1.b] }
-        LogicalScan { table: t2, columns: [t2.b, t2.c] }
-      LogicalJoin { type: Inner, on: true, output: [t1.a, t1.a] }
-        LogicalAgg { group_key: [t1.a], aggs: [] }
-          LogicalScan { table: t1, columns: [t1.a] }
-        LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    ├─LogicalJoin { type: Inner, on: (t1.b = t2.b), output: [t1.a, t2.c] }
+    | ├─LogicalScan { table: t1, columns: [t1.a, t1.b] }
+    | └─LogicalScan { table: t2, columns: [t2.b, t2.c] }
+    └─LogicalJoin { type: Inner, on: true, output: [t1.a, t1.a] }
+      ├─LogicalAgg { group_key: [t1.a], aggs: [] }
+      | └─LogicalScan { table: t1, columns: [t1.a] }
+      └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -648,24 +648,24 @@
     select * from t1 where exists(select t3.x from (select x,y from t2 where t1.y = t2.y) t2 join t3 on t2.x = t3.x);
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: IsNotDistinctFrom(t1.y, t2.y), output: all }
-      LogicalScan { table: t1, columns: [t1.x, t1.y] }
-      LogicalJoin { type: Inner, on: (t2.x = t3.x), output: [t2.y] }
-        LogicalProject { exprs: [t2.y, t2.x] }
-          LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.y) }
-        LogicalScan { table: t3, columns: [t3.x] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1.y] }
+    └─LogicalJoin { type: Inner, on: (t2.x = t3.x), output: [t2.y] }
+      ├─LogicalProject { exprs: [t2.y, t2.x] }
+      | └─LogicalScan { table: t2, output_columns: [t2.x, t2.y], required_columns: [x, y], predicate: IsNotNull(t2.y) }
+      └─LogicalScan { table: t3, columns: [t3.x] }
 - sql: |
     create table a (a1 int, a2 int);
     create table b (b1 int, b2 int);
     select * from a where a1 = (select min(b1) from (select * from b where b2 = a2) as z);
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: IsNotDistinctFrom(a.a2, a.a2) AND (a.a1 = min(b.b1)), output: [a.a1, a.a2] }
-      LogicalScan { table: a, columns: [a.a1, a.a2] }
-      LogicalAgg { group_key: [a.a2], aggs: [min(b.b1)] }
-        LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.a2, b.b2), output: [a.a2, b.b1] }
-          LogicalAgg { group_key: [a.a2], aggs: [] }
-            LogicalScan { table: a, columns: [a.a2] }
-          LogicalProject { exprs: [b.b2, b.b1] }
-            LogicalScan { table: b, output_columns: [b.b1, b.b2], required_columns: [b1, b2], predicate: IsNotNull(b.b2) }
+    ├─LogicalScan { table: a, columns: [a.a1, a.a2] }
+    └─LogicalAgg { group_key: [a.a2], aggs: [min(b.b1)] }
+      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(a.a2, b.b2), output: [a.a2, b.b1] }
+        ├─LogicalAgg { group_key: [a.a2], aggs: [] }
+        | └─LogicalScan { table: a, columns: [a.a2] }
+        └─LogicalProject { exprs: [b.b2, b.b1] }
+          └─LogicalScan { table: b, output_columns: [b.b1, b.b2], required_columns: [b1, b2], predicate: IsNotNull(b.b2) }
 - sql: |
     create table t1(x int, y int);
     create table t2(x int, y int);
@@ -682,5 +682,5 @@
     select t1.x, (select y from t2 where t2._row_id = t1._row_id) from t1;
   optimized_logical_plan: |
     LogicalJoin { type: LeftOuter, on: (t2._row_id = t1._row_id), output: [t1.x, t2.y] }
-      LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
-      LogicalScan { table: t2, columns: [t2.y, t2._row_id] }
+    ├─LogicalScan { table: t1, columns: [t1.x, t1._row_id] }
+    └─LogicalScan { table: t2, columns: [t2.y, t2._row_id] }

--- a/src/frontend/planner_test/tests/testdata/sysinfo_funcs.yaml
+++ b/src/frontend/planner_test/tests/testdata/sysinfo_funcs.yaml
@@ -3,14 +3,14 @@
     select current_schema();
   batch_plan: |
     BatchProject { exprs: ['public':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select current_schema;
   batch_plan: |
     BatchProject { exprs: ['public':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }
 - sql: |
     select session_user;
   batch_plan: |
     BatchProject { exprs: ['root':Varchar] }
-      BatchValues { rows: [[]] }
+    └─BatchValues { rows: [[]] }

--- a/src/frontend/planner_test/tests/testdata/table_primary_key.yaml
+++ b/src/frontend/planner_test/tests/testdata/table_primary_key.yaml
@@ -17,8 +17,8 @@
     select * from t1 where a = 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchFilter { predicate: (t1.a = 1:Int32) }
-        BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], distribution: SomeShard }
+    └─BatchFilter { predicate: (t1.a = 1:Int32) }
+      └─BatchScan { table: t1, columns: [t1.a, t1.b, t1.c], distribution: SomeShard }
 - before:
   - create_table_t1
   sql: |
@@ -26,7 +26,7 @@
     select _row_id from t1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t1, columns: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─BatchScan { table: t1, columns: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - before:
   - create_table_t2
   sql: |
@@ -39,25 +39,25 @@
     select * from t2 where a > 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t2, columns: [t2.a, t2.b, t2.c], scan_ranges: [t2.a > Int32(1)], distribution: UpstreamHashShard(t2.a) }
+    └─BatchScan { table: t2, columns: [t2.a, t2.b, t2.c], scan_ranges: [t2.a > Int32(1)], distribution: UpstreamHashShard(t2.a) }
 - before:
   - create_table_t3
   sql: |
     select * from t3 where a < 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t3, columns: [t3.a, t3.b, t3.c], scan_ranges: [t3.a < Int32(1)], distribution: UpstreamHashShard(t3.a) }
+    └─BatchScan { table: t3, columns: [t3.a, t3.b, t3.c], scan_ranges: [t3.a < Int32(1)], distribution: UpstreamHashShard(t3.a) }
 - before:
   - create_table_t4
   sql: |
     select * from t4 where a = 1 and c = 'abc';
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t4, columns: [t4.a, t4.b, t4.c], scan_ranges: [t4.a = Int32(1), t4.c = Utf8("abc")], distribution: UpstreamHashShard(t4.a, t4.c) }
+    └─BatchScan { table: t4, columns: [t4.a, t4.b, t4.c], scan_ranges: [t4.a = Int32(1), t4.c = Utf8("abc")], distribution: UpstreamHashShard(t4.a, t4.c) }
 - before:
   - create_table_t4
   sql: |
     select * from t4 where a >= 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchScan { table: t4, columns: [t4.a, t4.b, t4.c], scan_ranges: [t4.a >= Int32(1)], distribution: UpstreamHashShard(t4.a, t4.c) }
+    └─BatchScan { table: t4, columns: [t4.a, t4.b, t4.c], scan_ranges: [t4.a >= Int32(1)], distribution: UpstreamHashShard(t4.a, t4.c) }

--- a/src/frontend/planner_test/tests/testdata/time_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/time_window.yaml
@@ -4,12 +4,12 @@
     select * from tumble(t1, created_at, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-      LogicalProject { exprs: [t1.id, t1.created_at, t1._row_id, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalProject { exprs: [t1.id, t1.created_at, t1._row_id, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
+    └─BatchProject { exprs: [t1.id, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+      └─BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
 - sql: |
     create materialized view t as select * from s;
     select * from tumble(t, (country).created_at, interval '3' day);
@@ -67,135 +67,135 @@
     select * from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_start, window_end] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start, window_end] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, window_end, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_start from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_start] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at, window_end from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at, window_end] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_end] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_end, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_end, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select id, created_at from hop(t1, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, created_at date);
     select t_hop.id, t_hop.created_at from hop(t1, created_at, interval '1' day, interval '3' day) as t_hop;
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.created_at] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at] }
-      BatchExchange { order: [], dist: Single }
-        BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t1, columns: [t1.id, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, created_at, window_start(hidden), t1._row_id(hidden)], pk_columns: [t1._row_id, window_start] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
-        StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.created_at, window_start, t1._row_id] }
+      └─StreamTableScan { table: t1, columns: [t1.id, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t (v1 varchar, v2 timestamp, v3 float);
     select v1, window_end, avg(v3) as avg from hop( t, v2, interval '1' minute, interval '10' minute) group by v1, window_end;
   logical_plan: |
     LogicalProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
-      LogicalAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
-        LogicalProject { exprs: [t.v1, window_end, t.v3] }
-          LogicalHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: all }
-            LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    └─LogicalAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
+      └─LogicalProject { exprs: [t.v1, window_end, t.v3] }
+        └─LogicalHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: all }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
-        BatchHashAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
-          BatchExchange { order: [], dist: HashShard(t.v1, window_end) }
-            BatchProject { exprs: [t.v1, window_end, t.v3] }
-              BatchHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end] }
-                BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
+      └─BatchHashAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, window_end) }
+          └─BatchProject { exprs: [t.v1, window_end, t.v3] }
+            └─BatchHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end] }
+              └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [v1, window_end, avg], pk_columns: [v1, window_end] }
-      StreamProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
-        StreamHashAgg { group_key: [t.v1, window_end], aggs: [count, sum(t.v3), count(t.v3)] }
-          StreamExchange { dist: HashShard(t.v1, window_end) }
-            StreamProject { exprs: [t.v1, window_end, t.v3, t._row_id] }
-              StreamHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end, t._row_id] }
-                StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3))] }
+      └─StreamHashAgg { group_key: [t.v1, window_end], aggs: [count, sum(t.v3), count(t.v3)] }
+        └─StreamExchange { dist: HashShard(t.v1, window_end) }
+          └─StreamProject { exprs: [t.v1, window_end, t.v3, t._row_id] }
+            └─StreamHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end, t._row_id] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t1 (id int, v1 int, created_at date);
     with t2 as (select * from t1 where v1 >= 10)
     select * from tumble(t2, created_at, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-      LogicalProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        LogicalProject { exprs: [t1.id, t1.v1, t1.created_at] }
-          LogicalFilter { predicate: (t1.v1 >= 10:Int32) }
-            LogicalScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id] }
+    └─LogicalProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+      └─LogicalProject { exprs: [t1.id, t1.v1, t1.created_at] }
+        └─LogicalFilter { predicate: (t1.v1 >= 10:Int32) }
+          └─LogicalScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id] }
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
-        BatchFilter { predicate: (t1.v1 >= 10:Int32) }
-          BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
+    └─BatchProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval)] }
+      └─BatchFilter { predicate: (t1.v1 >= 10:Int32) }
+        └─BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id] }
-      StreamProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval), t1._row_id] }
-        StreamFilter { predicate: (t1.v1 >= 10:Int32) }
-          StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamProject { exprs: [t1.id, t1.v1, t1.created_at, TumbleStart(t1.created_at, '3 days 00:00:00':Interval), (TumbleStart(t1.created_at, '3 days 00:00:00':Interval) + '3 days 00:00:00':Interval), t1._row_id] }
+      └─StreamFilter { predicate: (t1.v1 >= 10:Int32) }
+        └─StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     create table t1 (id int, v1 int, created_at date);
     with t2 as (select * from t1 where v1 >= 10)
     select * from hop(t2, created_at, interval '1' day, interval '3' day);
   logical_plan: |
     LogicalProject { exprs: [t1.id, t1.v1, t1.created_at, window_start, window_end] }
-      LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-        LogicalProject { exprs: [t1.id, t1.v1, t1.created_at] }
-          LogicalFilter { predicate: (t1.v1 >= 10:Int32) }
-            LogicalScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id] }
+    └─LogicalHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
+      └─LogicalProject { exprs: [t1.id, t1.v1, t1.created_at] }
+        └─LogicalFilter { predicate: (t1.v1 >= 10:Int32) }
+          └─LogicalScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id] }
   batch_plan: |
     BatchHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: all }
-      BatchExchange { order: [], dist: Single }
-        BatchFilter { predicate: (t1.v1 >= 10:Int32) }
-          BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchFilter { predicate: (t1.v1 >= 10:Int32) }
+        └─BatchScan { table: t1, columns: [t1.id, t1.v1, t1.created_at], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [id, v1, created_at, window_start, window_end, t1._row_id(hidden)], pk_columns: [t1._row_id, window_start, window_end] }
-      StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.v1, t1.created_at, window_start, window_end, t1._row_id] }
-        StreamFilter { predicate: (t1.v1 >= 10:Int32) }
-          StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
+    └─StreamHopWindow { time_col: t1.created_at, slide: 1 day 00:00:00, size: 3 days 00:00:00, output: [t1.id, t1.v1, t1.created_at, window_start, window_end, t1._row_id] }
+      └─StreamFilter { predicate: (t1.v1 >= 10:Int32) }
+        └─StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1.created_at, t1._row_id], pk: [t1._row_id], distribution: UpstreamHashShard(t1._row_id) }
 - sql: |
     with t(ts) as (values ('2020-01-01 12:00:00'::timestamp)) select * from tumble(t, ts, interval '10' second) as z;
   logical_plan: |
     LogicalProject { exprs: [*VALUES*_0.column_0, TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval), (TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval) + '00:00:10':Interval)] }
-      LogicalProject { exprs: [*VALUES*_0.column_0, TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval), (TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval) + '00:00:10':Interval)] }
-        LogicalValues { rows: [['2020-01-01 12:00:00':Varchar::Timestamp]], schema: Schema { fields: [*VALUES*_0.column_0:Timestamp] } }
+    └─LogicalProject { exprs: [*VALUES*_0.column_0, TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval), (TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval) + '00:00:10':Interval)] }
+      └─LogicalValues { rows: [['2020-01-01 12:00:00':Varchar::Timestamp]], schema: Schema { fields: [*VALUES*_0.column_0:Timestamp] } }
   batch_plan: |
     BatchProject { exprs: [*VALUES*_0.column_0, TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval), (TumbleStart(*VALUES*_0.column_0, '00:00:10':Interval) + '00:00:10':Interval)] }
-      BatchValues { rows: [['2020-01-01 12:00:00':Varchar::Timestamp]] }
+    └─BatchValues { rows: [['2020-01-01 12:00:00':Varchar::Timestamp]] }

--- a/src/frontend/planner_test/tests/testdata/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch.yaml
@@ -120,32 +120,32 @@
       l_linestatus;
   logical_plan: |
     LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
-      LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
-        LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
-          LogicalFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+      └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
+        └─LogicalFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+          └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
-      LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
-        LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
-          LogicalScan { table: lineitem, output_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus], required_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+    └─LogicalAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+      └─LogicalProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
+        └─LogicalScan { table: lineitem, output_columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus], required_columns: [l_quantity, l_extendedprice, l_discount, l_tax, l_returnflag, l_linestatus, l_shipdate], predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC], dist: Single }
-      BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
-        BatchSort { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC] }
-          BatchHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
-            BatchExchange { order: [], dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
-              BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
-                BatchFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                  BatchScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate], distribution: SomeShard }
+    └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
+      └─BatchSort { order: [lineitem.l_returnflag ASC, lineitem.l_linestatus ASC] }
+        └─BatchHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+          └─BatchExchange { order: [], dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
+            └─BatchProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount] }
+              └─BatchFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+                └─BatchScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
-      StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
-        StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [count, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
-          StreamExchange { dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
-            StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
-              StreamFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
-                StreamTableScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32), RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32), RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32), count] }
+      └─StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [count, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax))), sum(lineitem.l_quantity), count(lineitem.l_quantity), sum(lineitem.l_extendedprice), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+        └─StreamExchange { dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
+          └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)), lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
+            └─StreamFilter { predicate: (lineitem.l_shipdate <= ('1998-12-01':Varchar::Date - '71 days 00:00:00':Interval)) }
+              └─StreamTableScan { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus] }
@@ -227,155 +227,155 @@
     limit 100;
   logical_plan: |
     LogicalTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
-      LogicalProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
-        LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)) }
-          LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-            LogicalJoin { type: Inner, on: true, output: all }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                    LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-              LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
-            LogicalProject { exprs: [min(partsupp.ps_supplycost)] }
-              LogicalAgg { aggs: [min(partsupp.ps_supplycost)] }
-                LogicalProject { exprs: [partsupp.ps_supplycost] }
-                  LogicalFilter { predicate: (CorrelatedInputRef { index: 5, correlated_id: 1 } = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalJoin { type: Inner, on: true, output: all }
-                        LogicalJoin { type: Inner, on: true, output: all }
-                          LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                          LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                        LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-                      LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
+    └─LogicalProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
+      └─LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)) }
+        └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+          ├─LogicalJoin { type: Inner, on: true, output: all }
+          | ├─LogicalJoin { type: Inner, on: true, output: all }
+          | | ├─LogicalJoin { type: Inner, on: true, output: all }
+          | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+          | | | | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+          | | | | └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+          | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+          | | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+          | └─LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
+          └─LogicalProject { exprs: [min(partsupp.ps_supplycost)] }
+            └─LogicalAgg { aggs: [min(partsupp.ps_supplycost)] }
+              └─LogicalProject { exprs: [partsupp.ps_supplycost] }
+                └─LogicalFilter { predicate: (CorrelatedInputRef { index: 5, correlated_id: 1 } = partsupp.ps_partkey) AND (supplier.s_suppkey = partsupp.ps_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'AFRICA':Varchar) }
+                  └─LogicalJoin { type: Inner, on: true, output: all }
+                    ├─LogicalJoin { type: Inner, on: true, output: all }
+                    | ├─LogicalJoin { type: Inner, on: true, output: all }
+                    | | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                    | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                    | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+                    └─LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
-      LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
-        LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
-          LogicalJoin { type: Inner, on: IsNotDistinctFrom(part.p_partkey, part.p_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-            LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-              LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
-                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
-                LogicalScan { table: part, output_columns: [part.p_partkey, part.p_mfgr], required_columns: [p_partkey, p_mfgr, p_type, p_size], predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-              LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-            LogicalAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
-              LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(part.p_partkey, partsupp.ps_partkey), output: [part.p_partkey, partsupp.ps_supplycost] }
-                LogicalAgg { group_key: [part.p_partkey], aggs: [] }
-                  LogicalScan { table: part, columns: [part.p_partkey] }
-                LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
-                  LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
-                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
-                      LogicalScan { table: partsupp, output_columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], required_columns: [ps_partkey, ps_suppkey, ps_supplycost], predicate: IsNotNull(partsupp.ps_partkey) }
-                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
-                  LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
-          LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
-        LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
+    └─LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
+      ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
+      | ├─LogicalJoin { type: Inner, on: IsNotDistinctFrom(part.p_partkey, part.p_partkey) AND (partsupp.ps_supplycost = min(partsupp.ps_supplycost)), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+      | | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+      | | | ├─LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
+      | | | | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+      | | | | └─LogicalScan { table: part, output_columns: [part.p_partkey, part.p_mfgr], required_columns: [p_partkey, p_mfgr, p_type, p_size], predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
+      | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+      | | └─LogicalAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
+      | |   └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(part.p_partkey, partsupp.ps_partkey), output: [part.p_partkey, partsupp.ps_supplycost] }
+      | |     ├─LogicalAgg { group_key: [part.p_partkey], aggs: [] }
+      | |     | └─LogicalScan { table: part, columns: [part.p_partkey] }
+      | |     └─LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
+      | |       ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
+      | |       | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
+      | |       | | ├─LogicalScan { table: partsupp, output_columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], required_columns: [ps_partkey, ps_suppkey, ps_supplycost], predicate: IsNotNull(partsupp.ps_partkey) }
+      | |       | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+      | |       | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
+      | |       └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
+      | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
+      └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'AFRICA':Varchar) }
   batch_plan: |
     BatchTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
-          BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
-            BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-              BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
-                BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                  BatchHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                    BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                      BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                        BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                          BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
-                            BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                              BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                            BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                              BatchProject { exprs: [part.p_partkey, part.p_mfgr] }
-                                BatchFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-                                  BatchScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], distribution: UpstreamHashShard(part.p_partkey) }
-                        BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                          BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                    BatchHashAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
-                      BatchHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost] }
-                        BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                          BatchSortAgg { group_key: [part.p_partkey], aggs: [] }
-                            BatchScan { table: part, columns: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                        BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                          BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
-                            BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                              BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
-                                BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                  BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
-                                    BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                                      BatchFilter { predicate: IsNotNull(partsupp.ps_partkey) }
-                                        BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                                    BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                      BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                  BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                            BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
-                              BatchProject { exprs: [region.r_regionkey] }
-                                BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                  BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
-                BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                  BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-            BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
-              BatchProject { exprs: [region.r_regionkey] }
-                BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                  BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
+        └─BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment] }
+          ├─BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
+          | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey] }
+          |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+          |   | └─BatchHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+          |   |   ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+          |   |   | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+          |   |   |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+          |   |   |   | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr] }
+          |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+          |   |   |   |   | └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+          |   |   |   |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+          |   |   |   |     └─BatchProject { exprs: [part.p_partkey, part.p_mfgr] }
+          |   |   |   |       └─BatchFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
+          |   |   |   |         └─BatchScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], distribution: UpstreamHashShard(part.p_partkey) }
+          |   |   |   └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+          |   |   |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], distribution: UpstreamHashShard(supplier.s_suppkey) }
+          |   |   └─BatchHashAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost)] }
+          |   |     └─BatchHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost] }
+          |   |       ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+          |   |       | └─BatchSortAgg { group_key: [part.p_partkey], aggs: [] }
+          |   |       |   └─BatchScan { table: part, columns: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+          |   |       └─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+          |   |         └─BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost] }
+          |   |           ├─BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
+          |   |           | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey] }
+          |   |           |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+          |   |           |   | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey] }
+          |   |           |   |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+          |   |           |   |   | └─BatchFilter { predicate: IsNotNull(partsupp.ps_partkey) }
+          |   |           |   |   |   └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+          |   |           |   |   └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+          |   |           |   |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+          |   |           |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+          |   |           |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+          |   |           └─BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
+          |   |             └─BatchProject { exprs: [region.r_regionkey] }
+          |   |               └─BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+          |   |                 └─BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
+          |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+          |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+          └─BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
+            └─BatchProject { exprs: [region.r_regionkey] }
+              └─BatchFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+                └─BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_plan: |
     StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, partsupp.ps_partkey(hidden), partsupp.ps_suppkey(hidden), supplier.s_suppkey(hidden), part.p_partkey(hidden), partsupp.ps_supplycost(hidden), min(partsupp.ps_supplycost)(hidden), nation.n_nationkey(hidden), supplier.s_nationkey(hidden), nation.n_regionkey(hidden), region.r_regionkey(hidden)], pk_columns: [partsupp.ps_partkey, partsupp.ps_suppkey, p_partkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey], order_descs: [s_acctbal, n_name, s_name, p_partkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
-      StreamProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
-        StreamTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0, group_key: [18] }
-              StreamProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey, Vnode(nation.n_regionkey)] }
-                StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
-                  StreamExchange { dist: HashShard(nation.n_regionkey) }
-                    StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), supplier.s_nationkey, nation.n_nationkey] }
-                      StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                        StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, partsupp.ps_supplycost, part.p_partkey, min(partsupp.ps_supplycost)] }
-                          StreamExchange { dist: HashShard(part.p_partkey) }
-                            StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey] }
-                              StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, partsupp.ps_partkey] }
-                                  StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                                    StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                                  StreamExchange { dist: HashShard(part.p_partkey) }
-                                    StreamProject { exprs: [part.p_partkey, part.p_mfgr] }
-                                      StreamFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
-                                        StreamTableScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                              StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                          StreamProject { exprs: [part.p_partkey, min(partsupp.ps_supplycost)] }
-                            StreamHashAgg { group_key: [part.p_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
-                              StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
-                                StreamExchange { dist: HashShard(part.p_partkey) }
-                                  StreamProject { exprs: [part.p_partkey] }
-                                    StreamHashAgg { group_key: [part.p_partkey], aggs: [count] }
-                                      StreamTableScan { table: part, columns: [part.p_partkey], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                                StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                                  StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
-                                    StreamExchange { dist: HashShard(nation.n_regionkey) }
-                                      StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
-                                        StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                                          StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_suppkey, supplier.s_suppkey] }
-                                            StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                                              StreamFilter { predicate: IsNotNull(partsupp.ps_partkey) }
-                                                StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                                            StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                        StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                          StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                                    StreamExchange { dist: HashShard(region.r_regionkey) }
-                                      StreamProject { exprs: [region.r_regionkey] }
-                                        StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                                          StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
-                      StreamExchange { dist: HashShard(nation.n_nationkey) }
-                        StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                  StreamExchange { dist: HashShard(region.r_regionkey) }
-                    StreamProject { exprs: [region.r_regionkey] }
-                      StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
-                        StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─StreamProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
+      └─StreamTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[supplier.s_acctbal DESC, nation.n_name ASC, supplier.s_name ASC, part.p_partkey ASC]", limit: 100, offset: 0, group_key: [18] }
+            └─StreamProject { exprs: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey, Vnode(nation.n_regionkey)] }
+              └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [supplier.s_acctbal, supplier.s_name, nation.n_name, part.p_partkey, part.p_mfgr, supplier.s_address, supplier.s_phone, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
+                ├─StreamExchange { dist: HashShard(nation.n_regionkey) }
+                | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, nation.n_name, nation.n_regionkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), supplier.s_nationkey, nation.n_nationkey] }
+                |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                |   | └─StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey AND partsupp.ps_supplycost = min(partsupp.ps_supplycost), output: [part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, partsupp.ps_supplycost, part.p_partkey, min(partsupp.ps_supplycost)] }
+                |   |   ├─StreamExchange { dist: HashShard(part.p_partkey) }
+                |   |   | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey] }
+                |   |   |   ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                |   |   |   | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, partsupp.ps_supplycost, part.p_partkey, part.p_mfgr, partsupp.ps_partkey] }
+                |   |   |   |   ├─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+                |   |   |   |   | └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                |   |   |   |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+                |   |   |   |     └─StreamProject { exprs: [part.p_partkey, part.p_mfgr] }
+                |   |   |   |       └─StreamFilter { predicate: (part.p_size = 4:Int32) AND Like(part.p_type, '%TIN':Varchar) }
+                |   |   |   |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_mfgr, part.p_type, part.p_size], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                |   |   |   └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                |   |   |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |   └─StreamProject { exprs: [part.p_partkey, min(partsupp.ps_supplycost)] }
+                |   |     └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
+                |   |       └─StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
+                |   |         ├─StreamExchange { dist: HashShard(part.p_partkey) }
+                |   |         | └─StreamProject { exprs: [part.p_partkey] }
+                |   |         |   └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count] }
+                |   |         |     └─StreamTableScan { table: part, columns: [part.p_partkey], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                |   |         └─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+                |   |           └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, nation.n_regionkey, region.r_regionkey] }
+                |   |             ├─StreamExchange { dist: HashShard(nation.n_regionkey) }
+                |   |             | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, nation.n_regionkey, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
+                |   |             |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                |   |             |   | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_suppkey, supplier.s_suppkey] }
+                |   |             |   |   ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                |   |             |   |   | └─StreamFilter { predicate: IsNotNull(partsupp.ps_partkey) }
+                |   |             |   |   |   └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                |   |             |   |   └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                |   |             |   |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |             |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                |   |             |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                |   |             └─StreamExchange { dist: HashShard(region.r_regionkey) }
+                |   |               └─StreamProject { exprs: [region.r_regionkey] }
+                |   |                 └─StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+                |   |                   └─StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
+                |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                └─StreamExchange { dist: HashShard(region.r_regionkey) }
+                  └─StreamProject { exprs: [region.r_regionkey] }
+                    └─StreamFilter { predicate: (region.r_name = 'AFRICA':Varchar) }
+                      └─StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, partsupp.ps_partkey(hidden), partsupp.ps_suppkey(hidden), supplier.s_suppkey(hidden), part.p_partkey(hidden), partsupp.ps_supplycost(hidden), min(partsupp.ps_supplycost)(hidden), nation.n_nationkey(hidden), supplier.s_nationkey(hidden), nation.n_regionkey(hidden), region.r_regionkey(hidden)], pk_columns: [partsupp.ps_partkey, partsupp.ps_suppkey, p_partkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey], order_descs: [s_acctbal, n_name, s_name, p_partkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, part.p_partkey, partsupp.ps_supplycost, min(partsupp.ps_supplycost), nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
@@ -573,72 +573,72 @@
     limit 10;
   logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
-      LogicalProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
-        LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) AND (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate < '1995-03-29':Varchar::Date) AND (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                  LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
+      └─LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+          └─LogicalFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) AND (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate < '1995-03-29':Varchar::Date) AND (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
-      LogicalProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
-        LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
-              LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
-                LogicalScan { table: customer, output_columns: [customer.c_custkey], required_columns: [c_custkey, c_mktsegment], predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], required_columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority], predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-              LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
+    └─LogicalProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
+      └─LogicalAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─LogicalProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+          └─LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
+            ├─LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
+            | ├─LogicalScan { table: customer, output_columns: [customer.c_custkey], required_columns: [c_custkey, c_mktsegment], predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
+            | └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], required_columns: [o_orderkey, o_custkey, o_orderdate, o_shippriority], predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
+            └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
   batch_plan: |
     BatchTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
-          BatchProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
-            BatchHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
-                BatchProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                    BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
-                        BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                          BatchProject { exprs: [customer.c_custkey] }
-                            BatchFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                              BatchScan { table: customer, columns: [customer.c_custkey, customer.c_mktsegment], distribution: UpstreamHashShard(customer.c_custkey) }
-                        BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                          BatchFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-                            BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], distribution: UpstreamHashShard(orders.o_orderkey) }
-                    BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                      BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                        BatchFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
+        └─BatchProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
+          └─BatchHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+            └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
+              └─BatchProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+                └─BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                  ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+                  | └─BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority] }
+                  |   ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+                  |   | └─BatchProject { exprs: [customer.c_custkey] }
+                  |   |   └─BatchFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
+                  |   |     └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_mktsegment], distribution: UpstreamHashShard(customer.c_custkey) }
+                  |   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+                  |     └─BatchFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
+                  |       └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], distribution: UpstreamHashShard(orders.o_orderkey) }
+                  └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                    └─BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                      └─BatchFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
+                        └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
-      StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
-        StreamTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0, group_key: [4] }
-              StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority, Vnode(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority)] }
-                StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
-                  StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                    StreamExchange { dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
-                      StreamProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
-                        StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
-                          StreamExchange { dist: HashShard(orders.o_orderkey) }
-                            StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority, customer.c_custkey, orders.o_custkey] }
-                              StreamExchange { dist: HashShard(customer.c_custkey) }
-                                StreamProject { exprs: [customer.c_custkey] }
-                                  StreamFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
-                                    StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_mktsegment], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                              StreamExchange { dist: HashShard(orders.o_custkey) }
-                                StreamFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
-                                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                          StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                            StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber] }
-                              StreamFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
-                                StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
+      └─StreamTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0, group_key: [4] }
+            └─StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority, Vnode(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority)] }
+              └─StreamProject { exprs: [lineitem.l_orderkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), orders.o_orderdate, orders.o_shippriority] }
+                └─StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                  └─StreamExchange { dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
+                    └─StreamProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
+                      └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
+                        ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                        | └─StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [orders.o_orderkey, orders.o_orderdate, orders.o_shippriority, customer.c_custkey, orders.o_custkey] }
+                        |   ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+                        |   | └─StreamProject { exprs: [customer.c_custkey] }
+                        |   |   └─StreamFilter { predicate: (customer.c_mktsegment = 'FURNITURE':Varchar) }
+                        |   |     └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_mktsegment], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                        |   └─StreamExchange { dist: HashShard(orders.o_custkey) }
+                        |     └─StreamFilter { predicate: (orders.o_orderdate < '1995-03-29':Varchar::Date) }
+                        |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate, orders.o_shippriority], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                        └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                          └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber] }
+                            └─StreamFilter { predicate: (lineitem.l_shipdate > '1995-03-29':Varchar::Date) }
+                              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [l_orderkey, revenue, o_orderdate, o_shippriority], pk_columns: [l_orderkey, o_orderdate, o_shippriority], order_descs: [revenue, o_orderdate, l_orderkey, o_shippriority] }
@@ -730,47 +730,47 @@
       o_orderpriority;
   logical_plan: |
     LogicalProject { exprs: [orders.o_orderpriority, count] }
-      LogicalAgg { group_key: [orders.o_orderpriority], aggs: [count] }
-        LogicalProject { exprs: [orders.o_orderpriority] }
-          LogicalFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-            LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-              LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 0, correlated_id: 1 }) AND (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                  LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalAgg { group_key: [orders.o_orderpriority], aggs: [count] }
+      └─LogicalProject { exprs: [orders.o_orderpriority] }
+        └─LogicalFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+          └─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+            ├─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+            └─LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              └─LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 0, correlated_id: 1 }) AND (lineitem.l_commitdate < lineitem.l_receiptdate) }
+                └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [orders.o_orderpriority], aggs: [count] }
-      LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderpriority] }
-        LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_orderpriority], required_columns: [o_orderkey, o_orderpriority, o_orderdate], predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-        LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey], required_columns: [l_orderkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
+    └─LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = orders.o_orderkey), output: [orders.o_orderpriority] }
+      ├─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_orderpriority], required_columns: [o_orderkey, o_orderpriority, o_orderdate], predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+      └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey], required_columns: [l_orderkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
   batch_plan: |
     BatchExchange { order: [orders.o_orderpriority ASC], dist: Single }
-      BatchSort { order: [orders.o_orderpriority ASC] }
-        BatchHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
-          BatchExchange { order: [], dist: HashShard(orders.o_orderpriority) }
-            BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority] }
-              BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                BatchProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
-                  BatchFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-              BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                BatchProject { exprs: [lineitem.l_orderkey] }
-                  BatchFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
+    └─BatchSort { order: [orders.o_orderpriority ASC] }
+      └─BatchHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
+        └─BatchExchange { order: [], dist: HashShard(orders.o_orderpriority) }
+          └─BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority] }
+            ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+            | └─BatchProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
+            |   └─BatchFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+            |     └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+            └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+              └─BatchProject { exprs: [lineitem.l_orderkey] }
+                └─BatchFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
+                  └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority] }
-      StreamProject { exprs: [orders.o_orderpriority, count] }
-        StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count, count] }
-          StreamExchange { dist: HashShard(orders.o_orderpriority) }
-            StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders.o_orderkey] }
-              StreamExchange { dist: HashShard(orders.o_orderkey) }
-                StreamProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
-                  StreamFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-              StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_linenumber] }
-                  StreamFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                    StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [orders.o_orderpriority, count] }
+      └─StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count, count] }
+        └─StreamExchange { dist: HashShard(orders.o_orderpriority) }
+          └─StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders.o_orderkey] }
+            ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+            | └─StreamProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
+            |   └─StreamFilter { predicate: (orders.o_orderdate >= '1997-07-01':Varchar::Date) AND (orders.o_orderdate < ('1997-07-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+            |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+            └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+              └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_linenumber] }
+                └─StreamFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
+                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority] }
@@ -837,96 +837,96 @@
       revenue desc;
   logical_plan: |
     LogicalProject { exprs: [nation.n_name, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey) AND (customer.c_nationkey = supplier.s_nationkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'MIDDLE EAST':Varchar) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true, output: all }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                      LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                    LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-              LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
+    └─LogicalAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey) AND (customer.c_nationkey = supplier.s_nationkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'MIDDLE EAST':Varchar) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+          └─LogicalJoin { type: Inner, on: true, output: all }
+            ├─LogicalJoin { type: Inner, on: true, output: all }
+            | ├─LogicalJoin { type: Inner, on: true, output: all }
+            | | ├─LogicalJoin { type: Inner, on: true, output: all }
+            | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+            | | | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+            | | | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+            | | | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+            | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+            | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+            └─LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey), output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
-              LogicalJoin { type: Inner, on: (customer.c_nationkey = supplier.s_nationkey), output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
-                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_nationkey, orders.o_orderkey] }
-                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
-                  LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
-            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
-          LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
+    └─LogicalProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+      └─LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
+        ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
+        | ├─LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey) AND (lineitem.l_suppkey = supplier.s_suppkey), output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
+        | | ├─LogicalJoin { type: Inner, on: (customer.c_nationkey = supplier.s_nationkey), output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
+        | | | ├─LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_nationkey, orders.o_orderkey] }
+        | | | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+        | | | | └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+        | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+        | | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+        | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey] }
+        └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
   batch_plan: |
     BatchExchange { order: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC], dist: Single }
-      BatchSort { order: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC] }
-        BatchHashAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          BatchExchange { order: [], dist: HashShard(nation.n_name) }
-            BatchProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
-                BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
-                    BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                      BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                        BatchExchange { order: [], dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
-                          BatchHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
-                            BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                              BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey] }
-                                BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                                  BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                                BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                                  BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                                    BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                      BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-                            BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                              BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                        BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
-                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
-                    BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                      BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
-                  BatchProject { exprs: [region.r_regionkey] }
-                    BatchFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
-                      BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─BatchSort { order: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) DESC] }
+      └─BatchHashAgg { group_key: [nation.n_name], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─BatchExchange { order: [], dist: HashShard(nation.n_name) }
+          └─BatchProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+            └─BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
+              ├─BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
+              | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey] }
+              |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+              |   | └─BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount] }
+              |   |   ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
+              |   |   | └─BatchHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey] }
+              |   |   |   ├─BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
+              |   |   |   | └─BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey] }
+              |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+              |   |   |   |   | └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
+              |   |   |   |   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+              |   |   |   |     └─BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+              |   |   |   |       └─BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+              |   |   |   |         └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+              |   |   |   └─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+              |   |   |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+              |   |   └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
+              |   |     └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
+              |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+              |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+              └─BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
+                └─BatchProject { exprs: [region.r_regionkey] }
+                  └─BatchFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
+                    └─BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_plan: |
     StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
-      StreamProject { exprs: [nation.n_name, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        StreamHashAgg { group_key: [nation.n_name], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          StreamExchange { dist: HashShard(nation.n_name) }
-            StreamProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, region.r_regionkey, nation.n_regionkey] }
-              StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, nation.n_regionkey, region.r_regionkey] }
-                StreamExchange { dist: HashShard(nation.n_regionkey) }
-                  StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey] }
-                    StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                      StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey] }
-                        StreamExchange { dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
-                          StreamHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, customer.c_nationkey] }
-                            StreamExchange { dist: HashShard(customer.c_nationkey) }
-                              StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey] }
-                                StreamExchange { dist: HashShard(customer.c_custkey) }
-                                  StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                                StreamExchange { dist: HashShard(orders.o_custkey) }
-                                  StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                                    StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                                      StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                            StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                        StreamExchange { dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
-                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                    StreamExchange { dist: HashShard(nation.n_nationkey) }
-                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                StreamExchange { dist: HashShard(region.r_regionkey) }
-                  StreamProject { exprs: [region.r_regionkey] }
-                    StreamFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
-                      StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─StreamProject { exprs: [nation.n_name, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─StreamHashAgg { group_key: [nation.n_name], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─StreamExchange { dist: HashShard(nation.n_name) }
+          └─StreamProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, region.r_regionkey, nation.n_regionkey] }
+            └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, nation.n_regionkey, region.r_regionkey] }
+              ├─StreamExchange { dist: HashShard(nation.n_regionkey) }
+              | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, nation.n_regionkey, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey] }
+              |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+              |   | └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey AND supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_extendedprice, lineitem.l_discount, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey] }
+              |   |   ├─StreamExchange { dist: HashShard(orders.o_orderkey, supplier.s_suppkey) }
+              |   |   | └─StreamHashJoin { type: Inner, predicate: customer.c_nationkey = supplier.s_nationkey, output: [orders.o_orderkey, supplier.s_suppkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, customer.c_nationkey] }
+              |   |   |   ├─StreamExchange { dist: HashShard(customer.c_nationkey) }
+              |   |   |   | └─StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey] }
+              |   |   |   |   ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+              |   |   |   |   | └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+              |   |   |   |   └─StreamExchange { dist: HashShard(orders.o_custkey) }
+              |   |   |   |     └─StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+              |   |   |   |       └─StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+              |   |   |   |         └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+              |   |   |   └─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+              |   |   |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+              |   |   └─StreamExchange { dist: HashShard(lineitem.l_orderkey, lineitem.l_suppkey) }
+              |   |     └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+              |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+              |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+              └─StreamExchange { dist: HashShard(region.r_regionkey) }
+                └─StreamProject { exprs: [region.r_regionkey] }
+                  └─StreamFilter { predicate: (region.r_name = 'MIDDLE EAST':Varchar) }
+                    └─StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name] }
@@ -1039,30 +1039,30 @@
       and l_quantity < 24;
   logical_plan: |
     LogicalProject { exprs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
-      LogicalAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
-        LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
-          LogicalFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
+      └─LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
+        └─LogicalFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
+          └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
-      LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
-        LogicalScan { table: lineitem, output_columns: [lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_extendedprice, l_discount, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
+    └─LogicalProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
+      └─LogicalScan { table: lineitem, output_columns: [lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_extendedprice, l_discount, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
-          BatchProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
-            BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-              BatchScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * lineitem.l_discount))] }
+        └─BatchProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount)] }
+          └─BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
+            └─BatchScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [revenue], pk_columns: [] }
-      StreamProject { exprs: [sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * lineitem.l_discount))] }
-              StreamProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount), lineitem.l_orderkey, lineitem.l_linenumber] }
-                StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
-                  StreamTableScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * lineitem.l_discount)))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * lineitem.l_discount))] }
+            └─StreamProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount), lineitem.l_orderkey, lineitem.l_linenumber] }
+              └─StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND (lineitem.l_discount >= (0.08:Decimal - 0.01:Decimal)) AND (lineitem.l_discount <= (0.08:Decimal + 0.01:Decimal)) AND (lineitem.l_quantity < 24:Int32) }
+                └─StreamTableScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [revenue], pk_columns: [] }
@@ -1128,93 +1128,93 @@
       l_year;
   logical_plan: |
     LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (customer.c_custkey = orders.o_custkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) AND (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalJoin { type: Inner, on: true, output: all }
-                        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                      LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                    LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+    └─LogicalAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+          └─LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (customer.c_custkey = orders.o_custkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) AND (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+              | | | | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              | | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              | | └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, nation.n_name] }
-          LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
-              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-                  LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], required_columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
-              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey] }
-            LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
-          LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+    └─LogicalProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+      └─LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey) AND (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, nation.n_name] }
+        ├─LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
+        | ├─LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
+        | | ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
+        | | | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
+        | | | | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+        | | | | └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], required_columns: [l_orderkey, l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
+        | | | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+        | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey] }
+        | └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+        └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |
     BatchExchange { order: [nation.n_name ASC, nation.n_name ASC, Extract('YEAR':Varchar, lineitem.l_shipdate) ASC], dist: Single }
-      BatchSort { order: [nation.n_name ASC, nation.n_name ASC, Extract('YEAR':Varchar, lineitem.l_shipdate) ASC] }
-        BatchHashAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          BatchExchange { order: [], dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
-            BatchProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              BatchFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
-                BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
-                  BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
-                      BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                        BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
-                          BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
-                              BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
-                                  BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                    BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                  BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                                    BatchFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
-                              BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-                          BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                            BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                      BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                        BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                  BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─BatchSort { order: [nation.n_name ASC, nation.n_name ASC, Extract('YEAR':Varchar, lineitem.l_shipdate) ASC] }
+      └─BatchHashAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─BatchExchange { order: [], dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
+          └─BatchProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+            └─BatchFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
+              └─BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
+                ├─BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
+                | └─BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey] }
+                |   ├─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+                |   | └─BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey] }
+                |   |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                |   |   | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name] }
+                |   |   |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+                |   |   |   | └─BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate] }
+                |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                |   |   |   |   | └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |   |   |   └─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+                |   |   |   |     └─BatchFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
+                |   |   |   |       └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
+                |   |   |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                |   |   |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+                |   |   └─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+                |   |     └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                |   └─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+                |     └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                  └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year] }
-      StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        StreamHashAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          StreamExchange { dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
-            StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey] }
-              StreamFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
-                StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
-                  StreamExchange { dist: HashShard(customer.c_nationkey) }
-                    StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, orders.o_custkey, customer.c_custkey] }
-                      StreamExchange { dist: HashShard(orders.o_custkey) }
-                        StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
-                          StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                            StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, supplier.s_suppkey, lineitem.l_linenumber, lineitem.l_suppkey, supplier.s_nationkey, nation.n_nationkey] }
-                              StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                                StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, supplier.s_suppkey, lineitem.l_linenumber, lineitem.l_suppkey] }
-                                  StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                    StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                  StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                                    StreamFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
-                                      StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                              StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                          StreamExchange { dist: HashShard(orders.o_orderkey) }
-                            StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                      StreamExchange { dist: HashShard(customer.c_custkey) }
-                        StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                  StreamExchange { dist: HashShard(nation.n_nationkey) }
-                    StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─StreamHashAgg { group_key: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─StreamExchange { dist: HashShard(nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate)) }
+          └─StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey] }
+            └─StreamFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
+              └─StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: all }
+                ├─StreamExchange { dist: HashShard(customer.c_nationkey) }
+                | └─StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, customer.c_nationkey, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, orders.o_custkey, customer.c_custkey] }
+                |   ├─StreamExchange { dist: HashShard(orders.o_custkey) }
+                |   | └─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, orders.o_custkey, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
+                |   |   ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                |   |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, nation.n_name, supplier.s_suppkey, lineitem.l_linenumber, lineitem.l_suppkey, supplier.s_nationkey, nation.n_nationkey] }
+                |   |   |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                |   |   |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, supplier.s_suppkey, lineitem.l_linenumber, lineitem.l_suppkey] }
+                |   |   |   |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                |   |   |   |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |   |   |   └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+                |   |   |   |     └─StreamFilter { predicate: (lineitem.l_shipdate >= '1983-01-01':Varchar::Date) AND (lineitem.l_shipdate <= '2000-12-31':Varchar::Date) }
+                |   |   |   |       └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                |   |   |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                |   |   |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                |   |   └─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                |   |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                |   └─StreamExchange { dist: HashShard(customer.c_custkey) }
+                |     └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                  └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year] }
@@ -1355,125 +1355,125 @@
       o_year;
   logical_plan: |
     LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
-      LogicalAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), nation.n_name] }
-            LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (supplier.s_suppkey = lineitem.l_suppkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_custkey = customer.c_custkey) AND (customer.c_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'ASIA':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) AND (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalJoin { type: Inner, on: true, output: all }
-                        LogicalJoin { type: Inner, on: true, output: all }
-                          LogicalJoin { type: Inner, on: true, output: all }
-                            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                            LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-                          LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                        LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                      LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-                LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
+    └─LogicalAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), nation.n_name] }
+          └─LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (supplier.s_suppkey = lineitem.l_suppkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_custkey = customer.c_custkey) AND (customer.c_nationkey = nation.n_nationkey) AND (nation.n_regionkey = region.r_regionkey) AND (region.r_name = 'ASIA':Varchar) AND (supplier.s_nationkey = nation.n_nationkey) AND (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) AND (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | | | ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              | | | | | | └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+              | | | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+              | | | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              | | | └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              └─LogicalScan { table: region, columns: [region.r_regionkey, region.r_name, region.r_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
-      LogicalAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
-            LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
-              LogicalJoin { type: Inner, on: (orders.o_custkey = customer.c_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
-                LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
-                  LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
-                    LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
-                      LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                        LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_type], predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-                    LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
-                LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
-              LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
-            LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'ASIA':Varchar) }
+    └─LogicalAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalJoin { type: Inner, on: (nation.n_regionkey = region.r_regionkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
+          ├─LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
+          | ├─LogicalJoin { type: Inner, on: (orders.o_custkey = customer.c_custkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
+          | | ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
+          | | | ├─LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
+          | | | | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+          | | | | | ├─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+          | | | | | | ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+          | | | | | | └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_type], predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
+          | | | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+          | | | | └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
+          | | | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+          | | └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey] }
+          | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey] }
+          └─LogicalScan { table: region, output_columns: [region.r_regionkey], required_columns: [r_regionkey, r_name], predicate: (region.r_name = 'ASIA':Varchar) }
   batch_plan: |
     BatchExchange { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC], dist: Single }
-      BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
-        BatchSort { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC] }
-          BatchHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-            BatchExchange { order: [], dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
-              BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
-                  BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
-                    BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
-                      BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                        BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
-                          BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
-                              BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                                BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
-                                  BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                                    BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
-                                      BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                                        BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                                          BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                                            BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
-                                          BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                                            BatchProject { exprs: [part.p_partkey] }
-                                              BatchFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                                                BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: UpstreamHashShard(part.p_partkey) }
-                                      BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                                        BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                  BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                                    BatchFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                                      BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-                              BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                                BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-                          BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                            BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                      BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                        BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                  BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
-                    BatchProject { exprs: [region.r_regionkey] }
-                      BatchFilter { predicate: (region.r_name = 'ASIA':Varchar) }
-                        BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
+      └─BatchSort { order: [Extract('YEAR':Varchar, orders.o_orderdate) ASC] }
+        └─BatchHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+          └─BatchExchange { order: [], dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
+            └─BatchProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+              └─BatchHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name] }
+                ├─BatchExchange { order: [], dist: HashShard(nation.n_regionkey) }
+                | └─BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey] }
+                |   ├─BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
+                |   | └─BatchHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey] }
+                |   |   ├─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+                |   |   | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name] }
+                |   |   |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+                |   |   |   | └─BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate] }
+                |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                |   |   |   |   | └─BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+                |   |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+                |   |   |   |   |   | └─BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                |   |   |   |   |   |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                |   |   |   |   |   |   | └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
+                |   |   |   |   |   |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                |   |   |   |   |   |     └─BatchProject { exprs: [part.p_partkey] }
+                |   |   |   |   |   |       └─BatchFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
+                |   |   |   |   |   |         └─BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: UpstreamHashShard(part.p_partkey) }
+                |   |   |   |   |   └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                |   |   |   |   |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |   |   |   └─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+                |   |   |   |     └─BatchFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
+                |   |   |   |       └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+                |   |   |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                |   |   |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+                |   |   └─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+                |   |     └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                └─BatchExchange { order: [], dist: HashShard(region.r_regionkey) }
+                  └─BatchProject { exprs: [region.r_regionkey] }
+                    └─BatchFilter { predicate: (region.r_name = 'ASIA':Varchar) }
+                      └─BatchScan { table: region, columns: [region.r_regionkey, region.r_name], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
-      StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
-        StreamHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          StreamExchange { dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
-            StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, region.r_regionkey, nation.n_regionkey] }
-              StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, nation.n_regionkey, region.r_regionkey] }
-                StreamExchange { dist: HashShard(nation.n_regionkey) }
-                  StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, customer.c_nationkey, nation.n_nationkey] }
-                    StreamExchange { dist: HashShard(customer.c_nationkey) }
-                      StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, orders.o_custkey, customer.c_custkey] }
-                        StreamExchange { dist: HashShard(orders.o_custkey) }
-                          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, supplier.s_nationkey, nation.n_nationkey] }
-                            StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                              StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey] }
-                                StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                                  StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, lineitem.l_suppkey, supplier.s_suppkey] }
-                                    StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
-                                        StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                                        StreamExchange { dist: HashShard(part.p_partkey) }
-                                          StreamProject { exprs: [part.p_partkey] }
-                                            StreamFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
-                                              StreamTableScan { table: part, columns: [part.p_partkey, part.p_type], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                                    StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                      StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                StreamExchange { dist: HashShard(orders.o_orderkey) }
-                                  StreamFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
-                                    StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                            StreamExchange { dist: HashShard(nation.n_nationkey) }
-                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                        StreamExchange { dist: HashShard(customer.c_custkey) }
-                          StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                    StreamExchange { dist: HashShard(nation.n_nationkey) }
-                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                StreamExchange { dist: HashShard(region.r_regionkey) }
-                  StreamProject { exprs: [region.r_regionkey] }
-                    StreamFilter { predicate: (region.r_name = 'ASIA':Varchar) }
-                      StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
+    └─StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit((sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))), 6:Int32)] }
+      └─StreamHashAgg { group_key: [Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─StreamExchange { dist: HashShard(Extract('YEAR':Varchar, orders.o_orderdate)) }
+          └─StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate), Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, region.r_regionkey, nation.n_regionkey] }
+            └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, nation.n_regionkey, region.r_regionkey] }
+              ├─StreamExchange { dist: HashShard(nation.n_regionkey) }
+              | └─StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, nation.n_regionkey, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, customer.c_custkey, orders.o_custkey, customer.c_nationkey, nation.n_nationkey] }
+              |   ├─StreamExchange { dist: HashShard(customer.c_nationkey) }
+              |   | └─StreamHashJoin { type: Inner, predicate: orders.o_custkey = customer.c_custkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey, orders.o_custkey, customer.c_custkey] }
+              |   |   ├─StreamExchange { dist: HashShard(orders.o_custkey) }
+              |   |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_custkey, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey, supplier.s_nationkey, nation.n_nationkey] }
+              |   |   |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+              |   |   |   | └─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, orders.o_custkey, orders.o_orderdate, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, orders.o_orderkey] }
+              |   |   |   |   ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+              |   |   |   |   | └─StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, lineitem.l_suppkey, supplier.s_suppkey] }
+              |   |   |   |   |   ├─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+              |   |   |   |   |   | └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
+              |   |   |   |   |   |   ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+              |   |   |   |   |   |   | └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+              |   |   |   |   |   |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+              |   |   |   |   |   |     └─StreamProject { exprs: [part.p_partkey] }
+              |   |   |   |   |   |       └─StreamFilter { predicate: (part.p_type = 'PROMO ANODIZED STEEL':Varchar) }
+              |   |   |   |   |   |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_type], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+              |   |   |   |   |   └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+              |   |   |   |   |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+              |   |   |   |   └─StreamExchange { dist: HashShard(orders.o_orderkey) }
+              |   |   |   |     └─StreamFilter { predicate: (orders.o_orderdate >= '1995-01-01':Varchar::Date) AND (orders.o_orderdate <= '1996-12-31':Varchar::Date) }
+              |   |   |   |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+              |   |   |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+              |   |   |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+              |   |   └─StreamExchange { dist: HashShard(customer.c_custkey) }
+              |   |     └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_nationkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+              |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+              |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_regionkey], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+              └─StreamExchange { dist: HashShard(region.r_regionkey) }
+                └─StreamProject { exprs: [region.r_regionkey] }
+                  └─StreamFilter { predicate: (region.r_name = 'ASIA':Varchar) }
+                    └─StreamTableScan { table: region, columns: [region.r_regionkey, region.r_name], pk: [region.r_regionkey], distribution: UpstreamHashShard(region.r_regionkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year] }
@@ -1643,93 +1643,93 @@
       o_year desc;
   logical_plan: |
     LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
-      LogicalAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
-        LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-          LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-            LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey) AND (part.p_partkey = lineitem.l_partkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (supplier.s_nationkey = nation.n_nationkey) AND Like(part.p_name, '%yellow%':Varchar) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalJoin { type: Inner, on: true, output: all }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                        LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                    LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                  LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+    └─LogicalAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
+      └─LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
+        └─LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
+          └─LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey) AND (part.p_partkey = lineitem.l_partkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (supplier.s_nationkey = nation.n_nationkey) AND Like(part.p_name, '%yellow%':Varchar) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              | | | | └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+              | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+              | | └─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+              | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
-      LogicalAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
-        LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
-              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
-                  LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
-                    LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
-                    LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, '%yellow%':Varchar) }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
-              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate] }
-            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+    └─LogicalAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
+      └─LogicalProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
+        └─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
+          ├─LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
+          | ├─LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = lineitem.l_suppkey) AND (partsupp.ps_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
+          | | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+          | | | ├─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+          | | | | ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+          | | | | └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, '%yellow%':Varchar) }
+          | | | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+          | | └─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost] }
+          | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate] }
+          └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
   batch_plan: |
     BatchExchange { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC], dist: Single }
-      BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
-        BatchSort { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC] }
-          BatchHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
-            BatchExchange { order: [], dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
-              BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
-                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
-                  BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
-                      BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                        BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
-                          BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
-                            BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
-                                BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                                  BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
-                                BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                                  BatchProject { exprs: [part.p_partkey] }
-                                    BatchFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
-                                      BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: UpstreamHashShard(part.p_partkey) }
-                            BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                              BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                          BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                            BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                      BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                        BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-                  BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
+      └─BatchSort { order: [nation.n_name ASC, Extract('YEAR':Varchar, orders.o_orderdate) DESC] }
+        └─BatchHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
+          └─BatchExchange { order: [], dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
+            └─BatchProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))] }
+              └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name] }
+                ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+                | └─BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate] }
+                |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                |   | └─BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost] }
+                |   |   ├─BatchHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey] }
+                |   |   | ├─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+                |   |   | | └─BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+                |   |   | |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                |   |   | |   | └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], distribution: SomeShard }
+                |   |   | |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                |   |   | |     └─BatchProject { exprs: [part.p_partkey] }
+                |   |   | |       └─BatchFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
+                |   |   | |         └─BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: UpstreamHashShard(part.p_partkey) }
+                |   |   | └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                |   |   |   └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                |   |   └─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+                |   |     └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                |   └─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+                |     └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+                └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                  └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
-      StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
-        StreamHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
-          StreamExchange { dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
-            StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey] }
-              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey, supplier.s_nationkey, nation.n_nationkey] }
-                StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                  StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey] }
-                    StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                      StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey] }
-                        StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem.l_linenumber, part.p_partkey, supplier.s_suppkey] }
-                          StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                            StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
-                              StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                                StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                              StreamExchange { dist: HashShard(part.p_partkey) }
-                                StreamProject { exprs: [part.p_partkey] }
-                                  StreamFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
-                                    StreamTableScan { table: part, columns: [part.p_partkey, part.p_name], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                          StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                            StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                        StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                          StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    StreamExchange { dist: HashShard(orders.o_orderkey) }
-                      StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                StreamExchange { dist: HashShard(nation.n_nationkey) }
-                  StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), RoundDigit(sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity))), 2:Int32)] }
+      └─StreamHashAgg { group_key: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)], aggs: [count, sum(((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)))] }
+        └─StreamExchange { dist: HashShard(nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate)) }
+          └─StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate), ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey, nation.n_nationkey, supplier.s_nationkey] }
+            └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey, supplier.s_nationkey, nation.n_nationkey] }
+              ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+              | └─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, orders.o_orderdate, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey] }
+              |   ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+              |   | └─StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = partsupp.ps_suppkey AND lineitem.l_partkey = partsupp.ps_partkey, output: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, partsupp.ps_supplycost, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, partsupp.ps_partkey, partsupp.ps_suppkey] }
+              |   |   ├─StreamHashJoin { type: Inner, predicate: lineitem.l_suppkey = supplier.s_suppkey, output: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, supplier.s_nationkey, lineitem.l_linenumber, part.p_partkey, supplier.s_suppkey] }
+              |   |   | ├─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+              |   |   | | └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
+              |   |   | |   ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+              |   |   | |   | └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+              |   |   | |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+              |   |   | |     └─StreamProject { exprs: [part.p_partkey] }
+              |   |   | |       └─StreamFilter { predicate: Like(part.p_name, '%yellow%':Varchar) }
+              |   |   | |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_name], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+              |   |   | └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+              |   |   |   └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+              |   |   └─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+              |   |     └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+              |   └─StreamExchange { dist: HashShard(orders.o_orderkey) }
+              |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+              └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year] }
@@ -1860,82 +1860,82 @@
     limit 20;
   logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
-      LogicalProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-        LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
-          LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
-            LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) AND (lineitem.l_returnflag = 'R':Varchar) AND (customer.c_nationkey = nation.n_nationkey) }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                    LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                  LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+    └─LogicalProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
+      └─LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
+        └─LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
+          └─LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (lineitem.l_orderkey = orders.o_orderkey) AND (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) AND (lineitem.l_returnflag = 'R':Varchar) AND (customer.c_nationkey = nation.n_nationkey) }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
-      LogicalProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-        LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
-          LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
-            LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
-              LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
-                LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
-                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment] }
-                  LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
-              LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag], predicate: (lineitem.l_returnflag = 'R':Varchar) }
+    └─LogicalProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
+      └─LogicalAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
+        └─LogicalProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
+          └─LogicalJoin { type: Inner, on: (lineitem.l_orderkey = orders.o_orderkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
+            ├─LogicalJoin { type: Inner, on: (customer.c_nationkey = nation.n_nationkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
+            | ├─LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
+            | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment] }
+            | | └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_orderdate], predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+            | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name] }
+            └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_orderkey, l_extendedprice, l_discount, l_returnflag], predicate: (lineitem.l_returnflag = 'R':Varchar) }
   batch_plan: |
     BatchTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
-          BatchProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-            BatchHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
-              BatchExchange { order: [], dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
-                BatchProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
-                  BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
-                    BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
-                        BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
-                          BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
-                            BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                              BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment], distribution: UpstreamHashShard(customer.c_custkey) }
-                            BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                              BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                                BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                                  BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-                        BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                          BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-                    BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                      BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                        BatchFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
-                          BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_returnflag], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
+        └─BatchProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
+          └─BatchHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
+            └─BatchExchange { order: [], dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
+              └─BatchProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))] }
+                └─BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name] }
+                  ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+                  | └─BatchHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name] }
+                  |   ├─BatchExchange { order: [], dist: HashShard(customer.c_nationkey) }
+                  |   | └─BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey] }
+                  |   |   ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+                  |   |   | └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment], distribution: UpstreamHashShard(customer.c_custkey) }
+                  |   |   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+                  |   |     └─BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+                  |   |       └─BatchFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                  |   |         └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+                  |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                  |     └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+                  └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                    └─BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount] }
+                      └─BatchFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
+                        └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_returnflag], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
-      StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-        StreamTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0, group_key: [8] }
-              StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, Vnode(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment)] }
-                StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-                  StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [count, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
-                    StreamExchange { dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
-                      StreamProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)), orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-                        StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-                          StreamExchange { dist: HashShard(orders.o_orderkey) }
-                            StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name, orders.o_custkey, customer.c_nationkey, nation.n_nationkey] }
-                              StreamExchange { dist: HashShard(customer.c_nationkey) }
-                                StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: all }
-                                  StreamExchange { dist: HashShard(customer.c_custkey) }
-                                    StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                                  StreamExchange { dist: HashShard(orders.o_custkey) }
-                                    StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                                      StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                                        StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                              StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                          StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                            StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber] }
-                              StreamFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
-                                StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_returnflag], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
+      └─StreamTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))) DESC]", limit: 20, offset: 0, group_key: [8] }
+            └─StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, Vnode(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment)] }
+              └─StreamProject { exprs: [customer.c_custkey, customer.c_name, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount))), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
+                └─StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [count, sum((lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)))] }
+                  └─StreamExchange { dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
+                    └─StreamProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)), orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+                      └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+                        ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                        | └─StreamHashJoin { type: Inner, predicate: customer.c_nationkey = nation.n_nationkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, orders.o_orderkey, nation.n_name, orders.o_custkey, customer.c_nationkey, nation.n_nationkey] }
+                        |   ├─StreamExchange { dist: HashShard(customer.c_nationkey) }
+                        |   | └─StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: all }
+                        |   |   ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+                        |   |   | └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_comment], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                        |   |   └─StreamExchange { dist: HashShard(orders.o_custkey) }
+                        |   |     └─StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+                        |   |       └─StreamFilter { predicate: (orders.o_orderdate >= '1994-01-01':Varchar::Date) AND (orders.o_orderdate < ('1994-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                        |   |         └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                        |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                        |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                        └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                          └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber] }
+                            └─StreamFilter { predicate: (lineitem.l_returnflag = 'R':Varchar) }
+                              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_linenumber, lineitem.l_returnflag], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [c_custkey, c_name, revenue, c_acctbal, n_name, c_address, c_phone, c_comment], pk_columns: [c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment], order_descs: [revenue, c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] }
@@ -2048,112 +2048,112 @@
       value desc;
   logical_plan: |
     LogicalProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-      LogicalFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-            LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
-              LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                    LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                  LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-          LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
-            LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-              LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
-                LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                      LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+    └─LogicalFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+        | └─LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
+        |   └─LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
+        |     └─LogicalJoin { type: Inner, on: true, output: all }
+        |       ├─LogicalJoin { type: Inner, on: true, output: all }
+        |       | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+        |       | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+        |       └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+        └─LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
+          └─LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+            └─LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
+              └─LogicalFilter { predicate: (partsupp.ps_suppkey = supplier.s_suppkey) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'ARGENTINA':Varchar) }
+                └─LogicalJoin { type: Inner, on: true, output: all }
+                  ├─LogicalJoin { type: Inner, on: true, output: all }
+                  | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+                  | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+                  └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)), output: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-      LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-        LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
-          LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
-            LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
-              LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
-              LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-            LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-      LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
-        LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-          LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
-            LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
-              LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
-                LogicalScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
-                LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
-              LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+    ├─LogicalAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+    | └─LogicalProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
+    |   └─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+    |     ├─LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+    |     | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+    |     | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+    |     └─LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+    └─LogicalProject { exprs: [(sum((partsupp.ps_supplycost * partsupp.ps_availqty)) * 0.0001000000:Decimal)] }
+      └─LogicalAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+        └─LogicalProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
+          └─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
+            ├─LogicalJoin { type: Inner, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+            | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+            | └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey] }
+            └─LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'ARGENTINA':Varchar) }
   batch_plan: |
     BatchSort { order: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)) DESC] }
-      BatchNestedLoopJoin { type: Inner, predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)), output: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-        BatchExchange { order: [], dist: Single }
-          BatchHashAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-            BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-              BatchProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
-                BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
-                  BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                    BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
-                      BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                        BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                      BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                        BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                  BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                    BatchProject { exprs: [nation.n_nationkey] }
-                      BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                        BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-        BatchProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
-          BatchSimpleAgg { aggs: [sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
-            BatchExchange { order: [], dist: Single }
-              BatchSimpleAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-                BatchProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
-                  BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
-                    BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                      BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
-                        BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                          BatchScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: SomeShard }
-                        BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                          BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                    BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                      BatchProject { exprs: [nation.n_nationkey] }
-                        BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                          BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─BatchNestedLoopJoin { type: Inner, predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)), output: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+      ├─BatchExchange { order: [], dist: Single }
+      | └─BatchHashAgg { group_key: [partsupp.ps_partkey], aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+      |   └─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+      |     └─BatchProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty)] }
+      |       └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost] }
+      |         ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+      |         | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+      |         |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+      |         |   | └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+      |         |   └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+      |         |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+      |         └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+      |           └─BatchProject { exprs: [nation.n_nationkey] }
+      |             └─BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+      |               └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+      └─BatchProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
+        └─BatchSimpleAgg { aggs: [sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
+          └─BatchExchange { order: [], dist: Single }
+            └─BatchSimpleAgg { aggs: [sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+              └─BatchProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty)] }
+                └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost] }
+                  ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+                  | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey] }
+                  |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+                  |   | └─BatchScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], distribution: SomeShard }
+                  |   └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                  |     └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                  └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+                    └─BatchProject { exprs: [nation.n_nationkey] }
+                      └─BatchFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+                        └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_plan: |
     StreamMaterialize { columns: [ps_partkey, value], pk_columns: [ps_partkey], order_descs: [value, ps_partkey] }
-      StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-        StreamDynamicFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)) }
-          StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-            StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-              StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty), partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-                  StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
-                    StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                      StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_suppkey, supplier.s_suppkey] }
-                        StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                          StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                        StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                          StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                    StreamExchange { dist: HashShard(nation.n_nationkey) }
-                      StreamProject { exprs: [nation.n_nationkey] }
-                        StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                          StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-          StreamExchange { dist: Broadcast }
-            StreamProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
-              StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
-                StreamExchange { dist: Single }
-                  StreamStatelessLocalSimpleAgg { aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
-                    StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty), partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-                      StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
-                        StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                          StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey] }
-                            StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                              StreamTableScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_partkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                            StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                        StreamExchange { dist: HashShard(nation.n_nationkey) }
-                          StreamProject { exprs: [nation.n_nationkey] }
-                            StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
-                              StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+    └─StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+      └─StreamDynamicFilter { predicate: (sum((partsupp.ps_supplycost * partsupp.ps_availqty)) > (sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)) }
+        ├─StreamProject { exprs: [partsupp.ps_partkey, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+        | └─StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty)), sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+        |   └─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+        |     └─StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty), partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
+        |       └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
+        |         ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+        |         | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_suppkey, supplier.s_suppkey] }
+        |         |   ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+        |         |   | └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+        |         |   └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+        |         |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+        |         └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+        |           └─StreamProject { exprs: [nation.n_nationkey] }
+        |             └─StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+        |               └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+        └─StreamExchange { dist: Broadcast }
+          └─StreamProject { exprs: [(sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty))) * 0.0001000000:Decimal)] }
+            └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((partsupp.ps_supplycost * partsupp.ps_availqty)))] }
+              └─StreamExchange { dist: Single }
+                └─StreamStatelessLocalSimpleAgg { aggs: [count, sum((partsupp.ps_supplycost * partsupp.ps_availqty))] }
+                  └─StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty), partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
+                    └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
+                      ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                      | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [partsupp.ps_availqty, partsupp.ps_supplycost, supplier.s_nationkey, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey] }
+                      |   ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                      |   | └─StreamTableScan { table: partsupp, columns: [partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_partkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                      |   └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                      |     └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                      └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                        └─StreamProject { exprs: [nation.n_nationkey] }
+                          └─StreamFilter { predicate: (nation.n_name = 'ARGENTINA':Varchar) }
+                            └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [ps_partkey, value], pk_columns: [ps_partkey], order_descs: [value, ps_partkey] }
@@ -2292,44 +2292,44 @@
         l_shipmode;
   logical_plan: |
     LogicalProject { exprs: [lineitem.l_shipmode, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-      LogicalAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-        LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-          LogicalFilter { predicate: (orders.o_orderkey = lineitem.l_orderkey) AND In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true, output: all }
-              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
+      └─LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+        └─LogicalFilter { predicate: (orders.o_orderkey = lineitem.l_orderkey) AND In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+          └─LogicalJoin { type: Inner, on: true, output: all }
+            ├─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+            └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-      LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-        LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [orders.o_orderpriority, lineitem.l_shipmode] }
-          LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority] }
-          LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_shipmode], required_columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate], predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+    └─LogicalProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+      └─LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [orders.o_orderpriority, lineitem.l_shipmode] }
+        ├─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority] }
+        └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_shipmode], required_columns: [l_orderkey, l_shipmode, l_shipdate, l_commitdate, l_receiptdate], predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [lineitem.l_shipmode ASC], dist: Single }
-      BatchSort { order: [lineitem.l_shipmode ASC] }
-        BatchHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-          BatchExchange { order: [], dist: HashShard(lineitem.l_shipmode) }
-            BatchProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
-              BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode] }
-                BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                  BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority], distribution: UpstreamHashShard(orders.o_orderkey) }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                  BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode] }
-                    BatchFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
+    └─BatchSort { order: [lineitem.l_shipmode ASC] }
+      └─BatchHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
+        └─BatchExchange { order: [], dist: HashShard(lineitem.l_shipmode) }
+          └─BatchProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32)] }
+            └─BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode] }
+              ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+              | └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority], distribution: UpstreamHashShard(orders.o_orderkey) }
+              └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                └─BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode] }
+                  └─BatchFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                    └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode] }
-      StreamProject { exprs: [lineitem.l_shipmode, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-        StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [count, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
-          StreamExchange { dist: HashShard(lineitem.l_shipmode) }
-            StreamProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-              StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode, orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-                StreamExchange { dist: HashShard(orders.o_orderkey) }
-                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                  StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_linenumber] }
-                    StreamFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                      StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_linenumber, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [lineitem.l_shipmode, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
+      └─StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [count, sum(Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32)), sum(Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32))] }
+        └─StreamExchange { dist: HashShard(lineitem.l_shipmode) }
+          └─StreamProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32), Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32), orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+            └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode, orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+              ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+              | └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+              └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_linenumber] }
+                  └─StreamFilter { predicate: In(lineitem.l_shipmode, 'FOB':Varchar, 'SHIP':Varchar) AND (lineitem.l_commitdate < lineitem.l_receiptdate) AND (lineitem.l_shipdate < lineitem.l_commitdate) AND (lineitem.l_receiptdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_receiptdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                    └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_shipmode, lineitem.l_linenumber, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode] }
@@ -2392,49 +2392,49 @@
       c_count desc;
   logical_plan: |
     LogicalProject { exprs: [count(orders.o_orderkey), count] }
-      LogicalAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
-        LogicalProject { exprs: [count(orders.o_orderkey)] }
-          LogicalProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
-            LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
-              LogicalProject { exprs: [customer.c_custkey, orders.o_orderkey] }
-                LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey) AND Not(Like(orders.o_comment, '%:1%:2%':Varchar)), output: all }
-                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                  LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+    └─LogicalAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
+      └─LogicalProject { exprs: [count(orders.o_orderkey)] }
+        └─LogicalProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
+          └─LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
+            └─LogicalProject { exprs: [customer.c_custkey, orders.o_orderkey] }
+              └─LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey) AND Not(Like(orders.o_comment, '%:1%:2%':Varchar)), output: all }
+                ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+                └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
-      LogicalProject { exprs: [count(orders.o_orderkey)] }
-        LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
-          LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, orders.o_orderkey] }
-            LogicalScan { table: customer, columns: [customer.c_custkey] }
-            LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_comment], predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
+    └─LogicalProject { exprs: [count(orders.o_orderkey)] }
+      └─LogicalAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
+        └─LogicalJoin { type: LeftOuter, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, orders.o_orderkey] }
+          ├─LogicalScan { table: customer, columns: [customer.c_custkey] }
+          └─LogicalScan { table: orders, output_columns: [orders.o_orderkey, orders.o_custkey], required_columns: [o_orderkey, o_custkey, o_comment], predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
   batch_plan: |
     BatchExchange { order: [count DESC, count(orders.o_orderkey) DESC], dist: Single }
-      BatchSort { order: [count DESC, count(orders.o_orderkey) DESC] }
-        BatchHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
-          BatchExchange { order: [], dist: HashShard(count(orders.o_orderkey)) }
-            BatchProject { exprs: [count(orders.o_orderkey)] }
-              BatchHashAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
-                BatchHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, orders.o_orderkey] }
-                  BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                    BatchScan { table: customer, columns: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                  BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                    BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                      BatchFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                        BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], distribution: UpstreamHashShard(orders.o_orderkey) }
+    └─BatchSort { order: [count DESC, count(orders.o_orderkey) DESC] }
+      └─BatchHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
+        └─BatchExchange { order: [], dist: HashShard(count(orders.o_orderkey)) }
+          └─BatchProject { exprs: [count(orders.o_orderkey)] }
+            └─BatchHashAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey)] }
+              └─BatchHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, orders.o_orderkey] }
+                ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+                | └─BatchScan { table: customer, columns: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+                  └─BatchProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+                    └─BatchFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
+                      └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], distribution: UpstreamHashShard(orders.o_orderkey) }
   stream_plan: |
     StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
-      StreamProject { exprs: [count(orders.o_orderkey), count] }
-        StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count, count] }
-          StreamExchange { dist: HashShard(count(orders.o_orderkey)) }
-            StreamProject { exprs: [count(orders.o_orderkey), customer.c_custkey] }
-              StreamHashAgg { group_key: [customer.c_custkey], aggs: [count, count(orders.o_orderkey)] }
-                StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: all }
-                  StreamExchange { dist: HashShard(customer.c_custkey) }
-                    StreamTableScan { table: customer, columns: [customer.c_custkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                  StreamExchange { dist: HashShard(orders.o_custkey) }
-                    StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                      StreamFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                        StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+    └─StreamProject { exprs: [count(orders.o_orderkey), count] }
+      └─StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count, count] }
+        └─StreamExchange { dist: HashShard(count(orders.o_orderkey)) }
+          └─StreamProject { exprs: [count(orders.o_orderkey), customer.c_custkey] }
+            └─StreamHashAgg { group_key: [customer.c_custkey], aggs: [count, count(orders.o_orderkey)] }
+              └─StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: all }
+                ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+                | └─StreamTableScan { table: customer, columns: [customer.c_custkey], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                └─StreamExchange { dist: HashShard(orders.o_custkey) }
+                  └─StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+                    └─StreamFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
+                      └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count] }
@@ -2493,46 +2493,46 @@
       and l_shipdate < date '1995-09-01' + interval '1' month;
   logical_plan: |
     LogicalProject { exprs: [((100.00:Decimal * sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-      LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalFilter { predicate: (lineitem.l_partkey = part.p_partkey) AND (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-            LogicalJoin { type: Inner, on: true, output: all }
-              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-              LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+    └─LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalFilter { predicate: (lineitem.l_partkey = part.p_partkey) AND (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
+          └─LogicalJoin { type: Inner, on: true, output: all }
+            ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+            └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [((100.00:Decimal * sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))) / sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-      LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalJoin { type: Inner, on: (lineitem.l_partkey = part.p_partkey), output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
-            LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-            LogicalScan { table: part, columns: [part.p_partkey, part.p_type] }
+    └─LogicalAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalJoin { type: Inner, on: (lineitem.l_partkey = part.p_partkey), output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
+          ├─LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
+          └─LogicalScan { table: part, columns: [part.p_partkey, part.p_type] }
   batch_plan: |
     BatchProject { exprs: [((100.00:Decimal * sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)))) / sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-      BatchSimpleAgg { aggs: [sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-        BatchExchange { order: [], dist: Single }
-          BatchSimpleAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-            BatchProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                  BatchProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount] }
-                    BatchFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
-                BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                  BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: UpstreamHashShard(part.p_partkey) }
+    └─BatchSimpleAgg { aggs: [sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+          └─BatchProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+            └─BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type] }
+              ├─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+              | └─BatchProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount] }
+              |   └─BatchFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
+              |     └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
+              └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                └─BatchScan { table: part, columns: [part.p_partkey, part.p_type], distribution: UpstreamHashShard(part.p_partkey) }
   stream_plan: |
     StreamMaterialize { columns: [promo_revenue], pk_columns: [] }
-      StreamProject { exprs: [((100.00:Decimal * sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)))) / sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              StreamProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
-                StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
-                  StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                    StreamProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
-                      StreamFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
-                        StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                  StreamExchange { dist: HashShard(part.p_partkey) }
-                    StreamTableScan { table: part, columns: [part.p_partkey, part.p_type], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+    └─StreamProject { exprs: [((100.00:Decimal * sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)))) / sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal))), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal)), sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+            └─StreamProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Int32::Decimal), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
+              └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
+                ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                | └─StreamProject { exprs: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
+                |   └─StreamFilter { predicate: (lineitem.l_shipdate >= '1995-09-01':Varchar::Date) AND (lineitem.l_shipdate < ('1995-09-01':Varchar::Date + '1 mon 00:00:00':Interval)) }
+                |     └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                └─StreamExchange { dist: HashShard(part.p_partkey) }
+                  └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_type], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [promo_revenue], pk_columns: [] }
@@ -2607,83 +2607,83 @@
       s_suppkey;
   logical_plan: |
     LogicalProject { exprs: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
-        LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-          LogicalJoin { type: Inner, on: true, output: all }
-            LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-            LogicalProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                  LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                    LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-          LogicalProject { exprs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-            LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-              LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                LogicalProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                  LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                    LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                      LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))) }
+      └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+        ├─LogicalJoin { type: Inner, on: true, output: all }
+        | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+        | └─LogicalProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        |   └─LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        |     └─LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        |       └─LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+        |         └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+        └─LogicalProject { exprs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+          └─LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+            └─LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+              └─LogicalProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                └─LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                  └─LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+                    └─LogicalFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                      └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone] }
-        LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-      LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-        LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-            LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-              LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+    ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+    | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone] }
+    | └─LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+    |   └─LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+    |     └─LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+    └─LogicalAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+      └─LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─LogicalAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+          └─LogicalProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+            └─LogicalScan { table: lineitem, output_columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_suppkey, l_extendedprice, l_discount, l_shipdate], predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
   batch_plan: |
     BatchExchange { order: [supplier.s_suppkey ASC], dist: Single }
-      BatchSort { order: [supplier.s_suppkey ASC] }
-        BatchHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          BatchExchange { order: [], dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
-            BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], distribution: UpstreamHashShard(supplier.s_suppkey) }
-              BatchHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                  BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                    BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
-          BatchExchange { order: [], dist: HashShard(max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))) }
-            BatchSimpleAgg { aggs: [max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-              BatchExchange { order: [], dist: Single }
-                BatchSimpleAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-                  BatchProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                    BatchHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                      BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                        BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-                          BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                            BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
+    └─BatchSort { order: [supplier.s_suppkey ASC] }
+      └─BatchHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        ├─BatchExchange { order: [], dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
+        | └─BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+        |   | └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], distribution: UpstreamHashShard(supplier.s_suppkey) }
+        |   └─BatchHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        |     └─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+        |       └─BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        |         └─BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+        |           └─BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
+        └─BatchExchange { order: [], dist: HashShard(max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))) }
+          └─BatchSimpleAgg { aggs: [max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
+            └─BatchExchange { order: [], dist: Single }
+              └─BatchSimpleAgg { aggs: [max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+                └─BatchProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                  └─BatchHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                    └─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+                      └─BatchProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+                        └─BatchFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                          └─BatchScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, lineitem.l_suppkey(hidden), max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))(hidden)], pk_columns: [s_suppkey, lineitem.l_suppkey, total_revenue, max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-      StreamHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: all }
-        StreamExchange { dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
-          StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey] }
-            StreamExchange { dist: HashShard(supplier.s_suppkey) }
-              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-            StreamProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                  StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber] }
-                    StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                      StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-        StreamExchange { dist: HashShard(max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))) }
-          StreamProject { exprs: [max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-            StreamGlobalSimpleAgg { aggs: [sum(count), max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
-              StreamExchange { dist: Single }
-                StreamHashAgg { group_key: [Vnode(lineitem.l_suppkey)], aggs: [count, max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-                  StreamProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey, Vnode(lineitem.l_suppkey)] }
-                    StreamProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey] }
-                      StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-                        StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                          StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber] }
-                            StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
-                              StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamHashJoin { type: Inner, predicate: sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))) = max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))), output: all }
+      ├─StreamExchange { dist: HashShard(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))) }
+      | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey] }
+      |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+      |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+      |   └─StreamProject { exprs: [lineitem.l_suppkey, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      |     └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      |       └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+      |         └─StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber] }
+      |           └─StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+      |             └─StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+      └─StreamExchange { dist: HashShard(max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))) }
+        └─StreamProject { exprs: [max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
+          └─StreamGlobalSimpleAgg { aggs: [sum(count), max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
+            └─StreamExchange { dist: Single }
+              └─StreamHashAgg { group_key: [Vnode(lineitem.l_suppkey)], aggs: [count, max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+                └─StreamProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey, Vnode(lineitem.l_suppkey)] }
+                  └─StreamProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))), lineitem.l_suppkey] }
+                    └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+                      └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+                        └─StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber] }
+                          └─StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1993-01-01':Varchar::Date + '3 mons 00:00:00':Interval)) }
+                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, lineitem.l_suppkey(hidden), max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))(hidden)], pk_columns: [s_suppkey, lineitem.l_suppkey, total_revenue, max(max(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))))] }
@@ -2789,61 +2789,61 @@
       p_size;
   logical_plan: |
     LogicalProject { exprs: [part.p_brand, part.p_type, part.p_size, count(distinct partsupp.ps_suppkey)] }
-      LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(distinct partsupp.ps_suppkey)] }
-        LogicalProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-          LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-            LogicalApply { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), correlated_id: 1 }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-              LogicalProject { exprs: [supplier.s_suppkey] }
-                LogicalFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+    └─LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(distinct partsupp.ps_suppkey)] }
+      └─LogicalProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
+        └─LogicalFilter { predicate: (part.p_partkey = partsupp.ps_partkey) AND (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+          └─LogicalApply { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), correlated_id: 1 }
+            ├─LogicalJoin { type: Inner, on: true, output: all }
+            | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+            | └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+            └─LogicalProject { exprs: [supplier.s_suppkey] }
+              └─LogicalFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
+                └─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(partsupp.ps_suppkey)] }
-      LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [] }
-        LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-          LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
-            LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
-            LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], required_columns: [p_partkey, p_brand, p_type, p_size], predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-          LogicalScan { table: supplier, output_columns: [supplier.s_suppkey], required_columns: [s_suppkey, s_comment], predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
+    └─LogicalAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [] }
+      └─LogicalJoin { type: LeftAnti, on: (partsupp.ps_suppkey = supplier.s_suppkey), output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
+        ├─LogicalJoin { type: Inner, on: (part.p_partkey = partsupp.ps_partkey), output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
+        | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
+        | └─LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], required_columns: [p_partkey, p_brand, p_type, p_size], predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+        └─LogicalScan { table: supplier, output_columns: [supplier.s_suppkey], required_columns: [s_suppkey, s_comment], predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
   batch_plan: |
     BatchExchange { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC], dist: Single }
-      BatchSort { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC] }
-        BatchHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(partsupp.ps_suppkey)] }
-          BatchExchange { order: [], dist: HashShard(part.p_brand, part.p_type, part.p_size) }
-            BatchHashAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [] }
-              BatchHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-                BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-                  BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
-                    BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                      BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                      BatchFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                        BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], distribution: UpstreamHashShard(part.p_partkey) }
-                BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                  BatchProject { exprs: [supplier.s_suppkey] }
-                    BatchFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                      BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_comment], distribution: UpstreamHashShard(supplier.s_suppkey) }
+    └─BatchSort { order: [count(partsupp.ps_suppkey) DESC, part.p_brand ASC, part.p_type ASC, part.p_size ASC] }
+      └─BatchHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(partsupp.ps_suppkey)] }
+        └─BatchExchange { order: [], dist: HashShard(part.p_brand, part.p_type, part.p_size) }
+          └─BatchHashAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [] }
+            └─BatchHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
+              ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+              | └─BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size] }
+              |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+              |   | └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+              |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+              |     └─BatchFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+              |       └─BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], distribution: UpstreamHashShard(part.p_partkey) }
+              └─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+                └─BatchProject { exprs: [supplier.s_suppkey] }
+                  └─BatchFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
+                    └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_comment], distribution: UpstreamHashShard(supplier.s_suppkey) }
   stream_plan: |
     StreamMaterialize { columns: [p_brand, p_type, p_size, supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size] }
-      StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, count(partsupp.ps_suppkey)] }
-        StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count, count(partsupp.ps_suppkey)] }
-          StreamExchange { dist: HashShard(part.p_brand, part.p_type, part.p_size) }
-            StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
-              StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [count] }
-                StreamHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_partkey, part.p_partkey] }
-                  StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-                    StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size, partsupp.ps_partkey, part.p_partkey] }
-                      StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                        StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                      StreamExchange { dist: HashShard(part.p_partkey) }
-                        StreamFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
-                          StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                  StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                    StreamProject { exprs: [supplier.s_suppkey] }
-                      StreamFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
-                        StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_comment], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+    └─StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, count(partsupp.ps_suppkey)] }
+      └─StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count, count(partsupp.ps_suppkey)] }
+        └─StreamExchange { dist: HashShard(part.p_brand, part.p_type, part.p_size) }
+          └─StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey] }
+            └─StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey], aggs: [count] }
+              └─StreamHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_partkey, part.p_partkey] }
+                ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+                | └─StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey = part.p_partkey, output: [partsupp.ps_suppkey, part.p_brand, part.p_type, part.p_size, partsupp.ps_partkey, part.p_partkey] }
+                |   ├─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+                |   | └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+                |     └─StreamFilter { predicate: (part.p_brand <> 'Brand#45':Varchar) AND Not(Like(part.p_type, 'SMALL PLATED%':Varchar)) AND In(part.p_size, 19:Int32, 17:Int32, 16:Int32, 23:Int32, 10:Int32, 4:Int32, 38:Int32, 11:Int32) }
+                |       └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_type, part.p_size], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                └─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                  └─StreamProject { exprs: [supplier.s_suppkey] }
+                    └─StreamFilter { predicate: Like(supplier.s_comment, '%Customer%Complaints%':Varchar) }
+                      └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_comment], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [p_brand, p_type, p_size, supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size] }
@@ -2921,83 +2921,83 @@
       );
   logical_plan: |
     LogicalProject { exprs: [RoundDigit((sum(lineitem.l_extendedprice) / 7.0:Decimal), 16:Int32)] }
-      LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
-        LogicalProject { exprs: [lineitem.l_extendedprice] }
-          LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-            LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
-              LogicalJoin { type: Inner, on: true, output: all }
-                LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-              LogicalProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-                LogicalAgg { aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                  LogicalProject { exprs: [lineitem.l_quantity] }
-                    LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 16, correlated_id: 1 }) }
-                      LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
+      └─LogicalProject { exprs: [lineitem.l_extendedprice] }
+        └─LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
+          └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
+            ├─LogicalJoin { type: Inner, on: true, output: all }
+            | ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+            | └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+            └─LogicalProject { exprs: [(0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+              └─LogicalAgg { aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                └─LogicalProject { exprs: [lineitem.l_quantity] }
+                  └─LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 16, correlated_id: 1 }) }
+                    └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalProject { exprs: [RoundDigit((sum(lineitem.l_extendedprice) / 7.0:Decimal), 16:Int32)] }
-      LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
-        LogicalJoin { type: Inner, on: IsNotDistinctFrom(part.p_partkey, part.p_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))), output: [lineitem.l_extendedprice] }
-          LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
-            LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice] }
-            LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_brand, p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-          LogicalProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-            LogicalAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-              LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(part.p_partkey, lineitem.l_partkey), output: [part.p_partkey, lineitem.l_quantity] }
-                LogicalAgg { group_key: [part.p_partkey], aggs: [] }
-                  LogicalScan { table: part, columns: [part.p_partkey] }
-                LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_quantity], required_columns: [l_partkey, l_quantity], predicate: IsNotNull(lineitem.l_partkey) }
+    └─LogicalAgg { aggs: [sum(lineitem.l_extendedprice)] }
+      └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(part.p_partkey, part.p_partkey) AND (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))), output: [lineitem.l_extendedprice] }
+        ├─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey), output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
+        | ├─LogicalScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice] }
+        | └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_brand, p_container], predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+        └─LogicalProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+          └─LogicalAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+            └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(part.p_partkey, lineitem.l_partkey), output: [part.p_partkey, lineitem.l_quantity] }
+              ├─LogicalAgg { group_key: [part.p_partkey], aggs: [] }
+              | └─LogicalScan { table: part, columns: [part.p_partkey] }
+              └─LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_quantity], required_columns: [l_partkey, l_quantity], predicate: IsNotNull(lineitem.l_partkey) }
   batch_plan: |
     BatchProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
-      BatchSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice))] }
-        BatchExchange { order: [], dist: Single }
-          BatchSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
-            BatchProject { exprs: [lineitem.l_extendedprice] }
-              BatchFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-                BatchHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
-                  BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                    BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
-                      BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                        BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice], distribution: SomeShard }
-                      BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                        BatchProject { exprs: [part.p_partkey] }
-                          BatchFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-                            BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], distribution: UpstreamHashShard(part.p_partkey) }
-                  BatchProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-                    BatchHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                      BatchHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity] }
-                        BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                          BatchSortAgg { group_key: [part.p_partkey], aggs: [] }
-                            BatchScan { table: part, columns: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                        BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                          BatchFilter { predicate: IsNotNull(lineitem.l_partkey) }
-                            BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
+    └─BatchSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
+          └─BatchProject { exprs: [lineitem.l_extendedprice] }
+            └─BatchFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
+              └─BatchHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
+                ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                | └─BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey] }
+                |   ├─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                |   | └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice], distribution: SomeShard }
+                |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                |     └─BatchProject { exprs: [part.p_partkey] }
+                |       └─BatchFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+                |         └─BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], distribution: UpstreamHashShard(part.p_partkey) }
+                └─BatchProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+                  └─BatchHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                    └─BatchHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity] }
+                      ├─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                      | └─BatchSortAgg { group_key: [part.p_partkey], aggs: [] }
+                      |   └─BatchScan { table: part, columns: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                      └─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+                        └─BatchFilter { predicate: IsNotNull(lineitem.l_partkey) }
+                          └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly], pk_columns: [] }
-      StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(lineitem.l_extendedprice))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
-              StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, part.p_partkey] }
-                StreamFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
-                  StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
-                    StreamExchange { dist: HashShard(part.p_partkey) }
-                      StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
-                        StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                          StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                        StreamExchange { dist: HashShard(part.p_partkey) }
-                          StreamProject { exprs: [part.p_partkey] }
-                            StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
-                              StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                    StreamProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
-                      StreamHashAgg { group_key: [part.p_partkey], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
-                        StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
-                          StreamExchange { dist: HashShard(part.p_partkey) }
-                            StreamProject { exprs: [part.p_partkey] }
-                              StreamHashAgg { group_key: [part.p_partkey], aggs: [count] }
-                                StreamTableScan { table: part, columns: [part.p_partkey], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                          StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                            StreamFilter { predicate: IsNotNull(lineitem.l_partkey) }
-                              StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32)] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(lineitem.l_extendedprice))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
+            └─StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, part.p_partkey] }
+              └─StreamFilter { predicate: (lineitem.l_quantity < (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))) }
+                └─StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
+                  ├─StreamExchange { dist: HashShard(part.p_partkey) }
+                  | └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
+                  |   ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                  |   | └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                  |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+                  |     └─StreamProject { exprs: [part.p_partkey] }
+                  |       └─StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
+                  |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                  └─StreamProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity)))] }
+                    └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                      └─StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
+                        ├─StreamExchange { dist: HashShard(part.p_partkey) }
+                        | └─StreamProject { exprs: [part.p_partkey] }
+                        |   └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count] }
+                        |     └─StreamTableScan { table: part, columns: [part.p_partkey], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+                        └─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                          └─StreamFilter { predicate: IsNotNull(lineitem.l_partkey) }
+                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [avg_yearly], pk_columns: [] }
@@ -3113,79 +3113,79 @@
     LIMIT 100;
   logical_plan: |
     LogicalTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
-      LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
-        LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
-          LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
-            LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (orders.o_orderkey = lineitem.l_orderkey) }
-              LogicalApply { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), correlated_id: 1 }
-                LogicalJoin { type: Inner, on: true, output: all }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                    LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                  LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                LogicalProject { exprs: [lineitem.l_orderkey] }
-                  LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
-                    LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
-                      LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_quantity] }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
+      └─LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
+        └─LogicalProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
+          └─LogicalFilter { predicate: (customer.c_custkey = orders.o_custkey) AND (orders.o_orderkey = lineitem.l_orderkey) }
+            └─LogicalApply { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), correlated_id: 1 }
+              ├─LogicalJoin { type: Inner, on: true, output: all }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              └─LogicalProject { exprs: [lineitem.l_orderkey] }
+                └─LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
+                  └─LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
+                    └─LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_quantity] }
+                      └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
-      LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
-        LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
-          LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
-            LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
-              LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name] }
-              LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate] }
-            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
-          LogicalProject { exprs: [lineitem.l_orderkey] }
-            LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
-              LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
-                LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
+    └─LogicalAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
+      └─LogicalJoin { type: LeftSemi, on: (orders.o_orderkey = lineitem.l_orderkey), output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
+        ├─LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
+        | ├─LogicalJoin { type: Inner, on: (customer.c_custkey = orders.o_custkey), output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
+        | | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name] }
+        | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate] }
+        | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
+        └─LogicalProject { exprs: [lineitem.l_orderkey] }
+          └─LogicalFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
+            └─LogicalAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
+              └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity] }
   batch_plan: |
     BatchTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
-          BatchHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
-            BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
-              BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
-                BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                  BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
-                    BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                      BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name], distribution: UpstreamHashShard(customer.c_custkey) }
-                    BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                      BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                  BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
-              BatchProject { exprs: [lineitem.l_orderkey] }
-                BatchFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
-                  BatchHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
-                    BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
+        └─BatchHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity)] }
+          └─BatchHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity] }
+            ├─BatchHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity] }
+            | ├─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+            | | └─BatchHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate] }
+            | |   ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+            | |   | └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_name], distribution: UpstreamHashShard(customer.c_custkey) }
+            | |   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+            | |     └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate], distribution: UpstreamHashShard(orders.o_orderkey) }
+            | └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+            |   └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
+            └─BatchProject { exprs: [lineitem.l_orderkey] }
+              └─BatchFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
+                └─BatchHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
+                  └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                    └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
-      StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
-        StreamTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0, group_key: [6] }
-              StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity), Vnode(orders.o_orderkey)] }
-                StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
-                  StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [count, sum(lineitem.l_quantity)] }
-                    StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-                      StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
-                        StreamExchange { dist: HashShard(orders.o_orderkey) }
-                          StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, orders.o_custkey] }
-                            StreamExchange { dist: HashShard(customer.c_custkey) }
-                              StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                            StreamExchange { dist: HashShard(orders.o_custkey) }
-                              StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                        StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                      StreamProject { exprs: [lineitem.l_orderkey] }
-                        StreamFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
-                          StreamProject { exprs: [lineitem.l_orderkey, sum(lineitem.l_quantity)] }
-                            StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [count, sum(lineitem.l_quantity)] }
-                              StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                                StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
+      └─StreamTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0, group_key: [6] }
+            └─StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity), Vnode(orders.o_orderkey)] }
+              └─StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
+                └─StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [count, sum(lineitem.l_quantity)] }
+                  └─StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+                    ├─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
+                    | ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                    | | └─StreamHashJoin { type: Inner, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, orders.o_custkey] }
+                    | |   ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+                    | |   | └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_name], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+                    | |   └─StreamExchange { dist: HashShard(orders.o_custkey) }
+                    | |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_totalprice, orders.o_orderdate], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                    | └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                    |   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                    └─StreamProject { exprs: [lineitem.l_orderkey] }
+                      └─StreamFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
+                        └─StreamProject { exprs: [lineitem.l_orderkey, sum(lineitem.l_quantity)] }
+                          └─StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [count, sum(lineitem.l_quantity)] }
+                            └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], pk_columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice], order_descs: [o_totalprice, o_orderdate, c_name, c_custkey, o_orderkey] }
@@ -3301,48 +3301,48 @@
       );
   logical_plan: |
     LogicalProject { exprs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-        LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-          LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_size >= 1:Int32) AND In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-            LogicalJoin { type: Inner, on: true, output: all }
-              LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-              LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+    └─LogicalAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+      └─LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+        └─LogicalFilter { predicate: (part.p_partkey = lineitem.l_partkey) AND (part.p_size >= 1:Int32) AND In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
+          └─LogicalJoin { type: Inner, on: true, output: all }
+            ├─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+            └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
   optimized_logical_plan: |
     LogicalAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-      LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-        LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))), output: [lineitem.l_extendedprice, lineitem.l_discount] }
-          LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode], predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-          LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], required_columns: [p_partkey, p_brand, p_size, p_container], predicate: (part.p_size >= 1:Int32) }
+    └─LogicalProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+      └─LogicalJoin { type: Inner, on: (part.p_partkey = lineitem.l_partkey) AND (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))), output: [lineitem.l_extendedprice, lineitem.l_discount] }
+        ├─LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount], required_columns: [l_partkey, l_quantity, l_extendedprice, l_discount, l_shipinstruct, l_shipmode], predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
+        └─LogicalScan { table: part, output_columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], required_columns: [p_partkey, p_brand, p_size, p_container], predicate: (part.p_size >= 1:Int32) }
   batch_plan: |
     BatchSimpleAgg { aggs: [sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-      BatchExchange { order: [], dist: Single }
-        BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-          BatchProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
-            BatchFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-              BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
-                  BatchProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
-                    BatchFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipinstruct, lineitem.l_shipmode], distribution: SomeShard }
-                BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                  BatchFilter { predicate: (part.p_size >= 1:Int32) }
-                    BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], distribution: UpstreamHashShard(part.p_partkey) }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+        └─BatchProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))] }
+          └─BatchFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
+            └─BatchHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
+              ├─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey) }
+              | └─BatchProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount] }
+              |   └─BatchFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
+              |     └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_shipinstruct, lineitem.l_shipmode], distribution: SomeShard }
+              └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                └─BatchFilter { predicate: (part.p_size >= 1:Int32) }
+                  └─BatchScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], distribution: UpstreamHashShard(part.p_partkey) }
   stream_plan: |
     StreamMaterialize { columns: [revenue], pk_columns: [] }
-      StreamProject { exprs: [sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-        StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
-          StreamExchange { dist: Single }
-            StreamStatelessLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
-              StreamProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
-                StreamFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
-                  StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
-                    StreamExchange { dist: HashShard(lineitem.l_partkey) }
-                      StreamProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
-                        StreamFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
-                          StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipinstruct, lineitem.l_shipmode], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                    StreamExchange { dist: HashShard(part.p_partkey) }
-                      StreamFilter { predicate: (part.p_size >= 1:Int32) }
-                        StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+    └─StreamProject { exprs: [sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount))))] }
+        └─StreamExchange { dist: Single }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)))] }
+            └─StreamProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
+              └─StreamFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
+                └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
+                  ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
+                  | └─StreamProject { exprs: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
+                  |   └─StreamFilter { predicate: In(lineitem.l_shipmode, 'AIR':Varchar, 'AIR REG':Varchar) AND (lineitem.l_shipinstruct = 'DELIVER IN PERSON':Varchar) }
+                  |     └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipinstruct, lineitem.l_shipmode], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                  └─StreamExchange { dist: HashShard(part.p_partkey) }
+                    └─StreamFilter { predicate: (part.p_size >= 1:Int32) }
+                      └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_size, part.p_container], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [revenue], pk_columns: [] }
@@ -3424,107 +3424,107 @@
       s_name;
   logical_plan: |
     LogicalProject { exprs: [supplier.s_name, supplier.s_address] }
-      LogicalFilter { predicate: (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'KENYA':Varchar) }
-        LogicalApply { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey), correlated_id: 1 }
-          LogicalJoin { type: Inner, on: true, output: all }
-            LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-            LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-          LogicalProject { exprs: [partsupp.ps_suppkey] }
-            LogicalFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-              LogicalApply { type: LeftOuter, on: true, correlated_id: 3, max_one_row: true }
-                LogicalApply { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), correlated_id: 2 }
-                  LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
-                  LogicalProject { exprs: [part.p_partkey] }
-                    LogicalFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                      LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
-                LogicalProject { exprs: [(0.5:Decimal * sum(lineitem.l_quantity))] }
-                  LogicalAgg { aggs: [sum(lineitem.l_quantity)] }
-                    LogicalProject { exprs: [lineitem.l_quantity] }
-                      LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 0, correlated_id: 3 }) AND (lineitem.l_suppkey = CorrelatedInputRef { index: 1, correlated_id: 3 }) AND (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalFilter { predicate: (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'KENYA':Varchar) }
+      └─LogicalApply { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey), correlated_id: 1 }
+        ├─LogicalJoin { type: Inner, on: true, output: all }
+        | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+        | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+        └─LogicalProject { exprs: [partsupp.ps_suppkey] }
+          └─LogicalFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
+            └─LogicalApply { type: LeftOuter, on: true, correlated_id: 3, max_one_row: true }
+              ├─LogicalApply { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), correlated_id: 2 }
+              | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_comment] }
+              | └─LogicalProject { exprs: [part.p_partkey] }
+              |   └─LogicalFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
+              |     └─LogicalScan { table: part, columns: [part.p_partkey, part.p_name, part.p_mfgr, part.p_brand, part.p_type, part.p_size, part.p_container, part.p_retailprice, part.p_comment] }
+              └─LogicalProject { exprs: [(0.5:Decimal * sum(lineitem.l_quantity))] }
+                └─LogicalAgg { aggs: [sum(lineitem.l_quantity)] }
+                  └─LogicalProject { exprs: [lineitem.l_quantity] }
+                    └─LogicalFilter { predicate: (lineitem.l_partkey = CorrelatedInputRef { index: 0, correlated_id: 3 }) AND (lineitem.l_suppkey = CorrelatedInputRef { index: 1, correlated_id: 3 }) AND (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) }
+                      └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalJoin { type: LeftSemi, on: (supplier.s_suppkey = partsupp.ps_suppkey), output: [supplier.s_name, supplier.s_address] }
-      LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
-        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey] }
-        LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'KENYA':Varchar) }
-      LogicalJoin { type: Inner, on: IsNotDistinctFrom(partsupp.ps_partkey, partsupp.ps_partkey) AND IsNotDistinctFrom(partsupp.ps_suppkey, partsupp.ps_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))), output: [partsupp.ps_suppkey] }
-        LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), output: all }
-          LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty] }
-          LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, 'forest%':Varchar) }
-        LogicalProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
-          LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
-            LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(partsupp.ps_partkey, lineitem.l_partkey) AND IsNotDistinctFrom(partsupp.ps_suppkey, lineitem.l_suppkey), output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
-              LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
-                LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
-              LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
+    ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
+    | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey] }
+    | └─LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'KENYA':Varchar) }
+    └─LogicalJoin { type: Inner, on: IsNotDistinctFrom(partsupp.ps_partkey, partsupp.ps_partkey) AND IsNotDistinctFrom(partsupp.ps_suppkey, partsupp.ps_suppkey) AND (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))), output: [partsupp.ps_suppkey] }
+      ├─LogicalJoin { type: LeftSemi, on: (partsupp.ps_partkey = part.p_partkey), output: all }
+      | ├─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty] }
+      | └─LogicalScan { table: part, output_columns: [part.p_partkey], required_columns: [p_partkey, p_name], predicate: Like(part.p_name, 'forest%':Varchar) }
+      └─LogicalProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
+        └─LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
+          └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(partsupp.ps_partkey, lineitem.l_partkey) AND IsNotDistinctFrom(partsupp.ps_suppkey, lineitem.l_suppkey), output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
+            ├─LogicalAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
+            | └─LogicalScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey] }
+            └─LogicalScan { table: lineitem, output_columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity], required_columns: [l_partkey, l_suppkey, l_quantity, l_shipdate], predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
   batch_plan: |
     BatchExchange { order: [supplier.s_name ASC], dist: Single }
-      BatchSort { order: [supplier.s_name ASC] }
-        BatchHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address] }
-          BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-            BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
-              BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-              BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                BatchProject { exprs: [nation.n_nationkey] }
-                  BatchFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
-                    BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-          BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
-            BatchProject { exprs: [partsupp.ps_suppkey] }
-              BatchFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-                BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM partsupp.ps_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM partsupp.ps_suppkey, output: all }
-                  BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    BatchHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
-                      BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
-                        BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                      BatchExchange { order: [], dist: HashShard(part.p_partkey) }
-                        BatchProject { exprs: [part.p_partkey] }
-                          BatchFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                            BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: UpstreamHashShard(part.p_partkey) }
-                  BatchProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
-                    BatchHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
-                      BatchHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
-                        BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                          BatchSortAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
-                            BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                        BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                          BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity] }
-                            BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
-                              BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
+    └─BatchSort { order: [supplier.s_name ASC] }
+      └─BatchHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address] }
+        ├─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+        | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_suppkey, supplier.s_name, supplier.s_address] }
+        |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+        |   | └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+        |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+        |     └─BatchProject { exprs: [nation.n_nationkey] }
+        |       └─BatchFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
+        |         └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+        └─BatchExchange { order: [], dist: HashShard(partsupp.ps_suppkey) }
+          └─BatchProject { exprs: [partsupp.ps_suppkey] }
+            └─BatchFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
+              └─BatchHashJoin { type: Inner, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM partsupp.ps_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM partsupp.ps_suppkey, output: all }
+                ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                | └─BatchHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
+                |   ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey) }
+                |   | └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                |   └─BatchExchange { order: [], dist: HashShard(part.p_partkey) }
+                |     └─BatchProject { exprs: [part.p_partkey] }
+                |       └─BatchFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
+                |         └─BatchScan { table: part, columns: [part.p_partkey, part.p_name], distribution: UpstreamHashShard(part.p_partkey) }
+                └─BatchProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
+                  └─BatchHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity)] }
+                    └─BatchHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity] }
+                      ├─BatchExchange { order: [], dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                      | └─BatchSortAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [] }
+                      |   └─BatchScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                      └─BatchExchange { order: [], dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
+                        └─BatchProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity] }
+                          └─BatchFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
+                            └─BatchScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_shipdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_name, s_address, supplier.s_suppkey(hidden), nation.n_nationkey(hidden), supplier.s_nationkey(hidden)], pk_columns: [supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey], order_descs: [s_name, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-      StreamHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-        StreamExchange { dist: HashShard(supplier.s_suppkey) }
-          StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: all }
-            StreamExchange { dist: HashShard(supplier.s_nationkey) }
-              StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-            StreamExchange { dist: HashShard(nation.n_nationkey) }
-              StreamProject { exprs: [nation.n_nationkey] }
-                StreamFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
-                  StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-        StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
-          StreamProject { exprs: [partsupp.ps_suppkey, partsupp.ps_partkey, partsupp.ps_partkey, partsupp.ps_suppkey] }
-            StreamFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
-              StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM partsupp.ps_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM partsupp.ps_suppkey, output: all }
-                StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                  StreamHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
-                    StreamExchange { dist: HashShard(partsupp.ps_partkey) }
-                      StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                    StreamExchange { dist: HashShard(part.p_partkey) }
-                      StreamProject { exprs: [part.p_partkey] }
-                        StreamFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
-                          StreamTableScan { table: part, columns: [part.p_partkey, part.p_name], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
-                StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
-                  StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count, sum(lineitem.l_quantity)] }
-                    StreamHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, lineitem.l_suppkey] }
-                      StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                        StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey] }
-                          StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count] }
-                            StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
-                      StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
-                        StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber] }
-                          StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
-                            StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamHashJoin { type: LeftSemi, predicate: supplier.s_suppkey = partsupp.ps_suppkey, output: [supplier.s_name, supplier.s_address, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
+      ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+      | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: all }
+      |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+      |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+      |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+      |     └─StreamProject { exprs: [nation.n_nationkey] }
+      |       └─StreamFilter { predicate: (nation.n_name = 'KENYA':Varchar) }
+      |         └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+      └─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
+        └─StreamProject { exprs: [partsupp.ps_suppkey, partsupp.ps_partkey, partsupp.ps_partkey, partsupp.ps_suppkey] }
+          └─StreamFilter { predicate: (partsupp.ps_availqty > (0.5:Decimal * sum(lineitem.l_quantity))) }
+            └─StreamHashJoin { type: Inner, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM partsupp.ps_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM partsupp.ps_suppkey, output: all }
+              ├─StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+              | └─StreamHashJoin { type: LeftSemi, predicate: partsupp.ps_partkey = part.p_partkey, output: all }
+              |   ├─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
+              |   | └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey, partsupp.ps_availqty], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+              |   └─StreamExchange { dist: HashShard(part.p_partkey) }
+              |     └─StreamProject { exprs: [part.p_partkey] }
+              |       └─StreamFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
+              |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_name], pk: [part.p_partkey], distribution: UpstreamHashShard(part.p_partkey) }
+              └─StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity))] }
+                └─StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count, sum(lineitem.l_quantity)] }
+                  └─StreamHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, lineitem.l_suppkey] }
+                    ├─StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                    | └─StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey] }
+                    |   └─StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count] }
+                    |     └─StreamTableScan { table: partsupp, columns: [partsupp.ps_partkey, partsupp.ps_suppkey], pk: [partsupp.ps_partkey, partsupp.ps_suppkey], distribution: UpstreamHashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
+                    └─StreamExchange { dist: HashShard(lineitem.l_partkey, lineitem.l_suppkey) }
+                      └─StreamProject { exprs: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber] }
+                        └─StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Varchar::Date) AND (lineitem.l_shipdate < ('1994-01-01':Varchar::Date + '1 year 00:00:00':Interval)) AND IsNotNull(lineitem.l_partkey) AND IsNotNull(lineitem.l_suppkey) }
+                          └─StreamTableScan { table: lineitem, columns: [lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [s_name, s_address, supplier.s_suppkey(hidden), nation.n_nationkey(hidden), supplier.s_nationkey(hidden)], pk_columns: [supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey], order_descs: [s_name, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
@@ -3669,109 +3669,109 @@
     LIMIT 100;
   logical_plan: |
     LogicalTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
-      LogicalProject { exprs: [supplier.s_name, count] }
-        LogicalAgg { group_key: [supplier.s_name], aggs: [count] }
-          LogicalProject { exprs: [supplier.s_name] }
-            LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (orders.o_orderstatus = 'F':Varchar) AND (lineitem.l_receiptdate > lineitem.l_commitdate) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'GERMANY':Varchar) }
-              LogicalApply { type: LeftAnti, on: true, correlated_id: 2 }
-                LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
-                  LogicalJoin { type: Inner, on: true, output: all }
-                    LogicalJoin { type: Inner, on: true, output: all }
-                      LogicalJoin { type: Inner, on: true, output: all }
-                        LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
-                        LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                      LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                    LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
-                  LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                    LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 7, correlated_id: 1 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 9, correlated_id: 1 }) }
-                      LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
-                  LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 7, correlated_id: 2 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 9, correlated_id: 2 }) AND (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                    LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+    └─LogicalProject { exprs: [supplier.s_name, count] }
+      └─LogicalAgg { group_key: [supplier.s_name], aggs: [count] }
+        └─LogicalProject { exprs: [supplier.s_name] }
+          └─LogicalFilter { predicate: (supplier.s_suppkey = lineitem.l_suppkey) AND (orders.o_orderkey = lineitem.l_orderkey) AND (orders.o_orderstatus = 'F':Varchar) AND (lineitem.l_receiptdate > lineitem.l_commitdate) AND (supplier.s_nationkey = nation.n_nationkey) AND (nation.n_name = 'GERMANY':Varchar) }
+            └─LogicalApply { type: LeftAnti, on: true, correlated_id: 2 }
+              ├─LogicalApply { type: LeftSemi, on: true, correlated_id: 1 }
+              | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | ├─LogicalJoin { type: Inner, on: true, output: all }
+              | | | | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_nationkey, supplier.s_phone, supplier.s_acctbal, supplier.s_comment] }
+              | | | | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              | | | └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              | | └─LogicalScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey, nation.n_comment] }
+              | └─LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              |   └─LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 7, correlated_id: 1 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 9, correlated_id: 1 }) }
+              |     └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+              └─LogicalProject { exprs: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
+                └─LogicalFilter { predicate: (lineitem.l_orderkey = CorrelatedInputRef { index: 7, correlated_id: 2 }) AND (lineitem.l_suppkey <> CorrelatedInputRef { index: 9, correlated_id: 2 }) AND (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                  └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_partkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_shipdate, lineitem.l_commitdate, lineitem.l_receiptdate, lineitem.l_shipinstruct, lineitem.l_shipmode, lineitem.l_comment] }
   optimized_logical_plan: |
     LogicalTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
-      LogicalAgg { group_key: [supplier.s_name], aggs: [count] }
-        LogicalJoin { type: LeftAnti, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
-          LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
-            LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
-              LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
-                LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
-                  LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey] }
-                  LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'GERMANY':Varchar) }
-              LogicalScan { table: orders, output_columns: [orders.o_orderkey], required_columns: [o_orderkey, o_orderstatus], predicate: (orders.o_orderstatus = 'F':Varchar) }
-            LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey] }
-          LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+    └─LogicalAgg { group_key: [supplier.s_name], aggs: [count] }
+      └─LogicalJoin { type: LeftAnti, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
+        ├─LogicalJoin { type: LeftSemi, on: (lineitem.l_orderkey = lineitem.l_orderkey) AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+        | ├─LogicalJoin { type: Inner, on: (orders.o_orderkey = lineitem.l_orderkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+        | | ├─LogicalJoin { type: Inner, on: (supplier.s_nationkey = nation.n_nationkey), output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+        | | | ├─LogicalJoin { type: Inner, on: (supplier.s_suppkey = lineitem.l_suppkey), output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
+        | | | | ├─LogicalScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey] }
+        | | | | └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+        | | | └─LogicalScan { table: nation, output_columns: [nation.n_nationkey], required_columns: [n_nationkey, n_name], predicate: (nation.n_name = 'GERMANY':Varchar) }
+        | | └─LogicalScan { table: orders, output_columns: [orders.o_orderkey], required_columns: [o_orderkey, o_orderstatus], predicate: (orders.o_orderstatus = 'F':Varchar) }
+        | └─LogicalScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey] }
+        └─LogicalScan { table: lineitem, output_columns: [lineitem.l_orderkey, lineitem.l_suppkey], required_columns: [l_orderkey, l_suppkey, l_commitdate, l_receiptdate], predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
   batch_plan: |
     BatchTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
-      BatchExchange { order: [], dist: Single }
-        BatchTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
-          BatchHashAgg { group_key: [supplier.s_name], aggs: [count] }
-            BatchExchange { order: [], dist: HashShard(supplier.s_name) }
-              BatchHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
-                BatchHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
-                  BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
-                    BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                      BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
-                        BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
-                          BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
-                            BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
-                              BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                            BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
-                              BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
-                                BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                                  BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
-                        BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
-                          BatchProject { exprs: [nation.n_nationkey] }
-                            BatchFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
-                              BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
-                    BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
-                      BatchProject { exprs: [orders.o_orderkey] }
-                        BatchFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
-                          BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], distribution: UpstreamHashShard(orders.o_orderkey) }
-                  BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                    BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey], distribution: SomeShard }
-                BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
-                  BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
-                    BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                      BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
+        └─BatchHashAgg { group_key: [supplier.s_name], aggs: [count] }
+          └─BatchExchange { order: [], dist: HashShard(supplier.s_name) }
+            └─BatchHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name] }
+              ├─BatchHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+              | ├─BatchHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+              | | ├─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+              | | | └─BatchHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey] }
+              | | |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_nationkey) }
+              | | |   | └─BatchHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey] }
+              | | |   |   ├─BatchExchange { order: [], dist: HashShard(supplier.s_suppkey) }
+              | | |   |   | └─BatchScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+              | | |   |   └─BatchExchange { order: [], dist: HashShard(lineitem.l_suppkey) }
+              | | |   |     └─BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
+              | | |   |       └─BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+              | | |   |         └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
+              | | |   └─BatchExchange { order: [], dist: HashShard(nation.n_nationkey) }
+              | | |     └─BatchProject { exprs: [nation.n_nationkey] }
+              | | |       └─BatchFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
+              | | |         └─BatchScan { table: nation, columns: [nation.n_nationkey, nation.n_name], distribution: UpstreamHashShard(nation.n_nationkey) }
+              | | └─BatchExchange { order: [], dist: HashShard(orders.o_orderkey) }
+              | |   └─BatchProject { exprs: [orders.o_orderkey] }
+              | |     └─BatchFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
+              | |       └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], distribution: UpstreamHashShard(orders.o_orderkey) }
+              | └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+              |   └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey], distribution: SomeShard }
+              └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                └─BatchProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey] }
+                  └─BatchFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                    └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [s_name, numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
-      StreamProject { exprs: [supplier.s_name, count] }
-        StreamTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
-          StreamExchange { dist: Single }
-            StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
-              StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name)] }
-                StreamProject { exprs: [supplier.s_name, count] }
-                  StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
-                    StreamExchange { dist: HashShard(supplier.s_name) }
-                      StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
-                        StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
-                          StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
-                            StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
-                                StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                                  StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
-                                    StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                                      StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
-                                    StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                                      StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
-                                        StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                                StreamExchange { dist: HashShard(nation.n_nationkey) }
-                                  StreamProject { exprs: [nation.n_nationkey] }
-                                    StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
-                                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
-                            StreamExchange { dist: HashShard(orders.o_orderkey) }
-                              StreamProject { exprs: [orders.o_orderkey] }
-                                StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
-                                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                          StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                            StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                        StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                          StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
-                            StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                              StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamProject { exprs: [supplier.s_name, count] }
+      └─StreamTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
+            └─StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name)] }
+              └─StreamProject { exprs: [supplier.s_name, count] }
+                └─StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
+                  └─StreamExchange { dist: HashShard(supplier.s_name) }
+                    └─StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
+                      ├─StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+                      | ├─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
+                      | | ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                      | | | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
+                      | | |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                      | | |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
+                      | | |   |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                      | | |   |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
+                      | | |   |   └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+                      | | |   |     └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
+                      | | |   |       └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                      | | |   |         └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                      | | |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                      | | |     └─StreamProject { exprs: [nation.n_nationkey] }
+                      | | |       └─StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
+                      | | |         └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
+                      | | └─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                      | |   └─StreamProject { exprs: [orders.o_orderkey] }
+                      | |     └─StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
+                      | |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+                      | └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                      |   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                      └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                        └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
+                          └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [s_name, numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
@@ -3920,70 +3920,70 @@
       cntrycode;
   logical_plan: |
     LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), count, sum(customer.c_acctbal)] }
-      LogicalAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
-        LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-          LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-            LogicalFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) AND (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))) }
-              LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
-                LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
-                  LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
-                  LogicalProject { exprs: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                    LogicalFilter { predicate: (orders.o_custkey = CorrelatedInputRef { index: 0, correlated_id: 1 }) }
-                      LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
-                LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
-                  LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
-                    LogicalProject { exprs: [customer.c_acctbal] }
-                      LogicalFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                        LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+    └─LogicalAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
+      └─LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
+        └─LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
+          └─LogicalFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) AND (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))) }
+            └─LogicalApply { type: LeftOuter, on: true, correlated_id: 2, max_one_row: true }
+              ├─LogicalApply { type: LeftAnti, on: true, correlated_id: 1 }
+              | ├─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
+              | └─LogicalProject { exprs: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              |   └─LogicalFilter { predicate: (orders.o_custkey = CorrelatedInputRef { index: 0, correlated_id: 1 }) }
+              |     └─LogicalScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_orderstatus, orders.o_totalprice, orders.o_orderdate, orders.o_orderpriority, orders.o_clerk, orders.o_shippriority, orders.o_comment] }
+              └─LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
+                └─LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
+                  └─LogicalProject { exprs: [customer.c_acctbal] }
+                    └─LogicalFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                      └─LogicalScan { table: customer, columns: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_nationkey, customer.c_phone, customer.c_acctbal, customer.c_mktsegment, customer.c_comment] }
   optimized_logical_plan: |
     LogicalAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
-      LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-        LogicalJoin { type: Inner, on: (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))), output: [customer.c_phone, customer.c_acctbal] }
-          LogicalJoin { type: LeftAnti, on: (orders.o_custkey = customer.c_custkey), output: [customer.c_phone, customer.c_acctbal] }
-            LogicalScan { table: customer, output_columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], required_columns: [c_custkey, c_phone, c_acctbal], predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-            LogicalScan { table: orders, columns: [orders.o_custkey] }
-          LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
-            LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
-              LogicalScan { table: customer, output_columns: [customer.c_acctbal], required_columns: [c_acctbal, c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+    └─LogicalProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
+      └─LogicalJoin { type: Inner, on: (customer.c_acctbal > (sum(customer.c_acctbal) / count(customer.c_acctbal))), output: [customer.c_phone, customer.c_acctbal] }
+        ├─LogicalJoin { type: LeftAnti, on: (orders.o_custkey = customer.c_custkey), output: [customer.c_phone, customer.c_acctbal] }
+        | ├─LogicalScan { table: customer, output_columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], required_columns: [c_custkey, c_phone, c_acctbal], predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+        | └─LogicalScan { table: orders, columns: [orders.o_custkey] }
+        └─LogicalProject { exprs: [(sum(customer.c_acctbal) / count(customer.c_acctbal))] }
+          └─LogicalAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
+            └─LogicalScan { table: customer, output_columns: [customer.c_acctbal], required_columns: [c_acctbal, c_phone], predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
   batch_plan: |
     BatchExchange { order: [Substr(customer.c_phone, 1:Int32, 2:Int32) ASC], dist: Single }
-      BatchSort { order: [Substr(customer.c_phone, 1:Int32, 2:Int32) ASC] }
-        BatchHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
-          BatchExchange { order: [], dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
-            BatchProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
-              BatchNestedLoopJoin { type: Inner, predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))), output: [customer.c_phone, customer.c_acctbal] }
-                BatchExchange { order: [], dist: Single }
-                  BatchHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal] }
-                    BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
-                      BatchFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                        BatchScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], distribution: UpstreamHashShard(customer.c_custkey) }
-                    BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
-                      BatchScan { table: orders, columns: [orders.o_custkey], distribution: SomeShard }
-                BatchProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
-                  BatchSimpleAgg { aggs: [sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
-                    BatchExchange { order: [], dist: Single }
-                      BatchSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
-                        BatchProject { exprs: [customer.c_acctbal] }
-                          BatchFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                            BatchScan { table: customer, columns: [customer.c_acctbal, customer.c_phone], distribution: SomeShard }
+    └─BatchSort { order: [Substr(customer.c_phone, 1:Int32, 2:Int32) ASC] }
+      └─BatchHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, sum(customer.c_acctbal)] }
+        └─BatchExchange { order: [], dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
+          └─BatchProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal] }
+            └─BatchNestedLoopJoin { type: Inner, predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))), output: [customer.c_phone, customer.c_acctbal] }
+              ├─BatchExchange { order: [], dist: Single }
+              | └─BatchHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal] }
+              |   ├─BatchExchange { order: [], dist: HashShard(customer.c_custkey) }
+              |   | └─BatchFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+              |   |   └─BatchScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], distribution: UpstreamHashShard(customer.c_custkey) }
+              |   └─BatchExchange { order: [], dist: HashShard(orders.o_custkey) }
+              |     └─BatchScan { table: orders, columns: [orders.o_custkey], distribution: SomeShard }
+              └─BatchProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
+                └─BatchSimpleAgg { aggs: [sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
+                  └─BatchExchange { order: [], dist: Single }
+                    └─BatchSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
+                      └─BatchProject { exprs: [customer.c_acctbal] }
+                        └─BatchFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                          └─BatchScan { table: customer, columns: [customer.c_acctbal, customer.c_phone], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [cntrycode, numcust, totacctbal], pk_columns: [cntrycode] }
-      StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), count, sum(customer.c_acctbal)] }
-        StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, count, sum(customer.c_acctbal)] }
-          StreamExchange { dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
-            StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer.c_custkey] }
-              StreamDynamicFilter { predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
-                StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
-                  StreamExchange { dist: HashShard(customer.c_custkey) }
-                    StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                      StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
-                  StreamExchange { dist: HashShard(orders.o_custkey) }
-                    StreamTableScan { table: orders, columns: [orders.o_custkey, orders.o_orderkey], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
-                StreamExchange { dist: Broadcast }
-                  StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
-                    StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
-                      StreamExchange { dist: Single }
-                        StreamStatelessLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
-                          StreamProject { exprs: [customer.c_acctbal, customer.c_custkey] }
-                            StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                              StreamTableScan { table: customer, columns: [customer.c_acctbal, customer.c_custkey, customer.c_phone], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+    └─StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), count, sum(customer.c_acctbal)] }
+      └─StreamHashAgg { group_key: [Substr(customer.c_phone, 1:Int32, 2:Int32)], aggs: [count, count, sum(customer.c_acctbal)] }
+        └─StreamExchange { dist: HashShard(Substr(customer.c_phone, 1:Int32, 2:Int32)) }
+          └─StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32), customer.c_acctbal, customer.c_custkey] }
+            └─StreamDynamicFilter { predicate: (customer.c_acctbal > (sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))) }
+              ├─StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
+              | ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+              | | └─StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+              | |   └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }
+              | └─StreamExchange { dist: HashShard(orders.o_custkey) }
+              |   └─StreamTableScan { table: orders, columns: [orders.o_custkey, orders.o_orderkey], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
+              └─StreamExchange { dist: Broadcast }
+                └─StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum(count(customer.c_acctbal)))] }
+                  └─StreamGlobalSimpleAgg { aggs: [sum(count), sum(sum(customer.c_acctbal)), sum(count(customer.c_acctbal))] }
+                    └─StreamExchange { dist: Single }
+                      └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
+                        └─StreamProject { exprs: [customer.c_acctbal, customer.c_custkey] }
+                          └─StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                            └─StreamTableScan { table: customer, columns: [customer.c_acctbal, customer.c_custkey, customer.c_phone], pk: [customer.c_custkey], distribution: UpstreamHashShard(customer.c_custkey) }

--- a/src/frontend/planner_test/tests/testdata/types.yaml
+++ b/src/frontend/planner_test/tests/testdata/types.yaml
@@ -29,7 +29,7 @@
 - sql: select ''::iNt2;
   logical_plan: |
     LogicalProject { exprs: ['':Varchar::Int16] }
-      LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: select ''::"iNt2";
   binder_error: |-
     Feature is not yet implemented: unsupported data type: "iNt2"

--- a/src/frontend/planner_test/tests/testdata/update.yaml
+++ b/src/frontend/planner_test/tests/testdata/update.yaml
@@ -4,9 +4,9 @@
     update t set v1 = 0;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t, exprs: [0:Int32, $1, $2] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchUpdate { table: t, exprs: [0:Int32, $1, $2] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = true;
@@ -16,32 +16,32 @@
     update t set v1 = v2 + 1;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t, exprs: [($1 + 1:Int32), $1, $2] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchUpdate { table: t, exprs: [($1 + 1:Int32), $1, $2] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 real);
     update t set v1 = v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t, exprs: [$1::Int32, $1, $2] }
-        BatchExchange { order: [], dist: Single }
-          BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchUpdate { table: t, exprs: [$1::Int32, $1, $2] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set v1 = v2 + 1 where v2 > 0;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t, exprs: [($1 + 1:Int32), $1, $2] }
-        BatchExchange { order: [], dist: Single }
-          BatchFilter { predicate: (t.v2 > 0:Int32) }
-            BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchUpdate { table: t, exprs: [($1 + 1:Int32), $1, $2] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchFilter { predicate: (t.v2 > 0:Int32) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (v1 int, v2 int);
     update t set (v1, v2) = (v2 + 1, v1 - 1) where v1 != v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-      BatchUpdate { table: t, exprs: [($1 + 1:Int32), ($0 - 1:Int32), $2] }
-        BatchExchange { order: [], dist: Single }
-          BatchFilter { predicate: (t.v1 <> t.v2) }
-            BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+    └─BatchUpdate { table: t, exprs: [($1 + 1:Int32), ($0 - 1:Int32), $2] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchFilter { predicate: (t.v1 <> t.v2) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Main:
```sql
stream_plan: |
    StreamMaterialize { columns: [s_name, numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
      StreamProject { exprs: [supplier.s_name, count] }
        StreamTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
          StreamExchange { dist: Single }
            StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
              StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name)] }
                StreamProject { exprs: [supplier.s_name, count] }
                  StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
                    StreamExchange { dist: HashShard(supplier.s_name) }
                      StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
                        StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
                          StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
                            StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                              StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
                                StreamExchange { dist: HashShard(supplier.s_nationkey) }
                                  StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
                                    StreamExchange { dist: HashShard(supplier.s_suppkey) }
                                      StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
                                    StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                                      StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
                                        StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
                                          StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
                                StreamExchange { dist: HashShard(nation.n_nationkey) }
                                  StreamProject { exprs: [nation.n_nationkey] }
                                    StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
                                      StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
                            StreamExchange { dist: HashShard(orders.o_orderkey) }
                              StreamProject { exprs: [orders.o_orderkey] }
                                StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
                                  StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
                          StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                            StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
                        StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                          StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
                            StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
                              StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
  
```
This PR: 

```sql
stream_plan: |
    StreamMaterialize { columns: [s_name, numwait], pk_columns: [s_name], order_descs: [numwait, s_name] }
    └─StreamProject { exprs: [supplier.s_name, count] }
      └─StreamTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0 }
        └─StreamExchange { dist: Single }
          └─StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
            └─StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name)] }
              └─StreamProject { exprs: [supplier.s_name, count] }
                └─StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
                  └─StreamExchange { dist: HashShard(supplier.s_name) }
                    └─StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
                      ├─StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
                      | ├─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
                      | | ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                      | | | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
                      | | |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
                      | | |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
                      | | |   |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
                      | | |   |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], distribution: UpstreamHashShard(supplier.s_suppkey) }
                      | | |   |   └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                      | | |   |     └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
                      | | |   |       └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
                      | | |   |         └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
                      | | |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
                      | | |     └─StreamProject { exprs: [nation.n_nationkey] }
                      | | |       └─StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
                      | | |         └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], distribution: UpstreamHashShard(nation.n_nationkey) }
                      | | └─StreamExchange { dist: HashShard(orders.o_orderkey) }
                      | |   └─StreamProject { exprs: [orders.o_orderkey] }
                      | |     └─StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
                      | |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], distribution: UpstreamHashShard(orders.o_orderkey) }
                      | └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                      |   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
                      └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                        └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
                          └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], distribution: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }

```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)



## Refer to a related PR or issue link (optional)
Fixes: https://github.com/risingwavelabs/risingwave/issues/5540