### PR TITLE
style: remove unused imports while test feature is not enabled

### DIFF
--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -21,7 +21,6 @@ use itertools::Itertools;
 use parking_lot::RwLock;
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::StorageConfig;
-use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::{key_with_epoch, user_key};
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::LevelType;
@@ -34,9 +33,7 @@ use super::{
 };
 use crate::define_local_state_store_associated_type;
 use crate::error::StorageResult;
-use crate::hummock::compaction_group_client::{
-    CompactionGroupClientImpl, DummyCompactionGroupClient,
-};
+use crate::hummock::compaction_group_client::CompactionGroupClientImpl;
 use crate::hummock::local_version::local_version_manager::LocalVersionManagerRef;
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::utils::prune_ssts;
@@ -93,6 +90,10 @@ impl HummockStorageCore {
         hummock_meta_client: Arc<dyn HummockMetaClient>,
         uploader: UploaderRef,
     ) -> HummockResult<Self> {
+        use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
+
+        use crate::hummock::compaction_group_client::DummyCompactionGroupClient;
+
         Self::new(
             options,
             sstable_store,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- remove unused imports while test feature is not enabled 

I am confused that why clippy doesn't complain about these.

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


