### PR TITLE
refactor(storage): remove uploader directly dependency of new state store

### DIFF
--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -21,8 +21,9 @@ use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_pb::hummock::SstableInfo;
 use risingwave_storage::hummock::iterator::test_utils::iterator_test_key_of_epoch;
 use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
+use risingwave_storage::hummock::store::memtable::ImmutableMemtable;
 use risingwave_storage::hummock::store::version::{
-    HummockReadVersion, ImmutableMemtable, StagingData, StagingSstableInfo, VersionUpdate,
+    HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate,
 };
 use risingwave_storage::hummock::test_utils::{default_config_for_test, gen_dummy_batch};
 

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -58,12 +58,8 @@ async fn test_storage_basic() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new_with_read_version(
-            uploader.clone(),
-            event_rx,
-            Some(read_version.clone()),
-        )
-        .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
+            .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -21,7 +21,6 @@ use risingwave_hummock_sdk::HummockSstableId;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_pb::hummock::pin_version_response::Payload;
 use risingwave_pb::hummock::HummockVersion;
-use risingwave_storage::hummock::local_version::local_version_manager::LocalVersionManager;
 use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use risingwave_storage::hummock::shared_buffer::UncommittedData;
 use risingwave_storage::hummock::test_utils::{
@@ -66,10 +65,7 @@ async fn test_update_pinned_version() {
         assert_eq!(
             local_version.get_shared_buffer(epochs[i]).unwrap().size(),
             SharedBufferBatch::measure_batch_size(
-                &LocalVersionManager::build_shared_buffer_item_batches(
-                    batches[i].clone(),
-                    epochs[i]
-                )
+                &SharedBufferBatch::build_shared_buffer_item_batches(batches[i].clone(), epochs[i])
             )
         );
     }
@@ -88,7 +84,7 @@ async fn test_update_pinned_version() {
 
     let build_batch = |pairs, epoch| {
         SharedBufferBatch::for_test(
-            LocalVersionManager::build_shared_buffer_item_batches(pairs, epoch),
+            SharedBufferBatch::build_shared_buffer_item_batches(pairs, epoch),
             epoch,
             StaticCompactionGroupId::StateDefault.into(),
             TableId::from(0),
@@ -155,7 +151,7 @@ async fn test_update_pinned_version() {
     assert_eq!(
         local_version.get_shared_buffer(epochs[1]).unwrap().size(),
         SharedBufferBatch::measure_batch_size(
-            &LocalVersionManager::build_shared_buffer_item_batches(batches[1].clone(), epochs[1])
+            &SharedBufferBatch::build_shared_buffer_item_batches(batches[1].clone(), epochs[1])
         )
     );
 
@@ -226,7 +222,7 @@ async fn test_update_uncommitted_ssts() {
             .unwrap();
         let local_version = local_version_manager.get_local_version();
         let batch = SharedBufferBatch::for_test(
-            LocalVersionManager::build_shared_buffer_item_batches(kvs[i].clone(), epochs[i]),
+            SharedBufferBatch::build_shared_buffer_item_batches(kvs[i].clone(), epochs[i]),
             epochs[i],
             StaticCompactionGroupId::StateDefault.into(),
             Default::default(),
@@ -418,10 +414,7 @@ async fn test_clear_shared_buffer() {
         assert_eq!(
             local_version.get_shared_buffer(epochs[i]).unwrap().size(),
             SharedBufferBatch::measure_batch_size(
-                &LocalVersionManager::build_shared_buffer_item_batches(
-                    batches[i].clone(),
-                    epochs[i]
-                )
+                &SharedBufferBatch::build_shared_buffer_item_batches(batches[i].clone(), epochs[i])
             )
         );
     }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -330,7 +330,7 @@ impl HummockEventHandler {
                         // TODO update the ReadVersion
                     }
 
-                    HummockEvent::SendToUploader(imm) => {
+                    HummockEvent::ImmToUploader(imm) => {
                         self.local_version_manager.write_shared_buffer_batch(imm);
                     }
                 },

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -88,21 +88,14 @@ pub struct HummockEventHandler {
     pending_sync_requests: HashMap<HummockEpoch, oneshot::Sender<HummockResult<SyncResult>>>,
 
     // TODO: replace it with hashmap<id, read_version>
-    _read_version: Option<Arc<RwLock<HummockReadVersion>>>,
+    _read_version: Arc<RwLock<HummockReadVersion>>,
 }
 
 impl HummockEventHandler {
     pub fn new(
         local_version_manager: Arc<LocalVersionManager>,
         shared_buffer_event_receiver: mpsc::UnboundedReceiver<HummockEvent>,
-    ) -> Self {
-        Self::new_with_read_version(local_version_manager, shared_buffer_event_receiver, None)
-    }
-
-    pub fn new_with_read_version(
-        local_version_manager: Arc<LocalVersionManager>,
-        shared_buffer_event_receiver: mpsc::UnboundedReceiver<HummockEvent>,
-        read_version: Option<Arc<RwLock<HummockReadVersion>>>,
+        read_version: Arc<RwLock<HummockReadVersion>>,
     ) -> Self {
         Self {
             buffer_tracker: local_version_manager.buffer_tracker().clone(),

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -17,6 +17,7 @@ use risingwave_pb::hummock::pin_version_response;
 use tokio::sync::oneshot;
 
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
+use crate::hummock::store::memtable::ImmutableMemtable;
 use crate::hummock::HummockResult;
 use crate::store::SyncResult;
 
@@ -50,5 +51,5 @@ pub enum HummockEvent {
 
     VersionUpdate(pin_version_response::Payload),
 
-    SendToUploader(SharedBufferBatch),
+    ImmToUploader(ImmutableMemtable),
 }

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -49,4 +49,6 @@ pub enum HummockEvent {
     Shutdown,
 
     VersionUpdate(pin_version_response::Payload),
+
+    SendToUploader(SharedBufferBatch),
 }

--- a/src/storage/src/hummock/local_version/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version/local_version_manager.rs
@@ -17,14 +17,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use itertools::Itertools;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use risingwave_common::catalog::TableId;
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 #[cfg(any(test, feature = "test"))]
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
-use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockReadEpoch};
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::hummock::pin_version_response::Payload;
@@ -39,7 +37,7 @@ use crate::hummock::conflict_detector::ConflictDetector;
 use crate::hummock::event_handler::{BufferTracker, HummockEvent};
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::{LocalVersion, ReadVersion};
-use crate::hummock::shared_buffer::shared_buffer_batch::{SharedBufferBatch, SharedBufferItem};
+use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use crate::hummock::shared_buffer::shared_buffer_uploader::{
     SharedBufferUploader, UploadTaskPayload,
 };
@@ -48,8 +46,8 @@ use crate::hummock::shared_buffer::OrderIndex;
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::utils::validate_table_key_range;
 use crate::hummock::{
-    HummockEpoch, HummockError, HummockResult, HummockVersionId, SstableIdManagerRef, TrackerId,
-    INVALID_VERSION_ID,
+    HummockEpoch, HummockError, HummockResult, HummockVersionId, MemoryLimiter,
+    SstableIdManagerRef, TrackerId, INVALID_VERSION_ID,
 };
 #[cfg(any(test, feature = "test"))]
 use crate::monitor::StateStoreMetrics;
@@ -83,6 +81,7 @@ impl LocalVersionManager {
         sstable_id_manager: SstableIdManagerRef,
         shared_buffer_uploader: Arc<SharedBufferUploader>,
         event_sender: UnboundedSender<HummockEvent>,
+        memory_limiter: Arc<MemoryLimiter>,
     ) -> Arc<Self> {
         let (version_update_notifier_tx, _) = tokio::sync::watch::channel(INVALID_VERSION_ID);
 
@@ -92,7 +91,8 @@ impl LocalVersionManager {
             // 0.8 * capacity
             // TODO: enable setting the ratio with config
             capacity * 4 / 5,
-            capacity,
+            // capacity,
+            memory_limiter,
             event_sender,
         );
 
@@ -134,6 +134,7 @@ impl LocalVersionManager {
                 Arc::new(FilterKeyExtractorManager::default()),
             )),
             event_sender,
+            MemoryLimiter::unlimit(),
         )
     }
 
@@ -262,39 +263,6 @@ impl LocalVersionManager {
         }
     }
 
-    pub fn build_shared_buffer_item_batches(
-        kv_pairs: Vec<(Bytes, StorageValue)>,
-        epoch: HummockEpoch,
-    ) -> Vec<SharedBufferItem> {
-        kv_pairs
-            .into_iter()
-            .map(|(key, value)| {
-                (
-                    Bytes::from(FullKey::from_user_key(key.to_vec(), epoch).into_inner()),
-                    value.into(),
-                )
-            })
-            .collect_vec()
-    }
-
-    pub async fn build_shared_buffer_batch(
-        &self,
-        epoch: HummockEpoch,
-        compaction_group_id: CompactionGroupId,
-        kv_pairs: Vec<(Bytes, StorageValue)>,
-        table_id: TableId,
-    ) -> SharedBufferBatch {
-        let sorted_items = Self::build_shared_buffer_item_batches(kv_pairs, epoch);
-        SharedBufferBatch::build(
-            sorted_items,
-            epoch,
-            Some(self.buffer_tracker.get_memory_limiter().as_ref()),
-            compaction_group_id,
-            table_id,
-        )
-        .await
-    }
-
     pub fn write_shared_buffer_batch(&self, batch: SharedBufferBatch) {
         self.write_shared_buffer_inner(batch.epoch(), batch);
         if self.buffer_tracker.need_more_flush() {
@@ -309,9 +277,14 @@ impl LocalVersionManager {
         kv_pairs: Vec<(Bytes, StorageValue)>,
         table_id: TableId,
     ) -> HummockResult<usize> {
-        let batch = self
-            .build_shared_buffer_batch(epoch, compaction_group_id, kv_pairs, table_id)
-            .await;
+        let batch = SharedBufferBatch::build_shared_buffer_batch(
+            epoch,
+            compaction_group_id,
+            kv_pairs,
+            table_id,
+            Some(self.buffer_tracker.get_memory_limiter().as_ref()),
+        )
+        .await;
         let batch_size = batch.size();
         self.write_shared_buffer_inner(batch.epoch(), batch);
         Ok(batch_size)

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -204,6 +204,9 @@ impl HummockStorage {
             filter_key_extractor_manager.clone(),
         ));
 
+        let memory_limiter_quota = (options.shared_buffer_capacity_mb as usize) * (1 << 20);
+        let memory_limiter = Arc::new(MemoryLimiter::new(memory_limiter_quota as u64));
+
         let local_version_manager = LocalVersionManager::new(
             options.clone(),
             pinned_version,
@@ -211,6 +214,7 @@ impl HummockStorage {
             sstable_id_manager.clone(),
             shared_buffer_uploader,
             event_tx.clone(),
+            memory_limiter,
         );
 
         let hummock_event_handler =

--- a/src/storage/src/hummock/store/memtable.rs
+++ b/src/storage/src/hummock/store/memtable.rs
@@ -17,6 +17,13 @@ use std::ops::RangeBounds;
 
 use bytes::Bytes;
 
+use crate::hummock::shared_buffer::shared_buffer_batch::{SharedBufferBatch, SharedBufferBatchId};
+
+// TODO: refine to use use a custom data structure Memtable
+pub type ImmutableMemtable = SharedBufferBatch;
+
+pub type ImmId = SharedBufferBatchId;
+
 macro_rules! memtable_impl_method_body {
     ($memtable:expr, $method_name:ident, $($args:expr),+) => {
         {

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -32,7 +32,8 @@ use risingwave_pb::hummock::LevelType;
 use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::mpsc;
 
-use super::version::{HummockReadVersion, ImmutableMemtable, StagingData, VersionUpdate};
+use super::memtable::ImmutableMemtable;
+use super::version::{HummockReadVersion, StagingData, VersionUpdate};
 use super::{
     GetFutureTrait, IngestKVBatchFutureTrait, IterFutureTrait, ReadOptions, StateStore,
     WriteOptions,
@@ -534,7 +535,7 @@ impl StateStore for HummockStorage {
             // insert imm to uploader
             self.core
                 .event_sender
-                .send(HummockEvent::SendToUploader(imm))
+                .send(HummockEvent::ImmToUploader(imm))
                 .unwrap();
             Ok(imm_size)
         }

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -514,7 +514,6 @@ impl StateStore for HummockStorage {
         async move {
             let epoch = write_options.epoch;
             let table_id = write_options.table_id;
-            // let uploader = self.core.uploader.clone();
             let compaction_group_id = self
                 .core
                 .get_compaction_group_id(write_options.table_id)

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -30,6 +30,7 @@ use risingwave_hummock_sdk::key::{key_with_epoch, user_key};
 use risingwave_hummock_sdk::{can_concat, CompactionGroupId};
 use risingwave_pb::hummock::LevelType;
 use risingwave_rpc_client::HummockMetaClient;
+use tokio::sync::mpsc;
 
 use super::version::{HummockReadVersion, ImmutableMemtable, StagingData, VersionUpdate};
 use super::{
@@ -38,23 +39,23 @@ use super::{
 };
 use crate::error::StorageResult;
 use crate::hummock::compaction_group_client::CompactionGroupClientImpl;
+use crate::hummock::event_handler::HummockEvent;
 use crate::hummock::iterator::{
     ConcatIterator, ConcatIteratorInner, Forward, HummockIteratorUnion, OrderedMergeIteratorInner,
     UnorderedMergeIteratorInner, UserIterator,
 };
-use crate::hummock::local_version::local_version_manager::LocalVersionManagerRef;
-use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatchIterator;
+use crate::hummock::shared_buffer::shared_buffer_batch::{
+    SharedBufferBatch, SharedBufferBatchIterator,
+};
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::SstableStoreRef;
-use crate::hummock::{
-    get_from_batch, get_from_sstable_info, SstableIdManager, SstableIdManagerRef,
-};
-use crate::storage_value::StorageValue;
-
-pub type UploaderRef = LocalVersionManagerRef;
 use crate::hummock::utils::{prune_ssts, search_sst_idx};
-use crate::hummock::{hit_sstable_bloom_filter, HummockResult, SstableIterator};
+use crate::hummock::{
+    get_from_batch, get_from_sstable_info, hit_sstable_bloom_filter, HummockResult, MemoryLimiter,
+    SstableIdManager, SstableIdManagerRef, SstableIterator,
+};
 use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
+use crate::storage_value::StorageValue;
 use crate::{define_local_state_store_associated_type, StateStoreIter};
 
 #[expect(dead_code)]
@@ -63,13 +64,10 @@ pub struct HummockStorageCore {
     // memtable: Memtable,
 
     /// Read handle.
-    read_version: RwLock<HummockReadVersion>,
+    read_version: Arc<RwLock<HummockReadVersion>>,
 
     /// Event sender.
-    // event_sender: mpsc::UnboundedSender<HummockEvent>,
-
-    // TODO: use a dedicated uploader implementation to replace `LocalVersionManager`
-    uploader: UploaderRef,
+    event_sender: mpsc::UnboundedSender<HummockEvent>,
 
     hummock_meta_client: Arc<dyn HummockMetaClient>,
 
@@ -86,6 +84,8 @@ pub struct HummockStorageCore {
 
     #[cfg(not(madsim))]
     tracing: Arc<risingwave_tracing::RwTracingService>,
+
+    memory_limiter: Arc<MemoryLimiter>,
 }
 
 #[derive(Clone)]
@@ -99,7 +99,8 @@ impl HummockStorageCore {
         options: Arc<StorageConfig>,
         sstable_store: SstableStoreRef,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
-        uploader: UploaderRef,
+        read_version: Arc<RwLock<HummockReadVersion>>,
+        event_sender: mpsc::UnboundedSender<HummockEvent>,
     ) -> HummockResult<Self> {
         use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 
@@ -113,10 +114,13 @@ impl HummockStorageCore {
             Arc::new(CompactionGroupClientImpl::Dummy(
                 DummyCompactionGroupClient::new(StaticCompactionGroupId::StateDefault.into()),
             )),
-            uploader,
+            read_version,
+            event_sender,
+            MemoryLimiter::unlimit(),
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         options: Arc<StorageConfig>,
         sstable_store: SstableStoreRef,
@@ -124,21 +128,18 @@ impl HummockStorageCore {
         // TODO: separate `HummockStats` from `StateStoreMetrics`.
         stats: Arc<StateStoreMetrics>,
         compaction_group_client: Arc<CompactionGroupClientImpl>,
-        uploader: UploaderRef,
+        read_version: Arc<RwLock<HummockReadVersion>>,
+        event_sender: mpsc::UnboundedSender<HummockEvent>,
+        memory_limiter: Arc<MemoryLimiter>,
     ) -> HummockResult<Self> {
-        // For conflict key detection. Enabled by setting `write_conflict_detection_enabled` to
-        // true in `StorageConfig`
         let sstable_id_manager = Arc::new(SstableIdManager::new(
             hummock_meta_client.clone(),
             options.sstable_id_remote_fetch_number,
         ));
 
-        let read_version = HummockReadVersion::new(uploader.get_pinned_version());
-
         let instance = Self {
             options,
-            read_version: RwLock::new(read_version),
-            uploader,
+            read_version,
             hummock_meta_client,
             sstable_store,
             stats,
@@ -146,6 +147,8 @@ impl HummockStorageCore {
             sstable_id_manager,
             #[cfg(not(madsim))]
             tracing: Arc::new(risingwave_tracing::RwTracingService::new()),
+            event_sender,
+            memory_limiter,
         };
         Ok(instance)
     }
@@ -510,21 +513,29 @@ impl StateStore for HummockStorage {
         async move {
             let epoch = write_options.epoch;
             let table_id = write_options.table_id;
-            let uploader = self.core.uploader.clone();
+            // let uploader = self.core.uploader.clone();
             let compaction_group_id = self
                 .core
                 .get_compaction_group_id(write_options.table_id)
                 .await?;
 
-            let imm = uploader
-                .build_shared_buffer_batch(epoch, compaction_group_id, kv_pairs, table_id)
-                .await;
+            let imm = SharedBufferBatch::build_shared_buffer_batch(
+                epoch,
+                compaction_group_id,
+                kv_pairs,
+                table_id,
+                Some(self.core.memory_limiter.as_ref()),
+            )
+            .await;
             let imm_size = imm.size();
             self.core
                 .update(VersionUpdate::Staging(StagingData::ImmMem(imm.clone())));
 
             // insert imm to uploader
-            uploader.write_shared_buffer_batch(imm);
+            self.core
+                .event_sender
+                .send(HummockEvent::SendToUploader(imm))
+                .unwrap();
             Ok(imm_size)
         }
     }
@@ -536,33 +547,15 @@ impl HummockStorage {
         options: Arc<StorageConfig>,
         sstable_store: SstableStoreRef,
         hummock_meta_client: Arc<dyn HummockMetaClient>,
-        uploader: UploaderRef,
+        read_version: Arc<RwLock<HummockReadVersion>>,
+        event_sender: mpsc::UnboundedSender<HummockEvent>,
     ) -> HummockResult<Self> {
-        let storage_core =
-            HummockStorageCore::for_test(options, sstable_store, hummock_meta_client, uploader)?;
-
-        let instance = Self {
-            core: Arc::new(storage_core),
-        };
-        Ok(instance)
-    }
-
-    pub fn new(
-        options: Arc<StorageConfig>,
-        sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-        // TODO: separate `HummockStats` from `StateStoreMetrics`.
-        stats: Arc<StateStoreMetrics>,
-        compaction_group_client: Arc<CompactionGroupClientImpl>,
-        uploader: UploaderRef,
-    ) -> HummockResult<Self> {
-        let storage_core = HummockStorageCore::new(
+        let storage_core = HummockStorageCore::for_test(
             options,
             sstable_store,
             hummock_meta_client,
-            stats,
-            compaction_group_client,
-            uploader,
+            read_version,
+            event_sender,
         )?;
 
         let instance = Self {
@@ -571,8 +564,33 @@ impl HummockStorage {
         Ok(instance)
     }
 
-    pub fn uploader(&self) -> &UploaderRef {
-        &self.core.uploader
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        options: Arc<StorageConfig>,
+        sstable_store: SstableStoreRef,
+        hummock_meta_client: Arc<dyn HummockMetaClient>,
+        // TODO: separate `HummockStats` from `StateStoreMetrics`.
+        stats: Arc<StateStoreMetrics>,
+        compaction_group_client: Arc<CompactionGroupClientImpl>,
+        read_version: Arc<RwLock<HummockReadVersion>>,
+        event_sender: mpsc::UnboundedSender<HummockEvent>,
+        memory_limiter: Arc<MemoryLimiter>,
+    ) -> HummockResult<Self> {
+        let storage_core = HummockStorageCore::new(
+            options,
+            sstable_store,
+            hummock_meta_client,
+            stats,
+            compaction_group_client,
+            read_version,
+            event_sender,
+            memory_limiter,
+        )?;
+
+        let instance = Self {
+            core: Arc::new(storage_core),
+        };
+        Ok(instance)
     }
 
     /// See `HummockReadVersion::update` for more details.

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -18,14 +18,9 @@ use std::ops::Bound;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch};
 use risingwave_pb::hummock::{HummockVersionDelta, SstableInfo};
 
+use super::memtable::{ImmId, ImmutableMemtable};
 use crate::hummock::local_version::pinned_version::PinnedVersion;
-use crate::hummock::shared_buffer::shared_buffer_batch::{SharedBufferBatch, SharedBufferBatchId};
 use crate::hummock::utils::{filter_single_sst, range_overlap};
-
-pub type ImmutableMemtable = SharedBufferBatch;
-
-// TODO: refine to use use a custom data structure Memtable
-type ImmId = SharedBufferBatchId;
 
 // TODO: use a custom data structure to allow in-place update instead of proto
 // pub type CommittedVersion = HummockVersion;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

as title

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- remove `Uploader` directly dependency of `StorageCore`
- shared `ReadVersion` between `StorageCore` and `EventHandler`

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/issues/5621