### PR TITLE
feat(pgwire):support binary format param of timestampz and interval type 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,6 +5029,7 @@ dependencies = [
  "num-traits",
  "parse-display",
  "paste",
+ "postgres-types",
  "prost",
  "regex",
  "risingwave_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3858,6 +3858,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pg_interval"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47354dbd658c57a5ee1cc97a79937345170234d4c817768de80ea6d2e9f5b98a"
+dependencies = [
+ "bytes",
+ "chrono",
+ "postgres-types",
+]
+
+[[package]]
 name = "pgwire"
 version = "0.2.0-alpha"
 dependencies = [
@@ -3870,6 +3881,7 @@ dependencies = [
  "itertools",
  "madsim-tokio",
  "openssl",
+ "pg_interval",
  "postgres-types",
  "regex",
  "rust_decimal",

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -492,7 +492,7 @@ impl ToSql for IntervalUnit {
         out: &mut BytesMut,
     ) -> std::result::Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
         // refer: https://github.com/postgres/postgres/blob/517bf2d91/src/backend/utils/adt/timestamp.c#L1008
-        out.put_i64(self.ms);
+        out.put_i64(self.ms * 1000);
         out.put_i32(self.days);
         out.put_i32(self.months);
         Ok(IsNull::No)
@@ -511,7 +511,9 @@ impl<'a> FromSql<'a> for IntervalUnit {
         let micros = raw.read_i64::<NetworkEndian>()?;
         let days = raw.read_i32::<NetworkEndian>()?;
         let months = raw.read_i32::<NetworkEndian>()?;
-        Ok(IntervalUnit::new(months, days, micros))
+        // TODO: https://github.com/risingwavelabs/risingwave/issues/4514
+        // Only support ms now.
+        Ok(IntervalUnit::new(months, days, micros / 1000))
     }
 
     fn accepts(ty: &Type) -> bool {

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
+use std::error::Error;
 use std::fmt::{Display, Formatter, Write as _};
 use std::hash::{Hash, Hasher};
 use std::io::Write;
 use std::ops::{Add, Neg, Sub};
 
 use anyhow::anyhow;
-use byteorder::{BigEndian, WriteBytesExt};
+use byteorder::{BigEndian, NetworkEndian, ReadBytesExt, WriteBytesExt};
 use bytes::BytesMut;
 use num_traits::{CheckedAdd, CheckedSub, Zero};
+use postgres_types::{to_sql_checked, FromSql};
 use risingwave_pb::data::IntervalUnit as IntervalUnitProto;
 use smallvec::SmallVec;
 
@@ -478,6 +480,42 @@ impl Display for IntervalUnit {
         }
         v.push(format_time);
         Display::fmt(&v.join(" "), f)
+    }
+}
+
+impl ToSql for IntervalUnit {
+    to_sql_checked!();
+
+    fn to_sql(
+        &self,
+        _: &Type,
+        out: &mut BytesMut,
+    ) -> std::result::Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
+        // refer: https://github.com/postgres/postgres/blob/517bf2d91/src/backend/utils/adt/timestamp.c#L1008
+        out.put_i64(self.ms);
+        out.put_i32(self.days);
+        out.put_i32(self.months);
+        Ok(IsNull::No)
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(*ty, Type::INTERVAL)
+    }
+}
+
+impl<'a> FromSql<'a> for IntervalUnit {
+    fn from_sql(
+        _: &Type,
+        mut raw: &'a [u8],
+    ) -> std::result::Result<IntervalUnit, Box<dyn Error + Sync + Send>> {
+        let micros = raw.read_i64::<NetworkEndian>()?;
+        let days = raw.read_i32::<NetworkEndian>()?;
+        let months = raw.read_i32::<NetworkEndian>()?;
+        Ok(IntervalUnit::new(months, days, micros))
+    }
+
+    fn accepts(ty: &Type) -> bool {
+        matches!(*ty, Type::INTERVAL)
     }
 }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -763,7 +763,7 @@ impl ScalarRefImpl<'_> {
             Self::NaiveTime(v) => v.0.to_sql(ty, &mut output).unwrap(),
             Self::Struct(_) => todo!("Don't support struct serialization yet"),
             Self::List(_) => todo!("Don't support list serialization yet"),
-            Self::Interval(_) => todo!("Don't support interval serialization yet"),
+            Self::Interval(v) => v.to_sql(ty, &mut output).unwrap(),
         };
         output.freeze()
     }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -21,6 +21,7 @@ memcomparable = { path = "../utils/memcomparable" }
 num-traits = "0.2"
 parse-display = "0.6"
 paste = "1"
