### PR TITLE
feat(state_store): preload l0-data to memory

### DIFF
--- a/src/storage/src/hummock/shared_buffer/cache_l0.rs
+++ b/src/storage/src/hummock/shared_buffer/cache_l0.rs
@@ -1,0 +1,162 @@
+use std::collections::binary_heap::PeekMut;
+use std::collections::{BinaryHeap, HashSet};
+use std::sync::Arc;
+use bytes::Bytes;
+use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, key, VersionedComparator};
+use risingwave_pb::hummock::SstableInfo;
+use crate::hummock::HummockResult;
+use crate::hummock::iterator::{Forward, HummockIterator, HummockIteratorDirection};
+use crate::hummock::shared_buffer::shared_buffer_batch::{SharedBufferBatch, SharedBufferBatchInner, SharedBufferBatchIterator};
+use crate::hummock::value::HummockValue;
+
+const MIN_MERGE_BATCH_LIMIT: usize = 8 * 1024 * 1024;
+const MAX_MERGE_WRITE_AMPLIFICATION: usize = 8;
+
+pub struct InMemorySstableData {
+    data: Arc<SharedBufferBatchInner>,
+    compaction_group_id: CompactionGroupId,
+    ssts: HashSet<u64>,
+}
+
+impl InMemorySstableData {
+    pub fn new(data: Arc<SharedBufferBatchInner>, compaction_group_id: CompactionGroupId, mut sst_ids: Vec<u64>) -> Self {
+        sst_ids.sort();
+        sst_ids.dedup();
+       Self {
+           data,
+           compaction_group_id,
+           ssts: sst_ids.into_iter().collect(),
+       }
+    }
+
+    pub fn iter<D: HummockIteratorDirection>(&self) -> SharedBufferBatchIterator<D> {
+        SharedBufferBatchIterator::<D>::new(self.data.clone())
+    }
+
+    pub fn contains_sst(&self, sst_id: u64) -> bool {
+        self.ssts.contains(&sst_id)
+    }
+
+    pub fn get_ssts(&self) -> HashSet<u64> {
+        self.ssts.clone()
+    }
+
+    pub fn compaction_group_id(&self) -> u64 {
+        self.compaction_group_id
+    }
+
+    pub fn can_merge(&self, new_batch_size: usize) -> bool {
+        if self.data.size() > MIN_MERGE_BATCH_LIMIT && self.data.size() > new_batch_size * MAX_MERGE_WRITE_AMPLIFICATION {
+            return false;
+        }
+        true
+    }
+    pub fn start_key(&self) -> &[u8] {
+        &self.data.first().unwrap().0
+    }
+
+    pub fn end_key(&self) -> &[u8] {
+        &self.data.last().unwrap().0
+    }
+
+    pub fn start_user_key(&self) -> &[u8] {
+        key::user_key(&self.data.first().unwrap().0)
+    }
+
+    pub fn end_user_key(&self) -> &[u8] {
+        key::user_key(&self.data.last().unwrap().0)
+    }
+
+    pub fn to_batch(&self) -> SharedBufferBatch {
+        SharedBufferBatch::from_inner(self.data.clone(), 0,
+            self.compaction_group_id)
+    }
+
+    pub async fn build<I: HummockIterator<Direction=Forward>>(mut iter: I, key_count: usize, compaction_group_id: u64, sst_ids: Vec<u64>) -> HummockResult<Self> {
+        let mut data = Vec::with_capacity(key_count);
+        let mut data_size = 0;
+        iter.rewind().await?;
+        while iter.is_valid() {
+            let value = iter.value().to_bytes();
+            data_size += iter.key().len();
+            if let HummockValue::Put(t) = &value {
+                data_size += t.len();
+            }
+            data.push((Bytes::copy_from_slice(iter.key()), value));
+            iter.next().await?;
+        }
+        Ok(InMemorySstableData::new(
+                Arc::new(SharedBufferBatchInner::new(data, data_size, None)),
+                compaction_group_id,
+                sst_ids
+            ))
+    }
+
+    pub fn merge(batches: Vec<InMemorySstableData>) -> Self {
+        let mut heap = BinaryHeap::with_capacity(batches.len());
+        let mut key_count = 0;
+        let mut data_size = 0;
+        let mut ssts = vec![];
+        let compaction_group_id = batches[0].compaction_group_id;
+        for batch in batches {
+            key_count += batch.data.key_count();
+            data_size += batch.data.size();
+            ssts.extend(batch.ssts.iter());
+            let mut iter = batch.iter::<Forward>();
+            iter.rewind_inner();
+            if iter.is_valid() {
+                heap.push(Node { iter });
+            }
+        }
+
+        let mut data = Vec::with_capacity(key_count);
+        while heap.peek().map_or(false, |n| n.iter.is_valid()) {
+            let mut node = heap.peek_mut().expect("no inner iter");
+            data.push(node.iter.current_item().clone());
+            node.iter.next_inner();
+            if !node.iter.is_valid() {
+                // Put back to `unused_iters`
+                PeekMut::pop(node);
+            } else {
+                // This will update the heap top.
+                drop(node);
+            }
+        }
+        InMemorySstableData::new(
+            Arc::new(SharedBufferBatchInner::new(data, data_size, None)),
+            compaction_group_id,
+            ssts
+        )
+    }
+}
+
+struct Node {
+    iter: SharedBufferBatchIterator<Forward>,
+}
+
+impl Ord for Node
+    where
+        Self: PartialOrd,
+{
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+/// Implement `PartialOrd` for unordered iter node. Only compare the key.
+impl PartialOrd<Node> for Node  {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // Note: to implement min-heap by using max-heap internally, the comparing
+        // order should be reversed.
+
+        Some(VersionedComparator::compare_key(other.iter.key(), self.iter.key()))
+    }
+}
+
+impl PartialEq for Node {
+    fn eq(&self, other: &Self) -> bool {
+        self.iter.key() == other.iter.key()
+    }
+}
+
+impl Eq for Node where Self: PartialEq {}

