### PR TITLE
refactor(source): delete a redundant log output

### DIFF
--- a/src/source/src/parser/pb_parser.rs
+++ b/src/source/src/parser/pb_parser.rs
@@ -164,7 +164,6 @@ fn from_protobuf_value(field_desc: &FieldDescriptor, value: &Value) -> Result<Da
             // fields is a btree map in descriptor
             // so it's order is the same as datatype
             for field_desc in dyn_msg.descriptor().fields() {
-                tracing::info!("field {}", field_desc.name());
                 // missing field
                 if !dyn_msg.has_field(&field_desc)
                     && field_desc.cardinality() == Cardinality::Required


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?


- delete a redundant log output

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

