### PR TITLE
fix(source): fix parse avro datetime

### DIFF
--- a/src/source/src/parser/avro_parser.rs
+++ b/src/source/src/parser/avro_parser.rs
@@ -247,7 +247,10 @@ pub(crate) fn from_avro_value(column: &SourceColumnDesc, field_value: Value) -> 
             from_avro_datetime!(
                 field_value,
                 TimestampMillis,
-                |millis| NaiveDateTimeWrapper::with_secs_nsecs(millis, 0),
+                |millis| NaiveDateTimeWrapper::with_secs_nsecs(
+                    millis / 1000,
+                    (millis % 1000) as u32 * 1_000_000
+                ),
                 ScalarImpl::NaiveDateTime
             )
         }
@@ -529,7 +532,10 @@ mod test {
                     let datetime = from_avro_datetime!(
                         value,
                         TimestampMillis,
-                        |millis| NaiveDateTimeWrapper::with_secs_nsecs(millis, 0),
+                        |millis| NaiveDateTimeWrapper::with_secs_nsecs(
+                            millis / 1000,
+                            (millis % 1000) as u32 * 1_000_000
+                        ),
                         ScalarImpl::NaiveDateTime
                     )
                     .ok();
@@ -637,7 +643,7 @@ mod test {
                     }
                     Schema::TimestampMillis => {
                         let datetime = NaiveDate::from_ymd(1970, 1, 1).and_hms(0, 0, 0);
-                        let timestamp_mills = Value::TimestampMillis(datetime.timestamp());
+                        let timestamp_mills = Value::TimestampMillis(datetime.timestamp() * 1_000);
                         record.put(field.name.as_str(), timestamp_mills);
                     }
                     _ => {

--- a/src/source/src/test_data/complex-schema.avsc
+++ b/src/source/src/test_data/complex-schema.avsc
@@ -39,28 +39,31 @@
     },
     {
       "name": "xfa",
-      "type": "record",
-      "doc": "Xandr synthetic ID record.",
-      "fields": [
-        {
-          "name": "device_model_id",
-          "type": "int",
-          "doc": "Device atlas device model.",
-          "default": 0
-        },
-        {
-          "name": "device_make_id",
-          "type": "int",
-          "doc": "Device atlas device make.",
-          "default": 0
-        },
-        {
-          "name": "ip",
-          "type": "string",
-          "default": "",
-          "doc": "Residential IP address."
-        }
-      ]
+      "type": {
+        "name": "xfa",
+        "type": "record",
+        "doc": "Xandr synthetic ID record.",
+        "fields": [
+          {
+            "name": "device_model_id",
+            "type": "int",
+            "doc": "Device atlas device model.",
+            "default": 0
+          },
+          {
+            "name": "device_make_id",
+            "type": "int",
+            "doc": "Device atlas device make.",
+            "default": 0
+          },
+          {
+            "name": "ip",
+            "type": "string",
+            "default": "",
+            "doc": "Residential IP address."
+          }
+        ]
+      }
     }
   ]
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

- fix bug in parsing avro datetime which will cause panic when convert to nano_secs also 
- fix the complex-schema example.

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

