### PR TITLE
fix: `from_proto_bytes` support `timestamp with time zone`

### DIFF
--- a/e2e_test/batch/types/timestamptz_utc.slt.part
+++ b/e2e_test/batch/types/timestamptz_utc.slt.part
@@ -61,6 +61,34 @@ select v1, v2 from t where v2 BETWEEN '2022-10-01T11:00:05Z' AND '2022-10-01T11:
 statement ok
 drop table t;
 
+statement ok
+create table t (v1 int, v2 timestamp with time zone primary key);
+
+statement ok
+insert into t values (7, '2022-10-01 12:00:00+01:00'), (9, '2022-10-01 12:01:00+01:00'), (2, '2022-10-01 12:02:00+01:00');
+
+query T
+select v1, v2 from t where v2 BETWEEN '2022-10-01T11:00:05Z' AND '2022-10-01T11:01:05Z';
+----
+9 2022-10-01 11:01:00+00:00
+
+statement ok
+drop table t;
+
+statement ok
+create table t (v1 timestamp with time zone[], v2 struct<a timestamp with time zone>);
+
+statement ok
+insert into t values (array['2022-10-01 12:00:00+01:00'::timestamp with time zone], row('2022-10-01 12:01:00+01:00'));
+
+query TT
+select v1[1], (v2).a from t;
+----
+2022-10-01 11:00:00+00:00 2022-10-01 11:01:00+00:00
+
+statement ok
+drop table t;
+
 # Timestamptz values can also be constructed from unix epoch seconds
 
 query T

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -944,11 +944,11 @@ impl ScalarImpl {
                     .try_into()
                     .map_err(|e| anyhow!("Failed to deserialize i32, reason: {:?}", e))?,
             )),
-            TypeName::Int64 => ScalarImpl::Int64(i64::from_be_bytes(
-                b.as_slice()
-                    .try_into()
-                    .map_err(|e| anyhow!("Failed to deserialize i64, reason: {:?}", e))?,
-            )),
+            t @ (TypeName::Int64 | TypeName::Timestampz) => {
+                ScalarImpl::Int64(i64::from_be_bytes(b.as_slice().try_into().map_err(
+                    |e| anyhow!("Failed to deserialize i64 for {:?}, reason: {:?}", t, e),
+                )?))
+            }
             TypeName::Float => ScalarImpl::Float32(
                 f32::from_be_bytes(
                     b.as_slice()
@@ -978,11 +978,6 @@ impl ScalarImpl {
                 b,
                 data_type.get_interval_type().unwrap_or(Unspecified),
             )?),
-            TypeName::Timestampz => ScalarImpl::Int64(i64::from_be_bytes(
-                b.as_slice()
-                    .try_into()
-                    .map_err(|e| anyhow!("Failed to deserialize i64, reason: {:?}", e))?,
-            )),
             TypeName::Timestamp => {
                 ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper::from_protobuf_bytes(b)?)
             }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

At title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#4672