### PR TITLE
fix: not force tick in meta recovery process

### DIFF
--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -613,7 +613,7 @@ where
         let current_splits_ref = worker.current_splits.clone();
         tracing::info!("spawning new watcher for source {}", source.id);
 
-        // don't force tick in process of recovery. One broker down should not lead to meta recovery
+        // don't force tick in process of recovery. One source down should not lead to meta recovery
         // failure.
         if force_tick {
             // if fail to fetch meta info, will refuse to create source

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -607,13 +607,14 @@ where
     async fn create_source_worker(
         source: &Source,
         managed_sources: &mut HashMap<SourceId, ConnectorSourceWorkerHandle>,
-        force_tick: bool
+        force_tick: bool,
     ) -> MetaResult<()> {
         let mut worker = ConnectorSourceWorker::create(source, Duration::from_secs(10)).await?;
         let current_splits_ref = worker.current_splits.clone();
         tracing::info!("spawning new watcher for source {}", source.id);
 
-        // don't force tick in process of recovery. One broker down should not lead to meta recovery failure.
+        // don't force tick in process of recovery. One broker down should not lead to meta recovery
+        // failure.
         if force_tick {
             // if fail to fetch meta info, will refuse to create source
             worker.tick().await?;

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -409,7 +409,7 @@ where
 
             for source in sources {
                 if let Some(StreamSource(_)) = source.info {
-                    Self::create_source_worker(&source, &mut managed_sources, true).await?
+                    Self::create_source_worker(&source, &mut managed_sources, false).await?
                 }
             }
         }
@@ -599,7 +599,7 @@ where
         }
 
         if let Some(StreamSource(_)) = source.info {
-            Self::create_source_worker(source, &mut core.managed_sources, false).await?;
+            Self::create_source_worker(source, &mut core.managed_sources, true).await?;
         }
         Ok(())
     }

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -607,13 +607,13 @@ where
     async fn create_source_worker(
         source: &Source,
         managed_sources: &mut HashMap<SourceId, ConnectorSourceWorkerHandle>,
-        force_tick: bool,
+        force_tick: bool
     ) -> MetaResult<()> {
         let mut worker = ConnectorSourceWorker::create(source, Duration::from_secs(10)).await?;
         let current_splits_ref = worker.current_splits.clone();
         tracing::info!("spawning new watcher for source {}", source.id);
 
-        // if
+        // don't force tick in process of recovery. One broker down should not lead to meta recovery failure.
         if force_tick {
             // if fail to fetch meta info, will refuse to create source
             worker.tick().await?;


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, one kafka broker down should not lead to meta recovery failure.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

resolve #5809 