### PR TITLE
chore: use version `0.2.0-alpha` for main branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "0.1.0"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "global_stats_alloc"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "stats_alloc",
  "tikv-jemallocator",
@@ -2871,7 +2871,7 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "local_stats_alloc"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "workspace-hack",
 ]
@@ -3119,7 +3119,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memcomparable"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "hyper",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "clap 3.2.17",
  "madsim-tokio",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "bytes",
  "hex",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "async_stack_trace",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "bytes",
  "madsim-tonic",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "console",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_regress_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "console",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_source"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "itertools",
  "matches",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "fail",
  "workspace-hack",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_tracing"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "sync_point_unit_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "isahc",
  "log",
@@ -7375,7 +7375,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2271,7 +2271,7 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "global_stats_alloc"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "stats_alloc",
  "tikv-jemallocator",
@@ -2871,7 +2871,7 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "local_stats_alloc"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "workspace-hack",
 ]
@@ -3119,7 +3119,7 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memcomparable"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "bytes",
  "rand 0.8.5",
@@ -3859,7 +3859,7 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "risedev"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4566,7 +4566,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_batch"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4622,7 +4622,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_bench"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -4664,7 +4664,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_cmd_all"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_common_service"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "hyper",
@@ -4790,7 +4790,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compaction_test"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4817,7 +4817,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compactor"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "clap 3.2.17",
  "madsim-tokio",
@@ -4841,7 +4841,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_compute"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4898,7 +4898,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_connector"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_ctl"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4990,7 +4990,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_expr"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -5026,7 +5026,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_frontend"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -5080,7 +5080,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_sdk"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "bytes",
  "hex",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_hummock_test"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5123,7 +5123,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_meta"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5182,7 +5182,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_object_store"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "async_stack_trace",
@@ -5210,7 +5210,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_pb"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "bytes",
  "madsim-tonic",
@@ -5226,7 +5226,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_planner_test"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "console",
@@ -5261,7 +5261,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rpc_client"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_rt"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "console",
@@ -5352,7 +5352,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_source"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -5407,7 +5407,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlparser"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "itertools",
  "matches",
@@ -5433,7 +5433,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_sqlsmith"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5456,7 +5456,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_storage"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5524,7 +5524,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_stream"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_test_runner"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "fail",
  "workspace-hack",
@@ -5614,7 +5614,7 @@ dependencies = [
 
 [[package]]
 name = "risingwave_tracing"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "anyhow",
  "futures",
@@ -6340,7 +6340,7 @@ dependencies = [
 
 [[package]]
 name = "sync_point_unit_test"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7364,7 +7364,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-config"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "isahc",
  "log",
@@ -7375,7 +7375,7 @@ dependencies = [
 
 [[package]]
 name = "workspace-hack"
-version = "0.1.11"
+version = "0.1-alpha"
 dependencies = [
  "ahash",
  "anyhow",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_batch"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 
 [dependencies]
 anyhow = "1"
@@ -60,7 +60,7 @@ url = "2"
 uuid = "1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.3.5", features = ["async_tokio", "async"] }

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_batch"
-version = "0.1.11"
+version = "0.1-alpha"
 
 [dependencies]
 anyhow = "1"

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_bench"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_bench"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -54,7 +54,7 @@ tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = "0.3.16"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [[bin]]
 name = "file-cache-bench"

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_cmd"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [features]

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_cmd"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [features]
@@ -33,7 +33,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 ] }
 tracing = { version = "0.1" }
 workspace-config = { path = "../utils/workspace-config", optional = true }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [[bin]]
 name = "frontend"

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_cmd_all"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [features]

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_cmd_all"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [features]
@@ -34,7 +34,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 ] }
 tracing = { version = "0.1" }
 workspace-config = { path = "../utils/workspace-config", optional = true }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [[bin]]
 name = "risingwave"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_common"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -54,7 +54,7 @@ twox-hash = "1"
 url = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procinfo = { git = "https://github.com/tikv/procinfo-rs", rev = "6599eb9dca74229b2c1fcc44118bef7eff127128" }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_common"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/common/common_service/Cargo.toml
+++ b/src/common/common_service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_common_service"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -18,4 +18,4 @@ tower-http = { version = "0.3", features = ["add-extension", "cors"] }
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/common/common_service/Cargo.toml
+++ b/src/common/common_service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_common_service"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_compute"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 
 [dependencies]
 anyhow = "1"
@@ -62,7 +62,7 @@ twox-hash = "1"
 url = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 futures-async-stream = "0.2"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_compute"
-version = "0.1.11"
+version = "0.1-alpha"
 
 [dependencies]
 anyhow = "1"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_connector"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 
 [dependencies]
 anyhow = "1"
@@ -63,7 +63,7 @@ url = "2"
 urlencoding = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_connector"
