### PR TITLE
feat(source): improve impl of parsing list

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -45,6 +45,8 @@ cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- e2e test w/ Rust frontend - source with kafka"
+apt update
+apt install -y kafkacat
 cargo make clean-data
 cargo make ci-start ci-kafka
 ./scripts/source/prepare_ci_kafka.sh

--- a/e2e_test/source/kafka.slt
+++ b/e2e_test/source/kafka.slt
@@ -144,6 +144,7 @@ create materialized source s11 with (
   proto.message = 'test.User'
 ) row format protobuf message 'test.User' row schema location 'file:///risingwave/proto-complex-schema.proto'
 
+statement ok
 CREATE materialized SOURCE s12(
     id int,
     code string, 

--- a/e2e_test/source/kafka.slt
+++ b/e2e_test/source/kafka.slt
@@ -144,6 +144,18 @@ create materialized source s11 with (
   proto.message = 'test.User'
 ) row format protobuf message 'test.User' row schema location 'file:///risingwave/proto-complex-schema.proto'
 
+CREATE materialized SOURCE s12(
+    id int,
+    code string, 
+    timestamp bigint, 
+    xfas struct<device_model_id int, device_make_id int, ip string>[],
+    contacts struct<emails string[], phones string[]>)
+WITH (
+    connector = 'kafka',
+    topic = 'json_c',
+    properties.bootstrap.server = '127.0.0.1:29092',
+    scan.startup.mode = 'earliest')
+ROW format JSON;
 
 statement ok
 flush;
@@ -285,6 +297,11 @@ select id, code, timestamp, xfas, contacts from s11;
 ----
 0 abc 1473305798 {(0,200,127.0.0.1),(1,400,127.0.0.2)} ({1xxx,2xxx},{1xxx,2xxx})
 
+query ITITT
+select id, code, timestamp, xfas, contacts from s12;
+----
+100 abc 1473305798 {(0,200,10.0.0.1),(1,400,10.0.0.2)} ({1xxx,2xxx},{1xxx,2xxx})
+
 statement ok
 drop materialized view source_mv1
 
@@ -305,3 +322,6 @@ drop source s10
 
 statement ok
 drop source s11
+
+statement ok
+drop source s12

--- a/scripts/source/prepare_ci_kafka.sh
+++ b/scripts/source/prepare_ci_kafka.sh
@@ -3,9 +3,6 @@
 # Exits as soon as any line fails.
 set -e
 
-apt update
-apt install -y kafkacat
-
 SCRIPT_PATH="$(cd "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPT_PATH/.." || exit 1
 

--- a/scripts/source/test_data/json_c.1
+++ b/scripts/source/test_data/json_c.1
@@ -1,0 +1,1 @@
+{"id": 100, "code": "abc", "timestamp": 1473305798, "xfas": [{"device_model_id": 0, "device_make_id": 200, "ip": "10.0.0.1"}, {"device_model_id": 1, "device_make_id": 400, "ip": "10.0.0.2"}], "contacts": {"phones": ["1xxx", "2xxx"], "emails": ["1xxx", "2xxx"]}}

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -211,33 +211,6 @@ impl From<&ColumnDesc> for ProstColumnDesc {
     }
 }
 
