### PR TITLE
refactor(storage): new event handler and local version manager init

### DIFF
--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::ops::Bound;
-use std::sync::Arc;
 
 use risingwave_common::catalog::TableId;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
@@ -24,20 +23,19 @@ use risingwave_storage::hummock::store::memtable::ImmutableMemtable;
 use risingwave_storage::hummock::store::version::{
     HummockReadVersion, StagingData, StagingSstableInfo, VersionUpdate,
 };
-use risingwave_storage::hummock::test_utils::{default_config_for_test, gen_dummy_batch};
+use risingwave_storage::hummock::test_utils::gen_dummy_batch;
 
-use crate::test_utils::prepare_local_version_manager;
+use crate::test_utils::prepare_first_valid_version;
 
 #[tokio::test]
 async fn test_read_version_basic() {
-    let opt = Arc::new(default_config_for_test());
     let (env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
         setup_compute_env(8080).await;
 
-    let local_version_manager =
-        prepare_local_version_manager(opt, env, hummock_manager_ref, worker_node).await;
+    let (pinned_version, _, _) =
+        prepare_first_valid_version(env, hummock_manager_ref, worker_node).await;
 
-    let mut read_version = HummockReadVersion::new(local_version_manager.get_pinned_version());
+    let mut read_version = HummockReadVersion::new(pinned_version);
     let mut epoch = 1;
     let table_id = 0;
 

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -13,28 +13,83 @@
 // limitations under the License.
 
 use std::ops::Bound::{Included, Unbounded};
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
-use parking_lot::RwLock;
+use risingwave_common::config::StorageConfig;
+use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::HummockEpoch;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
-use risingwave_meta::hummock::MockHummockMetaClient;
+use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
+use risingwave_meta::manager::MetaSrvEnv;
+use risingwave_meta::storage::MemStore;
+use risingwave_pb::common::WorkerNode;
 use risingwave_rpc_client::HummockMetaClient;
-use risingwave_storage::hummock::conflict_detector::ConflictDetector;
-use risingwave_storage::hummock::event_handler::HummockEventHandler;
+use risingwave_storage::hummock::compactor::Context;
+use risingwave_storage::hummock::event_handler::hummock_event_handler::BufferTracker;
+use risingwave_storage::hummock::event_handler::{HummockEvent, HummockEventHandler};
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
+use risingwave_storage::hummock::local_version::local_version_manager::LocalVersionManager;
 use risingwave_storage::hummock::store::state_store::HummockStorage;
-use risingwave_storage::hummock::store::version::HummockReadVersion;
 use risingwave_storage::hummock::store::{ReadOptions, StateStore};
 use risingwave_storage::hummock::test_utils::default_config_for_test;
+use risingwave_storage::hummock::{SstableIdManager, SstableStore};
+use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::storage_value::StorageValue;
-use risingwave_storage::store::WriteOptions;
+use risingwave_storage::store::{SyncResult, WriteOptions};
 use risingwave_storage::StateStoreIter;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::sync::oneshot;
 
-use crate::test_utils::{prefixed_key, prepare_local_version_manager_new};
+use crate::test_utils::{prefixed_key, prepare_first_valid_version};
+
+pub async fn prepare_hummock_event_handler(
+    opt: Arc<StorageConfig>,
+    env: MetaSrvEnv<MemStore>,
+    hummock_manager_ref: HummockManagerRef<MemStore>,
+    worker_node: WorkerNode,
+    sstable_store_ref: Arc<SstableStore>,
+) -> (HummockEventHandler, UnboundedSender<HummockEvent>) {
+    let (pinned_version, event_tx, event_rx) =
+        prepare_first_valid_version(env, hummock_manager_ref.clone(), worker_node.clone()).await;
+
+    let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+        hummock_manager_ref.clone(),
+        worker_node.id,
+    ));
+
+    let sstable_id_manager = Arc::new(SstableIdManager::new(
+        hummock_meta_client.clone(),
+        opt.sstable_id_remote_fetch_number,
+    ));
+    let compactor_context = Arc::new(Context::new_local_compact_context(
+        opt.clone(),
+        sstable_store_ref,
+        hummock_meta_client,
+        Arc::new(StateStoreMetrics::unused()),
+        sstable_id_manager,
+        Arc::new(FilterKeyExtractorManager::default()),
+    ));
+
+    let buffer_tracker = BufferTracker::from_storage_config(&opt);
+
+    let local_version_manager = LocalVersionManager::new(
+        pinned_version.clone(),
+        compactor_context.clone(),
+        buffer_tracker,
+        event_tx.clone(),
+    );
+
+    let hummock_event_handler = HummockEventHandler::new(
+        local_version_manager,
+        event_rx,
+        pinned_version,
+        compactor_context,
+    );
+
+    (hummock_event_handler, event_tx)
+}
 
 async fn try_wait_epoch_for_test(
     wait_epoch: u64,
@@ -65,6 +120,23 @@ async fn try_wait_epoch_for_test(
     }
 }
 
