### PR TITLE
refactor: simplify HashKeyDispatcher

### DIFF
--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -25,9 +25,7 @@ use risingwave_common::array::{Array, DataChunk, RowRef};
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{Result, RwError};
-use risingwave_common::hash::{
-    calc_hash_key_kind, HashKey, HashKeyDispatcher, PrecomputedBuildHasher,
-};
+use risingwave_common::hash::{HashKey, HashKeyDispatcher, PrecomputedBuildHasher};
 use risingwave_common::types::DataType;
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_expr::expr::{build_from_prost, BoxedExpression, Expression};
@@ -1635,47 +1633,60 @@ impl BoxedExecutorBuilder for HashJoinExecutor<()> {
             .map(|&idx| right_data_types[idx].clone())
             .collect_vec();
 
-        let hash_key_kind = calc_hash_key_kind(&right_key_types);
-
         let output_indices: Vec<usize> = hash_join_node
             .get_output_indices()
             .iter()
             .map(|&x| x as usize)
             .collect();
 
-        Ok(HashJoinExecutor::dispatch_by_kind(
-            hash_key_kind,
-            HashJoinExecutor::new(
-                join_type,
-                output_indices,
-                left_child,
-                right_child,
-                left_key_idxs,
-                right_key_idxs,
-                hash_join_node.get_null_safe().clone(),
-                cond,
-                context.plan_node().get_identity().clone(),
-            ),
-        ))
+        Ok(HashJoinExecutorArgs {
+            join_type,
+            output_indices,
+            probe_side_source: left_child,
+            build_side_source: right_child,
+            probe_key_idxs: left_key_idxs,
+            build_key_idxs: right_key_idxs,
+            null_matched: hash_join_node.get_null_safe().clone(),
+            cond,
+            identity: context.plan_node().get_identity().clone(),
+            right_key_types,
+        }
+        .dispatch())
     }
 }
 
-impl HashKeyDispatcher for HashJoinExecutor<()> {
-    type Input = Self;
+struct HashJoinExecutorArgs {
+    join_type: JoinType,
+    output_indices: Vec<usize>,
+    probe_side_source: BoxedExecutor,
+    build_side_source: BoxedExecutor,
+    probe_key_idxs: Vec<usize>,
+    build_key_idxs: Vec<usize>,
+    null_matched: Vec<bool>,
+    cond: Option<BoxedExpression>,
+    identity: String,
+    right_key_types: Vec<DataType>,
+}
+
+impl HashKeyDispatcher for HashJoinExecutorArgs {
     type Output = BoxedExecutor;
 
-    fn dispatch<K: HashKey>(input: Self::Input) -> Self::Output {
+    fn dispatch_impl<K: HashKey>(self) -> Self::Output {
         Box::new(HashJoinExecutor::<K>::new(
-            input.join_type,
-            input.output_indices,
-            input.probe_side_source,
-            input.build_side_source,
-            input.probe_key_idxs,
-            input.build_key_idxs,
-            input.null_matched,
-            input.cond,
-            input.identity,
+            self.join_type,
+            self.output_indices,
+            self.probe_side_source,
+            self.build_side_source,
+            self.probe_key_idxs,
+            self.build_key_idxs,
+            self.null_matched,
+            self.cond,
+            self.identity,
         ))
+    }
+
+    fn data_types(&self) -> &[DataType] {
+        &self.right_key_types
     }
 }
 

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//! This module contains implementation for hash key serialization for
+//! hash-agg, hash-join, and perhaps other hash-based operators.
+//!
+//! There may be multiple columns in one row being combined and encoded into
+//! one single hash key.
+//! For example, `SELECT sum(t.a) FROM t GROUP BY t.b, t.c`, the hash keys
+//! are encoded from both `t.b` and `t.c`. If `t.b="abc"` and `t.c=1`, the hashkey may be
+//! encoded in certain format of `("abc", 1)`.
+
 use std::convert::TryInto;
 use std::default::Default;
 use std::fmt::Debug;
@@ -33,15 +42,6 @@ use crate::types::{
     VIRTUAL_NODE_COUNT,
 };
 use crate::util::hash_util::Crc32FastBuilder;
-
-/// This file contains implementation for hash key serialization for
-/// hash-agg, hash-join, and perhaps other hash-based operators.
-///
-/// There may be multiple columns in one row being combined and encoded into
-/// one single hash key.
-/// For example, `SELECT sum(t.a) FROM t GROUP BY t.b, t.c`, the hash keys
-/// are encoded from both `t.b, t.c`. If t.b="abc", t.c=1, the hashkey may be
-/// encoded in certain format of ("abc", 1).
 
 /// A wrapper for u64 hash result.
 #[derive(Default, Clone, Debug, PartialEq)]

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::marker::PhantomData;
 use std::sync::Arc;
 
-use risingwave_common::hash::{calc_hash_key_kind, HashKey, HashKeyDispatcher, HashKeyKind};
+use risingwave_common::hash::{HashKey, HashKeyDispatcher};
+use risingwave_common::types::DataType;
 use risingwave_expr::expr::{build_from_prost, BoxedExpression};
 use risingwave_pb::plan_common::JoinType as JoinTypeProto;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
@@ -82,43 +82,11 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
         };
         trace!("Join non-equi condition: {:?}", condition);
 
-        macro_rules! impl_create_hash_join_executor {
-            ([], $( { $join_type_proto:ident, $join_type:ident } ),*) => {
-                fn create_hash_join_executor<S: StateStore>(
-                    typ: JoinTypeProto, kind: HashKeyKind,
-                    args: HashJoinExecutorDispatcherArgs<S>,
-                ) -> StreamResult<BoxedExecutor> {
-                    match typ {
-                        $( JoinTypeProto::$join_type_proto => HashJoinExecutorDispatcher::<_, {JoinType::$join_type}>::dispatch_by_kind(kind, args), )*
-                        JoinTypeProto::Unspecified => unreachable!(),
-                        // _ => todo!("Join type {:?} not implemented", typ),
-                    }
-                }
-            }
-        }
-
-        macro_rules! for_all_join_types {
-            ($macro:ident $(, $x:tt)*) => {
-                $macro! {
-                    [$($x),*],
-                    { Inner, Inner },
-                    { LeftOuter, LeftOuter },
-                    { RightOuter, RightOuter },
-                    { FullOuter, FullOuter },
-                    { LeftSemi, LeftSemi },
-                    { RightSemi, RightSemi },
-                    { LeftAnti, LeftAnti },
-                    { RightAnti, RightAnti }
-                }
-            };
-        }
-
         let join_key_data_types = params_l
             .join_key_indices
             .iter()
             .map(|idx| source_l.schema().fields[*idx].data_type())
             .collect_vec();
-        let kind = calc_hash_key_kind(&join_key_data_types);
 
         let state_table_l =
             StateTable::from_table_catalog(table_l, store.clone(), Some(vnodes.clone()));
@@ -150,15 +118,13 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
             lru_manager: stream.context.lru_manager.clone(),
             is_append_only,
             metrics: params.executor_stats,
+            join_type_proto: node.get_join_type()?,
+            join_key_data_types,
         };
 
