### PR TITLE
feat(source): allow importing avro schema from https & refactor code

### DIFF
--- a/src/source/src/parser/avro_parser.rs
+++ b/src/source/src/parser/avro_parser.rs
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 use std::collections::HashMap;
-use std::ffi::OsStr;
 use std::fmt::Debug;
-use std::future::Future;
 use std::path::Path;
 
 use apache_avro::types::Value;
 use apache_avro::{Reader, Schema};
 use chrono::{Datelike, NaiveDate};
+use hyper::http::uri::InvalidUri;
+use hyper_tls::HttpsConnector;
 use itertools::Itertools;
 use risingwave_common::array::{ListValue, StructValue};
-use risingwave_common::error::ErrorCode::{InternalError, InvalidConfigValue, ProtocolError};
+use risingwave_common::error::ErrorCode::{
+    InternalError, InvalidConfigValue, InvalidParameterValue, ProtocolError,
+};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::{
     DataType, Datum, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, OrderedF32, OrderedF64,
@@ -51,35 +53,18 @@ impl AvroParser {
             InternalError(format!("failed to parse url ({}): {}", schema_location, e))
         })?;
         let url_schema = url.scheme();
-        let schema_path = url.path();
-        let arvo_schema =
-            match url_schema {
-                "file" => {
-                    load_schema_async(
-                        |path, _props| async move { read_schema_from_local(path) },
-                        schema_path.to_string(),
-                        None,
-                    )
-                    .await
-                }
-                "s3" => load_schema_async(
-                    |path, props| async move { read_schema_from_s3(path, props.unwrap()).await },
-                    // note that Url parse bucket as domain, so must pass the origin
-                    // schema_location
-                    schema_location.to_string(),
-                    Some(props),
-                )
-                .await,
-                _ => Err(RwError::from(ProtocolError(format!(
-                    "path scheme {} is not supported",
-                    url_schema
-                )))),
-            };
-        if let Ok(schema) = arvo_schema {
-            Ok(Self { schema })
-        } else {
-            Err(arvo_schema.err().unwrap())
-        }
+        let schema_content = match url_schema {
+            "file" => read_schema_from_local(url.path()),
+            "s3" => read_schema_from_s3(&url, props).await,
+            "https" => read_schema_from_https(&url).await,
+            _ => Err(RwError::from(ProtocolError(format!(
+                "path scheme {} is not supported",
+                url_schema
+            )))),
+        }?;
+        let schema = Schema::parse_str(&schema_content)
+            .map_err(|e| RwError::from(InternalError(format!("Avro schema parse error {}", e))))?;
+        Ok(Self { schema })
     }
 
     pub fn map_to_columns(&self) -> Result<Vec<ColumnDesc>> {
@@ -287,125 +272,66 @@ impl SourceParser for AvroParser {
 
 /// Read schema from s3 bucket.
 /// S3 file location format: <s3://bucket_name/file_name>
-pub async fn read_schema_from_s3(
-    location: String,
-    properties: HashMap<String, String>,
-) -> Result<String> {
-    let s3_url = Url::parse(location.as_str());
-    if let Ok(url) = s3_url {
-        let bucket = if let Some(bucket) = url.domain() {
-            bucket
-        } else {
-            return Err(RwError::from(InternalError(format!(
-                "Illegal Avro schema path {}",
-                url
-            ))));
-        };
-        if properties.get(AVRO_SCHEMA_LOCATION_S3_REGION).is_none() {
-            return Err(RwError::from(InvalidConfigValue {
-                config_entry: AVRO_SCHEMA_LOCATION_S3_REGION.to_string(),
-                config_value: "NONE".to_string(),
-            }));
-        }
-        let key = url.path().replace('/', "");
-        let config = AwsConfigV2::from(properties.clone());
-        let sdk_config = config.load_config(None).await;
-        let s3_client = s3_client(&sdk_config, Some(default_conn_config()));
-        let schema_content = s3_client
-            .get_object()
-            .bucket(bucket.to_string())
-            .key(key)
-            .send()
-            .await;
-        match schema_content {
-            Ok(response) => {
-                let body = response.body.collect().await;
-                if let Ok(body_bytes) = body {
-                    let schema_bytes = body_bytes.into_bytes().to_vec();
-                    let schema_str = std::str::from_utf8(&schema_bytes);
-                    if let Ok(str) = schema_str {
-                        Ok(str.to_string())
-                    } else {
-                        let schema_decode_err =
-                            anyhow::Error::from(schema_str.err().unwrap()).to_string();
-                        Err(RwError::from(InternalError(format!(
-                            "Avro schema not valid utf8 {}",
-                            schema_decode_err
-                        ))))
-                    }
-                } else {
-                    let read_schema_err = body.err().unwrap().to_string();
-                    Err(RwError::from(InternalError(format!(
-                        "Read Avro schema file from s3 {}",
-                        read_schema_err
-                    ))))
-                }
-            }
-            Err(err) => Err(RwError::from(InternalError(err.to_string()))),
-        }
-    } else {
-        Err(RwError::from(InternalError(format!(
-            "Illegal S3 Path {}",
-            s3_url.err().unwrap()
-        ))))
+pub async fn read_schema_from_s3(url: &Url, properties: HashMap<String, String>) -> Result<String> {
+    let bucket = url
+        .domain()
+        .ok_or_else(|| RwError::from(InternalError(format!("Illegal Avro schema path {}", url))))?;
+    if properties.get(AVRO_SCHEMA_LOCATION_S3_REGION).is_none() {
+        return Err(RwError::from(InvalidConfigValue {
+            config_entry: AVRO_SCHEMA_LOCATION_S3_REGION.to_string(),
+            config_value: "NONE".to_string(),
+        }));
     }
+    let key = url.path().replace('/', "");
+    let config = AwsConfigV2::from(properties.clone());
+    let sdk_config = config.load_config(None).await;
+    let s3_client = s3_client(&sdk_config, Some(default_conn_config()));
+    let response = s3_client
+        .get_object()
+        .bucket(bucket.to_string())
+        .key(key)
+        .send()
+        .await
+        .map_err(|e| RwError::from(InternalError(e.to_string())))?;
+    let body_bytes = response.body.collect().await.map_err(|e| {
+        RwError::from(InternalError(format!(
+            "Read Avro schema file from s3 {}",
+            e
+        )))
+    })?;
+    let schema_bytes = body_bytes.into_bytes().to_vec();
+    String::from_utf8(schema_bytes)
+        .map_err(|e| RwError::from(InternalError(format!("Avro schema not valid utf8 {}", e))))
 }
 
 /// Read avro schema file from local file.For on-premise or testing.
-pub fn read_schema_from_local(path: String) -> Result<String> {
-    let content_rs = std::fs::read_to_string(path.as_str());
-    if let Ok(content) = content_rs {
-        Ok(content)
-    } else {
-        Err(content_rs.err().unwrap().into())
-    }
+pub fn read_schema_from_local(path: impl AsRef<Path>) -> Result<String> {
+    std::fs::read_to_string(path.as_ref()).map_err(|e| e.into())
 }
 
-pub async fn load_schema_async<F, Fut>(
-    f: F,
-    schema_path: String,
-    properties: Option<HashMap<String, String>>,
-) -> Result<Schema>
-where
-    F: Fn(String, Option<HashMap<String, String>>) -> Fut,
-    Fut: Future<Output = Result<String>>,
-{
-    let file_extension = Path::new(schema_path.as_str())
-        .extension()
-        .and_then(OsStr::to_str);
-
-    if let Some(extension) = file_extension {
-        if !extension.eq("avsc") {
-            Err(RwError::from(InternalError(
-                "Please specify the correct schema file XXX.avsc".to_string(),
-            )))
-        } else {
-            let read_schema_rs = f(schema_path, properties).await;
-            let schema_content = if let Ok(content) = read_schema_rs {
-                content
-            } else {
-                return Err(RwError::from(InternalError(format!(
-                    "Load Avro schema file error {}",
-                    anyhow::Error::from(read_schema_rs.err().unwrap())
-                ))));
-            };
-            let schema_rs = Schema::parse_str(schema_content.as_str());
-            if let Ok(avro_schema) = schema_rs {
-                Ok(avro_schema)
-            } else {
-                let schema_parse_err = schema_rs.err().unwrap();
-                Err(RwError::from(InternalError(format!(
-                    "Avro schema parse error {}",
-                    anyhow::Error::from(schema_parse_err)
-                ))))
-            }
-        }
-    } else {
-        Err(RwError::from(InternalError(format!(
-            "Illegal Avro schema path. {}",
-            schema_path
-        ))))
-    }
+/// Read avro schema file from local file.For common usage.
+async fn read_schema_from_https(location: &Url) -> Result<String> {
+    let client = hyper::Client::builder().build::<_, hyper::Body>(HttpsConnector::new());
+    let res = client
+        .get(
+            location
+                .to_string()
+                .parse()
+                .map_err(|e: InvalidUri| InvalidParameterValue(e.to_string()))?,
+        )
+        .await
+        .map_err(|e| {
+            InvalidParameterValue(format!("failed to read from URL {}: {}", location, e))
+        })?;
+    let buf = hyper::body::to_bytes(res)
+        .await
+        .map_err(|e| InvalidParameterValue(format!("failed to read HTTP body: {}", e)))?;
+    String::from_utf8(buf.into()).map_err(|e| {
+        RwError::from(InternalError(format!(
+            "read schema string from https failed {}",
+            e
+        )))
+    })
 }
 
 #[cfg(test)]
@@ -423,9 +349,11 @@ mod test {
     use risingwave_common::types::{
         DataType, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, ScalarImpl,
     };
+    use url::Url;
 
     use crate::parser::avro_parser::{
-        load_schema_async, read_schema_from_local, read_schema_from_s3, unix_epoch_days, AvroParser,
+        read_schema_from_https, read_schema_from_local, read_schema_from_s3, unix_epoch_days,
+        AvroParser,
     };
     use crate::{SourceColumnDesc, SourceParser, SourceStreamChunkBuilder};
 
@@ -444,30 +372,38 @@ mod test {
     #[tokio::test]
     #[ignore]
     async fn test_load_schema_from_s3() {
-        let schema_location = "s3://dd-storage-s3/complex-schema.avsc".to_string();
+        let schema_location = "s3://mingchao-schemas/complex-schema.avsc".to_string();
         let mut s3_config_props = HashMap::new();
-        s3_config_props.insert("region".to_string(), "cn-north-1".to_string());
-        let schema_rs = load_schema_async(
-            |path, props| read_schema_from_s3(path, props.unwrap()),
-            schema_location,
-            Some(s3_config_props.clone()),
-        )
-        .await;
-        assert!(schema_rs.is_ok());
-        println!("schema_rs = {:?}", schema_rs);
+        s3_config_props.insert("region".to_string(), "ap-southeast-1".to_string());
+        let url = Url::parse(&schema_location).unwrap();
+        let schema_content = read_schema_from_s3(&url, s3_config_props).await;
+        assert!(schema_content.is_ok());
+        let schema = Schema::parse_str(&schema_content.unwrap());
+        assert!(schema.is_ok());
+        println!("schema = {:?}", schema.unwrap());
     }
 
     #[tokio::test]
     async fn test_load_schema_from_local() {
         let schema_location = test_data_path("complex-schema.avsc");
-        let schema_rs = load_schema_async(
-            |path, _props| async move { read_schema_from_local(path) },
-            schema_location,
-            None,
-        )
-        .await;
-        assert!(schema_rs.is_ok());
-        println!("schema rs = {:?}", schema_rs);
+        let schema_content = read_schema_from_local(schema_location);
+        assert!(schema_content.is_ok());
+        let schema = Schema::parse_str(&schema_content.unwrap());
+        assert!(schema.is_ok());
+        println!("schema = {:?}", schema.unwrap());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn test_load_schema_from_https() {
+        let schema_location =
+            "https://mingchao-schemas.s3.ap-southeast-1.amazonaws.com/complex-schema.avsc";
+        let url = Url::parse(schema_location).unwrap();
+        let schema_content = read_schema_from_https(&url).await;
+        assert!(schema_content.is_ok());
+        let schema = Schema::parse_str(&schema_content.unwrap());
+        assert!(schema.is_ok());
+        println!("schema = {:?}", schema.unwrap());
     }
 
     async fn new_avro_parser_from_local(file_name: &str) -> error::Result<AvroParser> {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
- allow importing avro schema from https
- refactor some code of avro/pb parser to remove redundant match clause

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation


### Types of user-facing changes


* Connector (sources & sinks)


### Release note

```sql
create materialized source s with (
    connector = 'kafka',
    topic = 'avro_c_bin',
    properties.bootstrap.server = '127.0.0.1:29092',
    scan.startup.mode = 'earliest')
row format avro message 'user'
row schema location 'https://xxx.com/complex-schema.avsc';
```

## Refer to a related PR or issue link (optional)
#6114 