### PR TITLE
refactor(plan_node): Introduce `GenericPlanRef`

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic.rs
+++ b/src/frontend/src/optimizer/plan_node/generic.rs
@@ -533,11 +533,7 @@ impl<PlanRef: GenericPlanRef> Project<PlanRef> {
         (self.exprs, self.input)
     }
 
-    pub(super) fn fmt_with_name(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        name: &str,
-    ) -> fmt::Result {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let mut builder = f.debug_struct(name);
         builder.field(
             "exprs",

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -24,7 +24,7 @@ use risingwave_common::util::sort_util::OrderType;
 use risingwave_expr::expr::AggKind;
 use risingwave_pb::stream_plan::{agg_call_state, AggCallState as AggCallStateProst};
 
-use super::generic::{self, PlanAggCall, PlanAggCallDisplay, PlanAggOrderByField};
+use super::generic::{self, GenericPlanRef, PlanAggCall, PlanAggCallDisplay, PlanAggOrderByField};
 use super::{
     BatchHashAgg, BatchSimpleAgg, ColPrunable, LogicalProjectBuilder, PlanBase, PlanRef,
     PlanTreeNodeUnary, PredicatePushdown, StreamGlobalSimpleAgg, StreamHashAgg,
@@ -850,11 +850,11 @@ impl LogicalAgg {
     }
 
     pub fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
-        self.core.agg_calls_display(|x| x.schema())
+        self.core.agg_calls_display()
     }
 
     pub fn group_key_display(&self) -> Vec<FieldDisplay<'_>> {
-        self.core.group_key_display(|x| x.schema())
+        self.core.group_key_display()
     }
 
     /// Get a reference to the logical agg's group key.

--- a/src/frontend/src/optimizer/plan_node/logical_expand.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_expand.rs
@@ -94,7 +94,7 @@ impl LogicalExpand {
     }
 
     pub fn column_subsets_display(&self) -> Vec<Vec<FieldDisplay<'_>>> {
-        self.core.column_subsets_display(|x| x.schema())
+        self.core.column_subsets_display()
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {

--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -189,7 +189,7 @@ impl LogicalHopWindow {
     }
 
     pub fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
-        self.core.fmt_with_name(f, name, |x| x.schema())
+        self.core.fmt_with_name(f, name)
     }
 
     /// Map the order of the input to use the updated indices

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -227,8 +227,8 @@ impl LogicalMultiJoin {
 
         let inner_i2o_mappings = {
             let mut i2o_maps = vec![];
-            for input_schma in &input_schemas {
-                let map = vec![None; input_schma.len()];
+            for input_schema in &input_schemas {
+                let map = vec![None; input_schema.len()];
                 i2o_maps.push(map);
             }
             for (out_idx, (input_idx, in_idx)) in inner_o2i_mapping.iter().enumerate() {

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -243,7 +243,7 @@ impl LogicalProject {
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
-        self.core.fmt_with_name(f, name, |x| x.schema())
+        self.core.fmt_with_name(f, name)
     }
 
     pub fn is_identity(&self) -> bool {

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -168,7 +168,6 @@ impl dyn PlanNode {
     /// Note that [`StreamTableScan`] has its own implementation of `to_stream_prost`. We have a
     /// hook inside to do some ad-hoc thing for [`StreamTableScan`].
     pub fn to_stream_prost(&self, state: &mut BuildFragmentGraphState) -> StreamPlanProst {
-        use generic::GenericPlanRef;
         if let Some(stream_table_scan) = self.as_stream_table_scan() {
             return stream_table_scan.adhoc_to_stream_prost();
         }

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -40,6 +40,7 @@ use risingwave_pb::batch_plan::PlanNode as BatchPlanProst;
 use risingwave_pb::stream_plan::StreamNode as StreamPlanProst;
 use serde::Serialize;
 
+use self::generic::GenericPlanRef;
 use super::property::{Distribution, FunctionalDependencySet, Order};
 
 /// The common trait over all plan nodes. Used by optimizer framework which will treat all node as
@@ -76,6 +77,12 @@ pub enum Convention {
     Logical,
     Batch,
     Stream,
+}
+
+impl GenericPlanRef for PlanRef {
+    fn schema(&self) -> &Schema {
+        &self.plan_base().schema
+    }
 }
 
 impl dyn PlanNode {
@@ -161,6 +168,7 @@ impl dyn PlanNode {
     /// Note that [`StreamTableScan`] has its own implementation of `to_stream_prost`. We have a
     /// hook inside to do some ad-hoc thing for [`StreamTableScan`].
     pub fn to_stream_prost(&self, state: &mut BuildFragmentGraphState) -> StreamPlanProst {
+        use generic::GenericPlanRef;
         if let Some(stream_table_scan) = self.as_stream_table_scan() {
             return stream_table_scan.adhoc_to_stream_prost();
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

+ Introduced a `trait` that in the future, `PlanRef` will be split down into three variants and this trait will be shared by them.
+ Use the trait to improve some of the existing code.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#5630, #5699, #5700, #5765, #5766