### PR TITLE
refactor:add to_binary trait and fix row_description 

### DIFF
--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -15,9 +15,11 @@
 use std::hash::Hash;
 use std::io::Write;
 
-use bytes::{BufMut, BytesMut};
+use bytes::{BufMut, Bytes, BytesMut};
 use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike};
+use postgres_types::{ToSql, Type};
 
+use super::to_binary::ToBinary;
 use super::to_text::ToText;
 use super::{CheckedAdd, IntervalUnit};
 use crate::array::ArrayResult;
@@ -83,6 +85,30 @@ impl ToText for NaiveTimeWrapper {
 impl ToText for NaiveDateTimeWrapper {
     fn to_text(&self) -> String {
         self.0.to_string()
+    }
+}
+
+impl ToBinary for NaiveDateWrapper {
+    fn to_binary(&self) -> Option<Bytes> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Some(output.freeze())
+    }
+}
+
+impl ToBinary for NaiveTimeWrapper {
+    fn to_binary(&self) -> Option<Bytes> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Some(output.freeze())
+    }
+}
+
+impl ToBinary for NaiveDateTimeWrapper {
+    fn to_binary(&self) -> Option<Bytes> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Some(output.freeze())
     }
 }
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -28,6 +28,7 @@ use risingwave_pb::data::IntervalUnit as IntervalUnitProto;
 use smallvec::SmallVec;
 
 use super::ops::IsNegative;
+use super::to_binary::ToBinary;
 use super::*;
 use crate::error::{ErrorCode, Result, RwError};
 
@@ -532,6 +533,14 @@ impl<'a> FromSql<'a> for IntervalUnit {
 
     fn accepts(ty: &Type) -> bool {
         matches!(*ty, Type::INTERVAL)
+    }
+}
+
+impl ToBinary for IntervalUnit {
+    fn to_binary(&self) -> Option<Bytes> {
+        let mut output = BytesMut::new();
+        self.to_sql(&Type::ANY, &mut output).unwrap();
+        Some(output.freeze())
     }
 }
 

--- a/src/common/src/types/to_binary.rs
+++ b/src/common/src/types/to_binary.rs
@@ -1,0 +1,75 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use bytes::{Bytes, BytesMut};
+use postgres_types::{ToSql, Type};
+
+use super::{DatumRef, ScalarRefImpl};
+
+// Used to convert ScalarRef to text format
+pub trait ToBinary {
+    fn to_binary(&self) -> Option<Bytes>;
+}
+
+// implement use to_sql
+macro_rules! implement_using_to_sql {
+    ($({ $scalar_type:ty } ),*) => {
+        $(
+            impl ToBinary for $scalar_type {
+                fn to_binary(&self) -> Option<Bytes> {
+                    let mut output = BytesMut::new();
+                    self.to_sql(&Type::ANY, &mut output).unwrap();
+                    Some(output.freeze())
+                }
+            }
+        )*
+    };
+}
+
+implement_using_to_sql! {
+    { i16  },
+    { i32  },
+    { i64  },
+    { &str },
+    { crate::types::OrderedF32 },
+    { crate::types::OrderedF64 },
+    { bool }
+}
+
+impl ToBinary for ScalarRefImpl<'_> {
+    fn to_binary(&self) -> Option<Bytes> {
+        match self {
+            ScalarRefImpl::Int16(v) => v.to_binary(),
+            ScalarRefImpl::Int32(v) => v.to_binary(),
+            ScalarRefImpl::Int64(v) => v.to_binary(),
+            ScalarRefImpl::Float32(v) => v.to_binary(),
+            ScalarRefImpl::Float64(v) => v.to_binary(),
+            ScalarRefImpl::Utf8(v) => v.to_binary(),
+            ScalarRefImpl::Bool(v) => v.to_binary(),
+            ScalarRefImpl::Decimal(v) => v.to_binary(),
+            ScalarRefImpl::Interval(v) => v.to_binary(),
+            ScalarRefImpl::NaiveDate(v) => v.to_binary(),
+            ScalarRefImpl::NaiveDateTime(v) => v.to_binary(),
+            ScalarRefImpl::NaiveTime(v) => v.to_binary(),
+            ScalarRefImpl::Struct(_) => todo!(),
+            ScalarRefImpl::List(_) => todo!(),
+        }
+    }
+}
+
+impl ToBinary for DatumRef<'_> {
+    fn to_binary(&self) -> Option<Bytes> {
+        self.map(|v| v.to_binary().unwrap())
+    }
+}

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -81,12 +81,22 @@ impl PgStatement {
     {
         let instance_query_string = self.prepared_statement.instance(params, param_format)?;
 
+        let row_description: Vec<PgFieldDescriptor> = if result_format {
+            let mut row_description = self.row_description.clone();
+            row_description
+                .iter_mut()
+                .for_each(|desc| desc.set_to_binary());
+            row_description
+        } else {
+            self.row_description.clone()
+        };
+
         Ok(PgPortal {
             name: portal_name,
             query_string: instance_query_string,
             result_format,
             is_query: self.is_query,
-            row_description: self.row_description.clone(),
+            row_description,
             result: None,
             row_cache: vec![].into_iter(),
         })

--- a/src/utils/pgwire/src/pg_field_descriptor.rs
+++ b/src/utils/pgwire/src/pg_field_descriptor.rs
@@ -61,6 +61,12 @@ impl PgFieldDescriptor {
         }
     }
 
+    /// Set the format code as binary format.
+    /// NOTE: Format code is text format by default.
+    pub fn set_to_binary(&mut self) {
+        self.format_code = 1;
+    }
+
     pub fn get_name(&self) -> &str {
         &self.name
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

1. add to_binary trait 
2. fix row_description:return the correct format code( we used to return text all the time   


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
