### PR TITLE
refactor: refine error handle and error msg in pgwire

### DIFF
--- a/src/utils/pgwire/src/error.rs
+++ b/src/utils/pgwire/src/error.rs
@@ -14,6 +14,7 @@
 
 use std::io::Error as IoError;
 
+use anyhow::anyhow;
 use thiserror::Error;
 
 use crate::pg_server::BoxedError;
@@ -22,10 +23,7 @@ pub type PsqlResult<T> = std::result::Result<T, PsqlError>;
 /// Error type used in pgwire crates.
 #[derive(Error, Debug)]
 pub enum PsqlError {
-    #[error("SslError: {0}")]
-    SslError(IoError),
-
-    #[error("StartupError: {0}")]
+    #[error("Startup Error when connect to session: {0}")]
     StartupError(BoxedError),
 
     #[error("PasswordError: {0}")]
@@ -34,56 +32,26 @@ pub enum PsqlError {
     #[error("QueryError: {0}")]
     QueryError(BoxedError),
 
-    #[error("Encode error {0}")]
-    CancelMsg(String),
-
     #[error("ParseError: {0}")]
     ParseError(BoxedError),
-
-    #[error("BindError: {0}")]
-    BindError(BoxedError),
 
     #[error("ExecuteError: {0}")]
     ExecuteError(BoxedError),
 
-    #[error("DescribeError: {0}")]
-    DescribeError(String),
-
-    #[error("CloseError: {0}")]
-    CloseError(IoError),
-
-    #[error("ReadMsgError: {0}")]
-    ReadMsgError(IoError),
-
     #[error("{0}")]
     IoError(#[from] IoError),
 
-    #[error("Cancel Not Found")]
-    CancelNotFound,
-
     #[error("{0}")]
+    /// Include error for describe, bind, parse, execute etc.
     Internal(#[from] anyhow::Error),
 }
 
 impl PsqlError {
-    /// Construct a Cancel error. Used when Ctrl-c a processing query. Similar to PG.
-    pub fn cancel() -> Self {
-        PsqlError::CancelMsg("ERROR:  canceling statement due to user request".to_string())
+    pub fn no_statement() -> Self {
+        PsqlError::Internal(anyhow!("No statement found".to_string()))
     }
 
-    pub fn no_statement_in_describe() -> Self {
-        PsqlError::DescribeError("No statement found".to_string())
-    }
-
-    pub fn no_statement_in_bind() -> Self {
-        PsqlError::BindError("No statement found".into())
-    }
-
-    pub fn no_portal_in_describe() -> Self {
-        PsqlError::DescribeError("No portal found".to_string())
-    }
-
-    pub fn no_portal_in_execute() -> Self {
-        PsqlError::ExecuteError("No portal found".into())
+    pub fn no_portal() -> Self {
+        PsqlError::Internal(anyhow!("No portal found".to_string()))
     }
 }

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::vec::IntoIter;
 
+use anyhow::anyhow;
 use bytes::Bytes;
 use futures::stream::FusedStream;
 use futures::{Stream, StreamExt, TryStreamExt};
@@ -363,9 +364,9 @@ impl PreparedStatement {
         param_format: bool,
     ) -> PsqlResult<Vec<String>> {
         if type_description.len() != raw_params.len() {
-            return Err(PsqlError::BindError(
-                "The number of params doesn't match the number of types".into(),
-            ));
+            return Err(PsqlError::Internal(anyhow!(
+                "The number of params doesn't match the number of types"
+            )));
         }
         assert_eq!(type_description.len(), raw_params.len());
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Try to simplify the error handle in pgwire crate. This is just one step.
* Reduce unnecessary variant like SslError(IoError).
* Use PsqlError::Internal(anyhow) to represent some Error variant



## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
