### PR TITLE
refactor(meta): remove ddl lock for scaling

### DIFF
--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -33,7 +33,6 @@ use risingwave_pb::meta::stream_manager_service_server::StreamManagerServiceServ
 use risingwave_pb::meta::{MetaLeaderInfo, MetaLeaseInfo};
 use risingwave_pb::user::user_service_server::UserServiceServer;
 use tokio::sync::oneshot::Sender;
-use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 
 use super::intercept::MetricsMiddlewareLayer;
@@ -428,7 +427,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         hummock_manager.clone(),
         compactor_manager.clone(),
     ));
-    let ddl_lock = Arc::new(RwLock::new(()));
 
     let heartbeat_srv = HeartbeatServiceImpl::new(cluster_manager.clone());
     let ddl_srv = DdlServiceImpl::<S>::new(
@@ -439,7 +437,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         cluster_manager.clone(),
         fragment_manager.clone(),
         table_background_deleter,
-        ddl_lock.clone(),
     );
 
     let user_srv = UserServiceImpl::<S>::new(env.clone(), catalog_manager.clone());
@@ -451,7 +448,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         source_manager,
         catalog_manager.clone(),
         stream_manager.clone(),
-        ddl_lock,
     );
 
     let cluster_srv = ClusterServiceImpl::<S>::new(cluster_manager.clone());


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR removes the DDL lock from meta. This is introduced to avoid corrupting the running state when manually pausing or resuming the sources. As we support scaling now, the `pause` and `resume` will rarely be called by ourselves, so there's no need to have this. Besides, the naming of "ddl lock" gives a misconception of the DDL service body executing sequentially.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #3471