### PR TITLE
refactor: improve sanity check error message

### DIFF
--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -363,9 +363,7 @@ pub struct RowDeserializer {
 impl RowDeserializer {
     /// Creates a new `RowDeserializer` with row schema.
     pub fn new(data_types: Vec<DataType>) -> Self {
-        RowDeserializer {
-            data_types,
-        }
+        RowDeserializer { data_types }
     }
 
     /// Deserialize the row from value encoding bytes.

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -15,7 +15,6 @@
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::{cmp, ops};
 
-use bytes::Buf;
 use itertools::Itertools;
 
 use super::column::Column;
@@ -356,23 +355,30 @@ impl EstimateSize for Row {
 }
 
 /// Deserializer of the `Row`.
+#[derive(Clone, Debug)]
 pub struct RowDeserializer {
     data_types: Vec<DataType>,
 }
 
 impl RowDeserializer {
     /// Creates a new `RowDeserializer` with row schema.
-    pub fn new(schema: Vec<DataType>) -> Self {
-        RowDeserializer { data_types: schema }
+    pub fn new(data_types: Vec<DataType>) -> Self {
+        RowDeserializer {
+            data_types: data_types,
+        }
     }
 
     /// Deserialize the row from value encoding bytes.
-    pub fn deserialize(&self, mut data: impl Buf) -> value_encoding::Result<Row> {
+    pub fn deserialize(&self, mut data: impl bytes::Buf) -> value_encoding::Result<Row> {
         let mut values = Vec::with_capacity(self.data_types.len());
         for typ in &self.data_types {
             values.push(deserialize_datum(&mut data, typ)?);
         }
         Ok(Row(values))
+    }
+
+    pub fn data_types(&self) -> &[DataType] {
+        &self.data_types
     }
 }
 

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -364,7 +364,7 @@ impl RowDeserializer {
     /// Creates a new `RowDeserializer` with row schema.
     pub fn new(data_types: Vec<DataType>) -> Self {
         RowDeserializer {
-            data_types: data_types,
+            data_types,
         }
     }
 

--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -62,6 +62,7 @@ pub fn parse_raw_key_to_vnode_and_key(raw_key: &[u8]) -> (VirtualNode, &[u8]) {
 }
 
 /// used for batch table deserialize
+// TODO(eric): remove usages of this. Use `RowDeserializer` instead
 pub fn batch_deserialize(
     column_mapping: Arc<ColumnDescMapping>,
     value: impl AsRef<[u8]>,
@@ -75,8 +76,8 @@ pub fn batch_deserialize(
     Ok(Row(output_row))
 }
 
-/// used for streaming table deserialize
-pub fn streaming_deserialize(data_types: &[DataType], mut row: impl Buf) -> Result<Row> {
+// TODO(eric): remove me along with batch_deserialize
+fn streaming_deserialize(data_types: &[DataType], mut row: impl Buf) -> Result<Row> {
     // value encoding
     let mut values = Vec::with_capacity(data_types.len());
     for ty in data_types {

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -21,14 +21,12 @@ use itertools::Itertools;
 use risingwave_common::array::{DataChunk, Row};
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::Schema;
-use risingwave_common::types::{DataType, VirtualNode, VIRTUAL_NODE_COUNT};
+use risingwave_common::types::{VirtualNode, VIRTUAL_NODE_COUNT};
 use risingwave_common::util::hash_util::Crc32FastBuilder;
 
 use crate::error::StorageResult;
 /// For tables without distribution (singleton), the `DEFAULT_VNODE` is encoded.
 pub const DEFAULT_VNODE: VirtualNode = 0;
-
-type DataTypes = Arc<[DataType]>;
 
 /// Represents the distribution for a specific table instance.
 #[derive(Debug)]

--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -183,7 +183,11 @@ impl MemTable {
 }
 
 impl RowOp {
-    /// Print as debug string
+    /// Print as debug string with decoded data.
+    ///
+    /// # Panics
+    ///
+    /// The function will panic if it failed to decode the bytes with provided data types.
     pub fn debug_fmt(&self, data_types: &[DataType]) -> String {
         match self {
             Self::Insert(after) => {

--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -16,7 +16,7 @@ use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 
 use risingwave_common::array::RowDeserializer;
-use risingwave_common::types::DataType;
+
 use thiserror::Error;
 
 #[derive(Clone, Debug)]

--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -16,7 +16,6 @@ use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 
 use risingwave_common::array::RowDeserializer;
-
 use thiserror::Error;
 
 #[derive(Clone, Debug)]

--- a/src/storage/src/table/streaming_table/mem_table.rs
+++ b/src/storage/src/table/streaming_table/mem_table.rs
@@ -15,10 +15,9 @@ use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::ops::RangeBounds;
 
+use risingwave_common::array::RowDeserializer;
 use risingwave_common::types::DataType;
 use thiserror::Error;
-
-use crate::row_serde::row_serde_util::streaming_deserialize;
 
 #[derive(Clone, Debug)]
 pub enum RowOp {
@@ -188,19 +187,19 @@ impl RowOp {
     /// # Panics
     ///
     /// The function will panic if it failed to decode the bytes with provided data types.
-    pub fn debug_fmt(&self, data_types: &[DataType]) -> String {
+    pub fn debug_fmt(&self, row_deserializer: &RowDeserializer) -> String {
         match self {
             Self::Insert(after) => {
-                let after = streaming_deserialize(data_types, after.as_ref()).unwrap();
+                let after = row_deserializer.deserialize(after.as_ref());
                 format!("Insert({:?})", &after)
             }
             Self::Delete(before) => {
-                let before = streaming_deserialize(data_types, before.as_ref()).unwrap();
+                let before = row_deserializer.deserialize(before.as_ref());
                 format!("Delete({:?})", &before)
             }
             Self::Update((before, after)) => {
-                let before = streaming_deserialize(data_types, before.as_ref()).unwrap();
-                let after = streaming_deserialize(data_types, after.as_ref()).unwrap();
+                let after = row_deserializer.deserialize(after.as_ref());
+                let before = row_deserializer.deserialize(before.as_ref());
                 format!("Update({:?}, {:?})", &before, &after)
             }
         }

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -94,7 +94,7 @@ pub struct StateTable<S: StateStore> {
 
     /// an optional column index which is the vnode of each row computed by the table's consistent
     /// hash distribution
-    pub vnode_col_idx_in_pk: Option<usize>,
+    vnode_col_idx_in_pk: Option<usize>,
 
     value_indices: Vec<usize>,
 

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -20,7 +20,6 @@ use std::ops::RangeBounds;
 use std::sync::Arc;
 
 use async_stack_trace::StackTrace;
-use bytes::Bytes;
 use futures::{pin_mut, Stream, StreamExt};
 use futures_async_stream::try_stream;
 use itertools::{izip, Itertools};
@@ -45,7 +44,7 @@ use crate::row_serde::row_serde_util::{
 use crate::storage_value::StorageValue;
 use crate::store::{ReadOptions, WriteOptions};
 use crate::table::streaming_table::mem_table::MemTableError;
-use crate::table::{compute_chunk_vnode, compute_vnode, DataTypes, Distribution};
+use crate::table::{compute_chunk_vnode, compute_vnode, Distribution};
 use crate::{Keyspace, StateStore, StateStoreIter};
 
 /// `StateTable` is the interface accessing relational data in KV(`StateStore`) with
@@ -682,7 +681,7 @@ impl<S: StateStore> StateTable<S> {
             .get(key, false, self.get_read_option(epoch))
             .await?;
 
-        if stored_value.is_none() || stored_value.as_ref().unwrap() != &old_row {
+        if stored_value.is_none() || stored_value.as_ref().unwrap() != old_row {
             let (vnode, key) = deserialize_pk_with_vnode(key, &self.pk_deserializer).unwrap();
             let stored_row =
                 stored_value.map(|bytes| self.row_deserializer.deserialize(bytes).unwrap());
@@ -712,7 +711,7 @@ impl<S: StateStore> StateTable<S> {
             .get(key, false, self.get_read_option(epoch))
             .await?;
 
-        if stored_value.is_none() || stored_value.as_ref().unwrap() != &old_row {
+        if stored_value.is_none() || stored_value.as_ref().unwrap() != old_row {
             let (vnode, key) = deserialize_pk_with_vnode(key, &self.pk_deserializer).unwrap();
             let expected_row = self.row_deserializer.deserialize(old_row).unwrap();
             let stored_row =

--- a/src/storage/src/table/streaming_table/state_table.rs
+++ b/src/storage/src/table/streaming_table/state_table.rs
@@ -650,12 +650,9 @@ impl<S: StateStore> StateTable<S> {
             .get(key, false, self.get_read_option(epoch))
             .await?;
 
-        if stored_value.is_some() {
+        if let Some(stored_value) = stored_value {
             let (vnode, key) = deserialize_pk_with_vnode(key, &self.pk_deserializer).unwrap();
-            let in_storage = self
-                .row_deserializer
-                .deserialize(stored_value.unwrap())
-                .unwrap();
+            let in_storage = self.row_deserializer.deserialize(stored_value).unwrap();
             let to_write = self.row_deserializer.deserialize(value).unwrap();
             panic!(
                 "overwrites an existing key!\ntable_id: {}, vnode: {}, key: {:?}\nvalue in storage: {:?}\nvalue to write: {:?}",


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

1. Improved error messages of sanity check in StateTable #5524
2. By the way, refactored the StateTable to replace `streaming_deserialize()` to `RowDeserializer`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

Closes #5524