### PR TITLE
fix(expr): replace `unimplemented` panic with Err

### DIFF
--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -180,9 +180,9 @@ impl HopWindowExecutor {
                 DataType::Timestamp,
                 time_col_ref,
                 window_size_sub_slide_expr,
-            ),
+            )?,
             window_slide_expr,
-        );
+        )?;
 
         let mut window_start_exprs = Vec::with_capacity(units);
         let mut window_end_exprs = Vec::with_capacity(units);
@@ -215,14 +215,14 @@ impl HopWindowExecutor {
                 DataType::Timestamp,
                 InputRefExpression::new(DataType::Timestamp, 0).boxed(),
                 window_start_offset_expr,
-            );
+            )?;
             window_start_exprs.push(window_start_expr);
             let window_end_expr = new_binary_expr(
                 expr_node::Type::Add,
                 DataType::Timestamp,
                 InputRefExpression::new(DataType::Timestamp, 0).boxed(),
                 window_end_offset_expr,
-            );
+            )?;
             window_end_exprs.push(window_end_expr);
         }
         let window_start_col_index = child.schema().len();

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -1942,6 +1942,7 @@ mod tests {
                 Box::new(left_expr),
                 Box::new(right_expr),
             )
+            .unwrap()
         }
 
         fn create_join_executor(&self, has_non_equi_cond: bool, null_safe: bool) -> BoxedExecutor {

--- a/src/batch/src/executor/join/lookup_join.rs
+++ b/src/batch/src/executor/join/lookup_join.rs
@@ -879,15 +879,18 @@ mod tests {
              2 8.4 2 5.5",
         );
 
-        let condition = Some(new_binary_expr(
-            Type::LessThan,
-            DataType::Boolean,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(5)),
-            )),
-            Box::new(InputRefExpression::new(DataType::Float32, 3)),
-        ));
+        let condition = Some(
+            new_binary_expr(
+                Type::LessThan,
+                DataType::Boolean,
+                Box::new(LiteralExpression::new(
+                    DataType::Int32,
+                    Some(ScalarImpl::Int32(5)),
+                )),
+                Box::new(InputRefExpression::new(DataType::Float32, 3)),
+            )
+            .unwrap(),
+        );
 
         do_test(JoinType::Inner, condition, false, expected).await;
     }
@@ -905,15 +908,18 @@ mod tests {
              . .   . .",
         );
 
-        let condition = Some(new_binary_expr(
-            Type::LessThan,
-            DataType::Boolean,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(5)),
-            )),
-            Box::new(InputRefExpression::new(DataType::Float32, 3)),
-        ));
+        let condition = Some(
+            new_binary_expr(
+                Type::LessThan,
+                DataType::Boolean,
+                Box::new(LiteralExpression::new(
+                    DataType::Int32,
+                    Some(ScalarImpl::Int32(5)),
+                )),
+                Box::new(InputRefExpression::new(DataType::Float32, 3)),
+            )
+            .unwrap(),
+        );
 
         do_test(JoinType::LeftOuter, condition, false, expected).await;
     }
@@ -927,15 +933,18 @@ mod tests {
              2 8.4",
         );
 
-        let condition = Some(new_binary_expr(
-            Type::LessThan,
-            DataType::Boolean,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(5)),
-            )),
-            Box::new(InputRefExpression::new(DataType::Float32, 3)),
-        ));
+        let condition = Some(
+            new_binary_expr(
+                Type::LessThan,
+                DataType::Boolean,
+                Box::new(LiteralExpression::new(
+                    DataType::Int32,
+                    Some(ScalarImpl::Int32(5)),
+                )),
+                Box::new(InputRefExpression::new(DataType::Float32, 3)),
+            )
+            .unwrap(),
+        );
 
         do_test(JoinType::LeftSemi, condition, false, expected).await;
     }
@@ -950,15 +959,18 @@ mod tests {
             . .",
         );
 