--- a/src/storage/src/hummock/shared_buffer/mod.rs
+++ b/src/storage/src/hummock/shared_buffer/mod.rs
@@ -15,6 +15,8 @@
 pub mod shared_buffer_batch;
 #[expect(dead_code)]
 pub mod shared_buffer_uploader;
+mod cache_l0;
+pub use cache_l0::InMemorySstableData;
 
 use std::collections::{BTreeMap, HashMap};
 use std::ops::{Bound, RangeBounds};

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -17,12 +17,15 @@ use std::sync::Arc;
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManagerRef;
 use risingwave_hummock_sdk::{HummockEpoch, LocalSstableInfo};
+use risingwave_pb::hummock::{HummockVersion, LevelType};
 use risingwave_rpc_client::HummockMetaClient;
 
-use crate::hummock::compactor::{compact, CompactionExecutor, Context};
+use crate::hummock::compactor::{compact, CompactionExecutor, ConcatSstableIterator, Context};
 use crate::hummock::conflict_detector::ConflictDetector;
-use crate::hummock::shared_buffer::OrderSortedUncommittedData;
-use crate::hummock::{HummockResult, MemoryLimiter, SstableIdManagerRef, SstableStoreRef};
+use crate::hummock::shared_buffer::{InMemorySstableData, OrderSortedUncommittedData};
+use crate::hummock::{HummockError, HummockResult, MemoryLimiter, SstableIdManagerRef, SstableStoreRef};
+use crate::hummock::iterator::{ConcatIterator, UnorderedMergeIteratorInner};
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::monitor::StateStoreMetrics;
 
 pub(crate) type UploadTaskPayload = OrderSortedUncommittedData;
@@ -119,5 +122,51 @@ impl SharedBufferUploader {
         // }
 
         Ok(uploaded_sst_info)
+    }
+
+    pub async fn compact_l0_to_cache(&self, version: Arc<HummockVersion>) -> HummockResult<Vec<InMemorySstableData>> {
+        const MIN_CACHE_DATA_NUMBER: usize = 4;
+        let sstable_store = self.sstable_store.clone();
+        let max_cache_size = (self.compactor_context.options.shared_buffer_capacity_mb as u64 / 4) << 20;
+        let max_sstable_size = (self.compactor_context.options.sstable_size_mb as u64 / 4) << 20;
+        let ret = self.compaction_executor.spawn(async move {
+            let mut ret = vec![];
+            for (group, levels) in &version.levels {
+                let mut cache_size = 0;
+                let mut iters = vec![];
+                let mut sst_ids = vec![];
+                for level in levels.l0.as_ref().unwrap().sub_levels.iter().rev() {
+                    if cache_size + level.total_file_size > max_sstable_size {
+                        break;
+                    }
+                    if level.level_type != (LevelType::Overlapping as u32) {
+                        if level.table_infos.len() > 1 {
+                            break;
+                        }
+                        iters.push(ConcatIterator::new(
+                            level.table_infos.clone(),
+                            sstable_store.clone(),
+                            Arc::new(SstableIteratorReadOptions::default()),
+                        ));
+                        sst_ids.extend(level.table_infos.iter().map(|table|table.id));
+                    } else {
+                        for table in &level.table_infos {
+                            iters.push(ConcatIterator::new(
+                                vec![table.clone()],
+                                sstable_store.clone(),
+                                Arc::new(SstableIteratorReadOptions::default()),
+                            ));
+                        }
+                    }
+                }
+                if iters.len() > MIN_CACHE_DATA_NUMBER {
+                    let iter = UnorderedMergeIteratorInner::new(iters);
+                    let data = InMemorySstableData::build(iter, key_count, *group, sst_ids).await?;
+                    ret.push(data);
+                }
+            }
+            Ok(ret)
+        }).await.map_err(|_| HummockError::compaction_executor("failed to schedule in memory compact"))?;
+        ret
     }
 }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- preload l0-data to in-memory to reduce query on small sst files.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
