### PR TITLE
feat(hash agg): commit dirty state only

### DIFF
--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -405,8 +405,10 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         let dirty_cnt = group_change_set.len();
         if dirty_cnt > 0 {
             // Batch commit data.
-            for agg_group in agg_groups.values().flatten() {
-                agg_group.commit_state(storages).await?;
+            for (key, agg_group) in agg_groups.iter() {
+                if group_change_set.contains(key) && let Some(agg_group) = agg_group {
+                    agg_group.commit_state(storages).await?;
+                }
             }
             futures::future::try_join_all(
                 iter_table_storage(storages).map(|state_table| state_table.commit(epoch)),

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -405,8 +405,11 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         let dirty_cnt = group_change_set.len();
         if dirty_cnt > 0 {
             // Batch commit data.
-            for (key, agg_group) in agg_groups.iter() {
-                if group_change_set.contains(key) && let Some(agg_group) = agg_group {
+            for changed_key in group_change_set.iter() {
+                if let Some(agg_group) = agg_groups
+                    .get(changed_key)
+                    .and_then(|agg_group_item| agg_group_item.as_ref())
+                {
                     agg_group.commit_state(storages).await?;
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
commit dirty state only among `agg_group`s
- How does this PR work? Need a brief introduction for the changed logic (optional)
in table state, commit `agg_group` whose key in `group_change_set` among `agg_group`s in `flush_data` in hash agg

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
