### PR TITLE
feat(storage): reduce read_lock acquisition in try_wait_epoch

### DIFF
--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -345,7 +345,6 @@ async fn test_update_uncommitted_ssts() {
     };
     assert!(local_version_manager
         .try_update_pinned_version(Payload::PinnedVersion(version.clone()))
-        .0
         .is_some());
     let local_version = local_version_manager.get_local_version();
     // Check shared buffer

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -156,7 +156,7 @@ pub async fn prepare_local_version_manager(
 
         (
             Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
+            Arc::new(AtomicU64::new(basic_max_committed_epoch)),
         )
     };
 

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -146,6 +147,19 @@ pub async fn prepare_local_version_manager(
         event_tx,
     );
 
+    let (version_update_notifier_tx, seal_epoch) = {
+        let basic_max_committed_epoch = local_version_manager
+            .get_pinned_version()
+            .max_committed_epoch();
+        let (version_update_notifier_tx, _rx) =
+            tokio::sync::watch::channel(basic_max_committed_epoch);
+
+        (
+            Arc::new(version_update_notifier_tx),
+            Arc::new(AtomicU64::new(0)),
+        )
+    };
+
     tokio::spawn(
         HummockEventHandler::new(
             local_version_manager.clone(),
@@ -153,6 +167,8 @@ pub async fn prepare_local_version_manager(
             Arc::new(RwLock::new(HummockReadVersion::new(
                 local_version_manager.get_pinned_version(),
             ))),
+            version_update_notifier_tx,
+            seal_epoch,
         )
         .start_hummock_event_handler_worker(),
     );

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -299,7 +299,7 @@ impl HummockEventHandler {
             .local_version_manager
             .try_update_pinned_version(version_payload)
         {
-            let new_version_id = new_version.id();
+            let max_committed_epoch = new_version.max_committed_epoch();
             // update the read_version of hummock instance
             self.read_version
                 .write()
@@ -309,7 +309,7 @@ impl HummockEventHandler {
                 // only notify local_version_manager when MCE change
                 // TODO: use MCE to replace new_version_id
                 self.local_version_manager
-                    .notify_version_id_to_worker_context(new_version_id);
+                    .notify_max_committed_epoch(max_committed_epoch);
             }
         }
     }

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::iter::once;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use futures::future::{select, try_join_all, Either};
@@ -91,6 +91,10 @@ pub struct HummockEventHandler {
 
     // TODO: replace it with hashmap<id, read_version>
     read_version: Arc<RwLock<HummockReadVersion>>,
+
+    version_update_notifier_tx: Arc<tokio::sync::watch::Sender<HummockEpoch>>,
+
+    seal_epoch: Arc<AtomicU64>,
 }
 
 impl HummockEventHandler {
@@ -98,6 +102,8 @@ impl HummockEventHandler {
         local_version_manager: Arc<LocalVersionManager>,
         shared_buffer_event_receiver: mpsc::UnboundedReceiver<HummockEvent>,
         read_version: Arc<RwLock<HummockReadVersion>>,
+        version_update_notifier_tx: Arc<tokio::sync::watch::Sender<HummockEpoch>>,
+        seal_epoch: Arc<AtomicU64>,
     ) -> Self {
         Self {
             buffer_tracker: local_version_manager.buffer_tracker().clone(),
@@ -107,6 +113,8 @@ impl HummockEventHandler {
             upload_handle_manager: UploadHandleManager::new(),
             pending_sync_requests: Default::default(),
             read_version,
+            version_update_notifier_tx,
+            seal_epoch,
         }
     }
 
@@ -295,7 +303,7 @@ impl HummockEventHandler {
     }
 
     fn handle_version_update(&self, version_payload: Payload) {
-        if let (Some(new_version), mce_change) = self
+        if let Some(new_version) = self
             .local_version_manager
             .try_update_pinned_version(version_payload)
         {
@@ -305,12 +313,15 @@ impl HummockEventHandler {
                 .write()
                 .update(VersionUpdate::CommittedSnapshot(new_version));
 
-            if mce_change {
-                // only notify local_version_manager when MCE change
-                // TODO: use MCE to replace new_version_id
-                self.local_version_manager
-                    .notify_max_committed_epoch(max_committed_epoch);
-            }
+            // only notify local_version_manager when MCE change
+            self.version_update_notifier_tx.send_if_modified(|state| {
+                if max_committed_epoch > *state {
+                    *state = max_committed_epoch;
+                    true
+                } else {
+                    false
+                }
+            });
         }
     }
 
@@ -369,11 +380,14 @@ impl HummockEventHandler {
                     HummockEvent::SealEpoch {
                         epoch,
                         is_checkpoint,
-                    } => self
-                        .local_version_manager
-                        .local_version
-                        .write()
-                        .seal_epoch(epoch, is_checkpoint),
+                    } => {
+                        self.local_version_manager
+                            .local_version
+                            .write()
+                            .seal_epoch(epoch, is_checkpoint);
+
+                        self.seal_epoch.store(epoch, Ordering::SeqCst);
+                    }
                 },
                 Either::Right(None) => {
                     break;

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -14,6 +14,7 @@
 
 //! Hummock is the state store of the streaming system.
 
+use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use bytes::Bytes;
@@ -130,6 +131,10 @@ pub struct HummockStorage {
     _shutdown_guard: Arc<HummockStorageShutdownGuard>,
 
     storage_core: HummockStorageV2,
+
+    version_update_notifier_tx: Arc<tokio::sync::watch::Sender<HummockEpoch>>,
+
+    seal_epoch: Arc<AtomicU64>,
 }
 
 impl HummockStorage {
@@ -201,10 +206,24 @@ impl HummockStorage {
             local_version_manager.get_pinned_version(),
         )));
 
+        let (version_update_notifier_tx, seal_epoch) = {
+            let basic_max_committed_epoch = local_version_manager
+                .get_pinned_version()
+                .max_committed_epoch();
+            let (version_update_notifier_tx, _rx) =
+                tokio::sync::watch::channel(basic_max_committed_epoch);
+
+            (
+                Arc::new(version_update_notifier_tx),
+                Arc::new(AtomicU64::new(0)),
+            )
+        };
         let hummock_event_handler = HummockEventHandler::new(
             local_version_manager.clone(),
             event_rx,
             read_version.clone(),
+            version_update_notifier_tx.clone(),
+            seal_epoch.clone(),
         );
 
         // Buffer size manager.
@@ -233,6 +252,8 @@ impl HummockStorage {
                 shutdown_sender: event_tx,
             }),
             storage_core,
+            version_update_notifier_tx,
+            seal_epoch,
         };
         Ok(instance)
     }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -215,7 +215,7 @@ impl HummockStorage {
 
             (
                 Arc::new(version_update_notifier_tx),
-                Arc::new(AtomicU64::new(0)),
+                Arc::new(AtomicU64::new(basic_max_committed_epoch)),
             )
         };
         let hummock_event_handler = HummockEventHandler::new(

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -16,7 +16,9 @@ use std::cmp::Ordering;
 use std::future::Future;
 use std::ops::Bound::{Excluded, Included};
 use std::ops::RangeBounds;
+use std::sync::atomic::Ordering as MemOrdering;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytes::Bytes;
 use itertools::Itertools;
@@ -38,7 +40,7 @@ use super::{
     BackwardSstableIterator, HummockStorage, HummockStorageIterator, SstableIterator,
     SstableIteratorType,
 };
-use crate::error::StorageResult;
+use crate::error::{StorageError, StorageResult};
 use crate::hummock::iterator::{
     Backward, BackwardUserIteratorType, DirectedUserIteratorBuilder, DirectionEnum, Forward,
     ForwardUserIteratorType, HummockIteratorDirection,
@@ -48,7 +50,7 @@ use crate::hummock::shared_buffer::build_ordered_merge_iter;
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::store::{ReadOptions as ReadOptionsV2, StateStore as StateStoreV2};
 use crate::hummock::utils::prune_ssts;
-use crate::hummock::HummockResult;
+use crate::hummock::{HummockEpoch, HummockError, HummockResult};
 use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
 use crate::storage_value::StorageValue;
 use crate::store::*;
@@ -599,8 +601,70 @@ impl StateStore for HummockStorage {
         }
     }
 
-    fn try_wait_epoch(&self, epoch: HummockReadEpoch) -> Self::WaitEpochFuture<'_> {
-        async move { Ok(self.local_version_manager.try_wait_epoch(epoch).await?) }
+    /// Waits until the local hummock version contains the epoch. If `wait_epoch` is `Current`,
+    /// we will only check whether it is le `sealed_epoch` and won't wait.
+    fn try_wait_epoch(&self, wait_epoch: HummockReadEpoch) -> Self::WaitEpochFuture<'_> {
+        async move {
+            // Ok(self.local_version_manager.try_wait_epoch(epoch).await?)
+            let wait_epoch = match wait_epoch {
+                HummockReadEpoch::Committed(epoch) => epoch,
+                HummockReadEpoch::Current(epoch) => {
+                    // let sealed_epoch = self.local_version.read().get_sealed_epoch();
+                    let sealed_epoch = (*self.seal_epoch).load(MemOrdering::SeqCst);
+                    assert!(
+                        epoch <= sealed_epoch
+                            && epoch != HummockEpoch::MAX
+                        ,
+                        "current epoch can't read, because the epoch in storage is not updated, epoch{}, sealed epoch{}"
+                        ,epoch
+                        ,sealed_epoch
+                    );
+                    return Ok(());
+                }
+                HummockReadEpoch::NoWait(_) => return Ok(()),
+            };
+            if wait_epoch == HummockEpoch::MAX {
+                panic!("epoch should not be u64::MAX");
+            }
+
+            let mut receiver = self.version_update_notifier_tx.subscribe();
+            let max_committed_epoch = *receiver.borrow();
+            if max_committed_epoch >= wait_epoch {
+                return Ok(());
+            }
+            loop {
+                match tokio::time::timeout(Duration::from_secs(30), receiver.changed()).await {
+                    Err(elapsed) => {
+                        // The reason that we need to retry here is batch scan in
+                        // chain/rearrange_chain is waiting for an
+                        // uncommitted epoch carried by the CreateMV barrier, which
+                        // can take unbounded time to become committed and propagate
+                        // to the CN. We should consider removing the retry as well as wait_epoch
+                        // for chain/rearrange_chain if we enforce
+                        // chain/rearrange_chain to be scheduled on the same
+                        // CN with the same distribution as the upstream MV.
+                        // See #3845 for more details.
+                        tracing::warn!(
+                            "wait_epoch {:?} timeout when waiting for version update elapsed {:?}s",
+                            wait_epoch,
+                            elapsed
+                        );
+                        continue;
+                    }
+                    Ok(Err(_)) => {
+                        return StorageResult::Err(StorageError::Hummock(
+                            HummockError::wait_epoch("tx dropped"),
+                        ));
+                    }
+                    Ok(Ok(_)) => {
+                        let max_committed_epoch = *receiver.borrow();
+                        if max_committed_epoch >= wait_epoch {
+                            return Ok(());
+                        }
+                    }
+                }
+            }
+        }
     }
 
     fn sync(&self, epoch: u64) -> Self::SyncFuture<'_> {

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -628,7 +628,8 @@ impl StateStore for HummockStorage {
             }
 
             let mut receiver = self.version_update_notifier_tx.subscribe();
-            let max_committed_epoch = *receiver.borrow();
+            // avoid unnecessary check in the loop if the value does not change
+            let max_committed_epoch = *receiver.borrow_and_update();
             if max_committed_epoch >= wait_epoch {
                 return Ok(());
             }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

related to https://github.com/risingwavelabs/risingwave/pull/5902.

notify max_committed_epoch instead of verison_id to reduce read_lock acquisition in try_wait_epoch

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- reduce read_lock acquisition in `try_wait_epoch` by reducing access to read_version
- ~rename `notify_version_id_to_worker_context` to `notify_max_committed_epoch`~
- add `Arc<version_update_tx>` and `Arc<seal_epoch>` to reduce dependence of `local_version_manager`, so we can move function `try_wait_epoch` from `local_version_manager` to `state_store`. And notify version update in event_handler directly without visiting `ReadVersion`
- remove `WorkerContext` 

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/pull/5902
