### PR TITLE
feat(state_table): add `upsert` method for `StateTable` to make the semantics clean

### DIFF
--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -163,7 +163,6 @@ impl MemTable {
                     e.insert(RowOp::Update((old_val, value)));
                 }
                 RowOp::Update((old_value, _)) => {
-                    // replace the update op
                     let old_val = std::mem::take(old_value);
                     e.insert(RowOp::Update((old_val, value)));
                 }

--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -148,6 +148,29 @@ impl MemTable {
         }
     }
 
+    pub fn upsert(&mut self, pk: Vec<u8>, value: Vec<u8>) {
+        let entry = self.buffer.entry(pk);
+        match entry {
+            Entry::Vacant(e) => {
+                e.insert(RowOp::Insert(value));
+            }
+            Entry::Occupied(mut e) => match e.get_mut() {
+                RowOp::Insert(_) => {
+                    e.insert(RowOp::Insert(value));
+                }
+                RowOp::Delete(ref mut old_value) => {
+                    let old_val = std::mem::take(old_value);
+                    e.insert(RowOp::Update((old_val, value)));
+                }
+                RowOp::Update((old_value, _)) => {
+                    // replace the update op
+                    let old_val = std::mem::take(old_value);
+                    e.insert(RowOp::Update((old_val, value)));
+                }
+            },
+        }
+    }
+
     pub fn into_parts(self) -> BTreeMap<Vec<u8>, RowOp> {
         self.buffer
     }

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -500,12 +500,11 @@ impl<S: StateStore> StateTable<S> {
     }
 
     /// Update or insert a row. If the row with the same pk exists, update it. Otherwise, insert it.
-    pub fn upsert(&mut self, value: Row) -> StorageResult<()> {
+    pub fn upsert(&mut self, value: Row) {
         let pk = value.by_indices(self.pk_indices());
         let key_bytes = serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode(&pk));
         let value_bytes = value.serialize(&self.value_indices);
         self.mem_table.upsert(key_bytes, value_bytes);
-        Ok(())
     }
 
     /// Write batch with a `StreamChunk` which should have the same schema with the table.

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -499,6 +499,15 @@ impl<S: StateStore> StateTable<S> {
             .unwrap_or_else(|e| self.handle_mem_table_error(e));
     }
 
+    /// Update or insert a row. If the row with the same pk exists, update it. Otherwise, insert it.
+    pub fn upsert(&mut self, value: Row) -> StorageResult<()> {
+        let pk = value.by_indices(self.pk_indices());
+        let key_bytes = serialize_pk_with_vnode(&pk, &self.pk_serializer, self.compute_vnode(&pk));
+        let value_bytes = value.serialize(&self.value_indices);
+        self.mem_table.upsert(key_bytes, value_bytes);
+        Ok(())
+    }
+
     /// Write batch with a `StreamChunk` which should have the same schema with the table.
     // allow(izip, which use zip instead of zip_eq)
     #[allow(clippy::disallowed_methods)]

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -126,7 +126,7 @@ impl ManagedValueState {
                 .as_ref()
                 .unwrap_or_else(Row::empty)
                 .values()
-                .map(|v| v.clone())
+                .cloned()
                 .chain(std::iter::once(output))
                 .collect(),
         );

--- a/src/stream/src/executor/managed_state/aggregation/value.rs
+++ b/src/stream/src/executor/managed_state/aggregation/value.rs
@@ -130,7 +130,7 @@ impl ManagedValueState {
                 .chain(std::iter::once(output))
                 .collect(),
         );
-        state_table.upsert(row)?;
+        state_table.upsert(row);
 
         self.is_dirty = false;
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Previously I attempted to add `upsert` in #5191 to get rid of `flush` and `is_dirty` of managed agg states, but the benchmark result showed a degradation. According discussions in #3885 and #3893, I think it's still worth adding this method to make the semantics clean, also to allow enabling sanity check in simple/hash agg.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)