### PR TITLE
chore(log): remove unnecessary warning

### DIFF
--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -343,7 +343,7 @@ mod tests {
         // No task
         let compactor = hummock_manager.get_idle_compactor().await.unwrap();
         assert_eq!(
-            ScheduleStatus::PickFailure,
+            ScheduleStatus::NoTask,
             compaction_scheduler
                 .pick_and_assign(
                     StaticCompactionGroupId::StateDefault.into(),

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -961,6 +961,7 @@ async fn test_hummock_compaction_task_heartbeat() {
     assert!(hummock_manager
         .get_compact_task(StaticCompactionGroupId::StateDefault.into())
         .await
+        .unwrap()
         .is_none());
 
     // Add some sstables and commit.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Before this PR we will observe several misleading warning in meta log. This PR removes unnecessary warning as below

- It's fine for get_compact_task_impl to return None, if its compaction group is created but not sync_group via commit_epoch, which mean no data for this group is written yet.
- It's fine for CN to use an inaccurate table_id->compaction_group mapping when commit_epoch, because commit_epoch will correct it.


## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
