### PR TITLE
feat(watermark): Make Exchange be aware of the watermark (close #6050)

### DIFF
--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -75,7 +75,6 @@ impl LocalInput {
 
     #[cfg(test)]
     pub fn for_test(actor_id: ActorId, channel: Receiver<Message>) -> BoxedInput {
-        // `actor_id` is currently only used by configuration change, use a dummy value.
         Self::new(channel, actor_id).boxed_input()
     }
 

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -74,9 +74,9 @@ impl LocalInput {
     }
 
     #[cfg(test)]
-    pub fn for_test(channel: Receiver<Message>) -> BoxedInput {
+    pub fn for_test(actor_id: ActorId, channel: Receiver<Message>) -> BoxedInput {
         // `actor_id` is currently only used by configuration change, use a dummy value.
-        Self::new(channel, 0).boxed_input()
+        Self::new(channel, actor_id).boxed_input()
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]

--- a/src/stream/src/executor/exchange/input.rs
+++ b/src/stream/src/executor/exchange/input.rs
@@ -66,16 +66,11 @@ pub struct LocalInput {
 type LocalInputStreamInner = impl MessageStream;
 
 impl LocalInput {
-    fn new(channel: Receiver<Message>, actor_id: ActorId) -> Self {
+    pub fn new(channel: Receiver<Message>, actor_id: ActorId) -> Self {
         Self {
             inner: Self::run(channel, actor_id),
             actor_id,
         }
-    }
-
-    #[cfg(test)]
-    pub fn for_test(actor_id: ActorId, channel: Receiver<Message>) -> BoxedInput {
-        Self::new(channel, actor_id).boxed_input()
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -319,20 +319,17 @@ impl SelectReceivers {
     fn remove_upstreams(&mut self, upstream_actor_ids: &HashSet<ActorId>) {
         assert!(self.blocks.is_empty() && self.barrier.is_none());
 
-        let drain_actor_ids: HashSet<_> = self
-            .upstreams
-            .drain_filter(|u| upstream_actor_ids.contains(&u.actor_id()))
-            .map(|u| u.actor_id())
-            .collect();
+        self.upstreams
+            .retain(|u| !upstream_actor_ids.contains(&u.actor_id()));
         for UntransferredWatermarks {
             first_untransferred_watermarks,
             other_untransferred_watermarks,
         } in self.untransferred_watermarks.values_mut()
         {
             first_untransferred_watermarks
-                .retain(|Reverse((_, actor_id))| !drain_actor_ids.contains(actor_id));
+                .retain(|Reverse((_, actor_id))| !upstream_actor_ids.contains(actor_id));
             other_untransferred_watermarks
-                .retain(|actor_id, _| !drain_actor_ids.contains(actor_id));
+                .retain(|actor_id, _| !upstream_actor_ids.contains(actor_id));
         }
         self.last_base = 0;
     }

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -260,7 +260,11 @@ impl SelectReceivers {
         let mut watermark_to_transfer = None;
         let col_data = self.buffered_watermarks.get_mut(&col_idx).unwrap();
         while !col_data.first_buffered_watermarks.is_empty()
-            && col_data.first_buffered_watermarks.len() == self.upstreams.len() + self.blocks.len()
+            && (col_data.first_buffered_watermarks.len()
+                == self.upstreams.len() + self.blocks.len()
+                || watermark_to_transfer.as_ref().map_or(false, |watermark| {
+                    watermark == &col_data.first_buffered_watermarks.peek().unwrap().0 .0
+                }))
         {
             let Reverse((watermark, actor_id)) = col_data.first_buffered_watermarks.pop().unwrap();
             watermark_to_transfer = Some(watermark);

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -224,8 +224,8 @@ struct StagedWatermarks {
 }
 
 struct UntransferredWatermarks {
-    // We store the smallest watermark of each upstream, because the next watermark to emit is
-    // among them.
+    /// We store the smallest watermark of each upstream, because the next watermark to emit is
+    /// among them.
     pub first_untransferred_watermarks: BinaryHeap<Reverse<(Watermark, ActorId)>>,
     // We buffer other watermarks of each upstream. The next-to-smallest one will become the
     // smallest and be moved into heap

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -229,7 +229,7 @@ struct BufferedWatermarks {
     pub first_buffered_watermarks: BinaryHeap<Reverse<(Watermark, ActorId)>>,
     /// We buffer other watermarks of each upstream. The next-to-smallest one will become the
     /// smallest when the smallest is emitted and be moved into heap.
-    pub other_buffered_watermarks: HashMap<ActorId, StagedWatermarks>,
+    pub other_buffered_watermarks: BTreeMap<ActorId, StagedWatermarks>,
 }
 
 pub struct SelectReceivers {
@@ -290,7 +290,7 @@ impl SelectReceivers {
                 .entry(col_idx)
                 .or_insert_with(|| BufferedWatermarks {
                     first_buffered_watermarks: BinaryHeap::with_capacity(self.upstreams.len()),
-                    other_buffered_watermarks: HashMap::with_capacity(self.upstreams.len()),
+                    other_buffered_watermarks: BTreeMap::default(),
                 });
         let staged = watermarks
             .other_buffered_watermarks

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -184,6 +184,8 @@ impl MergeExecutor {
                             let col_idxes =
                                 select_all.buffered_watermarks.keys().cloned().collect_vec();
                             for col_idx in col_idxes {
+                                // Call `check_heap` in case the only upstream(s) that does not have
+                                // watermark in heap is removed
                                 if let Some(watermark) = select_all.check_heap(col_idx) {
                                     yield Message::Watermark(watermark);
                                 }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -516,18 +516,11 @@ impl Barrier {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Watermark {
     col_idx: usize,
     val: Datum,
 }
-
-impl PartialEq for Watermark {
-    fn eq(&self, other: &Self) -> bool {
-        self.col_idx == other.col_idx && self.val == other.val
-    }
-}
-impl Eq for Watermark {}
 
 impl PartialOrd for Watermark {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -538,7 +538,7 @@ impl PartialOrd for Watermark {
 impl Ord for Watermark {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.partial_cmp(other)
-            .expect("Watermarks in the same group should be comparable!")
+            .unwrap_or_else(|| panic!("cannot compare {self:?} with {other:?}"))
     }
 }
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -516,10 +516,37 @@ impl Barrier {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Clone)]
 pub struct Watermark {
     col_idx: usize,
     val: Datum,
+}
+
+impl PartialEq for Watermark {
+    fn eq(&self, other: &Self) -> bool {
+        self.col_idx == other.col_idx && self.val == other.val
+    }
+}
+impl Eq for Watermark {}
+
+impl PartialOrd for Watermark {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        if self.col_idx == other.col_idx {
+            self.val
+                .as_ref()
+                .unwrap()
+                .partial_cmp(other.val.as_ref().unwrap())
+        } else {
+            None
+        }
+    }
+}
+
+impl Ord for Watermark {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other)
+            .expect("Watermarks in the same group should be comparable!")
+    }
 }
 
 impl Watermark {

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -94,6 +94,7 @@ impl ReceiverExecutor {
     #[cfg(test)]
     pub fn for_test(input: tokio::sync::mpsc::Receiver<Message>) -> Self {
         use super::exchange::input::LocalInput;
+        use crate::executor::exchange::input::Input;
         use crate::executor::ActorContext;
 
         Self::new(
@@ -102,7 +103,7 @@ impl ReceiverExecutor {
             ActorContext::create(114),
             514,
             1919,
-            LocalInput::for_test(0, input),
+            LocalInput::new(input, 0).boxed_input(),
             SharedContext::for_test().into(),
             810,
             StreamingMetrics::unused().into(),

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -102,7 +102,7 @@ impl ReceiverExecutor {
             ActorContext::create(114),
             514,
             1919,
-            LocalInput::for_test(input),
+            LocalInput::for_test(0, input),
             SharedContext::for_test().into(),
             810,
             StreamingMetrics::unused().into(),
@@ -128,7 +128,7 @@ impl Executor for ReceiverExecutor {
 
                 match &mut msg {
                     Message::Watermark(_) => {
-                        todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                        // Do nothing.
                     }
                     Message::Chunk(chunk) => {
                         self.metrics

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -14,6 +14,7 @@
 
 #![allow(rustdoc::private_intra_doc_links)]
 #![allow(clippy::derive_partial_eq_without_eq)]
+#![feature(binary_heap_retain)]
 #![feature(iterator_try_collect)]
 #![feature(trait_alias)]
 #![feature(type_alias_impl_trait)]


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

feat(watermark): Make Exchange be aware of the watermark (close #6050)
doc: https://www.notion.so/risingwave-labs/Watermark-Operators-Explained-a6f9645a068a435bb11074e9596abdf8
thanks to @BugenZhao 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
