### PR TITLE
chore: refine error message for null before field in debezium parser

### DIFF
--- a/src/source/src/parser/debezium/json.rs
+++ b/src/source/src/parser/debezium/json.rs
@@ -58,7 +58,7 @@ impl SourceParser for DebeziumJsonParser {
             DEBEZIUM_UPDATE_OP => {
                 let before = payload.before.as_mut().ok_or_else(|| {
                     RwError::from(ProtocolError(
-                        "before is missing for updating event, if you are using postgres, you may try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
+                        "before is missing for updating event. If you are using postgres, you may want to try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
                     ))
                 })?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, suggest user alter table replica to FULL

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

resolve #5543 