### PR TITLE
fix(expr, agg): batch array_agg return `NULL` when there's no input raws

### DIFF
--- a/e2e_test/batch/aggregate/array_agg.slt.part
+++ b/e2e_test/batch/aggregate/array_agg.slt.part
@@ -4,6 +4,22 @@ SET RW_IMPLICIT_FLUSH TO true;
 statement ok
 create table t(v1 varchar, v2 int, v3 int)
 
+query T
+select array_agg(v1) from t;
+----
+NULL
+
+statement ok
+insert into t values (null, null, null);
+
+query T
+select array_agg(v1) from t;
+----
+{NULL}
+
+statement ok
+delete from t;
+
 statement ok
 insert into t values ('aaa', 1, 1), ('bbb', 0, 2), ('ccc', 0, 5), ('ddd', 1, 4)
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/5962