### PR TITLE
refactor(handler): extract RowSet formatting from scheduler to handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5054,6 +5054,7 @@ dependencies = [
  "parse-display",
  "paste",
  "pgwire",
+ "pin-project-lite",
  "prometheus",
  "prost",
  "rand 0.8.5",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -28,6 +28,7 @@ parking_lot = "0.12"
 parse-display = "0.6"
 paste = "1"
 pgwire = { path = "../utils/pgwire" }
+pin-project-lite = "0.2"
 prometheus = { version = "0.13", features = ["process"] }
 prost = "0.11"
 rand = "0.8"

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -61,7 +61,7 @@ pub mod variable;
 pub type RwPgResponse = PgResponse<PgResponseStream>;
 
 pub struct PgResponseStream(BoxStream<'static, RowSetResult>);
-pub enum DataChunkResponseStream {
+pub enum XResponseStream {
     LocalQuery(LocalQueryStream),
     DistributedQuery(DistributedQueryStream),
 }
@@ -73,13 +73,13 @@ impl Stream for PgResponseStream {
         self.0.poll_next_unpin(cx)
     }
 }
-impl Stream for DataChunkResponseStream {
+impl Stream for XResponseStream {
     type Item = std::result::Result<DataChunk, BoxedError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match &mut *self {
-            DataChunkResponseStream::LocalQuery(inner) => inner.poll_next_unpin(cx),
-            DataChunkResponseStream::DistributedQuery(inner) => inner.poll_next_unpin(cx),
+            Self::LocalQuery(inner) => inner.poll_next_unpin(cx),
+            Self::DistributedQuery(inner) => inner.poll_next_unpin(cx),
         }
     }
 }

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -22,14 +22,15 @@ use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::session_config::QueryMode;
 use risingwave_sqlparser::ast::Statement;
 
-use super::{DataChunkResponseStream, PgResponseStream, RwPgResponse};
+use super::{PgResponseStream, RwPgResponse};
 use crate::binder::{Binder, BoundSetExpr, BoundStatement};
 use crate::handler::privilege::{check_privileges, resolve_privileges};
 use crate::handler::util::{to_pg_field, to_pg_rows};
 use crate::planner::Planner;
 use crate::scheduler::plan_fragmenter::Query;
 use crate::scheduler::{
-    BatchPlanFragmenter, ExecutionContext, ExecutionContextRef, LocalQueryExecution,
+    BatchPlanFragmenter, DistributedQueryStream, ExecutionContext, ExecutionContextRef,
+    LocalQueryExecution, LocalQueryStream,
 };
 use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
 use crate::PlanRef;
@@ -113,13 +114,17 @@ pub async fn handle_query(
     };
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
 
-    let chunk_stream = match query_mode {
-        QueryMode::Local => local_execute(session.clone(), query).await?,
+    let mut row_stream = match query_mode {
+        QueryMode::Local => local_execute(session.clone(), query)
+            .await?
+            .map(move |chunk| chunk.map(|chunk| to_pg_rows(chunk, format)))
+            .boxed(),
         // Local mode do not support cancel tasks.
-        QueryMode::Distributed => distribute_execute(session.clone(), query).await?,
+        QueryMode::Distributed => distribute_execute(session.clone(), query)
+            .await?
+            .map(move |chunk| chunk.map(|chunk| to_pg_rows(chunk, format)))
+            .boxed(),
     };
-    let mut row_stream =
-        chunk_stream.map(move |chunk| chunk.map(|chunk| to_pg_rows(chunk, format)));
 
     let rows_count = match stmt_type {
         StatementType::SELECT => None,
@@ -166,7 +171,7 @@ pub async fn handle_query(
     Ok(PgResponse::new_for_stream(
         stmt_type,
         rows_count,
-        PgResponseStream(row_stream.boxed()),
+        PgResponseStream(row_stream),
         pg_descs,
     ))
 }
@@ -186,7 +191,7 @@ fn to_statement_type(stmt: &Statement) -> StatementType {
 pub async fn distribute_execute(
     session: Arc<SessionImpl>,
     query: Query,
-) -> Result<DataChunkResponseStream> {
+) -> Result<DistributedQueryStream> {
     let execution_context: ExecutionContextRef = ExecutionContext::new(session.clone()).into();
     let query_manager = execution_context.session().env().query_manager().clone();
     query_manager
@@ -195,7 +200,7 @@ pub async fn distribute_execute(
         .map_err(|err| err.into())
 }
 
-async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<DataChunkResponseStream> {
+async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<LocalQueryStream> {
     let front_env = session.env();
 
     // Acquire hummock snapshot for local execution.

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -28,6 +28,12 @@ use risingwave_common::catalog::{ColumnDesc, Field};
 use risingwave_common::types::{DataType, ScalarRefImpl};
 
 pin_project! {
+    /// Wrapper struct that converts a stream of DataChunk to a stream of RowSet based on formatting
+    /// parameters.
+    ///
+    /// This is essentially `StreamExt::map(self, move |res| res.map(|chunk| to_pg_rows(chunk,
+    /// format)))` but we need a nameable type as part of [`super::PgResponseStream`], but we cannot
+    /// name the type of a closure.
     pub struct DataChunkToRowSetAdapter<VS>
     where
         VS: Stream<Item = Result<DataChunk, BoxedError>>,

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -12,13 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
 use bytes::Bytes;
+use futures::Stream;
 use itertools::Itertools;
 use pgwire::pg_field_descriptor::{PgFieldDescriptor, TypeOid};
+use pgwire::pg_response::RowSetResult;
+use pgwire::pg_server::BoxedError;
 use pgwire::types::Row;
+use pin_project_lite::pin_project;
 use risingwave_common::array::DataChunk;
 use risingwave_common::catalog::{ColumnDesc, Field};
 use risingwave_common::types::{DataType, ScalarRefImpl};
+
+pin_project! {
+    pub struct DataChunkToRowSetAdapter<VS>
+    where
+        VS: Stream<Item = Result<DataChunk, BoxedError>>,
+    {
+        #[pin]
+        chunk_stream: VS,
+        format: bool,
+    }
+}
+impl<VS> DataChunkToRowSetAdapter<VS>
+where
+    VS: Stream<Item = Result<DataChunk, BoxedError>>,
+{
+    pub fn new(chunk_stream: VS, format: bool) -> Self {
+        Self {
+            chunk_stream,
+            format,
+        }
+    }
+}
+
+impl<VS> Stream for DataChunkToRowSetAdapter<VS>
+where
+    VS: Stream<Item = Result<DataChunk, BoxedError>>,
+{
+    type Item = RowSetResult;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        match this.chunk_stream.as_mut().poll_next(cx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(chunk) => match chunk {
+                Some(chunk_result) => match chunk_result {
+                    Ok(chunk) => Poll::Ready(Some(Ok(to_pg_rows(chunk, *this.format)))),
+                    Err(err) => Poll::Ready(Some(Err(err))),
+                },
+                None => Poll::Ready(None),
+            },
+        }
+    }
+}
 
 /// Format scalars according to postgres convention.
 fn pg_value_format(d: ScalarRefImpl<'_>, format: bool) -> Bytes {
@@ -34,7 +84,7 @@ fn pg_value_format(d: ScalarRefImpl<'_>, format: bool) -> Bytes {
     }
 }
 
-pub fn to_pg_rows(chunk: DataChunk, format: bool) -> Vec<Row> {
+fn to_pg_rows(chunk: DataChunk, format: bool) -> Vec<Row> {
     chunk
         .rows()
         .map(|r| {

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -31,7 +31,6 @@ use tracing::debug;
 
 use super::QueryExecution;
 use crate::catalog::catalog_service::CatalogReader;
-use crate::handler::DataChunkResponseStream;
 use crate::scheduler::plan_fragmenter::{Query, QueryId};
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
 use crate::scheduler::{ExecutionContextRef, HummockSnapshotManagerRef, SchedulerResult};
@@ -104,7 +103,7 @@ impl QueryManager {
         &self,
         context: ExecutionContextRef,
         query: Query,
-    ) -> SchedulerResult<DataChunkResponseStream> {
+    ) -> SchedulerResult<DistributedQueryStream> {
         let query_id = query.query_id().clone();
         let epoch = self
             .hummock_snapshot_manager
@@ -211,10 +210,10 @@ impl QueryResultFetcher {
         Box::pin(self.run_inner())
     }
 
-    fn stream_from_channel(self) -> DataChunkResponseStream {
-        DataChunkResponseStream::DistributedQuery(DistributedQueryStream {
+    fn stream_from_channel(self) -> DistributedQueryStream {
+        DistributedQueryStream {
             chunk_rx: self.chunk_rx,
-        })
+        }
     }
 }
 

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -38,16 +38,6 @@ use crate::scheduler::{ExecutionContextRef, HummockSnapshotManagerRef, Scheduler
 
 pub struct DistributedQueryStream {
     chunk_rx: tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>,
-    format: bool,
-}
-
-impl DistributedQueryStream {
-    pub fn new(
-        chunk_rx: tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>,
-        format: bool,
-    ) -> Self {
-        Self { chunk_rx, format }
-    }
 }
 
 impl Stream for DistributedQueryStream {
@@ -114,7 +104,6 @@ impl QueryManager {
         &self,
         context: ExecutionContextRef,
         query: Query,
-        format: bool,
     ) -> SchedulerResult<DataChunkResponseStream> {
         let query_id = query.query_id().clone();
         let epoch = self
@@ -154,7 +143,7 @@ impl QueryManager {
 
         // TODO: Clean up queries status when ends. This should be done lazily.
 
-        Ok(query_result_fetcher.stream_from_channel(format))
+        Ok(query_result_fetcher.stream_from_channel())
     }
 
     pub fn cancel_queries_in_session(&self, session_id: SessionId) {
@@ -222,10 +211,9 @@ impl QueryResultFetcher {
         Box::pin(self.run_inner())
     }
 
-    fn stream_from_channel(self, format: bool) -> DataChunkResponseStream {
+    fn stream_from_channel(self) -> DataChunkResponseStream {
         DataChunkResponseStream::DistributedQuery(DistributedQueryStream {
             chunk_rx: self.chunk_rx,
-            format,
         })
     }
 }

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -38,7 +38,6 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::plan_fragmenter::{PartitionInfo, QueryStageRef};
-use crate::handler::DataChunkResponseStream;
 use crate::optimizer::plan_node::PlanNodeType;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query, StageId};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
@@ -123,10 +122,10 @@ impl LocalQueryExecution {
         Box::pin(self.run_inner())
     }
 
-    pub fn stream_rows(self) -> DataChunkResponseStream {
-        DataChunkResponseStream::LocalQuery(LocalQueryStream {
+    pub fn stream_rows(self) -> LocalQueryStream {
+        LocalQueryStream {
             data_stream: self.run(),
-        })
+        }
     }
 
     /// Convert query to plan fragment.

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -47,16 +47,6 @@ use crate::session::{AuthContext, FrontendEnv};
 
 pub struct LocalQueryStream {
     data_stream: BoxedDataChunkStream,
-    format: bool,
-}
-
-impl LocalQueryStream {
-    pub fn new(data_stream: BoxedDataChunkStream, format: bool) -> Self {
-        Self {
-            data_stream,
-            format,
-        }
-    }
 }
 
 impl Stream for LocalQueryStream {
@@ -133,10 +123,9 @@ impl LocalQueryExecution {
         Box::pin(self.run_inner())
     }
 
-    pub fn stream_rows(self, format: bool) -> DataChunkResponseStream {
+    pub fn stream_rows(self) -> DataChunkResponseStream {
         DataChunkResponseStream::LocalQuery(LocalQueryStream {
             data_stream: self.run(),
-            format,
         })
     }
 

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -21,7 +21,7 @@ use std::task::{Context, Poll};
 use futures::Stream;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use pgwire::pg_response::RowSetResult;
+use pgwire::pg_server::BoxedError;
 use risingwave_batch::executor::{BoxedDataChunkStream, ExecutorBuilder};
 use risingwave_batch::task::TaskId;
 use risingwave_common::array::DataChunk;
@@ -38,8 +38,7 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::plan_fragmenter::{PartitionInfo, QueryStageRef};
-use crate::handler::query::QueryResultSet;
-use crate::handler::util::to_pg_rows;
+use crate::handler::DataChunkResponseStream;
 use crate::optimizer::plan_node::PlanNodeType;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query, StageId};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
@@ -61,14 +60,14 @@ impl LocalQueryStream {
 }
 
 impl Stream for LocalQueryStream {
-    type Item = RowSetResult;
+    type Item = Result<DataChunk, BoxedError>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         match self.data_stream.as_mut().poll_next(cx) {
             Poll::Pending => Poll::Pending,
             Poll::Ready(chunk) => match chunk {
                 Some(chunk_result) => match chunk_result {
-                    Ok(chunk) => Poll::Ready(Some(Ok(to_pg_rows(chunk, self.format)))),
+                    Ok(chunk) => Poll::Ready(Some(Ok(chunk))),
                     Err(err) => Poll::Ready(Some(Err(Box::new(err)))),
                 },
                 None => Poll::Ready(None),
@@ -134,8 +133,8 @@ impl LocalQueryExecution {
         Box::pin(self.run_inner())
     }
 
-    pub fn stream_rows(self, format: bool) -> QueryResultSet {
-        QueryResultSet::LocalQuery(LocalQueryStream {
+    pub fn stream_rows(self, format: bool) -> DataChunkResponseStream {
+        DataChunkResponseStream::LocalQuery(LocalQueryStream {
             data_stream: self.run(),
             format,
         })


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Our system returns `DataChunk` while pgwire expects `RowSet`. The conversion is being done by `to_pg_row`, which is currently invoked as part of `LocalQueryStream` or `DistributedQueryStream` in the scheduler mod.

This PR lifts the invocation of `to_pg_row` from these streams to an adapter stream created in the handler mod. This allows us to pass more formatting control parameters (TEXT/BINARY bool, DataType, DateStyle, TimeZone, floating number style) more easily in the future.

The immediate need is to pass `column_types` to `to_pg_rows` to enhance our support of the `timestamp with time zone` type.

Note that after this refactor, the job of `LocalQueryStream` and `DistributedQueryStream` get even smaller: they are simply wrapper around `BoxedDataChunkStream` or `tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>` that converts from `RwError` or `SchedulerError` to `BoxedError`. We could have simplified this as well. But let's tackle them one by one.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
