### PR TITLE
chore: remove Arc from Registry

### DIFF
--- a/src/common/common_service/src/metrics_manager.rs
+++ b/src/common/common_service/src/metrics_manager.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use hyper::{Body, Request, Response};
 use prometheus::{Encoder, Registry, TextEncoder};
@@ -25,7 +24,7 @@ use tracing::info;
 pub struct MetricsManager {}
 
 impl MetricsManager {
-    pub fn boot_metrics_service(listen_addr: String, registry: Arc<Registry>) {
+    pub fn boot_metrics_service(listen_addr: String, registry: Registry) {
         tokio::spawn(async move {
             info!(
                 "Prometheus listener for Prometheus is set up on http://{}",
@@ -44,7 +43,7 @@ impl MetricsManager {
 
     #[expect(clippy::unused_async, reason = "required by service_fn")]
     async fn metrics_service(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
-        let registry = req.extensions().get::<Arc<Registry>>().unwrap();
+        let registry = req.extensions().get::<Registry>().unwrap();
         let encoder = TextEncoder::new();
         let mut buffer = vec![];
         let mf = registry.gather();

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -272,7 +272,7 @@ pub async fn compute_node_serve(
     if opts.metrics_level > 0 {
         MetricsManager::boot_metrics_service(
             opts.prometheus_listener_addr.clone(),
-            Arc::new(registry.clone()),
+            registry.clone(),
         );
     }
 

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -330,10 +330,7 @@ impl FrontendEnv {
         let frontend_metrics = Arc::new(FrontendMetrics::new(registry.clone()));
 
         if opts.metrics_level > 0 {
-            MetricsManager::boot_metrics_service(
-                opts.prometheus_listener_addr.clone(),
-                Arc::new(registry),
-            );
+            MetricsManager::boot_metrics_service(opts.prometheus_listener_addr.clone(), registry);
         }
 
         Ok((

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -465,7 +465,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
     if let Some(prometheus_addr) = address_info.prometheus_addr {
         MetricsManager::boot_metrics_service(
             prometheus_addr.to_string(),
-            Arc::new(meta_metrics.registry().clone()),
+            meta_metrics.registry().clone(),
         )
     }
 

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -173,7 +173,7 @@ pub async fn compactor_serve(
     if opts.metrics_level > 0 {
         MetricsManager::boot_metrics_service(
             opts.prometheus_listener_addr.clone(),
-            Arc::new(registry.clone()),
+            registry.clone(),
         );
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`prometheus::Registry` is clonable, so there's no need to wrap it with an `Arc`.

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
