### PR TITLE
feat(compactor): support set config at runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5014,6 +5014,7 @@ dependencies = [
 name = "risingwave_compactor"
 version = "0.2.0-alpha"
 dependencies = [
+ "async-trait",
  "clap 3.2.17",
  "madsim-tokio",
  "madsim-tonic",

--- a/dashboard/proto/gen/compactor.ts
+++ b/dashboard/proto/gen/compactor.ts
@@ -1,0 +1,100 @@
+/* eslint-disable */
+
+export const protobufPackage = "compactor";
+
+export interface CompactorRuntimeConfig {
+  maxConcurrentTaskNumber: number;
+}
+
+export interface SetRuntimeConfigRequest {
+  config: CompactorRuntimeConfig | undefined;
+}
+
+export interface SetRuntimeConfigResponse {
+}
+
+function createBaseCompactorRuntimeConfig(): CompactorRuntimeConfig {
+  return { maxConcurrentTaskNumber: 0 };
+}
+
+export const CompactorRuntimeConfig = {
+  fromJSON(object: any): CompactorRuntimeConfig {
+    return {
+      maxConcurrentTaskNumber: isSet(object.maxConcurrentTaskNumber) ? Number(object.maxConcurrentTaskNumber) : 0,
+    };
+  },
+
+  toJSON(message: CompactorRuntimeConfig): unknown {
+    const obj: any = {};
+    message.maxConcurrentTaskNumber !== undefined &&
+      (obj.maxConcurrentTaskNumber = Math.round(message.maxConcurrentTaskNumber));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CompactorRuntimeConfig>, I>>(object: I): CompactorRuntimeConfig {
+    const message = createBaseCompactorRuntimeConfig();
+    message.maxConcurrentTaskNumber = object.maxConcurrentTaskNumber ?? 0;
+    return message;
+  },
+};
+
+function createBaseSetRuntimeConfigRequest(): SetRuntimeConfigRequest {
+  return { config: undefined };
+}
+
+export const SetRuntimeConfigRequest = {
+  fromJSON(object: any): SetRuntimeConfigRequest {
+    return { config: isSet(object.config) ? CompactorRuntimeConfig.fromJSON(object.config) : undefined };
+  },
+
+  toJSON(message: SetRuntimeConfigRequest): unknown {
+    const obj: any = {};
+    message.config !== undefined &&
+      (obj.config = message.config ? CompactorRuntimeConfig.toJSON(message.config) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SetRuntimeConfigRequest>, I>>(object: I): SetRuntimeConfigRequest {
+    const message = createBaseSetRuntimeConfigRequest();
+    message.config = (object.config !== undefined && object.config !== null)
+      ? CompactorRuntimeConfig.fromPartial(object.config)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSetRuntimeConfigResponse(): SetRuntimeConfigResponse {
+  return {};
+}
+
+export const SetRuntimeConfigResponse = {
+  fromJSON(_: any): SetRuntimeConfigResponse {
+    return {};
+  },
+
+  toJSON(_: SetRuntimeConfigResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SetRuntimeConfigResponse>, I>>(_: I): SetRuntimeConfigResponse {
+    const message = createBaseSetRuntimeConfigResponse();
+    return message;
+  },
+};
+
+type Builtin = Date | Function | Uint8Array | string | number | boolean | undefined;
+
+export type DeepPartial<T> = T extends Builtin ? T
+  : T extends Array<infer U> ? Array<DeepPartial<U>> : T extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>>
+  : T extends { $case: string } ? { [K in keyof Omit<T, "$case">]?: DeepPartial<T[K]> } & { $case: T["$case"] }
+  : T extends {} ? { [K in keyof T]?: DeepPartial<T[K]> }
+  : Partial<T>;
+
+type KeysOfUnion<T> = T extends T ? keyof T : never;
+export type Exact<P, I extends P> = P extends Builtin ? P
+  : P & { [K in keyof P]: Exact<P[K], I[K]> } & { [K in Exclude<keyof I, KeysOfUnion<P>>]: never };
+
+function isSet(value: any): boolean {
+  return value !== null && value !== undefined;
+}

--- a/dashboard/proto/gen/hummock.ts
+++ b/dashboard/proto/gen/hummock.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 import { Table } from "./catalog";
 import { Status, WorkerNode } from "./common";
+import { CompactorRuntimeConfig } from "./compactor";
 
 export const protobufPackage = "hummock";
 
@@ -680,6 +681,14 @@ export interface RiseCtlUpdateCompactionConfigRequest_MutableConfig {
 
 export interface RiseCtlUpdateCompactionConfigResponse {
   status: Status | undefined;
+}
+
+export interface SetCompactorRuntimeConfigRequest {
+  contextId: number;
+  config: CompactorRuntimeConfig | undefined;
+}
+
+export interface SetCompactorRuntimeConfigResponse {
 }
 
 export interface CompactionConfig {
@@ -4042,6 +4051,60 @@ export const RiseCtlUpdateCompactionConfigResponse = {
     message.status = (object.status !== undefined && object.status !== null)
       ? Status.fromPartial(object.status)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseSetCompactorRuntimeConfigRequest(): SetCompactorRuntimeConfigRequest {
+  return { contextId: 0, config: undefined };
+}
+
+export const SetCompactorRuntimeConfigRequest = {
+  fromJSON(object: any): SetCompactorRuntimeConfigRequest {
+    return {
+      contextId: isSet(object.contextId) ? Number(object.contextId) : 0,
+      config: isSet(object.config) ? CompactorRuntimeConfig.fromJSON(object.config) : undefined,
+    };
+  },
+
+  toJSON(message: SetCompactorRuntimeConfigRequest): unknown {
+    const obj: any = {};
+    message.contextId !== undefined && (obj.contextId = Math.round(message.contextId));
+    message.config !== undefined &&
+      (obj.config = message.config ? CompactorRuntimeConfig.toJSON(message.config) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SetCompactorRuntimeConfigRequest>, I>>(
+    object: I,
+  ): SetCompactorRuntimeConfigRequest {
+    const message = createBaseSetCompactorRuntimeConfigRequest();
+    message.contextId = object.contextId ?? 0;
+    message.config = (object.config !== undefined && object.config !== null)
+      ? CompactorRuntimeConfig.fromPartial(object.config)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseSetCompactorRuntimeConfigResponse(): SetCompactorRuntimeConfigResponse {
+  return {};
+}
+
+export const SetCompactorRuntimeConfigResponse = {
+  fromJSON(_: any): SetCompactorRuntimeConfigResponse {
+    return {};
+  },
+
+  toJSON(_: SetCompactorRuntimeConfigResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SetCompactorRuntimeConfigResponse>, I>>(
+    _: I,
+  ): SetCompactorRuntimeConfigResponse {
+    const message = createBaseSetCompactorRuntimeConfigResponse();
     return message;
   },
 };

--- a/proto/compactor.proto
+++ b/proto/compactor.proto
@@ -1,0 +1,19 @@
+syntax = "proto3";
+
+package compactor;
+
+option optimize_for = SPEED;
+
+message CompactorRuntimeConfig {
+  uint64 max_concurrent_task_number = 1;
+}
+
+message SetRuntimeConfigRequest {
+  CompactorRuntimeConfig config = 1;
+}
+
+message SetRuntimeConfigResponse {}
+
+service CompactorService {
+  rpc SetRuntimeConfig(SetRuntimeConfigRequest) returns (SetRuntimeConfigResponse);
+}

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -4,6 +4,7 @@ package hummock;
 
 import "catalog.proto";
 import "common.proto";
+import "compactor.proto";
 
 option optimize_for = SPEED;
 
@@ -508,6 +509,13 @@ message RiseCtlUpdateCompactionConfigResponse {
   common.Status status = 1;
 }
 
+message SetCompactorRuntimeConfigRequest {
+  uint32 context_id = 1;
+  compactor.CompactorRuntimeConfig config = 2;
+}
+
+message SetCompactorRuntimeConfigResponse {}
+
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);
   rpc GetCurrentVersion(GetCurrentVersionRequest) returns (GetCurrentVersionResponse);
@@ -536,9 +544,8 @@ service HummockManagerService {
   rpc RiseCtlListCompactionGroup(RiseCtlListCompactionGroupRequest) returns (RiseCtlListCompactionGroupResponse);
   rpc RiseCtlUpdateCompactionConfig(RiseCtlUpdateCompactionConfigRequest) returns (RiseCtlUpdateCompactionConfigResponse);
   rpc InitMetadataForReplay(InitMetadataForReplayRequest) returns (InitMetadataForReplayResponse);
+  rpc SetCompactorRuntimeConfig(SetCompactorRuntimeConfigRequest) returns (SetCompactorRuntimeConfigResponse);
 }
-
-service CompactorService {}
 
 message CompactionConfig {
   enum CompactionMode {

--- a/src/meta/src/hummock/compactor_manager.rs
+++ b/src/meta/src/hummock/compactor_manager.rs
@@ -224,7 +224,9 @@ impl CompactorManager {
         context_id: HummockContextId,
         config: CompactorRuntimeConfig,
     ) {
-        self.policy.read().set_compactor_config(context_id, config);
+        if let Some(compactor) = self.policy.read().get_compactor(context_id) {
+            compactor.set_config(config);
+        }
     }
 
     pub fn get_compactor(&self, context_id: HummockContextId) -> Option<Arc<Compactor>> {

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -507,4 +507,14 @@ where
             .await?;
         Ok(Response::new(InitMetadataForReplayResponse {}))
     }
+
+    async fn set_compactor_runtime_config(
+        &self,
+        request: Request<SetCompactorRuntimeConfigRequest>,
+    ) -> Result<Response<SetCompactorRuntimeConfigResponse>, Status> {
+        let request = request.into_inner();
+        self.compactor_manager
+            .set_compactor_config(request.context_id, request.config.unwrap().into());
+        Ok(Response::new(SetCompactorRuntimeConfigResponse {}))
+    }
 }

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -31,6 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "task_service",
         "stream_plan",
         "stream_service",
+        "compactor",
         "hummock",
         "user",
         "source",

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -54,6 +54,9 @@ pub mod stream_service;
 #[cfg_attr(madsim, path = "sim/hummock.rs")]
 pub mod hummock;
 #[rustfmt::skip]
+#[cfg_attr(madsim, path = "sim/compactor.rs")]
+pub mod compactor;
+#[rustfmt::skip]
 #[cfg_attr(madsim, path = "sim/user.rs")]
 pub mod user;
 #[rustfmt::skip]
@@ -102,6 +105,9 @@ pub mod stream_service_serde;
 #[rustfmt::skip]
 #[path = "hummock.serde.rs"]
 pub mod hummock_serde;
+#[rustfmt::skip]
+#[path = "compactor.serde.rs"]
+pub mod compactor_serde;
 #[rustfmt::skip]
 #[path = "user.serde.rs"]
 pub mod user_serde;

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -20,6 +20,7 @@ use async_trait::async_trait;
 use risingwave_common::catalog::{CatalogVersion, IndexId, TableId};
 use risingwave_common::config::MAX_CONNECTION_WINDOW_SIZE;
 use risingwave_common::util::addr::HostAddr;
+use risingwave_hummock_sdk::compact::CompactorRuntimeConfig;
 use risingwave_hummock_sdk::{
     CompactionGroupId, HummockEpoch, HummockSstableId, HummockVersionId, LocalSstableInfo,
     SstIdRange,
@@ -514,6 +515,15 @@ impl MetaClient {
         Ok(())
     }
 
+    pub async fn set_compactor_runtime_config(&self, config: CompactorRuntimeConfig) -> Result<()> {
+        let req = SetCompactorRuntimeConfigRequest {
+            context_id: self.worker_id,
+            config: Some(config.into()),
+        };
+        let _resp = self.inner.set_compactor_runtime_config(req).await?;
+        Ok(())
+    }
+
     pub async fn replay_version_delta(
         &self,
         version_delta: HummockVersionDelta,
@@ -889,6 +899,7 @@ macro_rules! for_all_meta_rpc {
             ,{ hummock_client, rise_ctl_list_compaction_group, RiseCtlListCompactionGroupRequest, RiseCtlListCompactionGroupResponse }
             ,{ hummock_client, rise_ctl_update_compaction_config, RiseCtlUpdateCompactionConfigRequest, RiseCtlUpdateCompactionConfigResponse }
             ,{ hummock_client, init_metadata_for_replay, InitMetadataForReplayRequest, InitMetadataForReplayResponse }
+            ,{ hummock_client, set_compactor_runtime_config, SetCompactorRuntimeConfigRequest, SetCompactorRuntimeConfigResponse }
             ,{ user_client, create_user, CreateUserRequest, CreateUserResponse }
             ,{ user_client, update_user, UpdateUserRequest, UpdateUserResponse }
             ,{ user_client, drop_user, DropUserRequest, DropUserResponse }

--- a/src/storage/compactor/Cargo.toml
+++ b/src/storage/compactor/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+async-trait = "0.1"
 clap = { version = "3", features = ["derive"] }
 parking_lot = "0.12"
 prometheus = { version = "0.13" }

--- a/src/storage/compactor/src/rpc.rs
+++ b/src/storage/compactor/src/rpc.rs
@@ -12,8 +12,47 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_pb::hummock::compactor_service_server::CompactorService;
+use std::sync::Arc;
 
-pub struct CompactorServiceImpl {}
+use risingwave_common::error::RwError;
+use risingwave_hummock_sdk::compact::CompactorRuntimeConfig;
+use risingwave_pb::compactor::compactor_service_server::CompactorService;
+use risingwave_pb::compactor::{SetRuntimeConfigRequest, SetRuntimeConfigResponse};
+use risingwave_rpc_client::MetaClient;
+use risingwave_storage::hummock::compactor::CompactorContext;
+use tonic::{Request, Response, Status};
 
-impl CompactorService for CompactorServiceImpl {}
+pub struct CompactorServiceImpl {
+    context: Arc<CompactorContext>,
+    meta_client: MetaClient,
+}
+
+impl CompactorServiceImpl {
+    pub fn new(context: Arc<CompactorContext>, meta_client: MetaClient) -> Self {
+        Self {
+            context,
+            meta_client,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl CompactorService for CompactorServiceImpl {
+    async fn set_runtime_config(
+        &self,
+        request: Request<SetRuntimeConfigRequest>,
+    ) -> Result<Response<SetRuntimeConfigResponse>, Status> {
+        // The lock ensures config is synchronized in compactor and meta. Otherwise this may happen:
+        // 1. set_compactor_runtime_config succeeds with new config.
+        // 2. subscribe_compact_tasks succeeds with old config.
+        // 3. Local config is set with new config. But the one in meta is stale.
+        let mut local_config = self.context.lock_config().await;
+        let new_config = CompactorRuntimeConfig::from(request.into_inner().config.unwrap());
+        self.meta_client
+            .set_compactor_runtime_config(new_config.clone())
+            .await
+            .map_err(RwError::from)?;
+        *local_config = new_config;
+        Ok(Response::new(SetRuntimeConfigResponse {}))
+    }
+}

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -21,10 +21,11 @@ use risingwave_common::monitor::process_linux::monitor_process;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common_service::metrics_manager::MetricsManager;
 use risingwave_common_service::observer_manager::ObserverManager;
+use risingwave_hummock_sdk::compact::CompactorRuntimeConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_object_store::object::parse_remote_object_store;
 use risingwave_pb::common::WorkerType;
-use risingwave_pb::hummock::compactor_service_server::CompactorServiceServer;
+use risingwave_pb::compactor::compactor_service_server::CompactorServiceServer;
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::compactor::{CompactionExecutor, CompactorContext, Context};
 use risingwave_storage::hummock::hummock_meta_client::MonitoredHummockMetaClient;
@@ -129,10 +130,13 @@ pub async fn compactor_serve(
         sstable_id_manager: sstable_id_manager.clone(),
         task_progress_manager: Default::default(),
     });
-    let compactor_context = Arc::new(CompactorContext {
+    let compactor_context = Arc::new(CompactorContext::with_config(
         context,
-        sstable_store: compact_sstable_store,
-    });
+        compact_sstable_store,
+        CompactorRuntimeConfig {
+            max_concurrent_task_number: opts.max_concurrent_task_number,
+        },
+    ));
     let sub_tasks = vec![
         MetaClient::start_heartbeat_loop(
             meta_client.clone(),
@@ -140,16 +144,18 @@ pub async fn compactor_serve(
             vec![sstable_id_manager],
         ),
         risingwave_storage::hummock::compactor::Compactor::start_compactor(
-            compactor_context,
+            compactor_context.clone(),
             hummock_meta_client,
-            opts.max_concurrent_task_number,
         ),
     ];
 
     let (shutdown_send, mut shutdown_recv) = tokio::sync::oneshot::channel();
     let join_handle = tokio::spawn(async move {
         tonic::transport::Server::builder()
-            .add_service(CompactorServiceServer::new(CompactorServiceImpl {}))
+            .add_service(CompactorServiceServer::new(CompactorServiceImpl::new(
+                compactor_context,
+                meta_client.clone(),
+            )))
             .serve_with_shutdown(listen_addr, async move {
                 tokio::select! {
                     _ = tokio::signal::ctrl_c() => {},

--- a/src/storage/hummock_sdk/src/compact.rs
+++ b/src/storage/hummock_sdk/src/compact.rs
@@ -93,3 +93,37 @@ pub fn append_sstable_info_to_string(s: &mut String, sstable_info: &SstableInfo)
         .unwrap();
     }
 }
+
+/// Config that is updatable when compactor is running.
+#[derive(Clone)]
+pub struct CompactorRuntimeConfig {
+    pub max_concurrent_task_number: u64,
+}
+
+impl From<risingwave_pb::compactor::CompactorRuntimeConfig> for CompactorRuntimeConfig {
+    fn from(value: risingwave_pb::compactor::CompactorRuntimeConfig) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&risingwave_pb::compactor::CompactorRuntimeConfig> for CompactorRuntimeConfig {
+    fn from(value: &risingwave_pb::compactor::CompactorRuntimeConfig) -> Self {
+        Self {
+            max_concurrent_task_number: value.max_concurrent_task_number,
+        }
+    }
+}
+
+impl From<CompactorRuntimeConfig> for risingwave_pb::compactor::CompactorRuntimeConfig {
+    fn from(value: CompactorRuntimeConfig) -> Self {
+        (&value).into()
+    }
+}
+
+impl From<&CompactorRuntimeConfig> for risingwave_pb::compactor::CompactorRuntimeConfig {
+    fn from(value: &CompactorRuntimeConfig) -> Self {
+        risingwave_pb::compactor::CompactorRuntimeConfig {
+            max_concurrent_task_number: value.max_concurrent_task_number,
+        }
+    }
+}

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -145,13 +145,13 @@ mod tests {
             )),
             task_progress_manager: Default::default(),
         });
-        CompactorContext {
-            sstable_store: Arc::new(CompactorSstableStore::new(
+        CompactorContext::new(
+            context.clone(),
+            Arc::new(CompactorSstableStore::new(
                 context.sstable_store.clone(),
                 context.read_memory_limiter.clone(),
             )),
-            context,
-        }
+        )
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/compactor/context.rs
+++ b/src/storage/src/hummock/compactor/context.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use risingwave_common::config::StorageConfig;
+use risingwave_hummock_sdk::compact::CompactorRuntimeConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManagerRef;
 use risingwave_rpc_client::HummockMetaClient;
 
@@ -90,4 +91,33 @@ impl Context {
 pub struct CompactorContext {
     pub context: Arc<Context>,
     pub sstable_store: CompactorSstableStoreRef,
+    config: Arc<tokio::sync::Mutex<CompactorRuntimeConfig>>,
+}
+
+impl CompactorContext {
+    pub fn new(context: Arc<Context>, sstable_store: CompactorSstableStoreRef) -> Self {
+        Self::with_config(
+            context,
+            sstable_store,
+            CompactorRuntimeConfig {
+                max_concurrent_task_number: u64::MAX,
+            },
+        )
+    }
+
+    pub fn with_config(
+        context: Arc<Context>,
+        sstable_store: CompactorSstableStoreRef,
+        config: CompactorRuntimeConfig,
+    ) -> Self {
+        Self {
+            context,
+            sstable_store,
+            config: Arc::new(tokio::sync::Mutex::new(config)),
+        }
+    }
+
+    pub async fn lock_config(&self) -> tokio::sync::MutexGuard<'_, CompactorRuntimeConfig> {
+        self.config.lock().await
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Before this PR, compactor reads config from CLI arguments, and syncs it to meta node when (re)establishing gRPC stream. The compactor config can only be updated by restarting compactor with new CLI arguments. 

After this PR, we can update compactor config at runtime. 
- Compactor exposes a RPC to accept new config. Compactor will apply new config both to local and to meta.
- Compactor's local (modified) config is lost after restart, as before.
- Compactor's local config remains the source of truth, as before.
- Meta node only stores compactor config in memory, as before.

## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
