### PR TITLE
refactor(source): all in async-stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5063,7 +5063,6 @@ dependencies = [
  "farmhash",
  "futures",
  "futures-async-stream",
- "futures-concurrency",
  "itertools",
  "madsim-tokio",
  "madsim-tonic",

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,6 @@
 disallowed-methods = [
     { path = "std::iter::Iterator::zip", reason = "Please use Itertools::zip_eq instead." },
+    { path = "futures::stream::select_all", reason = "Please use `risingwave_common::util::select_all` instead." },
 ]
 doc-valid-idents = [
     "RisingWave",

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -183,7 +183,10 @@ mod tests {
         // Create reader
         let source_desc = source_builder.build().await?;
         let source = source_desc.source.as_table().unwrap();
-        let mut reader = source.stream_reader(vec![0.into(), 1.into()]).await?;
+        let mut reader = source
+            .stream_reader(vec![0.into(), 1.into()])
+            .await?
+            .into_stream();
 
         // Delete
         let delete_executor = Box::new(DeleteExecutor::new(
@@ -212,7 +215,7 @@ mod tests {
         });
 
         // Read
-        let chunk = reader.next().await?;
+        let chunk = reader.next().await.unwrap()?.chunk;
 
         assert_eq!(chunk.ops().to_vec(), vec![Op::Delete; 5]);
 

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -219,7 +219,8 @@ mod tests {
         let source = source_desc.source.as_table().unwrap();
         let mut reader = source
             .stream_reader(vec![0.into(), 1.into(), 2.into()])
-            .await?;
+            .await?
+            .into_stream();
 
         // Insert
         let insert_executor = Box::new(InsertExecutor::new(
@@ -244,7 +245,7 @@ mod tests {
         });
 
         // Read
-        let chunk = reader.next().await?;
+        let chunk = reader.next().await.unwrap()?.chunk;
 
         assert_eq!(
             chunk.columns()[0]

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -324,7 +324,7 @@ impl<S: StateStore> Executor for RowSeqScanExecutor<S> {
             .map(|scan_type| {
                 Self::do_execute(scan_type, schema.clone(), chunk_size, histogram.clone())
             })
-            .collect();
+            .collect_vec();
         if let (Some(histogram), Some(metrics)) = (histogram, metrics) {
             metrics.unregister(Box::new(histogram));
         }

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -240,7 +240,10 @@ mod tests {
         // Create reader
         let source_desc = source_builder.build().await?;
         let source = source_desc.source.as_table().unwrap();
-        let mut reader = source.stream_reader(vec![0.into(), 1.into()]).await?;
+        let mut reader = source
+            .stream_reader(vec![0.into(), 1.into()])
+            .await?
+            .into_stream();
 
         // Update
         let update_executor = Box::new(UpdateExecutor::new(
@@ -270,7 +273,7 @@ mod tests {
         });
 
         // Read
-        let chunk = reader.next().await?;
+        let chunk = reader.next().await.unwrap()?.chunk;
 
         assert_eq!(
             chunk.ops().chunks(2).collect_vec(),

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -243,9 +243,7 @@ impl DataChunk {
         match &self.vis2 {
             Vis::Compact(_) => self,
             Vis::Bitmap(visibility) => {
-                let cardinality = visibility
-                    .iter()
-                    .fold(0, |vis_cnt, vis| vis_cnt + vis as usize);
+                let cardinality = visibility.iter().filter(|&vis| vis).count();
                 let columns = self
                     .columns
                     .into_iter()
@@ -289,11 +287,7 @@ impl DataChunk {
             return Ok(Vec::new());
         }
 
-        let mut total_capacity = chunks
-            .iter()
-            .map(|chunk| chunk.capacity())
-            .reduce(|x, y| x + y)
-            .unwrap();
+        let mut total_capacity = chunks.iter().map(|chunk| chunk.capacity()).sum();
         let num_chunks = (total_capacity + each_size_limit - 1) / each_size_limit;
 
         // the idx of `chunks`
@@ -437,6 +431,25 @@ impl DataChunk {
             columns: new_columns,
             ..self
         }
+    }
+
+    /// Reorder rows by indexes.
+    pub fn reorder_rows(&self, indexes: &[usize]) -> Self {
+        let mut array_builders: Vec<ArrayBuilderImpl> = self
+            .columns
+            .iter()
+            .map(|col| col.array_ref().create_builder(indexes.len()))
+            .collect();
+        for &i in indexes {
+            for (builder, col) in array_builders.iter_mut().zip_eq(&self.columns) {
+                builder.append_datum_ref(col.array_ref().value_at(i));
+            }
+        }
+        let columns = array_builders
+            .into_iter()
+            .map(|builder| builder.finish().into())
+            .collect();
+        DataChunk::new(columns, indexes.len())
     }
 
     /// Serialize each rows into value encoding bytes.
@@ -796,6 +809,7 @@ mod tests {
         assert_eq!(chunk_after_serde.rows().count(), 10);
         assert_eq!(chunk_after_serde.cardinality(), 10);
     }
+
     #[test]
     fn reorder_columns() {
         let chunk = DataChunk::from_pretty(
@@ -804,29 +818,25 @@ mod tests {
              4 9 2
              6 9 3",
         );
-        let reorder = chunk.clone().reorder_columns(&[2, 1, 0]);
         assert_eq!(
-            reorder,
+            chunk.clone().reorder_columns(&[2, 1, 0]),
             DataChunk::from_pretty(
                 "I I I
-             1 5 2
-             2 9 4
-             3 9 6",
+                 1 5 2
+                 2 9 4
+                 3 9 6",
             )
         );
-        let reorder = chunk.clone().reorder_columns(&[2, 0]);
         assert_eq!(
-            reorder,
+            chunk.clone().reorder_columns(&[2, 0]),
             DataChunk::from_pretty(
                 "I I
-             1 2
-             2 4
-             3 6",
+                 1 2
+                 2 4
+                 3 6",
             )
         );
-        let reorder = chunk.clone().reorder_columns(&[0, 1, 2]);
-        assert_eq!(reorder, chunk);
-        let reorder = chunk.reorder_columns(&[]);
-        assert_eq!(reorder.cardinality(), 3);
+        assert_eq!(chunk.clone().reorder_columns(&[0, 1, 2]), chunk);
+        assert_eq!(chunk.reorder_columns(&[]).cardinality(), 3);
     }
 }

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -178,7 +178,7 @@ impl<'a> RowRef<'a> {
     }
 }
 
-impl<'a> PartialEq for RowRef<'a> {
+impl PartialEq for RowRef<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.values()
             .zip_longest(other.values())
@@ -186,7 +186,19 @@ impl<'a> PartialEq for RowRef<'a> {
     }
 }
 
-impl<'a> Eq for RowRef<'a> {}
+impl Eq for RowRef<'_> {}
+
+impl PartialOrd for RowRef<'_> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.values().partial_cmp(other.values())
+    }
+}
+
+impl Ord for RowRef<'_> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
 
 #[derive(Clone)]
 struct RowRefIter<'a> {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -390,14 +390,14 @@ impl StreamChunkTestExt for StreamChunk {
     fn concat(chunks: Vec<StreamChunk>) -> StreamChunk {
         assert!(!chunks.is_empty());
         let mut ops = vec![];
-        let mut datas = vec![];
+        let mut data_chunks = vec![];
         let mut capacity = 0;
         for chunk in chunks {
             capacity += chunk.capacity();
             ops.extend(chunk.ops);
-            datas.push(chunk.data);
+            data_chunks.push(chunk.data);
         }
-        let data = DataChunk::rechunk(&datas, capacity)
+        let data = DataChunk::rechunk(&data_chunks, capacity)
             .unwrap()
             .into_iter()
             .next()

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -285,11 +285,17 @@ impl fmt::Debug for StreamChunk {
 }
 
 /// Test utilities for [`StreamChunk`].
-pub trait StreamChunkTestExt {
+pub trait StreamChunkTestExt: Sized {
     fn from_pretty(s: &str) -> Self;
 
     /// Validate the `StreamChunk` layout.
     fn valid(&self) -> bool;
+
+    /// Concatenate multiple `StreamChunk` into one.
+    fn concat(chunks: Vec<Self>) -> Self;
+
+    /// Sort rows.
+    fn sort_rows(self) -> Self;
 }
 
 impl StreamChunkTestExt for StreamChunk {
@@ -380,23 +386,51 @@ impl StreamChunkTestExt for StreamChunk {
                 .iter()
                 .all(|col| col.array_ref().len() == len)
     }
+
+    fn concat(chunks: Vec<StreamChunk>) -> StreamChunk {
+        assert!(!chunks.is_empty());
+        let mut ops = vec![];
+        let mut datas = vec![];
+        let mut capacity = 0;
+        for chunk in chunks {
+            capacity += chunk.capacity();
+            ops.extend(chunk.ops);
+            datas.push(chunk.data);
+        }
+        let data = DataChunk::rechunk(&datas, capacity)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap();
+        StreamChunk { ops, data }
+    }
+
+    fn sort_rows(self) -> Self {
+        if self.capacity() == 0 {
+            return self;
+        }
+        let rows = self.rows().collect_vec();
+        let mut idx = (0..self.capacity()).collect_vec();
+        idx.sort_by_key(|&i| &rows[i]);
+        StreamChunk {
+            ops: idx.iter().map(|&i| self.ops[i]).collect(),
+            data: self.data.reorder_rows(&idx),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::array::I64Array;
-    use crate::{column, column_nonnull};
 
     #[test]
     fn test_to_pretty_string() {
-        let chunk = StreamChunk::new(
-            vec![Op::Insert, Op::Delete, Op::UpdateDelete, Op::UpdateInsert],
-            vec![
-                column_nonnull!(I64Array, [1, 2, 3, 4]),
-                column!(I64Array, [Some(6), None, Some(7), None]),
-            ],
-            None,
+        let chunk = StreamChunk::from_pretty(
+            "  I I
+             + 1 6
+             - 2 .
+            U- 3 7
+            U+ 4 .",
         );
         assert_eq!(
             chunk.to_pretty_string(),

--- a/src/common/src/util/future_utils.rs
+++ b/src/common/src/util/future_utils.rs
@@ -63,6 +63,6 @@ impl<S: Stream + Unpin> Stream for MergeStream<S> {
     }
 }
 
-pub fn select_all<S: Stream + Unpin>(streams: Vec<S>) -> MergeStream<S> {
-    MergeStream::new(streams)
+pub fn select_all<S: Stream + Unpin>(streams: impl IntoIterator<Item = S>) -> MergeStream<S> {
+    MergeStream::new(streams.into_iter().collect())
 }

--- a/src/connector/src/lib.rs
+++ b/src/connector/src/lib.rs
@@ -23,6 +23,7 @@
 #![feature(binary_heap_drain_sorted)]
 #![feature(lint_reasons)]
 #![feature(once_cell)]
+#![feature(result_option_inspect)]
 
 pub mod aws_utils;
 pub mod error;

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -106,13 +106,13 @@ macro_rules! impl_split {
 macro_rules! impl_split_reader {
     ($({ $variant_name:ident, $split_reader_name:ident} ),*) => {
         impl SplitReaderImpl {
-            pub async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
+            pub fn into_stream(self) -> BoxSourceStream {
                 match self {
-                    $( Self::$variant_name(inner) => inner.next().await, )*
+                    $( Self::$variant_name(inner) => inner.into_stream(), )*
                 }
             }
 
-             pub async fn create(
+            pub async fn create(
                 config: ConnectorProperties,
                 state: ConnectorState,
                 columns: Option<Vec<Column>>,

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -38,7 +38,7 @@ use crate::source::kafka::enumerator::KafkaSplitEnumerator;
 use crate::source::kafka::source::KafkaSplitReader;
 use crate::source::kafka::{KafkaProperties, KafkaSplit, KAFKA_CONNECTOR};
 use crate::source::kinesis::enumerator::client::KinesisSplitEnumerator;
-use crate::source::kinesis::source::reader::KinesisMultiSplitReader;
+use crate::source::kinesis::source::reader::KinesisSplitReader;
 use crate::source::kinesis::split::KinesisSplit;
 use crate::source::kinesis::{KinesisProperties, KINESIS_CONNECTOR};
 use crate::source::nexmark::source::reader::NexmarkSplitReader;
@@ -94,7 +94,7 @@ pub enum SplitImpl {
 }
 
 pub enum SplitReaderImpl {
-    Kinesis(Box<KinesisMultiSplitReader>),
+    Kinesis(Box<KinesisSplitReader>),
     Kafka(Box<KafkaSplitReader>),
     Dummy(Box<DummySplitReader>),
     Nexmark(Box<NexmarkSplitReader>),
@@ -149,7 +149,7 @@ impl_split! {
 impl_split_reader! {
     { Kafka, KafkaSplitReader },
     { Pulsar, PulsarSplitReader },
-    { Kinesis, KinesisMultiSplitReader },
+    { Kinesis, KinesisSplitReader },
     { Nexmark, NexmarkSplitReader },
     { Datagen, DatagenSplitReader },
     { Dummy, DummySplitReader }

--- a/src/connector/src/source/datagen/mod.rs
+++ b/src/connector/src/source/datagen/mod.rs
@@ -20,11 +20,13 @@ use std::collections::HashMap;
 
 pub use enumerator::*;
 use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 pub use source::*;
 pub use split::*;
 
 pub const DATAGEN_CONNECTOR: &str = "datagen";
 
+#[serde_as]
 #[derive(Clone, Debug, Deserialize)]
 pub struct DatagenProperties {
     /// split_num means data source partition
@@ -38,7 +40,8 @@ pub struct DatagenProperties {
         rename = "datagen.rows.per.second",
         default = "default_rows_per_second"
     )]
-    pub rows_per_second: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub rows_per_second: u64,
 
     /// Some connector options of the datagen source's fields
     /// for example: create datagen source with column v1 int, v2 float
@@ -52,6 +55,6 @@ pub struct DatagenProperties {
     fields: HashMap<String, String>,
 }
 
-fn default_rows_per_second() -> String {
-    "10".to_string()
+fn default_rows_per_second() -> u64 {
+    10
 }

--- a/src/connector/src/source/datagen/source/mod.rs
+++ b/src/connector/src/source/datagen/source/mod.rs
@@ -15,8 +15,10 @@
 mod generator;
 mod reader;
 
+use std::time::Duration;
+
 pub use reader::*;
 
 const SEQUENCE_FIELD_KIND: &str = "sequence";
 /// default datagen generator next() interval
-const DEFAULT_DATAGEN_INTERVAL: u128 = 1000;
+const DEFAULT_DATAGEN_INTERVAL: Duration = Duration::from_secs(1);

--- a/src/connector/src/source/datagen/source/mod.rs
+++ b/src/connector/src/source/datagen/source/mod.rs
@@ -15,10 +15,6 @@
 mod generator;
 mod reader;
 
-use std::time::Duration;
-
 pub use reader::*;
 
 const SEQUENCE_FIELD_KIND: &str = "sequence";
-/// default datagen generator next() interval
-const DEFAULT_DATAGEN_INTERVAL: Duration = Duration::from_secs(1);

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -67,7 +67,7 @@ impl SplitReader for DatagenSplitReader {
         let split_index = assigned_split.split_index as u64;
         let split_num = assigned_split.split_num as u64;
 
-        let rows_per_second = properties.rows_per_second.parse::<u64>()?;
+        let rows_per_second = properties.rows_per_second;
         let fields_option_map = properties.fields;
         let mut fields_map = HashMap::<String, FieldGeneratorImpl>::new();
 
@@ -260,7 +260,7 @@ mod tests {
         })]);
         let properties = DatagenProperties {
             split_num: None,
-            rows_per_second: "10".to_string(),
+            rows_per_second: 10,
             fields: convert_args!(hashmap!(
                 "fields.random_int.min" => "1",
                 "fields.random_int.max" => "1000",
@@ -312,7 +312,7 @@ mod tests {
         })]);
         let properties = DatagenProperties {
             split_num: None,
-            rows_per_second: "10".to_string(),
+            rows_per_second: 10,
             fields: HashMap::new(),
         };
         let mut reader =

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -28,8 +28,6 @@ use crate::source::{
     SplitImpl, SplitMetaData, SplitReader,
 };
 
-const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
-
 pub struct DatagenSplitReader {
     generator: DatagenEventGenerator,
     assigned_split: DatagenSplit,

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use futures::StreamExt;
 use itertools::zip_eq;
 use risingwave_common::field_generator::FieldGeneratorImpl;
 
@@ -23,15 +24,14 @@ use super::generator::DatagenEventGenerator;
 use crate::source::datagen::source::SEQUENCE_FIELD_KIND;
 use crate::source::datagen::{DatagenProperties, DatagenSplit};
 use crate::source::{
-    spawn_data_generation_stream, Column, ConnectorState, DataGenerationReceiver, DataType,
-    SourceMessage, SplitId, SplitImpl, SplitMetaData, SplitReader,
+    spawn_data_generation_stream, BoxSourceStream, Column, ConnectorState, DataType, SplitId,
+    SplitImpl, SplitMetaData, SplitReader,
 };
 
 const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
 
 pub struct DatagenSplitReader {
-    generation_rx: DataGenerationReceiver,
-
+    generator: DatagenEventGenerator,
     assigned_split: DatagenSplit,
 }
 
@@ -43,10 +43,7 @@ impl SplitReader for DatagenSplitReader {
         properties: DatagenProperties,
         state: ConnectorState,
         columns: Option<Vec<Column>>,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
+    ) -> Result<Self> {
         let mut assigned_split = DatagenSplit::default();
         let mut split_id: SplitId = "".into();
         let mut events_so_far = u64::default();
@@ -117,17 +114,14 @@ impl SplitReader for DatagenSplitReader {
             split_index,
         )?;
 
-        // Spawn a new runtime for data generation since it's CPU intensive.
-        let generation_rx = spawn_data_generation_stream(generator.into_stream());
-
         Ok(DatagenSplitReader {
-            generation_rx,
+            generator,
             assigned_split,
         })
     }
 
-    async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
-        self.generation_rx.recv().await.transpose()
+    fn into_stream(self) -> BoxSourceStream {
+        spawn_data_generation_stream(self.generator.into_stream()).boxed()
     }
 }
 
@@ -231,7 +225,7 @@ fn generator_from_data_type(
 mod tests {
     use std::sync::Arc;
 
-    use maplit::hashmap;
+    use maplit::{convert_args, hashmap};
     use risingwave_common::types::struct_type::StructType;
 
     use super::*;
@@ -267,38 +261,33 @@ mod tests {
         let properties = DatagenProperties {
             split_num: None,
             rows_per_second: "10".to_string(),
-            fields: hashmap! {
-                "fields.random_int.min".to_string() => "1".to_string(),
-                "fields.random_int.max".to_string() => "1000".to_string(),
-                "fields.random_int.seed".to_string() => "12345".to_string(),
+            fields: convert_args!(hashmap!(
+                "fields.random_int.min" => "1",
+                "fields.random_int.max" => "1000",
+                "fields.random_int.seed" => "12345",
 
-                "fields.random_float.min".to_string() => "1".to_string(),
-                "fields.random_float.max".to_string() => "1000".to_string(),
-                "fields.random_float.seed".to_string() => "12345".to_string(),
+                "fields.random_float.min" => "1",
+                "fields.random_float.max" => "1000",
+                "fields.random_float.seed" => "12345",
 
-                "fields.sequence_int.kind".to_string() => "sequence".to_string(),
-                "fields.sequence_int.start".to_string() => "1".to_string(),
-                "fields.sequence_int.end".to_string() => "1000".to_string(),
+                "fields.sequence_int.kind" => "sequence",
+                "fields.sequence_int.start" => "1",
+                "fields.sequence_int.end" => "1000",
 
-                "fields.struct.random_int.min".to_string() => "1001".to_string(),
-                "fields.struct.random_int.max".to_string() => "2000".to_string(),
-                "fields.struct.random_int.seed".to_string() => "12345".to_string(),
-            },
+                "fields.struct.random_int.min" => "1001",
+                "fields.struct.random_int.max" => "2000",
+                "fields.struct.random_int.seed" => "12345",
+            )),
         };
 
-        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum)).await?;
-        let res = "{\"random_float\":533.1488647460938,\"random_int\":533,\"sequence_int\":1,\"struct\":{\"random_int\":1533}}";
+        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum))
+            .await?
+            .into_stream();
 
+        let msg = reader.next().await.unwrap().unwrap();
         assert_eq!(
-            res,
-            std::str::from_utf8(
-                reader.next().await.unwrap().unwrap()[0]
-                    .payload
-                    .as_ref()
-                    .unwrap()
-                    .as_ref()
-            )
-            .unwrap()
+            std::str::from_utf8(msg.payload.as_ref().unwrap().as_ref()).unwrap(),
+            "{\"random_float\":533.1488647460938,\"random_int\":533,\"sequence_int\":1,\"struct\":{\"random_int\":1533}}"
         );
 
         Ok(())
@@ -327,17 +316,21 @@ mod tests {
             fields: HashMap::new(),
         };
         let mut reader =
-            DatagenSplitReader::new(properties.clone(), state, Some(mock_datum.clone())).await?;
+            DatagenSplitReader::new(properties.clone(), state, Some(mock_datum.clone()))
+                .await?
+                .into_stream();
         let _ = reader.next().await;
-        let v1 = reader.next().await?.unwrap();
+        let v1 = reader.next().await.unwrap()?;
 
         let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
             split_index: 0,
             split_num: 1,
             start_offset: Some(9),
         })]);
-        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum)).await?;
-        let v2 = reader.next().await?.unwrap();
+        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum))
+            .await?
+            .into_stream();
+        let v2 = reader.next().await.unwrap()?;
 
         assert_eq!(v1, v2);
         Ok(())

--- a/src/connector/src/source/dummy_connector.rs
+++ b/src/connector/src/source/dummy_connector.rs
@@ -14,9 +14,9 @@
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::future;
+use futures::StreamExt;
 
-use crate::source::{Column, ConnectorState, SourceMessage, SplitReader};
+use crate::source::{BoxSourceStream, Column, ConnectorState, SplitReader};
 
 /// [`DummySplitReader`] is a placeholder for source executor that is assigned no split. It will
 /// wait forever when calling `next`.
@@ -35,10 +35,7 @@ impl SplitReader for DummySplitReader {
         Ok(Self {})
     }
 
-    async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
-        let pending = future::pending();
-        let () = pending.await;
-
-        unreachable!()
+    fn into_stream(self) -> BoxSourceStream {
+        futures::stream::pending().boxed()
     }
 }

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -17,12 +17,13 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use futures::StreamExt;
 use futures_async_stream::try_stream;
 use rdkafka::config::RDKafkaLogLevel;
 use rdkafka::consumer::{Consumer, DefaultConsumerContext, StreamConsumer};
 use rdkafka::{ClientConfig, Offset, TopicPartitionList};
 
-use crate::source::base::{SourceMessage, SplitReader};
+use crate::source::base::{SourceMessage, SplitReader, MAX_CHUNK_SIZE};
 use crate::source::kafka::split::KafkaSplit;
 use crate::source::kafka::KafkaProperties;
 use crate::source::{BoxSourceStream, Column, ConnectorState, SplitImpl};
@@ -104,11 +105,15 @@ impl SplitReader for KafkaSplitReader {
 }
 
 impl KafkaSplitReader {
-    #[try_stream(boxed, ok = SourceMessage, error = anyhow::Error)]
+    #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
     pub async fn into_stream(self) {
         #[for_await]
-        for msg in self.consumer.stream() {
-            yield SourceMessage::from(msg?);
+        for msgs in self.consumer.stream().ready_chunks(MAX_CHUNK_SIZE) {
+            let mut res = Vec::with_capacity(msgs.len());
+            for msg in msgs {
+                res.push(SourceMessage::from(msg?));
+            }
+            yield res;
         }
     }
 }

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -27,8 +27,6 @@ use crate::source::kafka::split::KafkaSplit;
 use crate::source::kafka::KafkaProperties;
 use crate::source::{BoxSourceStream, Column, ConnectorState, SplitImpl};
 
-const KAFKA_MAX_FETCH_MESSAGES: usize = 1024;
-
 pub struct KafkaSplitReader {
     consumer: StreamConsumer<DefaultConsumerContext>,
     assigned_splits: HashMap<String, Vec<KafkaSplit>>,

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -21,9 +21,10 @@ use aws_sdk_kinesis::model::ShardIteratorType;
 use aws_sdk_kinesis::output::GetRecordsOutput;
 use aws_sdk_kinesis::types::SdkError;
 use aws_sdk_kinesis::Client as KinesisClient;
-use futures::stream::{select_all, FuturesUnordered};
+use futures::stream::FuturesUnordered;
 use futures::TryStreamExt;
 use futures_async_stream::try_stream;
+use risingwave_common::util::select_all;
 
 use crate::source::kinesis::source::message::KinesisMessage;
 use crate::source::kinesis::split::{KinesisOffset, KinesisSplit};

--- a/src/connector/src/source/nexmark/source/event.rs
+++ b/src/connector/src/source/nexmark/source/event.rs
@@ -71,22 +71,14 @@ impl Event {
         let new_wall_clock_base_time = timestamp - nex.base_time + wall_clock_base_time;
         let id = nex.first_event_id + nex.next_adjusted_event(events_so_far);
         let mut rng = SmallRng::seed_from_u64(id as u64);
-        if rem < nex.person_proportion {
-            (
-                Event::Person(Person::new(id, timestamp, &mut rng, nex)),
-                new_wall_clock_base_time,
-            )
+        let event = if rem < nex.person_proportion {
+            Event::Person(Person::new(id, timestamp, &mut rng, nex))
         } else if rem < nex.person_proportion + nex.auction_proportion {
-            (
-                Event::Auction(Auction::new(events_so_far, id, timestamp, &mut rng, nex)),
-                new_wall_clock_base_time,
-            )
+            Event::Auction(Auction::new(events_so_far, id, timestamp, &mut rng, nex))
         } else {
-            (
-                Event::Bid(Bid::new(id, timestamp, &mut rng, nex)),
-                new_wall_clock_base_time,
-            )
-        }
+            Event::Bid(Bid::new(id, timestamp, &mut rng, nex))
+        };
+        (event, new_wall_clock_base_time)
     }
 
     pub fn to_json(&self) -> String {

--- a/src/connector/src/source/nexmark/source/generator.rs
+++ b/src/connector/src/source/nexmark/source/generator.rs
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use anyhow::{Ok, Result};
 use futures_async_stream::try_stream;
 use risingwave_common::bail;
 
@@ -32,7 +31,6 @@ pub struct NexmarkEventGenerator {
     pub split_index: i32,
     pub split_num: i32,
     pub split_id: SplitId,
-    pub last_event: Option<Event>,
     pub event_type: EventType,
     pub use_real_time: bool,
     pub min_event_gap_in_ns: u64,
@@ -40,83 +38,75 @@ pub struct NexmarkEventGenerator {
 }
 
 impl NexmarkEventGenerator {
-    #[try_stream(ok = Vec<SourceMessage>, error = anyhow::Error)]
+    #[try_stream(ok = SourceMessage, error = anyhow::Error)]
     pub async fn into_stream(mut self) {
-        loop {
-            yield self.next().await?
-        }
-    }
-
-    pub async fn next(&mut self) -> Result<Vec<SourceMessage>> {
         if self.split_num == 0 {
             bail!("NexmarkEventGenerator is not ready");
         }
-        let mut res: Vec<SourceMessage> = vec![];
-        let mut num_event = 0;
-        let old_events_so_far = self.events_so_far;
+        let mut last_event = None;
+        loop {
+            let mut num_event = 0;
+            let old_events_so_far = self.events_so_far;
 
-        // Get unix timestamp in milliseconds
-        let current_timestamp = if self.use_real_time {
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .unwrap()
-                .as_millis() as u64
-        } else {
-            0
-        };
+            // Get unix timestamp in milliseconds
+            let current_timestamp_ms = if self.use_real_time {
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_millis() as u64
+            } else {
+                0
+            };
 
-        if let Some(event) = self.last_event.take() {
-            num_event += 1;
-            res.push(
-                NexmarkMessage::new(self.split_id.clone(), self.events_so_far as u64, event).into(),
-            );
-        }
-
-        while num_event < self.max_chunk_size {
-            if self.event_num > 0 && self.events_so_far >= self.event_num as u64 {
-                break;
+            if let Some(event) = last_event.take() {
+                num_event += 1;
+                yield NexmarkMessage::new(self.split_id.clone(), self.events_so_far as u64, event)
+                    .into();
             }
 
-            let (event, new_wall_clock_base_time) = Event::new(
-                self.events_so_far as usize,
-                &self.config,
-                self.wall_clock_base_time,
-            );
+            while num_event < self.max_chunk_size {
+                if self.event_num > 0 && self.events_so_far >= self.event_num as u64 {
+                    break;
+                }
 
-            self.wall_clock_base_time = new_wall_clock_base_time;
-            self.events_so_far += 1;
+                let (event, new_wall_clock_base_time) = Event::new(
+                    self.events_so_far as usize,
+                    &self.config,
+                    self.wall_clock_base_time,
+                );
 
-            if event.event_type() != self.event_type
-                || self.events_so_far % self.split_num as u64 != self.split_index as u64
-            {
-                continue;
+                self.wall_clock_base_time = new_wall_clock_base_time;
+                self.events_so_far += 1;
+
+                if event.event_type() != self.event_type
+                    || self.events_so_far % self.split_num as u64 != self.split_index as u64
+                {
+                    continue;
+                }
+
+                // When the generated timestamp is larger then current timestamp, if its the first
+                // event, sleep and continue. Otherwise, directly return.
+                if self.use_real_time && current_timestamp_ms < new_wall_clock_base_time as u64 {
+                    tokio::time::sleep(Duration::from_millis(
+                        new_wall_clock_base_time as u64 - current_timestamp_ms,
+                    ))
+                    .await;
+
+                    last_event = Some(event);
+                    break;
+                }
+
+                num_event += 1;
+                yield NexmarkMessage::new(self.split_id.clone(), self.events_so_far as u64, event)
+                    .into();
             }
 
-            // When the generated timestamp is larger then current timestamp, if its the first
-            // event, sleep and continue. Otherwise, directly return.
-            if self.use_real_time && current_timestamp < new_wall_clock_base_time as u64 {
-                tokio::time::sleep(std::time::Duration::from_millis(
-                    new_wall_clock_base_time as u64 - current_timestamp,
+            if !self.use_real_time && self.min_event_gap_in_ns > 0 {
+                tokio::time::sleep(Duration::from_nanos(
+                    (self.events_so_far - old_events_so_far) as u64 * self.min_event_gap_in_ns,
                 ))
                 .await;
-
-                self.last_event = Some(event);
-                break;
             }
-
-            num_event += 1;
-            res.push(
-                NexmarkMessage::new(self.split_id.clone(), self.events_so_far as u64, event).into(),
-            );
         }
-
-        if !self.use_real_time && self.min_event_gap_in_ns > 0 {
-            tokio::time::sleep(std::time::Duration::from_nanos(
-                (self.events_so_far - old_events_so_far) as u64 * self.min_event_gap_in_ns,
-            ))
-            .await;
-        }
-
-        Ok(res)
     }
 }

--- a/src/connector/src/source/nexmark/source/reader.rs
+++ b/src/connector/src/source/nexmark/source/reader.rs
@@ -16,21 +16,21 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use futures::StreamExt;
 
 use crate::source::nexmark::config::NexmarkConfig;
 use crate::source::nexmark::source::event::EventType;
 use crate::source::nexmark::source::generator::NexmarkEventGenerator;
 use crate::source::nexmark::{NexmarkProperties, NexmarkSplit};
 use crate::source::{
-    spawn_data_generation_stream, Column, ConnectorState, DataGenerationReceiver, SourceMessage,
-    SplitImpl, SplitMetaData, SplitReader,
+    spawn_data_generation_stream, BoxSourceStream, Column, ConnectorState, SplitImpl,
+    SplitMetaData, SplitReader,
 };
 
 #[derive(Debug)]
 pub struct NexmarkSplitReader {
-    generation_rx: DataGenerationReceiver,
-
-    assigned_split: Option<NexmarkSplit>,
+    generator: NexmarkEventGenerator,
+    assigned_split: NexmarkSplit,
 }
 
 #[async_trait]
@@ -41,10 +41,7 @@ impl SplitReader for NexmarkSplitReader {
         properties: NexmarkProperties,
         state: ConnectorState,
         _columns: Option<Vec<Column>>,
-    ) -> Result<Self>
-    where
-        Self: Sized,
-    {
+    ) -> Result<Self> {
         let wall_clock_base_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
@@ -76,7 +73,6 @@ impl SplitReader for NexmarkSplitReader {
             split_index: 0,
             split_num: 0,
             split_id: "".into(),
-            last_event: None,
             event_type,
             use_real_time,
             min_event_gap_in_ns,
@@ -103,21 +99,17 @@ impl SplitReader for NexmarkSplitReader {
             }
         }
 
-        // Spawn a new runtime for data generation since it's CPU intensive.
-        let generation_rx = spawn_data_generation_stream(generator.into_stream());
-
         Ok(Self {
-            generation_rx,
-            assigned_split: Some(assigned_split),
+            generator,
+            assigned_split,
         })
     }
 
-    async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
-        self.generation_rx.recv().await.transpose()
+    fn into_stream(self) -> BoxSourceStream {
+        spawn_data_generation_stream(self.generator.into_stream()).boxed()
     }
 }
 
-impl NexmarkSplitReader {}
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
@@ -145,9 +137,10 @@ mod tests {
             .collect();
 
         let state = Some(list_splits_resp);
-        let mut reader = NexmarkSplitReader::new(props, state, None).await?;
-        let chunk = reader.next().await?.unwrap();
-        assert_eq!(chunk.len(), 5);
+        let mut reader = NexmarkSplitReader::new(props, state, None)
+            .await?
+            .into_stream();
+        let _chunk = reader.next().await.unwrap()?;
 
         Ok(())
     }

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -18,7 +18,6 @@ enum-as-inner = "0.5"
 farmhash = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = "0.2"
-futures-concurrency = "3"
 itertools = "0.10"
 maplit = "1"
 memcomparable = { path = "../utils/memcomparable" }

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -16,12 +16,13 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
-use futures::stream::{select_all, BoxStream};
+use futures::stream::BoxStream;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::catalog::{ColumnId, TableId};
 use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
+use risingwave_common::util::select_all;
 use risingwave_connector::source::{
     Column, ConnectorProperties, ConnectorState, SourceMessage, SplitId, SplitMetaData,
     SplitReaderImpl,

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use futures::future::try_join_all;
-use futures::stream::BoxStream;
+use futures::stream::{select_all, BoxStream};
 use futures::StreamExt;
 use futures_async_stream::try_stream;
-use futures_concurrency::prelude::*;
 use itertools::Itertools;
 use risingwave_common::catalog::{ColumnId, TableId};
 use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
@@ -28,7 +27,6 @@ use risingwave_connector::source::{
     SplitReaderImpl,
 };
 
-use crate::common::SourceChunkBuilder;
 use crate::monitor::SourceMetrics;
 use crate::{SourceColumnDesc, SourceParserImpl, SourceStreamChunkBuilder, StreamChunkWithState};
 
@@ -47,7 +45,9 @@ impl SourceContext {
     }
 }
 
-static DEFAULT_SPLIT_ID: LazyLock<SplitId> = LazyLock::new(|| "None".into());
+fn default_split_id() -> SplitId {
+    "None".into()
+}
 
 struct InnerConnectorSourceReader {
     reader: SplitReaderImpl,
@@ -64,13 +64,12 @@ struct InnerConnectorSourceReader {
 /// Parallel means that multiple [`InnerConnectorSourceReader`] will run in parallel during the
 /// `next`, so that 0 or more Splits reads can be handled at the Source level.
 pub struct ConnectorSourceReader {
-    pub config: ConnectorProperties,
-    pub parser: Arc<SourceParserImpl>,
-    pub columns: Vec<SourceColumnDesc>,
+    parser: Arc<SourceParserImpl>,
+    columns: Vec<SourceColumnDesc>,
 
     // merge all streams of inner reader into one
     // TODO: make this static dispatch instead of box
-    all_reader_stream: BoxStream<'static, Result<Vec<SourceMessage>>>,
+    stream: BoxStream<'static, Result<SourceMessage>>,
 }
 
 impl InnerConnectorSourceReader {
@@ -113,93 +112,49 @@ impl InnerConnectorSourceReader {
         })
     }
 
-    async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
-        loop {
-            let chunk = self.reader.next().await;
-
-            match chunk.map_err(|e| internal_error(e.to_string())) {
-                Err(e) => {
-                    return Err(e);
-                }
-                Ok(None) => {
-                    return Ok(None);
-                }
-                Ok(Some(msg)) => {
-                    if msg.is_empty() {
-                        continue;
-                    }
-                    // Avoid occupying too much CPU time if the source is a data generator, like
-                    // DataGen or Nexmark.
-                    tokio::task::consume_budget().await;
-
-                    return Ok(Some(msg));
-                }
-            }
+    #[try_stream(boxed, ok = SourceMessage, error = RwError)]
+    async fn into_stream(self) {
+        let actor_id = self.context.actor_id.to_string();
+        let source_id = self.context.source_id.to_string();
+        let id = match &self.split {
+            Some(splits) => splits[0].id(),
+            None => default_split_id(),
+        };
+        #[for_await]
+        for msg in self.reader.into_stream() {
+            self.metrics
+                .partition_input_count
+                .with_label_values(&[&actor_id, &source_id, &id])
+                .inc();
+            yield msg?;
         }
     }
 }
-
-#[try_stream(ok = Vec<SourceMessage>, error = RwError)]
-async fn inner_connector_source_reader_into_stream(mut reader: InnerConnectorSourceReader) {
-    let actor_id = reader.context.actor_id.to_string();
-    let source_id = reader.context.source_id.to_string();
-    let id = match &reader.split {
-        Some(splits) => splits[0].id(),
-        None => DEFAULT_SPLIT_ID.clone(),
-    };
-    loop {
-        match reader.next().await {
-            Ok(None) => {
-                tracing::warn!("connector reader {} stream stopped", id);
-                break;
-            }
-            Ok(Some(msg)) => {
-                reader
-                    .metrics
-                    .partition_input_count
-                    .with_label_values(&[actor_id.as_str(), source_id.as_str(), &*id])
-                    .inc_by(msg.len() as u64);
-                yield msg
-            }
-            Err(e) => {
-                tracing::error!("connector reader {} error happened {}", id, e.to_string());
-                return Err(e);
-            }
-        }
-    }
-}
-
-impl SourceChunkBuilder for ConnectorSourceReader {}
 
 impl ConnectorSourceReader {
-    pub async fn next(&mut self) -> Result<StreamChunkWithState> {
-        let batch = self.all_reader_stream.next().await.unwrap()?;
+    #[try_stream(boxed, ok = StreamChunkWithState, error = RwError)]
+    pub async fn into_stream(self) {
+        #[for_await]
+        for batch in self.stream.ready_chunks(1000) {
+            let mut builder =
+                SourceStreamChunkBuilder::with_capacity(self.columns.clone(), batch.len());
+            let mut split_offset_mapping: HashMap<SplitId, String> = HashMap::new();
 
-        let mut split_offset_mapping: HashMap<SplitId, String> = HashMap::new();
-
-        let mut builder =
-            SourceStreamChunkBuilder::with_capacity(self.columns.clone(), batch.len());
-
-        for msg in batch {
-            if let Some(content) = msg.payload {
-                split_offset_mapping.insert(msg.split_id, msg.offset);
-                let writer = builder.row_writer();
-                match self.parser.parse(content.as_ref(), writer) {
-                    Err(e) => {
+            for msg in batch {
+                let msg = msg?;
+                if let Some(content) = msg.payload {
+                    split_offset_mapping.insert(msg.split_id, msg.offset);
+                    if let Err(e) = self.parser.parse(content.as_ref(), builder.row_writer()) {
                         tracing::warn!("message parsing failed {}, skipping", e.to_string());
                         continue;
                     }
-                    Ok(_guard) => {}
                 }
             }
+            yield StreamChunkWithState {
+                chunk: builder.finish(),
+                split_offset_mapping: Some(split_offset_mapping),
+            };
         }
-
-        let chunk = builder.finish();
-
-        Ok(StreamChunkWithState {
-            chunk,
-            split_offset_mapping: Some(split_offset_mapping),
-        })
     }
 }
 
@@ -261,19 +216,12 @@ impl ConnectorSource {
             }))
             .await?;
 
-        let streams = readers
-            .into_iter()
-            .map(inner_connector_source_reader_into_stream)
-            .collect::<Vec<_>>()
-            .merge()
-            .into_stream()
-            .boxed();
+        let stream = select_all(readers.into_iter().map(|r| r.into_stream())).boxed();
 
         Ok(ConnectorSourceReader {
-            config: self.config.clone(),
             parser: self.parser.clone(),
             columns,
-            all_reader_stream: streams,
+            stream,
         })
     }
 }

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -131,11 +131,13 @@ impl InnerConnectorSourceReader {
     }
 }
 
+const MAX_CHUNK_SIZE: usize = 1024;
+
 impl ConnectorSourceReader {
     #[try_stream(boxed, ok = StreamChunkWithState, error = RwError)]
     pub async fn into_stream(self) {
         #[for_await]
-        for batch in self.stream.ready_chunks(1000) {
+        for batch in self.stream.ready_chunks(MAX_CHUNK_SIZE) {
             let mut builder =
                 SourceStreamChunkBuilder::with_capacity(self.columns.clone(), batch.len());
             let mut split_offset_mapping: HashMap<SplitId, String> = HashMap::new();

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -19,21 +19,21 @@
 #![feature(binary_heap_drain_sorted)]
 #![feature(lint_reasons)]
 #![feature(result_option_inspect)]
-#![feature(once_cell)]
 #![feature(generators)]
 
 use std::collections::HashMap;
 use std::fmt::Debug;
 
 use enum_as_inner::EnumAsInner;
+use futures::stream::BoxStream;
 pub use manager::*;
 pub use parser::*;
 use risingwave_common::array::StreamChunk;
-use risingwave_common::error::Result;
+use risingwave_common::error::RwError;
 use risingwave_connector::source::SplitId;
 pub use table::*;
 
-use crate::connector_source::{ConnectorSource, ConnectorSourceReader};
+use crate::connector_source::ConnectorSource;
 
 pub mod parser;
 
@@ -61,20 +61,7 @@ pub enum SourceImpl {
     Connector(ConnectorSource),
 }
 
-#[expect(clippy::large_enum_variant)]
-pub enum SourceStreamReaderImpl {
-    Table(TableStreamReader),
-    Connector(ConnectorSourceReader),
-}
-
-impl SourceStreamReaderImpl {
-    pub async fn next(&mut self) -> Result<StreamChunkWithState> {
-        match self {
-            SourceStreamReaderImpl::Table(t) => t.next().await.map(Into::into),
-            SourceStreamReaderImpl::Connector(c) => c.next().await,
-        }
-    }
-}
+pub type BoxSourceWithStateStream = BoxStream<'static, Result<StreamChunkWithState, RwError>>;
 
 /// [`StreamChunkWithState`] returns stream chunk together with offset for each split. In the
 /// current design, one connector source can have multiple split reader. The keys are unique

--- a/src/stream/src/executor/source/reader.rs
+++ b/src/stream/src/executor/source/reader.rs
@@ -51,9 +51,11 @@ impl SourceReaderStream {
 
     /// Receive chunks and states from the source reader, hang up on error.
     #[try_stream(ok = StreamChunkWithState, error = StreamExecutorError)]
-    async fn source_chunk_reader(mut reader: Box<SourceStreamReaderImpl>) {
-        loop {
-            match reader.next().stack_trace("source_recv_chunk").await {
+    async fn source_stream(stream: BoxSourceWithStateStream) {
+        // TODO: support stack trace for Stream
+        #[for_await]
+        for chunk in stream {
+            match chunk {
                 Ok(chunk) => yield chunk,
                 Err(err) => {
                     error!("hang up stream reader due to polling error: {}", err);
@@ -66,14 +68,14 @@ impl SourceReaderStream {
     /// Convert this reader to a stream.
     pub fn new(
         barrier_receiver: UnboundedReceiver<Barrier>,
-        source_chunk_reader: Box<SourceStreamReaderImpl>,
+        source_stream: BoxSourceWithStateStream,
     ) -> Self {
         let barrier_receiver = Self::barrier_receiver(barrier_receiver);
-        let source_chunk_reader = Self::source_chunk_reader(source_chunk_reader);
+        let source_stream = Self::source_stream(source_stream);
 
         let inner = select_with_strategy(
             barrier_receiver.map(Either::Left).boxed(),
-            source_chunk_reader.map(Either::Right).boxed(),
+            source_stream.map(Either::Right).boxed(),
             // We prefer barrier on the left hand side over source chunks.
             |_: &mut ()| PollNext::Left,
         );
@@ -84,13 +86,10 @@ impl SourceReaderStream {
         }
     }
 
-    /// Replace the source chunk reader with a new one for given `stream`. Used for split change.
-    pub fn replace_source_chunk_reader(&mut self, reader: Box<SourceStreamReaderImpl>) {
-        assert!(
-            !self.paused,
-            "should not replace source chunk reader when paused"
-        );
-        *self.inner.get_mut().1 = Self::source_chunk_reader(reader).map(Either::Right).boxed();
+    /// Replace the source stream with a new one for given `stream`. Used for split change.
+    pub fn replace_source_stream(&mut self, stream: BoxSourceWithStateStream) {
+        assert!(!self.paused, "should not replace source stream when paused");
+        *self.inner.get_mut().1 = Self::source_stream(stream).map(Either::Right).boxed();
     }
 
     /// Pause the source stream.
@@ -135,10 +134,13 @@ mod tests {
         let (barrier_tx, barrier_rx) = mpsc::unbounded_channel();
 
         let table_source = TableSource::new(vec![]);
-        let source_reader =
-            SourceStreamReaderImpl::Table(table_source.stream_reader(vec![]).await.unwrap());
+        let source_stream = table_source
+            .stream_reader(vec![])
+            .await
+            .unwrap()
+            .into_stream();
 
-        let stream = SourceReaderStream::new(barrier_rx, Box::new(source_reader));
+        let stream = SourceReaderStream::new(barrier_rx, source_stream);
         pin_mut!(stream);
 
         macro_rules! next {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -447,10 +447,11 @@ impl<S: StateStore> Debug for SourceExecutor<S> {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use bytes::Bytes;
     use futures::StreamExt;
-    use maplit::hashmap;
+    use maplit::{convert_args, hashmap};
     use risingwave_common::array::stream_chunk::StreamChunkTestExt;
     use risingwave_common::array::StreamChunk;
     use risingwave_common::catalog::{Field, Schema};
@@ -646,12 +647,12 @@ mod tests {
     }
 
     fn mock_stream_source_info() -> StreamSourceInfo {
-        let properties: HashMap<String, String> = hashmap! {
-            "connector".to_string() => "datagen".to_string(),
-            "fields.v1.min".to_string() => "1".to_string(),
-            "fields.v1.max".to_string() => "1000".to_string(),
-            "fields.v1.seed".to_string() => "12345".to_string(),
-        };
+        let properties = convert_args!(hashmap!(
+            "connector" => "datagen",
+            "fields.v1.min" => "1",
+            "fields.v1.max" => "1000",
+            "fields.v1.seed" => "12345",
+        ));
 
         let columns = vec![
             ProstColumnCatalog {
@@ -766,13 +767,11 @@ mod tests {
         .boxed()
         .execute();
 
-        let curr_epoch = 1919;
-        let init_barrier = Barrier::new_test_barrier(curr_epoch).with_mutation(Mutation::Add {
+        let init_barrier = Barrier::new_test_barrier(1).with_mutation(Mutation::Add {
             adds: HashMap::new(),
             splits: hashmap! {
                 ActorId::default() => vec![
-                    SplitImpl::Datagen(
-                    DatagenSplit {
+                    SplitImpl::Datagen(DatagenSplit {
                         split_index: 0,
                         split_num: 3,
                         start_offset: None,
@@ -782,23 +781,26 @@ mod tests {
         });
         barrier_tx.send(init_barrier).unwrap();
 
-        let _ = materialize.next().await.unwrap(); // barrier
+        (materialize.next().await.unwrap().unwrap())
+            .into_barrier()
+            .unwrap();
 
-        let chunk_1 = (materialize.next().await.unwrap().unwrap())
-            .into_chunk()
-            .unwrap()
-            .drop_row_id();
-
-        let chunk_1_truth = StreamChunk::from_pretty(
-            " I i
-            + 0 533
-            + 0 833
-            + 0 738
-            + 0 344",
-        )
-        .drop_row_id();
-
-        assert_eq!(chunk_1, chunk_1_truth);
+        let mut ready_chunks = materialize.ready_chunks(10);
+        let chunks = (ready_chunks.next().await.unwrap())
+            .into_iter()
+            .map(|msg| msg.unwrap().into_chunk().unwrap())
+            .collect();
+        let chunk_1 = StreamChunk::concat(chunks).drop_row_id();
+        assert_eq!(
+            chunk_1,
+            StreamChunk::from_pretty(
+                " i
+                + 533
+                + 833
+                + 738
+                + 344",
+            )
+        );
 
         let new_assignments = vec![
             SplitImpl::Datagen(DatagenSplit {
@@ -812,58 +814,47 @@ mod tests {
                 start_offset: None,
             }),
         ];
-        let change_split_mutation = Barrier::new_test_barrier(curr_epoch + 1).with_mutation(
-            Mutation::SourceChangeSplit(hashmap! {
+        let change_split_mutation =
+            Barrier::new_test_barrier(2).with_mutation(Mutation::SourceChangeSplit(hashmap! {
                 ActorId::default() => Some(new_assignments.clone())
-            }),
-        );
+            }));
         barrier_tx.send(change_split_mutation).unwrap();
 
-        let _ = materialize.next().await.unwrap(); // barrier
+        let _ = ready_chunks.next().await.unwrap(); // barrier
 
         // there must exist state for new add partition
-        source_state_handler.init_epoch(EpochPair::new_test_epoch(curr_epoch + 1));
+        source_state_handler.init_epoch(EpochPair::new_test_epoch(2));
         source_state_handler
             .get(new_assignments[1].id())
             .await
             .unwrap()
             .unwrap();
 
-        let chunk_2 = (materialize.next().await.unwrap().unwrap())
-            .into_chunk()
-            .unwrap()
-            .drop_row_id();
-        let chunk_3 = (materialize.next().await.unwrap().unwrap())
-            .into_chunk()
-            .unwrap()
-            .drop_row_id();
-
-        let chunk_2_truth = StreamChunk::from_pretty(
-            " I i
-            + 0 525
-            + 0 425
-            + 0 29
-            + 0 201",
-        )
-        .drop_row_id();
-        let chunk_3_truth = StreamChunk::from_pretty(
-            " I i
-            + 0 833
-            + 0 533
-            + 0 344",
-        )
-        .drop_row_id();
-        assert!(
-            chunk_2 == chunk_2_truth && chunk_3 == chunk_3_truth
-                || chunk_3 == chunk_2_truth && chunk_2 == chunk_3_truth
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let chunks = (ready_chunks.next().await.unwrap())
+            .into_iter()
+            .map(|msg| msg.unwrap().into_chunk().unwrap())
+            .collect();
+        let chunk_2 = StreamChunk::concat(chunks).drop_row_id().sort_rows();
+        assert_eq!(
+            chunk_2,
+            // mixed from datagen split 0 and 1
+            StreamChunk::from_pretty(
+                " i
+                + 29
+                + 201
+                + 344
+                + 425
+                + 525
+                + 533
+                + 833",
+            )
         );
 
-        let pause_barrier =
-            Barrier::new_test_barrier(curr_epoch + 2).with_mutation(Mutation::Pause);
-        barrier_tx.send(pause_barrier).unwrap();
+        let barrier = Barrier::new_test_barrier(3).with_mutation(Mutation::Pause);
+        barrier_tx.send(barrier).unwrap();
 
-        let pause_barrier =
-            Barrier::new_test_barrier(curr_epoch + 3).with_mutation(Mutation::Resume);
-        barrier_tx.send(pause_barrier).unwrap();
+        let barrier = Barrier::new_test_barrier(4).with_mutation(Mutation::Resume);
+        barrier_tx.send(barrier).unwrap();
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR changes all source readers to async-stream, in order to be more consistent with executors and prevent omitting events caused by select.

~~This also includes a significant change that the stream now yields **ONE** `SourceMessage` at a time instead of a batch of them. The point of batching is now delayed to after merging splits. This will make back pressure more accurate and avoid memory allocation of Vec. But I'm not sure whether it has any impact. Feel free to comment below about it.~~
(reverted due to performance issue, leave it for future PR)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
