### PR TITLE
refactor: Remove unnecessary to_secs method

### DIFF
--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -150,15 +150,11 @@ pub async fn handle_query(
 
     // update some metrics
     if query_mode == QueryMode::Local {
-        fn duration_to_seconds(d: Duration) -> f64 {
-            let nanos = f64::from(d.subsec_nanos()) / 1e9;
-            d.as_secs() as f64 + nanos
-        }
         session
             .env()
             .frontend_metrics
             .latency_local_execution
-            .observe(duration_to_seconds(query_start_time.elapsed()));
+            .observe(query_start_time.elapsed().as_secs_f64());
 
         session
             .env()


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Remove unnecessary to_secs method.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
