### PR TITLE
fix(sort operator): Sort Operator should delay irrelevant watermarks …

### DIFF
--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -306,6 +306,9 @@ impl<S: StateStore> SortExecutor<S> {
             values_per_vnode.push(value_iter);
         }
         if !values_per_vnode.is_empty() {
+            self.buffer
+                .values_mut()
+                .for_each(|(_, _, irrel_watermarks)| irrel_watermarks.clear());
             let mut stream = select_all(values_per_vnode);
             while let Some(storage_result) = stream.next().await {
                 // Insert the data into buffer.

--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -288,11 +288,7 @@ impl<S: StateStore> SortExecutor<S> {
             curr_vnode_bitmap.to_owned()
         };
         let mut values_per_vnode = Vec::new();
-        for (owned_vnode, _) in newly_owned_vnodes
-            .iter()
-            .enumerate()
-            .filter(|(_, is_set)| *is_set)
-        {
+        for owned_vnode in newly_owned_vnodes.ones() {
             let value_iter = self
                 .state_table
                 .iter_with_pk_range(&(Bound::Unbounded, Bound::Unbounded), owned_vnode as _)


### PR DESCRIPTION
…(close #6297)

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Sort Operator should not emit irrelevant watermarks until corresponding chunks are all emitted.
- How does this PR work? Need a brief introduction for the changed logic (optional)
Buffer irrelevant watermarks.
- Describe any limitations of the current code (optional)
Watermarks are not persisted, because new watermarks will soon come after recovery.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6297 