### PR TITLE
fix(ctl): fix sst_dump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4991,6 +4991,7 @@ dependencies = [
  "clap 3.2.17",
  "comfy-table",
  "futures",
+ "itertools",
  "madsim-tokio",
  "parking_lot 0.12.1",
  "regex",

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -40,14 +40,6 @@ pub fn serialize_cell(cell: &Datum) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
-/// Deserialize cell bytes into datum (Not order guarantee, used in value decoding).
-pub fn deserialize_cell(mut data: impl Buf, ty: &DataType) -> Result<Datum> {
-    if data.remaining() < 1 {
-        return Ok(None);
-    }
-    deserialize_value(ty, &mut data)
-}
-
 /// Serialize a datum into bytes (Not order guarantee, used in value encoding).
 pub fn serialize_datum(cell: &Datum, mut buf: impl BufMut) {
     serialize_datum_ref(&to_datum_ref(cell), &mut buf);

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -10,6 +10,7 @@ chrono = "0.4"
 clap = { version = "3", features = ["derive"] }
 comfy-table = "6"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+itertools = "0.10"
 parking_lot = "0.12"
 regex = "1.6.0"
 risingwave_common = { path = "../common" }

--- a/src/storage/src/row_serde/row_serde_util.rs
+++ b/src/storage/src/row_serde/row_serde_util.rs
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use memcomparable::from_slice;
 use risingwave_common::array::Row;
-use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::Result;
 use risingwave_common::types::{VirtualNode, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::ordered::OrderedRowSerde;
@@ -42,11 +40,6 @@ pub fn deserialize_pk_with_vnode(
     let vnode = VirtualNode::from_be_bytes(key[0..VIRTUAL_NODE_SIZE].try_into().unwrap());
     let pk = deserializer.deserialize(&key[VIRTUAL_NODE_SIZE..])?;
     Ok((vnode, pk))
-}
-
-pub fn deserialize_column_id(bytes: &[u8]) -> Result<ColumnId> {
-    let column_id = from_slice::<u32>(bytes)? ^ (1 << 31);
-    Ok((column_id as i32).into())
 }
 
 pub fn parse_raw_key_to_vnode_and_key(raw_key: &[u8]) -> (VirtualNode, &[u8]) {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Fix sst_dump. It originally uses deprecated cell_table interface and doesn't output correct info.

Example output:
```
                  full key: [74, 00, 00, 05, 37, 59, 00, 80, 00, 00, 00, 00, 00, 09, 03, 00, 80, 00, 00, 00, 00, 00, 09, 03, 00, 80, 00, 00, 04, ff, f4, 9a, fa, b3, 45, ff, ff]
                full value: [00, 01, 03, 09, 00, 00, 00, 00, 00, 00, 01, 06, 00, 00, 00, 01, 04, 00, 00, 00]
                  user key: [74, 00, 00, 05, 37, 59, 00, 80, 00, 00, 00, 00, 00, 09, 03, 00, 80, 00, 00, 00, 00, 00, 09, 03, 00, 80, 00, 00, 04]
                user value: [01, 03, 09, 00, 00, 00, 00, 00, 00, 01, 06, 00, 00, 00, 01, 04, 00, 00, 00]
                     epoch: 3207298180317184
                      type: Put
                     table: 1335 - __internal_tpch_q21_179_hashjoinright_1335
                    column: lineitem.l_orderkey 2307
                    column: lineitem.l_suppkey 6
                    column: lineitem.l_linenumber 4

```

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