-#[inline]
-pub fn dtype_to_column_desc(dtype: &DataType) -> ColumnDesc {
-    let fields_desc = if let DataType::Struct(fields) = dtype {
-        let mut field_descs = fields.fields.iter().map(dtype_to_column_desc).collect_vec();
-        if !fields.field_names.is_empty() {
-            field_descs = field_descs
-                .into_iter()
-                .zip_eq(fields.field_names.clone())
-                .map(|(mut desc, name)| {
-                    desc.name = name;
-                    desc
-                })
-                .collect_vec();
-        }
-        field_descs
-    } else {
-        Vec::new()
-    };
-    ColumnDesc {
-        name: String::new(),
-        data_type: dtype.clone(),
-        column_id: ColumnId(-1),
-        field_descs: fields_desc,
-        type_name: String::new(),
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     use risingwave_pb::plan_common::ColumnDesc as ProstColumnDesc;

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use parking_lot::{Mutex, MutexGuard};
-use risingwave_common::catalog::{dtype_to_column_desc, ColumnDesc, ColumnId, TableId};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId};
 use risingwave_common::ensure;
 use risingwave_common::error::ErrorCode::{ConnectorError, InternalError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
@@ -90,18 +90,6 @@ impl From<&ColumnDesc> for SourceColumnDesc {
     }
 }
 
-impl From<ColumnDesc> for SourceColumnDesc {
-    fn from(c: ColumnDesc) -> Self {
-        Self {
-            name: c.name,
-            data_type: c.data_type,
-            column_id: c.column_id,
-            fields: c.field_descs,
-            skip_parse: false,
-        }
-    }
-}
-
 impl From<&SourceColumnDesc> for ColumnDesc {
     fn from(s: &SourceColumnDesc) -> Self {
         ColumnDesc {
@@ -112,11 +100,6 @@ impl From<&SourceColumnDesc> for ColumnDesc {
             type_name: "".to_string(),
         }
     }
-}
-
-#[inline]
-pub fn dtype_to_source_column_desc(dtype: &DataType) -> SourceColumnDesc {
-    SourceColumnDesc::from(dtype_to_column_desc(dtype))
 }
 
 /// `SourceDesc` is used to describe a `Source`

--- a/src/source/src/parser/avro_parser.rs
+++ b/src/source/src/parser/avro_parser.rs
@@ -32,10 +32,7 @@ use risingwave_connector::aws_utils::{default_conn_config, s3_client, AwsConfigV
 use risingwave_pb::plan_common::ColumnDesc;
 use url::Url;
 
-use crate::{
-    dtype_to_source_column_desc, SourceColumnDesc, SourceParser, SourceStreamChunkRowWriter,
-    WriteGuard,
-};
+use crate::{SourceColumnDesc, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
 
 const AVRO_SCHEMA_LOCATION_S3_REGION: &str = "region";
 
@@ -86,14 +83,17 @@ impl AvroParser {
     }
 
     pub fn map_to_columns(&self) -> Result<Vec<ColumnDesc>> {
+        // there must be a record at top level
         if let Schema::Record { fields, .. } = &self.schema {
             let mut index = 0;
-            Ok(fields
+            let fields = fields
                 .iter()
                 .map(|field| {
                     Self::avro_field_to_column_desc(&field.name, &field.schema, &mut index)
                 })
-                .collect::<Result<Vec<_>>>()?)
+                .collect::<Result<Vec<_>>>()?;
+            tracing::info!("fields is {:?}", fields);
+            Ok(fields)
         } else {
             Err(RwError::from(InternalError(
                 "schema invalid, record required".into(),
@@ -107,32 +107,45 @@ impl AvroParser {
         index: &mut i32,
     ) -> Result<ColumnDesc> {
         let data_type = Self::avro_type_mapping(schema)?;
-        if let Schema::Record {
-            name: schema_name,
-            fields,
-            ..
-        } = schema
-        {
-            let vec_column = fields
-                .iter()
-                .map(|f| Self::avro_field_to_column_desc(&f.name, &f.schema, index))
-                .collect::<Result<Vec<_>>>()?;
-            *index += 1;
-            Ok(ColumnDesc {
-                column_type: Some(data_type.to_protobuf()),
-                column_id: *index,
-                name: name.to_owned(),
-                field_descs: vec_column,
-                type_name: schema_name.to_string(),
-            })
-        } else {
-            *index += 1;
-            Ok(ColumnDesc {
-                column_type: Some(data_type.to_protobuf()),
-                column_id: *index,
-                name: name.to_owned(),
-                ..Default::default()
-            })
+        match schema {
+            Schema::Record {
+                name: schema_name,
+                fields,
+                ..
+            } => {
+                let vec_column = fields
+                    .iter()
+                    .map(|f| Self::avro_field_to_column_desc(&f.name, &f.schema, index))
+                    .collect::<Result<Vec<_>>>()?;
+                *index += 1;
+                Ok(ColumnDesc {
+                    column_type: Some(data_type.to_protobuf()),
+                    column_id: *index,
+                    name: name.to_owned(),
+                    field_descs: vec_column,
+                    type_name: schema_name.to_string(),
+                })
+            }
+            Schema::Array(item_schema) => {
+                let item_desc = Self::avro_field_to_column_desc(name, item_schema, index)?;
+                *index += 1;
+                Ok(ColumnDesc {
+                    column_type: Some(data_type.to_protobuf()),
+                    column_id: *index,
+                    name: name.to_owned(),
+                    field_descs: vec![item_desc],
+                    ..Default::default()
+                })
+            }
+            _ => {
+                *index += 1;
+                Ok(ColumnDesc {
+                    column_type: Some(data_type.to_protobuf()),
+                    column_id: *index,
+                    name: name.to_owned(),
+                    ..Default::default()
+                })
+            }
         }
     }
 
@@ -203,6 +216,7 @@ macro_rules! from_avro_primitive {
         }
     };
 }
+
 /// Convert Avro value to datum.For now, support the following [Avro type](https://avro.apache.org/docs/current/spec.html).
 ///  - boolean
 ///  - int : i32
@@ -212,8 +226,9 @@ macro_rules! from_avro_primitive {
 ///  - string: String
 ///  - Date (the number of days from the unix epoch, 1970-1-1 UTC)
 ///  - Timestamp (the number of milliseconds from the unix epoch,  1970-1-1 00:00:00.000 UTC)
-pub(crate) fn from_avro_value(column: &SourceColumnDesc, field_value: Value) -> Result<ScalarImpl> {
-    match &column.data_type {
+#[inline]
+fn parse_avro_value(dtype: &DataType, field_value: Value) -> Result<ScalarImpl> {
+    match dtype {
         DataType::Boolean => {
             from_avro_primitive!(field_value, Boolean, |b: bool| Ok(ScalarImpl::Bool(b)))
         }
@@ -266,57 +281,61 @@ pub(crate) fn from_avro_value(column: &SourceColumnDesc, field_value: Value) -> 
                 ScalarImpl::NaiveDateTime
             )
         }
-        DataType::Struct(_) => {
-            if let Value::Record(fields) = field_value {
-                let field_values = column
-                    .fields
+        DataType::Struct(struct_type_info) => {
+            if let Value::Record(field_values) = field_value {
+                let field_values = struct_type_info
+                    .field_names
                     .iter()
+                    .zip_eq(struct_type_info.fields.iter())
                     .map(|field_desc| {
-                        let tuple = fields
+                        let tuple = field_values
                             .iter()
-                            .find(|&val| field_desc.name.eq(&val.0))
+                            .find(|&val| field_desc.0.eq(&val.0))
                             .unwrap();
-                        from_avro_value(&field_desc.into(), tuple.1.clone()).ok()
+                        parse_avro_value(field_desc.1, tuple.1.clone()).ok()
                     })
                     .collect();
                 Ok(ScalarImpl::Struct(StructValue::new(field_values)))
             } else {
                 let err_msg = format!(
-                    "avro parse struct but fields values are empty, column_desc {:?}",
-                    column
+                    "avro parse error.type incompatible, dtype {:?}, value {:?}",
+                    dtype, field_value
                 );
-                tracing::debug!(err_msg);
-                Err(ErrorCode::ProtocolError(err_msg).into())
+                tracing::error!(err_msg);
+                Err(RwError::from(InternalError(err_msg)))
             }
         }
         DataType::List {
             datatype: item_type,
         } => {
             if let Value::Array(array_values) = field_value {
-                let item_schema = dtype_to_source_column_desc(item_type);
                 let values = array_values
                     .into_iter()
-                    .map(|v| from_avro_value(&item_schema, v).ok())
-                    .collect();
+                    .map(|value| parse_avro_value(item_type, value).ok())
+                    .collect_vec();
                 Ok(ScalarImpl::List(ListValue::new(values)))
             } else {
                 let err_msg = format!(
-                    "avro parse list but fields values are empty, column_desc {:?}",
-                    column
+                    "avro parse error.type incompatible, dtype {:?}, value {:?}",
+                    dtype, field_value
                 );
-                tracing::debug!(err_msg);
-                Err(ErrorCode::ProtocolError(err_msg).into())
+                tracing::error!(err_msg);
+                Err(RwError::from(InternalError(err_msg)))
             }
         }
         _ => {
             let err_msg = format!(
-                "unsupported type {} for avro parser, column_desc {:?}, value {:?}",
-                column.data_type, column, field_value
+                "unsupported type {} for avro parser, value {:?}",
+                dtype, field_value
             );
-            tracing::debug!(err_msg);
+            tracing::error!(err_msg);
             Err(ErrorCode::NotImplemented(err_msg, None.into()).into())
         }
     }
+}
+
+fn from_avro_value(column: &SourceColumnDesc, field_value: Value) -> Result<ScalarImpl> {
+    parse_avro_value(&column.data_type, field_value)
 }
 
 impl SourceParser for AvroParser {

--- a/src/source/src/parser/debezium/json.rs
+++ b/src/source/src/parser/debezium/json.rs
@@ -69,8 +69,8 @@ impl SourceParser for DebeziumJsonParser {
                 })?;
 
                 writer.update(|column| {
-                    let before = json_parse_value(&column.into(), before.get(&column.name))?;
-                    let after = json_parse_value(&column.into(), after.get(&column.name))?;
+                    let before = json_parse_value(&column.data_type, before.get(&column.name))?;
+                    let after = json_parse_value(&column.data_type, after.get(&column.name))?;
 
                     Ok((before, after))
                 })
@@ -83,7 +83,7 @@ impl SourceParser for DebeziumJsonParser {
                 })?;
 
                 writer.insert(|column| {
-                    json_parse_value(&column.into(), after.get(&column.name)).map_err(Into::into)
+                    json_parse_value(&column.data_type, after.get(&column.name)).map_err(Into::into)
                 })
             }
             DEBEZIUM_DELETE_OP => {
@@ -94,7 +94,8 @@ impl SourceParser for DebeziumJsonParser {
                 })?;
 
                 writer.delete(|column| {
-                    json_parse_value(&column.into(), before.get(&column.name)).map_err(Into::into)
+                    json_parse_value(&column.data_type, before.get(&column.name))
+                        .map_err(Into::into)
                 })
             }
             _ => Err(RwError::from(ProtocolError(format!(

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -36,7 +36,7 @@ impl SourceParser for JsonParser {
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
         writer.insert(|desc| {
-            json_parse_value(&desc.into(), value.get(&desc.name)).map_err(|e| {
+            json_parse_value(&desc.data_type, value.get(&desc.name)).map_err(|e| {
                 tracing::error!(
                     "failed to process value ({}): {}",
                     String::from_utf8_lossy(payload),
@@ -64,7 +64,7 @@ impl SourceParser for JsonParser {
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
         writer.insert(|desc| {
-            simd_json_parse_value(&desc.into(), value.get(desc.name.as_str())).map_err(|e| {
+            simd_json_parse_value(&desc.data_type, value.get(desc.name.as_str())).map_err(|e| {
                 tracing::error!(
                     "failed to process value ({}): {}",
                     String::from_utf8_lossy(payload),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Reduce overhead of conversions bewteen ColumnDescs
- Support parsing list value in json parser
- move installation of kafkacat to `ci/scripts/e2e-source-test.sh` so that developers could still use `scripts/source/prepare_ci_kafka.sh` to load data locally.

## Checklist

~- [] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- Connector (sources & sinks)

### Release note
Support parsing list value in json parser, user can create a materialized source as follow:
```SQL
CREATE materialized SOURCE js(
    id int,
    code string, 
    timestamp bigint, 
    xfas struct<device_model_id int, device_make_id int, ip string>[],
    contacts struct<emails string[], phones string[]>)
WITH (
    connector = 'kafka',
    topic = 'json_c',
    properties.bootstrap.server = '127.0.0.1:29092',
    scan.startup.mode = 'earliest')
ROW format JSON;
```


## Refer to a related PR or issue link (optional)
#5776 