### PR TITLE
refactor: migrate all from_to_bytes to value_encoding

### DIFF
--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -17,6 +17,7 @@ pub mod utils;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, FilterExecutor};
 use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::expr::expr_node::RexNode;
@@ -53,7 +54,7 @@ fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor 
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(2).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(2)).as_ref()),
             })),
         };
 
@@ -76,7 +77,7 @@ fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor 
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(0).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(0)).as_ref()),
             })),
         };
 

--- a/src/batch/benches/hash_join.rs
+++ b/src/batch/benches/hash_join.rs
@@ -21,6 +21,7 @@ use risingwave_batch::executor::{BoxedExecutor, JoinType};
 use risingwave_common::catalog::schema_test_utils::field_n;
 use risingwave_common::hash;
 use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::expr::expr_node::RexNode;
@@ -59,7 +60,7 @@ fn create_hash_join_executor(
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(123).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(123)).as_ref()),
             })),
         };
         ExprNode {
@@ -89,7 +90,7 @@ fn create_hash_join_executor(
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(456).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(456)).as_ref()),
             })),
         };
         ExprNode {
@@ -142,7 +143,7 @@ fn create_hash_join_executor(
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(100).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(100)).as_ref()),
             })),
         };
         Some(ExprNode {

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -16,6 +16,7 @@ pub mod utils;
 use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, JoinType, NestedLoopJoinExecutor};
 use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::expr::expr_node::RexNode;
@@ -68,7 +69,7 @@ fn create_nested_loop_join_executor(
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(2).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(2)).as_ref()),
             })),
         };
 
