### PR TITLE
feat(compaction group): trigger sst stat for delted groups

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -178,7 +178,6 @@ macro_rules! start_measure_real_process_timer {
 }
 pub(crate) use start_measure_real_process_timer;
 
-use super::compaction::compaction_config::CompactionConfigBuilder;
 use super::Compactor;
 
 static CANCEL_STATUS_SET: LazyLock<HashSet<TaskStatus>> = LazyLock::new(|| {
@@ -1138,7 +1137,7 @@ where
         &'a self,
         versioning: &'a mut Versioning,
         compaction_groups: &mut HashMap<CompactionGroupId, CompactionGroup>,
-        deleted_compaction_groups: &mut Vec<(CompactionGroupId, usize)>,
+        deleted_compaction_groups: &mut Vec<CompactionGroupId>,
     ) -> Result<Option<(u64, HummockVersionDelta, HummockVersion)>> {
         // We need 2 steps to sync groups:
         // Insert new groups that are not in current `HummockVersion`;
@@ -1188,7 +1187,7 @@ where
                     .or_default()
                     .group_deltas;
                 let levels = new_hummock_version.get_levels().get(&group_id).unwrap();
-                deleted_compaction_groups.push((group_id, levels.get_levels().len() + 1));
+                deleted_compaction_groups.push(group_id);
                 let mut gc_sst_ids = vec![];
                 if let Some(ref l0) = levels.l0 {
                     for sub_level in l0.get_sub_levels() {
@@ -1543,7 +1542,7 @@ where
                 *compaction_group_id,
             );
         }
-        for (compaction_group_id, num_levels) in deleted_compaction_groups {
+        for compaction_group_id in deleted_compaction_groups {
             remove_compaction_group_in_sst_stat(&self.metrics, compaction_group_id);
         }
 

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -333,11 +333,7 @@ where
                         DeltaType::GroupDestroy(_)
                     )
                 }) {
-                    remove_compaction_group_in_sst_stat(
-                        &self.metrics,
-                        *compaction_group_id,
-                        CompactionConfigBuilder::default().build().get_max_level() as usize + 1,
-                    );
+                    remove_compaction_group_in_sst_stat(&self.metrics, *compaction_group_id);
                 }
             }
         }
@@ -1548,7 +1544,7 @@ where
             );
         }
         for (compaction_group_id, num_levels) in deleted_compaction_groups {
-            remove_compaction_group_in_sst_stat(&self.metrics, compaction_group_id, num_levels);
+            remove_compaction_group_in_sst_stat(&self.metrics, compaction_group_id);
         }
 
         tracing::trace!("new committed epoch {}", epoch);

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -124,14 +124,14 @@ pub fn trigger_sst_stat(
 pub fn remove_compaction_group_in_sst_stat(
     metrics: &MetaMetrics,
     compaction_group_id: CompactionGroupId,
-    num_levels: usize,
 ) {
-    for idx in 0..num_levels {
+    let mut idx = 0;
+    loop {
         let level_label = format!("{}_{}", idx, compaction_group_id);
-        metrics
+        let should_continue = metrics
             .level_sst_num
             .remove_label_values(&[&level_label])
-            .ok();
+            .is_ok();
         metrics
             .level_file_size
             .remove_label_values(&[&level_label])
@@ -140,6 +140,10 @@ pub fn remove_compaction_group_in_sst_stat(
             .level_compact_cnt
             .remove_label_values(&[&level_label])
             .ok();
+        if !should_continue {
+            break;
+        }
+        idx += 1;
     }
 
     let level_label = format!("cg{}_l0_sub", compaction_group_id);

--- a/src/meta/src/hummock/metrics_utils.rs
+++ b/src/meta/src/hummock/metrics_utils.rs
@@ -121,6 +121,34 @@ pub fn trigger_sst_stat(
     }
 }
 
+pub fn remove_compaction_group_in_sst_stat(
+    metrics: &MetaMetrics,
+    compaction_group_id: CompactionGroupId,
+    num_levels: usize,
+) {
+    for idx in 0..num_levels {
+        let level_label = format!("{}_{}", idx, compaction_group_id);
+        metrics
+            .level_sst_num
+            .remove_label_values(&[&level_label])
+            .ok();
+        metrics
+            .level_file_size
+            .remove_label_values(&[&level_label])
+            .ok();
+        metrics
+            .level_compact_cnt
+            .remove_label_values(&[&level_label])
+            .ok();
+    }
+
+    let level_label = format!("cg{}_l0_sub", compaction_group_id);
+    metrics
+        .level_sst_num
+        .remove_label_values(&[&level_label])
+        .ok();
+}
+
 pub fn trigger_pin_unpin_version_state(
     metrics: &MetaMetrics,
     pinned_versions: &BTreeMap<HummockContextId, HummockPinnedVersion>,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

feat(compaction group): trigger sst stat for delted groups
background:
@zwang28 found that metric keeps after deletion
![image](https://user-images.githubusercontent.com/44948473/198015146-8c7728b8-2990-4e00-9dd6-15a4660372fd.png)


## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