+async fn sync_epoch(event_tx: &UnboundedSender<HummockEvent>, epoch: HummockEpoch) -> SyncResult {
+    event_tx
+        .send(HummockEvent::SealEpoch {
+            epoch,
+            is_checkpoint: true,
+        })
+        .unwrap();
+    let (tx, rx) = oneshot::channel();
+    event_tx
+        .send(HummockEvent::SyncEpoch {
+            new_sync_epoch: epoch,
+            sync_result_sender: tx,
+        })
+        .unwrap();
+    rx.await.unwrap().unwrap()
+}
+
 #[tokio::test]
 async fn test_storage_basic() {
     let sstable_store = mock_sstable_store();
@@ -76,7 +148,7 @@ async fn test_storage_basic() {
         worker_node.id,
     ));
 
-    let (uploader, event_tx, event_rx) = prepare_local_version_manager_new(
+    let (hummock_event_handler, event_tx) = prepare_hummock_event_handler(
         hummock_options.clone(),
         env,
         hummock_manager_ref,
@@ -85,32 +157,9 @@ async fn test_storage_basic() {
     )
     .await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-        uploader.get_pinned_version(),
-    )));
+    let read_version = hummock_event_handler.read_version();
 
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = uploader.get_pinned_version().max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
-
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            uploader.clone(),
-            event_rx,
-            read_version.clone(),
-            version_update_notifier_tx,
-            seal_epoch,
-            ConflictDetector::new_from_config(hummock_options.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
+    tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
     let hummock_storage = HummockStorage::for_test(
         hummock_options,
@@ -444,7 +493,7 @@ async fn test_state_store_sync() {
         worker_node.id,
     ));
 
-    let (uploader, event_tx, event_rx) = prepare_local_version_manager_new(
+    let (hummock_event_handler, event_tx) = prepare_hummock_event_handler(
         hummock_options.clone(),
         env,
         hummock_manager_ref,
@@ -453,43 +502,21 @@ async fn test_state_store_sync() {
     )
     .await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-        uploader.get_pinned_version(),
-    )));
+    let read_version = hummock_event_handler.read_version();
 
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = uploader.get_pinned_version().max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
+    let version_update_notifier_tx = hummock_event_handler.version_update_notifier_tx();
+    let epoch1: _ = read_version.read().committed().max_committed_epoch() + 1;
 
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            uploader.clone(),
-            event_rx,
-            read_version.clone(),
-            version_update_notifier_tx.clone(),
-            seal_epoch,
-            ConflictDetector::new_from_config(hummock_options.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
+    tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
     let hummock_storage = HummockStorage::for_test(
         hummock_options,
         sstable_store,
         hummock_meta_client.clone(),
         read_version,
-        event_tx,
+        event_tx.clone(),
     )
     .unwrap();
-
-    let epoch1: _ = uploader.get_pinned_version().max_committed_epoch() + 1;
 
     // ingest 26B batch
     let mut batch1 = vec![
@@ -562,11 +589,7 @@ async fn test_state_store_sync() {
         .await
         .unwrap();
 
-    let ssts = uploader
-        .sync_shared_buffer(epoch1)
-        .await
-        .unwrap()
-        .uncommitted_ssts;
+    let ssts = sync_epoch(&event_tx, epoch1).await.uncommitted_ssts;
     hummock_meta_client
         .commit_epoch(epoch1, ssts)
         .await
@@ -607,11 +630,7 @@ async fn test_state_store_sync() {
         }
     }
 
-    let ssts = uploader
-        .sync_shared_buffer(epoch2)
-        .await
-        .unwrap()
-        .uncommitted_ssts;
+    let ssts = sync_epoch(&event_tx, epoch2).await.uncommitted_ssts;
 
     hummock_meta_client
         .commit_epoch(epoch2, ssts)
@@ -726,7 +745,7 @@ async fn test_delete_get() {
         worker_node.id,
     ));
 
-    let (uploader, event_tx, event_rx) = prepare_local_version_manager_new(
+    let (hummock_event_handler, event_tx) = prepare_hummock_event_handler(
         hummock_options.clone(),
         env,
         hummock_manager_ref,
@@ -735,43 +754,22 @@ async fn test_delete_get() {
     )
     .await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-        uploader.get_pinned_version(),
-    )));
+    let read_version = hummock_event_handler.read_version();
+    let version_update_notifier_tx = hummock_event_handler.version_update_notifier_tx();
 
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = uploader.get_pinned_version().max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
+    tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            uploader.clone(),
-            event_rx,
-            read_version.clone(),
-            version_update_notifier_tx.clone(),
-            seal_epoch,
-            ConflictDetector::new_from_config(hummock_options.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
+    let initial_epoch = read_version.read().committed().max_committed_epoch();
 
     let hummock_storage = HummockStorage::for_test(
         hummock_options,
         sstable_store,
         hummock_meta_client.clone(),
         read_version,
-        event_tx,
+        event_tx.clone(),
     )
     .unwrap();
 
-    let initial_epoch = uploader.get_pinned_version().max_committed_epoch();
     let epoch1 = initial_epoch + 1;
     let batch1 = vec![
         (
@@ -793,11 +791,8 @@ async fn test_delete_get() {
         )
         .await
         .unwrap();
-    let ssts = uploader
-        .sync_shared_buffer(epoch1)
-        .await
-        .unwrap()
-        .uncommitted_ssts;
+
+    let ssts = sync_epoch(&event_tx, epoch1).await.uncommitted_ssts;
     hummock_meta_client
         .commit_epoch(epoch1, ssts)
         .await
@@ -814,11 +809,7 @@ async fn test_delete_get() {
         )
         .await
         .unwrap();
-    let ssts = uploader
-        .sync_shared_buffer(epoch2)
-        .await
-        .unwrap()
-        .uncommitted_ssts;
+    let ssts = sync_epoch(&event_tx, epoch2).await.uncommitted_ssts;
     hummock_meta_client
         .commit_epoch(epoch2, ssts)
         .await
@@ -852,7 +843,7 @@ async fn test_multiple_epoch_sync() {
         worker_node.id,
     ));
 
-    let (uploader, event_tx, event_rx) = prepare_local_version_manager_new(
+    let (hummock_event_handler, event_tx) = prepare_hummock_event_handler(
         hummock_options.clone(),
         env,
         hummock_manager_ref,
@@ -861,43 +852,22 @@ async fn test_multiple_epoch_sync() {
     )
     .await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-        uploader.get_pinned_version(),
-    )));
+    let read_version = hummock_event_handler.read_version();
+    let version_update_notifier_tx = hummock_event_handler.version_update_notifier_tx();
 
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = uploader.get_pinned_version().max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
+    tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            uploader.clone(),
-            event_rx,
-            read_version.clone(),
-            version_update_notifier_tx.clone(),
-            seal_epoch,
-            ConflictDetector::new_from_config(hummock_options.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
+    let initial_epoch = read_version.read().committed().max_committed_epoch();
 
     let hummock_storage = HummockStorage::for_test(
         hummock_options,
         sstable_store,
         hummock_meta_client.clone(),
         read_version,
-        event_tx,
+        event_tx.clone(),
     )
     .unwrap();
 
-    let initial_epoch = uploader.get_pinned_version().max_committed_epoch();
     let epoch1 = initial_epoch + 1;
     let batch1 = vec![
         (
@@ -1008,8 +978,14 @@ async fn test_multiple_epoch_sync() {
         }
     };
     test_get().await;
-    let sync_result2 = uploader.sync_shared_buffer(epoch2).await.unwrap();
-    let sync_result3 = uploader.sync_shared_buffer(epoch3).await.unwrap();
+    event_tx
+        .send(HummockEvent::SealEpoch {
+            epoch: epoch1,
+            is_checkpoint: false,
+        })
+        .unwrap();
+    let sync_result2 = sync_epoch(&event_tx, epoch2).await;
+    let sync_result3 = sync_epoch(&event_tx, epoch3).await;
     test_get().await;
     hummock_meta_client
         .commit_epoch(epoch2, sync_result2.uncommitted_ssts)
@@ -1035,7 +1011,7 @@ async fn test_iter_with_min_epoch() {
         worker_node.id,
     ));
 
-    let (uploader, event_tx, event_rx) = prepare_local_version_manager_new(
+    let (hummock_event_handler, event_tx) = prepare_hummock_event_handler(
         hummock_options.clone(),
         env,
         hummock_manager_ref,
@@ -1044,39 +1020,17 @@ async fn test_iter_with_min_epoch() {
     )
     .await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-        uploader.get_pinned_version(),
-    )));
+    let read_version = hummock_event_handler.read_version();
+    let version_update_notifier_tx = hummock_event_handler.version_update_notifier_tx();
 
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = uploader.get_pinned_version().max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
-
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(0)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            uploader.clone(),
-            event_rx,
-            read_version.clone(),
-            version_update_notifier_tx.clone(),
-            seal_epoch,
-            ConflictDetector::new_from_config(hummock_options.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
+    tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
     let hummock_storage = HummockStorage::for_test(
         hummock_options,
         sstable_store,
         hummock_meta_client.clone(),
         read_version,
-        event_tx,
+        event_tx.clone(),
     )
     .unwrap();
 
@@ -1194,8 +1148,8 @@ async fn test_iter_with_min_epoch() {
     {
         // test after sync
 
-        let sync_result1 = uploader.sync_shared_buffer(epoch1).await.unwrap();
-        let sync_result2 = uploader.sync_shared_buffer(epoch2).await.unwrap();
+        let sync_result1 = sync_epoch(&event_tx, epoch1).await;
+        let sync_result2 = sync_epoch(&event_tx, epoch2).await;
         hummock_meta_client
             .commit_epoch(epoch1, sync_result1.uncommitted_ssts)
             .await

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -17,18 +17,83 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use risingwave_common::catalog::TableId;
+use risingwave_common::config::StorageConfig;
+use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::HummockSstableId;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
+use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
+use risingwave_meta::manager::MetaSrvEnv;
+use risingwave_meta::storage::MemStore;
+use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::pin_version_response::Payload;
 use risingwave_pb::hummock::HummockVersion;
+use risingwave_storage::hummock::compactor::Context;
+use risingwave_storage::hummock::event_handler::hummock_event_handler::BufferTracker;
+use risingwave_storage::hummock::event_handler::HummockEventHandler;
+use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
+use risingwave_storage::hummock::local_version::local_version_manager::{
+    LocalVersionManager, LocalVersionManagerRef,
+};
 use risingwave_storage::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use risingwave_storage::hummock::shared_buffer::UncommittedData;
 use risingwave_storage::hummock::test_utils::{
     default_config_for_test, gen_dummy_batch, gen_dummy_batch_several_keys, gen_dummy_sst_info,
 };
+use risingwave_storage::hummock::SstableIdManager;
+use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::storage_value::StorageValue;
+use tokio::spawn;
 
-use crate::test_utils::prepare_local_version_manager;
+use crate::test_utils::prepare_first_valid_version;
+
+pub async fn prepare_local_version_manager(
+    opt: Arc<StorageConfig>,
+    env: MetaSrvEnv<MemStore>,
+    hummock_manager_ref: HummockManagerRef<MemStore>,
+    worker_node: WorkerNode,
+) -> LocalVersionManagerRef {
+    let (pinned_version, event_tx, event_rx) =
+        prepare_first_valid_version(env, hummock_manager_ref.clone(), worker_node.clone()).await;
+
+    let sstable_store = mock_sstable_store();
+
+    let hummock_meta_client = Arc::new(MockHummockMetaClient::new(
+        hummock_manager_ref.clone(),
+        worker_node.id,
+    ));
+
+    let sstable_id_manager = Arc::new(SstableIdManager::new(
+        hummock_meta_client.clone(),
+        opt.sstable_id_remote_fetch_number,
+    ));
+
+    let buffer_tracker = BufferTracker::from_storage_config(&opt);
+    let compactor_context = Arc::new(Context::new_local_compact_context(
+        opt.clone(),
+        sstable_store,
+        hummock_meta_client,
+        Arc::new(StateStoreMetrics::unused()),
+        sstable_id_manager,
+        Arc::new(FilterKeyExtractorManager::default()),
+    ));
+
+    let local_version_manager = LocalVersionManager::new(
+        pinned_version.clone(),
+        compactor_context.clone(),
+        buffer_tracker,
+        event_tx,
+    );
+
+    let hummock_event_handler = HummockEventHandler::new(
+        local_version_manager.clone(),
+        event_rx,
+        pinned_version,
+        compactor_context,
+    );
+    spawn(hummock_event_handler.start_hummock_event_handler_worker());
+
+    local_version_manager
+}
 
 #[tokio::test]
 async fn test_update_pinned_version() {

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -1144,6 +1144,7 @@ async fn test_multiple_epoch_sync() {
         }
     };
     test_get().await;
+    hummock_storage.seal_epoch(epoch1, false);
     let sync_result2 = hummock_storage.seal_and_sync_epoch(epoch2).await.unwrap();
     let sync_result3 = hummock_storage.seal_and_sync_epoch(epoch3).await.unwrap();
     test_get().await;

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -12,33 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use bytes::{BufMut, Bytes};
-use parking_lot::RwLock;
-use risingwave_common::config::StorageConfig;
 use risingwave_common::error::Result;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common_service::observer_manager::{Channel, NotificationClient, ObserverManager};
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
-use risingwave_meta::hummock::{HummockManager, HummockManagerRef, MockHummockMetaClient};
+use risingwave_meta::hummock::{HummockManager, HummockManagerRef};
 use risingwave_meta::manager::{MessageStatus, MetaSrvEnv, NotificationManagerRef, WorkerKey};
 use risingwave_meta::storage::{MemStore, MetaStore};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::{MetaSnapshot, SubscribeResponse, SubscribeType};
-use risingwave_storage::hummock::conflict_detector::ConflictDetector;
-use risingwave_storage::hummock::event_handler::{HummockEvent, HummockEventHandler};
-use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
-use risingwave_storage::hummock::local_version::local_version_manager::{
-    LocalVersionManager, LocalVersionManagerRef,
-};
+use risingwave_storage::hummock::event_handler::HummockEvent;
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
 use risingwave_storage::hummock::observer_manager::HummockObserverNode;
-use risingwave_storage::hummock::store::version::HummockReadVersion;
-use risingwave_storage::hummock::SstableStore;
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 pub struct TestNotificationClient<S: MetaStore> {
@@ -113,18 +103,21 @@ pub fn get_test_notification_client(
     )
 }
 
-pub async fn prepare_local_version_manager(
-    opt: Arc<StorageConfig>,
+pub async fn prepare_first_valid_version(
     env: MetaSrvEnv<MemStore>,
     hummock_manager_ref: HummockManagerRef<MemStore>,
     worker_node: WorkerNode,
-) -> LocalVersionManagerRef {
+) -> (
+    PinnedVersion,
+    UnboundedSender<HummockEvent>,
+    UnboundedReceiver<HummockEvent>,
+) {
     let (tx, mut rx) = unbounded_channel();
     let notification_client =
         get_test_notification_client(env, hummock_manager_ref.clone(), worker_node.clone());
     let observer_manager = ObserverManager::new(
         notification_client,
-        HummockObserverNode::new(Arc::new(FilterKeyExtractorManager::default()), tx),
+        HummockObserverNode::new(Arc::new(FilterKeyExtractorManager::default()), tx.clone()),
     )
     .await;
     let _ = observer_manager.start().await.unwrap();
@@ -135,95 +128,11 @@ pub async fn prepare_local_version_manager(
         _ => unreachable!("should be full version"),
     };
 
-    let (tx, _rx) = unbounded_channel();
-    let (event_tx, event_rx) = unbounded_channel();
-
-    let local_version_manager = LocalVersionManager::for_test(
-        opt.clone(),
-        PinnedVersion::new(hummock_version, tx),
-        mock_sstable_store(),
-        Arc::new(MockHummockMetaClient::new(
-            hummock_manager_ref.clone(),
-            worker_node.id,
-        )),
-        event_tx,
-    );
-
-    let (version_update_notifier_tx, seal_epoch) = {
-        let basic_max_committed_epoch = local_version_manager
-            .get_pinned_version()
-            .max_committed_epoch();
-        let (version_update_notifier_tx, _rx) =
-            tokio::sync::watch::channel(basic_max_committed_epoch);
-
-        (
-            Arc::new(version_update_notifier_tx),
-            Arc::new(AtomicU64::new(basic_max_committed_epoch)),
-        )
-    };
-
-    tokio::spawn(
-        HummockEventHandler::new(
-            local_version_manager.clone(),
-            event_rx,
-            Arc::new(RwLock::new(HummockReadVersion::new(
-                local_version_manager.get_pinned_version(),
-            ))),
-            version_update_notifier_tx,
-            seal_epoch,
-            ConflictDetector::new_from_config(opt.clone()),
-        )
-        .start_hummock_event_handler_worker(),
-    );
-
-    local_version_manager
-}
-
-pub async fn prepare_local_version_manager_new(
-    opt: Arc<StorageConfig>,
-    env: MetaSrvEnv<MemStore>,
-    hummock_manager_ref: HummockManagerRef<MemStore>,
-    worker_node: WorkerNode,
-    sstable_store_ref: Arc<SstableStore>,
-) -> (
-    LocalVersionManagerRef,
-    UnboundedSender<HummockEvent>,
-    UnboundedReceiver<HummockEvent>,
-) {
-    let (event_tx, mut event_rx) = unbounded_channel();
-
-    let notification_client =
-        get_test_notification_client(env, hummock_manager_ref.clone(), worker_node.clone());
-    let observer_manager = ObserverManager::new(
-        notification_client,
-        HummockObserverNode::new(
-            Arc::new(FilterKeyExtractorManager::default()),
-            event_tx.clone(),
-        ),
+    (
+        PinnedVersion::new(hummock_version, unbounded_channel().0),
+        tx,
+        rx,
     )
-    .await;
-    let _ = observer_manager.start().await.unwrap();
-    let hummock_version = match event_rx.recv().await {
-        Some(HummockEvent::VersionUpdate(pin_version_response::Payload::PinnedVersion(
-            version,
-        ))) => version,
-        _ => unreachable!("should be full version"),
-    };
-
-    let (tx, _rx) = unbounded_channel();
-
-    let local_version_manager = LocalVersionManager::for_test(
-        opt.clone(),
-        PinnedVersion::new(hummock_version, tx),
-        sstable_store_ref,
-        Arc::new(MockHummockMetaClient::new(
-            hummock_manager_ref.clone(),
-            worker_node.id,
-        )),
-        event_tx.clone(),
-    );
-
-    (local_version_manager, event_tx, event_rx)
 }
 
 /// Prefix the `key` with a dummy table id.

--- a/src/storage/src/hummock/conflict_detector.rs
+++ b/src/storage/src/hummock/conflict_detector.rs
@@ -40,7 +40,7 @@ impl Default for ConflictDetector {
 }
 
 impl ConflictDetector {
-    pub fn new_from_config(options: Arc<StorageConfig>) -> Option<Arc<ConflictDetector>> {
+    pub fn new_from_config(options: &StorageConfig) -> Option<Arc<ConflictDetector>> {
         if options.write_conflict_detection_enabled {
             Some(Arc::new(ConflictDetector::default()))
         } else {

--- a/src/storage/src/hummock/event_handler/mod.rs
+++ b/src/storage/src/hummock/event_handler/mod.rs
@@ -21,8 +21,8 @@ use crate::hummock::store::memtable::ImmutableMemtable;
 use crate::hummock::HummockResult;
 use crate::store::SyncResult;
 
-mod hummock_event_handler;
-pub use hummock_event_handler::{BufferTracker, HummockEventHandler};
+pub mod hummock_event_handler;
+pub use hummock_event_handler::HummockEventHandler;
 
 #[derive(Debug)]
 pub struct BufferWriteRequest {

--- a/src/storage/src/hummock/local_version/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version/local_version_manager.rs
@@ -19,21 +19,18 @@ use std::sync::Arc;
 use bytes::Bytes;
 use parking_lot::{RwLock, RwLockWriteGuard};
 use risingwave_common::catalog::TableId;
-use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
-#[cfg(any(test, feature = "test"))]
-use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::pin_version_response;
 use risingwave_pb::hummock::pin_version_response::Payload;
-#[cfg(any(test, feature = "test"))]
-use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
 
-use crate::hummock::event_handler::{BufferTracker, HummockEvent};
+use crate::hummock::compactor::Context;
+use crate::hummock::event_handler::hummock_event_handler::BufferTracker;
+use crate::hummock::event_handler::HummockEvent;
 use crate::hummock::local_version::pinned_version::PinnedVersion;
 use crate::hummock::local_version::{LocalVersion, ReadVersion};
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
@@ -41,12 +38,8 @@ use crate::hummock::shared_buffer::shared_buffer_uploader::{
     SharedBufferUploader, UploadTaskPayload,
 };
 use crate::hummock::shared_buffer::OrderIndex;
-#[cfg(any(test, feature = "test"))]
-use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::utils::validate_table_key_range;
-use crate::hummock::{HummockEpoch, HummockResult, MemoryLimiter, SstableIdManagerRef, TrackerId};
-#[cfg(any(test, feature = "test"))]
-use crate::monitor::StateStoreMetrics;
+use crate::hummock::{HummockEpoch, HummockResult, SstableIdManagerRef, TrackerId};
 use crate::storage_value::StorageValue;
 use crate::store::SyncResult;
 
@@ -61,65 +54,30 @@ pub struct LocalVersionManager {
     buffer_tracker: BufferTracker,
     shared_buffer_uploader: Arc<SharedBufferUploader>,
     sstable_id_manager: SstableIdManagerRef,
+    event_sender: UnboundedSender<HummockEvent>,
 }
 
 impl LocalVersionManager {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        options: Arc<StorageConfig>,
         pinned_version: PinnedVersion,
-        sstable_id_manager: SstableIdManagerRef,
-        shared_buffer_uploader: Arc<SharedBufferUploader>,
+        compactor_context: Arc<Context>,
+        buffer_tracker: BufferTracker,
         event_sender: UnboundedSender<HummockEvent>,
-        memory_limiter: Arc<MemoryLimiter>,
     ) -> Arc<Self> {
         assert!(pinned_version.is_valid());
-        let capacity = (options.shared_buffer_capacity_mb as usize) * (1 << 20);
-
-        let buffer_tracker = BufferTracker::new(
-            // 0.8 * capacity
-            // TODO: enable setting the ratio with config
-            capacity * 4 / 5,
-            // capacity,
-            memory_limiter,
-            event_sender,
-        );
+        let sstable_id_manager = compactor_context.sstable_id_manager.clone();
 
         Arc::new(LocalVersionManager {
             local_version: RwLock::new(LocalVersion::new(pinned_version)),
             buffer_tracker,
-            shared_buffer_uploader,
+            shared_buffer_uploader: Arc::new(SharedBufferUploader::new(compactor_context)),
             sstable_id_manager,
+            event_sender,
         })
     }
 
-    #[cfg(any(test, feature = "test"))]
-    pub fn for_test(
-        options: Arc<StorageConfig>,
-        pinned_version: PinnedVersion,
-        sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-        event_sender: UnboundedSender<HummockEvent>,
-    ) -> LocalVersionManagerRef {
-        let sstable_id_manager = Arc::new(crate::hummock::SstableIdManager::new(
-            hummock_meta_client.clone(),
-            options.sstable_id_remote_fetch_number,
-        ));
-        Self::new(
-            options.clone(),
-            pinned_version,
-            sstable_id_manager.clone(),
-            Arc::new(SharedBufferUploader::new(
-                options,
-                sstable_store,
-                hummock_meta_client,
-                Arc::new(StateStoreMetrics::unused()),
-                sstable_id_manager,
-                Arc::new(FilterKeyExtractorManager::default()),
-            )),
-            event_sender,
-            MemoryLimiter::unlimit(),
-        )
+    fn send_event(&self, event: HummockEvent) {
+        self.event_sender.send(event).expect("should send success");
     }
 
     pub fn get_buffer_tracker(&self) -> &BufferTracker {
@@ -179,7 +137,7 @@ impl LocalVersionManager {
     pub fn write_shared_buffer_batch(&self, batch: SharedBufferBatch) {
         self.write_shared_buffer_inner(batch.epoch(), batch);
         if self.buffer_tracker.need_more_flush() {
-            self.buffer_tracker.send_event(HummockEvent::BufferMayFlush);
+            self.send_event(HummockEvent::BufferMayFlush);
         }
     }
 
@@ -215,13 +173,13 @@ impl LocalVersionManager {
         let shared_buffer = match local_version_guard.get_mut_shared_buffer(epoch) {
             Some(shared_buffer) => shared_buffer,
             None => local_version_guard
-                .new_shared_buffer(epoch, self.buffer_tracker.global_upload_task_size.clone()),
+                .new_shared_buffer(epoch, self.buffer_tracker.global_upload_task_size()),
         };
         // The batch will be synced to S3 asynchronously if it is a local batch
         shared_buffer.write_batch(batch);
 
         // Notify the buffer tracker after the batch has been added to shared buffer.
-        self.buffer_tracker.send_event(HummockEvent::BufferMayFlush);
+        self.send_event(HummockEvent::BufferMayFlush);
     }
 
     /// Issue a concurrent upload task to flush some local shared buffer batch to object store.
@@ -283,7 +241,7 @@ impl LocalVersionManager {
 
     /// send event to `event_handler` thaen seal epoch in local version.
     pub fn seal_epoch(&self, epoch: HummockEpoch, is_checkpoint: bool) {
-        self.buffer_tracker.send_event(HummockEvent::SealEpoch {
+        self.send_event(HummockEvent::SealEpoch {
             epoch,
             is_checkpoint,
         });
@@ -294,7 +252,7 @@ impl LocalVersionManager {
 
         // Wait all epochs' task that less than epoch.
         let (tx, rx) = oneshot::channel();
-        self.buffer_tracker.send_event(HummockEvent::SyncEpoch {
+        self.send_event(HummockEvent::SyncEpoch {
             new_sync_epoch: epoch,
             sync_result_sender: tx,
         });
@@ -359,7 +317,7 @@ impl LocalVersionManager {
                 Err(e)
             }
         };
-        self.buffer_tracker.send_event(HummockEvent::BufferMayFlush);
+        self.send_event(HummockEvent::BufferMayFlush);
         ret
     }
 
@@ -393,7 +351,7 @@ impl LocalVersionManager {
 impl LocalVersionManager {
     pub async fn clear_shared_buffer(&self) {
         let (tx, rx) = oneshot::channel();
-        self.buffer_tracker.send_event(HummockEvent::Clear(tx));
+        self.send_event(HummockEvent::Clear(tx));
         rx.await.unwrap();
     }
 }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -65,7 +65,6 @@ pub mod value;
 
 pub use error::*;
 use local_version::local_version_manager::{LocalVersionManager, LocalVersionManagerRef};
-use parking_lot::RwLock;
 pub use risingwave_common::cache::{CacheableEntry, LookupResult, LruCache};
 use risingwave_common_service::observer_manager::{NotificationClient, ObserverManager};
 use risingwave_hummock_sdk::filter_key_extractor::{
@@ -81,15 +80,14 @@ use value::*;
 use self::iterator::HummockIterator;
 use self::key::user_key;
 pub use self::sstable_store::*;
-use super::hummock::store::version::HummockReadVersion;
 use super::monitor::StateStoreMetrics;
 use crate::error::StorageResult;
-use crate::hummock::conflict_detector::ConflictDetector;
+use crate::hummock::compactor::Context;
+use crate::hummock::event_handler::hummock_event_handler::BufferTracker;
 use crate::hummock::event_handler::{HummockEvent, HummockEventHandler};
 use crate::hummock::local_version::pinned_version::{start_pinned_version_worker, PinnedVersion};
 use crate::hummock::observer_manager::HummockObserverNode;
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
-use crate::hummock::shared_buffer::shared_buffer_uploader::SharedBufferUploader;
 use crate::hummock::shared_buffer::{OrderSortedUncommittedData, UncommittedData};
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::{SstableStoreRef, TableHolder};
@@ -127,6 +125,8 @@ pub struct HummockStorage {
     sstable_id_manager: SstableIdManagerRef,
 
     filter_key_extractor_manager: FilterKeyExtractorManagerRef,
+
+    hummock_event_sender: UnboundedSender<HummockEvent>,
 
     _shutdown_guard: Arc<HummockStorageShutdownGuard>,
 
@@ -179,7 +179,7 @@ impl HummockStorage {
             hummock_meta_client.clone(),
         ));
 
-        let shared_buffer_uploader = Arc::new(SharedBufferUploader::new(
+        let compactor_context = Arc::new(Context::new_local_compact_context(
             options.clone(),
             sstable_store.clone(),
             hummock_meta_client.clone(),
@@ -188,45 +188,23 @@ impl HummockStorage {
             filter_key_extractor_manager.clone(),
         ));
 
-        let memory_limiter_quota = (options.shared_buffer_capacity_mb as usize) * (1 << 20);
-        let memory_limiter = Arc::new(MemoryLimiter::new(memory_limiter_quota as u64));
+        let buffer_tracker = BufferTracker::from_storage_config(&options);
 
         let local_version_manager = LocalVersionManager::new(
-            options.clone(),
-            pinned_version,
-            sstable_id_manager.clone(),
-            shared_buffer_uploader,
+            pinned_version.clone(),
+            compactor_context.clone(),
+            buffer_tracker,
             event_tx.clone(),
-            memory_limiter.clone(),
         );
 
-        let read_version = Arc::new(RwLock::new(HummockReadVersion::new(
-            local_version_manager.get_pinned_version(),
-        )));
-
-        let (version_update_notifier_tx, seal_epoch) = {
-            let basic_max_committed_epoch = local_version_manager
-                .get_pinned_version()
-                .max_committed_epoch();
-            let (version_update_notifier_tx, _rx) =
-                tokio::sync::watch::channel(basic_max_committed_epoch);
-
-            (
-                Arc::new(version_update_notifier_tx),
-                Arc::new(AtomicU64::new(basic_max_committed_epoch)),
-            )
-        };
         let hummock_event_handler = HummockEventHandler::new(
             local_version_manager.clone(),
             event_rx,
-            read_version.clone(),
-            version_update_notifier_tx.clone(),
-            seal_epoch.clone(),
-            ConflictDetector::new_from_config(options.clone()),
+            pinned_version,
+            compactor_context,
         );
 
-        // Buffer size manager.
-        tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
+        let read_version = hummock_event_handler.read_version();
 
         let storage_core = HummockStorageV2::new(
             options.clone(),
@@ -235,7 +213,10 @@ impl HummockStorage {
             stats.clone(),
             read_version,
             event_tx.clone(),
-            memory_limiter,
+            hummock_event_handler
+                .buffer_tracker()
+                .get_memory_limiter()
+                .clone(),
         )
         .expect("storage_core mut be init");
 
@@ -248,12 +229,16 @@ impl HummockStorage {
             sstable_id_manager,
             filter_key_extractor_manager,
             _shutdown_guard: Arc::new(HummockStorageShutdownGuard {
-                shutdown_sender: event_tx,
+                shutdown_sender: event_tx.clone(),
             }),
             storage_core,
-            version_update_notifier_tx,
-            seal_epoch,
+            version_update_notifier_tx: hummock_event_handler.version_update_notifier_tx(),
+            seal_epoch: hummock_event_handler.sealed_epoch(),
+            hummock_event_sender: event_tx,
         };
+
+        tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
+
         Ok(instance)
     }
 
@@ -285,7 +270,7 @@ impl HummockStorage {
     }
 
     pub fn get_pinned_version(&self) -> PinnedVersion {
-        self.local_version_manager.get_pinned_version()
+        self.storage_core.read_version().read().committed().clone()
     }
 }
 
@@ -293,9 +278,7 @@ impl HummockStorage {
 impl HummockStorage {
     pub async fn update_version_and_wait(&self, version: HummockVersion) {
         let version_id = version.id;
-        self.local_version_manager
-            .buffer_tracker()
-            .buffer_event_sender
+        self.hummock_event_sender
             .send(HummockEvent::VersionUpdate(Payload::PinnedVersion(version)))
             .unwrap();
         // loop to wait for the version to be applied

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -28,6 +28,7 @@ use risingwave_common::util::epoch::INVALID_EPOCH;
 use risingwave_hummock_sdk::key::{key_with_epoch, next_key, user_key};
 use risingwave_hummock_sdk::{can_concat, HummockReadEpoch};
 use risingwave_pb::hummock::LevelType;
+use tokio::sync::oneshot;
 use tracing::log::warn;
 
 use super::iterator::{
@@ -41,6 +42,7 @@ use super::{
     SstableIteratorType,
 };
 use crate::error::{StorageError, StorageResult};
+use crate::hummock::event_handler::HummockEvent;
 use crate::hummock::iterator::{
     Backward, BackwardUserIteratorType, DirectedUserIteratorBuilder, DirectionEnum, Forward,
     ForwardUserIteratorType, HummockIteratorDirection,
@@ -677,11 +679,14 @@ impl StateStore for HummockStorage {
                     uncommitted_ssts: vec![],
                 });
             }
-            let sync_result = self
-                .local_version_manager
-                .await_sync_shared_buffer(epoch)
-                .await?;
-            Ok(sync_result)
+            let (tx, rx) = oneshot::channel();
+            self.hummock_event_sender
+                .send(HummockEvent::SyncEpoch {
+                    new_sync_epoch: epoch,
+                    sync_result_sender: tx,
+                })
+                .expect("should send success");
+            Ok(rx.await.expect("should wait success")?)
         }
     }
 
@@ -690,12 +695,21 @@ impl StateStore for HummockStorage {
             warn!("sealing invalid epoch");
             return;
         }
-        self.local_version_manager.seal_epoch(epoch, is_checkpoint);
+        self.hummock_event_sender
+            .send(HummockEvent::SealEpoch {
+                epoch,
+                is_checkpoint,
+            })
+            .expect("should send success");
     }
 
     fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
         async move {
-            self.local_version_manager.clear_shared_buffer().await;
+            let (tx, rx) = oneshot::channel();
+            self.hummock_event_sender
+                .send(HummockEvent::Clear(tx))
+                .expect("should send success");
+            rx.await.expect("should wait success");
             Ok(())
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR is before the new hummock uploader PR. In this PR, we refactor the code of initializing hummock event handler and local version manager so that in future PR, hummock event handler initialization can be easily made independent to the initialization of local version manager.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
