### PR TITLE
fix(frontend): internal table scan of source operator

### DIFF
--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -17,6 +17,7 @@ use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use itertools::Itertools;
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::TableDesc;
 use risingwave_common::types::{ParallelUnitId, VnodeMapping, VIRTUAL_NODE_COUNT};
@@ -449,10 +450,9 @@ impl BatchPlanFragmenter {
                             *partitions = partitions
                                 .drain()
                                 .take(1)
-                                .map(|(id, mut info)| {
+                                .update(|(_, info)| {
                                     info.vnode_bitmap =
                                         Bitmap::all_high_bits(VIRTUAL_NODE_COUNT).to_protobuf();
-                                    (id, info)
                                 })
                                 .collect();
                         }

--- a/src/frontend/src/scheduler/plan_fragmenter.rs
+++ b/src/frontend/src/scheduler/plan_fragmenter.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use risingwave_common::buffer::{Bitmap, BitmapBuilder};
 use risingwave_common::catalog::TableDesc;
-use risingwave_common::types::{ParallelUnitId, VnodeMapping};
+use risingwave_common::types::{ParallelUnitId, VnodeMapping, VIRTUAL_NODE_COUNT};
 use risingwave_common::util::scan_range::ScanRange;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{ExchangeInfo, ScanRange as ScanRangeProto};
@@ -188,6 +188,9 @@ impl Query {
 
 #[derive(Clone, Debug)]
 pub struct TableScanInfo {
+    /// The name of the table to scan.
+    name: String,
+
     /// Indicates the table partitions to be read by scan tasks. Unnecessary partitions are already
     /// pruned.
     ///
@@ -200,15 +203,23 @@ pub struct TableScanInfo {
 
 impl TableScanInfo {
     /// For normal tables, `partitions` should always be `Some`.
-    pub fn new(partitions: HashMap<ParallelUnitId, PartitionInfo>) -> Self {
+    pub fn new(name: String, partitions: HashMap<ParallelUnitId, PartitionInfo>) -> Self {
         Self {
+            name,
             partitions: Some(partitions),
         }
     }
 
     /// For system table, there's no partition info.
-    pub fn system_table() -> Self {
-        Self { partitions: None }
+    pub fn system_table(name: String) -> Self {
+        Self {
+            name,
+            partitions: None,
+        }
+    }
+
+    pub fn name(&self) -> &str {
+        self.name.as_ref()
     }
 
     pub fn partitions(&self) -> Option<&HashMap<u32, PartitionInfo>> {
@@ -421,18 +432,36 @@ impl BatchPlanFragmenter {
         let next_stage_id = self.next_stage_id;
         self.next_stage_id += 1;
 
-        let table_scan_info = self.collect_stage_table_scan(root.clone())?;
+        let mut table_scan_info = self.collect_stage_table_scan(root.clone())?;
         let parallelism = match root.distribution() {
             Distribution::Single => {
-                assert!(
-                    table_scan_info.is_none() // no table scan
-                        || table_scan_info.as_ref().unwrap().partitions().is_none() // system table
-                        || table_scan_info.as_ref().unwrap().partitions().unwrap().len() == 1, // single partition
-                    "The stage has single distribution, but contains a table scan node with multiple partitions.
-                    \nplan: {:#?}\ntable_scan_info: {:#?}",
-                    root,
-                    table_scan_info
-                );
+                if let Some(info) = &mut table_scan_info {
+                    if let Some(partitions) = &mut info.partitions {
+                        if partitions.len() != 1 {
+                            // This is rare case, but it's possible on the internal state of the
+                            // Source operator.
+                            tracing::warn!(
+                                "The stage has single distribution, but contains a scan of table `{}` with {} partitions. A single random worker will be assigned",
+                                info.name,
+                                partitions.len()
+                            );
+
+                            *partitions = partitions
+                                .drain()
+                                .take(1)
+                                .map(|(id, mut info)| {
+                                    info.vnode_bitmap =
+                                        Bitmap::all_high_bits(VIRTUAL_NODE_COUNT).to_protobuf();
+                                    (id, info)
+                                })
+                                .collect();
+                        }
+                    } else {
+                        // System table
+                    }
+                } else {
+                    // No table scan
+                }
                 1
             }
             _ => match &table_scan_info {
@@ -513,8 +542,9 @@ impl BatchPlanFragmenter {
         }
 
         if let Some(scan_node) = node.as_batch_seq_scan() {
+            let name = scan_node.logical().table_name().to_owned();
             let info = if scan_node.logical().is_sys_table() {
-                TableScanInfo::system_table()
+                TableScanInfo::system_table(name)
             } else {
                 let table_desc = scan_node.logical().table_desc();
                 let table_catalog = self
@@ -532,7 +562,7 @@ impl BatchPlanFragmenter {
                     })?;
                 let partitions =
                     derive_partitions(scan_node.scan_ranges(), table_desc, &vnode_mapping);
-                TableScanInfo::new(partitions)
+                TableScanInfo::new(name, partitions)
             };
             Ok(Some(info))
         } else {

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -316,10 +316,9 @@ impl<S: StateStore> SourceExecutor<S> {
         yield Message::Barrier(barrier);
 
         while let Some(msg) = stream.next().await {
-            match msg {
+            match msg? {
                 // This branch will be preferred.
                 Either::Left(barrier) => {
-                    let barrier = barrier?;
                     let epoch = barrier.epoch;
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
@@ -360,12 +359,10 @@ impl<S: StateStore> SourceExecutor<S> {
                     yield Message::Barrier(barrier);
                 }
 
-                Either::Right(chunk_with_state) => {
-                    let StreamChunkWithState {
-                        mut chunk,
-                        split_offset_mapping,
-                    } = chunk_with_state?;
-
+                Either::Right(StreamChunkWithState {
+                    mut chunk,
+                    split_offset_mapping,
+                }) => {
                     if let Some(mapping) = split_offset_mapping {
                         let state: HashMap<_, _> = mapping
                             .iter()


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

For this case, we randomly pick a parallel unit to schedule.
- When reading with checkpoint, it's okay and necessary to have some remote accesses.
- If reading with the barrier (in the future), as the consistency is not preserved, it's okay to randomly pick one worker to schedule the scanning. 😅

```
dev=> select * from rw_table(1006);
 partition_id |                                offset                                
--------------+----------------------------------------------------------------------
 6-0          |                                                                     +
              | \x07nexmark\x124{"split_index":0,"split_num":6,"start_offset":73464}
 6-1          |                                                                     +
              | \x07nexmark\x124{"split_index":1,"split_num":6,"start_offset":73459}
 6-2          |                                                                     +
              | \x07nexmark\x124{"split_index":2,"split_num":6,"start_offset":73460}
 6-3          |                                                                     +
              | \x07nexmark\x124{"split_index":3,"split_num":6,"start_offset":73461}
 6-4          |                                                                     +
              | \x07nexmark\x124{"split_index":4,"split_num":6,"start_offset":73462}
 6-5          |                                                                     +
              | \x07nexmark\x124{"split_index":5,"split_num":6,"start_offset":73463}
(6 rows)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- Close #5590 