### PR TITLE
feat: limit source ingestion by barrier and add max allowed heartbeat interval

### DIFF
--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -22,7 +22,7 @@ steps:
     if: build.source != "schedule"
     env:
       BUILDPIPE_SCOPE: project
-      PUSH_GHCR: false
+      PUSH: false
     retry: *auto-retry
 
   - label: "docker-build-push: amd64"

--- a/docker/risingwave.toml
+++ b/docker/risingwave.toml
@@ -1,5 +1,6 @@
 [server]
 heartbeat_interval_ms = 1000
+max_heartbeat_interval_secs = 600
 
 [batch]
 

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -52,6 +52,10 @@ pub struct ServerConfig {
     #[serde(default = "default::heartbeat_interval_ms")]
     pub heartbeat_interval_ms: u32,
 
+    /// The maximum allowed heartbeat interval for workers.
+    #[serde(default = "default::max_heartbeat_interval_secs")]
+    pub max_heartbeat_interval_secs: u32,
+
     #[serde(default = "default::connection_pool_size")]
     pub connection_pool_size: u16,
 }
@@ -294,6 +298,10 @@ mod default {
 
     pub fn heartbeat_interval_ms() -> u32 {
         1000
+    }
+
+    pub fn max_heartbeat_interval_secs() -> u32 {
+        600
     }
 
     pub fn connection_pool_size() -> u16 {

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -174,6 +174,7 @@ pub async fn compute_node_serve(
     sub_tasks.push(MetaClient::start_heartbeat_loop(
         meta_client.clone(),
         Duration::from_millis(config.server.heartbeat_interval_ms as u64),
+        Duration::from_secs(config.server.max_heartbeat_interval_secs as u64),
         extra_info_sources,
     ));
 

--- a/src/config/risingwave.toml
+++ b/src/config/risingwave.toml
@@ -1,5 +1,6 @@
 [server]
 heartbeat_interval_ms = 1000
+max_heartbeat_interval_secs = 600
 connection_pool_size = 16
 
 [batch]

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -88,6 +88,7 @@ risectl requires a full persistent cluster to operate. Please make sure you're n
         let (heartbeat_handle, heartbeat_shutdown_sender) = MetaClient::start_heartbeat_loop(
             meta_client.clone(),
             Duration::from_millis(1000),
+            Duration::from_secs(600),
             vec![],
         );
         self.heartbeat_handle = Some(heartbeat_handle);

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -285,6 +285,7 @@ impl FrontendEnv {
         let (heartbeat_join_handle, heartbeat_shutdown_sender) = MetaClient::start_heartbeat_loop(
             meta_client.clone(),
             Duration::from_millis(frontend_config.server.heartbeat_interval_ms as u64),
+            Duration::from_secs(frontend_config.server.max_heartbeat_interval_secs as u64),
             vec![],
         );
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -382,20 +382,29 @@ impl MetaClient {
     pub fn start_heartbeat_loop(
         meta_client: MetaClient,
         min_interval: Duration,
+        max_interval: Duration,
         extra_info_sources: Vec<ExtraInfoSourceRef>,
     ) -> (JoinHandle<()>, Sender<()>) {
+        assert!(min_interval < max_interval);
         let (shutdown_tx, mut shutdown_rx) = tokio::sync::oneshot::channel();
         let join_handle = tokio::spawn(async move {
             let mut min_interval_ticker = tokio::time::interval(min_interval);
+            let mut max_interval_ticker = tokio::time::interval(max_interval);
             loop {
                 tokio::select! {
-                    // Wait for interval
-                    _ = min_interval_ticker.tick() => {},
+                    biased;
                     // Shutdown
                     _ = &mut shutdown_rx => {
                         tracing::info!("Heartbeat loop is stopped");
                         return;
                     }
+                    // Wait for interval
+                    _ = min_interval_ticker.tick() => {},
+                    _ = max_interval_ticker.tick() => {
+                        // Client has lost connection to the server and reached time limit, it should exit.
+                        tracing::error!("Heartbeat timeout, exiting...");
+                        std::process::exit(1);
+                    },
                 }
                 let mut extra_info = Vec::with_capacity(extra_info_sources.len());
                 for extra_info_source in &extra_info_sources {
@@ -413,7 +422,9 @@ impl MetaClient {
                 )
                 .await
                 {
-                    Ok(Ok(_)) => {}
+                    Ok(Ok(_)) => {
+                        max_interval_ticker.reset();
+                    }
                     Ok(Err(err)) => {
                         tracing::warn!("Failed to send_heartbeat: error {}", err);
                     }

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -137,6 +137,7 @@ pub async fn compactor_serve(
         MetaClient::start_heartbeat_loop(
             meta_client.clone(),
             Duration::from_millis(config.server.heartbeat_interval_ms as u64),
+            Duration::from_secs(config.server.max_heartbeat_interval_secs as u64),
             vec![sstable_id_manager],
         ),
         risingwave_storage::hummock::compactor::Compactor::start_compactor(

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -29,6 +29,7 @@ use risingwave_source::row_id::RowIdGenerator;
 use risingwave_source::*;
 use risingwave_storage::StateStore;
 use tokio::sync::mpsc::UnboundedReceiver;
+use tokio::time::Instant;
 
 use super::reader::SourceReaderStream;
 use crate::error::StreamResult;
@@ -70,7 +71,6 @@ pub struct SourceExecutor<S: StateStore> {
 
     state_cache: HashMap<SplitId, SplitImpl>,
 
-    #[expect(dead_code)]
     /// Expected barrier latency
     expected_barrier_latency_ms: u64,
 }
@@ -306,7 +306,6 @@ impl<S: StateStore> SourceExecutor<S> {
             recover_state
         );
 
-        // todo: use epoch from msg to restore state from state store
         let source_chunk_reader = self
             .build_stream_source_reader(&source_desc, recover_state)
             .stack_trace("source_build_reader")
@@ -320,10 +319,20 @@ impl<S: StateStore> SourceExecutor<S> {
 
         yield Message::Barrier(barrier);
 
+        // We allow data to flow for 5 * `expected_barrier_latency_ms` milliseconds, considering
+        // some other latencies like network and cost in Meta.
+        let max_wait_barrier_time_ms = self.expected_barrier_latency_ms as u128 * 5;
+        let mut last_barrier_time = Instant::now();
+        let mut self_paused = false;
         while let Some(msg) = stream.next().await {
             match msg? {
                 // This branch will be preferred.
                 Either::Left(barrier) => {
+                    last_barrier_time = Instant::now();
+                    if self_paused {
+                        stream.resume_source();
+                        self_paused = false;
+                    }
                     let epoch = barrier.epoch;
 
                     if let Some(mutation) = barrier.mutation.as_deref() {
@@ -368,6 +377,13 @@ impl<S: StateStore> SourceExecutor<S> {
                     mut chunk,
                     split_offset_mapping,
                 }) => {
+                    if last_barrier_time.elapsed().as_millis() > max_wait_barrier_time_ms {
+                        // Exceeds the max wait barrier time, the source will be paused. Currently
+                        // we can guarantee the source is not paused since it received stream
+                        // chunks.
+                        self_paused = true;
+                        stream.pause_source();
+                    }
                     if let Some(mapping) = split_offset_mapping {
                         let state: HashMap<_, _> = mapping
                             .iter()

--- a/src/tests/compaction_test/src/runner.rs
+++ b/src/tests/compaction_test/src/runner.rs
@@ -259,8 +259,12 @@ async fn pull_version_deltas(
     tracing::info!("Assigned pull worker id {}", worker_id);
     meta_client.activate(client_addr).await.unwrap();
 
-    let (handle, shutdown_tx) =
-        MetaClient::start_heartbeat_loop(meta_client.clone(), Duration::from_millis(1000), vec![]);
+    let (handle, shutdown_tx) = MetaClient::start_heartbeat_loop(
+        meta_client.clone(),
+        Duration::from_millis(1000),
+        Duration::from_secs(600),
+        vec![],
+    );
     let res = meta_client
         .list_version_deltas(0, u32::MAX, u64::MAX)
         .await
@@ -306,6 +310,7 @@ async fn start_replay(
     let sub_tasks = vec![MetaClient::start_heartbeat_loop(
         meta_client.clone(),
         Duration::from_millis(1000),
+        Duration::from_secs(600),
         vec![],
     )];
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

As title. In this PR, I added source limit back, and other components will kill themselves when losing connection to Meta for too long. Currently the max allowed heartbeat interval is 10mins by default.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Resolve #4916 .