### PR TITLE
feat(filecache): support btrfs and tmpfs

### DIFF
--- a/src/bench/file_cache_bench/main.rs
+++ b/src/bench/file_cache_bench/main.rs
@@ -77,6 +77,10 @@ pub struct Args {
     /// Endpoint for jaeger, only valid when feature `trace` is enabled.
     #[clap(long, default_value = "http://127.0.0.1:14268/api/traces")]
     jaeger_endpoint: String,
+    /// Some filesystem (e.g. btrfs) can span across multiple block devices and it's hard to decide
+    /// which device to moitor. Use this argument to specify which block device to monitor.
+    #[clap(long, default_value = "")]
+    iostat_dev: String,
 }
 
 #[cfg(target_os = "linux")]

--- a/src/bench/file_cache_bench/utils.rs
+++ b/src/bench/file_cache_bench/utils.rs
@@ -20,7 +20,7 @@ use nix::sys::stat::stat;
 
 /// Given a normal file path, returns the containing block device static file path (of the
 /// partition).
-pub fn dev_stat_path(path: impl AsRef<Path>) -> PathBuf {
+pub fn file_stat_path(path: impl AsRef<Path>) -> PathBuf {
     let st_dev = stat(path.as_ref()).unwrap().st_dev;
 
     let major = unsafe { libc::major(st_dev) };
@@ -30,7 +30,10 @@ pub fn dev_stat_path(path: impl AsRef<Path>) -> PathBuf {
 
     let linkname = readlink(&dev).unwrap();
     let devname = Path::new(linkname.as_os_str()).file_name().unwrap();
+    dev_stat_path(devname.to_str().unwrap())
+}
 
+pub fn dev_stat_path(devname: &str) -> PathBuf {
     let classpath = Path::new("/sys/class/block").join(devname);
     let devclass = readlink(&classpath).unwrap();
 

--- a/src/storage/src/hummock/file_cache/cache.rs
+++ b/src/storage/src/hummock/file_cache/cache.rs
@@ -24,7 +24,7 @@ use super::buffer::TwoLevelBuffer;
 use super::error::Result;
 use super::meta::SlotId;
 use super::metrics::FileCacheMetricsRef;
-use super::store::{Store, StoreOptions, StoreRef};
+use super::store::{FsType, Store, StoreOptions, StoreRef};
 use super::{utils, LRU_SHARD_BITS};
 use crate::hummock::{HashBuilder, TieredCacheEntryHolder, TieredCacheKey, TieredCacheValue};
 
@@ -290,6 +290,10 @@ where
         timer.observe_duration();
 
         Ok(())
+    }
+
+    pub fn fs_type(&self) -> FsType {
+        self.store.fs_type()
     }
 }
 

--- a/src/storage/src/hummock/file_cache/store.rs
+++ b/src/storage/src/hummock/file_cache/store.rs
@@ -17,7 +17,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use itertools::Itertools;
-use nix::sys::statfs::{statfs, FsType as NixFsType, EXT4_SUPER_MAGIC};
+use nix::sys::statfs::{
+    statfs, FsType as NixFsType, BTRFS_SUPER_MAGIC, EXT4_SUPER_MAGIC, TMPFS_MAGIC,
+};
 use parking_lot::RwLock;
 use risingwave_common::cache::{LruCache, LruCacheEventListener};
 use tokio::sync::RwLock as AsyncRwLock;
@@ -37,8 +39,10 @@ const FREELIST_DEFAULT_CAPACITY: usize = 64;
 
 #[derive(Clone, Copy, Debug)]
 pub enum FsType {
-    Ext4,
     Xfs,
+    Ext4,
+    Btrfs,
+    Tmpfs,
 }
 
 pub struct StoreBatchWriter<'a, K, V>
@@ -226,7 +230,7 @@ where
     dir: String,
     _capacity: usize,
 
-    _fs_type: FsType,
+    fs_type: FsType,
     _fs_block_size: usize,
     block_size: usize,
     buffer_capacity: usize,
@@ -255,9 +259,13 @@ where
         // Get file system type and block size by `statfs(2)`.
         let fs_stat = statfs(options.dir.as_str())?;
         let fs_type = match fs_stat.filesystem_type() {
-            EXT4_SUPER_MAGIC => FsType::Ext4,
             // FYI: https://github.com/nix-rust/nix/issues/1742
+            // FYI: Aftere https://github.com/nix-rust/nix/pull/1743 is release,
+            //      we can bump to the new nix version and use nix type instead of libc's.
             NixFsType(libc::XFS_SUPER_MAGIC) => FsType::Xfs,
+            EXT4_SUPER_MAGIC => FsType::Ext4,
+            BTRFS_SUPER_MAGIC => FsType::Btrfs,
+            TMPFS_MAGIC => FsType::Tmpfs,
             nix_fs_type => return Err(Error::UnsupportedFilesystem(nix_fs_type.0)),
         };
         let fs_block_size = fs_stat.block_size() as usize;
@@ -283,7 +291,7 @@ where
             dir: options.dir,
             _capacity: options.capacity,
 
-            _fs_type: fs_type,
+            fs_type,
             _fs_block_size: fs_block_size,
             // TODO: Make it configurable.
             block_size: fs_block_size,
@@ -299,6 +307,10 @@ where
 
             _phantom: PhantomData::default(),
         })
+    }
+
+    pub fn fs_type(&self) -> FsType {
+        self.fs_type
     }
 
     pub fn block_size(&self) -> usize {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

The file cache used *fallocate(2)* with *FALLOC_FL_PUNCH_HOLE* flag which is only supported by limited file systems. 

*tmpfs* and *btrfs* support the syscall and look fine after testing with the file cache. So this PR looses the limitation.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #5750 