### PR TITLE
feat: add pg_catalog.pg_index and support \di

### DIFF
--- a/e2e_test/batch/catalog/pg_class.slt.part
+++ b/e2e_test/batch/catalog/pg_class.slt.part
@@ -1,5 +1,5 @@
 query ITIIT
-SELECT oid,relname,relowner,relkind FROM pg_catalog.pg_class ORDER BY oid limit 6;
+SELECT oid,relname,relowner,relkind FROM pg_catalog.pg_class ORDER BY oid limit 7;
 ----
 1 pg_type 1 r
 2 pg_namespace 1 r
@@ -7,3 +7,4 @@ SELECT oid,relname,relowner,relkind FROM pg_catalog.pg_class ORDER BY oid limit 
 4 pg_matviews_info 1 r
 5 pg_user 1 r
 6 pg_class 1 r
+7 pg_index 1 r

--- a/src/frontend/src/catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/pg_catalog/mod.rs
@@ -302,7 +302,7 @@ impl SysCatalogReaderImpl {
                     Row::new(vec![
                         Some(ScalarImpl::Int32(index.id.index_id() as i32)),
                         Some(ScalarImpl::Int32(index.primary_table.id.table_id() as i32)),
-                        Some(ScalarImpl::Int32(index.index_item.len() as i32)),
+                        Some(ScalarImpl::Int16(index.index_item.len() as i16)),
                     ])
                 })
             })

--- a/src/frontend/src/catalog/pg_catalog/pg_index.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_index.rs
@@ -22,5 +22,5 @@ pub const PG_INDEX_TABLE_NAME: &str = "pg_index";
 pub const PG_INDEX_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "indexrelid"),
     (DataType::Int32, "indrelid"),
-    (DataType::Int32, "indnatts"),
+    (DataType::Int16, "indnatts"),
 ];

--- a/src/frontend/src/catalog/pg_catalog/pg_index.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_index.rs
@@ -1,0 +1,26 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::DataType;
+
+use crate::catalog::pg_catalog::PgCatalogColumnsDef;
+
+/// The catalog `pg_index` contains part of the information about indexes.
+/// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-class.html`]
+pub const PG_INDEX_TABLE_NAME: &str = "pg_index";
+pub const PG_INDEX_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
+    (DataType::Int32, "indexrelid"),
+    (DataType::Int32, "indrelid"),
+    (DataType::Int32, "indnatts"),
+];

--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -144,7 +144,9 @@ impl SchemaCatalog {
     pub fn iter_mv(&self) -> impl Iterator<Item = &TableCatalog> {
         self.table_by_name
             .iter()
-            .filter(|(_, v)| v.associated_source_id.is_none() && valid_table_name(&v.name))
+            .filter(|(_, v)| {
+                v.associated_source_id.is_none() && valid_table_name(&v.name) && !v.is_index
+            })
             .map(|(_, v)| v)
     }
 

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -230,7 +230,7 @@ impl LocalStreamManager {
             .complete_receiver
             .expect("no rx for local mode")
             .await
-            .unwrap();
+            .context("failed to collect barrier")?;
         complete_receiver
             .barrier_inflight_timer
             .expect("no timer for test")


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title, hidden indexes for `\d` and `\dm` and support `\di`.
```sql
dev=> create table t1 (v1 int, v2 int, v3 int);
CREATE_TABLE
dev=> create index idx2 on t1 (v1);
CREATE_INDEX
dev=> create materialized view mv1 as select * from t1;
CREATE_MATERIALIZED_VIEW
dev=> \d
             List of relations
 Schema | Name |       Type        | Owner
--------+------+-------------------+-------
 public | mv1  | materialized view | root
 public | t1   | table             | root
(2 rows)

dev=> \dm
             List of relations
 Schema | Name |       Type        | Owner
--------+------+-------------------+-------
 public | mv1  | materialized view | root
(1 row)

dev=> \di
           List of relations
 Schema | Name | Type  | Owner | Table
--------+------+-------+-------+-------
 public | idx2 | index | root  | t1
(1 row)

dev=> select * from pg_catalog.pg_index;
 indexrelid | indrelid | indnatts
------------+----------+----------
       1004 |     1002 |        2
(1 row)
```

Currently we only support three columns in `pg_indexes`:
|  name   |  type  | description | 
|  ----  | ----  | ---- |
| indexrelid  | int32 | The OID of the pg_class entry for this index |
| indrelid  | int32 | The OID of the pg_class entry for the table this index is for |
| indnatts  | int16 | The total number of columns in the index |

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

1. add system table: pg_catalog.pg_index.
2. fix psql commands `\d` and `\dm`, let them don't show indexes.
3. support psql command `\di` to show all indexes.

## Refer to a related PR or issue link (optional)
Resolve #5738 