### PR TITLE
refactor(storage): make ExecutorBuilder to async and introduce local state store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5740,6 +5740,7 @@ version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "async-recursion",
  "async-stream",
  "async-trait",
  "async_stack_trace",

--- a/src/batch/src/executor/row_seq_scan.rs
+++ b/src/batch/src/executor/row_seq_scan.rs
@@ -439,7 +439,8 @@ mod tests {
             column_descs.clone(),
             order_types.clone(),
             pk_indices.clone(),
-        );
+        )
+        .await;
         let column_ids_partial = vec![ColumnId::from(1), ColumnId::from(2)];
         let value_indices: Vec<usize> = vec![0, 1, 2];
         let table = StorageTable::new_partial(

--- a/src/compute/src/rpc/service/exchange_service.rs
+++ b/src/compute/src/rpc/service/exchange_service.rs
@@ -97,7 +97,7 @@ impl ExchangeService for ExchangeServiceImpl {
 
         let up_down_actor_ids = (get_req.up_actor_id, get_req.down_actor_id);
         let up_down_fragment_ids = (get_req.up_fragment_id, get_req.down_fragment_id);
-        let receiver = self.stream_mgr.take_receiver(up_down_actor_ids)?;
+        let receiver = self.stream_mgr.take_receiver(up_down_actor_ids).await?;
 
         // Map the remaining stream to add-permits.
         let add_permits_stream = request_stream.map_ok(|req| match req.value.unwrap() {

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -52,6 +52,7 @@ impl MonitorService for MonitorServiceImpl {
         let actor_traces = self
             .stream_mgr
             .get_actor_traces()
+            .await
             .into_iter()
             .map(|(k, v)| (k, v.to_string()))
             .collect();

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -140,8 +140,7 @@ impl StreamService for StreamServiceImpl {
             Barrier::from_protobuf(req.get_barrier().unwrap()).map_err(StreamError::from)?;
 
         self.mgr
-            .send_barrier(&barrier, req.actor_ids_to_send, req.actor_ids_to_collect)
-            .await?;
+            .send_barrier(&barrier, req.actor_ids_to_send, req.actor_ids_to_collect)?;
 
         Ok(Response::new(InjectBarrierResponse {
             request_id: req.request_id,

--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -46,7 +46,10 @@ impl StreamService for StreamServiceImpl {
         request: Request<UpdateActorsRequest>,
     ) -> std::result::Result<Response<UpdateActorsResponse>, Status> {
         let req = request.into_inner();
-        let res = self.mgr.update_actors(&req.actors, &req.hanging_channels);
+        let res = self
+            .mgr
+            .update_actors(&req.actors, &req.hanging_channels)
+            .await;
         match res {
             Err(e) => {
                 error!("failed to update stream actor {}", e);
@@ -64,7 +67,10 @@ impl StreamService for StreamServiceImpl {
         let req = request.into_inner();
 
         let actor_id = req.actor_id;
-        let res = self.mgr.build_actors(actor_id.as_slice(), self.env.clone());
+        let res = self
+            .mgr
+            .build_actors(actor_id.as_slice(), self.env.clone())
+            .await;
         match res {
             Err(e) => {
                 error!("failed to build actors {}", e);
@@ -84,7 +90,7 @@ impl StreamService for StreamServiceImpl {
     ) -> std::result::Result<Response<BroadcastActorInfoTableResponse>, Status> {
         let req = request.into_inner();
 
-        let res = self.mgr.update_actor_info(&req.info);
+        let res = self.mgr.update_actor_info(&req.info).await;
         match res {
             Err(e) => {
                 error!("failed to update actor info table actor {}", e);
@@ -103,7 +109,7 @@ impl StreamService for StreamServiceImpl {
     ) -> std::result::Result<Response<DropActorsResponse>, Status> {
         let req = request.into_inner();
         let actors = req.actor_ids;
-        self.mgr.drop_actor(&actors)?;
+        self.mgr.drop_actor(&actors).await?;
         Ok(Response::new(DropActorsResponse {
             request_id: req.request_id,
             status: None,
@@ -134,7 +140,8 @@ impl StreamService for StreamServiceImpl {
             Barrier::from_protobuf(req.get_barrier().unwrap()).map_err(StreamError::from)?;
 
         self.mgr
-            .send_barrier(&barrier, req.actor_ids_to_send, req.actor_ids_to_collect)?;
+            .send_barrier(&barrier, req.actor_ids_to_send, req.actor_ids_to_collect)
+            .await?;
 
         Ok(Response::new(InjectBarrierResponse {
             request_id: req.request_id,

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -131,7 +131,8 @@ async fn test_table_materialize() -> StreamResult<()> {
     let state_table = SourceStateTableHandler::from_table_catalog(
         &default_source_internal_table(0x2333),
         MemoryStateStore::new(),
-    );
+    )
+    .await;
     let stream_source = SourceExecutor::new(
         ActorContext::create(0x3f3f3f),
         source_builder,
@@ -159,6 +160,7 @@ async fn test_table_materialize() -> StreamResult<()> {
         all_column_ids.clone(),
         2,
     )
+    .await
     .boxed()
     .execute();
 
@@ -383,7 +385,8 @@ async fn test_row_seq_scan() -> Result<()> {
         column_descs.clone(),
         vec![OrderType::Ascending],
         vec![0_usize],
-    );
+    )
+    .await;
     let table = StorageTable::for_test(
         memory_state_store.clone(),
         TableId::from(0x42),

--- a/src/ctl/src/cmd_impl/bench.rs
+++ b/src/ctl/src/cmd_impl/bench.rs
@@ -88,7 +88,7 @@ pub async fn do_bench(cmd: BenchCommands) -> Result<()> {
                 let handler = spawn_okk(async move {
                     tracing::info!(thread = i, "starting scan");
                     let state_table = {
-                        let mut tb = make_state_table(hummock, &table);
+                        let mut tb = make_state_table(hummock, &table).await;
                         tb.init_epoch(EpochPair::new_test_epoch(u64::MAX));
                         tb
                     };

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -53,7 +53,7 @@ pub fn print_table_catalog(table: &TableCatalog) {
     println!("{:#?}", table);
 }
 
-pub fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StateTable<S> {
+pub async fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StateTable<S> {
     StateTable::new_with_distribution(
         hummock,
         table.id,
@@ -67,6 +67,7 @@ pub fn make_state_table<S: StateStore>(hummock: S, table: &TableCatalog) -> Stat
         Distribution::all_vnodes(table.distribution_key().to_vec()), // scan all vnodes
         table.value_indices.clone(),
     )
+    .await
 }
 
 pub fn make_storage_table<S: StateStore>(hummock: S, table: &TableCatalog) -> StorageTable<S> {

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -198,7 +198,7 @@ impl StateStoreWrite for HummockStorage {
 impl StateStore for HummockStorage {
     type Local = LocalHummockStorage;
 
-    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + 'a;
+    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + Send + 'a;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/hummock/state_store_v1.rs
+++ b/src/storage/src/hummock/state_store_v1.rs
@@ -502,7 +502,7 @@ impl LocalStateStore for HummockStorageV1 {}
 impl StateStore for HummockStorageV1 {
     type Local = Self;
 
-    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + 'a;
+    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + Send + 'a;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -299,7 +299,7 @@ impl LocalStateStore for MemoryStateStore {}
 impl StateStore for MemoryStateStore {
     type Local = Self;
 
-    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + 'a;
+    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + Send + 'a;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/panic_store.rs
+++ b/src/storage/src/panic_store.rs
@@ -78,7 +78,7 @@ impl LocalStateStore for PanicStateStore {}
 impl StateStore for PanicStateStore {
     type Local = Self;
 
-    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + 'a;
+    type NewLocalFuture<'a> = impl Future<Output = Self::Local> + Send + 'a;
 
     define_state_store_associated_type!();
 

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -206,7 +206,7 @@ pub trait StateStore: StateStoreRead + StateStoreWrite + StaticSendSync + Clone 
 
     type ClearSharedBufferFuture<'a>: EmptyFutureTrait<'a>;
 
-    type NewLocalFuture<'a>: Future<Output = Self::Local> + 'a;
+    type NewLocalFuture<'a>: Future<Output = Self::Local> + Send + 'a;
 
     /// If epoch is `Committed`, we will wait until the epoch is committed and its data is ready to
     /// read. If epoch is `Current`, we will only check if the data can be read with this epoch.

--- a/src/storage/src/table/batch_table/test_batch_table.rs
+++ b/src/storage/src/table/batch_table/test_batch_table.rs
@@ -50,7 +50,8 @@ async fn test_storage_table_get_row() -> StorageResult<()> {
         column_descs.clone(),
         order_types.clone(),
         pk_indices.clone(),
-    );
+    )
+    .await;
     let table: StorageTable<MemoryStateStore> = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
@@ -133,7 +134,8 @@ async fn test_storage_get_row_for_string() {
         column_descs.clone(),
         order_types.clone(),
         pk_indices.clone(),
-    );
+    )
+    .await;
     let table: StorageTable<MemoryStateStore> = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),
@@ -212,7 +214,8 @@ async fn test_shuffled_column_id_for_storage_table_get_row() {
         column_descs.clone(),
         order_types.clone(),
         pk_indices.clone(),
-    );
+    )
+    .await;
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
     epoch.inc();
@@ -293,7 +296,8 @@ async fn test_row_based_storage_table_point_get_in_batch_mode() {
         column_descs.clone(),
         order_types.clone(),
         pk_indices.clone(),
-    );
+    )
+    .await;
     let column_ids_partial = vec![ColumnId::from(1), ColumnId::from(2)];
     let value_indices: Vec<usize> = vec![0, 1, 2];
     let table = StorageTable::new_partial(
@@ -374,7 +378,8 @@ async fn test_row_based_storage_table_scan_in_batch_mode() {
         column_descs.clone(),
         order_types.clone(),
         pk_indices.clone(),
-    );
+    )
+    .await;
     let column_ids_partial = vec![ColumnId::from(1), ColumnId::from(2)];
     let value_indices: Vec<usize> = vec![0, 1, 2];
     let table = StorageTable::new_partial(

--- a/src/storage/src/table/streaming_table/test_streaming_table.rs
+++ b/src/storage/src/table/streaming_table/test_streaming_table.rs
@@ -42,7 +42,8 @@ async fn test_state_table() -> StorageResult<()> {
         column_descs,
         order_types,
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);
@@ -167,7 +168,8 @@ async fn test_state_table_update_insert() -> StorageResult<()> {
         column_descs,
         order_types,
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);
@@ -336,7 +338,8 @@ async fn test_state_table_iter() {
         column_descs.clone(),
         order_types.clone(),
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
@@ -559,7 +562,8 @@ async fn test_state_table_iter_with_prefix() {
         column_descs.clone(),
         order_types.clone(),
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
@@ -676,7 +680,8 @@ async fn test_state_table_iter_with_pk_range() {
         column_descs.clone(),
         order_types.clone(),
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
@@ -802,7 +807,8 @@ async fn test_mem_table_assertion() {
         column_descs,
         order_types,
         pk_index,
-    );
+    )
+    .await;
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);
     state_table.insert(Row(vec![
@@ -836,7 +842,8 @@ async fn test_state_table_iter_with_value_indices() {
         order_types.clone(),
         pk_index,
         vec![2],
-    );
+    )
+    .await;
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
 
@@ -988,7 +995,8 @@ async fn test_state_table_iter_with_shuffle_value_indices() {
         order_types.clone(),
         pk_index,
         vec![2, 1, 0],
-    );
+    )
+    .await;
     let epoch = EpochPair::new_test_epoch(1);
     state.init_epoch(epoch);
 
@@ -1214,7 +1222,8 @@ async fn test_state_table_write_chunk() {
         column_descs,
         order_types,
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);
@@ -1335,7 +1344,8 @@ async fn test_state_table_write_chunk_visibility() {
         column_descs,
         order_types,
         pk_index,
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);
@@ -1454,7 +1464,8 @@ async fn test_state_table_write_chunk_value_indices() {
         order_types,
         pk_index,
         vec![2, 1],
-    );
+    )
+    .await;
 
     let epoch = EpochPair::new_test_epoch(1);
     state_table.init_epoch(epoch);

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
+async-recursion = "1"
 async-stream = "0.3"
 async-trait = "0.1"
 async_stack_trace = { path = "../utils/async_stack_trace" }

--- a/src/stream/src/executor/aggregation/minput.rs
+++ b/src/stream/src/executor/aggregation/minput.rs
@@ -318,7 +318,7 @@ mod tests {
         chunk
     }
 
-    fn create_mem_state_table(
+    async fn create_mem_state_table(
         input_schema: &Schema,
         upstream_columns: Vec<usize>,
         order_types: Vec<OrderType>,
@@ -339,7 +339,8 @@ mod tests {
             columns,
             order_types,
             (0..pk_len).collect(),
-        );
+        )
+        .await;
         (table, mapping)
     }
 
@@ -376,7 +377,8 @@ mod tests {
                 OrderType::Ascending, // for AggKind::Min
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,
@@ -490,7 +492,8 @@ mod tests {
                 OrderType::Descending, // for AggKind::Max
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,
@@ -605,7 +608,8 @@ mod tests {
                 OrderType::Ascending, // for AggKind::Min
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
         let (mut table_2, mapping_2) = create_mem_state_table(
             &input_schema,
             vec![1, 3],
@@ -613,7 +617,8 @@ mod tests {
                 OrderType::Descending, // for AggKind::Max
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
 
         let epoch = EpochPair::new_test_epoch(1);
         table_1.init_epoch(epoch);
@@ -715,7 +720,8 @@ mod tests {
                 OrderType::Descending, // b DESC for AggKind::Max
                 OrderType::Ascending,  // _row_id ASC
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,
@@ -826,7 +832,8 @@ mod tests {
                 OrderType::Ascending, // for AggKind::Min
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
 
         let epoch = EpochPair::new_test_epoch(1);
         table.init_epoch(epoch);
@@ -940,7 +947,8 @@ mod tests {
                 OrderType::Ascending, // for AggKind::Min
                 OrderType::Ascending,
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,
@@ -1073,7 +1081,8 @@ mod tests {
                 OrderType::Descending, // a DESC
                 OrderType::Ascending,  // b ASC
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,
@@ -1174,7 +1183,8 @@ mod tests {
                 OrderType::Descending, // a DESC
                 OrderType::Ascending,  // _row_id ASC
             ],
-        );
+        )
+        .await;
 
         let mut state = MaterializedInputState::new(
             &agg_call,

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -431,7 +431,8 @@ mod tests {
             agg_calls,
             vec![2],
             1,
-        );
+        )
+        .await;
         let mut simple_agg = simple_agg.execute();
 
         // Consume the init barrier

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -959,7 +959,7 @@ mod tests {
     use crate::executor::test_utils::{MessageSender, MockSource};
     use crate::executor::{ActorContext, Barrier, EpochPair, Message};
 
-    fn create_in_memory_state_table(
+    async fn create_in_memory_state_table(
         mem_state: MemoryStateStore,
         data_types: &[DataType],
         order_types: &[OrderType],
@@ -977,7 +977,8 @@ mod tests {
             column_descs,
             order_types.to_vec(),
             pk_indices.to_vec(),
-        );
+        )
+        .await;
 
         // Create degree table
         let mut degree_table_column_descs = vec![];
@@ -997,7 +998,8 @@ mod tests {
             degree_table_column_descs,
             order_types.to_vec(),
             pk_indices.to_vec(),
-        );
+        )
+        .await;
         (state_table, degree_state_table)
     }
 
@@ -1013,7 +1015,7 @@ mod tests {
         .unwrap()
     }
 
-    fn create_executor<const T: JoinTypePrimitive>(
+    async fn create_executor<const T: JoinTypePrimitive>(
         with_condition: bool,
         null_safe: bool,
     ) -> (MessageSender, MessageSender, BoxedMessageStream) {
@@ -1037,7 +1039,8 @@ mod tests {
             &[OrderType::Ascending, OrderType::Ascending],
             &[0, 1],
             0,
-        );
+        )
+        .await;
 
         let (state_r, degree_state_r) = create_in_memory_state_table(
             mem_state,
@@ -1045,7 +1048,8 @@ mod tests {
             &[OrderType::Ascending, OrderType::Ascending],
             &[0, 1],
             2,
-        );
+        )
+        .await;
         let schema_len = match T {
             JoinType::LeftSemi | JoinType::LeftAnti => source_l.schema().len(),
             JoinType::RightSemi | JoinType::RightAnti => source_r.schema().len(),
@@ -1076,7 +1080,7 @@ mod tests {
         (tx_l, tx_r, Box::new(executor).execute())
     }
 
-    fn create_append_only_executor<const T: JoinTypePrimitive>(
+    async fn create_append_only_executor<const T: JoinTypePrimitive>(
         with_condition: bool,
     ) -> (MessageSender, MessageSender, BoxedMessageStream) {
         let schema = Schema {
@@ -1104,7 +1108,8 @@ mod tests {
             ],
             &[0, 1, 0],
             0,
-        );
+        )
+        .await;
 
         let (state_r, degree_state_r) = create_in_memory_state_table(
             mem_state,
@@ -1116,7 +1121,8 @@ mod tests {
             ],
             &[0, 1, 1],
             0,
-        );
+        )
+        .await;
         let schema_len = match T {
             JoinType::LeftSemi | JoinType::LeftAnti => source_l.schema().len(),
             JoinType::RightSemi | JoinType::RightAnti => source_r.schema().len(),
@@ -1172,7 +1178,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::Inner }>(false, false);
+            create_executor::<{ JoinType::Inner }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1248,7 +1254,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::Inner }>(false, true);
+            create_executor::<{ JoinType::Inner }>(false, true).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1336,7 +1342,7 @@ mod tests {
              - 6 9",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::LeftSemi }>(false, false);
+            create_executor::<{ JoinType::LeftSemi }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1447,7 +1453,7 @@ mod tests {
              - 6 9",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::LeftSemi }>(false, true);
+            create_executor::<{ JoinType::LeftSemi }>(false, true).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1547,7 +1553,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_append_only_executor::<{ JoinType::Inner }>(false);
+            create_append_only_executor::<{ JoinType::Inner }>(false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1626,7 +1632,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_append_only_executor::<{ JoinType::LeftSemi }>(false);
+            create_append_only_executor::<{ JoinType::LeftSemi }>(false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1705,7 +1711,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_append_only_executor::<{ JoinType::RightSemi }>(false);
+            create_append_only_executor::<{ JoinType::RightSemi }>(false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1795,7 +1801,7 @@ mod tests {
              - 6 9",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::RightSemi }>(false, false);
+            create_executor::<{ JoinType::RightSemi }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -1908,7 +1914,7 @@ mod tests {
              - 1 3",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::LeftAnti }>(false, false);
+            create_executor::<{ JoinType::LeftAnti }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2037,7 +2043,7 @@ mod tests {
              - 1 3",
         );
         let (mut tx_r, mut tx_l, mut hash_join) =
-            create_executor::<{ JoinType::LeftAnti }>(false, false);
+            create_executor::<{ JoinType::LeftAnti }>(false, false).await;
 
         // push the init barrier for left and right
         tx_r.push_barrier(1, false);
@@ -2152,7 +2158,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::Inner }>(false, false);
+            create_executor::<{ JoinType::Inner }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2249,7 +2255,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::Inner }>(false, false);
+            create_executor::<{ JoinType::Inner }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2346,7 +2352,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::LeftOuter }>(false, false);
+            create_executor::<{ JoinType::LeftOuter }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2428,7 +2434,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::LeftOuter }>(false, true);
+            create_executor::<{ JoinType::LeftOuter }>(false, true).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2510,7 +2516,7 @@ mod tests {
              - 5 10",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::RightOuter }>(false, false);
+            create_executor::<{ JoinType::RightOuter }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2585,7 +2591,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_append_only_executor::<{ JoinType::LeftOuter }>(false);
+            create_append_only_executor::<{ JoinType::LeftOuter }>(false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2673,7 +2679,7 @@ mod tests {
         );
 
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_append_only_executor::<{ JoinType::RightOuter }>(false);
+            create_append_only_executor::<{ JoinType::RightOuter }>(false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2748,7 +2754,7 @@ mod tests {
              - 5 10",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::FullOuter }>(false, false);
+            create_executor::<{ JoinType::FullOuter }>(false, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2835,7 +2841,7 @@ mod tests {
              + 1 2",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::FullOuter }>(true, false);
+            create_executor::<{ JoinType::FullOuter }>(true, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);
@@ -2925,7 +2931,7 @@ mod tests {
              + 6 11",
         );
         let (mut tx_l, mut tx_r, mut hash_join) =
-            create_executor::<{ JoinType::Inner }>(true, false);
+            create_executor::<{ JoinType::Inner }>(true, false).await;
 
         // push the init barrier for left and right
         tx_l.push_barrier(1, false);

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -163,7 +163,8 @@ async fn test_merger_sum_aggr() {
         ],
         vec![],
         2,
-    );
+    )
+    .await;
 
     let projection = ProjectExecutor::new(
         actor_ctx.clone(),

--- a/src/stream/src/executor/lookup/tests.rs
+++ b/src/stream/src/executor/lookup/tests.rs
@@ -77,7 +77,7 @@ fn arrangement_col_arrange_rules_join_key() -> Vec<OrderPair> {
 /// | +  | 2337  | 8    | 3       |
 /// | -  | 2333  | 6    | 3       |
 /// | b  |       |      | 3 -> 4  |
-fn create_arrangement(
+async fn create_arrangement(
     table_id: TableId,
     memory_state_store: MemoryStateStore,
 ) -> Box<dyn Executor + Send> {
@@ -122,14 +122,17 @@ fn create_arrangement(
         ],
     );
 
-    Box::new(MaterializeExecutor::for_test(
-        Box::new(source),
-        memory_state_store,
-        table_id,
-        arrangement_col_arrange_rules(),
-        column_ids,
-        1,
-    ))
+    Box::new(
+        MaterializeExecutor::for_test(
+            Box::new(source),
+            memory_state_store,
+            table_id,
+            arrangement_col_arrange_rules(),
+            column_ids,
+            1,
+        )
+        .await,
+    )
 }
 
 /// Create a test source.
@@ -202,7 +205,7 @@ fn check_chunk_eq(chunk1: &StreamChunk, chunk2: &StreamChunk) {
     assert_eq!(format!("{:?}", chunk1), format!("{:?}", chunk2));
 }
 
-fn build_state_table_helper<S: StateStore>(
+async fn build_state_table_helper<S: StateStore>(
     s: S,
     table_id: TableId,
     columns: Vec<ColumnDesc>,
@@ -216,6 +219,7 @@ fn build_state_table_helper<S: StateStore>(
         order_types.iter().map(|pair| pair.order_type).collect_vec(),
         pk_indices,
     )
+    .await
 }
 #[tokio::test]
 async fn test_lookup_this_epoch() {
@@ -223,7 +227,7 @@ async fn test_lookup_this_epoch() {
     // fails because read epoch doesn't take effect in memory state store.
     let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
-    let arrangement = create_arrangement(table_id, store.clone());
+    let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let lookup_executor = Box::new(LookupExecutor::new(LookupExecutorParams {
         arrangement,
@@ -247,7 +251,8 @@ async fn test_lookup_this_epoch() {
             arrangement_col_descs(),
             arrangement_col_arrange_rules(),
             vec![1, 0],
-        ),
+        )
+        .await,
         lru_manager: None,
         cache_size: 1 << 16,
         chunk_size: 1024,
@@ -289,7 +294,7 @@ async fn test_lookup_this_epoch() {
 async fn test_lookup_last_epoch() {
     let store = MemoryStateStore::new();
     let table_id = TableId::new(1);
-    let arrangement = create_arrangement(table_id, store.clone());
+    let arrangement = create_arrangement(table_id, store.clone()).await;
     let stream = create_source();
     let lookup_executor = Box::new(LookupExecutor::new(LookupExecutorParams {
         arrangement,
@@ -313,7 +318,8 @@ async fn test_lookup_last_epoch() {
             arrangement_col_descs(),
             arrangement_col_arrange_rules(),
             vec![1, 0],
-        ),
+        )
+        .await,
         lru_manager: None,
         cache_size: 1 << 16,
         chunk_size: 1024,

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -324,7 +324,8 @@ mod tests {
                 &[DataType::Varchar, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             tb.init_epoch(EpochPair::new_test_epoch(1));
             tb
         };
@@ -403,7 +404,8 @@ mod tests {
                 &[DataType::Varchar, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             tb.init_epoch(EpochPair::new_test_epoch(1));
             tb
         };

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -51,7 +51,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
     /// `vnodes`. For singleton distribution, `distribution_keys` should be empty and `vnodes`
     /// should be `None`.
     #[allow(clippy::too_many_arguments)]
-    pub fn new(
+    pub async fn new(
         input: BoxedExecutor,
         store: S,
         key: Vec<OrderPair>,
@@ -65,7 +65,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
 
         let schema = input.schema().clone();
 
-        let state_table = StateTable::from_table_catalog(table_catalog, store, vnodes);
+        let state_table = StateTable::from_table_catalog(table_catalog, store, vnodes).await;
 
         Self {
             input,
@@ -82,7 +82,7 @@ impl<S: StateStore> MaterializeExecutor<S> {
     }
 
     /// Create a new `MaterializeExecutor` without distribution info for test purpose.
-    pub fn for_test(
+    pub async fn for_test(
         input: BoxedExecutor,
         store: S,
         table_id: TableId,
@@ -105,7 +105,9 @@ impl<S: StateStore> MaterializeExecutor<S> {
             columns,
             arrange_order_types,
             arrange_columns.clone(),
-        );
+        )
+        .await;
+
         Self {
             input,
             state_table,
@@ -250,14 +252,17 @@ mod tests {
             vec![0],
         );
 
-        let mut materialize_executor = Box::new(MaterializeExecutor::for_test(
-            Box::new(source),
-            memory_state_store,
-            table_id,
-            vec![OrderPair::new(0, OrderType::Ascending)],
-            column_ids,
-            1,
-        ))
+        let mut materialize_executor = Box::new(
+            MaterializeExecutor::for_test(
+                Box::new(source),
+                memory_state_store,
+                table_id,
+                vec![OrderPair::new(0, OrderType::Ascending)],
+                column_ids,
+                1,
+            )
+            .await,
+        )
         .execute();
         materialize_executor.next().await.transpose().unwrap();
 

--- a/src/stream/src/executor/mview/test_utils.rs
+++ b/src/stream/src/executor/mview/test_utils.rs
@@ -38,7 +38,8 @@ pub async fn gen_basic_table(row_count: usize) -> StorageTable<MemoryStateStore>
         column_descs.clone(),
         order_types,
         pk_indices,
-    );
+    )
+    .await;
     let table = StorageTable::for_test(
         state_store.clone(),
         TableId::from(0x42),

--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -352,7 +352,7 @@ mod tests {
         let watermark1 = Some(ScalarImpl::Int64(3));
         let watermark2 = Some(ScalarImpl::Int64(7));
 
-        let state_table = create_state_table();
+        let state_table = create_state_table().await;
         let (mut tx, mut sort_executor) = create_executor(sort_column_index, state_table);
 
         // Init barrier
@@ -442,7 +442,7 @@ mod tests {
         );
         let watermark = Some(ScalarImpl::Int64(3));
 
-        let state_table = create_state_table();
+        let state_table = create_state_table().await;
         let (mut tx, mut sort_executor) = create_executor(sort_column_index, state_table.clone());
 
         // Init barrier
@@ -501,7 +501,7 @@ mod tests {
         vec![0]
     }
 
-    fn create_state_table() -> StateTable<MemoryStateStore> {
+    async fn create_state_table() -> StateTable<MemoryStateStore> {
         let memory_state_store = MemoryStateStore::new();
         let table_id = TableId::new(1);
         let column_descs = vec![
@@ -517,6 +517,7 @@ mod tests {
             order_types,
             pk_indices,
         )
+        .await
     }
 
     fn create_executor(

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -550,7 +550,8 @@ mod tests {
         let state_table = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             MemoryStateStore::new(),
-        );
+        )
+        .await;
         let vnodes = Bitmap::from_bytes(Bytes::from_static(&[0b11111111]));
 
         let executor = SourceExecutor::new(
@@ -652,7 +653,8 @@ mod tests {
         let state_table = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             MemoryStateStore::new(),
-        );
+        )
+        .await;
 
         let vnodes = Bitmap::from_bytes(Bytes::from_static(&[0b11111111]));
         let executor = SourceExecutor::new(
@@ -777,17 +779,18 @@ mod tests {
         let pk_indices = vec![0_usize];
         let (barrier_tx, barrier_rx) = unbounded_channel::<Barrier>();
         let vnodes = Bitmap::from_bytes(Bytes::from_static(&[0b11111111]));
-        let mut source_state_handler = SourceStateTableHandler::from_table_catalog(
+        let source_state_handler = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             mem_state_store.clone(),
-        );
+        )
+        .await;
 
         let source_exec = SourceExecutor::new(
             ActorContext::create(0),
             source_builder,
             source_table_id,
             vnodes,
-            source_state_handler.clone(),
+            source_state_handler,
             column_ids.clone(),
             schema,
             pk_indices,
@@ -808,6 +811,7 @@ mod tests {
             column_ids.clone(),
             2,
         )
+        .await
         .boxed()
         .execute();
 
@@ -868,6 +872,11 @@ mod tests {
 
         let _ = ready_chunks.next().await.unwrap(); // barrier
 
+        let mut source_state_handler = SourceStateTableHandler::from_table_catalog(
+            &default_source_internal_table(0x2333),
+            mem_state_store.clone(),
+        )
+        .await;
         // there must exist state for new add partition
         source_state_handler.init_epoch(EpochPair::new_test_epoch(2));
         source_state_handler

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -31,7 +31,6 @@ use risingwave_storage::StateStore;
 use crate::executor::error::StreamExecutorError;
 use crate::executor::StreamExecutorResult;
 
-// #[derive(Clone)]
 pub struct SourceStateTableHandler<S: StateStore> {
     pub state_store: StateTable<S>,
 }

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -31,15 +31,15 @@ use risingwave_storage::StateStore;
 use crate::executor::error::StreamExecutorError;
 use crate::executor::StreamExecutorResult;
 
-#[derive(Clone)]
+// #[derive(Clone)]
 pub struct SourceStateTableHandler<S: StateStore> {
     pub state_store: StateTable<S>,
 }
 
 impl<S: StateStore> SourceStateTableHandler<S> {
-    pub fn from_table_catalog(table_catalog: &ProstTable, store: S) -> Self {
+    pub async fn from_table_catalog(table_catalog: &ProstTable, store: S) -> Self {
         Self {
-            state_store: StateTable::from_table_catalog(table_catalog, store, None),
+            state_store: StateTable::from_table_catalog(table_catalog, store, None).await,
         }
     }
 
@@ -164,7 +164,8 @@ pub(crate) mod tests {
     async fn test_from_table_catalog() {
         let store = MemoryStateStore::new();
         let mut state_table =
-            StateTable::from_table_catalog(&default_source_internal_table(0x2333), store, None);
+            StateTable::from_table_catalog(&default_source_internal_table(0x2333), store, None)
+                .await;
         let a: Arc<str> = String::from("a").into();
         let a: Datum = Some(ScalarImpl::Utf8(a.as_ref().into()));
         let b: Arc<str> = String::from("b").into();
@@ -189,7 +190,8 @@ pub(crate) mod tests {
         let mut state_table_handler = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             store,
-        );
+        )
+        .await;
         let split_impl = SplitImpl::Kafka(KafkaSplit::new(0, Some(0), None, "test".into()));
         let serialized = split_impl.encode_to_bytes();
 

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -392,7 +392,8 @@ mod tests {
                 OrderType::Ascending,
             ],
             &[1, 2, 0],
-        );
+        )
+        .await;
         let top_n_executor = Box::new(
             GroupTopNExecutor::new_without_ties(
                 source as Box<dyn Executor>,
@@ -489,7 +490,8 @@ mod tests {
                 OrderType::Ascending,
             ],
             &[1, 2, 0],
-        );
+        )
+        .await;
         let top_n_executor = Box::new(
             GroupTopNExecutor::new_without_ties(
                 source as Box<dyn Executor>,
@@ -578,7 +580,8 @@ mod tests {
                 OrderType::Ascending,
             ],
             &[1, 2, 0],
-        );
+        )
+        .await;
         let top_n_executor = Box::new(
             GroupTopNExecutor::new_without_ties(
                 source as Box<dyn Executor>,

--- a/src/stream/src/executor/top_n/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/top_n_appendonly.rs
@@ -332,7 +332,8 @@ mod tests {
             &[DataType::Int64, DataType::Int64],
             &[OrderType::Ascending, OrderType::Ascending],
             &[0, 1],
-        );
+        )
+        .await;
 
         let top_n_executor = Box::new(
             AppendOnlyTopNExecutor::new(
@@ -415,7 +416,8 @@ mod tests {
             &[DataType::Int64, DataType::Int64],
             &[OrderType::Ascending, OrderType::Ascending],
             &[0, 1],
-        );
+        )
+        .await;
 
         let top_n_executor = Box::new(
             AppendOnlyTopNExecutor::new(

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -383,7 +383,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_without_ties(
                     source as Box<dyn Executor>,
@@ -480,7 +481,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_without_ties(
                     source as Box<dyn Executor>,
@@ -589,7 +591,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_with_ties(
                     source as Box<dyn Executor>,
@@ -697,7 +700,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_without_ties(
                     source as Box<dyn Executor>,
@@ -910,7 +914,8 @@ mod tests {
                 ],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 3],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_without_ties(
                     source as Box<dyn Executor>,
@@ -990,7 +995,8 @@ mod tests {
                 ],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 3],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_without_ties(
                     create_source_new_before_recovery() as Box<dyn Executor>,
@@ -1147,7 +1153,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_with_ties_for_test(
                     source as Box<dyn Executor>,
@@ -1296,7 +1303,8 @@ mod tests {
                 &[DataType::Int64, DataType::Int64],
                 &[OrderType::Ascending, OrderType::Ascending],
                 &[0, 1],
-            );
+            )
+            .await;
             let top_n_executor = Box::new(
                 TopNExecutor::new_with_ties_for_test(
                     create_source_before_recovery() as Box<dyn Executor>,

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -289,7 +289,7 @@ mod tests {
 
     const WATERMARK_TYPE: DataType = DataType::Timestamp;
 
-    fn create_in_memory_state_table(
+    async fn create_in_memory_state_table(
         mem_state: MemoryStateStore,
         data_types: &[DataType],
         order_types: &[OrderType],
@@ -311,9 +311,10 @@ mod tests {
             Distribution::all_vnodes(vec![0]),
             val_indices.to_vec(),
         )
+        .await
     }
 
-    fn create_watermark_filter_executor(
+    async fn create_watermark_filter_executor(
         mem_state: MemoryStateStore,
     ) -> (BoxedExecutor, MessageSender) {
         let interval_type = DataType::Interval;
@@ -344,7 +345,8 @@ mod tests {
             &[0],
             &[1],
             0,
-        );
+        )
+        .await;
 
         let (tx, source) = MockSource::channel(schema, vec![0]);
 
@@ -384,7 +386,7 @@ mod tests {
 
         let mem_state = MemoryStateStore::new();
 
-        let (executor, mut tx) = create_watermark_filter_executor(mem_state.clone());
+        let (executor, mut tx) = create_watermark_filter_executor(mem_state.clone()).await;
         let mut executor = executor.execute();
 
         // push the init barrier
@@ -455,7 +457,7 @@ mod tests {
         drop(executor);
 
         // Build new executor
-        let (executor, mut tx) = create_watermark_filter_executor(mem_state.clone());
+        let (executor, mut tx) = create_watermark_filter_executor(mem_state.clone()).await;
         let mut executor = executor.execute();
 
         // push the 1st barrier after failover

--- a/src/stream/src/from_proto/agg_common.rs
+++ b/src/stream/src/from_proto/agg_common.rs
@@ -81,23 +81,24 @@ pub fn build_agg_call_from_prost(
 
 /// Parse from stream proto plan agg call states, generate state tables and column mappings.
 /// The `vnodes` is generally `Some` for Hash Agg and `None` for Simple Agg.
-pub fn build_agg_state_storages_from_proto<S: StateStore>(
+pub async fn build_agg_state_storages_from_proto<S: StateStore>(
     agg_call_states: &[risingwave_pb::stream_plan::AggCallState],
     store: S,
     vnodes: Option<Arc<Bitmap>>,
 ) -> Vec<AggStateStorage<S>> {
     use risingwave_pb::stream_plan::agg_call_state;
 
-    agg_call_states
-        .iter()
-        .map(|state| match state.get_inner().unwrap() {
+    let mut result = vec![];
+    for agg_call_state in agg_call_states {
+        let agg_state_store = match agg_call_state.get_inner().unwrap() {
             agg_call_state::Inner::ResultValueState(..) => AggStateStorage::ResultValue,
             agg_call_state::Inner::TableState(state) => {
                 let table = StateTable::from_table_catalog(
                     state.get_table().unwrap(),
                     store.clone(),
                     vnodes.clone(),
-                );
+                )
+                .await;
                 AggStateStorage::Table { table }
             }
             agg_call_state::Inner::MaterializedInputState(state) => {
@@ -105,7 +106,8 @@ pub fn build_agg_state_storages_from_proto<S: StateStore>(
                     state.get_table().unwrap(),
                     store.clone(),
                     vnodes.clone(),
-                );
+                )
+                .await;
                 let mapping = StateTableColumnMapping::new(
                     state
                         .get_included_upstream_indices()
@@ -122,6 +124,10 @@ pub fn build_agg_state_storages_from_proto<S: StateStore>(
                 );
                 AggStateStorage::MaterializedInput { table, mapping }
             }
-        })
-        .collect()
+        };
+
+        result.push(agg_state_store)
+    }
+
+    result
 }

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -25,8 +25,9 @@ use crate::executor::BatchQueryExecutor;
 
 pub struct BatchQueryExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for BatchQueryExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         state_store: impl StateStore,

--- a/src/stream/src/from_proto/chain.rs
+++ b/src/stream/src/from_proto/chain.rs
@@ -17,8 +17,9 @@ use crate::executor::{ChainExecutor, RearrangedChainExecutor};
 
 pub struct ChainExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for ChainExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/dynamic_filter.rs
+++ b/src/stream/src/from_proto/dynamic_filter.rs
@@ -22,8 +22,9 @@ use crate::executor::DynamicFilterExecutor;
 
 pub struct DynamicFilterExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for DynamicFilterExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -58,9 +59,11 @@ impl ExecutorBuilder for DynamicFilterExecutorBuilder {
             node.get_left_table()?,
             store.clone(),
             Some(vnodes.clone()),
-        );
+        )
+        .await;
 
-        let state_table_r = StateTable::from_table_catalog(node.get_right_table()?, store, None);
+        let state_table_r =
+            StateTable::from_table_catalog(node.get_right_table()?, store, None).await;
 
         Ok(Box::new(DynamicFilterExecutor::new(
             params.actor_context,

--- a/src/stream/src/from_proto/expand.rs
+++ b/src/stream/src/from_proto/expand.rs
@@ -17,8 +17,9 @@ use crate::executor::ExpandExecutor;
 
 pub struct ExpandExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for ExpandExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/filter.rs
+++ b/src/stream/src/from_proto/filter.rs
@@ -19,8 +19,9 @@ use crate::executor::FilterExecutor;
 
 pub struct FilterExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for FilterExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -23,8 +23,9 @@ use crate::executor::GlobalSimpleAggExecutor;
 
 pub struct GlobalSimpleAggExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -38,9 +39,10 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
             .map(|agg_call| build_agg_call_from_prost(node.is_append_only, agg_call))
             .try_collect()?;
         let storages =
-            build_agg_state_storages_from_proto(node.get_agg_call_states(), store.clone(), None);
+            build_agg_state_storages_from_proto(node.get_agg_call_states(), store.clone(), None)
+                .await;
         let result_table =
-            StateTable::from_table_catalog(node.get_result_table().unwrap(), store, None);
+            StateTable::from_table_catalog(node.get_result_table().unwrap(), store, None).await;
 
         Ok(GlobalSimpleAggExecutor::new(
             params.actor_context,

--- a/src/stream/src/from_proto/group_top_n.rs
+++ b/src/stream/src/from_proto/group_top_n.rs
@@ -22,8 +22,9 @@ use crate::executor::GroupTopNExecutor;
 
 pub struct GroupTopNExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for GroupTopNExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         mut params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -37,7 +38,7 @@ impl ExecutorBuilder for GroupTopNExecutorBuilder {
             .collect();
         let table = node.get_table()?;
         let vnodes = params.vnode_bitmap.map(Arc::new);
-        let state_table = StateTable::from_table_catalog(table, store, vnodes);
+        let state_table = StateTable::from_table_catalog(table, store, vnodes).await;
         let order_pairs = table.get_pk().iter().map(OrderPair::from_prost).collect();
 
         if node.with_ties {

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -73,8 +73,9 @@ impl<S: StateStore> HashKeyDispatcher for HashAggExecutorDispatcherArgs<S> {
 
 pub struct HashAggExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for HashAggExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -105,9 +106,11 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
             node.get_agg_call_states(),
             store.clone(),
             vnodes.clone(),
-        );
+        )
+        .await;
+
         let result_table =
-            StateTable::from_table_catalog(node.get_result_table().unwrap(), store, vnodes);
+            StateTable::from_table_catalog(node.get_result_table().unwrap(), store, vnodes).await;
 
         let args = HashAggExecutorDispatcherArgs {
             ctx: params.actor_context,

--- a/src/stream/src/from_proto/hash_join.rs
+++ b/src/stream/src/from_proto/hash_join.rs
@@ -28,8 +28,9 @@ use crate::executor::{ActorContextRef, PkIndices};
 
 pub struct HashJoinExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for HashJoinExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -89,14 +90,15 @@ impl ExecutorBuilder for HashJoinExecutorBuilder {
             .collect_vec();
 
         let state_table_l =
-            StateTable::from_table_catalog(table_l, store.clone(), Some(vnodes.clone()));
+            StateTable::from_table_catalog(table_l, store.clone(), Some(vnodes.clone())).await;
         let degree_state_table_l =
-            StateTable::from_table_catalog(degree_table_l, store.clone(), Some(vnodes.clone()));
+            StateTable::from_table_catalog(degree_table_l, store.clone(), Some(vnodes.clone()))
+                .await;
 
         let state_table_r =
-            StateTable::from_table_catalog(table_r, store.clone(), Some(vnodes.clone()));
+            StateTable::from_table_catalog(table_r, store.clone(), Some(vnodes.clone())).await;
         let degree_state_table_r =
-            StateTable::from_table_catalog(degree_table_r, store, Some(vnodes));
+            StateTable::from_table_catalog(degree_table_r, store, Some(vnodes)).await;
 
         let args = HashJoinExecutorDispatcherArgs {
             ctx: params.actor_context,

--- a/src/stream/src/from_proto/hop_window.rs
+++ b/src/stream/src/from_proto/hop_window.rs
@@ -21,8 +21,9 @@ use crate::executor::HopWindowExecutor;
 
 pub struct HopWindowExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for HopWindowExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/local_simple_agg.rs
+++ b/src/stream/src/from_proto/local_simple_agg.rs
@@ -19,8 +19,9 @@ use crate::executor::LocalSimpleAggExecutor;
 
 pub struct LocalSimpleAggExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for LocalSimpleAggExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/lookup.rs
+++ b/src/stream/src/from_proto/lookup.rs
@@ -23,8 +23,9 @@ use crate::executor::{LookupExecutor, LookupExecutorParams};
 
 pub struct LookupExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for LookupExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -51,7 +52,8 @@ impl ExecutorBuilder for LookupExecutorBuilder {
             lookup.arrangement_table.as_ref().unwrap(),
             store,
             params.vnode_bitmap.map(Arc::new),
-        );
+        )
+        .await;
 
         Ok(Box::new(LookupExecutor::new(LookupExecutorParams {
             schema: Schema::new(node.fields.iter().map(Field::from).collect()),

--- a/src/stream/src/from_proto/lookup_union.rs
+++ b/src/stream/src/from_proto/lookup_union.rs
@@ -17,8 +17,9 @@ use crate::executor::LookupUnionExecutor;
 
 pub struct LookupUnionExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for LookupUnionExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/merge.rs
+++ b/src/stream/src/from_proto/merge.rs
@@ -21,8 +21,9 @@ use crate::executor::{MergeExecutor, ReceiverExecutor};
 
 pub struct MergeExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for MergeExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         x_node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -75,9 +75,10 @@ use crate::error::StreamResult;
 use crate::executor::{BoxedExecutor, Executor, ExecutorInfo};
 use crate::task::{ExecutorParams, LocalStreamManagerCore};
 
+#[async_trait::async_trait]
 trait ExecutorBuilder {
     /// Create a [`BoxedExecutor`] from [`StreamNode`].
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -90,7 +91,7 @@ macro_rules! build_executor {
         match $node.get_node_body().unwrap() {
             $(
                 $proto_type_name(..) => {
-                    <$data_type>::new_boxed_executor($source, $node, $store, $stream)
+                    <$data_type>::new_boxed_executor($source, $node, $store, $stream).await
                 },
             )*
             NodeBody::Exchange(_) | NodeBody::DeltaIndexJoin(_) => unreachable!()
@@ -99,7 +100,7 @@ macro_rules! build_executor {
 }
 
 /// Create an executor from protobuf [`StreamNode`].
-pub fn create_executor(
+pub async fn create_executor(
     params: ExecutorParams,
     stream: &mut LocalStreamManagerCore,
     node: &StreamNode,

--- a/src/stream/src/from_proto/mview.rs
+++ b/src/stream/src/from_proto/mview.rs
@@ -21,8 +21,9 @@ use crate::executor::MaterializeExecutor;
 
 pub struct MaterializeExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for MaterializeExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -48,7 +49,8 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
             params.vnode_bitmap.map(Arc::new),
             table,
             do_sanity_check,
-        );
+        )
+        .await;
 
         Ok(executor.boxed())
     }
@@ -56,8 +58,9 @@ impl ExecutorBuilder for MaterializeExecutorBuilder {
 
 pub struct ArrangeExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for ArrangeExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -88,7 +91,8 @@ impl ExecutorBuilder for ArrangeExecutorBuilder {
             vnodes,
             table,
             ignore_on_conflict,
-        );
+        )
+        .await;
 
         Ok(executor.boxed())
     }

--- a/src/stream/src/from_proto/project.rs
+++ b/src/stream/src/from_proto/project.rs
@@ -19,8 +19,9 @@ use crate::executor::ProjectExecutor;
 
 pub struct ProjectExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for ProjectExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/project_set.rs
+++ b/src/stream/src/from_proto/project_set.rs
@@ -19,8 +19,9 @@ use crate::executor::ProjectSetExecutor;
 
 pub struct ProjectSetExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for ProjectSetExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -19,8 +19,9 @@ use crate::executor::SinkExecutor;
 
 pub struct SinkExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for SinkExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,

--- a/src/stream/src/from_proto/sort.rs
+++ b/src/stream/src/from_proto/sort.rs
@@ -21,8 +21,9 @@ use crate::executor::SortExecutor;
 
 pub struct SortExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for SortExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -32,7 +33,7 @@ impl ExecutorBuilder for SortExecutorBuilder {
         let [input]: [_; 1] = params.input.try_into().unwrap();
         let vnodes = Arc::new(params.vnode_bitmap.expect("vnodes not set for sort"));
         let state_table =
-            StateTable::from_table_catalog(node.get_state_table()?, store, Some(vnodes));
+            StateTable::from_table_catalog(node.get_state_table()?, store, Some(vnodes)).await;
         Ok(Box::new(SortExecutor::new(
             params.actor_context,
             input,

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -23,8 +23,9 @@ use crate::executor::SourceExecutor;
 
 pub struct SourceExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for SourceExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -69,7 +70,8 @@ impl ExecutorBuilder for SourceExecutorBuilder {
             .expect("vnodes not set for source executor");
 
         let state_table_handler =
-            SourceStateTableHandler::from_table_catalog(node.state_table.as_ref().unwrap(), store);
+            SourceStateTableHandler::from_table_catalog(node.state_table.as_ref().unwrap(), store)
+                .await;
 
         Ok(Box::new(SourceExecutor::new(
             params.actor_context,

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -22,8 +22,9 @@ use crate::executor::TopNExecutor;
 
 pub struct TopNExecutorNewBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for TopNExecutorNewBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -34,7 +35,7 @@ impl ExecutorBuilder for TopNExecutorNewBuilder {
 
         let table = node.get_table()?;
         let vnodes = params.vnode_bitmap.map(Arc::new);
-        let state_table = StateTable::from_table_catalog(table, store, vnodes);
+        let state_table = StateTable::from_table_catalog(table, store, vnodes).await;
         let order_pairs = table.get_pk().iter().map(OrderPair::from_prost).collect();
         if node.with_ties {
             Ok(TopNExecutor::new_with_ties(

--- a/src/stream/src/from_proto/top_n_appendonly.rs
+++ b/src/stream/src/from_proto/top_n_appendonly.rs
@@ -22,8 +22,9 @@ use crate::executor::AppendOnlyTopNExecutor;
 
 pub struct AppendOnlyTopNExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -34,7 +35,7 @@ impl ExecutorBuilder for AppendOnlyTopNExecutorBuilder {
 
         let table = node.get_table()?;
         let vnodes = params.vnode_bitmap.map(Arc::new);
-        let state_table = StateTable::from_table_catalog(table, store, vnodes);
+        let state_table = StateTable::from_table_catalog(table, store, vnodes).await;
         let order_pairs = table.get_pk().iter().map(OrderPair::from_prost).collect();
         if node.with_ties {
             unreachable!("Not supported yet. Banned in planner");

--- a/src/stream/src/from_proto/union.rs
+++ b/src/stream/src/from_proto/union.rs
@@ -17,8 +17,9 @@ use crate::executor::UnionExecutor;
 
 pub struct UnionExecutorBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for UnionExecutorBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         _store: impl StateStore,

--- a/src/stream/src/from_proto/watermark_filter.rs
+++ b/src/stream/src/from_proto/watermark_filter.rs
@@ -22,8 +22,9 @@ use crate::executor::WatermarkFilterExecutor;
 
 pub struct WatermarkFilterBuilder;
 
+#[async_trait::async_trait]
 impl ExecutorBuilder for WatermarkFilterBuilder {
-    fn new_boxed_executor(
+    async fn new_boxed_executor(
         params: ExecutorParams,
         node: &StreamNode,
         store: impl StateStore,
@@ -40,7 +41,7 @@ impl ExecutorBuilder for WatermarkFilterBuilder {
                 .expect("vnodes not set for watermark filter"),
         );
 
-        let table = StateTable::from_table_catalog(node.get_table()?, store, Some(vnodes));
+        let table = StateTable::from_table_catalog(node.get_table()?, store, Some(vnodes)).await;
 
         Ok(WatermarkFilterExecutor::new(
             input,

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -31,7 +31,6 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::StreamNode;
 use risingwave_pb::{stream_plan, stream_service};
 use risingwave_storage::{dispatch_state_store, StateStore, StateStoreImpl};
-// use parking_lot::Mutex;
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As a precondition for `StateStore` refacting, the `new_local` function is introduced for each executor's state_table to initialize the corresponding `local_state_store`.
Since `new_local` is an async function, we need to make the functions involved in the Executor async and modify the generic type of `KeySpace` to adapt to `LocalHummockStorage`

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- BoxedExecutorBuilder to `async_trait`
- Make the functions involved in the Executor async like `new_boxed_executor`
- Replace `parking_lot::Mutex` with `tokio::sync::Mutex` of `LocalStreamManager`
- Fix related unit tests
- Fix `MonitoredStateStore` new_local

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
