### PR TITLE
fix: an interval bug caused by missing check 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,9 +3865,9 @@ dependencies = [
 
 [[package]]
 name = "pg_interval"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47354dbd658c57a5ee1cc97a79937345170234d4c817768de80ea6d2e9f5b98a"
+checksum = "fe46640b465e284b048ef065cbed8ef17a622878d310c724578396b4cfd00df2"
 dependencies = [
  "bytes",
  "chrono",

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -762,7 +762,7 @@ impl IntervalUnit {
                     result = result + (|| match interval_unit {
                         Second => {
                             // TODO: IntervalUnit only support millisecond precision so the part smaller than millisecond will be truncated.
-                            if second < OrderedF64::from(0.001) {
+                            if second > OrderedF64::from(0) && second < OrderedF64::from(0.001) {
                                 return None;
                             }
                             let ms = (second * 1000_f64).round() as i64;
@@ -804,6 +804,9 @@ mod tests {
 
     #[test]
     fn test_parse() {
+        let interval = "04:00:00".parse::<IntervalUnit>().unwrap();
+        assert_eq!(interval, IntervalUnit::from_millis(4 * 3600 * 1000));
+
         let interval = "1 year 2 months 3 days 00:00:01"
             .parse::<IntervalUnit>()
             .unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Because IntervalUnit only has the precision of milliseconds, when we encounter a value less than 0.001 milliseconds we will return an error. But I forget to treat 0 seconds in particular, so `select '04:00:00'::interval` will fail.
This PR fixes it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
