### PR TITLE
test(regress): enable int4

### DIFF
--- a/src/tests/regress/README.md
+++ b/src/tests/regress/README.md
@@ -15,7 +15,7 @@ in rust.
 
 Just add another line in your schedule file with your test cast name.
 ```
-tests: boolean
+test: boolean
 ```
 
 If you want to ignore a certain test query from an input sql file, comment it out with `--@ `. Note the extra `@` after `--`.

--- a/src/tests/regress/data/schedule
+++ b/src/tests/regress/data/schedule
@@ -7,4 +7,4 @@
 # interferes with crash-recovery testing.
 # test: tablespace
 
-test: boolean varchar int2
+test: boolean varchar int2 int4

--- a/src/tests/regress/data/sql/int4.sql
+++ b/src/tests/regress/data/sql/int4.sql
@@ -29,69 +29,69 @@ INSERT INTO INT4_TBL(f1) VALUES ('');
 
 SELECT * FROM INT4_TBL;
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int4 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 = int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 = int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 = int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 = int4 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 < int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 < int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 < int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 < int4 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int4 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 > int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 > int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 > int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 > int4 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int2 '0';
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int4 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int4 '0';
 
 -- positive odds
-SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int2 '2') = int2 '1';
+--@ SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int2 '2') = int2 '1';
 
 -- any evens
-SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int4 '2') = int2 '0';
+--@ SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int4 '2') = int2 '0';
 
 SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i
-WHERE abs(f1) < 1073741824;
+--@ SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i
+--@ WHERE abs(f1) < 1073741824;
 
 SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i
-WHERE abs(f1) < 1073741824;
+--@ SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i
+--@ WHERE abs(f1) < 1073741824;
 
 SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i
-WHERE f1 < 2147483646;
+--@ SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i
+--@ WHERE f1 < 2147483646;
 
 SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i
-WHERE f1 < 2147483646;
+--@ SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i
+--@ WHERE f1 < 2147483646;
 
 SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i
-WHERE f1 > -2147483647;
+--@ SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i
+--@ WHERE f1 > -2147483647;
 
 SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i
-WHERE f1 > -2147483647;
+--@ SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i
+--@ WHERE f1 > -2147483647;
 
-SELECT i.f1, i.f1 / int2 '2' AS x FROM INT4_TBL i;
+--@ SELECT i.f1, i.f1 / int2 '2' AS x FROM INT4_TBL i;
 
-SELECT i.f1, i.f1 / int4 '2' AS x FROM INT4_TBL i;
+--@ SELECT i.f1, i.f1 / int4 '2' AS x FROM INT4_TBL i;
 
 --
 -- more complex expressions
@@ -106,13 +106,13 @@ SELECT 2- -1 AS three;
 
 SELECT 2 - -2 AS four;
 
-SELECT int2 '2' * int2 '2' = int2 '16' / int2 '4' AS true;
+--@ SELECT int2 '2' * int2 '2' = int2 '16' / int2 '4' AS true;
 
-SELECT int4 '2' * int2 '2' = int2 '16' / int4 '4' AS true;
+--@ SELECT int4 '2' * int2 '2' = int2 '16' / int4 '4' AS true;
 
-SELECT int2 '2' * int4 '2' = int4 '16' / int2 '4' AS true;
+--@ SELECT int2 '2' * int4 '2' = int4 '16' / int2 '4' AS true;
 
-SELECT int4 '1000' < int4 '999' AS false;
+--@ SELECT int4 '1000' < int4 '999' AS false;
 
 SELECT 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 AS ten;
 
@@ -121,26 +121,26 @@ SELECT 2 + 2 / 2 AS three;
 SELECT (2 + 2) / 2 AS two;
 
 -- corner case
-SELECT (-1::int4<<31)::text;
-SELECT ((-1::int4<<31)+1)::text;
+--@ SELECT (-1::int4<<31)::text;
+--@ SELECT ((-1::int4<<31)+1)::text;
 
 -- check sane handling of INT_MIN overflow cases
 SELECT (-2147483648)::int4 * (-1)::int4;
 SELECT (-2147483648)::int4 / (-1)::int4;
