### PR TITLE
fix(storage): use `KeyComparator` for  `can_concat`

### DIFF
--- a/src/storage/hummock_sdk/src/key_cmp.rs
+++ b/src/storage/hummock_sdk/src/key_cmp.rs
@@ -126,4 +126,15 @@ mod tests {
             Ordering::Less
         );
     }
+
+    #[test]
+    fn test_cmp_encode_key() {
+        let a_left = vec![0, 0, 3, 237, 0, 0, 11, 234, 98, 142, 90, 0, 0];
+        let a_right = vec![0, 0, 3, 237, 0, 0, 11, 234, 98, 133, 107, 0, 0];
+        let b_left = vec![0, 0, 3, 237, 0, 0, 11, 234, 98, 131, 241, 0, 0];
+        let b_right = vec![0, 0, 3, 237, 0, 0, 11, 234, 98, 126, 38, 0, 0];
+        assert!(KeyComparator::compare_encoded_full_key(&a_left, &a_right) == Ordering::Less);
+        assert!(KeyComparator::compare_encoded_full_key(&a_right, &b_left) == Ordering::Less);
+        assert!(KeyComparator::compare_encoded_full_key(&b_left, &b_right) == Ordering::Less);
+    }
 }

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -32,7 +32,6 @@ pub use key_cmp::*;
 use risingwave_pb::hummock::SstableInfo;
 
 use crate::compaction_group::StaticCompactionGroupId;
-use crate::key::user_key;
 use crate::table_stats::TableStats;
 
 pub mod compact;
@@ -153,9 +152,10 @@ impl SstIdRange {
 pub fn can_concat(ssts: &[impl Deref<Target = SstableInfo>]) -> bool {
     let len = ssts.len();
     for i in 0..len - 1 {
-        if user_key(&ssts[i].get_key_range().as_ref().unwrap().right).cmp(user_key(
-            &ssts[i + 1].get_key_range().as_ref().unwrap().left,
-        )) != Ordering::Less
+        if KeyComparator::compare_encoded_full_key(
+            &ssts[i].key_range.as_ref().unwrap().right,
+            &ssts[i + 1].key_range.as_ref().unwrap().left,
+        ) != Ordering::Less
         {
             return false;
         }


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

close https://github.com/risingwavelabs/risingwave/issues/6342
Because https://github.com/risingwavelabs/risingwave/pull/6198 would make the user-key of two neighboring equal, so we use `KeyComparator` to check overlap relationship in compaction. But we did not change the behavior in `can_concat`, so it caused a panic.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/6342