### PR TITLE
feat(workflow): remind developers to tag the correct component label on each PR

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,9 +13,10 @@ Please explain **IN DETAIL** what the changes are in this PR and why they are ne
 
 ## Checklist
 
-- [ ] I have written necessary rustdoc comments
-- [ ] I have added necessary unit tests and integration tests
-- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
+- [ ] I have written necessary rustdoc comments.
+- [ ] I have added necessary unit tests and integration tests.
+- [ ] I have tagged the correct `component/XXX` label(s) on this PR. 
+- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`).
 
 ## Documentation
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

The intention is to make it easier to collect how many bugs have appeared during a period of time. This is suggested by @cyliu0 .

Based on the statistics, we then know which component is more error-prone and complicated, and thus requires more testing.

We remark that some component is naturally more complicated than other ones, and we expect to encounter more bugs in such components than others.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
