### PR TITLE
fix(storage): Stronger requirement on input `range` for `iter` and `scan` in `StateStore`

### DIFF
--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -497,6 +497,8 @@ impl StateStore for HummockStorage {
 
     /// Returns an iterator that scan from the begin key to the end key
     /// The result is based on a snapshot corresponding to the given `epoch`.
+    /// The `key_range` needs to be prefixed by the serialized `table_id`, i.e.
+    /// `Unbounded` is forbidden.
     fn iter(
         &self,
         prefix_hint: Option<Vec<u8>>,

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -501,11 +501,7 @@ impl StateStore for HummockStorage {
                     Bound::Unbounded => {
                         debug_assert!(false, "key range must be prefixed with `table_id`")
                     }
-                    Bound::Included(b) | Bound::Excluded(b) => assert_eq!(
-                        b[..4],
-                        table_id_prefix,
-                        "key range must be prefixed with `table_id`"
-                    ),
+                    Bound::Included(b) | Bound::Excluded(b) => assert_eq!(b[..4], table_id_prefix,),
                 }
 
                 if !(end_bound_of_prefix(&table_id_prefix) == key_range.1) {
@@ -515,11 +511,9 @@ impl StateStore for HummockStorage {
                         Bound::Unbounded => {
                             debug_assert!(false, "key range must be prefixed with `table_id`")
                         }
-                        Bound::Included(b) | Bound::Excluded(b) => assert_eq!(
-                            b[..4],
-                            table_id_prefix,
-                            "key range must be prefixed with `table_id`"
-                        ),
+                        Bound::Included(b) | Bound::Excluded(b) => {
+                            assert_eq!(b[..4], table_id_prefix,)
+                        }
                     }
                 }
             }

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -92,9 +92,11 @@ pub trait StateStore: Send + Sync + 'static + Clone {
 
     /// Scans `limit` number of keys from a key range. If `limit` is `None`, scans all elements.
     /// Internally, `prefix_hint` will be used to for checking `bloom_filter` and
-    /// `full_key_range` used for iter.
+    /// `key_range` used for iter.
     /// The result is based on a snapshot corresponding to the given `epoch`.
-    ///
+    /// Furthermore, the `key_range` should always contain the `read_options.table_id`
+    /// as its first `size_of::<TableId>()` bytes. This means that `Unbounded` is forbidden in
+    /// `key_range`.
     ///
     /// By default, this simply calls `StateStore::iter` to fetch elements.
     fn scan(
@@ -127,11 +129,13 @@ pub trait StateStore: Send + Sync + 'static + Clone {
         write_options: WriteOptions,
     ) -> Self::IngestBatchFuture<'_>;
 
-    /// Opens and returns an iterator for given `prefix_hint` and `full_key_range`
+    /// Opens and returns an iterator for given `prefix_hint` and `key_range`
     /// Internally, `prefix_hint` will be used to for checking `bloom_filter` and
-    /// `full_key_range` used for iter. (if the `prefix_hint` not None, it should be be included in
+    /// `key_range` used for iter. (if the `prefix_hint` not None, it should be included in
     /// `key_range`) The returned iterator will iterate data based on a snapshot corresponding to
-    /// the given `epoch`.
+    /// the given `epoch`. Furthermore, the `key_range` should always contain the
+    /// `read_options.table_id` as its first `size_of::<TableId>()` bytes. This means that
+    /// `Unbounded` is forbidden in `key_range`.
     fn iter(
         &self,
         prefix_hint: Option<Vec<u8>>,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Stronger requirement on input `range` for `iter` and `scan` in `StateStore`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fix: https://github.com/risingwavelabs/risingwave/issues/6104