### PR TITLE
refactor(streaming): make StreamChunkBuilder output index aware

### DIFF
--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -16,6 +16,8 @@ use itertools::Itertools;
 use risingwave_common::array::{ArrayBuilderImpl, ArrayResult, Op, Row, RowRef, StreamChunk};
 use risingwave_common::types::DataType;
 
+type IndexMappings = Vec<(usize, usize)>;
+
 /// Build a array and it's corresponding operations.
 pub struct StreamChunkBuilder {
     /// operations in the data chunk to build
@@ -27,19 +29,11 @@ pub struct StreamChunkBuilder {
     /// Data types of columns
     data_types: Vec<DataType>,
 
-    /// The start position of the columns of the side
-    /// stream coming from. If the coming side is the
-    /// left, the `update_start_pos` should be 0.
-    /// If the coming side is the right, the `update_start_pos`
-    /// is the number of columns of the left side.
-    update_start_pos: usize,
+    /// The column index mapping from update side to output.
+    update_to_output: IndexMappings,
 
-    /// The start position of the columns of the opposite side
-    /// stream coming from. If the coming side is the
-    /// left, the `matched_start_pos` should be the number of columns of the left side.
-    /// If the coming side is the right, the `matched_start_pos`
-    /// should be 0.
-    matched_start_pos: usize,
+    /// The column index mapping from matched side to output.
+    matched_to_output: IndexMappings,
 
     /// Maximum capacity of column builder
     capacity: usize,
@@ -58,8 +52,8 @@ impl StreamChunkBuilder {
     pub fn new(
         capacity: usize,
         data_types: &[DataType],
-        update_start_pos: usize,
-        matched_start_pos: usize,
+        update_to_output: IndexMappings,
+        matched_to_output: IndexMappings,
     ) -> ArrayResult<Self> {
         // Leave room for paired `UpdateDelete` and `UpdateInsert`. When there are `capacity - 1`
         // ops in current builder and the last op is `UpdateDelete`, we delay the chunk generation
@@ -77,11 +71,32 @@ impl StreamChunkBuilder {
             ops,
             column_builders,
             data_types: data_types.to_owned(),
-            update_start_pos,
-            matched_start_pos,
+            update_to_output,
+            matched_to_output,
             capacity: reduced_capacity,
             size: 0,
         })
+    }
+
+    /// Get the mapping from left/right input indices to the output indices.
+    pub fn get_i2o_mapping(
+        output_indices: impl Iterator<Item = usize>,
+        left_len: usize,
+        right_len: usize,
+    ) -> (IndexMappings, IndexMappings) {
+        let mut left_to_output = vec![];
+        let mut right_to_output = vec![];
+
+        for (output_idx, idx) in output_indices.enumerate() {
+            if idx < left_len {
+                left_to_output.push((idx, output_idx))
+            } else if idx >= left_len && idx < left_len + right_len {
+                right_to_output.push((idx - left_len, output_idx));
+            } else {
+                unreachable!("output_indices out of bound")
+            }
+        }
+        (left_to_output, right_to_output)
     }
 
     /// Increase chunk size
@@ -109,11 +124,11 @@ impl StreamChunkBuilder {
         row_matched: &Row,
     ) -> ArrayResult<Option<StreamChunk>> {
         self.ops.push(op);
-        for (i, d) in row_update.values().enumerate() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(d);
+        for &(update_idx, output_idx) in &self.update_to_output {
+            self.column_builders[output_idx].append_datum_ref(row_update.value_at(update_idx));
         }
-        for (i, d) in row_matched.values().enumerate() {
-            self.column_builders[i + self.matched_start_pos].append_datum(d);
+        for &(matched_idx, output_idx) in &self.matched_to_output {
+            self.column_builders[output_idx].append_datum(&row_matched[matched_idx]);
         }
 
         self.inc_size()
@@ -128,11 +143,11 @@ impl StreamChunkBuilder {
         row_update: &RowRef<'_>,
     ) -> ArrayResult<Option<StreamChunk>> {
         self.ops.push(op);
-        for (i, d) in row_update.values().enumerate() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(d);
+        for &(update_idx, output_idx) in &self.update_to_output {
+            self.column_builders[output_idx].append_datum_ref(row_update.value_at(update_idx));
         }
-        for i in 0..self.column_builders.len() - row_update.size() {
-            self.column_builders[i + self.matched_start_pos].append_datum(&None);
+        for &(_matched_idx, output_idx) in &self.matched_to_output {
+            self.column_builders[output_idx].append_datum(&None);
         }
 
         self.inc_size()
@@ -147,11 +162,11 @@ impl StreamChunkBuilder {
         row_matched: &Row,
     ) -> ArrayResult<Option<StreamChunk>> {
         self.ops.push(op);
-        for i in 0..self.column_builders.len() - row_matched.size() {
-            self.column_builders[i + self.update_start_pos].append_datum_ref(None);
+        for &(_update_idx, output_idx) in &self.update_to_output {
+            self.column_builders[output_idx].append_datum_ref(None);
         }
-        for i in 0..row_matched.size() {
-            self.column_builders[i + self.matched_start_pos].append_datum(&row_matched[i]);
+        for &(matched_idx, output_idx) in &self.matched_to_output {
+            self.column_builders[output_idx].append_datum(&row_matched[matched_idx]);
         }
 
         self.inc_size()

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -107,8 +107,12 @@ const fn is_anti(join_type: JoinTypePrimitive) -> bool {
     join_type == JoinType::LeftAnti || join_type == JoinType::RightAnti
 }
 
-const fn is_semi_or_anti(join_type: JoinTypePrimitive) -> bool {
-    is_semi(join_type) || is_anti(join_type)
+const fn is_left_semi_or_anti(join_type: JoinTypePrimitive) -> bool {
+    join_type == JoinType::LeftSemi || join_type == JoinType::LeftAnti
+}
+
+const fn is_right_semi_or_anti(join_type: JoinTypePrimitive) -> bool {
+    join_type == JoinType::RightSemi || join_type == JoinType::RightAnti
 }
 
 const fn need_update_side_matched_degree(
@@ -166,6 +170,8 @@ struct JoinSide<K: HashKey, S: StateStore> {
     all_data_types: Vec<DataType>,
     /// The start position for the side in output new columns
     start_pos: usize,
+    /// The mapping from input indices of a side to output columes.
+    i2o_mapping: Vec<(usize, usize)>,
 }
 
 impl<K: HashKey, S: StateStore> std::fmt::Debug for JoinSide<K, S> {
@@ -175,6 +181,7 @@ impl<K: HashKey, S: StateStore> std::fmt::Debug for JoinSide<K, S> {
             .field("pk_indices", &self.pk_indices)
             .field("col_types", &self.all_data_types)
             .field("start_pos", &self.start_pos)
+            .field("i2o_mapping", &self.i2o_mapping)
             .finish()
     }
 }
@@ -212,9 +219,7 @@ pub struct HashJoinExecutor<K: HashKey, S: StateStore, const T: JoinTypePrimitiv
     /// Right input executor
     input_r: Option<BoxedExecutor>,
     /// The data types of the formed new columns
-    output_data_types: Vec<DataType>,
-    /// The output indices of the join executor
-    output_indices: Vec<usize>,
+    actual_output_data_types: Vec<DataType>,
     /// The schema of the hash join executor
     schema: Schema,
     /// The primary key indices of the schema
@@ -252,7 +257,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> std::fmt::Debug
             .field("side_r", &self.side_r)
             .field("pk_indices", &self.pk_indices)
             .field("schema", &self.schema)
-            .field("output_data_types", &self.output_data_types)
+            .field("actual_output_data_types", &self.actual_output_data_types)
             .finish()
     }
 }
@@ -446,10 +451,14 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
             .concat(),
         };
 
-        let original_output_data_types: Vec<_> = schema_fields
+        let original_output_data_types = schema_fields
             .iter()
             .map(|field| field.data_type.clone())
-            .collect();
+            .collect_vec();
+        let actual_output_data_types = output_indices
+            .iter()
+            .map(|&idx| original_output_data_types[idx].clone())
+            .collect_vec();
 
         // Data types of of hash join state.
         let state_all_data_types_l = input_l
@@ -540,11 +549,22 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         let need_degree_table_l = need_left_degree(T);
         let need_degree_table_r = need_right_degree(T);
 
+        let (left_to_output, right_to_output) = {
+            let (left_len, right_len) = if is_left_semi_or_anti(T) {
+                (state_all_data_types_l.len(), 0usize)
+            } else if is_right_semi_or_anti(T) {
+                (0usize, state_all_data_types_r.len())
+            } else {
+                (state_all_data_types_l.len(), state_all_data_types_r.len())
+            };
+            StreamChunkBuilder::get_i2o_mapping(output_indices.iter().cloned(), left_len, right_len)
+        };
+
         Self {
             ctx: ctx.clone(),
             input_l: Some(input_l),
             input_r: Some(input_r),
-            output_data_types: original_output_data_types,
+            actual_output_data_types,
             schema: actual_schema,
             side_l: JoinSide {
                 ht: JoinHashMap::new(
@@ -567,6 +587,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 all_data_types: state_all_data_types_l,
                 pk_indices: state_pk_indices_l,
                 start_pos: 0,
+                i2o_mapping: left_to_output,
             },
             side_r: JoinSide {
                 ht: JoinHashMap::new(
@@ -589,9 +610,9 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 all_data_types: state_all_data_types_r,
                 pk_indices: state_pk_indices_r,
                 start_pos: side_l_column_n,
+                i2o_mapping: right_to_output,
             },
             pk_indices,
-            output_indices,
             cond,
             identity: format!("HashJoinExecutor {:X}", executor_id),
             op_info,
@@ -639,16 +660,14 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                         &self.identity,
                         &mut self.side_l,
                         &mut self.side_r,
-                        &self.output_data_types,
+                        &self.actual_output_data_types,
                         &mut self.cond,
                         chunk,
                         self.append_only_optimize,
                         self.chunk_size,
                     ) {
                         yield chunk.map(|v| match v {
-                            Message::Chunk(chunk) => {
-                                Message::Chunk(chunk.reorder_columns(&self.output_indices))
-                            }
+                            Message::Chunk(chunk) => Message::Chunk(chunk),
                             barrier @ Message::Barrier(_) => barrier,
                         })?;
                     }
@@ -660,16 +679,14 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                         &self.identity,
                         &mut self.side_l,
                         &mut self.side_r,
-                        &self.output_data_types,
+                        &self.actual_output_data_types,
                         &mut self.cond,
                         chunk,
                         self.append_only_optimize,
                         self.chunk_size,
                     ) {
                         yield chunk.map(|v| match v {
-                            Message::Chunk(chunk) => {
-                                Message::Chunk(chunk.reorder_columns(&self.output_indices))
-                            }
+                            Message::Chunk(chunk) => Message::Chunk(chunk),
                             barrier @ Message::Barrier(_) => barrier,
                         })?;
                     }
@@ -764,7 +781,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         identity: &'a str,
         mut side_l: &'a mut JoinSide<K, S>,
         mut side_r: &'a mut JoinSide<K, S>,
-        output_data_types: &'a [DataType],
+        actual_output_data_types: &'a [DataType],
         cond: &'a mut Option<BoxedExpression>,
         chunk: StreamChunk,
         append_only_optimize: bool,
@@ -778,20 +795,13 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
             (&mut side_r, &mut side_l)
         };
 
-        let mut hashjoin_chunk_builder = {
-            let (update_start_pos, matched_start_pos) = if is_semi_or_anti(T) {
-                (0, 0)
-            } else {
-                (side_update.start_pos, side_match.start_pos)
-            };
-            HashJoinChunkBuilder::<T, SIDE> {
-                stream_chunk_builder: StreamChunkBuilder::new(
-                    chunk_size,
-                    output_data_types,
-                    update_start_pos,
-                    matched_start_pos,
-                )?,
-            }
+        let mut hashjoin_chunk_builder = HashJoinChunkBuilder::<T, SIDE> {
+            stream_chunk_builder: StreamChunkBuilder::new(
+                chunk_size,
+                actual_output_data_types,
+                side_update.i2o_mapping.clone(),
+                side_match.i2o_mapping.clone(),
+            )?,
         };
 
         let mut check_join_condition =


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

Apply `output_indices` while building `StreamChunk`, not after building it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#3588