### PR TITLE
refactor(storage): apply version delta in event handler

### DIFF
--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -21,6 +21,7 @@ use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::MockHummockMetaClient;
 use risingwave_rpc_client::HummockMetaClient;
+use risingwave_storage::hummock::conflict_detector::ConflictDetector;
 use risingwave_storage::hummock::event_handler::HummockEventHandler;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::local_version::local_version_manager::LocalVersionManager;
@@ -66,8 +67,13 @@ async fn test_storage_basic() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
-            .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(
+            uploader.clone(),
+            event_rx,
+            read_version.clone(),
+            ConflictDetector::new_from_config(hummock_options.clone()),
+        )
+        .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(
@@ -416,8 +422,13 @@ async fn test_state_store_sync() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
-            .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(
+            uploader.clone(),
+            event_rx,
+            read_version.clone(),
+            ConflictDetector::new_from_config(hummock_options.clone()),
+        )
+        .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(
@@ -662,8 +673,13 @@ async fn test_delete_get() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
-            .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(
+            uploader.clone(),
+            event_rx,
+            read_version.clone(),
+            ConflictDetector::new_from_config(hummock_options.clone()),
+        )
+        .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(
@@ -764,8 +780,13 @@ async fn test_multiple_epoch_sync() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
-            .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(
+            uploader.clone(),
+            event_rx,
+            read_version.clone(),
+            ConflictDetector::new_from_config(hummock_options.clone()),
+        )
+        .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(
@@ -917,8 +938,13 @@ async fn test_iter_with_min_epoch() {
     )));
 
     tokio::spawn(
-        HummockEventHandler::new(uploader.clone(), event_rx, read_version.clone())
-            .start_hummock_event_handler_worker(),
+        HummockEventHandler::new(
+            uploader.clone(),
+            event_rx,
+            read_version.clone(),
+            ConflictDetector::new_from_config(hummock_options.clone()),
+        )
+        .start_hummock_event_handler_worker(),
     );
 
     let hummock_storage = HummockStorage::for_test(

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -414,6 +414,8 @@ async fn test_clear_shared_buffer() {
     );
 }
 
+// TODO: add unit test for sst gc watermark on the new hummock without local version manager
+#[ignore]
 #[tokio::test]
 async fn test_sst_gc_watermark() {
     let opt = Arc::new(default_config_for_test());

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -414,8 +414,6 @@ async fn test_clear_shared_buffer() {
     );
 }
 
-// TODO: add unit test for sst gc watermark on the new hummock without local version manager
-#[ignore]
 #[tokio::test]
 async fn test_sst_gc_watermark() {
     let opt = Arc::new(default_config_for_test());

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -27,6 +27,7 @@ use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::{MetaSnapshot, SubscribeResponse, SubscribeType};
+use risingwave_storage::hummock::conflict_detector::ConflictDetector;
 use risingwave_storage::hummock::event_handler::{HummockEvent, HummockEventHandler};
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::local_version::local_version_manager::{
@@ -153,6 +154,7 @@ pub async fn prepare_local_version_manager(
             Arc::new(RwLock::new(HummockReadVersion::new(
                 local_version_manager.get_pinned_version(),
             ))),
+            ConflictDetector::new_from_config(opt.clone()),
         )
         .start_hummock_event_handler_worker(),
     );

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -106,6 +106,7 @@ impl HummockEventHandler {
         local_version_manager: Arc<LocalVersionManager>,
         shared_buffer_event_receiver: mpsc::UnboundedReceiver<HummockEvent>,
         read_version: Arc<RwLock<HummockReadVersion>>,
+        write_conflict_detector: Option<Arc<ConflictDetector>>,
     ) -> Self {
         Self {
             buffer_tracker: local_version_manager.buffer_tracker().clone(),
@@ -114,10 +115,7 @@ impl HummockEventHandler {
             upload_handle_manager: UploadHandleManager::new(),
             pending_sync_requests: Default::default(),
             pinned_version: local_version_manager.get_pinned_version(),
-            write_conflict_detector: local_version_manager
-                .write_conflict_detector
-                .as_ref()
-                .cloned(),
+            write_conflict_detector,
             read_version,
             local_version_manager,
         }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -144,7 +144,6 @@ impl HummockStorage {
     ) -> HummockResult<Self> {
         // For conflict key detection. Enabled by setting `write_conflict_detection_enabled` to
         // true in `StorageConfig`
-        let write_conflict_detector = ConflictDetector::new_from_config(options.clone());
         let sstable_id_manager = Arc::new(SstableIdManager::new(
             hummock_meta_client.clone(),
             options.sstable_id_remote_fetch_number,
@@ -190,7 +189,6 @@ impl HummockStorage {
         let local_version_manager = LocalVersionManager::new(
             options.clone(),
             pinned_version,
-            write_conflict_detector,
             sstable_id_manager.clone(),
             shared_buffer_uploader,
             event_tx.clone(),
@@ -205,6 +203,7 @@ impl HummockStorage {
             local_version_manager.clone(),
             event_rx,
             read_version.clone(),
+            ConflictDetector::new_from_config(options.clone()),
         );
 
         // Buffer size manager.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Currently, the logic of applying version delta and update the hummock version is in local version manager. However, local version manager will be deprecated soon after we support a new uploader. In this PR, we move the logic of applying version delta and update the hummock version to hummock event handler. The logic of calling conflict detector and removing sstable id manager watermark is moved by the way.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