+postgres-types = { version = "0.2.4", features = ["derive","with-chrono-0_4"] }
 prost = "0.11"
 regex = "1"
 risingwave_common = { path = "../common" }

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -15,8 +15,10 @@
 use std::any::type_name;
 use std::str::FromStr;
 
+use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use num_traits::ToPrimitive;
+use postgres_types::ToSql;
 use risingwave_common::array::{Array, ListRef, ListValue};
 use risingwave_common::types::{
     DataType, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
@@ -113,6 +115,17 @@ pub fn timestampz_to_utc_string(elem: i64) -> String {
     // PostgreSQL uses a space rather than `T` to separate the date and time.
     // https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
     instant.format("%Y-%m-%d %H:%M:%S%.f%:z").to_string()
+}
+
+pub fn timestampz_to_utc_binary(elem: i64) -> Bytes {
+    // Just a meaningful representation as placeholder. The real implementation depends on TimeZone
+    // from session. See #3552.
+    let instant = Utc.timestamp_nanos(elem * 1000);
+    let mut out = BytesMut::new();
+    instant
+        .to_sql(&postgres_types::Type::ANY, &mut out)
+        .unwrap();
+    out.freeze()
 }
 
 #[inline(always)]

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -122,6 +122,7 @@ pub fn timestampz_to_utc_binary(elem: i64) -> Bytes {
     // from session. See #3552.
     let instant = Utc.timestamp_nanos(elem * 1000);
     let mut out = BytesMut::new();
+    // postgres_types::Type::ANY is only used as a placeholder.
     instant
         .to_sql(&postgres_types::Type::ANY, &mut out)
         .unwrap();

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -13,6 +13,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 openssl = "0.10.3"
+pg_interval = "0.4"
 postgres-types = { version = "0.2.4", features = ["derive","with-chrono-0_4"] }
 regex = "1.5"
 rust_decimal = { version = "1", features = ["db-tokio-postgres"] }

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -362,6 +362,11 @@ impl PreparedStatement {
         raw_params: &[Bytes],
         param_format: bool,
     ) -> PsqlResult<Vec<String>> {
+        if type_description.len() != raw_params.len() {
+            return Err(PsqlError::BindError(
+                "The number of params doesn't match the number of types".into(),
+            ));
+        }
         assert_eq!(type_description.len(), raw_params.len());
 
         let mut params = Vec::with_capacity(raw_params.len());

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -462,7 +462,7 @@ impl PreparedStatement {
                     };
                     format!("{}::DECIMAL", tmp)
                 }
-                TypeOid::Timestampz => {
+                TypeOid::Timestamptz => {
                     let tmp = if param_format {
                         chrono::DateTime::<chrono::Utc>::from_sql(&place_hodler, raw_param)
                             .unwrap()
@@ -470,7 +470,7 @@ impl PreparedStatement {
                     } else {
                         cstr_to_str(raw_param).unwrap().to_string()
                     };
-                    format!("'{}'::TIMESTAMPZ", tmp)
+                    format!("'{}'::TIMESTAMPTZ", tmp)
                 }
                 TypeOid::Interval => {
                     let tmp = if param_format {
@@ -506,8 +506,8 @@ impl PreparedStatement {
                 TypeOid::Time => params.push("'00:00:00'::TIME".to_string()),
                 TypeOid::Timestamp => params.push("'2021-01-01 00:00:00'::TIMESTAMP".to_string()),
                 TypeOid::Decimal => params.push("'0'::DECIMAL".to_string()),
-                TypeOid::Timestampz => {
-                    params.push("'1970-01-01 00:01:01 UTC'::timestamp".to_string())
+                TypeOid::Timestamptz => {
+                    params.push("'2022-10-01 12:00:00+01:00'::timestamptz".to_string())
                 }
                 TypeOid::Interval => params.push("'2 months ago'::interval".to_string()),
             };

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -164,9 +164,9 @@ impl FromStr for TypeOid {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let s = s.to_ascii_lowercase();
         match s.as_str() {
-            "boolean" => Ok(TypeOid::Boolean),
-            "bigint" => Ok(TypeOid::BigInt),
-            "smallint" => Ok(TypeOid::SmallInt),
+            "bool" | "boolean" => Ok(TypeOid::Boolean),
+            "bigint" | "int8" => Ok(TypeOid::BigInt),
+            "smallint" | "int2" => Ok(TypeOid::SmallInt),
             "int" | "int4" => Ok(TypeOid::Int),
             "float4" => Ok(TypeOid::Float4),
             "float8" => Ok(TypeOid::Float8),

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -128,7 +128,7 @@ impl TypeOid {
             1114 => Ok(TypeOid::Timestamp),
             1184 => Ok(TypeOid::Timestampz),
             1700 => Ok(TypeOid::Decimal),
-            2201 => Ok(TypeOid::Interval),
+            1186 => Ok(TypeOid::Interval),
             v => Err(TypeOidError(v)),
         }
     }

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -45,7 +45,7 @@ impl PgFieldDescriptor {
             | TypeOid::Float8
             | TypeOid::Timestamp
             | TypeOid::Time
-            | TypeOid::Timestampz => 8,
+            | TypeOid::Timestamptz => 8,
             TypeOid::SmallInt => 2,
             TypeOid::Varchar | TypeOid::Decimal | TypeOid::Interval => -1,
         };
@@ -102,7 +102,7 @@ pub enum TypeOid {
     Date,
     Time,
     Timestamp,
-    Timestampz,
+    Timestamptz,
     Decimal,
     Interval,
 }
@@ -126,7 +126,7 @@ impl TypeOid {
             1082 => Ok(TypeOid::Date),
             1083 => Ok(TypeOid::Time),
             1114 => Ok(TypeOid::Timestamp),
-            1184 => Ok(TypeOid::Timestampz),
+            1184 => Ok(TypeOid::Timestamptz),
             1700 => Ok(TypeOid::Decimal),
             1186 => Ok(TypeOid::Interval),
             v => Err(TypeOidError(v)),
@@ -151,7 +151,7 @@ impl TypeOid {
             TypeOid::Date => 1082,
             TypeOid::Time => 1083,
             TypeOid::Timestamp => 1114,
-            TypeOid::Timestampz => 1184,
+            TypeOid::Timestamptz => 1184,
             TypeOid::Decimal => 1700,
             TypeOid::Interval => 1186,
         }
@@ -174,7 +174,7 @@ impl FromStr for TypeOid {
             "date" => Ok(TypeOid::Date),
             "time" => Ok(TypeOid::Time),
             "timestamp" => Ok(TypeOid::Timestamp),
-            "timestampz" => Ok(TypeOid::Timestampz),
+            "timestamptz" => Ok(TypeOid::Timestamptz),
             "decimal" => Ok(TypeOid::Decimal),
             "interval" => Ok(TypeOid::Interval),
             _ => Err(TypeOidError(0)),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- support binary format param of timestamptz and interval 
- support binary format result of timestamptz 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3676 