### PR TITLE
fix: license header

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -12,5 +12,6 @@ header:
   paths-ignore:
     - "**/gen/**"
     - "**/*.d.ts"
+    - "src/sqlparser/**/*.rs"
 
   comment: on-failure

--- a/src/frontend/src/optimizer/rule/reorder_multijoin.rs
+++ b/src/frontend/src/optimizer/rule/reorder_multijoin.rs
@@ -1,4 +1,4 @@
-// Copyrelation_c 2022 Singularity Data
+// Copyright 2022 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fix https://github.com/risingwavelabs/risingwave/actions/runs/3336563819/jobs/5521867475