### PR TITLE
refactor(storage): remove order_index of staging

### DIFF
--- a/src/storage/src/hummock/store/event_handler.rs
+++ b/src/storage/src/hummock/store/event_handler.rs
@@ -18,7 +18,6 @@ use risingwave_hummock_sdk::compaction_group::StateTableId;
 use tokio::sync::{mpsc, oneshot};
 
 use super::memtable::Memtable;
-use super::version::OrderIdx;
 use crate::hummock::local_version_manager::SyncResult;
 use crate::hummock::HummockResult;
 
@@ -29,8 +28,6 @@ pub type StateStoreId = u64;
 pub struct Batch {
     /// Immutable memtable.
     imm_mem: Arc<Memtable>,
-    /// Idx to identify immutable memtable in state store.
-    idx: OrderIdx,
     /// table_id to identify table configuration for writes.
     table_id: StateTableId,
     /// store_id to identify the state store instance.

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -42,7 +42,7 @@ pub struct HummockStorageCore {
     event_sender: mpsc::UnboundedSender<HummockEvent>,
 
     // TODO: use a dedicated uploader implementation to replace `LocalVersionManager`
-    uploder: Arc<LocalVersionManager>,
+    uploader: Arc<LocalVersionManager>,
 
     hummock_meta_client: Arc<dyn HummockMetaClient>,
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

 remove order_index of staging

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

-  remove order_index of staging
-  maintain the Mutex of ReadVersion instead of StorageCore

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

