### PR TITLE
chore(logging): Do not enable DEBUG logs for aws s3 sdk

### DIFF
--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -94,6 +94,8 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
             .with_ansi(settings.colorful);
 
         let filter = filter::Targets::new()
+            // Only enable INFO for aws s3 sdk.
+            .with_target("aws_sdk_s3", Level::INFO)
             // Only enable WARN and ERROR for 3rd-party crates
             .with_target("aws_endpoint", Level::WARN)
             .with_target("hyper", Level::WARN)


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

DEBUG log is enabled for the storage crate and aws credential cache debug log entries will flood the log file in some cases. This PR turns off aws s3 sdk debug log by defaul.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