-        let condition = Some(new_binary_expr(
-            Type::LessThan,
-            DataType::Boolean,
-            Box::new(LiteralExpression::new(
-                DataType::Int32,
-                Some(ScalarImpl::Int32(5)),
-            )),
-            Box::new(InputRefExpression::new(DataType::Float32, 3)),
-        ));
+        let condition = Some(
+            new_binary_expr(
+                Type::LessThan,
+                DataType::Boolean,
+                Box::new(LiteralExpression::new(
+                    DataType::Int32,
+                    Some(ScalarImpl::Int32(5)),
+                )),
+                Box::new(InputRefExpression::new(DataType::Float32, 3)),
+            )
+            .unwrap(),
+        );
 
         do_test(JoinType::LeftAnti, condition, false, expected).await;
     }

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -588,7 +588,8 @@ mod tests {
                     DataType::Boolean,
                     Box::new(InputRefExpression::new(DataType::Int32, 0)),
                     Box::new(InputRefExpression::new(DataType::Int32, 2)),
-                ),
+                )
+                .unwrap(),
                 join_type,
                 output_indices,
                 left_child,

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -56,12 +56,12 @@ pub fn build_binary_expr_prost(prost: &ExprNode) -> Result<BoxedExpression> {
     let [left_child, right_child]: [_; 2] = children.try_into().unwrap();
     let left_expr = expr_build_from_prost(&left_child)?;
     let right_expr = expr_build_from_prost(&right_child)?;
-    Ok(new_binary_expr(
+    new_binary_expr(
         prost.get_expr_type().unwrap(),
         ret_type,
         left_expr,
         right_expr,
-    ))
+    )
 }
 
 pub fn build_nullable_binary_expr_prost(prost: &ExprNode) -> Result<BoxedExpression> {

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -69,12 +69,12 @@ pub fn build_nullable_binary_expr_prost(prost: &ExprNode) -> Result<BoxedExpress
     let [left_child, right_child]: [_; 2] = children.try_into().unwrap();
     let left_expr = expr_build_from_prost(&left_child)?;
     let right_expr = expr_build_from_prost(&right_child)?;
-    Ok(new_nullable_binary_expr(
+    new_nullable_binary_expr(
         prost.get_expr_type().unwrap(),
         ret_type,
         left_expr,
         right_expr,
-    ))
+    )
 }
 
 pub fn build_overlay_expr(prost: &ExprNode) -> Result<BoxedExpression> {

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -101,7 +101,10 @@ macro_rules! gen_cmp_impl {
                 }
             ),*
             _ => {
-                unimplemented!("The expression ({:?}, {:?}) using vectorized expression framework is not supported yet!", $l.return_type(), $r.return_type())
+                return Err(ExprError::UnsupportedFunction(format!(
+                    "{:?} cmp {:?}",
+                    $l.return_type(), $r.return_type()
+                )));
             }
         }
     };
@@ -133,7 +136,10 @@ macro_rules! gen_shift_impl {
                 },
             )*
             _ => {
-                unimplemented!("The expression ({:?}, {:?}, {:?}) using vectorized expression framework is not supported yet!", $l.return_type(), $r.return_type(), $ret)
+                return Err(ExprError::UnsupportedFunction(format!(
+                    "{:?} shift {:?}",
+                    $l.return_type(), $r.return_type()
+                )));
             }
         }
     };
