### PR TITLE
refactor(stream,agg): introduce `enum AggStateStorage` to represent different storage type for agg states

### DIFF
--- a/src/common/src/util/match_util.rs
+++ b/src/common/src/util/match_util.rs
@@ -32,6 +32,16 @@ macro_rules! try_match_expand {
     };
 }
 
+#[macro_export]
+macro_rules! must_match {
+    ($expression:expr, $(|)? $( $pattern:pat_param )|+ $( if $guard: expr )? => $action:expr) => {
+        match $expression {
+            $( $pattern )|+ $( if $guard )? => $action,
+            _ => panic!("enum variant mismatch: `{}` is required", stringify!($( $pattern )|+ $( if $guard )?)),
+        }
+    };
+}
+
 mod tests {
     #[test]
     fn test_try_match() -> crate::error::Result<()> {
@@ -63,6 +73,36 @@ mod tests {
             crate::error::ErrorCode::InternalError
         )?;
         assert_eq!(err_str, "failure");
+        Ok(())
+    }
+
+    #[test]
+    fn test_must_match() -> crate::error::Result<()> {
+        #[allow(dead_code)]
+        enum A {
+            Foo,
+            Bar,
+        }
+        let a = A::Foo;
+        let val = must_match!(a, A::Foo => 42);
+        assert_eq!(val, 42);
+
+        #[allow(dead_code)]
+        enum B {
+            Foo,
+            Bar(i32),
+            Baz { x: u32, y: u32 },
+        }
+        let b = B::Baz { x: 1, y: 2 };
+        let val = must_match!(b, B::Baz { x, y } if x == 1 => x + y);
+        assert_eq!(val, 3);
+        let b = B::Bar(42);
+        let val = must_match!(b, B::Bar(x) => {
+            let y = x + 1;
+            y * 2
+        });
+        assert_eq!(val, 86);
+
         Ok(())
     }
 }

--- a/src/common/src/util/mod.rs
+++ b/src/common/src/util/mod.rs
@@ -30,7 +30,7 @@ pub mod ordered;
 pub mod prost;
 pub mod sort_util;
 #[macro_use]
-pub mod try_match;
+pub mod match_util;
 pub mod epoch;
 mod future_utils;
 pub mod scan_range;

--- a/src/stream/src/executor/aggregation/agg_state.rs
+++ b/src/stream/src/executor/aggregation/agg_state.rs
@@ -16,13 +16,29 @@ use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::{ArrayImpl, Row};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
+use risingwave_common::must_match;
 use risingwave_common::types::Datum;
+use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use super::minput::MaterializedInputState;
 use super::value::ValueState;
-use super::{AggCall, AggStateTable};
+use super::AggCall;
+use crate::common::StateTableColumnMapping;
 use crate::executor::{PkIndices, StreamExecutorResult};
+
+pub enum AggStateStorage<S: StateStore> {
+    /// The state is stored in the result table. No standalone state table is needed.
+    ResultValue,
+
+    /// The state is stored as a materialization of input chunks, in a standalone state table.
+    /// `mapping` describes the mapping between the columns in the state table and the input
+    /// chunks.
+    MaterializedInput {
+        table: StateTable<S>,
+        mapping: StateTableColumnMapping,
+    },
+}
 
 /// Verify if the data going through the state is valid by checking if `ops.len() ==
 /// visibility.len() == columns[x].len()`.
