### PR TITLE
feat(pg_catalog): stub pg_opclass

### DIFF
--- a/e2e_test/batch/catalog/pg_opclass.slt.part
+++ b/e2e_test/batch/catalog/pg_opclass.slt.part
@@ -1,0 +1,14 @@
+query IITIIIIII
+SELECT
+    oid,
+    opcmethod,
+    opcname,
+    opcnamespace,
+    opcowner,
+    opcfamily,
+    opcintype,
+    opcdefault,
+    opckeytype
+FROM pg_catalog.pg_class;
+----
+(empty)

--- a/e2e_test/batch/catalog/pg_opclass.slt.part
+++ b/e2e_test/batch/catalog/pg_opclass.slt.part
@@ -9,6 +9,6 @@ SELECT
     opcintype,
     opcdefault,
     opckeytype
-FROM pg_catalog.pg_class;
+FROM pg_catalog.pg_opclass;
 ----
 (empty)

--- a/e2e_test/batch/catalog/pg_opclass.slt.part
+++ b/e2e_test/batch/catalog/pg_opclass.slt.part
@@ -11,4 +11,3 @@ SELECT
     opckeytype
 FROM pg_catalog.pg_opclass;
 ----
-(empty)

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -24,7 +24,6 @@ use risingwave_sqlparser::parser::Parser;
 
 use crate::binder::relation::BoundSubquery;
 use crate::binder::{Binder, Relation};