-        for_all_join_types! { impl_create_hash_join_executor };
-        let join_type_proto = node.get_join_type()?;
-        create_hash_join_executor(join_type_proto, kind, args)
+        args.dispatch()
     }
 }
-
-struct HashJoinExecutorDispatcher<S: StateStore, const T: JoinTypePrimitive>(PhantomData<S>);
 
 struct HashJoinExecutorDispatcherArgs<S: StateStore> {
     ctx: ActorContextRef,
@@ -180,35 +146,56 @@ struct HashJoinExecutorDispatcherArgs<S: StateStore> {
     lru_manager: Option<LruManagerRef>,
     is_append_only: bool,
     metrics: Arc<StreamingMetrics>,
+    join_type_proto: JoinTypeProto,
+    join_key_data_types: Vec<DataType>,
 }
 
-impl<S: StateStore, const T: JoinTypePrimitive> HashKeyDispatcher
-    for HashJoinExecutorDispatcher<S, T>
-{
-    type Input = HashJoinExecutorDispatcherArgs<S>;
+impl<S: StateStore> HashKeyDispatcher for HashJoinExecutorDispatcherArgs<S> {
     type Output = StreamResult<BoxedExecutor>;
 
-    fn dispatch<K: HashKey>(args: Self::Input) -> Self::Output {
-        Ok(Box::new(HashJoinExecutor::<K, S, T>::new(
-            args.ctx,
-            args.source_l,
-            args.source_r,
-            args.params_l,
-            args.params_r,
-            args.null_safe,
-            args.pk_indices,
-            args.output_indices,
-            args.executor_id,
-            args.cond,
-            args.op_info,
-            args.cache_size,
-            args.state_table_l,
-            args.degree_state_table_l,
-            args.state_table_r,
-            args.degree_state_table_r,
-            args.lru_manager,
-            args.is_append_only,
-            args.metrics,
-        )))
+    fn dispatch_impl<K: HashKey>(self) -> Self::Output {
+        /// This macro helps to fill the const generic type parameter.
+        macro_rules! build {
+            ($join_type:ident) => {
+                Ok(Box::new(
+                    HashJoinExecutor::<K, S, { JoinType::$join_type }>::new(
+                        self.ctx,
+                        self.source_l,
+                        self.source_r,
+                        self.params_l,
+                        self.params_r,
+                        self.null_safe,
+                        self.pk_indices,
+                        self.output_indices,
+                        self.executor_id,
+                        self.cond,
+                        self.op_info,
+                        self.cache_size,
+                        self.state_table_l,
+                        self.degree_state_table_l,
+                        self.state_table_r,
+                        self.degree_state_table_r,
+                        self.lru_manager,
+                        self.is_append_only,
+                        self.metrics,
+                    ),
+                ))
+            };
+        }
+        match self.join_type_proto {
+            JoinTypeProto::Unspecified => unreachable!(),
+            JoinTypeProto::Inner => build!(Inner),
+            JoinTypeProto::LeftOuter => build!(LeftOuter),
+            JoinTypeProto::RightOuter => build!(RightOuter),
+            JoinTypeProto::FullOuter => build!(FullOuter),
+            JoinTypeProto::LeftSemi => build!(LeftSemi),
+            JoinTypeProto::LeftAnti => build!(LeftAnti),
+            JoinTypeProto::RightSemi => build!(RightSemi),
+            JoinTypeProto::RightAnti => build!(RightAnti),
+        }
+    }
+
+    fn data_types(&self) -> &[DataType] {
+        &self.join_key_data_types
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
1. replace `Input` with `Self`
2. Hide `calc_hash_key_kind`