@@ -504,10 +510,12 @@ pub fn new_binary_expr(
         Type::ConcatOp => new_concat_op(l, r, ret),
 
         tp => {
-            unimplemented!(
-                "The expression {:?} using vectorized expression framework is not supported yet!",
-                tp
-            )
+            return Err(ExprError::UnsupportedFunction(format!(
+                "{:?}({:?}, {:?})",
+                tp,
+                l.return_type(),
+                r.return_type(),
+            )));
         }
     };
     Ok(expr)

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -79,10 +79,12 @@ pub fn new_nullable_binary_expr(
         Type::IsDistinctFrom => new_distinct_from_expr(l, r, ret)?,
         Type::IsNotDistinctFrom => new_not_distinct_from_expr(l, r, ret)?,
         tp => {
-            unimplemented!(
-                "The expression {:?} using vectorized expression framework is not supported yet!",
-                tp
-            )
+            return Err(ExprError::UnsupportedFunction(format!(
+                "{:?}({:?}, {:?})",
+                tp,
+                l.return_type(),
+                r.return_type(),
+            )));
         }
     };
     Ok(expr)

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -235,7 +235,8 @@ mod tests {
                 DataType::Boolean,
                 Box::new(InputRefExpression::new(DataType::Int32, 0)),
                 Box::new(LiteralExpression::new(DataType::Float32, Some(2f32.into()))),
-            ),
+            )
+            .unwrap(),
             Box::new(LiteralExpression::new(
                 DataType::Float32,
                 Some(3.1f32.into()),
@@ -273,7 +274,8 @@ mod tests {
                 DataType::Boolean,
                 Box::new(InputRefExpression::new(DataType::Int32, 0)),
                 Box::new(LiteralExpression::new(DataType::Float32, Some(3f32.into()))),
-            ),
+            )
+            .unwrap(),
             Box::new(LiteralExpression::new(
                 DataType::Float32,
                 Some(3.1f32.into()),
@@ -304,7 +306,8 @@ mod tests {
                 DataType::Boolean,
                 Box::new(InputRefExpression::new(DataType::Int32, 0)),
                 Box::new(LiteralExpression::new(DataType::Float32, Some(2f32.into()))),
-            ),
+            )
+            .unwrap(),
             Box::new(LiteralExpression::new(
                 DataType::Float32,
                 Some(3.1f32.into()),
@@ -339,7 +342,8 @@ mod tests {
                 DataType::Boolean,
                 Box::new(InputRefExpression::new(DataType::Int32, 0)),
                 Box::new(LiteralExpression::new(DataType::Float32, Some(3f32.into()))),
-            ),
+            )
+            .unwrap(),
             Box::new(LiteralExpression::new(
                 DataType::Float32,
                 Some(3.1f32.into()),

--- a/src/expr/src/vector_op/agg/filter.rs
+++ b/src/expr/src/vector_op/agg/filter.rs
@@ -179,12 +179,15 @@ mod tests {
     #[test]
     fn test_selective_agg() -> Result<()> {
         // filter (where $1 > 5)
-        let condition = Arc::from(new_binary_expr(
-            ProstType::GreaterThan,
-            DataType::Boolean,
-            InputRefExpression::new(DataType::Int64, 0).boxed(),
-            LiteralExpression::new(DataType::Int64, Some((5_i64).into())).boxed(),
-        ));
+        let condition = Arc::from(
+            new_binary_expr(
+                ProstType::GreaterThan,
+                DataType::Boolean,
+                InputRefExpression::new(DataType::Int64, 0).boxed(),
+                LiteralExpression::new(DataType::Int64, Some((5_i64).into())).boxed(),
+            )
+            .unwrap(),
+        );
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
             condition,
@@ -218,12 +221,15 @@ mod tests {
 
     #[test]
     fn test_selective_agg_null_condition() -> Result<()> {
-        let condition = Arc::from(new_binary_expr(
-            ProstType::Equal,
-            DataType::Boolean,
-            InputRefExpression::new(DataType::Int64, 0).boxed(),
-            LiteralExpression::new(DataType::Int64, None).boxed(),
-        ));
+        let condition = Arc::from(
+            new_binary_expr(
+                ProstType::Equal,
+                DataType::Boolean,
+                InputRefExpression::new(DataType::Int64, 0).boxed(),
+                LiteralExpression::new(DataType::Int64, None).boxed(),
+            )
+            .unwrap(),
+        );
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
             condition,

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -236,7 +236,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
         // Derive the dynamic expression
         let l_data_type = input_l.schema().data_types()[self.key_l].clone();
         let r_data_type = input_r.schema().data_types()[0].clone();
-        let dynamic_cond = move |literal: Datum| -> Option<BoxedExpression> {
+        let dynamic_cond = move |literal: Datum| {
             literal.map(|scalar| {
                 new_binary_expr(
                     self.comparator,
@@ -282,7 +282,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
 
                     // The condition is `None` if it is always false by virtue of a NULL right
                     // input, so we save evaluating it on the datachunk
-                    let condition = dynamic_cond(right_val);
+                    let condition = dynamic_cond(right_val).transpose()?;
 
                     let (new_ops, new_visibility) =
                         self.apply_batch(&data_chunk, ops, condition)?;

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -232,7 +232,8 @@ mod tests {
             DataType::Boolean,
             Box::new(left_expr),
             Box::new(right_expr),
-        );
+        )
+        .unwrap();
         let filter = Box::new(FilterExecutor::new(
             ActorContext::create(123),
             Box::new(source),

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -991,6 +991,7 @@ mod tests {
             Box::new(left_expr),
             Box::new(right_expr),
         )
+        .unwrap()
     }
 
     fn create_executor<const T: JoinTypePrimitive>(

--- a/src/stream/src/executor/hop_window.rs
+++ b/src/stream/src/executor/hop_window.rs
@@ -139,9 +139,9 @@ impl HopWindowExecutor {
                 DataType::Timestamp,
                 time_col_ref,
                 window_size_sub_slide_expr,
-            ),
+            )?,
             window_slide_expr,
-        );
+        )?;
         let mut window_start_exprs = Vec::with_capacity(units);
         let mut window_end_exprs = Vec::with_capacity(units);
         for i in 0..units {
@@ -180,14 +180,14 @@ impl HopWindowExecutor {
                 DataType::Timestamp,
                 InputRefExpression::new(DataType::Timestamp, 0).boxed(),
                 window_start_offset_expr,
-            );
+            )?;
             window_start_exprs.push(window_start_expr);
             let window_end_expr = new_binary_expr(
                 expr_node::Type::Add,
                 DataType::Timestamp,
                 InputRefExpression::new(DataType::Timestamp, 0).boxed(),
                 window_end_offset_expr,
-            );
+            )?;
             window_end_exprs.push(window_end_expr);
         }
         let window_start_col_index = input.schema().len();

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -171,7 +171,8 @@ mod tests {
             DataType::Int64,
             Box::new(left_expr),
             Box::new(right_expr),
-        );
+        )
+        .unwrap();
 
         let project = Box::new(ProjectExecutor::new(
             ActorContext::create(123),

--- a/src/stream/src/executor/project_set.rs
+++ b/src/stream/src/executor/project_set.rs
@@ -240,7 +240,8 @@ mod tests {
             DataType::Int64,
             Box::new(left_expr),
             Box::new(right_expr),
-        );
+        )
+        .unwrap();
         let tf1 = repeat_tf(
             LiteralExpression::new(DataType::Int32, Some(1_i32.into())).boxed(),
             1,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. `expr_unary` is already doing this. In most cases frontend should capture such invalid exprs that fail to build. But in case there is a discrepancy, or when the frontend code of a new expr is merged before backend impl, this can reduce the chance of a panic.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
