### PR TITLE
fix(sort operator): `enumerate()` should be before `filter()`

### DIFF
--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -267,8 +267,8 @@ impl<S: StateStore> SortExecutor<S> {
         let mut values_per_vnode = Vec::new();
         for (owned_vnode, _) in newly_owned_vnodes
             .iter()
-            .filter(|is_set| *is_set)
             .enumerate()
+            .filter(|(_, is_set)| *is_set)
         {
             let value_iter = self
                 .state_table


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`enumerate()` should be before `filter()`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/pull/6085
