### PR TITLE
chore(config): remove hard-coded batch size in BatchQuery executor

### DIFF
--- a/src/stream/src/executor/batch_query.rs
+++ b/src/stream/src/executor/batch_query.rs
@@ -40,12 +40,10 @@ impl<S> BatchQueryExecutor<S>
 where
     S: StateStore,
 {
-    const DEFAULT_BATCH_SIZE: usize = 100;
-
-    pub fn new(table: StorageTable<S>, batch_size: Option<usize>, info: ExecutorInfo) -> Self {
+    pub fn new(table: StorageTable<S>, batch_size: usize, info: ExecutorInfo) -> Self {
         Self {
             table,
-            batch_size: batch_size.unwrap_or(Self::DEFAULT_BATCH_SIZE),
+            batch_size,
             info,
         }
     }
@@ -117,7 +115,7 @@ mod test {
             identity: "BatchQuery".to_owned(),
         };
 
-        let executor = Box::new(BatchQueryExecutor::new(table, Some(test_batch_size), info));
+        let executor = Box::new(BatchQueryExecutor::new(table, test_batch_size, info));
 
         let stream = executor.execute_with_epoch(u64::MAX);
         let mut batch_cnt = 0;

--- a/src/stream/src/from_proto/batch_query.rs
+++ b/src/stream/src/from_proto/batch_query.rs
@@ -31,7 +31,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         params: ExecutorParams,
         node: &StreamNode,
         state_store: impl StateStore,
-        _stream: &mut LocalStreamManagerCore,
+        stream: &mut LocalStreamManagerCore,
     ) -> StreamResult<BoxedExecutor> {
         let node = try_match_expand!(node.get_node_body().unwrap(), NodeBody::BatchPlan)?;
 
@@ -101,7 +101,7 @@ impl ExecutorBuilder for BatchQueryExecutorBuilder {
         let schema = table.schema().clone();
         let executor = BatchQueryExecutor::new(
             table,
-            None,
+            stream.config.developer.stream_chunk_size,
             ExecutorInfo {
                 schema,
                 pk_indices: params.pk_indices,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
As per the title,
as per #5249 

## Checklist

- [x] ~I have written necessary rustdoc comments~
- [x] ~I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
