### PR TITLE
fix(storage): avoid unwrap when notifying clear completion

### DIFF
--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -329,7 +329,9 @@ impl HummockEventHandler {
             .remove_watermark_sst_id(TrackerId::Epoch(HummockEpoch::MAX));
 
         // Notify completion of the Clear event.
-        notifier.send(()).unwrap();
+        let _ = notifier.send(()).inspect_err(|e| {
+            error!("failed to notify completion of clear event: {:?}", e);
+        });
     }
 
     fn handle_version_update(&mut self, version_payload: Payload) {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
fix #6218 