### PR TITLE
refactor(sync group): remove compaction group in sst statistics in `s…

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1374,14 +1374,14 @@ where
 
         let (raw_compaction_groups, compaction_group_index) =
             self.compaction_groups_and_index().await;
-        let mut compaction_groups: HashMap<_, _> = raw_compaction_groups
+        let compaction_groups: HashMap<_, _> = raw_compaction_groups
             .into_iter()
             .map(|group| (group.group_id(), group))
             .collect();
 
         let versioning = versioning_guard.deref_mut();
         let (mut new_version_delta, mut new_hummock_version) =
-            match self.sync_group(versioning, &mut compaction_groups).await? {
+            match self.sync_group(versioning, &compaction_groups).await? {
                 Some((entry_k, entry_v, new_hummock_version)) => (
                     BTreeMapEntryTransaction::new_insert(
                         &mut versioning.hummock_version_deltas,

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1175,8 +1175,7 @@ where
     async fn sync_group<'a>(
         &'a self,
         versioning: &'a mut Versioning,
-        compaction_groups: &mut HashMap<CompactionGroupId, CompactionGroup>,
-        deleted_compaction_groups: &mut Vec<CompactionGroupId>,
+        compaction_groups: &HashMap<CompactionGroupId, CompactionGroup>,
     ) -> Result<Option<(u64, HummockVersionDelta, HummockVersion)>> {
         // We need 2 steps to sync groups:
         // Insert new groups that are not in current `HummockVersion`;
@@ -1217,6 +1216,7 @@ where
             )));
         }
 
+        let mut deleted_compaction_groups = vec![];
         let mut branched_ssts = BTreeMapTransaction::new(&mut versioning.branched_ssts);
         for group_id in old_version_groups {
             if !compaction_groups.contains_key(&group_id) {
@@ -1350,6 +1350,10 @@ where
                 }),
             );
 
+        for compaction_group_id in deleted_compaction_groups {
+            remove_compaction_group_in_sst_stat(&self.metrics, compaction_group_id);
+        }
+
         Ok(None)
     }
 
@@ -1374,45 +1378,38 @@ where
             .into_iter()
             .map(|group| (group.group_id(), group))
             .collect();
-        let mut deleted_compaction_groups = vec![];
 
         let versioning = versioning_guard.deref_mut();
-        let (mut new_version_delta, mut new_hummock_version) = match self
-            .sync_group(
-                versioning,
-                &mut compaction_groups,
-                &mut deleted_compaction_groups,
-            )
-            .await?
-        {
-            Some((entry_k, entry_v, new_hummock_version)) => (
-                BTreeMapEntryTransaction::new_insert(
-                    &mut versioning.hummock_version_deltas,
-                    entry_k,
-                    entry_v,
+        let (mut new_version_delta, mut new_hummock_version) =
+            match self.sync_group(versioning, &mut compaction_groups).await? {
+                Some((entry_k, entry_v, new_hummock_version)) => (
+                    BTreeMapEntryTransaction::new_insert(
+                        &mut versioning.hummock_version_deltas,
+                        entry_k,
+                        entry_v,
+                    ),
+                    new_hummock_version,
                 ),
-                new_hummock_version,
-            ),
-            None => {
-                let old_version = versioning.current_version.clone();
-                let new_version_id = old_version.id + 1;
-                let mut new_version_delta = BTreeMapEntryTransaction::new_insert(
-                    &mut versioning.hummock_version_deltas,
-                    new_version_id,
-                    HummockVersionDelta {
-                        prev_id: old_version.id,
-                        safe_epoch: old_version.safe_epoch,
-                        trivial_move: false,
-                        ..Default::default()
-                    },
-                );
+                None => {
+                    let old_version = versioning.current_version.clone();
+                    let new_version_id = old_version.id + 1;
+                    let mut new_version_delta = BTreeMapEntryTransaction::new_insert(
+                        &mut versioning.hummock_version_deltas,
+                        new_version_id,
+                        HummockVersionDelta {
+                            prev_id: old_version.id,
+                            safe_epoch: old_version.safe_epoch,
+                            trivial_move: false,
+                            ..Default::default()
+                        },
+                    );
 
-                let mut new_hummock_version = old_version;
-                new_version_delta.id = new_version_id;
-                new_hummock_version.id = new_version_id;
-                (new_version_delta, new_hummock_version)
-            }
-        };
+                    let mut new_hummock_version = old_version;
+                    new_version_delta.id = new_version_id;
+                    new_hummock_version.id = new_version_id;
+                    (new_version_delta, new_hummock_version)
+                }
+            };
         let mut branched_ssts = BTreeMapTransaction::new(&mut versioning.branched_ssts);
 
         if self.env.opts.enable_committed_sst_sanity_check {
@@ -1578,9 +1575,6 @@ where
                 &versioning.current_version,
                 *compaction_group_id,
             );
-        }
-        for compaction_group_id in deleted_compaction_groups {
-            remove_compaction_group_in_sst_stat(&self.metrics, compaction_group_id);
         }
 
         tracing::trace!("new committed epoch {}", epoch);


### PR DESCRIPTION
…ync_group`

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

remove compaction group in sst statistics in `sync_group`
previously it was in `commit_epoch`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