-version = "0.1.11"
+version = "0.1-alpha"
 
 [dependencies]
 anyhow = "1"

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_ctl"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_ctl"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -33,4 +33,4 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_expr"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_expr"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -36,4 +36,4 @@ toml = "0.5"
 tonic = { version = "0.2", package = "madsim-tonic" }
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_frontend"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -61,7 +61,7 @@ tracing = "0.1"
 uuid = "1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_frontend"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/frontend/planner_test/Cargo.toml
+++ b/src/frontend/planner_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_planner_test"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/frontend/planner_test/Cargo.toml
+++ b/src/frontend/planner_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_planner_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -27,7 +27,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 walkdir = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_meta"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -61,7 +61,7 @@ uuid = { version = "1", features = ["v4"] }
 [target.'cfg(not(madsim))'.dependencies]
 axum = "0.5"
 tower-http = { version = "0.3", features = ["add-extension", "cors", "fs"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_meta"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_object_store"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_object_store"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -30,4 +30,4 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_pb"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 
 [dependencies]
 bytes = "1"
@@ -13,7 +13,7 @@ serde = { version = "1", features = ["derive"] }
 tonic = { version = "0.2.4", package = "madsim-tonic" }
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [build-dependencies]
 pbjson-build = "0.4"

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_pb"
-version = "0.1.11"
+version = "0.1-alpha"
 
 [dependencies]
 bytes = "1"

--- a/src/prost/helpers/Cargo.toml
+++ b/src/prost/helpers/Cargo.toml
@@ -13,4 +13,4 @@ quote = "1"
 syn = "1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/risedevtool/Cargo.toml
+++ b/src/risedevtool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risedev"
-version = "0.1.11"
+version = "0.1-alpha"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/src/risedevtool/Cargo.toml
+++ b/src/risedevtool/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risedev"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -24,5 +24,5 @@ serde_json = "1"
 serde_with = "1"
 serde_yaml = "0.8"
 tempfile = "3"
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 yaml-rust = "0.4"

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_rpc_client"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/rpc_client/Cargo.toml
+++ b/src/rpc_client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_rpc_client"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -29,4 +29,4 @@ tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
 moka = { version = "0.9", features = ["future"] }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_source"
-version = "0.1.11"
+version = "0.1-alpha"
 
 [dependencies]
 anyhow = "1"

--- a/src/source/Cargo.toml
+++ b/src/source/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "risingwave_source"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 
 [dependencies]
 anyhow = "1"
@@ -52,7 +52,7 @@ twox-hash = "1"
 url = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/sqlparser/Cargo.toml
+++ b/src/sqlparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_sqlparser"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 license = "Apache-2.0"
 include = [
     "src/**/*.rs",
@@ -27,7 +27,7 @@ serde_json = { version = "1.0", optional = true }
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 matches = "0.1"

--- a/src/sqlparser/Cargo.toml
+++ b/src/sqlparser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_sqlparser"
-version = "0.1.11"
+version = "0.1-alpha"
 license = "Apache-2.0"
 include = [
     "src/**/*.rs",

--- a/src/sqlparser/test_runner/Cargo.toml
+++ b/src/sqlparser/test_runner/Cargo.toml
@@ -13,7 +13,7 @@ tempfile = "3"
 walkdir = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [build-dependencies]
 walkdir = "2"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_storage"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_storage"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -78,7 +78,7 @@ zstd = "0.11.2"
 
 [target.'cfg(not(madsim))'.dependencies]
 risingwave_tracing = { path = "../tracing" }
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["async_futures"] }

--- a/src/storage/compaction_test/Cargo.toml
+++ b/src/storage/compaction_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_compaction_test"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/storage/compaction_test/Cargo.toml
+++ b/src/storage/compaction_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_compaction_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -35,4 +35,4 @@ tonic = { version = "0.2", package = "madsim-tonic" }
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_compactor"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_compactor"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -32,4 +32,4 @@ tonic = { version = "0.2", package = "madsim-tonic" }
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_hummock_sdk"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -25,4 +25,4 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_hummock_sdk"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/storage/hummock_test/Cargo.toml
+++ b/src/storage/hummock_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_hummock_test"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/storage/hummock_test/Cargo.toml
+++ b/src/storage/hummock_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_hummock_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -24,7 +24,7 @@ risingwave_storage = { path = "..", features = ["test"] }
 tokio = { version = "0.2", package = "madsim-tokio" }
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false, features = ["alloc", "executor"] }

--- a/src/storage/hummock_test/sync_point_unit_test/Cargo.toml
+++ b/src/storage/hummock_test/sync_point_unit_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync_point_unit_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/storage/hummock_test/sync_point_unit_test/Cargo.toml
+++ b/src/storage/hummock_test/sync_point_unit_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sync_point_unit_test"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_stream"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_stream"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -73,7 +73,7 @@ twox-hash = "1"
 url = "2"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"

--- a/src/test_runner/Cargo.toml
+++ b/src/test_runner/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "risingwave_test_runner"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 fail = "0.5"
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/test_runner/Cargo.toml
+++ b/src/test_runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_test_runner"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/tests/regress/Cargo.toml
+++ b/src/tests/regress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_regress_test"
-version = "0.1.0"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/tests/regress/Cargo.toml
+++ b/src/tests/regress/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_regress_test"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -14,7 +14,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3.16"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [[bin]]
 name = "risingwave_regress_test"

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -25,4 +25,4 @@ tokio-postgres = "0.7.7"
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/tests/simulation_scale/Cargo.toml
+++ b/src/tests/simulation_scale/Cargo.toml
@@ -26,4 +26,4 @@ tokio-postgres = "0.7.7"
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_sqlsmith"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 
 [dependencies]

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_sqlsmith"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 
 [dependencies]
@@ -22,7 +22,7 @@ tracing = "0.1"
 tracing-subscriber = "0.3.16"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [[bin]]
 name = "sqlsmith"

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_tracing"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_tracing"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -17,4 +17,4 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../workspace-hack" }

--- a/src/utils/async_stack_trace/Cargo.toml
+++ b/src/utils/async_stack_trace/Cargo.toml
@@ -16,4 +16,4 @@ tracing = "0.1"
 triomphe = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/utils/global_stats_alloc/Cargo.toml
+++ b/src/utils/global_stats_alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "global_stats_alloc"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 description = "Global allocator with statistics"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/utils/global_stats_alloc/Cargo.toml
+++ b/src/utils/global_stats_alloc/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "global_stats_alloc"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 description = "Global allocator with statistics"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dependencies]
 stats_alloc = { version = "0.1", features = ["nightly"]}

--- a/src/utils/local_stats_alloc/Cargo.toml
+++ b/src/utils/local_stats_alloc/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "local_stats_alloc"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 description = "Local allocator with statistics"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dev-dependencies]

