### PR TITLE
feat(sqlsmith_e2e): increase fuzzing duration for longevity testing

### DIFF
--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -80,7 +80,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     # This avoids storing excess logs.
     # If there's errors, the failing query will be printed to stderr.
     # Use that to reproduce logs on local machine.
-    timeout 20m ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
+    timeout 120m ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 
     echo "--- Kill cluster"
     cargo make kill

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -68,7 +68,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 10
+    timeout_in_minutes: 120
     retry: *auto-retry
 
   - label: "end-to-end source test"

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -54,7 +54,7 @@ struct TestOptions {
     testdata: String,
 
     /// The number of test cases to generate.
-    #[clap(long, default_value = "100")]
+    #[clap(long, default_value = "600")]
     count: usize,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Fuzz queries over a longer duration. 
- Catch bugs which only occur over long duration.
- Also tests more queries in nightly cron.

## Checklist


## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
