### PR TITLE
fix: refine kafka error message

### DIFF
--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use rdkafka::consumer::{BaseConsumer, Consumer, DefaultConsumerContext};
 use rdkafka::error::KafkaResult;
@@ -89,11 +89,11 @@ impl SplitEnumerator for KafkaSplitEnumerator {
     }
 
     async fn list_splits(&mut self) -> anyhow::Result<Vec<KafkaSplit>> {
-        let topic_partitions = self.fetch_topic_partition().await.with_context(|| {
-            format!(
-                "failed to fetch metadata from kafka ({})",
-                self.broker_address
-            )
+        let topic_partitions = self.fetch_topic_partition().await.map_err(|e| {
+            anyhow!(format!(
+                "failed to fetch metadata from kafka ({}), error: {}",
+                self.broker_address, e
+            ))
         })?;
 
         let mut start_offsets = self.fetch_start_offset(topic_partitions.as_ref()).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

as title, now we have more detailed error message

```plain
dev=> create materialized source s1 (v1 int, v2 varchar) with (
dev(>   connector = 'kafka',
dev(>   topic = 'kafka_1_partition_topic',
dev(>   properties.bootstrap.server = '127.0.0.1:29092',
dev(>   scan.startup.mode = 'earliest'
dev(> ) row format json;
ERROR:  QueryError: internal error: connector error: failed to fetch metadata from kafka (127.0.0.1:29092), error: topic kafka_1_partition_topic not found
```

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)

resolve #6286 