### PR TITLE
fix(batch): fix dangling channel and prevent receiver from infinite waiting

### DIFF
--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -50,8 +50,7 @@ pub enum QueryMessage {
 enum QueryState {
     /// Not scheduled yet.
     ///
-    /// In this state, some data structures for starting executions are created to avoid holding
-    /// them `QueryExecution`
+    /// We put `msg_receiver` in `Pending` state to avoid holding it in `QueryExecution`.
     Pending {
         msg_receiver: Receiver<QueryMessage>,
     },

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -62,7 +62,13 @@ const TASK_SCHEDULING_PARALLELISM: usize = 10;
 
 #[derive(Debug)]
 enum StageState {
-    Pending { msg_sender: Sender<QueryMessage> },
+    /// In this state, some data structures for starting executions are created to avoid holding
+    /// them `StageExecution`. In this way, they could be efficiently moved into `StageRunner`
+    /// instead of cloning. This also ensures that they can get dropped once they are used up,
+    /// preventing some issues caused by unnecessarily long lifetime.
+    Pending {
+        msg_sender: Sender<QueryMessage>,
+    },
     Started,
     Running,
     Completed,

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -60,9 +60,9 @@ use crate::scheduler::{ExecutionContextRef, SchedulerError, SchedulerResult};
 
 const TASK_SCHEDULING_PARALLELISM: usize = 10;
 
-#[derive(PartialEq, Debug)]
+#[derive(Debug)]
 enum StageState {
-    Pending,
+    Pending { msg_sender: Sender<QueryMessage> },
     Started,
     Running,
     Completed,
@@ -104,7 +104,6 @@ pub struct StageExecution {
     worker_node_manager: WorkerNodeManagerRef,
     tasks: Arc<HashMap<TaskId, TaskStatusHolder>>,
     state: Arc<RwLock<StageState>>,
-    msg_sender: Sender<QueryMessage>,
     shutdown_rx: RwLock<Option<oneshot::Sender<StageMessage>>>,
     /// Children stage executions.
     ///
@@ -170,9 +169,8 @@ impl StageExecution {
             stage,
             worker_node_manager,
             tasks: Arc::new(tasks),
-            state: Arc::new(RwLock::new(Pending)),
+            state: Arc::new(RwLock::new(Pending { msg_sender })),
             shutdown_rx: RwLock::new(None),
-            msg_sender,
             children,
             compute_client_pool,
             catalog_reader,
@@ -183,14 +181,15 @@ impl StageExecution {
     /// Starts execution of this stage, returns error if already started.
     pub async fn start(&self) {
         let mut s = self.state.write().await;
-        match &*s {
-            &StageState::Pending => {
+        let cur_state = mem::replace(&mut *s, StageState::Failed);
+        match cur_state {
+            StageState::Pending { msg_sender } => {
                 let runner = StageRunner {
                     epoch: self.epoch,
                     stage: self.stage.clone(),
                     worker_node_manager: self.worker_node_manager.clone(),
                     tasks: self.tasks.clone(),
-                    msg_sender: self.msg_sender.clone(),
+                    msg_sender,
                     children: self.children.clone(),
                     state: self.state.clone(),
                     compute_client_pool: self.compute_client_pool.clone(),
@@ -233,7 +232,7 @@ impl StageExecution {
 
     pub async fn is_pending(&self) -> bool {
         let s = self.state.read().await;
-        matches!(*s, StageState::Pending)
+        matches!(*s, StageState::Pending { .. })
     }
 
     pub fn get_task_status_unchecked(&self, task_id: TaskId) -> Arc<TaskStatus> {
@@ -556,7 +555,7 @@ impl StageRunner {
         {
             let mut state = self.state.write().await;
             // Ignore if already finished.
-            if *state == StageState::Completed {
+            if let &StageState::Completed = &*state {
                 return Ok(());
             }
             // FIXME: Be careful for state jump back.

--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -62,10 +62,10 @@ const TASK_SCHEDULING_PARALLELISM: usize = 10;
 
 #[derive(Debug)]
 enum StageState {
-    /// In this state, some data structures for starting executions are created to avoid holding
-    /// them `StageExecution`. In this way, they could be efficiently moved into `StageRunner`
-    /// instead of cloning. This also ensures that they can get dropped once they are used up,
-    /// preventing some issues caused by unnecessarily long lifetime.
+    /// We put `msg_sender` in `Pending` state to avoid holding it in `StageExecution`. In this
+    /// way, it could be efficiently moved into `StageRunner` instead of being cloned. This also
+    /// ensures that the sender can get dropped once it is used up, preventing some issues caused
+    /// by unnecessarily long lifetime.
     Pending {
         msg_sender: Sender<QueryMessage>,
     },


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

### Problem

When fixing #5724 (which is caused by #5787) , we find that a receiver in `QueryRunner` waits infinitely in a `while` loop. To be more specific, it waits for messages coming from the senders, while the senders have finished sending all messages, but fail to be dropped because of some cyclic reference issues. View #5816 for more details.

### Solution

Align lifetime of the sender to that of `StageRunner` instead of `StageExecution`, so it will be dropped immediately when `StageRunner` ends its job. When all senders are dropped, the channel will be closed then, and the receiver will be dropped accordingly.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #5816 