### PR TITLE
feat: add definition column for pg_matviews_info

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -91,6 +91,7 @@ message Table {
   // The column indices which are stored in the state store's value with row-encoding.
   // Currently is not supported yet and expected to be `[0..columns.len()]`.
   repeated int32 value_indices = 19;
+  string definition = 20;
 }
 
 message Schema {

--- a/src/frontend/src/catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/pg_catalog/mod.rs
@@ -320,6 +320,7 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Utf8(schema.clone())),
                             Some(ScalarImpl::Int32(t.owner as i32)),
                             Some(ScalarImpl::Utf8(json!(fragments).to_string())),
+                            Some(ScalarImpl::Utf8(t.definition.clone())),
                         ]));
                     }
                 });

--- a/src/frontend/src/catalog/pg_catalog/pg_matviews_info.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_matviews_info.rs
@@ -26,4 +26,5 @@ pub const PG_MATVIEWS_INFO_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     // TODO: add index back when open create index doc again.
     // (DataType::Boolean, "hasindexes"),
     (DataType::Varchar, "matviewgraph"), // materialized view graph is json encoded fragment infos.
+    (DataType::Varchar, "definition"),
 ];

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -93,6 +93,9 @@ pub struct TableCatalog {
     /// The column indices which are stored in the state store's value with row-encoding. Currently
     /// is not supported yet and expected to be `[0..columns.len()]`
     pub value_indices: Vec<usize>,
+
+    /// Definition of the materialized view.
+    pub definition: String,
 }
 
 impl TableCatalog {
@@ -186,6 +189,7 @@ impl TableCatalog {
                 .vnode_col_idx
                 .map(|i| ProstColumnIndex { index: i as _ }),
             value_indices: self.value_indices.iter().map(|x| *x as _).collect(),
+            definition: self.definition.clone(),
         }
     }
 }
@@ -231,6 +235,7 @@ impl From<ProstTable> for TableCatalog {
             fragment_id: tb.fragment_id,
             vnode_col_idx: tb.vnode_col_idx.map(|x| x.index as usize),
             value_indices: tb.value_indices.iter().map(|x| *x as _).collect(),
+            definition: tb.definition.clone(),
         }
     }
 }

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -319,6 +319,7 @@ mod tests {
             fragment_id: 0,
             vnode_col_idx: None,
             value_indices: vec![0],
+            definition: "".into(),
         }
         .into();
 
@@ -375,6 +376,7 @@ mod tests {
                 fragment_id: 0,
                 vnode_col_idx: None,
                 value_indices: vec![0],
+                definition: "".into(),
             }
         );
         assert_eq!(table, TableCatalog::from(table.to_prost(0, 0)));

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -62,6 +62,7 @@ pub fn gen_create_mv_plan(
             .id();
         (db_id, schema_id)
     };
+    let definition = format!("{}", query);
 
     let bound = {
         let mut binder = Binder::new(session);
@@ -86,7 +87,7 @@ pub fn gen_create_mv_plan(
 
     let mut plan_root = Planner::new(context).plan_query(bound)?;
     plan_root.set_required_dist(RequiredDist::Any);
-    let materialize = plan_root.gen_create_mv_plan(table_name)?;
+    let materialize = plan_root.gen_create_mv_plan(table_name, definition)?;
     let mut table = materialize.table().to_prost(schema_id, database_id);
     if is_independent_compaction_group {
         table.properties.insert(

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -250,7 +250,7 @@ pub(crate) fn gen_materialized_source_plan(
             required_cols,
             out_names,
         )
-        .gen_create_mv_plan(source.name.clone())?
+        .gen_create_mv_plan(source.name.clone(), "".into())?
     };
     let mut table = materialize
         .table()

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -445,7 +445,11 @@ impl PlanRoot {
     }
 
     /// Optimize and generate a create materialize view plan.
-    pub fn gen_create_mv_plan(&mut self, mv_name: String) -> Result<StreamMaterialize> {
+    pub fn gen_create_mv_plan(
+        &mut self,
+        mv_name: String,
+        definition: String,
+    ) -> Result<StreamMaterialize> {
         let stream_plan = self.gen_stream_plan()?;
         StreamMaterialize::create(
             stream_plan,
@@ -454,6 +458,7 @@ impl PlanRoot {
             self.out_fields.clone(),
             self.out_names.clone(),
             false,
+            definition,
         )
     }
 
@@ -467,6 +472,7 @@ impl PlanRoot {
             self.out_fields.clone(),
             self.out_names.clone(),
             true,
+            "".into(),
         )
     }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -80,6 +80,7 @@ impl StreamMaterialize {
         user_cols: FixedBitSet,
         out_names: Vec<String>,
         is_index: bool,
+        definition: String,
     ) -> Result<Self> {
         let required_dist = match input.distribution() {
             Distribution::Single => RequiredDist::single(),
@@ -177,6 +178,7 @@ impl StreamMaterialize {
             fragment_id: FragmentId::MAX - 1,
             vnode_col_idx: None,
             value_indices,
+            definition,
         };
 
         Ok(Self { base, input, table })

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -116,6 +116,7 @@ impl TableCatalogBuilder {
             value_indices: self
                 .value_indices
                 .unwrap_or_else(|| (0..self.columns.len()).collect_vec()),
+            definition: "".into(),
         }
     }
 

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -465,6 +465,7 @@ mod tests {
             fragment_id: 0,
             vnode_col_idx: None,
             value_indices: vec![0],
+            definition: "".into(),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title.
```
dev=> select matviewname, definition from pg_catalog.pg_matviews_info;
-[ RECORD 1 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
matviewname | nexmark_q7
definition  | SELECT B.auction, B.price, B.bidder, B.date_time FROM bid AS B JOIN (SELECT MAX(price) AS maxprice, window_end AS date_time FROM TUMBLE(bid, date_time, INTERVAL '10' SECOND) GROUP BY window_end) AS B1 ON B.price = B1.maxprice WHERE B.date_time BETWEEN B1.date_time - INTERVAL '10' SECOND AND B1.date_time
-[ RECORD 2 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
matviewname | mv1
definition  | SELECT * FROM t1
-[ RECORD 3 ]-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
matviewname | mv2
definition  | SELECT t1.v1, t1.v2, t1.v3, t2.v1 AS v10, t2.v2 AS v20, t2.v3 AS v30 FROM t1 JOIN t2 ON t1.v1 = t2.v1
```
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Resolve #5635 