### PR TITLE
chore(ci): remove useless timeout in scripts

### DIFF
--- a/ci/scripts/deterministic-unit-test.sh
+++ b/ci/scripts/deterministic-unit-test.sh
@@ -9,4 +9,4 @@ echo "--- Generate RiseDev CI config"
 cp ci/risedev-components.ci.env risedev-components.user.env
 
 echo "--- Run unit tests in deterministic simulation mode"
-MADSIM_TEST_NUM=10 timeout 10m cargo make stest --no-fail-fast
+MADSIM_TEST_NUM=10 cargo make stest --no-fail-fast

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -40,7 +40,6 @@ cargo make link-all-in-one-binaries
 
 echo "--- e2e, ci-3cn-1fe, streaming"
 cargo make ci-start ci-3cn-1fe
-# Please make sure the regression is expected before increasing the timeout.
 sqllogictest -p 4566 -d dev './e2e_test/streaming/**/*.slt' --junit "streaming-${profile}"
 
 echo "--- Kill cluster"
@@ -80,7 +79,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     # This avoids storing excess logs.
     # If there's errors, the failing query will be printed to stderr.
     # Use that to reproduce logs on local machine.
-    timeout 20m ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
+    ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 
     echo "--- Kill cluster"
     cargo make kill


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
There is `timeout_in_minutes` in yaml