### PR TITLE
feat: mock show transaction isolation level

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -14,8 +14,8 @@
 
 mod query_mode;
 mod search_path;
+mod transaction_isolation_level;
 
-use std::fmt::Formatter;
 use std::ops::Deref;
 
 use itertools::Itertools;
@@ -23,6 +23,7 @@ pub use query_mode::QueryMode;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
 
 use crate::error::{ErrorCode, RwError};
+use crate::session_config::transaction_isolation_level::IsolationLevel;
 
 // This is a hack, &'static str is not allowed as a const generics argument.
 // TODO: refine this using the adt_const_params feature.
@@ -197,43 +198,6 @@ type ExtraFloatDigit = ConfigI32<EXTRA_FLOAT_DIGITS, 1>;
 type DateStyle = ConfigString<DATE_STYLE>;
 type BatchEnableLookupJoin = ConfigBool<BATCH_ENABLE_LOOKUP_JOIN, false>;
 type MaxSplitRangeGap = ConfigI32<MAX_SPLIT_RANGE_GAP, 8>;
-
-#[derive(Copy, Default, Debug, Clone, PartialEq, Eq)]
-enum IsolationLevel {
-    #[default]
-    READ_COMMITTED,
-    READ_UNCOMMITTED,
-    REPEATABLE_READ,
-    SERIALIZABLE,
-}
-
-impl ConfigEntry for IsolationLevel {
-    fn entry_name() -> &'static str {
-        CONFIG_KEYS[TRANSACTION_ISOLATION_LEVEL]
-    }
-}
-
-impl TryFrom<&[&str]> for IsolationLevel {
-    type Error = RwError;
-
-    fn try_from(_value: &[&str]) -> Result<Self, Self::Error> {
-        Err(
-            ErrorCode::InternalError("Support set transaction isolation level first".to_string())
-                .into(),
-        )
-    }
-}
-
-impl std::fmt::Display for IsolationLevel {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::READ_COMMITTED => write!(f, "READ_COMMITTED"),
-            Self::READ_UNCOMMITTED => write!(f, "READ_UNCOMMITTED"),
-            Self::REPEATABLE_READ => write!(f, "REPEATABLE_READ"),
-            Self::SERIALIZABLE => write!(f, "SERIALIZABLE"),
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct ConfigMap {

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -37,7 +37,7 @@ const CONFIG_KEYS: [&str; 10] = [
     "RW_BATCH_ENABLE_LOOKUP_JOIN",
     "MAX_SPLIT_RANGE_GAP",
     "SEARCH_PATH",
-    "TRANSACTION_ISOLATION_LEVEL",
+    "TRANSACTION ISOLATION LEVEL",
 ];
 
 // MUST HAVE 1v1 relationship to CONFIG_KEYS. e.g. CONFIG_KEYS[IMPLICIT_FLUSH] =
@@ -232,7 +232,7 @@ pub struct ConfigMap {
     /// see <https://www.postgresql.org/docs/14/runtime-config-client.html#GUC-SEARCH-PATH>
     search_path: SearchPath,
 
-    ///
+    /// see <https://www.postgresql.org/docs/current/transaction-iso.html>
     transaction_isolation_level: IsolationLevel,
 }
 

--- a/src/common/src/session_config/transaction_isolation_level.rs
+++ b/src/common/src/session_config/transaction_isolation_level.rs
@@ -1,0 +1,57 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Formatter;
+
+use crate::error::{ErrorCode, RwError};
+use crate::session_config::{ConfigEntry, CONFIG_KEYS, TRANSACTION_ISOLATION_LEVEL};
+
+#[derive(Copy, Default, Debug, Clone, PartialEq, Eq)]
+// Some variants are never constructed so allow dead code here.
+#[allow(dead_code)]
+pub enum IsolationLevel {
+    #[default]
+    ReadCommitted,
+    ReadUncommitted,
+    RepeatableRead,
+    Serializable,
+}
+
+impl ConfigEntry for IsolationLevel {
+    fn entry_name() -> &'static str {
+        CONFIG_KEYS[TRANSACTION_ISOLATION_LEVEL]
+    }
+}
+
+impl TryFrom<&[&str]> for IsolationLevel {
+    type Error = RwError;
+
+    fn try_from(_value: &[&str]) -> Result<Self, Self::Error> {
+        Err(
+            ErrorCode::InternalError("Support set transaction isolation level first".to_string())
+                .into(),
+        )
+    }
+}
+
+impl std::fmt::Display for IsolationLevel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ReadCommitted => write!(f, "READ_COMMITTED"),
+            Self::ReadUncommitted => write!(f, "READ_UNCOMMITTED"),
+            Self::RepeatableRead => write!(f, "REPEATABLE_READ"),
+            Self::Serializable => write!(f, "SERIALIZABLE"),
+        }
+    }
+}

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -42,7 +42,7 @@ pub fn handle_set(
 pub(super) fn handle_show(context: OptimizerContext, variable: Vec<Ident>) -> Result<RwPgResponse> {
     let config_reader = context.session_ctx.config();
     // TODO: Verify that the name used in `show` command is indeed always case-insensitive.
-    let name = variable.iter().map(|e| e.real_value()).join("_");
+    let name = variable.iter().map(|e| e.real_value()).join(" ");
     if name.eq_ignore_ascii_case("ALL") {
         return handle_show_all(&context);
     }

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -41,6 +41,7 @@ pub fn handle_set(
 
 pub(super) fn handle_show(context: OptimizerContext, variable: Vec<Ident>) -> Result<RwPgResponse> {
     let config_reader = context.session_ctx.config();
+    // TODO: Verify that the name used in `show` command is indeed always case-insensitive.
     let name = variable.iter().map(|e| e.real_value()).join("_");
     if name.eq_ignore_ascii_case("ALL") {
         return handle_show_all(&context);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This is a pre-req of many sql driver: require the support of `show transaction isolationl level`. 
After this pr, people should be able to run the demo.py in sqlalchemy-risingwave.
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
