### PR TITLE
refactor: remove `batch_deserialize` in stata table

### DIFF
--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 
-use bytes::Buf;
+
+
 use memcomparable::from_slice;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;
-use risingwave_common::types::{DataType, VirtualNode, VIRTUAL_NODE_SIZE};
+use risingwave_common::types::{VirtualNode, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
-use risingwave_common::util::value_encoding::deserialize_datum;
+
 
 pub fn serialize_pk(pk: &Row, serializer: &OrderedRowSerializer) -> Vec<u8> {
     let mut result = vec![];

--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -23,8 +23,6 @@ use risingwave_common::types::{DataType, VirtualNode, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
 use risingwave_common::util::value_encoding::deserialize_datum;
 
-use super::ColumnDescMapping;
-
 pub fn serialize_pk(pk: &Row, serializer: &OrderedRowSerializer) -> Vec<u8> {
     let mut result = vec![];
     serializer.serialize(pk, &mut result);
@@ -59,30 +57,4 @@ pub fn parse_raw_key_to_vnode_and_key(raw_key: &[u8]) -> (VirtualNode, &[u8]) {
     let (vnode_bytes, key_bytes) = raw_key.split_at(VIRTUAL_NODE_SIZE);
     let vnode = VirtualNode::from_be_bytes(vnode_bytes.try_into().unwrap());
     (vnode, key_bytes)
-}
-
-/// used for batch table deserialize
-// TODO(eric): remove usages of this. Use `RowDeserializer` instead
-pub fn batch_deserialize(
-    column_mapping: Arc<ColumnDescMapping>,
-    value: impl AsRef<[u8]>,
-) -> Result<Row> {
-    let mut origin_row = streaming_deserialize(&column_mapping.all_data_types, value.as_ref())?;
-
-    let mut output_row = Vec::with_capacity(column_mapping.output_index.len());
-    for col_idx in &column_mapping.output_index {
-        output_row.push(origin_row.0[*col_idx].take());
-    }
-    Ok(Row(output_row))
-}
-
-// TODO(eric): remove me along with batch_deserialize
-fn streaming_deserialize(data_types: &[DataType], mut row: impl Buf) -> Result<Row> {
-    // value encoding
-    let mut values = Vec::with_capacity(data_types.len());
-    for ty in data_types {
-        values.push(deserialize_datum(&mut row, ty)?);
-    }
-
-    Ok(Row(values))
 }

--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -12,16 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
-
-
 use memcomparable::from_slice;
 use risingwave_common::array::Row;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;
 use risingwave_common::types::{VirtualNode, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::ordered::{OrderedRowDeserializer, OrderedRowSerializer};
-
 
 pub fn serialize_pk(pk: &Row, serializer: &OrderedRowSerializer) -> Vec<u8> {
     let mut result = vec![];

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -170,8 +170,11 @@ impl<S: StateStore> StorageTable<S> {
     ) -> Self {
         assert_eq!(order_types.len(), pk_indices.len());
 
-        // let mapping = ColumnMapping::new(&table_columns, &column_ids, &value_indices);
         let (output_columns, output_indices) = find_columns_by_ids(&table_columns, &column_ids);
+        assert!(
+            output_indices.iter().all(|i| value_indices.contains(i)),
+            "output_indices must be a subset of value_indices"
+        );
         let schema = Schema::new(output_columns.iter().map(Into::into).collect());
         let mapping = ColumnMapping::new(output_indices);
 

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -22,7 +22,7 @@ use futures::future::try_join_all;
 use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use risingwave_common::array::Row;
+use risingwave_common::array::{Row, RowDeserializer};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema, TableId, TableOption};
 use risingwave_common::error::RwError;
@@ -37,9 +37,9 @@ use super::iter_utils;
 use crate::error::{StorageError, StorageResult};
 use crate::keyspace::StripPrefixIterator;
 use crate::row_serde::row_serde_util::{
-    batch_deserialize, parse_raw_key_to_vnode_and_key, serialize_pk, serialize_pk_with_vnode,
+    parse_raw_key_to_vnode_and_key, serialize_pk, serialize_pk_with_vnode,
 };
-use crate::row_serde::ColumnDescMapping;
+use crate::row_serde::{find_columns_by_ids, ColumnMapping};
 use crate::store::ReadOptions;
 use crate::table::{compute_vnode, Distribution, TableIter};
 use crate::{Keyspace, StateStore, StateStoreIter};
@@ -58,8 +58,11 @@ pub struct StorageTable<S: StateStore> {
     /// Used for serializing the primary key.
     pk_serializer: OrderedRowSerializer,
 
-    /// Mapping from column id to column index. Used for deserializing the row.
-    mapping: Arc<ColumnDescMapping>,
+    /// Mapping from column id to column index for deserializing the row.
+    mapping: Arc<ColumnMapping>,
+
+    /// Row deserializer to deserialize the whole value in storage to a row.
+    row_deserializer: Arc<RowDeserializer>,
 
     /// Indices of primary key.
     /// Note that the index is based on the all columns of the table, instead of the output ones.
@@ -166,9 +169,16 @@ impl<S: StateStore> StorageTable<S> {
         value_indices: Vec<usize>,
     ) -> Self {
         assert_eq!(order_types.len(), pk_indices.len());
-        let mapping = ColumnDescMapping::new_partial(&table_columns, &column_ids, &value_indices);
-        let schema = Schema::new(mapping.output_columns.iter().map(Into::into).collect());
+
+        // let mapping = ColumnMapping::new(&table_columns, &column_ids, &value_indices);
+        let (output_columns, output_indices) = find_columns_by_ids(&table_columns, &column_ids);
+        let schema = Schema::new(output_columns.iter().map(Into::into).collect());
+        let mapping = ColumnMapping::new(value_indices);
+
         let pk_serializer = OrderedRowSerializer::new(order_types);
+
+        let all_data_types = table_columns.iter().map(|d| d.data_type.clone()).collect();
+        let row_deserializer = RowDeserializer::new(all_data_types);
 
         let dist_key_in_pk_indices = dist_key_indices
             .iter()
@@ -184,12 +194,14 @@ impl<S: StateStore> StorageTable<S> {
                     })
             })
             .collect_vec();
+
         let keyspace = Keyspace::table_root(store, &table_id);
         Self {
             keyspace,
             schema,
             pk_serializer,
-            mapping,
+            mapping: Arc::new(mapping),
+            row_deserializer: Arc::new(row_deserializer),
             pk_indices,
             dist_key_indices,
             dist_key_in_pk_indices,
@@ -247,8 +259,9 @@ impl<S: StateStore> StorageTable<S> {
             )
             .await?
         {
-            let deserialize_res = batch_deserialize(self.mapping.clone(), &value).map_err(err)?;
-            Ok(Some(deserialize_res))
+            let full_row = self.row_deserializer.deserialize(value).map_err(err)?;
+            let result_row = self.mapping.project(full_row);
+            Ok(Some(result_row))
         } else {
             Ok(None)
         }
@@ -323,6 +336,7 @@ impl<S: StateStore> StorageTable<S> {
                 let iter = StorageTableIterInner::<S>::new(
                     &self.keyspace,
                     self.mapping.clone(),
+                    self.row_deserializer.clone(),
                     prefix_hint,
                     raw_key_range,
                     read_options,
@@ -488,14 +502,17 @@ struct StorageTableIterInner<S: StateStore> {
     /// An iterator that returns raw bytes from storage.
     iter: StripPrefixIterator<S::Iter>,
 
-    mapping: Arc<ColumnDescMapping>,
+    mapping: Arc<ColumnMapping>,
+
+    row_deserializer: Arc<RowDeserializer>,
 }
 
 impl<S: StateStore> StorageTableIterInner<S> {
     /// If `wait_epoch` is true, it will wait for the given epoch to be committed before iteration.
     async fn new<R, B>(
         keyspace: &Keyspace<S>,
-        mapping: Arc<ColumnDescMapping>,
+        mapping: Arc<ColumnMapping>,
+        row_deserializer: Arc<RowDeserializer>,
         prefix_hint: Option<Vec<u8>>,
         raw_key_range: R,
         read_options: ReadOptions,
@@ -509,7 +526,11 @@ impl<S: StateStore> StorageTableIterInner<S> {
         let iter = keyspace
             .iter_with_range(prefix_hint, raw_key_range, read_options)
             .await?;
-        let iter = Self { iter, mapping };
+        let iter = Self {
+            iter,
+            mapping,
+            row_deserializer,
+        };
         Ok(iter)
     }
 
@@ -523,8 +544,8 @@ impl<S: StateStore> StorageTableIterInner<S> {
             .await?
         {
             let (_, key) = parse_raw_key_to_vnode_and_key(&raw_key);
-            let row = batch_deserialize(self.mapping.clone(), &value).map_err(err)?;
-
+            let full_row = self.row_deserializer.deserialize(value).map_err(err)?;
+            let row = self.mapping.project(full_row);
             yield (key.to_vec(), row)
         }
     }

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -173,7 +173,7 @@ impl<S: StateStore> StorageTable<S> {
         // let mapping = ColumnMapping::new(&table_columns, &column_ids, &value_indices);
         let (output_columns, output_indices) = find_columns_by_ids(&table_columns, &column_ids);
         let schema = Schema::new(output_columns.iter().map(Into::into).collect());
-        let mapping = ColumnMapping::new(value_indices);
+        let mapping = ColumnMapping::new(output_indices);
 
         let pk_serializer = OrderedRowSerializer::new(order_types);
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Move the logic of mapping columns to struct `ColumnMapping`
- Simplify `ColumnMapping` and move these `ColumnDesc` stuff to the outside.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

None