### PR TITLE
feat(frontend): throw error when `UserOptions` has multiple conflicting or redundant options

### DIFF
--- a/src/sqlparser/tests/testdata/create.yaml
+++ b/src/sqlparser/tests/testdata/create.yaml
@@ -67,3 +67,23 @@
 
 - input: CREATE SINK IF NOT EXISTS snk FROM mv WITH (connector = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')
   formatted_sql: CREATE SINK IF NOT EXISTS snk FROM mv WITH (connector = 'mysql', mysql.endpoint = '127.0.0.1:3306', mysql.table = '<table_name>', mysql.database = '<database_name>', mysql.user = '<user_name>', mysql.password = '<password>')
+
+- input: create user tmp createdb nocreatedb
+  error_msg: |
+    sql parser error: conflicting or redundant options
+
+- input: create user tmp createdb createdb
+  error_msg: |
+    sql parser error: conflicting or redundant options
+
+- input: create user tmp with password '123' password null
+  error_msg: |
+    sql parser error: conflicting or redundant options
+
+- input: create user tmp with encrypted password '' password null
+  error_msg: |
+    sql parser error: conflicting or redundant options
+
+- input: create user tmp with encrypted password null
+  error_msg: |
+    sql parser error: Expected literal string, found: null


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As the title.

Error message of PostgreSQL:
```sql
postgres=# create user tmp with createrole createrole;
ERROR:  conflicting or redundant options
LINE 1: create user tmp with createrole createrole;
                                        ^
postgres=# create user tmp with createrole nocreaterole;
ERROR:  conflicting or redundant options
LINE 1: create user tmp with createrole nocreaterole;
                                        ^
```
```sql
postgres=# alter user tmp with createdb createdb;
ERROR:  conflicting or redundant options
postgres=# alter user tmp with createdb nocreatedb;
ERROR:  conflicting or redundant options
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #5904 