### PR TITLE
refactor: simplify for_all macros

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -10,5 +10,6 @@ doc-valid-idents = [
     "PostgreSQL",
     "MySQL",
     "TopN",
+    "VNode"
 ]
 avoid-breaking-exported-api = false

--- a/src/batch/src/executor/monitor/stats.rs
+++ b/src/batch/src/executor/monitor/stats.rs
@@ -97,11 +97,9 @@ impl BatchTaskMetricsManager {
     }
 }
 
-macro_rules! for_each_task_metric {
-    ($macro:ident, $($x:tt),*) => {
+macro_rules! for_all_task_metrics {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
-
             { task_first_poll_delay, GenericGauge<AtomicF64> },
             { task_fast_poll_duration, GenericGauge<AtomicF64> },
             { task_idle_duration, GenericGauge<AtomicF64> },
@@ -113,9 +111,9 @@ macro_rules! for_each_task_metric {
 }
 
 macro_rules! def_task_metrics {
-    ([$struct:ident], $( { $metric:ident, $type:ty }, )*) => {
+    ($( { $metric:ident, $type:ty }, )*) => {
         #[derive(Clone)]
-        pub struct $struct {
+        pub struct BatchTaskMetrics {
             labels: HashMap<String, String>,
             registry: Registry,
             sender: Option<UnboundedSender<Box<dyn Collector>>>,
@@ -124,22 +122,7 @@ macro_rules! def_task_metrics {
     };
 }
 
-macro_rules! delete_task_metrics {
-    ([$self:ident], $( { $metric:ident, $type:ty }, )*) => {
-        if let Some(sender) = $self.sender.as_ref() {
-            $(
-                if sender
-                    .send(Box::new($self.$metric.clone()))
-                    .is_err()
-                {
-                    error!("Failed to send delete record to delete queue");
-                }
-            )*
-        }
-    };
-}
-
-for_each_task_metric!(def_task_metrics, BatchTaskMetrics);
+for_all_task_metrics!(def_task_metrics);
 
 impl BatchTaskMetrics {
     pub fn new(
@@ -227,7 +210,21 @@ impl BatchTaskMetrics {
     /// This function execute after the exucution done.
     /// Send all the record to the delete queue.
     pub fn clear_record(&self) {
-        for_each_task_metric!(delete_task_metrics, self)
+        macro_rules! delete_task_metrics {
+            ($( { $metric:ident, $type:ty }, )*) => {
+                if let Some(sender) = self.sender.as_ref() {
+                    $(
+                        if sender
+                            .send(Box::new(self.$metric.clone()))
+                            .is_err()
+                        {
+                            error!("Failed to send delete record to delete queue");
+                        }
+                    )*
+                }
+            };
+        }
+        for_all_task_metrics!(delete_task_metrics)
     }
 
     /// Create a new `BatchTaskMetrics` instance used in tests or other places.

--- a/src/common/src/array/iterator.rs
+++ b/src/common/src/array/iterator.rs
@@ -101,7 +101,7 @@ mod tests {
     use crate::for_all_variants;
 
     macro_rules! test_trusted_len {
-        ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+        ($( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
             $(
                 paste! {
                     #[test]

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -264,16 +264,15 @@ impl<A: Array> CompactableArray for A {
 /// `for_all_variants` includes all variants of our array types. If you added a new array
 /// type inside the project, be sure to add a variant here.
 ///
-/// Every tuple has four elements, where
-/// `{ enum variant name, function suffix name, array type, builder type }`
+/// It is used to simplify the boilerplate code of repeating all array types, while each type
+/// has exactly the same code.
 ///
-/// There are typically two ways of using this macro, pass token or pass no token.
-/// See the following implementations for example.
+/// To use it, you need to provide a macro, whose input is `{ enum variant name, function suffix
+/// name, array type, builder type }` tuples. Refer to the following implementations as examples.
 #[macro_export]
 macro_rules! for_all_variants {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
             { Int16, int16, I16Array, I16ArrayBuilder },
             { Int32, int32, I32Array, I32ArrayBuilder },
             { Int64, int64, I64Array, I64ArrayBuilder },
@@ -294,7 +293,7 @@ macro_rules! for_all_variants {
 
 /// Define `ArrayImpl` with macro.
 macro_rules! array_impl_enum {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+    ( $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         /// `ArrayImpl` embeds all possible array in `array` module.
         #[derive(Debug, Clone)]
         pub enum ArrayImpl {
@@ -302,6 +301,8 @@ macro_rules! array_impl_enum {
         }
     };
 }
+
+for_all_variants! { array_impl_enum }
 
 impl<T: PrimitiveArrayItemType> From<PrimitiveArray<T>> for ArrayImpl {
     fn from(arr: PrimitiveArray<T>) -> Self {
@@ -339,8 +340,6 @@ impl From<ListArray> for ArrayImpl {
     }
 }
 
-for_all_variants! { array_impl_enum }
-
 /// `impl_convert` implements several conversions for `Array` and `ArrayBuilder`.
 /// * `ArrayImpl -> &Array` with `impl.as_int16()`.
 /// * `ArrayImpl -> Array` with `impl.into_int16()`.
@@ -348,7 +347,7 @@ for_all_variants! { array_impl_enum }
 /// * `&ArrayImpl -> &Array` with `From` trait.
 /// * `ArrayBuilder -> ArrayBuilderImpl` with `From` trait.
 macro_rules! impl_convert {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+    ($( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         $(
             paste! {
                 impl ArrayImpl {
@@ -399,7 +398,7 @@ for_all_variants! { impl_convert }
 
 /// Define `ArrayImplBuilder` with macro.
 macro_rules! array_builder_impl_enum {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+    ($( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         /// `ArrayBuilderImpl` embeds all possible array in `array` module.
         #[derive(Debug)]
         pub enum ArrayBuilderImpl {
@@ -412,7 +411,7 @@ for_all_variants! { array_builder_impl_enum }
 
 /// Implements all `ArrayBuilder` functions with `for_all_variant`.
 macro_rules! impl_array_builder {
-    ([], $({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+    ($({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         impl ArrayBuilderImpl {
             pub fn append_array(&mut self, other: &ArrayImpl) {
                 match self {
@@ -483,7 +482,7 @@ for_all_variants! { impl_array_builder }
 
 /// Implements all `Array` functions with `for_all_variant`.
 macro_rules! impl_array {
-    ([], $({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+    ($({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
         impl ArrayImpl {
             /// Number of items in array.
             pub fn len(&self) -> usize {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -88,7 +88,7 @@ macro_rules! impl_array_methods {
 }
 
 macro_rules! impl_primitive_for_native_types {
-    ([], $({ $naive_type:ty, $scalar_type:ident } ),*) => {
+    ($({ $naive_type:ty, $scalar_type:ident } ),*) => {
         $(
             impl PrimitiveArrayItemType for $naive_type {
                 impl_array_methods!($naive_type, $scalar_type, $scalar_type);

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -192,7 +192,6 @@ impl<const N: usize> EstimateSize for FixedSizeKey<N> {
     }
 }
 
-/// Fix clippy warning.
 impl<const N: usize> PartialEq for FixedSizeKey<N> {
     fn eq(&self, other: &Self) -> bool {
         (self.key == other.key) && (self.null_bitmap == other.null_bitmap)
@@ -636,13 +635,13 @@ where
 impl ArrayImpl {
     fn serialize_to_hash_key<S: HashKeySerializer>(&self, serializers: &mut [S]) {
         macro_rules! impl_all_serialize_to_hash_key {
-            ([$self:ident, $serializers: ident], $({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
-                match $self {
-                    $( Self::$variant_name(inner) => serialize_array_to_hash_key(inner, $serializers), )*
+            ($({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+                match self {
+                    $( Self::$variant_name(inner) => serialize_array_to_hash_key(inner, serializers), )*
                 }
             };
         }
-        for_all_variants! { impl_all_serialize_to_hash_key, self, serializers }
+        for_all_variants! { impl_all_serialize_to_hash_key }
     }
 }
 
@@ -652,13 +651,13 @@ impl ArrayBuilderImpl {
         deserializer: &mut S,
     ) -> ArrayResult<()> {
         macro_rules! impl_all_deserialize_from_hash_key {
-            ([$self:ident, $deserializer: ident], $({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
-                match $self {
-                    $( Self::$variant_name(inner) => deserialize_array_element_from_hash_key(inner, $deserializer), )*
+            ($({ $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+                match self {
+                    $( Self::$variant_name(inner) => deserialize_array_element_from_hash_key(inner, deserializer), )*
                 }
             };
         }
-        for_all_variants! { impl_all_deserialize_from_hash_key, self, deserializer }
+        for_all_variants! { impl_all_deserialize_from_hash_key }
     }
 }
 

--- a/src/common/src/hash/mod.rs
+++ b/src/common/src/hash/mod.rs
@@ -15,4 +15,4 @@
 mod key;
 pub use key::*;
 mod dispatcher;
-pub use dispatcher::*;
+pub use dispatcher::HashKeyDispatcher;

--- a/src/common/src/test_utils/rand_array.rs
+++ b/src/common/src/test_utils/rand_array.rs
@@ -163,7 +163,7 @@ mod tests {
     #[test]
     fn test_create_array() {
         macro_rules! gen_rand_array {
-            ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+            ($( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
             $(
                 {
                     let array = seed_rand_array::<$array>(10, 1024);

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -65,8 +65,8 @@ use crate::array::{
 pub type ParallelUnitId = u32;
 pub type VnodeMapping = Vec<ParallelUnitId>;
 
-// VirtualNode (a.k.a. VNode) is a minimal partition that a set of keys belong to. It is used for
-// consistent hashing.
+/// `VirtualNode` (a.k.a. VNode) is a minimal partition that a set of keys belong to. It is used for
+/// consistent hashing.
 pub type VirtualNode = u8;
 pub const VIRTUAL_NODE_SIZE: usize = std::mem::size_of::<VirtualNode>();
 pub const VNODE_BITS: usize = 8;

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -371,13 +371,16 @@ pub trait ScalarRef<'a>:
 /// `for_all_scalar_variants` includes all variants of our scalar types. If you added a new scalar
 /// type inside the project, be sure to add a variant here.
 ///
-/// Every tuple has four elements, where
-/// `{ enum variant name, function suffix name, scalar type, scalar ref type }`
+/// It is used to simplify the boilerplate code of repeating all scalar types, while each type
+/// has exactly the same code.
+///
+/// To use it, you need to provide a macro, whose input is `{ enum variant name, function suffix
+/// name, scalar type, scalar ref type }` tuples. Refer to the following implementations as
+/// examples.
 #[macro_export]
 macro_rules! for_all_scalar_variants {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
             { Int16, int16, i16, i16 },
             { Int32, int32, i32, i32 },
             { Int64, int64, i64, i64 },
@@ -398,7 +401,7 @@ macro_rules! for_all_scalar_variants {
 
 /// Define `ScalarImpl` and `ScalarRefImpl` with macro.
 macro_rules! scalar_impl_enum {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+    ($( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
         /// `ScalarImpl` embeds all possible scalars in the evaluation framework.
         #[derive(Debug, Display, Clone, PartialEq, Eq, PartialOrd, Ord)]
         pub enum ScalarImpl {
@@ -514,9 +517,8 @@ impl ToOwnedDatum for DatumRef<'_> {
 /// Specifically, it doesn't support u8/u16/u32/u64.
 #[macro_export]
 macro_rules! for_all_native_types {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
             { i16, Int16 },
             { i32, Int32 },
             { i64, Int64 },
@@ -532,7 +534,7 @@ macro_rules! for_all_native_types {
 /// * `&ScalarImpl -> &Scalar` with `impl.as_int16()`.
 /// * `ScalarImpl -> Scalar` with `impl.into_int16()`.
 macro_rules! impl_convert {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+    ($( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
         $(
             impl From<$scalar> for ScalarImpl {
                 fn from(val: $scalar) -> Self {
@@ -615,7 +617,7 @@ impl From<f64> for ScalarImpl {
 }
 
 macro_rules! impl_scalar_impl_ref_conversion {
-    ([], $( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+    ($( { $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
         impl ScalarImpl {
             /// Converts [`ScalarImpl`] to [`ScalarRefImpl`]
             pub fn as_scalar_ref_impl(&self) -> ScalarRefImpl<'_> {
@@ -647,8 +649,8 @@ for_all_scalar_variants! { impl_scalar_impl_ref_conversion }
 impl Hash for ScalarImpl {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         macro_rules! impl_all_hash {
-            ([$self:ident], $({ $variant_type:ty, $scalar_type:ident } ),*) => {
-                match $self {
+            ($({ $variant_type:ty, $scalar_type:ident } ),*) => {
+                match self {
                     // Primitive types
                     $( Self::$scalar_type(inner) => {
                         NativeType::hash_wrapper(inner, state);
@@ -667,7 +669,7 @@ impl Hash for ScalarImpl {
                 }
             };
         }
-        for_all_native_types! { impl_all_hash, self }
+        for_all_native_types! { impl_all_hash }
     }
 }
 

--- a/src/common/src/types/scalar_impl.rs
+++ b/src/common/src/types/scalar_impl.rs
@@ -27,7 +27,7 @@ pub trait ScalarPartialOrd: Scalar {
 /// Implement `Scalar` and `ScalarRef` for native type.
 /// For `PrimitiveArrayItemType`, clone is trivial, so `T` is both `Scalar` and `ScalarRef`.
 macro_rules! impl_all_native_scalar {
-    ([], $({ $scalar_type:ty, $variant_name:ident } ),*) => {
+    ($({ $scalar_type:ty, $variant_name:ident } ),*) => {
         $(
             impl Scalar for $scalar_type {
                 type ScalarRefType<'a> = Self;
@@ -292,25 +292,25 @@ impl<'a> ScalarRef<'a> for ListRef<'a> {
 impl ScalarImpl {
     pub fn get_ident(&self) -> &'static str {
         macro_rules! impl_all_get_ident {
-            ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-                match $self {
+            ($({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match self {
                     $( Self::$variant_name(_) => stringify!($variant_name), )*
                 }
             };
         }
-        for_all_scalar_variants! { impl_all_get_ident, self }
+        for_all_scalar_variants! { impl_all_get_ident }
     }
 }
 
 impl<'scalar> ScalarRefImpl<'scalar> {
     pub fn get_ident(&self) -> &'static str {
         macro_rules! impl_all_get_ident {
-            ([$self:ident], $({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
-                match $self {
+            ($({ $variant_name:ident, $suffix_name:ident, $scalar:ty, $scalar_ref:ty } ),*) => {
+                match self {
                     $( Self::$variant_name(_) => stringify!($variant_name), )*
                 }
             };
         }
-        for_all_scalar_variants! { impl_all_get_ident, self }
+        for_all_scalar_variants! { impl_all_get_ident }
     }
 }

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -119,9 +119,8 @@ pub fn is_full_range<T>(bounds: &impl RangeBounds<T>) -> bool {
 }
 
 macro_rules! for_all_scalar_int_variants {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
             { Int16 },
             { Int32 },
             { Int64 }
@@ -130,7 +129,7 @@ macro_rules! for_all_scalar_int_variants {
 }
 
 macro_rules! impl_split_small_range {
-    ([], $( { $type_name:ident} ),*) => {
+    ($( { $type_name:ident} ),*) => {
         paste! {
             impl ScanRange {
                 /// `Precondition`: make sure the first order key is int type if you call this method.

--- a/src/common/src/util/schema_check.rs
+++ b/src/common/src/util/schema_check.rs
@@ -39,7 +39,7 @@ where
         let builder = pair.as_ref().right().map(|d| d.create_array_builder(0)); // TODO: check `data_type` directly
 
         macro_rules! check_schema {
-            ([], $( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
+            ($( { $variant_name:ident, $suffix_name:ident, $array:ty, $builder:ty } ),*) => {
                 use crate::array::ArrayBuilderImpl;
                 use crate::array::ArrayImpl;
 

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -14,7 +14,7 @@
 
 #[macro_export]
 macro_rules! impl_split_enumerator {
-    ([], $({ $variant_name:ident, $split_enumerator_name:ident} ),*) => {
+    ($({ $variant_name:ident, $split_enumerator_name:ident} ),*) => {
         impl SplitEnumeratorImpl {
 
              pub async fn create(properties: ConnectorProperties) -> Result<Self> {
@@ -47,7 +47,7 @@ macro_rules! impl_split_enumerator {
 
 #[macro_export]
 macro_rules! impl_split {
-    ([], $({ $variant_name:ident, $connector_name:ident, $split:ty} ),*) => {
+    ($({ $variant_name:ident, $connector_name:ident, $split:ty} ),*) => {
         impl From<&SplitImpl> for ConnectorSplit {
             fn from(split: &SplitImpl) -> Self {
                 match split {
@@ -104,7 +104,7 @@ macro_rules! impl_split {
 
 #[macro_export]
 macro_rules! impl_split_reader {
-    ([], $({ $variant_name:ident, $split_reader_name:ident} ),*) => {
+    ($({ $variant_name:ident, $split_reader_name:ident} ),*) => {
         impl SplitReaderImpl {
             pub async fn next(&mut self) -> Result<Option<Vec<SourceMessage>>> {
                 match self {
@@ -134,7 +134,7 @@ macro_rules! impl_split_reader {
 
 #[macro_export]
 macro_rules! impl_connector_properties {
-    ([], $({ $variant_name:ident, $connector_name:ident } ),*) => {
+    ($({ $variant_name:ident, $connector_name:ident } ),*) => {
         impl ConnectorProperties {
             pub fn extract(mut props: HashMap<String, String>) -> Result<Self> {
                 const UPSTREAM_SOURCE_KEY: &str = "connector";

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -117,7 +117,6 @@ pub enum ConnectorProperties {
 }
 
 impl_connector_properties! {
-    [ ] ,
     { Kafka, KAFKA_CONNECTOR },
     { Pulsar, PULSAR_CONNECTOR },
     { Kinesis, KINESIS_CONNECTOR },
@@ -127,7 +126,6 @@ impl_connector_properties! {
 }
 
 impl_split_enumerator! {
-    [ ] ,
     { Kafka, KafkaSplitEnumerator },
     { Pulsar, PulsarSplitEnumerator },
     { Kinesis, KinesisSplitEnumerator },
@@ -136,7 +134,6 @@ impl_split_enumerator! {
 }
 
 impl_split! {
-    [ ] ,
     { Kafka, KAFKA_CONNECTOR, KafkaSplit },
     { Pulsar, PULSAR_CONNECTOR, PulsarSplit },
     { Kinesis, KINESIS_CONNECTOR, KinesisSplit },
@@ -145,7 +142,6 @@ impl_split! {
 }
 
 impl_split_reader! {
-    [ ] ,
     { Kafka, KafkaSplitReader },
     { Pulsar, PulsarSplitReader },
     { Kinesis, KinesisMultiSplitReader },

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -244,30 +244,16 @@ pub fn bool_out(input: bool) -> Result<String> {
     Ok(if input { "t".into() } else { "f".into() })
 }
 
-/// This macro helps to cast individual scalars.
-macro_rules! gen_cast_impl {
-    ([$source:expr, $source_ty:expr, $target_ty:expr], $( { $input:ident, $cast:ident, $func:expr } ),* $(,)?) => {
-        match ($source_ty, $target_ty) {
-            $(
-                ($input! { type_match_pattern }, $cast! { type_match_pattern }) => {
-                    let source: <$input! { type_array } as Array>::RefItem<'_> = $source.try_into()?;
-                    let target: Result<<$cast! { type_array } as Array>::OwnedItem> = $func(source);
-                    target.map(Scalar::to_scalar_value)
-                }
-            )*
-            _ => {
-                return Err(ExprError::Cast2($source_ty.clone(), $target_ty.clone()));
-            }
-        }
-    };
-}
-
+/// It accepts a macro whose input is `{ $input:ident, $cast:ident, $func:expr }` tuples
+///
+/// * `$input`: input type
+/// * `$cast`: The cast type in that the operation will calculate
+/// * `$func`: The scalar function for expression, it's a generic function and specialized by the
+///   type of `$input, $cast`
 #[macro_export]
-macro_rules! for_each_cast {
-    ($macro:ident, $($x:tt, )* ) => {
+macro_rules! for_all_cast_variants {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*],
-
             { varchar, date, str_to_date },
             { varchar, time, str_to_time },
             { varchar, interval, str_parse },
@@ -336,7 +322,7 @@ macro_rules! for_each_cast {
             { time, interval, general_cast },
             { timestamp, date, timestamp_to_date },
             { timestamp, time, timestamp_to_time },
-            { interval, time, interval_to_time },
+            { interval, time, interval_to_time }
         }
     };
 }
@@ -460,7 +446,23 @@ fn scalar_cast(
             },
         ) => str_to_list(source.try_into()?, target_elem_type).map(Scalar::to_scalar_value),
         (source_type, target_type) => {
-            for_each_cast!(gen_cast_impl, source, source_type, target_type,)
+            macro_rules! gen_cast_impl {
+                ($( { $input:ident, $cast:ident, $func:expr } ),*) => {
+                    match (source_type, target_type) {
+                        $(
+                            ($input! { type_match_pattern }, $cast! { type_match_pattern }) => {
+                                let source: <$input! { type_array } as Array>::RefItem<'_> = source.try_into()?;
+                                let target: Result<<$cast! { type_array } as Array>::OwnedItem> = $func(source);
+                                target.map(Scalar::to_scalar_value)
+                            }
+                        )*
+                        _ => {
+                            return Err(ExprError::Cast2(source_type.clone(), target_type.clone()));
+                        }
+                    }
+                };
+            }
+            for_all_cast_variants!(gen_cast_impl)
         }
     }
 }

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -65,10 +65,13 @@ pub fn align_types<'a>(exprs: impl Iterator<Item = &'a mut ExprImpl>) -> Result<
     Ok(ret_type)
 }
 
-/// aligns an array and an element by returning a possible common array type and casting them into
-/// the common type
-/// array_idx and element_idx indicate which element in inputs is the array and which the element
-///  Example: align_array_and_element(numeric[], int) -> numeric[]
+/// Aligns an array and an element by returning a possible common array type and casting them into
+/// the common type.
+///
+/// `array_idx` and `element_idx` indicate which element in inputs is the array and which the
+/// element.
+///
+/// Example: `align_array_and_element(numeric[], int) -> numeric[]`
 pub fn align_array_and_element(
     array_idx: usize,
     element_idx: usize,

--- a/src/frontend/src/optimizer/plan_node/col_pruning.rs
+++ b/src/frontend/src/optimizer/plan_node/col_pruning.rs
@@ -36,7 +36,7 @@ pub trait ColPrunable {
 
 /// Implements [`ColPrunable`] for batch and streaming node.
 macro_rules! impl_prune_col {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ColPrunable for [<$convention $name>] {
                 fn prune_col(&self, _required_cols: &[usize]) -> PlanRef {

--- a/src/frontend/src/optimizer/plan_node/convert.rs
+++ b/src/frontend/src/optimizer/plan_node/convert.rs
@@ -111,7 +111,7 @@ pub trait ToDistributedBatch {
 
 /// Implement [`ToBatch`] for batch and streaming node.
 macro_rules! ban_to_batch {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToBatch for [<$convention $name>] {
                 fn to_batch(&self) -> Result<PlanRef> {
@@ -126,7 +126,7 @@ for_stream_plan_nodes! { ban_to_batch }
 
 /// Implement [`ToStream`] for batch and streaming node.
 macro_rules! ban_to_stream {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToStream for [<$convention $name>] {
                 fn to_stream(&self) -> Result<PlanRef>{
@@ -144,7 +144,7 @@ for_stream_plan_nodes! { ban_to_stream }
 
 /// impl `ToDistributedBatch`  for logical and streaming node.
 macro_rules! ban_to_distributed {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToDistributedBatch for [<$convention $name>] {
                 fn to_distributed(&self) -> Result<PlanRef> {
@@ -159,7 +159,7 @@ for_stream_plan_nodes! { ban_to_distributed }
 
 /// impl `ToLocalBatch`  for logical and streaming node.
 macro_rules! ban_to_local {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToLocalBatch for [<$convention $name>] {
                 fn to_local(&self) -> Result<PlanRef> {

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -364,17 +364,16 @@ use crate::stream_fragmenter::BuildFragmentGraphState;
 /// You can use it as follows
 /// ```rust
 /// macro_rules! use_plan {
-///     ([], $({ $convention:ident, $name:ident }),*) => {};
+///     ($({ $convention:ident, $name:ident }),*) => {};
 /// }
 /// risingwave_frontend::for_all_plan_nodes! { use_plan }
 /// ```
 /// See the following implementations for example.
 #[macro_export]
 macro_rules! for_all_plan_nodes {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            , { Logical, Agg }
+              { Logical, Agg }
             , { Logical, Apply }
             , { Logical, Filter }
             , { Logical, Project }
@@ -443,10 +442,9 @@ macro_rules! for_all_plan_nodes {
 /// `for_logical_plan_nodes` includes all plan nodes with logical convention.
 #[macro_export]
 macro_rules! for_logical_plan_nodes {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            , { Logical, Agg }
+              { Logical, Agg }
             , { Logical, Apply }
             , { Logical, Filter }
             , { Logical, Project }
@@ -475,10 +473,9 @@ macro_rules! for_logical_plan_nodes {
 /// `for_batch_plan_nodes` includes all plan nodes with batch convention.
 #[macro_export]
 macro_rules! for_batch_plan_nodes {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            , { Batch, SimpleAgg }
+              { Batch, SimpleAgg }
             , { Batch, HashAgg }
             , { Batch, SortAgg }
             , { Batch, Project }
@@ -507,10 +504,9 @@ macro_rules! for_batch_plan_nodes {
 /// `for_stream_plan_nodes` includes all plan nodes with stream convention.
 #[macro_export]
 macro_rules! for_stream_plan_nodes {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            , { Stream, Project }
+              { Stream, Project }
             , { Stream, Filter }
             , { Stream, HashJoin }
             , { Stream, Exchange }
@@ -535,7 +531,7 @@ macro_rules! for_stream_plan_nodes {
 
 /// impl [`PlanNodeType`] fn for each node.
 macro_rules! enum_plan_node_type {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             /// each enum value represent a PlanNode struct type, help us to dispatch and downcast
             #[derive(Copy, Clone, PartialEq, Debug, Hash, Eq, Serialize)]
@@ -562,7 +558,7 @@ for_all_plan_nodes! { enum_plan_node_type }
 
 /// impl fn `plan_ref` for each node.
 macro_rules! impl_plan_ref {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl From<[<$convention $name>]> for PlanRef {
                 fn from(plan: [<$convention $name>]) -> Self {
@@ -577,7 +573,7 @@ for_all_plan_nodes! { impl_plan_ref }
 
 /// impl plan node downcast fn for each node.
 macro_rules! impl_down_cast_fn {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             impl dyn PlanNode {
                 $( pub fn [< as_$convention:snake _ $name:snake>](&self) -> Option<&[<$convention $name>]> {

--- a/src/frontend/src/optimizer/plan_node/plan_base.rs
+++ b/src/frontend/src/optimizer/plan_node/plan_base.rs
@@ -105,7 +105,7 @@ impl PlanBase {
     }
 }
 macro_rules! impl_base_delegate {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         $(paste! {
             impl [<$convention $name>] {
                 pub fn id(&self) -> PlanNodeId {

--- a/src/frontend/src/optimizer/plan_node/predicate_pushdown.rs
+++ b/src/frontend/src/optimizer/plan_node/predicate_pushdown.rs
@@ -39,7 +39,7 @@ pub trait PredicatePushdown {
 }
 
 macro_rules! ban_predicate_pushdown {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl PredicatePushdown for [<$convention $name>] {
                 fn predicate_pushdown(&self, _predicate: Condition) -> PlanRef {

--- a/src/frontend/src/optimizer/plan_node/to_prost.rs
+++ b/src/frontend/src/optimizer/plan_node/to_prost.rs
@@ -40,7 +40,7 @@ pub trait StreamNode {
 
 /// impl `ToProst` nodes which have impl `ToBatchProst` and `ToStreamProst`.
 macro_rules! impl_to_prost {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToProst for [<$convention $name>] { })*
         }
@@ -49,7 +49,7 @@ macro_rules! impl_to_prost {
 for_all_plan_nodes! { impl_to_prost }
 /// impl a panic `ToBatchProst` for logical and stream node.
 macro_rules! ban_to_batch_prost {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl ToBatchProst for [<$convention $name>] {
                 fn to_batch_prost_body(&self) -> pb_batch_node::NodeBody {
@@ -63,7 +63,7 @@ for_logical_plan_nodes! { ban_to_batch_prost }
 for_stream_plan_nodes! { ban_to_batch_prost }
 /// impl a panic `ToStreamProst` for logical and batch node.
 macro_rules! ban_to_stream_prost {
-    ([], $( { $convention:ident, $name:ident }),*) => {
+    ($( { $convention:ident, $name:ident }),*) => {
         paste!{
             $(impl StreamNode for [<$convention $name>] {
                 fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> pb_stream_node::NodeBody {

--- a/src/frontend/src/optimizer/plan_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter.rs
@@ -20,7 +20,7 @@ use crate::optimizer::plan_node::*;
 
 /// Define `PlanRewriter` trait.
 macro_rules! def_rewriter {
-    ([], $({ $convention:ident, $name:ident }),*) => {
+    ($({ $convention:ident, $name:ident }),*) => {
 
         /// it's kind of like a [`PlanVisitor<PlanRef>`](super::plan_visitor::PlanVisitor), but with default behaviour of each rewrite method
         pub trait PlanRewriter {

--- a/src/frontend/src/optimizer/plan_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor.rs
@@ -19,7 +19,7 @@ use crate::optimizer::plan_node::*;
 
 /// Define `PlanVisitor` trait.
 macro_rules! def_visitor {
-    ([], $({ $convention:ident, $name:ident }),*) => {
+    ($({ $convention:ident, $name:ident }),*) => {
         /// The visitor for plan nodes. visit all inputs and return the ret value of the left most input,
         /// and leaf node returns `R::default()`
         pub trait PlanVisitor<R:Default> {

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -72,10 +72,9 @@ pub use over_agg_to_topn::*;
 
 #[macro_export]
 macro_rules! for_all_rules {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            ,{ApplyAggRule}
+             {ApplyAggRule}
             ,{ApplyFilterRule}
             ,{ApplyProjRule}
             ,{ApplyScanRule}
@@ -100,7 +99,7 @@ macro_rules! for_all_rules {
 }
 
 macro_rules! impl_description {
-    ([], $( { $name:ident }),*) => {
+    ($( { $name:ident }),*) => {
         paste::paste!{
             $(impl Description for [<$name>] {
                 fn description(&self) -> &str {

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -141,7 +141,7 @@ pub type ExtraInfoSourceRef = Arc<dyn ExtraInfoSource>;
 
 #[macro_export]
 macro_rules! rpc_client_method_impl {
-    ([], $( { $client:tt, $fn_name:ident, $req:ty, $resp:ty }),*) => {
+    ($( { $client:tt, $fn_name:ident, $req:ty, $resp:ty }),*) => {
         $(
             pub async fn $fn_name(&self, request: $req) -> $crate::Result<$resp> {
                 Ok(self

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -717,10 +717,9 @@ impl GrpcMetaClient {
 }
 
 macro_rules! for_all_meta_rpc {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            ,{ cluster_client, add_worker_node, AddWorkerNodeRequest, AddWorkerNodeResponse }
+             { cluster_client, add_worker_node, AddWorkerNodeRequest, AddWorkerNodeResponse }
             ,{ cluster_client, activate_worker_node, ActivateWorkerNodeRequest, ActivateWorkerNodeResponse }
             ,{ cluster_client, delete_worker_node, DeleteWorkerNodeRequest, DeleteWorkerNodeResponse }
             ,{ cluster_client, list_all_nodes, ListAllNodesRequest, ListAllNodesResponse }

--- a/src/rpc_client/src/stream_client.rs
+++ b/src/rpc_client/src/stream_client.rs
@@ -50,10 +50,9 @@ pub type StreamClientPool = RpcClientPool<StreamClient>;
 pub type StreamClientPoolRef = Arc<StreamClientPool>;
 
 macro_rules! for_all_stream_rpc {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x),*]
-            ,{ 0, update_actors, UpdateActorsRequest, UpdateActorsResponse }
+             { 0, update_actors, UpdateActorsRequest, UpdateActorsResponse }
             ,{ 0, build_actors, BuildActorsRequest, BuildActorsResponse }
             ,{ 0, broadcast_actor_info_table, BroadcastActorInfoTableRequest, BroadcastActorInfoTableResponse }
             ,{ 0, drop_actors, DropActorsRequest, DropActorsResponse }

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -66,7 +66,7 @@ impl FilterKeyExtractorImpl {
 }
 
 macro_rules! impl_filter_key_extractor {
-    ([], $( { $variant_name:ident } ),*) => {
+    ($( { $variant_name:ident } ),*) => {
         impl FilterKeyExtractorImpl {
             pub fn extract<'a>(&self, full_key: &'a [u8]) -> &'a [u8]{
                 match self {
@@ -78,9 +78,8 @@ macro_rules! impl_filter_key_extractor {
 }
 
 macro_rules! for_all_filter_key_extractor_variants {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x), *],
             { Schema },
             { FullKey },
             { Dummy },

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -341,7 +341,7 @@ impl DispatcherImpl {
 }
 
 macro_rules! impl_dispatcher {
-    ([], $( { $variant_name:ident } ),*) => {
+    ($( { $variant_name:ident } ),*) => {
         impl DispatcherImpl {
             pub async fn dispatch_data(&mut self, chunk: StreamChunk) -> StreamResult<()> {
                 match self {
@@ -383,9 +383,8 @@ macro_rules! impl_dispatcher {
 }
 
 macro_rules! for_all_dispatcher_variants {
-    ($macro:ident $(, $x:tt)*) => {
+    ($macro:ident) => {
         $macro! {
-            [$($x), *],
             { Hash },
             { Broadcast },
             { Simple },


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Remove the extra parameters `$(, $x:tt)*` in 
```rust
macro_rules! for_all_xxx {
    ($macro:ident $(, $x:tt)*) 
```

It's only useful when we want to use a macro multiple times:
```rust
for_all_x! { y, a }
for_all_x! { y, b }
```

But there are no such usage in our codebase. Removing it can make the macros less daunting.