### PR TITLE
refactor(notification): introduce subscribe type and avoid passing addr and worker type

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -158,9 +158,17 @@ service ClusterService {
   rpc ListAllNodes(ListAllNodesRequest) returns (ListAllNodesResponse);
 }
 
+enum SubscribeType {
+  UNSPECIFIED = 0;
+  FRONTEND = 1;
+  COMPUTE_NODE = 2;
+  RISE_CTL = 3;
+  COMPACTOR = 4;
+}
+
 // Below for notification service.
 message SubscribeRequest {
-  common.WorkerType worker_type = 1;
+  SubscribeType subscribe_type = 1;
   common.HostAddress host = 2;
   uint32 worker_id = 3;
 }

--- a/src/compute/src/compute_observer/observer_manager.rs
+++ b/src/compute/src/compute_observer/observer_manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverNodeImpl;
+use risingwave_common_service::observer_manager::ObserverState;
 use risingwave_hummock_sdk::filter_key_extractor::{
     FilterKeyExtractorImpl, FilterKeyExtractorManagerRef,
 };
@@ -35,7 +35,7 @@ pub struct ComputeObserverNode {
     version: u64,
 }
 
-impl ObserverNodeImpl for ComputeObserverNode {
+impl ObserverState for ComputeObserverNode {
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/compute/src/compute_observer/observer_manager.rs
+++ b/src/compute/src/compute_observer/observer_manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverState;
+use risingwave_common_service::observer_manager::{ObserverState, SubscribeComputeNode};
 use risingwave_hummock_sdk::filter_key_extractor::{
     FilterKeyExtractorImpl, FilterKeyExtractorManagerRef,
 };
@@ -36,6 +36,8 @@ pub struct ComputeObserverNode {
 }
 
 impl ObserverState for ComputeObserverNode {
+    type SubscribeType = SubscribeComputeNode;
+
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/ctl/src/cmd_impl/hummock/observer.rs
+++ b/src/ctl/src/cmd_impl/hummock/observer.rs
@@ -27,7 +27,7 @@
 // limitations under the License.
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverNodeImpl;
+use risingwave_common_service::observer_manager::ObserverState;
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::meta::subscribe_response::Info;
 use risingwave_pb::meta::SubscribeResponse;
@@ -37,7 +37,7 @@ pub struct RiseCtlObserverNode {
     local_version_manager: LocalVersionManagerRef,
 }
 
-impl ObserverNodeImpl for RiseCtlObserverNode {
+impl ObserverState for RiseCtlObserverNode {
     fn handle_notification(&mut self, _resp: SubscribeResponse) {
         // We don't care about any update so far.
     }

--- a/src/ctl/src/cmd_impl/hummock/observer.rs
+++ b/src/ctl/src/cmd_impl/hummock/observer.rs
@@ -27,7 +27,7 @@
 // limitations under the License.
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverState;
+use risingwave_common_service::observer_manager::{ObserverState, SubscribeRiseCtl};
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::meta::subscribe_response::Info;
 use risingwave_pb::meta::SubscribeResponse;
@@ -38,6 +38,8 @@ pub struct RiseCtlObserverNode {
 }
 
 impl ObserverState for RiseCtlObserverNode {
+    type SubscribeType = SubscribeRiseCtl;
+
     fn handle_notification(&mut self, _resp: SubscribeResponse) {
         // We don't care about any update so far.
     }

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -20,7 +20,6 @@ use anyhow::{anyhow, bail, Result};
 use risingwave_common::config::StorageConfig;
 use risingwave_common_service::observer_manager::{ObserverManager, RpcNotificationClient};
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
-use risingwave_pb::common::WorkerType;
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
 use risingwave_storage::hummock::{HummockStorage, TieredCacheMetricsBuilder};
@@ -145,16 +144,9 @@ risectl requires a full persistent cluster to operate. Please make sure you're n
         &self,
         meta_client: MetaClient,
         hummock: MonitoredStateStore<HummockStorage>,
-    ) -> Result<ObserverManager<RpcNotificationClient>> {
+    ) -> Result<ObserverManager<RpcNotificationClient, RiseCtlObserverNode>> {
         let ctl_observer = RiseCtlObserverNode::new(hummock.local_version_manager());
-        let host_addr = meta_client.host_addr();
-        let observer_manager = ObserverManager::new(
-            meta_client,
-            host_addr,
-            Box::new(ctl_observer),
-            WorkerType::RiseCtl,
-        )
-        .await;
+        let observer_manager = ObserverManager::new(meta_client, ctl_observer).await;
         Ok(observer_manager)
     }
 

--- a/src/ctl/src/common/meta_service.rs
+++ b/src/ctl/src/common/meta_service.rs
@@ -53,14 +53,17 @@ risectl requires a full persistent cluster to operate. Please make sure you're n
 
     /// Create meta client from options, and register as rise-ctl worker
     pub async fn create_meta_client(&self) -> Result<MetaClient> {
-        let mut client = MetaClient::new(&self.meta_addr).await?;
+        let client = MetaClient::register_new(
+            &self.meta_addr,
+            WorkerType::RiseCtl,
+            &"127.0.0.1:2333".parse().unwrap(),
+            0,
+        )
+        .await?;
         // FIXME: don't use 127.0.0.1 for ctl
-        let worker_id = client
-            .register(WorkerType::RiseCtl, &"127.0.0.1:2333".parse().unwrap(), 0)
-            .await?;
+        let worker_id = client.worker_id();
         tracing::info!("registered as RiseCtl worker, worker_id = {}", worker_id);
         // TODO: remove worker node
-        client.set_worker_id(worker_id);
         Ok(client)
     }
 }

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -18,7 +18,7 @@ use parking_lot::RwLock;
 use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::util::compress::decompress_data;
-use risingwave_common_service::observer_manager::ObserverState;
+use risingwave_common_service::observer_manager::{ObserverState, SubscribeFrontend};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::SubscribeResponse;
@@ -40,6 +40,8 @@ pub(crate) struct FrontendObserverNode {
 }
 
 impl ObserverState for FrontendObserverNode {
+    type SubscribeType = SubscribeFrontend;
+
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -18,7 +18,7 @@ use parking_lot::RwLock;
 use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::util::compress::decompress_data;
-use risingwave_common_service::observer_manager::ObserverNodeImpl;
+use risingwave_common_service::observer_manager::ObserverState;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::SubscribeResponse;
@@ -39,7 +39,7 @@ pub(crate) struct FrontendObserverNode {
     hummock_snapshot_manager: HummockSnapshotManagerRef,
 }
 
-impl ObserverNodeImpl for FrontendObserverNode {
+impl ObserverState for FrontendObserverNode {
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/meta/src/manager/notification.rs
+++ b/src/meta/src/manager/notification.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use risingwave_pb::common::{WorkerNode, WorkerType};
 use risingwave_pb::hummock::CompactTask;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use risingwave_pb::meta::SubscribeResponse;
+use risingwave_pb::meta::{SubscribeResponse, SubscribeType};
 use tokio::sync::mpsc::{self, UnboundedSender};
 use tokio::sync::{oneshot, Mutex};
 use tonic::Status;
@@ -151,16 +151,16 @@ impl NotificationManager {
     /// Tell `NotificationManagerCore` to insert sender by `worker_type`.
     pub async fn insert_sender(
         &self,
-        worker_type: WorkerType,
+        subscribe_type: SubscribeType,
         worker_key: WorkerKey,
         sender: UnboundedSender<Notification>,
     ) {
         let mut core_guard = self.core.lock().await;
-        let senders = match worker_type {
-            WorkerType::Frontend => &mut core_guard.frontend_senders,
-            WorkerType::ComputeNode => &mut core_guard.compute_senders,
-            WorkerType::Compactor => &mut core_guard.compactor_senders,
-            WorkerType::RiseCtl => &mut core_guard.risectl_senders,
+        let senders = match subscribe_type {
+            SubscribeType::Frontend => &mut core_guard.frontend_senders,
+            SubscribeType::ComputeNode => &mut core_guard.compute_senders,
+            SubscribeType::Compactor => &mut core_guard.compactor_senders,
+            SubscribeType::RiseCtl => &mut core_guard.risectl_senders,
             _ => unreachable!(),
         };
 

--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -20,7 +20,7 @@ use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::notification_service_server::NotificationService;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use risingwave_pb::meta::{MetaSnapshot, SubscribeRequest, SubscribeResponse};
+use risingwave_pb::meta::{MetaSnapshot, SubscribeRequest, SubscribeResponse, SubscribeType};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::{Request, Response, Status};
@@ -74,8 +74,8 @@ where
         request: Request<SubscribeRequest>,
     ) -> Result<Response<Self::SubscribeStream>, Status> {
         let req = request.into_inner();
-        let worker_type = req.get_worker_type()?;
-        if worker_type == WorkerType::Frontend {
+        let subscribe_type = req.get_subscribe_type()?;
+        if subscribe_type == SubscribeType::Frontend {
             self.hummock_manager.pin_snapshot(req.worker_id).await?;
         }
         let host_address = req.get_host()?.clone();
@@ -95,7 +95,8 @@ where
 
         // We should only pin for workers to which we send a `meta_snapshot` that includes
         // `HummockVersion` below. As a result, these workers will eventually unpin.
-        if worker_type == WorkerType::ComputeNode || worker_type == WorkerType::RiseCtl {
+        if subscribe_type == SubscribeType::ComputeNode || subscribe_type == SubscribeType::RiseCtl
+        {
             self.hummock_manager
                 .pin_version(req.get_worker_id())
                 .await?;
@@ -106,8 +107,8 @@ where
         let cluster_guard = self.cluster_manager.get_cluster_core_guard().await;
         let nodes = cluster_guard.list_worker_node(WorkerType::ComputeNode, Some(Running));
 
-        match worker_type {
-            WorkerType::Compactor | WorkerType::ComputeNode => {
+        match subscribe_type {
+            SubscribeType::Compactor | SubscribeType::ComputeNode => {
                 tables.extend(creating_tables);
                 let all_table_set: HashSet<u32> = tables.iter().map(|table| table.id).collect();
                 // FIXME: since `SourceExecutor` doesn't have catalog yet, this is a workaround to
@@ -126,8 +127,8 @@ where
 
         // Send the snapshot on subscription. After that we will send only updates.
         // If we let `HummockVersion` be in `meta_snapshot`, we should call `pin_version` above.
-        let meta_snapshot = match worker_type {
-            WorkerType::Frontend => MetaSnapshot {
+        let meta_snapshot = match subscribe_type {
+            SubscribeType::Frontend => MetaSnapshot {
                 nodes,
                 databases,
                 schemas,
@@ -141,18 +142,18 @@ where
                 hummock_snapshot,
             },
 
-            WorkerType::Compactor => MetaSnapshot {
+            SubscribeType::Compactor => MetaSnapshot {
                 tables,
                 ..Default::default()
             },
 
-            WorkerType::ComputeNode => MetaSnapshot {
+            SubscribeType::ComputeNode => MetaSnapshot {
                 tables,
                 hummock_version: Some(hummock_manager_guard.current_version.clone()),
                 ..Default::default()
             },
 
-            WorkerType::RiseCtl => MetaSnapshot {
+            SubscribeType::RiseCtl => MetaSnapshot {
                 hummock_version: Some(hummock_manager_guard.current_version.clone()),
                 ..Default::default()
             },
@@ -170,7 +171,7 @@ where
 
         self.env
             .notification_manager()
-            .insert_sender(worker_type, WorkerKey(host_address), tx)
+            .insert_sender(subscribe_type, WorkerKey(host_address), tx)
             .await;
 
         Ok(Response::new(UnboundedReceiverStream::new(rx)))

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -82,12 +82,11 @@ impl MetaClient {
     /// Subscribe to notification from meta.
     pub async fn subscribe(
         &self,
-        addr: &HostAddr,
-        worker_type: WorkerType,
+        subscribe_type: SubscribeType,
     ) -> Result<Streaming<SubscribeResponse>> {
         let request = SubscribeRequest {
-            worker_type: worker_type as i32,
-            host: Some(addr.to_protobuf()),
+            subscribe_type: subscribe_type as i32,
+            host: Some(self.host_addr.to_protobuf()),
             worker_id: self.worker_id(),
         };
         self.inner.subscribe(request).await

--- a/src/storage/compactor/src/compactor_observer/observer_manager.rs
+++ b/src/storage/compactor/src/compactor_observer/observer_manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverNodeImpl;
+use risingwave_common_service::observer_manager::ObserverState;
 use risingwave_hummock_sdk::filter_key_extractor::{
     FilterKeyExtractorImpl, FilterKeyExtractorManagerRef,
 };
@@ -29,7 +29,7 @@ pub struct CompactorObserverNode {
     version: u64,
 }
 
-impl ObserverNodeImpl for CompactorObserverNode {
+impl ObserverState for CompactorObserverNode {
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/storage/compactor/src/compactor_observer/observer_manager.rs
+++ b/src/storage/compactor/src/compactor_observer/observer_manager.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use risingwave_common::error::{ErrorCode, Result};
-use risingwave_common_service::observer_manager::ObserverState;
+use risingwave_common_service::observer_manager::{ObserverState, SubscribeCompactor};
 use risingwave_hummock_sdk::filter_key_extractor::{
     FilterKeyExtractorImpl, FilterKeyExtractorManagerRef,
 };
@@ -30,6 +30,8 @@ pub struct CompactorObserverNode {
 }
 
 impl ObserverState for CompactorObserverNode {
+    type SubscribeType = SubscribeCompactor;
+
     fn handle_notification(&mut self, resp: SubscribeResponse) {
         let Some(info) = resp.info.as_ref() else {
             return;

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -55,12 +55,11 @@ pub async fn compactor_serve(
     );
 
     // Register to the cluster.
-    let mut meta_client = MetaClient::new(&opts.meta_address).await.unwrap();
-    let worker_id = meta_client
-        .register(WorkerType::Compactor, &client_addr, 0)
-        .await
-        .unwrap();
-    tracing::info!("Assigned compactor id {}", worker_id);
+    let meta_client =
+        MetaClient::register_new(&opts.meta_address, WorkerType::Compactor, &client_addr, 0)
+            .await
+            .unwrap();
+    tracing::info!("Assigned compactor id {}", meta_client.worker_id());
     meta_client.activate(&client_addr).await.unwrap();
 
     // Boot compactor
@@ -95,14 +94,7 @@ pub async fn compactor_serve(
 
     let filter_key_extractor_manager = Arc::new(FilterKeyExtractorManager::default());
     let compactor_observer_node = CompactorObserverNode::new(filter_key_extractor_manager.clone());
-    // todo use ObserverManager
-    let observer_manager = ObserverManager::new(
-        meta_client.clone(),
-        client_addr.clone(),
-        Box::new(compactor_observer_node),
-        WorkerType::Compactor,
-    )
-    .await;
+    let observer_manager = ObserverManager::new(meta_client.clone(), compactor_observer_node).await;
 
     let observer_join_handle = observer_manager.start().await.unwrap();
     let output_limit_mb = storage_config.compactor_memory_limit_mb as u64 / 2;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

In this PR, we do some simple refactor on the observer manager. Major changes are as followed:
- Combine the `new` and `register` of `MetaClient` into `register_new`. Our current usage of `new` and `register` are always associated together. Therefore, we can combine them together, and the returned client is always properly initialized.
- Introduce a separated `SubscribeType` enum proto to decouple worker type and the subscribed item. Currently both `ComputeNode` and `RiseCtl` only care about the changes of hummock, and for each of them we introduce a new `ObserverNode`, which is unnecessary. In future PR, we can combine the case of `ComputeNode` and `RiseCtl` into a new type named `Hummock`, and we start the observer of such type when we initialize hummock. In this way, we don't have to explicitly launch a standalone observer manager after we initialize hummock.
- For method `subscribe`, we only pass the `SubscribeType` instead of `host_addr` and `WorkerType`.
- We associate a `SubscribeType` to each `ObserverState`, and `ObserverManager` will take a generic `ObserverState` instead of `Box<dyn ...>`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
