### PR TITLE
feat: create outdated catalog and simulate multi-frontend issues to test meta

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -171,14 +171,15 @@ service ClusterService {
   rpc ListAllNodes(ListAllNodesRequest) returns (ListAllNodesResponse);
 }
 
+// Below for notification service.
 enum SubscribeType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   HUMMOCK = 2;
   COMPACTOR = 3;
+  DELAY_FRONTEND = 4;
 }
 
-// Below for notification service.
 message SubscribeRequest {
   SubscribeType subscribe_type = 1;
   common.HostAddress host = 2;
@@ -229,8 +230,17 @@ message SubscribeResponse {
   }
 }
 
+message DelayEnableRequest {
+  bool enable = 1;
+}
+
+message DelayEnableResponse {
+  common.Status status = 1;
+}
+
 service NotificationService {
   rpc Subscribe(SubscribeRequest) returns (stream SubscribeResponse);
+  rpc DelayEnable(DelayEnableRequest) returns (DelayEnableResponse);
 }
 
 message MetaLeaderInfo {

--- a/src/common/common_service/src/observer_manager.rs
+++ b/src/common/common_service/src/observer_manager.rs
@@ -46,6 +46,13 @@ impl SubscribeTypeEnum for SubscribeCompactor {
     }
 }
 
+pub struct SubscribeDelayFrontend {}
+impl SubscribeTypeEnum for SubscribeDelayFrontend {
+    fn subscribe_type() -> SubscribeType {
+        SubscribeType::DelayFrontend
+    }
+}
+
 /// `ObserverManager` is used to update data based on notification from meta.
 /// Call `start` to spawn a new asynchronous task
 /// We can write the notification logic by implementing `ObserverNodeImpl`.

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -93,6 +93,10 @@ pub struct FrontendOpts {
     /// >0 = open metrics
     #[clap(long, default_value = "0")]
     pub metrics_level: u32,
+
+    // #[cfg(madsim)]
+    #[clap(long, default_value = "false")]
+    pub delay_observer: bool,
 }
 
 impl Default for FrontendOpts {

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -95,7 +95,7 @@ pub struct FrontendOpts {
     pub metrics_level: u32,
 
     // #[cfg(madsim)]
-    #[clap(long, default_value = "false")]
+    #[clap(long, action)]
     pub delay_observer: bool,
 }
 

--- a/src/frontend/src/observer/mod.rs
+++ b/src/frontend/src/observer/mod.rs
@@ -13,4 +13,4 @@
 // limitations under the License.
 
 mod observer_manager;
-pub use observer_manager::FrontendObserverNode;
+pub use observer_manager::{FrontendDelayObserverNode, FrontendObserverNode};

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -18,7 +18,9 @@ use parking_lot::RwLock;
 use risingwave_common::catalog::CatalogVersion;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::util::compress::decompress_data;
-use risingwave_common_service::observer_manager::{ObserverState, SubscribeFrontend};
+use risingwave_common_service::observer_manager::{
+    ObserverState, SubscribeDelayFrontend, SubscribeFrontend,
+};
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::SubscribeResponse;
@@ -314,5 +316,25 @@ impl FrontendObserverNode {
             Operation::Delete => self.worker_node_manager.remove_worker_node(node),
             _ => (),
         }
+    }
+}
+
+pub struct FrontendDelayObserverNode(FrontendObserverNode);
+
+impl FrontendDelayObserverNode {
+    pub fn new(node: FrontendObserverNode) -> Self {
+        Self(node)
+    }
+}
+
+impl ObserverState for FrontendDelayObserverNode {
+    type SubscribeType = SubscribeDelayFrontend;
+
+    fn handle_notification(&mut self, resp: SubscribeResponse) {
+        self.0.handle_notification(resp)
+    }
+
+    fn handle_initialization_notification(&mut self, resp: SubscribeResponse) -> Result<()> {
+        self.0.handle_initialization_notification(resp)
     }
 }

--- a/src/meta/src/rpc/service/notification_service.rs
+++ b/src/meta/src/rpc/service/notification_service.rs
@@ -20,7 +20,10 @@ use risingwave_pb::common::worker_node::State::Running;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::notification_service_server::NotificationService;
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
-use risingwave_pb::meta::{MetaSnapshot, SubscribeRequest, SubscribeResponse, SubscribeType};
+use risingwave_pb::meta::{
+    DelayEnableRequest, DelayEnableResponse, MetaSnapshot, SubscribeRequest, SubscribeResponse,
+    SubscribeType,
+};
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 use tonic::{Request, Response, Status};
@@ -178,5 +181,17 @@ where
             .await;
 
         Ok(Response::new(UnboundedReceiverStream::new(rx)))
