### PR TITLE
fix(merger): clear buffered watermarks on upstream exchange (close #6…

### DIFF
--- a/src/stream/src/executor/watermark/mod.rs
+++ b/src/stream/src/executor/watermark/mod.rs
@@ -51,6 +51,15 @@ impl<ID: Ord + Hash> BufferedWatermarks<ID> {
         });
     }
 
+    pub fn clear(&mut self) {
+        self.first_buffered_watermarks.clear();
+        self.other_buffered_watermarks
+            .values_mut()
+            .for_each(|staged_watermarks| {
+                std::mem::take(staged_watermarks);
+            });
+    }
+
     /// Handle a new watermark message. Optionally returns the watermark message to emit and the
     /// buffer id.
     pub fn handle_watermark(&mut self, buffer_id: ID, watermark: Watermark) -> Option<Watermark> {


### PR DESCRIPTION
…308)

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Clear buffered watermarks on upstream exchange in `Merger` in `StreamExchange`.
- How does this PR work? Need a brief introduction for the changed logic (optional)
Since all queues are cleared, merger will no longer emit watermarks until it discovers a new global min among new watermarks of each upstream.
- Describe any limitations of the current code (optional)
We may lose some watermarks in `clear()`, but new watermarks will soon be generated after a scaling.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6308 