### PR TITLE
refactor(batch): pin snapshot in RAII style

### DIFF
--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -36,7 +36,8 @@ use crate::scheduler::distributed::StageExecution;
 use crate::scheduler::plan_fragmenter::{Query, StageId, ROOT_TASK_ID, ROOT_TASK_OUTPUT_ID};
 use crate::scheduler::worker_node_manager::WorkerNodeManagerRef;
 use crate::scheduler::{
-    ExecutionContextRef, HummockSnapshotManagerRef, SchedulerError, SchedulerResult,
+    ExecutionContextRef, HummockSnapshotManagerRef, PinnedHummockSnapshot, SchedulerError,
+    SchedulerResult,
 };
 
 /// Message sent to a `QueryRunner` to control its execution.
@@ -69,22 +70,14 @@ enum QueryState {
 pub struct QueryExecution {
     query: Arc<Query>,
     state: Arc<RwLock<QueryState>>,
-
-    /// These fields are just used for passing to Query Runner.
-    epoch: u64,
-    stage_executions: Arc<HashMap<StageId, Arc<StageExecution>>>,
-    hummock_snapshot_manager: HummockSnapshotManagerRef,
-    compute_client_pool: ComputeClientPoolRef,
-
     shutdown_tx: Sender<QueryMessage>,
-
     /// Identified by process_id, secret_key. Query in the same session should have same key.
     pub session_id: SessionId,
 }
 
 struct QueryRunner {
     query: Arc<Query>,
-    stage_executions: Arc<HashMap<StageId, Arc<StageExecution>>>,
+    stage_executions: HashMap<StageId, Arc<StageExecution>>,
     scheduled_stages_count: usize,
     /// Query messages receiver. For example, stage state change events, query commands.
     msg_receiver: Receiver<QueryMessage>,
@@ -92,52 +85,15 @@ struct QueryRunner {
     /// Will be set to `None` after all stage scheduled.
     root_stage_sender: Option<oneshot::Sender<SchedulerResult<QueryResultFetcher>>>,
 
-    epoch: u64,
-    hummock_snapshot_manager: HummockSnapshotManagerRef,
+    pinned_snapshot: PinnedHummockSnapshot,
     compute_client_pool: ComputeClientPoolRef,
 }
 
 impl QueryExecution {
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        context: ExecutionContextRef,
-        query: Query,
-        epoch: u64,
-        worker_node_manager: WorkerNodeManagerRef,
-        hummock_snapshot_manager: HummockSnapshotManagerRef,
-        compute_client_pool: ComputeClientPoolRef,
-        catalog_reader: CatalogReader,
-        session_id: SessionId,
-    ) -> Self {
+    pub fn new(query: Query, session_id: SessionId) -> Self {
         let query = Arc::new(query);
         let (sender, receiver) = channel(100);
-        let stage_executions = {
-            let mut stage_executions: HashMap<StageId, Arc<StageExecution>> =
-                HashMap::with_capacity(query.stage_graph.stages.len());
-
-            for stage_id in query.stage_graph.stage_ids_by_topo_order() {
-                let children_stages = query
-                    .stage_graph
-                    .get_child_stages_unchecked(&stage_id)
-                    .iter()
-                    .map(|s| stage_executions[s].clone())
-                    .collect::<Vec<Arc<StageExecution>>>();
-
-                let stage_exec = Arc::new(StageExecution::new(
-                    epoch,
-                    query.stage_graph.stages[&stage_id].clone(),
-                    worker_node_manager.clone(),
-                    sender.clone(),
-                    children_stages,
-                    compute_client_pool.clone(),
-                    catalog_reader.clone(),
-                    context.clone(),
-                ));
-                stage_executions.insert(stage_id, stage_exec);
-            }
-            Arc::new(stage_executions)
-        };
-
         let state = QueryState::Pending {
             msg_receiver: receiver,
         };
@@ -145,10 +101,6 @@ impl QueryExecution {
         Self {
             query,
             state: Arc::new(RwLock::new(state)),
-            stage_executions,
-            epoch,
-            compute_client_pool,
-            hummock_snapshot_manager,
             shutdown_tx: sender,
             session_id,
         }
@@ -158,26 +110,49 @@ impl QueryExecution {
     /// Note the two shutdown channel sender and receivers are not dual.
     /// One is used for propagate error to `QueryResultFetcher`, one is used for listening on
     /// cancel request (from ctrl-c, cli, ui etc).
-    pub async fn start(&self) -> SchedulerResult<QueryResultFetcher> {
+    pub async fn start(
+        &self,
+        context: ExecutionContextRef,
+        worker_node_manager: WorkerNodeManagerRef,
+        hummock_snapshot_manager: HummockSnapshotManagerRef,
+        compute_client_pool: ComputeClientPoolRef,
+        catalog_reader: CatalogReader,
+    ) -> SchedulerResult<QueryResultFetcher> {
         let mut state = self.state.write().await;
         let cur_state = mem::replace(&mut *state, QueryState::Failed);
+
+        // Acquired a pinned `HummockSnapshot`.
+        let pinned_snapshot = hummock_snapshot_manager
+            .acquire(&self.query.query_id)
+            .await?;
+
+        // Because the snapshot may be released before all stages are scheduled, we only pass a
+        // reference of `pinned_snapshot`. Its ownership will be moved into `QueryRunner` so that it
+        // can control when to release the snapshot.
+        let stage_executions = self.gen_stage_executions(
+            &pinned_snapshot,
+            context,
+            worker_node_manager,
+            compute_client_pool.clone(),
+            catalog_reader,
+        );
 
         match cur_state {
             QueryState::Pending { msg_receiver } => {
                 *state = QueryState::Running;
 
+                // Create a oneshot channel for QueryResultFetcher to get failed event.
                 let (root_stage_sender, root_stage_receiver) =
                     oneshot::channel::<SchedulerResult<QueryResultFetcher>>();
 
                 let runner = QueryRunner {
                     query: self.query.clone(),
-                    stage_executions: self.stage_executions.clone(),
+                    stage_executions,
                     msg_receiver,
                     root_stage_sender: Some(root_stage_sender),
                     scheduled_stages_count: 0,
-                    epoch: self.epoch,
-                    hummock_snapshot_manager: self.hummock_snapshot_manager.clone(),
-                    compute_client_pool: self.compute_client_pool.clone(),
+                    pinned_snapshot,
+                    compute_client_pool,
                 };
 
                 // Not trace the error here, it will be processed in scheduler.
@@ -214,6 +189,41 @@ impl QueryExecution {
             info!("Send cancel request to query-{:?}", self.query.query_id);
         };
     }
+
+    fn gen_stage_executions(
+        &self,
+        pinned_snapshot: &PinnedHummockSnapshot,
+        context: ExecutionContextRef,
+        worker_node_manager: WorkerNodeManagerRef,
+        compute_client_pool: ComputeClientPoolRef,
+        catalog_reader: CatalogReader,
+    ) -> HashMap<StageId, Arc<StageExecution>> {
+        let mut stage_executions: HashMap<StageId, Arc<StageExecution>> =
+            HashMap::with_capacity(self.query.stage_graph.stages.len());
+
+        for stage_id in self.query.stage_graph.stage_ids_by_topo_order() {
+            let children_stages = self
+                .query
+                .stage_graph
+                .get_child_stages_unchecked(&stage_id)
+                .iter()
+                .map(|s| stage_executions[s].clone())
+                .collect::<Vec<Arc<StageExecution>>>();
+
+            let stage_exec = Arc::new(StageExecution::new(
+                pinned_snapshot.snapshot.committed_epoch,
+                self.query.stage_graph.stages[&stage_id].clone(),
+                worker_node_manager.clone(),
+                self.shutdown_tx.clone(),
+                children_stages,
+                compute_client_pool.clone(),
+                catalog_reader.clone(),
+                context.clone(),
+            ));
+            stage_executions.insert(stage_id, stage_exec);
+        }
+        stage_executions
+    }
 }
 
 impl QueryRunner {
@@ -245,9 +255,8 @@ impl QueryRunner {
                         // thus they all successfully pinned a HummockVersion.
                         // So we can now unpin their epoch.
                         tracing::trace!("Query {:?} has scheduled all of its stages that have table scan (iterator creation).", self.query.query_id);
-                        self.hummock_snapshot_manager
-                            .release(self.epoch, self.query.query_id())
-                            .await;
+                        // TODO: how to tell the compiler it is only dropped once?
+                        // drop(self.pinned_snapshot);
                     }
 
                     // For root stage, we execute in frontend local. We will pass the root fragment
@@ -306,8 +315,6 @@ impl QueryRunner {
         };
 
         let root_stage_result = QueryResultFetcher::new(
-            self.epoch,
-            self.hummock_snapshot_manager.clone(),
             root_task_output_id,
             // Execute in local, so no need to fill meaningful address.
             HostAddress {
@@ -359,7 +366,7 @@ impl QueryRunner {
         // Query Result Fetcher.
 
         // Stop all running stages.
-        for (_stage_id, stage_execution) in self.stage_executions.iter() {
+        for stage_execution in self.stage_executions.values() {
             // The stop is return immediately so no need to spawn tasks.
             stage_execution.stop(err_str.clone()).await;
         }
@@ -400,19 +407,21 @@ mod tests {
         let worker_node_manager = Arc::new(WorkerNodeManager::mock(vec![]));
         let compute_client_pool = Arc::new(ComputeClientPool::default());
         let catalog_reader = CatalogReader::new(Arc::new(RwLock::new(Catalog::default())));
-        let query_execution = QueryExecution::new(
-            ExecutionContext::new(SessionImpl::mock().into()).into(),
-            create_query().await,
-            100,
-            worker_node_manager,
-            Arc::new(HummockSnapshotManager::new(Arc::new(
-                MockFrontendMetaClient {},
-            ))),
-            compute_client_pool,
-            catalog_reader,
-            (0, 0),
-        );
-        assert!(query_execution.start().await.is_err());
+        let query = create_query().await;
+        let hummock_snapshot_manager = Arc::new(HummockSnapshotManager::new(Arc::new(
+            MockFrontendMetaClient {},
+        )));
+        let query_execution = QueryExecution::new(query, (0, 0));
+        assert!(query_execution
+            .start(
+                ExecutionContext::new(SessionImpl::mock().into()).into(),
+                worker_node_manager,
+                hummock_snapshot_manager,
+                compute_client_pool,
+                catalog_reader,
+            )
+            .await
+            .is_err());
     }
 
     async fn create_query() -> Query {

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -71,10 +71,6 @@ impl Stream for DistributedQueryStream {
 }
 
 pub struct QueryResultFetcher {
-    // TODO: Remove these after implemented worker node level snapshot pinnning
-    epoch: u64,
-    hummock_snapshot_manager: HummockSnapshotManagerRef,
-
     task_output_id: TaskOutputId,
     task_host: HostAddress,
     compute_client_pool: ComputeClientPoolRef,
@@ -119,41 +115,26 @@ impl QueryManager {
         query: Query,
         format: bool,
     ) -> SchedulerResult<QueryResultSet> {
-        let query_id = query.query_id().clone();
-        let epoch = self
-            .hummock_snapshot_manager
-            .acquire(&query_id)
-            .await?
-            .committed_epoch;
         let query_id = query.query_id.clone();
-        let query_execution = Arc::new(QueryExecution::new(
-            context.clone(),
-            query,
-            epoch,
-            self.worker_node_manager.clone(),
-            self.hummock_snapshot_manager.clone(),
-            self.compute_client_pool.clone(),
-            self.catalog_reader.clone(),
-            context.session().id(),
-        ));
+        let query_execution = Arc::new(QueryExecution::new(query, context.session().id()));
 
         // Add queries status when begin.
         context
             .session()
             .env()
             .query_manager()
-            .add_query(query_id.clone(), query_execution.clone());
+            .add_query(query_id, query_execution.clone());
 
-        // Create a oneshot channel for QueryResultFetcher to get failed event.
-        let query_result_fetcher = match query_execution.start().await {
-            Ok(query_result_fetcher) => query_result_fetcher,
-            Err(e) => {
-                self.hummock_snapshot_manager
-                    .release(epoch, &query_id)
-                    .await;
-                return Err(e);
-            }
-        };
+        // Starts the execution of the query.
+        let query_result_fetcher = query_execution
+            .start(
+                context,
+                self.worker_node_manager.clone(),
+                self.hummock_snapshot_manager.clone(),
+                self.compute_client_pool.clone(),
+                self.catalog_reader.clone(),
+            )
+            .await?;
 
         // TODO: Clean up queries status when ends. This should be done lazily.
 
@@ -188,16 +169,12 @@ impl QueryManager {
 
 impl QueryResultFetcher {
     pub fn new(
-        epoch: u64,
-        hummock_snapshot_manager: HummockSnapshotManagerRef,
         task_output_id: TaskOutputId,
         task_host: HostAddress,
         compute_client_pool: ComputeClientPoolRef,
         chunk_rx: tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>,
     ) -> Self {
         Self {
-            epoch,
-            hummock_snapshot_manager,
             task_output_id,
             task_host,
             compute_client_pool,
@@ -236,7 +213,6 @@ impl QueryResultFetcher {
 impl Debug for QueryResultFetcher {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("QueryResultFetcher")
-            .field("epoch", &self.epoch)
             .field("task_output_id", &self.task_output_id)
             .field("task_host", &self.task_host)
             .finish()

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -72,7 +72,7 @@ impl Drop for HummockSnapshotGuard {
     fn drop(&mut self) {
         self.unpin_snapshot_sender
             .send(EpochOperation::ReleaseEpoch {
-                query_id: self.query_id,
+                query_id: self.query_id.clone(),
                 epoch: self.snapshot.committed_epoch,
             })
             .expect("Unpin channel should never closed");

--- a/src/storage/src/hummock/local_version/pinned_version.rs
+++ b/src/storage/src/hummock/local_version/pinned_version.rs
@@ -63,7 +63,7 @@ impl Drop for PinnedVersionGuard {
             .send(PinVersionAction::Unpin(self.version_id))
             .is_err()
         {
-            tracing::warn!("failed to send req unpin version id:{}", self.version_id);
+            tracing::warn!("failed to send req unpin version id: {}", self.version_id);
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Currently, a snapshot is unpinned using `HummockSnapshotManager::release`. This approach is very error-prone, as we may forget to call it in cases of error. So this PR introduces `PinnedHummockSnapshot`, which is an RAII object for `HummockSnapshot`, to make sure unused epochs are released. 

Besides, there are some refactors.

- Remove redundant `Arc`.
- Remove most of the fields in `QueryExecution`, which is only used for creating `QueryRunner`. These fields will become the parameters of the function creating `QueryRunner`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #5754 
