### PR TITLE
feat: add kill-rate for deterministic recovery test

### DIFF
--- a/ci/scripts/deterministic-recovery-test.sh
+++ b/ci/scripts/deterministic-recovery-test.sh
@@ -13,8 +13,8 @@ mkdir -p $LOGDIR
 
 # bugs here! Tracking issue https://github.com/risingwavelabs/risingwave/issues/4527
 echo "--- deterministic simulation e2e, ci-3cn-1fe, recovery, streaming"
-seq 1 | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill-meta --kill-frontend --kill-compute --kill-compactor ./e2e_test/streaming/\*\*/\*.slt > $LOGDIR/recovery-streaming-{}.log && rm $LOGDIR/recovery-streaming-{}.log'
+seq 1 | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill-meta --kill-frontend --kill-compute --kill-compactor --kill-rate=0.5 ./e2e_test/streaming/\*\*/\*.slt > $LOGDIR/recovery-streaming-{}.log && rm $LOGDIR/recovery-streaming-{}.log'
 
 # bugs here! Tracking issue https://github.com/risingwavelabs/risingwave/issues/4527
 echo "--- deterministic simulation e2e, ci-3cn-1fe, recovery, batch"
-seq 1 | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill-meta --kill-frontend --kill-compute --kill-compactor ./e2e_test/batch/\*\*/\*.slt > $LOGDIR/recovery-batch-{}.log && rm $LOGDIR/recovery-batch-{}.log'
+seq 1 | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill-meta --kill-frontend --kill-compute --kill-compactor --kill-rate=0.5 ./e2e_test/batch/\*\*/\*.slt > $LOGDIR/recovery-batch-{}.log && rm $LOGDIR/recovery-batch-{}.log'

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -138,7 +138,7 @@ steps:
     retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
-    command: "timeout 14m ci/scripts/deterministic-recovery-test.sh"
+    command: "timeout 10m ci/scripts/deterministic-recovery-test.sh"
     depends_on: "build-simulation"
     plugins:
       - gencer/cache#v2.4.10: *cargo-cache

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -199,7 +199,7 @@ steps:
     retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
-    command: "timeout 14m ci/scripts/deterministic-recovery-test.sh"
+    command: "timeout 10m ci/scripts/deterministic-recovery-test.sh"
     depends_on: "build-simulation"
     plugins:
       - gencer/cache#v2.4.10: *cargo-cache


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

As title, in this PR I added a `kill_rate` option for deterministic recovery test. Here are some local test result (with `outer_join.slt` disabled, on branch of @jon-chuang 's fix on `DynamicFilter` in #6247 ):
streaming recovery test:
|  kill-rate   | cost  |
|  ----  | ----  |
| 0.0  | 19s |
| 0.3  | 169.80s |
| 0.5  | 333.93s |
| 1.0 | 561.58s |

batch recovery test:
|  kill-rate   | cost  |
|  ----  | ----  |
| 0.0  | 8.05s |
| 0.3  | 20.09s |
| 0.5  | 30.08s |
| 1.0 | 50.12s |

So let's config `kill-rate` to 0.5 in the deterministic recovery test and setup it's timeout to 10m.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Close #6047 .