-SELECT (-2147483648)::int4 % (-1)::int4;
+--@ SELECT (-2147483648)::int4 % (-1)::int4;
 SELECT (-2147483648)::int4 * (-1)::int2;
 SELECT (-2147483648)::int4 / (-1)::int2;
-SELECT (-2147483648)::int4 % (-1)::int2;
+--@ SELECT (-2147483648)::int4 % (-1)::int2;
 
 -- check rounding when casting from float
-SELECT x, x::int4 AS int4_value
-FROM (VALUES (-2.5::float8),
-             (-1.5::float8),
-             (-0.5::float8),
-             (0.0::float8),
-             (0.5::float8),
-             (1.5::float8),
-             (2.5::float8)) t(x);
+--@ SELECT x, x::int4 AS int4_value
+--@ FROM (VALUES (-2.5::float8),
+--@              (-1.5::float8),
+--@              (-0.5::float8),
+--@              (0.0::float8),
+--@              (0.5::float8),
+--@              (1.5::float8),
+--@              (2.5::float8)) t(x);
 
 -- check rounding when casting from numeric
 SELECT x, x::int4 AS int4_value
@@ -153,26 +153,26 @@ FROM (VALUES (-2.5::numeric),
              (2.5::numeric)) t(x);
 
 -- test gcd()
-SELECT a, b, gcd(a, b), gcd(a, -b), gcd(b, a), gcd(-b, a)
-FROM (VALUES (0::int4, 0::int4),
-             (0::int4, 6410818::int4),
-             (61866666::int4, 6410818::int4),
-             (-61866666::int4, 6410818::int4),
-             ((-2147483648)::int4, 1::int4),
-             ((-2147483648)::int4, 2147483647::int4),
-             ((-2147483648)::int4, 1073741824::int4)) AS v(a, b);
+--@ SELECT a, b, gcd(a, b), gcd(a, -b), gcd(b, a), gcd(-b, a)
+--@ FROM (VALUES (0::int4, 0::int4),
+--@              (0::int4, 6410818::int4),
+--@              (61866666::int4, 6410818::int4),
+--@              (-61866666::int4, 6410818::int4),
+--@              ((-2147483648)::int4, 1::int4),
+--@              ((-2147483648)::int4, 2147483647::int4),
+--@              ((-2147483648)::int4, 1073741824::int4)) AS v(a, b);
 
 SELECT gcd((-2147483648)::int4, 0::int4); -- overflow
 SELECT gcd((-2147483648)::int4, (-2147483648)::int4); -- overflow
 
 -- test lcm()
-SELECT a, b, lcm(a, b), lcm(a, -b), lcm(b, a), lcm(-b, a)
-FROM (VALUES (0::int4, 0::int4),
-             (0::int4, 42::int4),
-             (42::int4, 42::int4),
-             (330::int4, 462::int4),
-             (-330::int4, 462::int4),
-             ((-2147483648)::int4, 0::int4)) AS v(a, b);
+--@ SELECT a, b, lcm(a, b), lcm(a, -b), lcm(b, a), lcm(-b, a)
+--@ FROM (VALUES (0::int4, 0::int4),
+--@              (0::int4, 42::int4),
+--@              (42::int4, 42::int4),
+--@              (330::int4, 462::int4),
+--@              (-330::int4, 462::int4),
+--@              ((-2147483648)::int4, 0::int4)) AS v(a, b);
 
 SELECT lcm((-2147483648)::int4, 1::int4); -- overflow
 SELECT lcm(2147483647::int4, 2147483646::int4); -- overflow


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Enable PostgreSQL regress test for `int4`.

- add `int4` in `schedule`
- comment out all not-passed SQL statement in `int4.sql`
- fix a typo in regress README

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)



## Refer to a related PR or issue link (optional)

#6190 