### PR TITLE
chore(test): add task for running scale tests in `risedev`

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -495,8 +495,22 @@ cargo nextest run \
   "$@"
 """
 
+[tasks.sscale-test]
+category = "RiseDev - Simulation scaling tests"
+description = "Run integration scaling tests in deterministic simulation mode"
+dependencies = ["warn-on-missing-tools"]
+env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
+script = """
+#!/bin/bash
+set -e
+
+cargo nextest run \
+  -p risingwave_simulation_scale \
+  "$@"
+"""
+
 [tasks.sarchive-scale-test]
-category = "RiseDev - Archive simulation scaling tests"
+category = "RiseDev - Simulation scaling tests"
 description = "Archive integration scaling tests in deterministic simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds a `risedev` task for running scale tests locally.
```
./risedev sscale-test --cargo-profile ci-sim
```

It's normal that there's some slight error in the results and tests fail with M1 Mac, due to #5487 (discussion at https://risingwave-labs.slack.com/archives/C03A2PSS8KU/p1664523047458579).

I will refine the developer doc after the test framework is mostly finished.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #5657 