### PR TITLE
feat(storage): use timeout for filter_extractor acquire

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4820,6 +4820,7 @@ dependencies = [
  "prost",
  "risingwave_common",
  "risingwave_pb",
+ "tracing",
  "workspace-hack",
 ]
 

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -172,7 +172,7 @@ pub(crate) use start_measure_real_process_timer;
 
 use super::Compactor;
 
-static CACEL_STATUS_SET: LazyLock<HashSet<TaskStatus>> = LazyLock::new(|| {
+static CANCEL_STATUS_SET: LazyLock<HashSet<TaskStatus>> = LazyLock::new(|| {
     [
         TaskStatus::ManualCanceled,
         TaskStatus::SendFailCanceled,
@@ -776,7 +776,7 @@ where
     }
 
     pub async fn cancel_compact_task_impl(&self, compact_task: &CompactTask) -> Result<bool> {
-        assert!(CACEL_STATUS_SET.contains(&compact_task.task_status()));
+        assert!(CANCEL_STATUS_SET.contains(&compact_task.task_status()));
         self.report_compact_task_impl(None, compact_task, None)
             .await
     }

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -22,6 +22,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
     "time",
     "signal",
 ] }
+tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { version = "0.1", path = "../../workspace-hack" }

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -302,14 +302,18 @@ impl FilterKeyExtractorManagerInner {
             }
 
             if !table_id_set.is_empty() {
-                timeout(ACQUIRE_TIMEOUT, notified)
-                    .await
-                    .unwrap_or_else(|_| {
-                        panic!(
-                            "acquire timeout missing {} table_catalog",
-                            table_id_set.len()
-                        )
-                    });
+                if cfg!(debug_assertions) {
+                    timeout(ACQUIRE_TIMEOUT, notified)
+                        .await
+                        .unwrap_or_else(|_| {
+                            panic!(
+                                "acquire timeout missing {} table_catalog",
+                                table_id_set.len()
+                            )
+                        });
+                } else {
+                    notified.await;
+                }
             }
         }
 

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -24,7 +24,6 @@ use risingwave_common::util::ordered::OrderedRowDeserializer;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::catalog::Table;
 use tokio::sync::Notify;
-use tokio::time::timeout;
 
 use crate::key::{get_table_id, TABLE_PREFIX_LEN};
 
@@ -301,19 +300,16 @@ impl FilterKeyExtractorManagerInner {
                 });
             }
 
-            if !table_id_set.is_empty() {
-                if cfg!(debug_assertions) {
-                    timeout(ACQUIRE_TIMEOUT, notified)
-                        .await
-                        .unwrap_or_else(|_| {
-                            panic!(
-                                "acquire timeout missing {} table_catalog",
-                                table_id_set.len()
-                            )
-                        });
-                } else {
-                    notified.await;
-                }
+            if !table_id_set.is_empty()
+                && tokio::time::timeout(ACQUIRE_TIMEOUT, notified)
+                    .await
+                    .is_err()
+            {
+                tracing::warn!(
+                    "filter_key_extractor acquire timeout missing {} table_catalog table_id_set {:?}",
+                    table_id_set.len(),
+                    table_id_set
+                );
             }
         }
 
@@ -519,9 +515,6 @@ mod tests {
     #[test]
     fn test_multi_filter_key_extractor() {
         let mut multi_filter_key_extractor = MultiFilterKeyExtractor::default();
-        // let last_state = multi_filter_key_extractor.last_filter_key_extractor_state();
-        // assert!(last_state.is_none());
-
         {
             // test table_id 1
             let prost_table = build_table_with_prefix_column_num(1);
@@ -564,10 +557,6 @@ mod tests {
                 TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + pk_prefix_len,
                 output_key.len()
             );
-
-            // let last_state = multi_filter_key_extractor.last_filter_key_extractor_state();
-            // assert!(last_state.is_some());
-            // assert_eq!(1, last_state.as_ref().unwrap().0);
         }
 
         {
@@ -613,10 +602,6 @@ mod tests {
                 TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + pk_prefix_len,
                 output_key.len()
             );
-
-            // let last_state = multi_filter_key_extractor.last_filter_key_extractor_state();
-            // assert!(last_state.is_some());
-            // assert_eq!(2, last_state.as_ref().unwrap().0);
         }
 
         {
@@ -646,10 +631,6 @@ mod tests {
                 TABLE_PREFIX_LEN + VIRTUAL_NODE_SIZE + row_bytes.len(),
                 output_key.len()
             );
-
-            // let last_state = multi_filter_key_extractor.last_filter_key_extractor_state();
-            // assert!(last_state.is_some());
-            // assert_eq!(3, last_state.as_ref().unwrap().0);
         }
     }
 

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![feature(lint_reasons)]
-#![feature(hash_drain_filter)]
 #![feature(async_closure)]
+#![feature(hash_drain_filter)]
+#![feature(lint_reasons)]
+#![feature(once_cell)]
 
 mod version_cmp;
 

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -15,7 +15,6 @@
 #![feature(async_closure)]
 #![feature(hash_drain_filter)]
 #![feature(lint_reasons)]
-#![feature(once_cell)]
 
 mod version_cmp;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title 

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- use timeout for notify to replace the unbound wait for debug

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/issues/5437