### PR TITLE
refactor(compaction): reduce the usage of mutex in task progress tracking

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -173,7 +173,7 @@ pub async fn compute_node_serve(
                 filter_key_extractor_manager: filter_key_extractor_manager.clone(),
                 read_memory_limiter,
                 sstable_id_manager: storage.sstable_id_manager(),
-                task_progress: Default::default(),
+                task_progress_manager: Default::default(),
             });
             // TODO: use normal sstable store for single-process mode.
             let compactor_sstable_store = CompactorSstableStore::new(

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -284,15 +284,11 @@ impl CompactorManager {
 
     pub fn remove_task_heartbeat(&self, context_id: HummockContextId, task_id: u64) {
         let mut guard = self.task_heartbeats.write();
-        let mut garbage_collect = false;
         if let Some(heartbeats) = guard.get_mut(&context_id) {
             heartbeats.remove(&task_id);
             if heartbeats.is_empty() {
-                garbage_collect = true;
+                guard.remove(&context_id);
             }
-        }
-        if garbage_collect {
-            guard.remove(&context_id);
         }
     }
 

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 
 use fail::fail_point;
 use parking_lot::RwLock;
-use risingwave_hummock_sdk::HummockContextId;
+use risingwave_hummock_sdk::{HummockCompactionTaskId, HummockContextId};
 use risingwave_pb::hummock::subscribe_compact_tasks_response::Task;
 use risingwave_pb::hummock::{
     CancelCompactTask, CompactTask, CompactTaskAssignment, CompactTaskProgress,
@@ -34,7 +34,6 @@ use crate::storage::MetaStore;
 use crate::MetaResult;
 
 pub type CompactorManagerRef = Arc<CompactorManager>;
-type TaskId = u64;
 
 /// Wraps the stream between meta node and compactor node.
 /// Compactor node will re-establish the stream when the previous one fails.
@@ -121,7 +120,8 @@ pub struct CompactorManager {
 
     pub task_expiry_seconds: u64,
     // A map: { context_id -> { task_id -> heartbeat } }
-    task_heartbeats: RwLock<HashMap<HummockContextId, HashMap<TaskId, TaskHeartbeat>>>,
+    task_heartbeats:
+        RwLock<HashMap<HummockContextId, HashMap<HummockCompactionTaskId, TaskHeartbeat>>>,
 }
 
 impl CompactorManager {

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -133,7 +133,7 @@ pub async fn compactor_serve(
         filter_key_extractor_manager: filter_key_extractor_manager.clone(),
         read_memory_limiter: memory_limiter,
         sstable_id_manager: sstable_id_manager.clone(),
-        task_progress: Default::default(),
+        task_progress_manager: Default::default(),
     });
     let compactor_context = Arc::new(CompactorContext {
         context,

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -158,7 +158,7 @@ mod tests {
                 hummock_meta_client.clone(),
                 storage.options().sstable_id_remote_fetch_number,
             )),
-            task_progress: Default::default(),
+            task_progress_manager: Default::default(),
         });
         CompactorContext {
             sstable_store: Arc::new(CompactorSstableStore::new(

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -21,7 +21,7 @@ use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorImpl;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_pb::hummock::{CompactTask, LevelType};
 
-use crate::hummock::compactor::context::TaskProgressTracker;
+use super::task_progress::TaskProgress;
 use crate::hummock::compactor::iterator::ConcatSstableIterator;
 use crate::hummock::compactor::{
     CompactOutput, CompactionFilter, Compactor, CompactorContext, CompactorSstableStoreRef,
@@ -83,22 +83,18 @@ impl CompactorRunner {
         &self,
         compaction_filter: impl CompactionFilter,
         filter_key_extractor: Arc<FilterKeyExtractorImpl>,
+        task_progress: Arc<TaskProgress>,
     ) -> HummockResult<CompactOutput> {
         let iter = self.build_sst_iter()?;
-        let task_progress = TaskProgressTracker::new(
-            self.compact_task.task_id,
-            self.compactor.context.task_progress.clone(),
-        );
         let ssts = self
             .compactor
             .compact_key_range(
                 iter,
                 compaction_filter,
                 filter_key_extractor,
-                Some(task_progress.clone()),
+                Some(task_progress),
             )
             .await?;
-        task_progress.on_task_complete();
         Ok((self.split_index, ssts))
     }
 

--- a/src/storage/src/hummock/compactor/context.rs
+++ b/src/storage/src/hummock/compactor/context.rs
@@ -50,7 +50,7 @@ pub struct Context {
 
     pub sstable_id_manager: SstableIdManagerRef,
 
-    pub task_progress: TaskProgressManagerRef,
+    pub task_progress_manager: TaskProgressManagerRef,
 }
 
 #[derive(Clone)]

--- a/src/storage/src/hummock/compactor/context.rs
+++ b/src/storage/src/hummock/compactor/context.rs
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManagerRef;
 use risingwave_rpc_client::HummockMetaClient;
 
+use super::task_progress::TaskProgressManagerRef;
 use crate::hummock::compactor::{CompactionExecutor, CompactorSstableStoreRef};
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::{MemoryLimiter, SstableIdManagerRef};
@@ -50,46 +50,7 @@ pub struct Context {
 
     pub sstable_id_manager: SstableIdManagerRef,
 
-    pub task_progress: Arc<Mutex<HashMap<u64, TaskProgress>>>,
-}
-
-#[derive(Default, Clone)]
-pub struct TaskProgress {
-    pub num_ssts_sealed: u32,
-    pub num_ssts_uploaded: u32,
-}
-
-/// Maps `task_id` to its `TaskProgress`
-#[derive(Default, Clone)]
-pub struct TaskProgressTracker {
-    task_id: u64,
-    map: Arc<Mutex<HashMap<u64, TaskProgress>>>,
-}
-
-impl TaskProgressTracker {
-    pub fn new(task_id: u64, task_progress_map: Arc<Mutex<HashMap<u64, TaskProgress>>>) -> Self {
-        Self {
-            task_id,
-            map: task_progress_map,
-        }
-    }
-
-    pub fn inc_ssts_sealed(&self) {
-        let mut guard = self.map.lock().unwrap();
-        let progress = guard.entry(self.task_id).or_insert_with(Default::default);
-        progress.num_ssts_sealed += 1;
-    }
-
-    pub fn inc_ssts_uploaded(&self) {
-        let mut guard = self.map.lock().unwrap();
-        let progress = guard.entry(self.task_id).or_insert_with(Default::default);
-        progress.num_ssts_uploaded += 1;
-    }
-
-    pub fn on_task_complete(&self) {
-        let mut guard = self.map.lock().unwrap();
-        guard.remove(&self.task_id);
-    }
+    pub task_progress: TaskProgressManagerRef,
 }
 
 #[derive(Clone)]

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -233,7 +233,7 @@ impl Compactor {
         let mut output_ssts = Vec::with_capacity(parallelism);
         let mut compaction_futures = vec![];
         let task_progress_guard =
-            TaskProgressGuard::new(compact_task.task_id, context.task_progress.clone());
+            TaskProgressGuard::new(compact_task.task_id, context.task_progress_manager.clone());
 
         for (split_index, _) in compact_task.splits.iter().enumerate() {
             let filter = multi_filter.clone();
@@ -367,7 +367,7 @@ impl Compactor {
         type CompactionShutdownMap = Arc<Mutex<HashMap<u64, Sender<()>>>>;
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let stream_retry_interval = Duration::from_secs(60);
-        let task_progress = compactor_context.context.task_progress.clone();
+        let task_progress = compactor_context.context.task_progress_manager.clone();
         let task_progress_update_interval = Duration::from_millis(1000);
         let join_handle = tokio::spawn(async move {
             let shutdown_map = CompactionShutdownMap::default();

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -19,7 +19,7 @@ mod context;
 mod iterator;
 mod shared_buffer_compact;
 mod sstable_store;
-mod task_progress;
+pub(super) mod task_progress;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -58,9 +58,11 @@ pub use sstable_store::{
 use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::task::JoinHandle;
 
+use self::task_progress::TaskProgress;
 use super::multi_builder::CapacitySplitTableBuilder;
 use super::{HummockResult, SstableBuilderOptions, SstableWriterOptions};
 use crate::hummock::compactor::compactor_runner::CompactorRunner;
+use crate::hummock::compactor::task_progress::TaskProgressGuard;
 use crate::hummock::iterator::{Forward, HummockIterator};
 use crate::hummock::multi_builder::{SplitTableOutput, TableBuilderFactory};
 use crate::hummock::utils::MemoryLimiter;
@@ -230,6 +232,8 @@ impl Compactor {
         let mut task_status = TaskStatus::Success;
         let mut output_ssts = Vec::with_capacity(parallelism);
         let mut compaction_futures = vec![];
+        let task_progress_guard =
+            TaskProgressGuard::new(compact_task.task_id, context.task_progress.clone());
 
         for (split_index, _) in compact_task.splits.iter().enumerate() {
             let filter = multi_filter.clone();
@@ -239,9 +243,10 @@ impl Compactor {
                 compactor_context.as_ref(),
                 compact_task.clone(),
             );
+            let task_progress = task_progress_guard.progress.clone();
             let handle = tokio::spawn(async move {
                 compactor_runner
-                    .run(filter, multi_filter_key_extractor)
+                    .run(filter, multi_filter_key_extractor, task_progress)
                     .await
             });
             compaction_futures.push(handle);
@@ -398,17 +403,16 @@ impl Compactor {
                 };
                 let executor = compactor_context.context.compaction_executor.clone();
 
-                // This inner loop is to consume stream.
+                // This inner loop is to consume stream or report task progress.
                 'consume_stream: loop {
                     let message = tokio::select! {
                         _ = task_progress_interval.tick() => {
                             let mut progress_list = Vec::new();
-                            #[allow(clippy::significant_drop_in_scrutinee)]
-                            for (&task_id, progress) in task_progress.lock().unwrap().iter() {
+                            for (&task_id, progress) in task_progress.lock().iter() {
                                 progress_list.push(CompactTaskProgress {
                                     task_id,
-                                    num_ssts_sealed: progress.num_ssts_sealed,
-                                    num_ssts_uploaded: progress.num_ssts_uploaded,
+                                    num_ssts_sealed: progress.num_ssts_sealed.load(Ordering::Relaxed),
+                                    num_ssts_uploaded: progress.num_ssts_uploaded.load(Ordering::Relaxed),
                                 });
                             }
                             if let Err(e) = hummock_meta_client.report_compaction_task_progress(progress_list).await {
@@ -618,12 +622,14 @@ impl Compactor {
 
     /// Compact the given key range and merge iterator.
     /// Upon a successful return, the built SSTs are already uploaded to object store.
+    ///
+    /// `task_progress` is only used for tasks on the compactor.
     async fn compact_key_range(
         &self,
         iter: impl HummockIterator<Direction = Forward>,
         compaction_filter: impl CompactionFilter,
         filter_key_extractor: Arc<FilterKeyExtractorImpl>,
-        task_progress_tracker: Option<TaskProgressTracker>,
+        task_progress: Option<Arc<TaskProgress>>,
     ) -> HummockResult<Vec<SstableInfo>> {
         let get_id_time = Arc::new(AtomicU64::new(0));
         // Monitor time cost building shared buffer to SSTs.
@@ -642,7 +648,7 @@ impl Compactor {
                 compaction_filter,
                 filter_key_extractor,
                 get_id_time.clone(),
-                task_progress_tracker.clone(),
+                task_progress.clone(),
             )
             .await?
         } else {
@@ -652,7 +658,7 @@ impl Compactor {
                 compaction_filter,
                 filter_key_extractor,
                 get_id_time.clone(),
-                task_progress_tracker.clone(),
+                task_progress.clone(),
             )
             .await?
         };
@@ -670,7 +676,7 @@ impl Compactor {
             let sst_size = sst_info.file_size;
             ssts.push(sst_info);
 
-            let tracker_cloned = task_progress_tracker.clone();
+            let tracker_cloned = task_progress.clone();
             let context_cloned = self.context.clone();
             upload_join_handles.push(
                 upload_join_handle
@@ -710,7 +716,7 @@ impl Compactor {
         compaction_filter: impl CompactionFilter,
         filter_key_extractor: Arc<FilterKeyExtractorImpl>,
         get_id_time: Arc<AtomicU64>,
-        task_progress_tracker: Option<TaskProgressTracker>,
+        task_progress: Option<Arc<TaskProgress>>,
     ) -> HummockResult<Vec<SplitTableOutput>> {
         let builder_factory = RemoteBuilderFactory {
             sstable_id_manager: self.context.sstable_id_manager.clone(),
@@ -725,7 +731,7 @@ impl Compactor {
         let mut sst_builder = CapacitySplitTableBuilder::new(
             builder_factory,
             self.context.stats.clone(),
-            task_progress_tracker,
+            task_progress,
         );
         Compactor::compact_and_build_sst(
             &mut sst_builder,

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -19,6 +19,7 @@ mod context;
 mod iterator;
 mod shared_buffer_compact;
 mod sstable_store;
+mod task_progress;
 
 use std::collections::{HashMap, HashSet};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -31,7 +32,7 @@ pub use compaction_filter::{
     CompactionFilter, DummyCompactionFilter, MultiCompactionFilter, StateCleanUpCompactionFilter,
     TtlCompactionFilter,
 };
-pub use context::{CompactorContext, Context, TaskProgressTracker};
+pub use context::{CompactorContext, Context};
 use futures::future::try_join_all;
 use futures::{stream, StreamExt, TryFutureExt};
 pub use iterator::ConcatSstableIterator;

--- a/src/storage/src/hummock/compactor/task_progress.rs
+++ b/src/storage/src/hummock/compactor/task_progress.rs
@@ -68,6 +68,7 @@ impl Drop for TaskProgressGuard {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::{TaskProgressGuard, TaskProgressManagerRef};
 

--- a/src/storage/src/hummock/compactor/task_progress.rs
+++ b/src/storage/src/hummock/compactor/task_progress.rs
@@ -67,3 +67,17 @@ impl Drop for TaskProgressGuard {
             .expect("task progress should exist when task is finished");
     }
 }
+
+mod tests {
+    use super::{TaskProgressGuard, TaskProgressManagerRef};
+
+    #[test]
+    fn test_progress_removal() {
+        let task_progress_manager = TaskProgressManagerRef::default();
+        {
+            let _guard = TaskProgressGuard::new(1, task_progress_manager.clone());
+            assert_eq!(task_progress_manager.lock().len(), 1);
+        }
+        assert_eq!(task_progress_manager.lock().len(), 0);
+    }
+}

--- a/src/storage/src/hummock/compactor/task_progress.rs
+++ b/src/storage/src/hummock/compactor/task_progress.rs
@@ -1,0 +1,69 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::Arc;
+
+use parking_lot::Mutex;
+use risingwave_hummock_sdk::HummockCompactionTaskId;
+
+pub type TaskProgressManagerRef = Arc<Mutex<HashMap<HummockCompactionTaskId, Arc<TaskProgress>>>>;
+
+/// The progress of a compaction task.
+#[derive(Default)]
+pub struct TaskProgress {
+    pub num_ssts_sealed: AtomicU32,
+    pub num_ssts_uploaded: AtomicU32,
+}
+
+impl TaskProgress {
+    pub fn inc_ssts_sealed(&self) {
+        self.num_ssts_sealed.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_ssts_uploaded(&self) {
+        self.num_ssts_uploaded.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// An RAII object that contains a [`TaskProgress`] and shares it to all the splits of the task.
+#[derive(Default)]
+pub struct TaskProgressGuard {
+    task_id: HummockCompactionTaskId,
+    progress_manager: TaskProgressManagerRef,
+
+    pub progress: Arc<TaskProgress>,
+}
+
+impl TaskProgressGuard {
+    pub fn new(task_id: HummockCompactionTaskId, progress_manager: TaskProgressManagerRef) -> Self {
+        let progress = progress_manager.lock().entry(task_id).or_default().clone();
+        Self {
+            task_id,
+            progress_manager,
+            progress,
+        }
+    }
+}
+
+impl Drop for TaskProgressGuard {
+    fn drop(&mut self) {
+        // The entry is created along with `TaskProgress`, so it must exist.
+        self.progress_manager
+            .lock()
+            .remove(&self.task_id)
+            .expect("task progress should exist when task is finished");
+    }
+}

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_uploader.rs
@@ -68,7 +68,7 @@ impl SharedBufferUploader {
             filter_key_extractor_manager,
             read_memory_limiter: memory_limiter,
             sstable_id_manager,
-            task_progress: Default::default(),
+            task_progress_manager: Default::default(),
         });
         Self {
             options,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

The changes are as follows:

- Move task progress related structs to another file
- Use atomic variables for `num_ssts_sealed/uploaded`. The map has to be modified in `compaction_executor`'s tasks, so the `Mutex` cannot be removed.
- Use a guard to make sure the `TaskProgress` is removed from the `HashMap` in a case where a task finishes with an error and `on_task_complete` is not called.
- Change when to create/remove `TaskProgress`: 
  - create: Originally it is created when the first sst is sealed. However, it is not semantically right - the progress should start from zero.
  - remove: Originally it is removed when a split finishes, which seems to be a bug. Now it will be removed when the entire task finishes.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #5121 