### PR TITLE
chore: exclude generated & vendored files in linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
-# regression test target file
-*.data linguist-generated=true
-*.source linguist-generated=true
-*.sql linguist-generated=true
+# regression test data
+src/tests/regress/data/** linguist-vendored
+# source test data
+scripts/source/test_data/** linguist-vendored
+# generated proto for dashboard
+dashboard/proto/gen/** linguist-generated
+# generated grafana dashboard
+grafana/risingwave-dashboard.json linguist-generated


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. The semantics of `vendored` and `generated` are explained [here](https://github.com/github/linguist/blob/f3f5de6288cd7b09eabc5a3b26df9c13add5a2bc/docs/overrides.md).

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #5155 