### PR TITLE
chore: set unused_must_use's lint level to Forbid

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,7 +25,7 @@ rustflags = [
     "tokio_unstable",
     # lints
     # TODO: use lint configuration in cargo https://github.com/rust-lang/cargo/issues/5034
-    "-Dunused_must_use",
+    "-Funused_must_use",
     "-Wclippy::dbg_macro",
     "-Wclippy::disallowed_methods",
     "-Wclippy::disallowed_types",

--- a/src/frontend/src/optimizer/heuristic.rs
+++ b/src/frontend/src/optimizer/heuristic.rs
@@ -111,7 +111,7 @@ impl Stats {
 
 impl fmt::Display for Stats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (rule, count) in self.rule_counter.iter() {
+        for (rule, count) in &self.rule_counter {
             writeln!(f, "apply {} {} time(s)", rule, count)?;
         }
         Ok(())

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -45,7 +45,7 @@ pub struct LogicalMultiJoin {
     // pk_derive soon.
     /// the mapping output_col_idx -> (input_idx, input_col_idx), **"output_col_idx" is internal,
     /// not consider output_indices**
-    #[allow(unused)]
+    #[expect(dead_code)]
     inner_o2i_mapping: Vec<(usize, usize)>,
     inner_i2o_mappings: Vec<ColIndexMapping>,
 }

--- a/src/storage/src/hummock/store/event_handler.rs
+++ b/src/storage/src/hummock/store/event_handler.rs
@@ -24,7 +24,7 @@ use crate::hummock::HummockResult;
 // TODO: may use a different type
 pub type StateStoreId = u64;
 
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct Batch {
     /// Immutable memtable.
     imm_mem: Arc<Memtable>,
@@ -45,13 +45,13 @@ pub enum HummockEvent {
     // TODO: may add more (e.g. event to add state store instance)
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct HummockEventHandler {
     receiver: mpsc::UnboundedReceiver<HummockEvent>,
     // TODO: may add more
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 impl HummockEventHandler {
     fn handle(&self) -> HummockResult<()> {
         unimplemented!()

--- a/src/storage/src/hummock/store/memtable.rs
+++ b/src/storage/src/hummock/store/memtable.rs
@@ -36,7 +36,7 @@ pub enum Memtable {
     BTree(BTreeMapMemtable),
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 impl Memtable {
     /// Inserts a key-value entry associated with a given `epoch` into memtable.
     fn insert(&mut self, key: Bytes, val: Bytes, epoch: u64) {
@@ -67,12 +67,12 @@ impl Memtable {
     }
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct BTreeMapMemtable {
     mem: BTreeMap<Bytes, Bytes>,
 }
 
-#[allow(unused)]
+#[expect(unused_variables, dead_code)]
 impl BTreeMapMemtable {
     fn insert(&mut self, key: Bytes, val: Bytes, epoch: u64) {
         unimplemented!()

--- a/src/storage/src/hummock/store/mod.rs
+++ b/src/storage/src/hummock/store/mod.rs
@@ -86,7 +86,7 @@ pub trait StateStore: Send + Sync + 'static + Clone {
     fn advance_write_epoch(&mut self, new_epoch: u64) -> StorageResult<()>;
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 #[derive(Default, Clone)]
 pub struct ReadOptions {
     /// A hint for prefix key to check bloom filter.

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -30,7 +30,7 @@ use crate::hummock::local_version_manager::LocalVersionManager;
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::{HummockResult, HummockStateStoreIter};
 
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct HummockStorageCore {
     /// Mutable memtable.
     memtable: Memtable,
@@ -51,13 +51,13 @@ pub struct HummockStorageCore {
     compaction_group_client: Arc<CompactionGroupClientImpl>,
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 #[derive(Clone)]
 pub struct HummockStorage {
     core: Arc<HummockStorageCore>,
 }
 
-#[allow(unused)]
+#[expect(unused_variables)]
 impl HummockStorageCore {
     /// See `HummockReadVersion::update` for more details.
     pub fn update(&mut self, info: VersionUpdate) -> HummockResult<()> {
@@ -65,7 +65,7 @@ impl HummockStorageCore {
     }
 }
 
-#[allow(unused)]
+#[expect(unused_variables)]
 impl StateStore for HummockStorage {
     type Iter = HummockStateStoreIter;
 

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -51,7 +51,7 @@ pub enum VersionUpdate {
     CommittedSnapshot(HummockVersion),
 }
 
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct StagingVersion {
     imm: VecDeque<Arc<ImmutableMemtable>>,
     sst: VecDeque<LocalSstableInfo>,
@@ -61,7 +61,7 @@ pub struct StagingVersion {
 pub type CommittedVersion = PinnedVersion;
 
 /// A container of information required for reading from hummock.
-#[allow(unused)]
+#[expect(dead_code)]
 pub struct HummockReadVersion {
     /// Local version for staging data.
     staging: StagingVersion,
@@ -72,7 +72,7 @@ pub struct HummockReadVersion {
     sstable_store: SstableStoreRef,
 }
 
-#[allow(unused)]
+#[expect(unused_variables)]
 impl HummockReadVersion {
     /// Updates the read version with `VersionUpdate`.
     /// A `OrderIdx` that can uniquely identify the newly added entry will be returned.

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -59,7 +59,6 @@ pub enum VersionUpdate {
     CommittedSnapshot(HummockVersion),
 }
 
-#[expect(dead_code)]
 pub struct StagingVersion {
     imm: VecDeque<ImmutableMemtable>,
     sst: VecDeque<StagingSstableInfo>,
@@ -101,7 +100,6 @@ impl StagingVersion {
 pub type CommittedVersion = PinnedVersion;
 
 /// A container of information required for reading from hummock.
-#[expect(dead_code)]
 pub struct HummockReadVersion {
     /// Local version for staging data.
     staging: StagingVersion,

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -95,7 +95,8 @@ macro_rules! dispatch_state_store {
 }
 
 impl StateStoreImpl {
-    #[expect(clippy::too_many_arguments, unused_variables)]
+    #[expect(clippy::too_many_arguments)]
+    #[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
     pub async fn new(
         s: &str,
         file_cache_dir: &str,

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -95,16 +95,16 @@ macro_rules! dispatch_state_store {
 }
 
 impl StateStoreImpl {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments, unused_variables)]
     pub async fn new(
         s: &str,
-        #[allow(unused)] file_cache_dir: &str,
+        file_cache_dir: &str,
         config: Arc<StorageConfig>,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
         state_store_stats: Arc<StateStoreMetrics>,
         object_store_metrics: Arc<ObjectStoreMetrics>,
         filter_key_extractor_manager: FilterKeyExtractorManagerRef,
-        #[allow(unused)] tiered_cache_metrics_builder: TieredCacheMetricsBuilder,
+        tiered_cache_metrics_builder: TieredCacheMetricsBuilder,
     ) -> StorageResult<Self> {
         #[cfg(not(target_os = "linux"))]
         let tiered_cache = TieredCache::none();

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -46,9 +46,9 @@ pub struct RangeCache<S: StateStore> {
     /// from storage
     range: (Bound<ScalarImpl>, Bound<ScalarImpl>),
 
-    #[allow(unused)]
+    #[expect(dead_code)]
     num_rows_stored: usize,
-    #[allow(unused)]
+    #[expect(dead_code)]
     capacity: usize,
 }
 

--- a/src/tests/regress/src/lib.rs
+++ b/src/tests/regress/src/lib.rs
@@ -24,7 +24,6 @@
 #![warn(clippy::map_flatten)]
 #![warn(clippy::no_effect_underscore_binding)]
 #![warn(clippy::await_holding_lock)]
-#![deny(unused_must_use)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![feature(path_file_prefix)]
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -572,7 +572,7 @@ where
         BeMessage::write(&mut self.write_buf, message)
     }
 
-    #[allow(unused)]
+    #[expect(dead_code)]
     async fn write(&mut self, message: &BeMessage<'_>) -> io::Result<()> {
         self.write_no_flush(message)?;
         self.flush().await?;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

[`forbit`](https://doc.rust-lang.org/rustc/lints/levels.html#forbid) level means `deny`+ *can not be overridden*,
which will forbid `#[allow(unused)]` 😄

<img width="539" alt="image" src="https://user-images.githubusercontent.com/37948597/192531547-492976fc-e191-40e0-b580-4f1a6fbd4990.png">
