### PR TITLE
feat(meta): Add disable_checkpoint configuration

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -592,6 +592,9 @@ template:
     # Whether to disable recovery mode
     unsafe-disable-recovery: false
 
+    # Whether to disable checkpoint by frequency
+    unsafe-disable-checkpoint: false
+
     # Interval of GC stale metadata and SST
     vacuum-interval-sec: 30
 

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -110,6 +110,12 @@ pub struct MetaNodeOpts {
     #[clap(long)]
     disable_recovery: bool,
 
+    /// Whether to disable checkpoint. If set, we will turn off sending checkpoints by frequency.
+    /// It means that except for configuration changes, we will only send barrier(checkpoint =
+    /// false)
+    #[clap(long)]
+    disable_checkpoint: bool,
+
     #[clap(long, default_value = "10")]
     meta_leader_lease_secs: u64,
 
@@ -218,6 +224,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
                 enable_committed_sst_sanity_check: opts.enable_committed_sst_sanity_check,
                 periodic_compaction_interval_sec: opts.periodic_compaction_interval_sec,
                 node_num_monitor_interval_sec: opts.node_num_monitor_interval_sec,
+                disable_checkpoint: opts.disable_checkpoint,
             },
         )
         .await

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -95,11 +95,14 @@ pub struct MetaOpts {
     pub periodic_compaction_interval_sec: u64,
     /// Interval of reporting the number of nodes in the cluster.
     pub node_num_monitor_interval_sec: u64,
+    /// Whether to support injection checkpoint by frequency
+    pub disable_checkpoint: bool,
 }
 
 impl Default for MetaOpts {
     fn default() -> Self {
         Self {
+            disable_checkpoint: false,
             enable_recovery: false,
             barrier_interval: Duration::from_millis(250),
             in_flight_barrier_nums: 40,

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -350,8 +350,11 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
 
     let catalog_manager = Arc::new(CatalogManager::new(env.clone()).await.unwrap());
 
-    let (barrier_scheduler, scheduled_barriers) =
-        BarrierScheduler::new_pair(hummock_manager.clone(), env.opts.checkpoint_frequency);
+    let (barrier_scheduler, scheduled_barriers) = BarrierScheduler::new_pair(
+        hummock_manager.clone(),
+        env.opts.checkpoint_frequency,
+        env.opts.disable_checkpoint,
+    );
 
     let source_manager = Arc::new(
         SourceManager::new(

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -951,8 +951,11 @@ mod tests {
                 .await?,
             );
 
-            let (barrier_scheduler, scheduled_barriers) =
-                BarrierScheduler::new_pair(hummock_manager.clone(), env.opts.checkpoint_frequency);
+            let (barrier_scheduler, scheduled_barriers) = BarrierScheduler::new_pair(
+                hummock_manager.clone(),
+                env.opts.checkpoint_frequency,
+                env.opts.disable_checkpoint,
+            );
 
             let compaction_group_manager =
                 Arc::new(CompactionGroupManager::new(env.clone()).await?);

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -63,6 +63,7 @@ pub struct MetaNodeConfig {
     pub enable_dashboard_v2: bool,
     pub max_heartbeat_interval_secs: u64,
     pub unsafe_disable_recovery: bool,
+    pub unsafe_disable_checkpoint: bool,
     pub max_idle_secs_to_exit: Option<u64>,
     pub vacuum_interval_sec: u64,
     pub collect_gc_watermark_spin_interval_sec: u64,

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -84,6 +84,10 @@ impl MetaNodeService {
             cmd.arg("--disable-recovery");
         }
 
+        if config.unsafe_disable_checkpoint {
+            cmd.arg("--disable-checkpoint");
+        }
+
         if let Some(sec) = config.max_idle_secs_to_exit {
             if sec > 0 {
                 cmd.arg("--dangerous-max-idle-secs").arg(format!("{}", sec));


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***
After https://github.com/risingwavelabs/risingwave/pull/4966, We support decouple barrier and checkpoint.
 And in this pr, We add a configuration item (`unsafe_disable_checkpoint`) to turn off sending checkpoints by frequency.
If `unsafe_disable_checkpoint = true`, we will send only the barrier(checkpoint = false) except for configuration changes 
May be useful for testing

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* RisingWave cluster configuration changes

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
