### PR TITLE
fix: fix hummock snapshot release in batch local execution

### DIFF
--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -225,7 +225,7 @@ async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<LocalQ
         query,
         front_env.clone(),
         "",
-        pinned_snapshot.snapshot.committed_epoch,
+        pinned_snapshot,
         session.auth_context(),
     );
 

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -213,7 +213,8 @@ impl QueryExecution {
                 .collect::<Vec<Arc<StageExecution>>>();
 
             let stage_exec = Arc::new(StageExecution::new(
-                pinned_snapshot.snapshot.committed_epoch,
+                // TODO: Add support to use current epoch when needed
+                pinned_snapshot.get_committed_epoch(),
                 self.query.stage_graph.stages[&stage_id].clone(),
                 worker_node_manager.clone(),
                 self.shutdown_tx.clone(),

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -63,9 +63,19 @@ enum EpochOperation {
 }
 
 pub struct HummockSnapshotGuard {
-    pub snapshot: HummockSnapshot,
+    snapshot: HummockSnapshot,
     query_id: QueryId,
     unpin_snapshot_sender: UnboundedSender<EpochOperation>,
+}
+
+impl HummockSnapshotGuard {
+    pub fn get_committed_epoch(&self) -> u64 {
+        self.snapshot.committed_epoch
+    }
+
+    pub fn get_current_epoch(&self) -> u64 {
+        self.snapshot.current_epoch
+    }
 }
 
 impl Drop for HummockSnapshotGuard {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Prior to this PR, batch query in local execution mode will release the hummock snapshot before query execution, which can cause the read epoch to be expired when reading from state store during query execution.

This PR fixes the issue by releasing the hummock snapshot after query execution is completed. Note the this is different from what we did for batch query in distributed execution mode, in which the hummock snapshot is released immediately after all scan executors are scheduled before the completion of query execution. I think this is acceptable since batch query in local execution mode is supposed to be fast and shouldn't hold the hummock snapshot for too long.

## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fix #5711 