-use crate::catalog::pg_catalog::pg_opclass::PG_OPCLASS_TABLE_NAME;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::catalog::system_catalog::SystemCatalog;
@@ -155,8 +154,7 @@ impl Binder {
                     let user_name = &self.auth_context.user_name;
 
                     for path in self.search_path.path() {
-                        if path == PG_CATALOG_SCHEMA_NAME || path == PG_OPCLASS_TABLE_NAME {
-                            // FIXME(noel): PG_OPCLASS is stubbed. See <https://github.com/risingwavelabs/risingwave/issues/3431#issuecomment-1164160988>.
+                        if path == PG_CATALOG_SCHEMA_NAME {
                             if let Ok(sys_table_catalog) = self
                                 .catalog
                                 .get_sys_table_by_name(&self.db_name, table_name)

--- a/src/frontend/src/binder/relation/table_or_source.rs
+++ b/src/frontend/src/binder/relation/table_or_source.rs
@@ -24,6 +24,7 @@ use risingwave_sqlparser::parser::Parser;
 
 use crate::binder::relation::BoundSubquery;
 use crate::binder::{Binder, Relation};
+use crate::catalog::pg_catalog::pg_opclass::PG_OPCLASS_TABLE_NAME;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::catalog::system_catalog::SystemCatalog;
@@ -154,7 +155,8 @@ impl Binder {
                     let user_name = &self.auth_context.user_name;
 
                     for path in self.search_path.path() {
-                        if path == PG_CATALOG_SCHEMA_NAME {
+                        if path == PG_CATALOG_SCHEMA_NAME || path == PG_OPCLASS_TABLE_NAME {
+                            // FIXME(noel): PG_OPCLASS is stubbed. See <https://github.com/risingwavelabs/risingwave/issues/3431#issuecomment-1164160988>.
                             if let Ok(sys_table_catalog) = self
                                 .catalog
                                 .get_sys_table_by_name(&self.db_name, table_name)

--- a/src/frontend/src/catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/pg_catalog/mod.rs
@@ -17,6 +17,7 @@ pub mod pg_class;
 pub mod pg_index;
 pub mod pg_matviews_info;
 pub mod pg_namespace;
+pub mod pg_opclass;
 pub mod pg_type;
 pub mod pg_user;
 
@@ -40,6 +41,7 @@ use crate::catalog::pg_catalog::pg_class::*;
 use crate::catalog::pg_catalog::pg_index::*;
 use crate::catalog::pg_catalog::pg_matviews_info::*;
 use crate::catalog::pg_catalog::pg_namespace::*;
+use crate::catalog::pg_catalog::pg_opclass::*;
 use crate::catalog::pg_catalog::pg_type::*;
 use crate::catalog::pg_catalog::pg_user::*;
 use crate::catalog::system_catalog::SystemCatalog;
@@ -92,6 +94,7 @@ impl SysCatalogReader for SysCatalogReaderImpl {
             PG_USER_TABLE_NAME => self.read_user_info(),
             PG_CLASS_TABLE_NAME => self.read_class_info(),
             PG_INDEX_TABLE_NAME => self.read_index_info(),
+            PG_OPCLASS_TABLE_NAME => self.read_opclass_info(),
             _ => {
                 Err(ErrorCode::ItemNotFound(format!("Invalid system table: {}", table_name)).into())
             }
@@ -207,6 +210,11 @@ impl SysCatalogReaderImpl {
                 ])
             })
             .collect_vec())
+    }
+
+    // FIXME(noel): Tracked by <https://github.com/risingwavelabs/risingwave/issues/3431#issuecomment-1164160988>
+    fn read_opclass_info(&self) -> Result<Vec<Row>> {
+        Ok(vec![])
     }
 
     fn read_class_info(&self) -> Result<Vec<Row>> {
@@ -390,6 +398,7 @@ pub(crate) static PG_CATALOG_MAP: LazyLock<HashMap<String, SystemCatalog>> = Laz
         PG_USER_TABLE_NAME.to_string() => def_sys_catalog!(5, PG_USER_TABLE_NAME, PG_USER_COLUMNS),
         PG_CLASS_TABLE_NAME.to_string() => def_sys_catalog!(6, PG_CLASS_TABLE_NAME, PG_CLASS_COLUMNS),
         PG_INDEX_TABLE_NAME.to_string() => def_sys_catalog!(7, PG_INDEX_TABLE_NAME, PG_INDEX_COLUMNS),
+        PG_OPCLASS_TABLE_NAME.to_string() => def_sys_catalog!(8, PG_OPCLASS_TABLE_NAME, PG_OPCLASS_COLUMNS),
     }
 });
 

--- a/src/frontend/src/catalog/pg_catalog/pg_opclass.rs
+++ b/src/frontend/src/catalog/pg_catalog/pg_opclass.rs
@@ -1,0 +1,32 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::DataType;
+
+use crate::catalog::pg_catalog::PgCatalogColumnsDef;
+
+/// The catalog `pg_opclass` defines index access method operator classes.
+/// Reference: [`https://www.postgresql.org/docs/current/catalog-pg-opclass.html`].
+pub const PG_OPCLASS_TABLE_NAME: &str = "pg_opclass";
+pub const PG_OPCLASS_COLUMNS: &[PgCatalogColumnsDef<'_>] = &[
+    (DataType::Int32, "oid"),
+    (DataType::Int32, "opcmethod"),
+    (DataType::Varchar, "opcname"),
+    (DataType::Int32, "opcnamespace"),
+    (DataType::Int32, "opcowner"),
+    (DataType::Int32, "opcfamily"),
+    (DataType::Int32, "opcintype"),
+    (DataType::Int32, "opcdefault"),
+    (DataType::Int32, "opckeytype"),
+];


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

stub pg_opclass to support sqlancer.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [x] Try out sqlancer, it should work with this branch. 
        Update: More system tables needed, see: https://github.com/risingwavelabs/risingwave/issues/3364#issuecomment-1299904725. Does not work for now.

## Documentation

-

### Types of user-facing changes

Note that although `pg_opclass` is user-facing. We do not want to expose it to end user. It is just introduced for sqlancer support.

### Release note

-

## Refer to a related PR or issue link (optional)

https://github.com/risingwavelabs/risingwave/issues/3431#issuecomment-1164160988