+    }
+
+    async fn delay_enable(
+        &self,
+        _request: Request<DelayEnableRequest>,
+    ) -> Result<Response<DelayEnableResponse>, Status> {
+        #[cfg(madsim)]
+        {
+            let enable = _request.into_inner().enable;
+            self.env.notification_manager().delay_enable(enable).await;
+        }
+        Ok(Response::new(DelayEnableResponse { status: None }))
     }
 }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -607,6 +607,13 @@ impl MetaClient {
         let _resp = self.inner.rise_ctl_update_compaction_config(req).await?;
         Ok(())
     }
+
+    // Used in e2e tests
+    pub async fn delay_enable(&self, enable: bool) -> Result<()> {
+        let request = DelayEnableRequest { enable };
+        self.inner.delay_enable(request).await?;
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -899,6 +906,7 @@ macro_rules! for_all_meta_rpc {
             ,{ scale_client, get_cluster_info, GetClusterInfoRequest, GetClusterInfoResponse }
             ,{ scale_client, reschedule, RescheduleRequest, RescheduleResponse }
             ,{ notification_client, subscribe, SubscribeRequest, Streaming<SubscribeResponse> }
+            ,{ notification_client, delay_enable, DelayEnableRequest, DelayEnableResponse }
         }
     };
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Over the past few weeks, we have found and fixed some multi-frontend issues. The reason for these issues is that the meta depends on frontend to check some information. If there are only checking procedures in the frontend but there is no checking procedure in meta, we may be able to construct some cases to make meta's catalog wrong.  #6054 shows some cases. We would like to construct some unit tests or e2e tests that cover these cases to test meta. However, it's hard for us to actually run two frontend nodes and make multiple frontend issues. And there is no way to bypass frontend's checking now.

In #5895, @st1page proposed a solution to bypass frontend's checking. We can add a switch in the frontend to control whether frontends' checking procedures are enable. But disabling some checking will prevent ddl statements. For example, `create index xxx on yyy` needs to get the table catalog of `yyy`, which means that we must check whether `yyy` exists in the frontend. So we don't have the ability to test whether creating index on a table deleted by other frontend will fail.

Before considering this draft's solution, we considered another solution that was not recorded in an issue. We can serialize and deserialize the RPC requests. We can prepare a RPC request's serialized text(it may be a json or some other formats) by serializing a legal request, change it's text to deserialize an illegal request like creating index on a table that does not exist. But, how to modify the serialized text is another difficult question. The serialized texts of whether the index catalog itself or the fragment graph in the RPC are both so complicated that it is inconvenient for manual modification.

Then we considered the solution in this draft and are constructing a simple demo test. 

**In this draft, I give meta's notification manager the ability to delay sending notifications to some clients.** I add a new subscription type `SubscribeType::DELAY_FRONTEND` to notifcation_manager. Every notification sent to frontend will also be sent to delay frontends by default. But we can send a RPC request `DelayEnableRequest` to stop or restart sending. Notifications during this period will be sent to delay frontends when restarting sending. I plan to construct a grpc client in risingwave_simulation to call this RPC.

With this ability, we can manually construct outdated catalogs for some frontends. We can use simulation test to connect to multiple frontends at the same time and read specially designed test cases which simulates a multi-frontend conflict. And every PR must make sure that these tests run successfully.

The related test demo is being written. We have a small issue(maybe?). If we use sqllogictest to run the test cases. We can only know whether a sql gets error message. We have no idea to know that whether the error is thrown by frontends or by meta. We expect this error to be thrown by meta, but if code in this draft has some bugs and `DelayEnableRequest` has not prevented meta to sending notification to `DELAY_FRONTEND`, then frontend's checking will be activated and throw errors. This false negative situation can interfere with our testing. If we can make sure that the error is thrown by meta, we will know that our testing framework is working.

If anyone has any related ideas, please let me know. If we think this idea is feasible, I will complete the demo and push it to this draft. I will mark this pull request as a draft until we think this demo test case is complete.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
relate #5895 