### PR TITLE
fix(meta): notify_finished when cluster is idle.

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -556,10 +556,7 @@ where
             // is an advance optimization. Besides if another barrier comes immediately,
             // it may send a same epoch and fail the epoch check.
             if info.nothing_to_do() {
-                let mut notifiers = notifiers;
-                notifiers.iter_mut().for_each(Notifier::notify_to_send);
-                notifiers.iter_mut().for_each(Notifier::notify_collected);
-                notifiers.into_iter().for_each(Notifier::notify_finished);
+                notifiers.into_iter().for_each(Notifier::notify_all);
                 continue;
             }
             let prev_epoch = state.in_flight_prev_epoch;

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -559,6 +559,7 @@ where
                 let mut notifiers = notifiers;
                 notifiers.iter_mut().for_each(Notifier::notify_to_send);
                 notifiers.iter_mut().for_each(Notifier::notify_collected);
+                notifiers.into_iter().for_each(Notifier::notify_finished);
                 continue;
             }
             let prev_epoch = state.in_flight_prev_epoch;

--- a/src/meta/src/barrier/notifier.rs
+++ b/src/meta/src/barrier/notifier.rs
@@ -61,4 +61,10 @@ impl Notifier {
             tx.send(()).ok();
         }
     }
+
+    pub fn notify_all(mut self) {
+        self.notify_to_send();
+        self.notify_collected();
+        self.notify_finished();
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Currently for a idle cluster, we drop the channel sender without calling `Notifier::notify_finished`:
https://github.com/risingwavelabs/risingwave/blob/df0c3f408c7267d721b7beeb3cb0f5862c3053c3/src/meta/src/barrier/mod.rs#L562

It causes a channel closed error here:
https://github.com/risingwavelabs/risingwave/blob/df0c3f408c7267d721b7beeb3cb0f5862c3053c3/src/meta/src/barrier/schedule.rs#L181

For example, if we run `risedev ctl meta pause` for an idle cluster, it will respond with an error.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