@@ -50,7 +66,7 @@ impl<S: StateStore> AggState<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn create(
         agg_call: &AggCall,
-        agg_state_table: Option<&AggStateTable<S>>,
+        storage: &AggStateStorage<S>,
         row_count: usize,
         prev_output: Option<&Datum>,
         pk_indices: &PkIndices,
@@ -58,11 +74,11 @@ impl<S: StateStore> AggState<S> {
         extreme_cache_size: usize,
         input_schema: &Schema,
     ) -> StreamExecutorResult<Self> {
-        // TODO(yuchao): Later we will make `Option<&AggStateTable<S>>` an enum corresponding to
-        // `AggCallState` from frontend.
-        Ok(match agg_state_table {
-            None => Self::Value(ValueState::new(agg_call, prev_output.cloned())?),
-            Some(AggStateTable { mapping, .. }) => {
+        Ok(match storage {
+            AggStateStorage::ResultValue => {
+                Self::Value(ValueState::new(agg_call, prev_output.cloned())?)
+            }
+            AggStateStorage::MaterializedInput { mapping, .. } => {
                 Self::MaterializedInput(MaterializedInputState::new(
                     agg_call,
                     group_key,
@@ -82,16 +98,19 @@ impl<S: StateStore> AggState<S> {
         ops: Ops<'_>,
         visibility: Option<&Bitmap>,
         columns: &[&ArrayImpl],
-        agg_state_table: Option<&mut AggStateTable<S>>,
+        storage: &mut AggStateStorage<S>,
     ) -> StreamExecutorResult<()> {
         debug_assert!(verify_chunk(ops, visibility, columns));
         match self {
-            Self::Value(state) => state.apply_chunk(ops, visibility, columns),
+            Self::Value(state) => {
+                debug_assert!(matches!(storage, AggStateStorage::ResultValue));
+                state.apply_chunk(ops, visibility, columns)
+            }
             Self::MaterializedInput(state) => {
-                let agg_state_table =
-                    agg_state_table.expect("State table is expected for materialized input state");
+                let state_table =
+                    must_match!(storage, AggStateStorage::MaterializedInput { table, .. } => table);
                 state
-                    .apply_chunk(ops, visibility, columns, &mut agg_state_table.table)
+                    .apply_chunk(ops, visibility, columns, state_table)
                     .await
             }
         }
@@ -100,14 +119,19 @@ impl<S: StateStore> AggState<S> {
     /// Get the output of the state.
     pub async fn get_output(
         &mut self,
-        agg_state_table: Option<&AggStateTable<S>>,
+        storage: &AggStateStorage<S>,
     ) -> StreamExecutorResult<Datum> {
         match self {
-            Self::Value(state) => Ok(state.get_output()),
+            Self::Value(state) => {
+                debug_assert!(matches!(storage, AggStateStorage::ResultValue));
+                Ok(state.get_output())
+            }
             Self::MaterializedInput(state) => {
-                let agg_state_table =
-                    agg_state_table.expect("State table is expected for materialized input state");
-                state.get_output(&agg_state_table.table).await
+                let state_table = must_match!(
+                    storage,
+                    AggStateStorage::MaterializedInput { table, .. } => table
+                );
+                state.get_output(state_table).await
             }
         }
     }

--- a/src/stream/src/executor/aggregation/agg_state.rs
+++ b/src/stream/src/executor/aggregation/agg_state.rs
@@ -27,6 +27,7 @@ use super::AggCall;
 use crate::common::StateTableColumnMapping;
 use crate::executor::{PkIndices, StreamExecutorResult};
 
+/// Represents the persistent storage of aggregation state.
 pub enum AggStateStorage<S: StateStore> {
     /// The state is stored in the result table. No standalone state table is needed.
     ResultValue,

--- a/src/stream/src/executor/aggregation/minput.rs
+++ b/src/stream/src/executor/aggregation/minput.rs
@@ -1,0 +1,103 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::array::stream_chunk::Ops;
+use risingwave_common::array::{ArrayImpl, Row};
+use risingwave_common::buffer::Bitmap;
+use risingwave_common::catalog::Schema;
+use risingwave_common::types::Datum;
+use risingwave_expr::expr::AggKind;
+use risingwave_storage::table::streaming_table::state_table::StateTable;
+use risingwave_storage::StateStore;
+
+use super::table_state::{
+    GenericExtremeState, ManagedArrayAggState, ManagedStringAggState, ManagedTableState,
+};
+use super::AggCall;
+use crate::common::StateTableColumnMapping;
+use crate::executor::{PkIndices, StreamExecutorResult};
+
+/// Aggregation state as a materialization of input chunks.
+///
+/// For example, in `string_agg`, several useful columns are picked from input chunks and
+/// stored in the state table when applying chunks, and the aggregation result is calculated
+/// when need to get output.
+pub struct MaterializedInputState<S: StateStore> {
+    inner: Box<dyn ManagedTableState<S>>,
+}
+
+impl<S: StateStore> MaterializedInputState<S> {
+    /// Create an instance from [`AggCall`].
+    pub fn new(
+        agg_call: &AggCall,
+        group_key: Option<&Row>,
+        pk_indices: &PkIndices,
+        col_mapping: StateTableColumnMapping,
+        row_count: usize,
+        extreme_cache_size: usize,
+        input_schema: &Schema,
+    ) -> Self {
+        Self {
+            inner: match agg_call.kind {
+                AggKind::Max | AggKind::Min | AggKind::FirstValue => {
+                    Box::new(GenericExtremeState::new(
+                        agg_call,
+                        group_key,
+                        pk_indices,
+                        col_mapping,
+                        row_count,
+                        extreme_cache_size,
+                        input_schema,
+                    ))
+                }
+                AggKind::StringAgg => Box::new(ManagedStringAggState::new(
+                    agg_call,
+                    group_key,
+                    pk_indices,
+                    col_mapping,
+                    row_count,
+                )),
+                AggKind::ArrayAgg => Box::new(ManagedArrayAggState::new(
+                    agg_call,
+                    group_key,
+                    pk_indices,
+                    col_mapping,
+                    row_count,
+                )),
+                _ => panic!(
+                    "Agg kind `{}` is not expected to have materialized input state",
+                    agg_call.kind
+                ),
+            },
+        }
+    }
+
+    /// Apply a chunk of data to the state.
+    pub async fn apply_chunk(
+        &mut self,
+        ops: Ops<'_>,
+        visibility: Option<&Bitmap>,
+        columns: &[&ArrayImpl],
+        state_table: &mut StateTable<S>,
+    ) -> StreamExecutorResult<()> {
+        self.inner
+            .apply_chunk(ops, visibility, columns, state_table)
+            .await
+    }
+
+    /// Get the output of the state.
+    pub async fn get_output(&mut self, state_table: &StateTable<S>) -> StreamExecutorResult<Datum> {
+        self.inner.get_output(state_table).await
+    }
+}

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -32,6 +32,7 @@ mod agg_call;
 mod agg_group;
 pub mod agg_impl;
 mod agg_state;
+mod minput;
 mod table_state;
 mod value;
 

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -92,10 +92,11 @@ pub fn agg_call_filter_res(
     }
 }
 
-pub fn for_each_table_storage<S, F>(state_storages: &mut [AggStateStorage<S>], f: F)
+pub fn iter_table_storage<S>(
+    state_storages: &mut [AggStateStorage<S>],
+) -> impl Iterator<Item = &mut StateTable<S>>
 where
     S: StateStore,
-    F: Fn(&mut StateTable<S>),
 {
     state_storages
         .iter_mut()
@@ -103,7 +104,4 @@ where
             AggStateStorage::ResultValue => None,
             AggStateStorage::MaterializedInput { table, .. } => Some(table),
         })
-        .for_each(|state_table| {
-            f(state_table);
-        });
 }

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -20,7 +20,7 @@ use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
 use super::aggregation::{
-    agg_call_filter_res, for_each_agg_state_table, AggChangesInfo, AggStateTable,
+    agg_call_filter_res, for_each_table_storage, AggChangesInfo, AggStateStorage,
 };
 use super::*;
 use crate::error::StreamResult;
@@ -55,9 +55,8 @@ pub struct GlobalSimpleAggExecutor<S: StateStore> {
     /// An operator will support multiple aggregation calls.
     agg_calls: Vec<AggCall>,
 
-    /// Relational state tables for each aggregation calls.
-    /// `None` means the agg call need not to maintain a state table by itself.
-    agg_state_tables: Vec<Option<AggStateTable<S>>>,
+    /// State storage for each agg calls.
+    storages: Vec<AggStateStorage<S>>,
 
     /// State table for the previous result of all agg calls.
     /// The outputs of all managed agg states are collected and stored in this
@@ -95,7 +94,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
         ctx: ActorContextRef,
         input: Box<dyn Executor>,
         agg_calls: Vec<AggCall>,
-        agg_state_tables: Vec<Option<AggStateTable<S>>>,
+        storages: Vec<AggStateStorage<S>>,
         result_table: StateTable<S>,
         pk_indices: PkIndices,
         executor_id: u64,
@@ -115,7 +114,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
             input_pk_indices: input_info.pk_indices,
             input_schema: input_info.schema,
             agg_calls,
-            agg_state_tables,
+            storages,
             result_table,
             extreme_cache_size,
             state_changed: false,
@@ -127,7 +126,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
         ctx: &ActorContextRef,
         identity: &str,
         agg_calls: &[AggCall],
-        agg_state_tables: &mut [Option<AggStateTable<S>>],
+        storages: &mut [AggStateStorage<S>],
         result_table: &mut StateTable<S>,
         input_pk_indices: &PkIndices,
         input_schema: &Schema,
@@ -143,7 +142,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
                 AggGroup::create(
                     None,
                     agg_calls,
-                    agg_state_tables,
+                    storages,
                     result_table,
                     input_pk_indices,
                     extreme_cache_size,
@@ -176,7 +175,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
             })
             .try_collect()?;
         agg_group
-            .apply_chunk(agg_state_tables, &ops, &columns, &visibilities)
+            .apply_chunk(storages, &ops, &columns, &visibilities)
             .await?;
 
         Ok(())
@@ -186,7 +185,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
         schema: &Schema,
         agg_group: &mut Option<AggGroup<S>>,
         epoch: EpochPair,
-        agg_state_tables: &mut [Option<AggStateTable<S>>],
+        storages: &mut [AggStateStorage<S>],
         result_table: &mut StateTable<S>,
         state_changed: &mut bool,
     ) -> StreamExecutorResult<Option<StreamChunk>> {
@@ -196,10 +195,13 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
 
             // Batch commit data.
             futures::future::try_join_all(
-                agg_state_tables
+                storages
                     .iter_mut()
-                    .filter_map(Option::as_mut)
-                    .map(|state_table| state_table.table.commit(epoch)),
+                    .filter_map(|storage| match storage {
+                        AggStateStorage::ResultValue => None,
+                        AggStateStorage::MaterializedInput { table, .. } => Some(table),
+                    })
+                    .map(|state_table| state_table.commit(epoch)),
             )
             .await?;
 
@@ -214,7 +216,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
                 prev_outputs,
                 ..
             } = agg_group
-                .build_changes(&mut builders, &mut new_ops, agg_state_tables)
+                .build_changes(&mut builders, &mut new_ops, storages)
                 .await?;
             if let Some(prev_outputs) = prev_outputs {
                 let old_row = agg_group
@@ -239,8 +241,8 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
         } else {
             // Nothing to flush.
             // Call commit on state table to increment the epoch.
-            for_each_agg_state_table(agg_state_tables, |state_table| {
-                state_table.table.commit_no_data_expected(epoch);
+            for_each_table_storage(storages, |state_table| {
+                state_table.commit_no_data_expected(epoch);
             });
             result_table.commit_no_data_expected(epoch);
             Ok(None)
@@ -257,7 +259,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
             input_schema,
             agg_calls,
             extreme_cache_size,
-            mut agg_state_tables,
+            mut storages,
             mut result_table,
             mut state_changed,
         } = self;
@@ -266,8 +268,8 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
 
         let mut input = input.execute();
         let barrier = expect_first_barrier(&mut input).await?;
-        for_each_agg_state_table(&mut agg_state_tables, |state_table| {
-            state_table.table.init_epoch(barrier.epoch);
+        for_each_table_storage(&mut storages, |state_table| {
+            state_table.init_epoch(barrier.epoch);
         });
         result_table.init_epoch(barrier.epoch);
 
@@ -282,7 +284,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
                         &ctx,
                         &info.identity,
                         &agg_calls,
-                        &mut agg_state_tables,
+                        &mut storages,
                         &mut result_table,
                         &input_pk_indices,
                         &input_schema,
@@ -298,7 +300,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
                         &info.schema,
                         &mut agg_group,
                         barrier.epoch,
-                        &mut agg_state_tables,
+                        &mut storages,
                         &mut result_table,
                         &mut state_changed,
                     )

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -31,7 +31,7 @@ use risingwave_common::util::hash_util::Crc32FastBuilder;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 use risingwave_storage::StateStore;
 
-use super::aggregation::{agg_call_filter_res, for_each_agg_state_table, AggStateTable};
+use super::aggregation::{agg_call_filter_res, for_each_table_storage, AggStateStorage};
 use super::{expect_first_barrier, ActorContextRef, Executor, PkIndicesRef, StreamExecutorResult};
 use crate::cache::{cache_may_stale, EvictableHashMap, ExecutorCache, LruManagerRef};
 use crate::error::StreamResult;
@@ -81,9 +81,9 @@ struct HashAggExecutorExtra<K: HashKey, S: StateStore> {
     /// A [`HashAggExecutor`] may have multiple [`AggCall`]s.
     agg_calls: Vec<AggCall>,
 
-    /// Relational state tables for each aggregation calls.
+    /// State storages for each aggregation calls.
     /// `None` means the agg call need not to maintain a state table by itself.
-    agg_state_tables: Vec<Option<AggStateTable<S>>>,
+    storages: Vec<AggStateStorage<S>>,
 
     /// State table for the previous result of all agg calls.
     /// The outputs of all managed agg states are collected and stored in this
@@ -141,7 +141,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         ctx: ActorContextRef,
         input: Box<dyn Executor>,
         agg_calls: Vec<AggCall>,
-        agg_state_tables: Vec<Option<AggStateTable<S>>>,
+        storages: Vec<AggStateStorage<S>>,
         result_table: StateTable<S>,
         pk_indices: PkIndices,
         executor_id: u64,
@@ -165,7 +165,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 input_pk_indices: input_info.pk_indices,
                 input_schema: input_info.schema,
                 agg_calls,
-                agg_state_tables,
+                storages,
                 result_table,
                 group_key_indices,
                 group_by_cache_size,
@@ -237,7 +237,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             ref identity,
             ref group_key_indices,
             ref agg_calls,
-            ref mut agg_state_tables,
+            ref mut storages,
             ref result_table,
             ref input_schema,
             ref input_pk_indices,
@@ -287,7 +287,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                 AggGroup::create(
                                     Some(key.clone().deserialize(group_key_types)?),
                                     agg_calls,
-                                    agg_state_tables,
+                                    storages,
                                     result_table,
                                     input_pk_indices,
                                     *extreme_cache_size,
@@ -327,7 +327,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 })
                 .try_collect()?;
             agg_group
-                .apply_chunk(agg_state_tables, &ops, &columns, &visibilities)
+                .apply_chunk(storages, &ops, &columns, &visibilities)
                 .await?;
         }
 
@@ -340,7 +340,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             ref ctx,
             ref group_key_indices,
             ref schema,
-            ref mut agg_state_tables,
+            ref mut storages,
             ref mut result_table,
             ref mut group_change_set,
             ref lookup_miss_count,
@@ -372,10 +372,13 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         if dirty_cnt > 0 {
             // Batch commit data.
             futures::future::try_join_all(
-                agg_state_tables
+                storages
                     .iter_mut()
-                    .filter_map(Option::as_mut)
-                    .map(|state_table| state_table.table.commit(epoch)),
+                    .filter_map(|storage| match storage {
+                        AggStateStorage::ResultValue => None,
+                        AggStateStorage::MaterializedInput { table, .. } => Some(table),
+                    })
+                    .map(|state_table| state_table.commit(epoch)),
             )
             .await?;
 
@@ -405,7 +408,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                         .build_changes(
                             &mut builders[group_key_indices.len()..],
                             &mut new_ops,
-                            agg_state_tables,
+                            storages,
                         )
                         .await?;
                     for _ in 0..n_appended_ops {
@@ -444,8 +447,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         } else {
             // Nothing to flush.
             // Call commit on state table to increment the epoch.
-            for_each_agg_state_table(agg_state_tables, |state_table| {
-                state_table.table.commit_no_data_expected(epoch);
+            for_each_table_storage(storages, |state_table| {
+                state_table.commit_no_data_expected(epoch);
             });
             result_table.commit_no_data_expected(epoch);
             return Ok(());
@@ -471,8 +474,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         // First barrier
         let mut input = input.execute();
         let barrier = expect_first_barrier(&mut input).await?;
-        for_each_agg_state_table(&mut extra.agg_state_tables, |state_table| {
-            state_table.table.init_epoch(barrier.epoch);
+        for_each_table_storage(&mut extra.storages, |state_table| {
+            state_table.init_epoch(barrier.epoch);
         });
         extra.result_table.init_epoch(barrier.epoch);
         agg_states.update_epoch(barrier.epoch.curr);
@@ -494,8 +497,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
 
                     // Update the vnode bitmap for state tables of all agg calls if asked.
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(extra.ctx.id) {
-                        for_each_agg_state_table(&mut extra.agg_state_tables, |state_table| {
-                            let _ = state_table.table.update_vnode_bitmap(vnode_bitmap.clone());
+                        for_each_table_storage(&mut extra.storages, |state_table| {
+                            let _ = state_table.update_vnode_bitmap(vnode_bitmap.clone());
                         });
                         let previous_vnode_bitmap =
                             extra.result_table.update_vnode_bitmap(vnode_bitmap.clone());

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -16,7 +16,7 @@
 
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 
-use super::agg_common::{build_agg_call_from_prost, build_agg_state_tables_from_proto};
+use super::agg_common::{build_agg_call_from_prost, build_agg_state_storages_from_proto};
 use super::*;
 use crate::executor::aggregation::AggCall;
 use crate::executor::GlobalSimpleAggExecutor;
@@ -37,8 +37,8 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
             .iter()
             .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
-        let agg_state_tables =
-            build_agg_state_tables_from_proto(node.get_agg_call_states(), store.clone(), None);
+        let storages =
+            build_agg_state_storages_from_proto(node.get_agg_call_states(), store.clone(), None);
         let result_table =
             StateTable::from_table_catalog(node.get_result_table().unwrap(), store, None);
 
@@ -46,7 +46,7 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
             params.actor_context,
             input,
             agg_calls,
-            agg_state_tables,
+            storages,
             result_table,
             params.pk_indices,
             params.executor_id,

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -20,10 +20,10 @@ use risingwave_common::hash::{HashKey, HashKeyDispatcher};
 use risingwave_common::types::DataType;
 use risingwave_storage::table::streaming_table::state_table::StateTable;
 
-use super::agg_common::{build_agg_call_from_prost, build_agg_state_tables_from_proto};
+use super::agg_common::{build_agg_call_from_prost, build_agg_state_storages_from_proto};
 use super::*;
 use crate::cache::LruManagerRef;
-use crate::executor::aggregation::{AggCall, AggStateTable};
+use crate::executor::aggregation::{AggCall, AggStateStorage};
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, HashAggExecutor, PkIndices};
 
@@ -31,7 +31,7 @@ pub struct HashAggExecutorDispatcherArgs<S: StateStore> {
     ctx: ActorContextRef,
     input: BoxedExecutor,
     agg_calls: Vec<AggCall>,
-    agg_state_tables: Vec<Option<AggStateTable<S>>>,
+    storages: Vec<AggStateStorage<S>>,
     result_table: StateTable<S>,
     group_key_indices: Vec<usize>,
     group_key_types: Vec<DataType>,
@@ -52,7 +52,7 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcherArgs<S> {
             self.ctx,
             self.input,
             self.agg_calls,
-            self.agg_state_tables,
+            self.storages,
             self.result_table,
             self.pk_indices,
             self.executor_id,
@@ -101,7 +101,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
         let vnodes = Some(Arc::new(
             params.vnode_bitmap.expect("vnodes not set for hash agg"),
         ));
-        let agg_state_tables = build_agg_state_tables_from_proto(
+        let storages = build_agg_state_storages_from_proto(
             node.get_agg_call_states(),
             store.clone(),
             vnodes.clone(),
@@ -113,7 +113,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             ctx: params.actor_context,
             input,
             agg_calls,
-            agg_state_tables,
+            storages,
             result_table,
             group_key_indices,
             group_key_types,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Hide `ManagedTableState` behind a new struct called `MaterializedInputState`, so that `AggState` need not to care about the detail.
- Introduce `enum AggStateStorage` to represent different storage type for agg states, replacing the old `Option<AggStateTable>`. This matches the backend implementation with what frontend infers.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#5806