### PR TITLE
chore(risedev): disable tier-cached

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -265,21 +265,21 @@ risedev:
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-0}
       enable-async-stack-trace: true
-      enable-tiered-cache: true
+      enable-tiered-cache: false
 
     - use: compute-node
       id: compute-node-1
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-1}
       enable-async-stack-trace: true
-      enable-tiered-cache: true
+      enable-tiered-cache: false
 
     - use: compute-node
       id: compute-node-2
       listen-address: "0.0.0.0"
       address: ${dns-host:rw-compute-2}
       enable-async-stack-trace: true
-      enable-tiered-cache: true
+      enable-tiered-cache: false
 
     - use: frontend
       id: frontend-node-0
@@ -318,7 +318,7 @@ risedev:
       unsafe-disable-recovery: true
       enable-committed-sst-sanity-check: true
     - use: compute-node
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: frontend
     - use: compactor
 
@@ -332,15 +332,15 @@ risedev:
     - use: compute-node
       port: 5687
       exporter-port: 1222
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: compute-node
       port: 5688
       exporter-port: 1223
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: compute-node
       port: 5689
       exporter-port: 1224
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: frontend
     - use: compactor
 
@@ -354,15 +354,15 @@ risedev:
     - use: compute-node
       port: 5687
       exporter-port: 1222
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: compute-node
       port: 5688
       exporter-port: 1223
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: compute-node
       port: 5689
       exporter-port: 1224
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: frontend
       port: 4565
       exporter-port: 2222
@@ -408,7 +408,7 @@ risedev:
     - use: meta-node
       unsafe-disable-recovery: true
     - use: compute-node
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: frontend
     - use: compactor
     - use: zookeeper
@@ -423,7 +423,7 @@ risedev:
     - use: meta-node
       unsafe-disable-recovery: true
     - use: compute-node
-      enable-tiered-cache: true
+      enable-tiered-cache: false
     - use: frontend
     - use: compactor
     - use: redis


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

File cache doesn't cleanup disk on restart which is fine. But when we use in-mem meta store in risedev-bench, each restart results a new DB instance, but CN still uses old file cache, which causes #5587, #5609 and #5614. 

Details in https://github.com/risingwavelabs/risingwave/issues/5587#issuecomment-1263486972

Let's disable it for now, or shall we 

- clean up file cache during risedev-bench deployment flow, e.g. --force-recreate?
- clean up file cache during rw process start?

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~


## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
close https://github.com/risingwavelabs/risingwave/issues/5587 
close https://github.com/risingwavelabs/risingwave/issues/5609
close https://github.com/risingwavelabs/risingwave/issues/5614
