### PR TITLE
refactor(stream,agg): remove row count column assert

### DIFF
--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -36,7 +36,6 @@ use risingwave_expr::*;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 pub use row_count::*;
-use static_assertions::const_assert_eq;
 
 use super::{ActorContextRef, PkIndices};
 use crate::common::{InfallibleExpression, StateTableColumnMapping};

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -292,8 +292,7 @@ pub async fn generate_managed_agg_state<S: StateStore>(
     if let Some(prev_outputs) = prev_outputs.as_ref() {
         assert_eq!(prev_outputs.len(), agg_calls.len());
     }
-    // Currently the loop here only works if `ROW_COUNT_COLUMN` is 0.
-    const_assert_eq!(ROW_COUNT_COLUMN, 0);
+
     let row_count = prev_outputs
         .as_ref()
         .and_then(|outputs| {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

With the newly implemented _result table_, `ROW_COUNT_COLUMN` is actually not required to be 0, so removing the assertion to clean the code.

## Checklist

- ~~[ ] I have written necessary rustdoc comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)