--- a/src/utils/local_stats_alloc/Cargo.toml
+++ b/src/utils/local_stats_alloc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "local_stats_alloc"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 description = "Local allocator with statistics"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/utils/memcomparable/Cargo.toml
+++ b/src/utils/memcomparable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memcomparable"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 description = "Memcomparable format."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -11,7 +11,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/utils/memcomparable/Cargo.toml
+++ b/src/utils/memcomparable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "memcomparable"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 description = "Memcomparable format."
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgwire"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -19,7 +19,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = ["rt", "macros"]
 tracing = "0.1"
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 
 [dev-dependencies]
 tokio-postgres = "0.7.7"

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pgwire"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/utils/runtime/Cargo.toml
+++ b/src/utils/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_rt"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -25,4 +25,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.16", features = ["fmt", "parking_lot"] }
 
 [target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }

--- a/src/utils/runtime/Cargo.toml
+++ b/src/utils/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "risingwave_rt"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/utils/workspace-config/Cargo.toml
+++ b/src/utils/workspace-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-config"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,5 +15,5 @@ log = { version = "0.4", optional = true, features = ["release_max_level_info"] 
 openssl = { version = "0.10", optional = true, features = ["vendored"] }
 rdkafka = { package = "madsim-rdkafka", version = "=0.2.8-alpha", optional = true, features = ["ssl-vendored", "gssapi-vendored"] }
 tracing = { version = "0.1", optional = true, features = ["release_max_level_info"] }
-# workspace-hack = { version = "0.1", path = "../../workspace-hack" }
+# workspace-hack = { version = "0.2.0-alpha", path = "../../workspace-hack" }
 # Don't add workspace-hack into this crate!

--- a/src/utils/workspace-config/Cargo.toml
+++ b/src/utils/workspace-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "workspace-config"
-version = "0.1.11"
+version = "0.1-alpha"
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "workspace-hack"
-version = "0.1.11"
+version = "0.1-alpha"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -4,7 +4,7 @@
 
 [package]
 name = "workspace-hack"
-version = "0.1-alpha"
+version = "0.2.0-alpha"
 description = "workspace-hack package, managed by hakari"
 # You can choose to publish this crate: see https://docs.rs/cargo-hakari/latest/cargo_hakari/publishing.
 publish = false


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR introduce a common practice of version managing: 

- Always use the version of **future** release in main developing branch but with a suffix e.g. `0.2.0-alpha`. 
- When release a new version, change it to concrete numbers e.g. `0.1.13`

PS. Rust enforces the triple style semantic version so `0.2-alpha` is prohibited; must use `0.2.0-alpha` instead.


## Checklist

NA
## Documentation

NA
## Refer to a related PR or issue link (optional)

NA