@@ -79,7 +80,7 @@ fn create_nested_loop_join_executor(
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::Int64(3).to_protobuf(),
+                body: serialize_datum_to_bytes(Some(ScalarImpl::Int64(3)).as_ref()),
             })),
         };
 

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -128,6 +128,7 @@ mod tests {
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{DataType, Scalar};
+    use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_expr::expr::build_from_prost;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::expr::expr_node::Type::InputRef;
@@ -241,8 +242,12 @@ mod tests {
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: ScalarImpl::List(ListValue::new(vec![Some(2.to_scalar_value())]))
-                    .to_protobuf(),
+                body: serialize_datum_to_bytes(
+                    Some(ScalarImpl::List(ListValue::new(vec![Some(
+                        2.to_scalar_value(),
+                    )])))
+                    .as_ref(),
+                ),
             })),
         };
         let function_call = FunctionCall {

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -22,7 +22,7 @@ use risingwave_common::array::{DataChunk, Row};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::{ColumnDesc, ColumnId, Schema, TableId, TableOption};
 use risingwave_common::error::{Result, RwError};
-use risingwave_common::types::{DataType, Datum, ScalarImpl};
+use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::select_all;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_common::util::value_encoding::deserialize_datum;
@@ -91,10 +91,7 @@ impl ScanRange {
 
         let bound_ty = pk_types.next().unwrap();
         let build_bound = |bound: &scan_range::Bound| -> Bound<Datum> {
-            let scalar =
-                ScalarImpl::from_proto_bytes(&bound.value, &bound_ty.to_protobuf()).unwrap();
-
-            let datum = Some(scalar);
+            let datum = deserialize_datum(bound.value.as_slice(), &bound_ty).unwrap();
             if bound.inclusive {
                 Bound::Included(datum)
             } else {

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -689,10 +689,10 @@ impl HashKey for SerializedKey {
         array_builders: &mut [ArrayBuilderImpl],
         data_types: &[DataType],
     ) -> ArrayResult<()> {
-        let key_buffer = self.key.as_slice();
+        let mut key_buffer = self.key.as_slice();
         for (datum_result, array_builder) in data_types
             .iter()
-            .map(|ty| deserialize_datum(key_buffer, ty))
+            .map(|ty| deserialize_datum(&mut key_buffer, ty))
             .zip_eq(array_builders.iter_mut())
         {
             array_builder.append_datum(&datum_result.map_err(ArrayError::internal)?);

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -689,10 +689,10 @@ impl HashKey for SerializedKey {
         array_builders: &mut [ArrayBuilderImpl],
         data_types: &[DataType],
     ) -> ArrayResult<()> {
-        let mut key_buffer = self.key.as_slice();
+        let key_buffer = self.key.as_slice();
         for (datum_result, array_builder) in data_types
             .iter()
-            .map(|ty| deserialize_datum(&mut key_buffer, ty))
+            .map(|ty| deserialize_datum(key_buffer, ty))
             .zip_eq(array_builders.iter_mut())
         {
             array_builder.append_datum(&datum_result.map_err(ArrayError::internal)?);

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -16,7 +16,6 @@ use std::convert::TryFrom;
 use std::hash::Hash;
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 use parse_display::Display;
 use risingwave_pb::data::DataType as ProstDataType;
@@ -902,99 +901,6 @@ impl ScalarImpl {
 
         Ok(deserializer.position() - base_position)
     }
-
-    pub fn to_protobuf(&self) -> Vec<u8> {
-        let body = match self {
-            ScalarImpl::Int16(v) => v.to_be_bytes().to_vec(),
-            ScalarImpl::Int32(v) => v.to_be_bytes().to_vec(),
-            ScalarImpl::Int64(v) => v.to_be_bytes().to_vec(),
-            ScalarImpl::Float32(v) => v.to_be_bytes().to_vec(),
-            ScalarImpl::Float64(v) => v.to_be_bytes().to_vec(),
-            ScalarImpl::Utf8(s) => s.as_bytes().to_vec(),
-            ScalarImpl::Bool(v) => (*v as i8).to_be_bytes().to_vec(),
-            ScalarImpl::Decimal(v) => v.to_string().as_bytes().to_vec(),
-            ScalarImpl::Interval(v) => v.to_protobuf_owned(),
-            ScalarImpl::NaiveDate(v) => v.to_protobuf_owned(),
-            ScalarImpl::NaiveDateTime(v) => v.to_protobuf_owned(),
-            ScalarImpl::NaiveTime(v) => v.to_protobuf_owned(),
-            ScalarImpl::Struct(v) => v.to_protobuf_owned(),
-            ScalarImpl::List(v) => v.to_protobuf_owned(),
-        };
-        body
-    }
-
-    /// This encoding should only be used in proto
-    /// TODO: replace with value encoding?
-    pub fn from_proto_bytes(b: &Vec<u8>, data_type: &ProstDataType) -> ArrayResult<Self> {
-        let value = match data_type.get_type_name()? {
-            TypeName::Boolean => ScalarImpl::Bool(
-                i8::from_be_bytes(
-                    b.as_slice()
-                        .try_into()
-                        .map_err(|e| anyhow!("Failed to deserialize bool, reason: {:?}", e))?,
-                ) == 1,
-            ),
-            TypeName::Int16 => ScalarImpl::Int16(i16::from_be_bytes(
-                b.as_slice()
-                    .try_into()
-                    .map_err(|e| anyhow!("Failed to deserialize i16, reason: {:?}", e))?,
-            )),
-            TypeName::Int32 => ScalarImpl::Int32(i32::from_be_bytes(
-                b.as_slice()
-                    .try_into()
-                    .map_err(|e| anyhow!("Failed to deserialize i32, reason: {:?}", e))?,
-            )),
-            t @ (TypeName::Int64 | TypeName::Timestampz) => {
-                ScalarImpl::Int64(i64::from_be_bytes(b.as_slice().try_into().map_err(
-                    |e| anyhow!("Failed to deserialize i64 for {:?}, reason: {:?}", t, e),
-                )?))
-            }
-            TypeName::Float => ScalarImpl::Float32(
-                f32::from_be_bytes(
-                    b.as_slice()
-                        .try_into()
-                        .map_err(|e| anyhow!("Failed to deserialize f32, reason: {:?}", e))?,
-                )
-                .into(),
-            ),
-            TypeName::Double => ScalarImpl::Float64(
-                f64::from_be_bytes(
-                    b.as_slice()
-                        .try_into()
-                        .map_err(|e| anyhow!("Failed to deserialize f64, reason: {:?}", e))?,
-                )
-                .into(),
-            ),
-            TypeName::Varchar => ScalarImpl::Utf8(
-                std::str::from_utf8(b)
-                    .map_err(|e| anyhow!("Failed to deserialize varchar, reason: {:?}", e))?
-                    .to_string(),
-            ),
-            TypeName::Decimal => ScalarImpl::Decimal(
-                Decimal::from_str(std::str::from_utf8(b).unwrap())
-                    .map_err(|e| anyhow!("Failed to deserialize decimal, reason: {:?}", e))?,
-            ),
-            TypeName::Interval => ScalarImpl::Interval(IntervalUnit::from_protobuf_bytes(
-                b,
-                data_type.get_interval_type().unwrap_or(Unspecified),
-            )?),
-            TypeName::Timestamp => {
-                ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper::from_protobuf_bytes(b)?)
-            }
-            TypeName::Time => ScalarImpl::NaiveTime(NaiveTimeWrapper::from_protobuf_bytes(b)?),
-            TypeName::Date => ScalarImpl::NaiveDate(NaiveDateWrapper::from_protobuf_bytes(b)?),
-            TypeName::Struct => {
-                ScalarImpl::Struct(StructValue::from_protobuf_bytes(data_type.clone(), b)?)
-            }
-            TypeName::List => {
-                ScalarImpl::List(ListValue::from_protobuf_bytes(data_type.clone(), b)?)
-            }
-            TypeName::TypeUnspecified => {
-                bail!("Unrecognized type name: {:?}", data_type.get_type_name())
-            }
-        };
-        Ok(value)
-    }
 }
 
 pub fn literal_type_match(data_type: &DataType, literal: Option<&ScalarImpl>) -> bool {
@@ -1112,31 +1018,6 @@ mod tests {
         assert_eq!(std::mem::size_of::<Decimal>(), 20);
         assert_eq!(std::mem::size_of::<ScalarImpl>(), 32);
         assert_eq!(std::mem::size_of::<Datum>(), 32);
-    }
-
-    #[test]
-    fn test_protobuf_conversion() {
-        let v = ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper::default());
-        let actual =
-            ScalarImpl::from_proto_bytes(&v.to_protobuf(), &DataType::Timestamp.to_protobuf())
-                .unwrap();
-        assert_eq!(v, actual);
-
-        let v = ScalarImpl::NaiveDate(NaiveDateWrapper::default());
-        let actual =
-            ScalarImpl::from_proto_bytes(&v.to_protobuf(), &DataType::Date.to_protobuf()).unwrap();
-        assert_eq!(v, actual);
-
-        let v = ScalarImpl::NaiveTime(NaiveTimeWrapper::default());
-        let actual =
-            ScalarImpl::from_proto_bytes(&v.to_protobuf(), &DataType::Time.to_protobuf()).unwrap();
-        assert_eq!(v, actual);
-
-        let v = ScalarImpl::Int64(1);
-        let actual =
-            ScalarImpl::from_proto_bytes(&v.to_protobuf(), &DataType::Timestampz.to_protobuf())
-                .unwrap();
-        assert_eq!(v, actual);
     }
 
     #[test]

--- a/src/common/src/util/scan_range.rs
+++ b/src/common/src/util/scan_range.rs
@@ -19,6 +19,7 @@ use paste::paste;
 use risingwave_pb::batch_plan::scan_range::Bound as BoundProst;
 use risingwave_pb::batch_plan::ScanRange as ScanRangeProst;
 
+use super::value_encoding::serialize_datum_to_bytes;
 use crate::array::Row;
 use crate::types::{Datum, ScalarImpl, VirtualNode};
 use crate::util::hash_util::Crc32FastBuilder;
@@ -34,11 +35,11 @@ pub struct ScanRange {
 fn bound_to_proto(bound: &Bound<ScalarImpl>) -> Option<BoundProst> {
     match bound {
         Bound::Included(literal) => Some(BoundProst {
-            value: literal.to_protobuf(),
+            value: serialize_datum_to_bytes(Some(literal)),
             inclusive: true,
         }),
         Bound::Excluded(literal) => Some(BoundProst {
-            value: literal.to_protobuf(),
+            value: serialize_datum_to_bytes(Some(literal)),
             inclusive: false,
         }),
         Bound::Unbounded => None,

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -31,15 +31,6 @@ use error::ValueEncodingError;
 
 pub type Result<T> = std::result::Result<T, ValueEncodingError>;
 
-/// Serialize datum into cell bytes (Not order guarantee, used in value encoding).
-pub fn serialize_cell(cell: &Datum) -> Result<Vec<u8>> {
-    let mut buf: Vec<u8> = vec![];
-    if let Some(datum) = cell {
-        serialize_value(datum.as_scalar_ref_impl(), &mut buf)
-    }
-    Ok(buf)
-}
-
 /// Serialize a datum into bytes and return (Not order guarantee, used in value encoding).
 pub fn serialize_datum_to_bytes(cell: Option<&ScalarImpl>) -> Vec<u8> {
     let mut buf: Vec<u8> = vec![];

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -40,6 +40,13 @@ pub fn serialize_cell(cell: &Datum) -> Result<Vec<u8>> {
     Ok(buf)
 }
 
+/// Serialize a datum into bytes and return (Not order guarantee, used in value encoding).
+pub fn serialize_datum_to_bytes(cell: Option<&ScalarImpl>) -> Vec<u8> {
+    let mut buf: Vec<u8> = vec![];
+    serialize_datum_ref(&cell.map(|scala| scala.as_scalar_ref_impl()), &mut buf);
+    buf
+}
+
 /// Serialize a datum into bytes (Not order guarantee, used in value encoding).
 pub fn serialize_datum(cell: &Datum, mut buf: impl BufMut) {
     serialize_datum_ref(&to_datum_ref(cell), &mut buf);

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::types::DataType;
+use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::ExprNode;
 
@@ -215,7 +216,7 @@ pub fn build_to_char_expr(prost: &ExprNode) -> Result<BoxedExpression> {
     let data_expr = expr_build_from_prost(&children[0])?;
     let tmpl_node = &children[1];
     if let RexNode::Constant(tmpl_value) = tmpl_node.get_rex_node().unwrap()
-        && let Ok(tmpl) = ScalarImpl::from_proto_bytes(tmpl_value.get_body(), tmpl_node.get_return_type().unwrap())
+        && let Ok(Some(tmpl)) = deserialize_datum(tmpl_value.get_body().as_slice(), &DataType::from(tmpl_node.get_return_type().unwrap()))
     {
         let tmpl = tmpl.as_utf8();
         let pattern = compile_pattern_to_chrono(tmpl);

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -238,6 +238,8 @@ mod tests {
     use std::vec;
 
     use risingwave_common::array::{ArrayImpl, DataChunk, Utf8Array};
+    use risingwave_common::types::Scalar;
+    use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
     use risingwave_pb::expr::expr_node::{RexNode, Type};
@@ -256,7 +258,9 @@ mod tests {
                         ..Default::default()
                     }),
                     rex_node: Some(RexNode::Constant(ConstantValue {
-                        body: "foo".as_bytes().to_vec(),
+                        body: serialize_datum_to_bytes(
+                            Some("foo".to_owned().to_scalar_value()).as_ref(),
+                        ),
                     })),
                 },
                 ExprNode {
@@ -266,7 +270,9 @@ mod tests {
                         ..Default::default()
                     }),
                     rex_node: Some(RexNode::Constant(ConstantValue {
-                        body: "bar".as_bytes().to_vec(),
+                        body: serialize_datum_to_bytes(
+                            Some("bar".to_owned().to_scalar_value()).as_ref(),
+                        ),
                     })),
                 },
             ],
@@ -292,7 +298,7 @@ mod tests {
                         ..Default::default()
                     }),
                     rex_node: Some(RexNode::Constant(ConstantValue {
-                        body: vec![0, 0, 0, 1],
+                        body: serialize_datum_to_bytes(Some(1_i32.to_scalar_value()).as_ref()),
                     })),
                 },
             ],
@@ -322,7 +328,7 @@ mod tests {
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ConstantValue {
-                body: "DAY".as_bytes().to_vec(),
+                body: serialize_datum_to_bytes(Some("DAY".to_string().to_scalar_value()).as_ref()),
             })),
         };
         let right_date = ExprNode {

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -123,6 +123,7 @@ mod tests {
     use risingwave_common::array::{DataChunk, Row};
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{DataType, Scalar, ScalarImpl};
+    use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
     use risingwave_pb::expr::expr_node::{RexNode, Type};
@@ -150,7 +151,9 @@ mod tests {
                     ..Default::default()
                 }),
                 rex_node: Some(RexNode::Constant(ConstantValue {
-                    body: "ABC".as_bytes().to_vec(),
+                    body: serialize_datum_to_bytes(
+                        Some("ABC".to_string().to_scalar_value()).as_ref(),
+                    ),
                 })),
             },
             ExprNode {
@@ -160,7 +163,9 @@ mod tests {
                     ..Default::default()
                 }),
                 rex_node: Some(RexNode::Constant(ConstantValue {
-                    body: "def".as_bytes().to_vec(),
+                    body: serialize_datum_to_bytes(
+                        Some("def".to_string().to_scalar_value()).as_ref(),
+                    ),
                 })),
             },
         ];

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -180,57 +180,39 @@ mod tests {
     fn test_expr_literal_from() {
         let v = true;
         let t = TypeName::Boolean;
-        let bytes = (v as i8).to_be_bytes().to_vec();
-        // construct LiteralExpression in various types below with value 1i8, and expect Err
-        for typ in [
-            TypeName::Int16,
-            TypeName::Int32,
-            TypeName::Int64,
-            TypeName::Float,
-            TypeName::Double,
-            TypeName::Interval,
-            TypeName::Date,
-            TypeName::Struct,
-        ] {
-            assert!(
-                LiteralExpression::try_from(&make_expression(Some(bytes.clone()), typ)).is_err()
-            );
-        }
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
+
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i16;
         let t = TypeName::Int16;
-        let bytes = v.to_be_bytes().to_vec();
-        assert!(LiteralExpression::try_from(&make_expression(
-            Some(bytes.clone()),
-            TypeName::Boolean,
-        ))
-        .is_err());
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
+
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i32;
         let t = TypeName::Int32;
-        let bytes = v.to_be_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i64;
         let t = TypeName::Int64;
-        let bytes = v.to_be_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1f32.into_ordered();
         let t = TypeName::Float;
-        let bytes = v.to_be_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1f64.into_ordered();
         let t = TypeName::Double;
-        let bytes = v.to_be_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
@@ -241,24 +223,20 @@ mod tests {
 
         let v = String::from("varchar");
         let t = TypeName::Varchar;
-        let bytes = v.as_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.clone().to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = Decimal::new(3141, 3);
         let t = TypeName::Decimal;
-        let bytes = v.to_string().as_bytes().to_vec();
+        let bytes = serialize_datum_to_bytes(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
-        let v = String::from("NaN");
-        let t = TypeName::Decimal;
-        let bytes = v.as_bytes().to_vec();
-        assert!(LiteralExpression::try_from(&make_expression(Some(bytes), t)).is_ok());
-
         let v = 32i32;
         let t = TypeName::Interval;
-        let bytes = v.to_be_bytes().to_vec();
+        let bytes =
+            serialize_datum_to_bytes(Some(IntervalUnit::from_month(v).to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
         assert_eq!(
             IntervalUnit::from_month(v).to_scalar_value(),

--- a/src/expr/src/expr/test_utils.rs
+++ b/src/expr/src/expr/test_utils.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use itertools::Itertools;
+use risingwave_common::types::ScalarImpl;
+use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::{DataType as ProstDataType, DataType};
 use risingwave_pb::expr::expr_node::Type::{Field, InputRef};
@@ -55,7 +57,7 @@ pub fn make_i32_literal(data: i32) -> ExprNode {
             ..Default::default()
         }),
         rex_node: Some(RexNode::Constant(ConstantValue {
-            body: data.to_be_bytes().to_vec(),
+            body: serialize_datum_to_bytes(Some(ScalarImpl::Int32(data)).as_ref()),
         })),
     }
 }

--- a/src/expr/src/table_function/regexp_matches.rs
+++ b/src/expr/src/table_function/regexp_matches.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use regex::Regex;
 use risingwave_common::array::{Array, ArrayRef, DataChunk, ListValue, Utf8Array};
 use risingwave_common::types::{Scalar, ScalarImpl};
+use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_common::{bail, ensure};
 use risingwave_pb::expr::expr_node::RexNode;
 
@@ -140,10 +141,13 @@ pub fn new_regexp_matches(
     let RexNode::Constant(pattern_value) = pattern_node.get_rex_node().unwrap() else {
         return Err(ExprError::UnsupportedFunction("non-constant pattern in regexp_match".to_string()))
     };
-    let pattern_scalar = ScalarImpl::from_proto_bytes(
-        pattern_value.get_body(),
-        pattern_node.get_return_type().unwrap(),
-    )?;
+    let pattern_scalar = deserialize_datum(
+        pattern_value.get_body().as_slice(),
+        &DataType::from(pattern_node.get_return_type().unwrap()),
+    )
+    .map_err(|e| ExprError::Internal(e.into()))?
+    .unwrap();
+
     let ScalarImpl::Utf8(pattern) = pattern_scalar else {
         bail!("Expected pattern to be an String");
     };

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use risingwave_common::types::{literal_type_match, DataType, Datum, ScalarImpl};
+use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
 use risingwave_pb::expr::expr_node::RexNode;
 
 use super::Expr;
@@ -68,18 +69,18 @@ impl Expr for Literal {
         ExprNode {
             expr_type: self.get_expr_type() as i32,
             return_type: Some(self.return_type().to_protobuf()),
-            rex_node: literal_to_protobuf(self.get_data()),
+            rex_node: literal_to_value_encoding(self.get_data()),
         }
     }
 }
 
 /// Convert a literal value (datum) into protobuf.
-fn literal_to_protobuf(d: &Datum) -> Option<RexNode> {
-    let Some(d) = d.as_ref() else {
+fn literal_to_value_encoding(d: &Datum) -> Option<RexNode> {
+    if d.is_none() {
         return None;
-    };
+    }
     use risingwave_pb::expr::*;
-    let body = d.to_protobuf();
+    let body = serialize_datum_to_bytes(d.as_ref());
     Some(RexNode::Constant(ConstantValue { body }))
 }
 
@@ -87,46 +88,51 @@ fn literal_to_protobuf(d: &Datum) -> Option<RexNode> {
 mod tests {
     use risingwave_common::array::{ListValue, StructValue};
     use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::util::value_encoding::deserialize_datum;
     use risingwave_pb::expr::expr_node::RexNode;
 
-    use crate::expr::literal::literal_to_protobuf;
+    use crate::expr::literal::literal_to_value_encoding;
 
     #[test]
-    fn test_struct_to_protobuf() {
+    fn test_struct_to_value_encoding() {
         let value = StructValue::new(vec![
-            Some(ScalarImpl::Utf8("12222".to_string())),
+            Some(ScalarImpl::Utf8("".to_string())),
             Some(2.into()),
             Some(3.into()),
         ]);
         let data = Some(ScalarImpl::Struct(value.clone()));
-        let node = literal_to_protobuf(&data);
+        let node = literal_to_value_encoding(&data);
         if let RexNode::Constant(prost) = node.as_ref().unwrap() {
-            let data2 = ScalarImpl::from_proto_bytes(
-                prost.get_body(),
+            let data2 = deserialize_datum(
+                prost.get_body().as_slice(),
                 &DataType::new_struct(
                     vec![DataType::Varchar, DataType::Int32, DataType::Int32],
                     vec![],
-                )
-                .to_protobuf(),
+                ),
             )
+            .unwrap()
             .unwrap();
             assert_eq!(ScalarImpl::Struct(value), data2);
         }
     }
 
     #[test]
-    fn test_list_to_protobuf() {
-        let value = ListValue::new(vec![Some(1.into()), Some(2.into()), Some(3.into())]);
+    fn test_list_to_value_encoding() {
+        let value = ListValue::new(vec![
+            Some(ScalarImpl::Utf8("1".to_owned())),
+            Some(ScalarImpl::Utf8("2".to_owned())),
+            Some(ScalarImpl::Utf8("".to_owned())),
+        ]);
         let data = Some(ScalarImpl::List(value.clone()));
-        let node = literal_to_protobuf(&data);
+        let node = literal_to_value_encoding(&data);
         if let RexNode::Constant(prost) = node.as_ref().unwrap() {
-            let data2 = ScalarImpl::from_proto_bytes(
-                prost.get_body(),
+            let data2 = deserialize_datum(
+                prost.get_body().as_slice(),
                 &DataType::List {
-                    datatype: Box::new(DataType::Int32),
-                }
-                .to_protobuf(),
+                    datatype: Box::new(DataType::Varchar),
+                },
             )
+            .unwrap()
             .unwrap();
             assert_eq!(ScalarImpl::List(value), data2);
         }

--- a/src/utils/memcomparable/src/de.rs
+++ b/src/utils/memcomparable/src/de.rs
@@ -161,22 +161,6 @@ impl<B: Buf> Deserializer<B> {
         Ok(byte_array)
     }
 
-    /// Read u8 from Bytes input in decimal form (Do not include null tag). Used by value encoding
-    /// (`serialize_cell`). TODO: It is a temporal solution For value encoding. Will moved to
-    /// value encoding serializer in future.
-    pub fn read_decimal_v2(&mut self) -> Result<Vec<u8>> {
-        let flag = self.input.get_u8();
-        let mut byte_array = vec![flag];
-        loop {
-            let byte = self.input.get_u8();
-            if byte == 100 {
-                break;
-            }
-            byte_array.push(byte);
-        }
-        Ok(byte_array)
-    }
-
     /// Read bytes_len without copy, it will consume offset
     pub fn read_bytes_len(&mut self) -> Result<usize> {
         use core::cmp;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- migrate all `from_to_bytes` to `value_encoding`

## Checklist

- [x] I have written necessary rustdoc comments
~- [ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)

#4672 