### PR TITLE
feat(approx distinct): add in-memory append-only approx_count_distinct

### DIFF
--- a/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
@@ -216,7 +216,7 @@ mod tests {
     }
 
     fn test_streaming_approx_count_distinct_insert_and_delete_inner<const DENSE_BITS: usize>() {
-        let mut agg = UpdatableStreamingApproxDistinct::<DENSE_BITS>::new();
+        let mut agg = UpdatableStreamingApproxDistinct::<DENSE_BITS>::with_no_initial();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 
         agg.apply_batch(
@@ -259,7 +259,7 @@ mod tests {
     /// error.
     #[test]
     fn test_error_ratio() {
-        let mut agg = UpdatableStreamingApproxDistinct::<16>::new();
+        let mut agg = UpdatableStreamingApproxDistinct::<16>::with_no_initial();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
         let actual_ndv = 1000000;
         for i in 0..1000000 {

--- a/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
@@ -149,16 +149,16 @@ impl<const DENSE_BITS: usize> RegisterBucket for UpdatableRegisterBucket<DENSE_B
         Ok(())
     }
 
-    fn get_max(&self) -> StreamExecutorResult<u8> {
+    fn get_max(&self) -> u8 {
         if !self.sparse_counts.is_empty() {
-            return Ok(self.sparse_counts.last_key());
+            return self.sparse_counts.last_key();
         }
         for i in (0..DENSE_BITS).rev() {
             if self.dense_counts[i] > 0 {
-                return Ok(i as u8 + 1);
+                return i as u8 + 1;
             }
         }
-        Ok(0)
+        0
     }
 }
 

--- a/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module implements `StreamingApproxCountDistinct`.
+//! This module implements `DeletableStreamingApproxDistinct`.
 
 use risingwave_common::bail;
 
@@ -163,13 +163,15 @@ impl<const DENSE_BITS: usize> RegisterBucket for DeletableRegisterBucket<DENSE_B
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct StreamingApproxCountDistinct<const DENSE_BITS: usize> {
+pub struct DeletableStreamingApproxDistinct<const DENSE_BITS: usize> {
     // TODO(yuchao): The state may need to be stored in state table to allow correct recovery.
     registers: Vec<DeletableRegisterBucket<DENSE_BITS>>,
     initial_count: i64,
 }
 
-impl<const DENSE_BITS: usize> StreamingApproxDistinct for StreamingApproxCountDistinct<DENSE_BITS> {
+impl<const DENSE_BITS: usize> StreamingApproxDistinct
+    for DeletableStreamingApproxDistinct<DENSE_BITS>
+{
     type Bucket = DeletableRegisterBucket<DENSE_BITS>;
 
     fn with_i64(registers_num: u32, initial_count: i64) -> Self {
@@ -214,7 +216,7 @@ mod tests {
     }
 
     fn test_streaming_approx_count_distinct_insert_and_delete_inner<const DENSE_BITS: usize>() {
-        let mut agg = StreamingApproxCountDistinct::<DENSE_BITS>::new();
+        let mut agg = DeletableStreamingApproxDistinct::<DENSE_BITS>::new();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 
         agg.apply_batch(
@@ -257,7 +259,7 @@ mod tests {
     /// error.
     #[test]
     fn test_error_ratio() {
-        let mut agg = StreamingApproxCountDistinct::<16>::new();
+        let mut agg = DeletableStreamingApproxDistinct::<16>::new();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
         let actual_ndv = 1000000;
         for i in 0..1000000 {

--- a/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_count_distinct.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//! This module implements `UpdatableStreamingApproxDistinct`.
+//! This module implements `UpdatableStreamingApproxCountDistinct`.
 
 use risingwave_common::bail;
 
-use super::approx_distinct_utils::{RegisterBucket, StreamingApproxDistinct};
+use super::approx_distinct_utils::{RegisterBucket, StreamingApproxCountDistinct};
 use crate::executor::error::StreamExecutorResult;
 
 pub(crate) const DENSE_BITS_DEFAULT: usize = 16; // number of bits in the dense repr of the `UpdatableRegisterBucket`
@@ -163,14 +163,14 @@ impl<const DENSE_BITS: usize> RegisterBucket for UpdatableRegisterBucket<DENSE_B
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct UpdatableStreamingApproxDistinct<const DENSE_BITS: usize> {
+pub struct UpdatableStreamingApproxCountDistinct<const DENSE_BITS: usize> {
     // TODO(yuchao): The state may need to be stored in state table to allow correct recovery.
     registers: Vec<UpdatableRegisterBucket<DENSE_BITS>>,
     initial_count: i64,
 }
 
-impl<const DENSE_BITS: usize> StreamingApproxDistinct
-    for UpdatableStreamingApproxDistinct<DENSE_BITS>
+impl<const DENSE_BITS: usize> StreamingApproxCountDistinct
+    for UpdatableStreamingApproxCountDistinct<DENSE_BITS>
 {
     type Bucket = UpdatableRegisterBucket<DENSE_BITS>;
 
@@ -216,7 +216,7 @@ mod tests {
     }
 
     fn test_streaming_approx_count_distinct_insert_and_delete_inner<const DENSE_BITS: usize>() {
-        let mut agg = UpdatableStreamingApproxDistinct::<DENSE_BITS>::with_no_initial();
+        let mut agg = UpdatableStreamingApproxCountDistinct::<DENSE_BITS>::with_no_initial();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
 
         agg.apply_batch(
@@ -259,7 +259,7 @@ mod tests {
     /// error.
     #[test]
     fn test_error_ratio() {
-        let mut agg = UpdatableStreamingApproxDistinct::<16>::with_no_initial();
+        let mut agg = UpdatableStreamingApproxCountDistinct::<16>::with_no_initial();
         assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &0);
         let actual_ndv = 1000000;
         for i in 0..1000000 {

--- a/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
@@ -43,8 +43,8 @@ impl RegisterBucket for AppendOnlyRegisterBucket {
         Ok(())
     }
 
-    fn get_max(&self) -> StreamExecutorResult<u8> {
-        Ok(self.max)
+    fn get_max(&self) -> u8 {
+        self.max
     }
 }
 

--- a/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
@@ -1,0 +1,83 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::bail;
+
+use super::approx_distinct_utils::{RegisterBucket, StreamingApproxDistinct};
+use crate::executor::StreamExecutorResult;
+
+#[derive(Clone, Debug)]
+pub(super) struct AppendOnlyRegisterBucket {
+    max: u8,
+}
+
+impl RegisterBucket for AppendOnlyRegisterBucket {
+    fn new() -> Self {
+        Self { max: 0 }
+    }
+
+    fn update_bucket(&mut self, index: usize, is_insert: bool) -> StreamExecutorResult<()> {
+        if index > 64 || index == 0 {
+            bail!("HyperLogLog: Invalid bucket index");
+        }
+
+        if !is_insert {
+            bail!("HyperLogLog: Deletion in append-only bucket");
+        }
+
+        if index as u8 > self.max {
+            self.max = index as u8;
+        }
+
+        Ok(())
+    }
+
+    fn get_max(&self) -> StreamExecutorResult<u8> {
+        Ok(self.max)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct AppendOnlyStreamingApproxDistinct {
+    // TODO(yuchao): The state may need to be stored in state table to allow correct recovery.
+    registers: Vec<AppendOnlyRegisterBucket>,
+    initial_count: i64,
+}
+
+impl StreamingApproxDistinct for AppendOnlyStreamingApproxDistinct {
+    type Bucket = AppendOnlyRegisterBucket;
+
+    fn with_i64(registers_num: u32, initial_count: i64) -> Self {
+        Self {
+            registers: vec![AppendOnlyRegisterBucket::new(); registers_num as usize],
+            initial_count,
+        }
+    }
+
+    fn get_initial_count(&self) -> i64 {
+        self.initial_count
+    }
+
+    fn reset_buckets(&mut self, registers_num: u32) {
+        self.registers = vec![AppendOnlyRegisterBucket::new(); registers_num as usize];
+    }
+
+    fn registers(&self) -> &[AppendOnlyRegisterBucket] {
+        &self.registers
+    }
+
+    fn registers_mut(&mut self) -> &mut [AppendOnlyRegisterBucket] {
+        &mut self.registers
+    }
+}

--- a/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_distinct_append.rs
@@ -14,7 +14,7 @@
 
 use risingwave_common::bail;
 
-use super::approx_distinct_utils::{RegisterBucket, StreamingApproxDistinct};
+use super::approx_distinct_utils::{RegisterBucket, StreamingApproxCountDistinct};
 use crate::executor::StreamExecutorResult;
 
 #[derive(Clone, Debug)]
@@ -49,13 +49,13 @@ impl RegisterBucket for AppendOnlyRegisterBucket {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct AppendOnlyStreamingApproxDistinct {
+pub struct AppendOnlyStreamingApproxCountDistinct {
     // TODO(yuchao): The state may need to be stored in state table to allow correct recovery.
     registers: Vec<AppendOnlyRegisterBucket>,
     initial_count: i64,
 }
 
-impl StreamingApproxDistinct for AppendOnlyStreamingApproxDistinct {
+impl StreamingApproxCountDistinct for AppendOnlyStreamingApproxCountDistinct {
     type Bucket = AppendOnlyRegisterBucket;
 
     fn with_i64(registers_num: u32, initial_count: i64) -> Self {

--- a/src/stream/src/executor/aggregation/agg_impl/approx_distinct_utils.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_distinct_utils.rs
@@ -41,7 +41,7 @@ pub(super) trait RegisterBucket {
     fn update_bucket(&mut self, index: usize, is_insert: bool) -> StreamExecutorResult<()>;
 
     /// Gets the number of the maximum bucket which has a count greater than zero.
-    fn get_max(&self) -> StreamExecutorResult<u8>;
+    fn get_max(&self) -> u8;
 }
 
 /// `StreamingApproxDistinct` approximates the count of non-null rows using a modified version
@@ -157,7 +157,7 @@ pub(super) trait StreamingApproxDistinct: Sized {
 
         // Get harmonic mean of all the counts in results
         for register_bucket in self.registers() {
-            let count = register_bucket.get_max()?;
+            let count = register_bucket.get_max();
             mean += 1.0 / ((1 << count) as f64);
         }
 
@@ -168,7 +168,7 @@ pub(super) trait StreamingApproxDistinct: Sized {
         let answer = if raw_estimate <= 2.5 * m {
             let mut zero_registers: f64 = 0.0;
             for i in self.registers() {
-                if i.get_max()? == 0 {
+                if i.get_max() == 0 {
                     zero_registers += 1.0;
                 }
             }

--- a/src/stream/src/executor/aggregation/agg_impl/approx_distinct_utils.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/approx_distinct_utils.rs
@@ -1,0 +1,203 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+use dyn_clone::DynClone;
+use itertools::Itertools;
+use risingwave_common::array::stream_chunk::Ops;
+use risingwave_common::array::*;
+use risingwave_common::buffer::Bitmap;
+use risingwave_common::types::{Datum, DatumRef, Scalar, ScalarImpl};
+
+use crate::executor::aggregation::agg_impl::StreamingAggImpl;
+use crate::executor::StreamExecutorResult;
+
+const INDEX_BITS: u8 = 16; // number of bits used for finding the index of each 64-bit hash
+const NUM_OF_REGISTERS: u32 = 1 << INDEX_BITS; // number of registers available
+const COUNT_BITS: u8 = 64 - INDEX_BITS; // number of non-index bits in each 64-bit hash
+
+// Approximation for bias correction for 16384 registers. See "HyperLogLog: the analysis of a
+// near-optimal cardinality estimation algorithm" by Philippe Flajolet et al.
+const BIAS_CORRECTION: f64 = 0.7213 / (1. + (1.079 / NUM_OF_REGISTERS as f64));
+
+pub(super) trait RegisterBucket {
+    fn new() -> Self;
+
+    /// Increments or decrements the bucket at `index` depending on the state of `is_insert`.
+    /// Returns an Error if `index` is invalid or if inserting will cause an overflow in the bucket.
+    fn update_bucket(&mut self, index: usize, is_insert: bool) -> StreamExecutorResult<()>;
+
+    /// Gets the number of the maximum bucket which has a count greater than zero.
+    fn get_max(&self) -> StreamExecutorResult<u8>;
+}
+
+/// `StreamingApproxDistinct` approximates the count of non-null rows using a modified version
+/// of the `HyperLogLog` algorithm. Each `RegisterBucket` stores a count of how many hash values
+/// have x trailing zeroes for all x from 1-64. This allows the algorithm to support insertion and
+/// deletion, but uses up more memory and limits the number of rows that can be counted.
+///
+/// `StreamingApproxDistinct` can count up to a total of 2^64 unduplicated rows.
+///
+/// The estimation error for `HyperLogLog` is 1.04/sqrt(num of registers). With 2^16 registers this
+/// is ~1/256, or about 0.4%. The memory usage for the default choice of parameters is about
+/// (1024 + 24) bits * 2^16 buckets, which is about 8.58 MB.
+pub(super) trait StreamingApproxDistinct: Sized {
+    type Bucket: RegisterBucket;
+
+    fn new() -> Self {
+        Self::with_datum(None)
+    }
+
+    fn with_datum(datum: Datum) -> Self {
+        let count = if let Some(c) = datum {
+            match c {
+                ScalarImpl::Int64(num) => num,
+                other => panic!(
+                    "type mismatch in streaming aggregator StreamingApproxCountDistinct init: expected i64, get {}",
+                    other.get_ident()
+                ),
+            }
+        } else {
+            0
+        };
+
+        Self::with_i64(NUM_OF_REGISTERS, count)
+    }
+
+    fn with_i64(registers_num: u32, initial_count: i64) -> Self;
+    fn get_initial_count(&self) -> i64;
+    fn reset_buckets(&mut self, registers_num: u32);
+    fn registers(&self) -> &[Self::Bucket];
+    fn registers_mut(&mut self) -> &mut [Self::Bucket];
+
+    /// Adds the count of the datum's hash into the register, if it is greater than the existing
+    /// count at the register.
+    fn update_registers(
+        &mut self,
+        datum_ref: DatumRef<'_>,
+        is_insert: bool,
+    ) -> StreamExecutorResult<()> {
+        if datum_ref.is_none() {
+            return Ok(());
+        }
+
+        let scalar_impl = datum_ref.unwrap().into_scalar_impl();
+        let hash = self.get_hash(scalar_impl);
+
+        let index = (hash as u32) & (NUM_OF_REGISTERS - 1); // Index is based on last few bits
+        let count = self.count_hash(hash) as usize;
+
+        self.registers_mut()[index as usize].update_bucket(count, is_insert)?;
+
+        Ok(())
+    }
+
+    /// Calculate the hash of the `scalar_impl`.
+    fn get_hash(&self, scalar_impl: ScalarImpl) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        scalar_impl.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    /// Counts the number of trailing zeroes plus 1 in the non-index bits of the hash.
+    fn count_hash(&self, mut hash: u64) -> u8 {
+        hash >>= INDEX_BITS; // Ignore bits used as index for the hash
+        hash |= 1 << COUNT_BITS; // To allow hash to terminate if it is all 0s
+
+        (hash.trailing_zeros() + 1) as u8
+    }
+}
+
+impl<B, T> StreamingAggImpl for T
+where
+    B: RegisterBucket,
+    T: std::fmt::Debug + DynClone + Send + Sync + 'static + StreamingApproxDistinct<Bucket = B>,
+{
+    fn apply_batch(
+        &mut self,
+        ops: Ops<'_>,
+        visibility: Option<&Bitmap>,
+        data: &[&ArrayImpl],
+    ) -> StreamExecutorResult<()> {
+        match visibility {
+            None => {
+                for (op, datum) in ops.iter().zip_eq(data[0].iter()) {
+                    match op {
+                        Op::Insert | Op::UpdateInsert => self.update_registers(datum, true)?,
+                        Op::Delete | Op::UpdateDelete => self.update_registers(datum, false)?,
+                    }
+                }
+            }
+            Some(visibility) => {
+                for ((visible, op), datum) in
+                    visibility.iter().zip_eq(ops.iter()).zip_eq(data[0].iter())
+                {
+                    if visible {
+                        match op {
+                            Op::Insert | Op::UpdateInsert => self.update_registers(datum, true)?,
+                            Op::Delete | Op::UpdateDelete => self.update_registers(datum, false)?,
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn get_output(&self) -> StreamExecutorResult<Datum> {
+        let m = NUM_OF_REGISTERS as f64;
+        let mut mean = 0.0;
+
+        // Get harmonic mean of all the counts in results
+        for register_bucket in self.registers() {
+            let count = register_bucket.get_max()?;
+            mean += 1.0 / ((1 << count) as f64);
+        }
+
+        let raw_estimate = BIAS_CORRECTION * m * m / mean;
+
+        // If raw_estimate is not much bigger than m and some registers have value 0, set answer to
+        // m * log(m/V) where V is the number of registers with value 0
+        let answer = if raw_estimate <= 2.5 * m {
+            let mut zero_registers: f64 = 0.0;
+            for i in self.registers() {
+                if i.get_max()? == 0 {
+                    zero_registers += 1.0;
+                }
+            }
+
+            if zero_registers == 0.0 {
+                raw_estimate
+            } else {
+                m * (m.log2() - (zero_registers.log2()))
+            }
+        } else {
+            raw_estimate
+        };
+
+        Ok(Some(
+            (answer as i64 + self.get_initial_count()).to_scalar_value(),
+        ))
+    }
+
+    fn new_builder(&self) -> ArrayBuilderImpl {
+        ArrayBuilderImpl::Int64(I64ArrayBuilder::new(0))
+    }
+
+    fn reset(&mut self) {
+        self.reset_buckets(NUM_OF_REGISTERS);
+    }
+}

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -18,7 +18,7 @@
 use std::any::Any;
 
 pub use approx_count_distinct::*;
-use approx_distinct_utils::StreamingApproxDistinct;
+use approx_distinct_utils::StreamingApproxCountDistinct;
 use dyn_clone::DynClone;
 pub use foldable::*;
 use risingwave_common::array::stream_chunk::Ops;
@@ -129,10 +129,10 @@ pub fn create_streaming_agg_impl(
                     }
                 )*
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, Some(datum)) => {
-                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
+                    Box::new(UpdatableStreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
-                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_no_initial())
+                    Box::new(UpdatableStreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_no_initial())
                 }
                 (other_agg, other_input, other_return, _) => panic!(
                     "streaming agg state not implemented: {:?} {:?} {:?}",

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -129,10 +129,10 @@ pub fn create_streaming_agg_impl(
                     }
                 )*
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, Some(datum)) => {
-                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
+                    Box::new(DeletableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
-                    Box::new(StreamingApproxCountDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
+                    Box::new(DeletableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
                 }
                 (other_agg, other_input, other_return, _) => panic!(
                     "streaming agg state not implemented: {:?} {:?} {:?}",

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -132,7 +132,7 @@ pub fn create_streaming_agg_impl(
                     Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
-                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
+                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_no_initial())
                 }
                 (other_agg, other_input, other_return, _) => panic!(
                     "streaming agg state not implemented: {:?} {:?} {:?}",

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -129,10 +129,10 @@ pub fn create_streaming_agg_impl(
                     }
                 )*
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, Some(datum)) => {
-                    Box::new(DeletableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
+                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::with_datum(datum))
                 }
                 (AggKind::ApproxCountDistinct, _, DataType::Int64, None) => {
-                    Box::new(DeletableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
+                    Box::new(UpdatableStreamingApproxDistinct::<{approx_count_distinct::DENSE_BITS_DEFAULT}>::new())
                 }
                 (other_agg, other_input, other_return, _) => panic!(
                     "streaming agg state not implemented: {:?} {:?} {:?}",

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -18,6 +18,7 @@
 use std::any::Any;
 
 pub use approx_count_distinct::*;
+use approx_distinct_utils::StreamingApproxDistinct;
 use dyn_clone::DynClone;
 pub use foldable::*;
 use risingwave_common::array::stream_chunk::Ops;
@@ -35,6 +36,8 @@ pub use row_count::*;
 use crate::executor::{StreamExecutorError, StreamExecutorResult};
 
 mod approx_count_distinct;
+mod approx_distinct_append;
+mod approx_distinct_utils;
 mod foldable;
 mod row_count;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

add in-memory append-only approx_count_distinct (#5871 )
- Describe any limitations of the current code (optional)
We haven't designed a state for it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#5871 #3414 #2727 
