### PR TITLE
fix(pgwire):cancel replace smallint,int,bigint param as xx::smallint,xx::int,xx::bigint 

### DIFF
--- a/src/utils/pgwire/src/lib.rs
+++ b/src/utils/pgwire/src/lib.rs
@@ -12,7 +12,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#![feature(lint_reasons)]
+#![feature(lint_reasons, once_cell)]
 #![expect(clippy::doc_markdown, reason = "FIXME: later")]
 
 pub mod error;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as title. fix #6163 

After the fix, the performance of enabling prepare statement is close to disabling prepare statement.

```
sysbench \
--db-driver=pgsql \
--pgsql-host=localhost  \
--pgsql-port=4566  \
--pgsql-user=root \
--pgsql-db=dev \
--threads=16 \
--report-interval=1 \
--events=0 \
--time=100 \
--percentile=99 \
--auto_inc=false \
--table_size=100000 \
--skip_trx=true \
--range_size=1 \
/usr/local/share/sysbench/oltp_point_select.lua \
run
sysbench 1.1.0-81dd8df (using system LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 16
Report intermediate results every 1 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 1s ] thds: 16 tps: 3665.38 qps: 3665.38 (r/w/o: 3665.38/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 2s ] thds: 16 tps: 3700.13 qps: 3700.13 (r/w/o: 3700.13/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 3s ] thds: 16 tps: 3719.56 qps: 3719.56 (r/w/o: 3719.56/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 4s ] thds: 16 tps: 3715.93 qps: 3715.93 (r/w/o: 3715.93/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 5s ] thds: 16 tps: 3715.31 qps: 3715.31 (r/w/o: 3715.31/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 6s ] thds: 16 tps: 3708.85 qps: 3708.85 (r/w/o: 3708.85/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00

```

```
sysbench \
--db-driver=pgsql \
--pgsql-host=localhost  \
--pgsql-port=4566  \
--pgsql-user=root \
--pgsql-db=dev --db-ps-mode=disable \
--threads=16 \
--report-interval=1 \
--events=0 \
--time=100 \
--percentile=99 \
--auto_inc=false \
--table_size=100000 \
--skip_trx=true \
--range_size=1 \
/usr/local/share/sysbench/oltp_point_select.lua \
run
sysbench 1.1.0-81dd8df (using system LuaJIT 2.1.0-beta3)

Running the test with following options:
Number of threads: 16
Report intermediate results every 1 second(s)
Initializing random number generator from current time


Initializing worker threads...

Threads started!

[ 1s ] thds: 16 tps: 3781.90 qps: 3781.90 (r/w/o: 3781.90/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 2s ] thds: 16 tps: 3906.95 qps: 3906.95 (r/w/o: 3906.95/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 3s ] thds: 16 tps: 3915.26 qps: 3915.26 (r/w/o: 3915.26/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 4s ] thds: 16 tps: 3915.68 qps: 3915.68 (r/w/o: 3915.68/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 5s ] thds: 16 tps: 3872.32 qps: 3872.32 (r/w/o: 3872.32/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 6s ] thds: 16 tps: 3591.19 qps: 3591.19 (r/w/o: 3591.19/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
[ 7s ] thds: 16 tps: 3895.55 qps: 3895.55 (r/w/o: 3895.55/0.00/0.00) lat (ms,99%): 0.00 err/s: 0.00 reconn/s: 0.00
```


- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6163 
