### PR TITLE
refactor(storage): make global state store read only

### DIFF
--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -48,7 +48,8 @@ mod tests {
     };
     use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
     use risingwave_storage::hummock::{
-        CompactorSstableStore, HummockStorage, MemoryLimiter, SstableIdManager,
+        CompactorSstableStore, HummockStorage as GlobalHummockStorage, MemoryLimiter,
+        SstableIdManager,
     };
     use risingwave_storage::monitor::{StateStoreMetrics, StoreLocalStatistic};
     use risingwave_storage::storage_value::StorageValue;
@@ -57,7 +58,10 @@ mod tests {
     };
     use risingwave_storage::Keyspace;
 
-    use crate::test_utils::{get_test_notification_client, prefixed_key};
+    use crate::test_utils::{
+        get_test_notification_client, prefixed_key, HummockV2MixedStateStore,
+        HummockV2MixedStateStore as HummockStorage,
+    };
 
     async fn get_hummock_storage(
         hummock_meta_client: Arc<dyn HummockMetaClient>,
@@ -74,14 +78,16 @@ mod tests {
         });
         let sstable_store = mock_sstable_store();
 
-        HummockStorage::for_test(
+        let hummock = GlobalHummockStorage::for_test(
             options,
             sstable_store,
             hummock_meta_client.clone(),
             notification_client,
         )
         .await
-        .unwrap()
+        .unwrap();
+
+        HummockV2MixedStateStore::new(hummock).await
     }
 
     async fn prepare_test_put_data(
@@ -128,7 +134,7 @@ mod tests {
     }
 
     fn get_compactor_context_with_filter_key_extractor_manager(
-        storage: &HummockStorage,
+        storage: &HummockV2MixedStateStore,
         hummock_meta_client: &Arc<dyn HummockMetaClient>,
         filter_key_extractor_manager: FilterKeyExtractorManagerRef,
     ) -> CompactorContext {
@@ -451,7 +457,7 @@ mod tests {
         }
     }
 
-    pub async fn prepare_compactor_and_filter(
+    pub(crate) async fn prepare_compactor_and_filter(
         storage: &HummockStorage,
         hummock_meta_client: &Arc<dyn HummockMetaClient>,
         hummock_manager_ref: HummockManagerRef<MemStore>,

--- a/src/storage/hummock_test/src/failpoint_tests.rs
+++ b/src/storage/hummock_test/src/failpoint_tests.rs
@@ -27,7 +27,7 @@ use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::{ReadOptions, StateStoreRead, StateStoreWrite, WriteOptions};
 use risingwave_storage::StateStore;
 
-use crate::test_utils::get_test_notification_client;
+use crate::test_utils::{get_test_notification_client, HummockV2MixedStateStore};
 
 #[tokio::test]
 #[ignore]
@@ -52,6 +52,8 @@ async fn test_failpoints_state_store_read_upload() {
     )
     .await
     .unwrap();
+
+    let hummock_storage = HummockV2MixedStateStore::new(hummock_storage).await;
 
     let anchor = Bytes::from("aa");
     let mut batch1 = vec![

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -150,15 +150,8 @@ async fn test_storage_basic() {
 
     tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
-    let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        hummock_meta_client.clone(),
-        read_version,
-        event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    let hummock_storage =
+        LocalHummockStorage::for_test(sstable_store, read_version, event_tx.clone());
 
     // First batch inserts the anchor and others.
     let mut batch1 = vec![
@@ -508,15 +501,8 @@ async fn test_state_store_sync() {
 
     tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
-    let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        hummock_meta_client.clone(),
-        read_version,
-        event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    let hummock_storage =
+        LocalHummockStorage::for_test(sstable_store, read_version, event_tx.clone());
 
     // ingest 26B batch
     let mut batch1 = vec![
@@ -770,15 +756,8 @@ async fn test_delete_get() {
 
     let initial_epoch = read_version.read().committed().max_committed_epoch();
 
-    let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        hummock_meta_client.clone(),
-        read_version,
-        event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    let hummock_storage =
+        LocalHummockStorage::for_test(sstable_store, read_version, event_tx.clone());
 
     let epoch1 = initial_epoch + 1;
     let batch1 = vec![
@@ -877,15 +856,8 @@ async fn test_multiple_epoch_sync() {
 
     let initial_epoch = read_version.read().committed().max_committed_epoch();
 
-    let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        hummock_meta_client.clone(),
-        read_version,
-        event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    let hummock_storage =
+        LocalHummockStorage::for_test(sstable_store, read_version, event_tx.clone());
 
     let epoch1 = initial_epoch + 1;
     let batch1 = vec![
@@ -1053,15 +1025,8 @@ async fn test_iter_with_min_epoch() {
 
     tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
-    let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        hummock_meta_client.clone(),
-        read_version,
-        event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    let hummock_storage =
+        LocalHummockStorage::for_test(sstable_store, read_version, event_tx.clone());
 
     let epoch1 = (31 * 1000) << 16;
 
@@ -1283,14 +1248,10 @@ async fn test_hummock_version_reader() {
     tokio::spawn(hummock_event_handler.start_hummock_event_handler_worker());
 
     let hummock_storage = LocalHummockStorage::for_test(
-        hummock_options,
         sstable_store.clone(),
-        hummock_meta_client.clone(),
         read_version.clone(),
         event_tx.clone(),
-        sstable_id_manager,
-    )
-    .unwrap();
+    );
 
     let hummock_version_reader =
         HummockVersionReader::new(sstable_store, Arc::new(StateStoreMetrics::unused()));

--- a/src/storage/hummock_test/src/lib.rs
+++ b/src/storage/hummock_test/src/lib.rs
@@ -15,6 +15,8 @@
 #![feature(custom_test_frameworks)]
 #![test_runner(risingwave_test_runner::test_runner::run_failpont_tests)]
 #![feature(bound_map)]
+#![feature(type_alias_impl_trait)]
+#![feature(associated_type_bounds)]
 
 #[cfg(test)]
 mod compactor_tests;

--- a/src/storage/hummock_test/src/snapshot_tests.rs
+++ b/src/storage/hummock_test/src/snapshot_tests.rs
@@ -23,6 +23,7 @@ use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::test_utils::default_config_for_test;
 use risingwave_storage::hummock::*;
+use risingwave_storage::monitor::StateStoreMetrics;
 use risingwave_storage::storage_value::StorageValue;
 use risingwave_storage::store::{ReadOptions, StateStoreIter, StateStoreWrite, WriteOptions};
 use risingwave_storage::StateStore;
@@ -299,11 +300,13 @@ async fn test_snapshot_backward_range_scan_inner(enable_sync: bool, enable_commi
         worker_node.id,
     ));
 
-    let hummock_storage = HummockStorage::for_test(
+    // TODO: may also test for v2 when the unit test is enabled.
+    let hummock_storage = HummockStorageV1::new(
         hummock_options,
         sstable_store,
         mock_hummock_meta_client.clone(),
         get_test_notification_client(env, hummock_manager_ref, worker_node),
+        Arc::new(StateStoreMetrics::unused()),
     )
     .await
     .unwrap();

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -12,13 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::Bound;
+use std::fmt::Debug;
+use std::future::Future;
+use std::ops::Deref;
 use std::sync::Arc;
 
 use bytes::{BufMut, Bytes};
+use risingwave_common::catalog::TableId;
 use risingwave_common::error::Result;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common_service::observer_manager::{Channel, NotificationClient, ObserverManager};
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
+use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_meta::hummock::test_utils::setup_compute_env;
 use risingwave_meta::hummock::{HummockManager, HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::{MessageStatus, MetaSrvEnv, NotificationManagerRef, WorkerKey};
@@ -32,11 +38,20 @@ use risingwave_storage::hummock::event_handler::HummockEvent;
 use risingwave_storage::hummock::iterator::test_utils::mock_sstable_store;
 use risingwave_storage::hummock::local_version::pinned_version::PinnedVersion;
 use risingwave_storage::hummock::observer_manager::HummockObserverNode;
+use risingwave_storage::hummock::store::state_store::LocalHummockStorage;
 use risingwave_storage::hummock::test_utils::default_config_for_test;
 use risingwave_storage::hummock::{HummockStorage, HummockStorageV1};
 use risingwave_storage::monitor::StateStoreMetrics;
-use risingwave_storage::store::SyncResult;
-use risingwave_storage::StateStore;
+use risingwave_storage::storage_value::StorageValue;
+use risingwave_storage::store::{
+    EmptyFutureTrait, GetFutureTrait, IngestBatchFutureTrait, IterFutureTrait, NextFutureTrait,
+    ReadOptions, StateStoreRead, StateStoreWrite, StaticSendSync, SyncFutureTrait, SyncResult,
+    WriteOptions,
+};
+use risingwave_storage::{
+    define_state_store_associated_type, define_state_store_read_associated_type,
+    define_state_store_write_associated_type, StateStore, StateStoreIter,
+};
 use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
 
 pub struct TestNotificationClient<S: MetaStore> {
@@ -156,7 +171,7 @@ pub fn prefixed_key<T: AsRef<[u8]>>(key: T) -> Bytes {
 }
 
 #[async_trait::async_trait]
-pub(crate) trait HummockStateStoreTestTrait: StateStore {
+pub(crate) trait HummockStateStoreTestTrait: StateStore + StateStoreWrite {
     fn get_pinned_version(&self) -> PinnedVersion;
     async fn seal_and_sync_epoch(&self, epoch: u64) -> StorageResult<SyncResult> {
         self.seal_epoch(epoch, true);
@@ -164,9 +179,157 @@ pub(crate) trait HummockStateStoreTestTrait: StateStore {
     }
 }
 
-impl HummockStateStoreTestTrait for HummockStorage {
+fn assert_result_eq<Item: PartialEq + Debug, E>(
+    first: &std::result::Result<Item, E>,
+    second: &std::result::Result<Item, E>,
+) {
+    match (first, second) {
+        (Ok(first), Ok(second)) => {
+            assert_eq!(first, second);
+        }
+        (Err(_), Err(_)) => {}
+        _ => panic!("result not equal"),
+    }
+}
+
+pub(crate) struct LocalGlobalStateStoreHolder<L, G> {
+    pub(crate) local: L,
+    pub(crate) global: G,
+}
+
+impl<L: StateStoreIter<Item: PartialEq + Debug>, G: StateStoreIter<Item = L::Item>> StateStoreIter
+    for LocalGlobalStateStoreHolder<L, G>
+{
+    type Item = L::Item;
+
+    type NextFuture<'a> = impl NextFutureTrait<'a, L::Item>;
+
+    fn next(&mut self) -> Self::NextFuture<'_> {
+        async {
+            let local_result = self.local.next().await;
+            let global_result = self.global.next().await;
+            assert_result_eq(&local_result, &global_result);
+            local_result
+        }
+    }
+}
+
+impl<L: StateStoreRead, G: StateStoreRead> StateStoreRead for LocalGlobalStateStoreHolder<L, G> {
+    type Iter = LocalGlobalStateStoreHolder<L::Iter, G::Iter>;
+
+    define_state_store_read_associated_type!();
+
+    fn get<'a>(
+        &'a self,
+        key: &'a [u8],
+        epoch: u64,
+        read_options: ReadOptions,
+    ) -> Self::GetFuture<'_> {
+        async move {
+            let local = self.local.get(key, epoch, read_options.clone()).await;
+            let global = self.global.get(key, epoch, read_options).await;
+            assert_result_eq(&local, &global);
+            local
+        }
+    }
+
+    fn iter(
+        &self,
+        key_range: (Bound<Vec<u8>>, Bound<Vec<u8>>),
+        epoch: u64,
+        read_options: ReadOptions,
+    ) -> Self::IterFuture<'_> {
+        async move {
+            let local_iter = self
+                .local
+                .iter(key_range.clone(), epoch, read_options.clone())
+                .await?;
+            let global_iter = self.global.iter(key_range, epoch, read_options).await?;
+            Ok(LocalGlobalStateStoreHolder {
+                local: local_iter,
+                global: global_iter,
+            })
+        }
+    }
+}
+
+impl<L: StateStoreWrite, G: StaticSendSync> StateStoreWrite for LocalGlobalStateStoreHolder<L, G> {
+    define_state_store_write_associated_type!();
+
+    fn ingest_batch(
+        &self,
+        kv_pairs: Vec<(Bytes, StorageValue)>,
+        delete_ranges: Vec<(Bytes, Bytes)>,
+        write_options: WriteOptions,
+    ) -> Self::IngestBatchFuture<'_> {
+        self.local
+            .ingest_batch(kv_pairs, delete_ranges, write_options)
+    }
+}
+
+impl<G: Clone, L: Clone> Clone for LocalGlobalStateStoreHolder<G, L> {
+    fn clone(&self) -> Self {
+        Self {
+            local: self.local.clone(),
+            global: self.global.clone(),
+        }
+    }
+}
+
+impl<G: StateStore> StateStore for LocalGlobalStateStoreHolder<G::Local, G>
+where
+    <G as StateStore>::Local: Clone,
+{
+    type Local = G::Local;
+
+    type NewLocalFuture<'a> = impl Future<Output = G::Local> + Send;
+
+    define_state_store_associated_type!();
+
+    fn try_wait_epoch(&self, epoch: HummockReadEpoch) -> Self::WaitEpochFuture<'_> {
+        self.global.try_wait_epoch(epoch)
+    }
+
+    fn sync(&self, epoch: u64) -> Self::SyncFuture<'_> {
+        self.global.sync(epoch)
+    }
+
+    fn seal_epoch(&self, epoch: u64, is_checkpoint: bool) {
+        self.global.seal_epoch(epoch, is_checkpoint)
+    }
+
+    fn clear_shared_buffer(&self) -> Self::ClearSharedBufferFuture<'_> {
+        async move { self.global.clear_shared_buffer().await }
+    }
+
+    fn new_local(&self, _table_id: TableId) -> Self::NewLocalFuture<'_> {
+        async { unimplemented!("should not be called new local again") }
+    }
+}
+
+impl<G: StateStore> LocalGlobalStateStoreHolder<G::Local, G> {
+    pub(crate) async fn new(state_store: G) -> Self {
+        LocalGlobalStateStoreHolder {
+            local: state_store.new_local(TEST_TABLE_ID).await,
+            global: state_store,
+        }
+    }
+}
+
+pub(crate) type HummockV2MixedStateStore =
+    LocalGlobalStateStoreHolder<LocalHummockStorage, HummockStorage>;
+
+impl Deref for HummockV2MixedStateStore {
+    type Target = HummockStorage;
+
+    fn deref(&self) -> &Self::Target {
+        &self.global
+    }
+}
+
+impl HummockStateStoreTestTrait for HummockV2MixedStateStore {
     fn get_pinned_version(&self) -> PinnedVersion {
-        self.get_pinned_version()
+        self.global.get_pinned_version()
     }
 }
 
@@ -199,7 +362,10 @@ pub(crate) async fn with_hummock_storage_v1() -> (HummockStorageV1, Arc<MockHumm
     (hummock_storage, meta_client)
 }
 
-pub(crate) async fn with_hummock_storage_v2() -> (HummockStorage, Arc<MockHummockMetaClient>) {
+pub(crate) const TEST_TABLE_ID: TableId = TableId { table_id: 233 };
+
+pub(crate) async fn with_hummock_storage_v2(
+) -> (HummockV2MixedStateStore, Arc<MockHummockMetaClient>) {
     let sstable_store = mock_sstable_store();
     let hummock_options = Arc::new(default_config_for_test());
     let (env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
@@ -218,5 +384,8 @@ pub(crate) async fn with_hummock_storage_v2() -> (HummockStorage, Arc<MockHummoc
     .await
     .unwrap();
 
-    (hummock_storage, meta_client)
+    (
+        HummockV2MixedStateStore::new(hummock_storage).await,
+        meta_client,
+    )
 }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -20,7 +20,6 @@ use std::sync::Arc;
 
 use arc_swap::ArcSwap;
 use bytes::Bytes;
-#[cfg(any(test, feature = "test"))]
 use parking_lot::RwLock;
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::{HummockEpoch, *};
@@ -94,9 +93,7 @@ use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
 use crate::hummock::shared_buffer::{OrderSortedUncommittedData, UncommittedData};
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::{SstableStoreRef, TableHolder};
-#[cfg(any(test, feature = "test"))]
-use crate::hummock::store::version::HummockReadVersion;
-use crate::hummock::store::version::HummockVersionReader;
+use crate::hummock::store::version::{HummockReadVersion, HummockVersionReader};
 use crate::monitor::StoreLocalStatistic;
 
 struct HummockStorageShutdownGuard {

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -32,6 +32,7 @@ use crate::hummock::iterator::{
 use crate::hummock::shared_buffer::shared_buffer_batch::{
     SharedBufferBatch, SharedBufferBatchIterator,
 };
+#[cfg(any(test, feature = "test"))]
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::store::version::{read_filter_for_local, HummockVersionReader};
 use crate::hummock::{MemoryLimiter, SstableIterator};

--- a/src/storage/src/hummock/store/state_store.rs
+++ b/src/storage/src/hummock/store/state_store.rs
@@ -20,8 +20,6 @@ use bytes::Bytes;
 #[cfg(not(madsim))]
 use minitrace::future::FutureExt;
 use parking_lot::RwLock;
-use risingwave_common::config::StorageConfig;
-use risingwave_rpc_client::HummockMetaClient;
 use tokio::sync::mpsc;
 
 use super::version::{HummockReadVersion, StagingData, VersionUpdate};
@@ -36,9 +34,7 @@ use crate::hummock::shared_buffer::shared_buffer_batch::{
 };
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::store::version::{read_filter_for_local, HummockVersionReader};
-use crate::hummock::{
-    HummockResult, MemoryLimiter, SstableIdManager, SstableIdManagerRef, SstableIterator,
-};
+use crate::hummock::{MemoryLimiter, SstableIterator};
 use crate::monitor::{StateStoreMetrics, StoreLocalStatistic};
 use crate::storage_value::StorageValue;
 use crate::store::{
@@ -60,77 +56,43 @@ pub struct HummockStorageCore {
     /// Event sender.
     event_sender: mpsc::UnboundedSender<HummockEvent>,
 
-    hummock_meta_client: Arc<dyn HummockMetaClient>,
-
-    sstable_store: SstableStoreRef,
-
-    options: Arc<StorageConfig>,
-
-    sstable_id_manager: SstableIdManagerRef,
-
-    #[cfg(not(madsim))]
-    tracing: Arc<risingwave_tracing::RwTracingService>,
-
     memory_limiter: Arc<MemoryLimiter>,
 
     hummock_version_reader: HummockVersionReader,
 }
 
-#[derive(Clone)]
 pub struct LocalHummockStorage {
     core: Arc<HummockStorageCore>,
+
+    #[cfg(not(madsim))]
+    tracing: Arc<risingwave_tracing::RwTracingService>,
+}
+
+// Clone is only used for unit test
+#[cfg(any(test, feature = "test"))]
+impl Clone for LocalHummockStorage {
+    fn clone(&self) -> Self {
+        Self {
+            core: self.core.clone(),
+            #[cfg(not(madsim))]
+            tracing: self.tracing.clone(),
+        }
+    }
 }
 
 impl HummockStorageCore {
-    #[cfg(any(test, feature = "test"))]
-    pub fn for_test(
-        options: Arc<StorageConfig>,
-        sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-        read_version: Arc<RwLock<HummockReadVersion>>,
-        event_sender: mpsc::UnboundedSender<HummockEvent>,
-        sstable_id_manager: Arc<SstableIdManager>,
-    ) -> HummockResult<Self> {
-        Self::new(
-            options,
-            sstable_store,
-            hummock_meta_client,
-            Arc::new(StateStoreMetrics::unused()),
-            read_version,
-            event_sender,
-            MemoryLimiter::unlimit(),
-            sstable_id_manager,
-            #[cfg(not(madsim))]
-            Arc::new(risingwave_tracing::RwTracingService::new()),
-        )
-    }
-
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        options: Arc<StorageConfig>,
-        sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-        // TODO: separate `HummockStats` from `StateStoreMetrics`.
-        stats: Arc<StateStoreMetrics>,
         read_version: Arc<RwLock<HummockReadVersion>>,
+        hummock_version_reader: HummockVersionReader,
         event_sender: mpsc::UnboundedSender<HummockEvent>,
         memory_limiter: Arc<MemoryLimiter>,
-        sstable_id_manager: Arc<SstableIdManager>,
-        #[cfg(not(madsim))] tracing: Arc<risingwave_tracing::RwTracingService>,
-    ) -> HummockResult<Self> {
-        let instance = Self {
+    ) -> Self {
+        Self {
             read_version,
             event_sender,
-            hummock_meta_client,
-            sstable_store: sstable_store.clone(),
-            options,
-            sstable_id_manager,
-            #[cfg(not(madsim))]
-            tracing,
             memory_limiter,
-            hummock_version_reader: HummockVersionReader::new(sstable_store, stats),
-        };
-        Ok(instance)
+            hummock_version_reader,
+        }
     }
 
     /// See `HummockReadVersion::update` for more details.
@@ -199,7 +161,7 @@ impl StateStoreRead for LocalHummockStorage {
     ) -> Self::IterFuture<'_> {
         let iter = self.core.iter_inner(key_range, epoch, read_options);
         #[cfg(not(madsim))]
-        return iter.in_span(self.core.tracing.new_tracer("hummock_iter"));
+        return iter.in_span(self.tracing.new_tracer("hummock_iter"));
         #[cfg(madsim)]
         iter
     }
@@ -250,58 +212,39 @@ impl LocalStateStore for LocalHummockStorage {}
 impl LocalHummockStorage {
     #[cfg(any(test, feature = "test"))]
     pub fn for_test(
-        options: Arc<StorageConfig>,
         sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
         read_version: Arc<RwLock<HummockReadVersion>>,
         event_sender: mpsc::UnboundedSender<HummockEvent>,
-        sstable_id_manager: Arc<SstableIdManager>,
-    ) -> HummockResult<Self> {
-        let storage_core = HummockStorageCore::for_test(
-            options,
-            sstable_store,
-            hummock_meta_client,
+    ) -> Self {
+        Self::new(
             read_version,
+            HummockVersionReader::new(sstable_store, Arc::new(StateStoreMetrics::unused())),
             event_sender,
-            sstable_id_manager,
-        )?;
-
-        let instance = Self {
-            core: Arc::new(storage_core),
-        };
-        Ok(instance)
+            MemoryLimiter::unlimit(),
+            #[cfg(not(madsim))]
+            Arc::new(risingwave_tracing::RwTracingService::new()),
+        )
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
-        options: Arc<StorageConfig>,
-        sstable_store: SstableStoreRef,
-        hummock_meta_client: Arc<dyn HummockMetaClient>,
-        // TODO: separate `HummockStats` from `StateStoreMetrics`.
-        stats: Arc<StateStoreMetrics>,
         read_version: Arc<RwLock<HummockReadVersion>>,
+        hummock_version_reader: HummockVersionReader,
         event_sender: mpsc::UnboundedSender<HummockEvent>,
         memory_limiter: Arc<MemoryLimiter>,
-        sstable_id_manager: Arc<SstableIdManager>,
         #[cfg(not(madsim))] tracing: Arc<risingwave_tracing::RwTracingService>,
-    ) -> HummockResult<Self> {
+    ) -> Self {
         let storage_core = HummockStorageCore::new(
-            options,
-            sstable_store,
-            hummock_meta_client,
-            stats,
             read_version,
+            hummock_version_reader,
             event_sender,
             memory_limiter,
-            sstable_id_manager,
+        );
+
+        Self {
+            core: Arc::new(storage_core),
             #[cfg(not(madsim))]
             tracing,
-        )?;
-
-        let instance = Self {
-            core: Arc::new(storage_core),
-        };
-        Ok(instance)
+        }
     }
 
     /// See `HummockReadVersion::update` for more details.
@@ -311,26 +254,6 @@ impl LocalHummockStorage {
 
     pub fn read_version(&self) -> Arc<RwLock<HummockReadVersion>> {
         self.core.read_version.clone()
-    }
-
-    pub fn get_memory_limiter(&self) -> Arc<MemoryLimiter> {
-        self.core.memory_limiter.clone()
-    }
-
-    pub fn hummock_meta_client(&self) -> &Arc<dyn HummockMetaClient> {
-        &self.core.hummock_meta_client
-    }
-
-    pub fn options(&self) -> &Arc<StorageConfig> {
-        &self.core.options
-    }
-
-    pub fn sstable_store(&self) -> SstableStoreRef {
-        self.core.sstable_store.clone()
-    }
-
-    pub fn sstable_id_manager(&self) -> &SstableIdManagerRef {
-        &self.core.sstable_id_manager
     }
 }
 

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -154,6 +154,11 @@ pub trait IngestBatchFutureTrait<'a> = Future<Output = StorageResult<usize>> + S
 pub trait StateStoreWrite: StaticSendSync {
     type IngestBatchFuture<'a>: IngestBatchFutureTrait<'a>;
 
+    /// Writes a batch to storage. The batch should be:
+    /// * Ordered. KV pairs will be directly written to the table, so it must be ordered.
+    /// * Locally unique. There should not be two or more operations on the same key in one write
+    ///   batch.
+    ///
     /// Ingests a batch of data into the state store. One write batch should never contain operation
     /// on the same key. e.g. Put(233, x) then Delete(233).
     /// An epoch should be provided to ingest a write batch. It is served as:
@@ -198,7 +203,7 @@ macro_rules! define_state_store_associated_type {
     };
 }
 
-pub trait StateStore: StateStoreRead + StateStoreWrite + StaticSendSync + Clone {
+pub trait StateStore: StateStoreRead + StaticSendSync + Clone {
     type Local: LocalStateStore;
 
     type WaitEpochFuture<'a>: EmptyFutureTrait<'a>;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

In this PR, we remove `StateStoreWrite` from global `StateStore` and make it read only. 

Some unused field are removed from `HummockStorage` and `LocalHummockStorage`.

After global state store cannot be read, to minimize the change on unit test, we introduce a holder that holds both the local and global state store, and write to local state store and read from both and compare the read result.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
