### PR TITLE
refactor(hummock manager): lazy init `HummockVersion` and `CompactStatus`

### DIFF
--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -344,7 +344,7 @@ mod tests {
         // No task
         let compactor = hummock_manager.get_idle_compactor().await.unwrap();
         assert_eq!(
-            ScheduleStatus::NoTask,
+            ScheduleStatus::PickFailure,
             compaction_scheduler
                 .pick_and_assign(
                     StaticCompactionGroupId::StateDefault.into(),

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -22,7 +22,9 @@ use risingwave_hummock_sdk::compact::compact_task_to_string;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 // use risingwave_hummock_sdk::key_range::KeyRange;
-use risingwave_hummock_sdk::{HummockContextId, HummockEpoch, HummockVersionId, FIRST_VERSION_ID};
+use risingwave_hummock_sdk::{
+    CompactionGroupId, HummockContextId, HummockEpoch, HummockVersionId, FIRST_VERSION_ID,
+};
 use risingwave_pb::common::{HostAddress, WorkerType};
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_pb::hummock::pin_version_response::Payload;
@@ -105,6 +107,7 @@ async fn test_unpin_snapshot_before() {
 
 #[tokio::test]
 async fn test_hummock_compaction_task() {
+    use crate::hummock::error::Error;
     let (_, hummock_manager, _, worker_node) = setup_compute_env(80).await;
     let sst_num = 2;
 
@@ -112,8 +115,15 @@ async fn test_hummock_compaction_task() {
     let task = hummock_manager
         .get_compact_task(StaticCompactionGroupId::StateDefault.into())
         .await
-        .unwrap();
-    assert_eq!(task, None);
+        .unwrap_err();
+    if let Error::InvalidCompactionGroup(group_id) = task {
+        assert_eq!(
+            group_id,
+            StaticCompactionGroupId::StateDefault as CompactionGroupId
+        );
+    } else {
+        panic!();
+    }
 
     // Add some sstables and commit.
     let epoch: u64 = 1;
@@ -506,10 +516,12 @@ async fn test_hummock_manager_basic() {
     commit_one(epoch, hummock_manager.clone()).await;
     epoch += 1;
 
+    let sync_group_version_id = FIRST_VERSION_ID + 1;
+
     // increased version id
     assert_eq!(
         hummock_manager.get_current_version().await.id,
-        FIRST_VERSION_ID + 1
+        sync_group_version_id + 1
     );
 
     // min pinned version id if no clients
@@ -536,11 +548,11 @@ async fn test_hummock_manager_basic() {
         };
         assert_eq!(
             version.hummock_version.as_ref().unwrap().get_id(),
-            FIRST_VERSION_ID + 1
+            sync_group_version_id + 1
         );
         assert_eq!(
             hummock_manager.get_min_pinned_version_id().await,
-            FIRST_VERSION_ID + 1
+            sync_group_version_id + 1
         );
     }
 
@@ -557,12 +569,12 @@ async fn test_hummock_manager_basic() {
         };
         assert_eq!(
             version.hummock_version.as_ref().unwrap().get_id(),
-            FIRST_VERSION_ID + 2
+            sync_group_version_id + 2
         );
         // pinned by context_id_1
         assert_eq!(
             hummock_manager.get_min_pinned_version_id().await,
-            FIRST_VERSION_ID + 1
+            sync_group_version_id + 1
         );
     }
 
@@ -577,7 +589,7 @@ async fn test_hummock_manager_basic() {
     );
     assert_eq!(
         hummock_manager.proceed_version_checkpoint().await.unwrap(),
-        1
+        sync_group_version_id
     );
     assert!(hummock_manager.get_ssts_to_delete().await.is_empty());
     assert_eq!(
@@ -585,7 +597,7 @@ async fn test_hummock_manager_basic() {
             .delete_version_deltas(usize::MAX)
             .await
             .unwrap(),
-        (1, 0)
+        (sync_group_version_id as usize, 0)
     );
 
     hummock_manager
@@ -594,7 +606,7 @@ async fn test_hummock_manager_basic() {
         .unwrap();
     assert_eq!(
         hummock_manager.get_min_pinned_version_id().await,
-        FIRST_VERSION_ID + 2
+        sync_group_version_id + 2
     );
     assert!(hummock_manager.get_ssts_to_delete().await.is_empty());
     assert_eq!(
@@ -832,7 +844,7 @@ async fn test_trigger_manual_compaction() {
             .await;
 
         assert_eq!(
-            "trigger_manual_compaction No compaction_task is available. compaction_group 2",
+            "Failed to get compaction task: InvalidCompactionGroup(\n    2,\n) compaction_group 2",
             result.err().unwrap().to_string()
         );
     }
@@ -965,8 +977,15 @@ async fn test_hummock_compaction_task_heartbeat() {
     let task = hummock_manager
         .get_compact_task(StaticCompactionGroupId::StateDefault.into())
         .await
-        .unwrap();
-    assert_eq!(task, None);
+        .unwrap_err();
+    if let Error::InvalidCompactionGroup(group_id) = task {
+        assert_eq!(
+            group_id,
+            StaticCompactionGroupId::StateDefault as CompactionGroupId
+        );
+    } else {
+        panic!();
+    }
 
     // Add some sstables and commit.
     let epoch: u64 = 1;
@@ -1083,8 +1102,15 @@ async fn test_hummock_compaction_task_heartbeat_removal_on_node_removal() {
     let task = hummock_manager
         .get_compact_task(StaticCompactionGroupId::StateDefault.into())
         .await
-        .unwrap();
-    assert_eq!(task, None);
+        .unwrap_err();
+    if let Error::InvalidCompactionGroup(group_id) = task {
+        assert_eq!(
+            group_id,
+            StaticCompactionGroupId::StateDefault as CompactionGroupId
+        );
+    } else {
+        panic!();
+    }
 
     // Add some sstables and commit.
     let epoch: u64 = 1;
@@ -1186,7 +1212,7 @@ async fn test_extend_ssts_to_delete() {
     // Checkpoint
     assert_eq!(
         hummock_manager.proceed_version_checkpoint().await.unwrap(),
-        3
+        4
     );
     assert_eq!(
         hummock_manager

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use itertools::Itertools;
-use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::key_with_epoch;
 use risingwave_hummock_sdk::{
@@ -226,8 +225,13 @@ pub fn get_sorted_sstable_ids(sstables: &[SstableInfo]) -> Vec<HummockSstableId>
 }
 
 pub fn get_sorted_committed_sstable_ids(hummock_version: &HummockVersion) -> Vec<HummockSstableId> {
-    let levels =
-        hummock_version.get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into());
+    let levels = match hummock_version
+        .levels
+        .get(&StaticCompactionGroupId::StateDefault.into())
+    {
+        Some(levels) => levels,
+        None => return vec![],
+    };
     levels
         .levels
         .iter()

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -356,7 +356,7 @@ mod tests {
 
         // Makes checkpoint and extends deltas_to_delete. Deletes deltas of v0->v1 and v2->v3.
         // Delta of v1->v2 cannot be deleted yet because it's used by ssts_to_delete.
-        assert_eq!(VacuumManager::vacuum_metadata(&vacuum).await.unwrap(), 2);
+        assert_eq!(VacuumManager::vacuum_metadata(&vacuum).await.unwrap(), 3);
         // No SST deletion is scheduled because no available worker.
         assert_eq!(
             VacuumManager::vacuum_sst_data(&vacuum).await.unwrap().len(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

lazy init `HummockVersion` and `CompactStatus` in `HummockManager`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
