### PR TITLE
feat(hummock): check `KeyRange` for open-boundary caused by range-tombstone

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -197,9 +197,12 @@ message UnpinSnapshotBeforeResponse {
   common.Status status = 1;
 }
 
+// When `right_exclusive=false`, it represents [left, right], of which both boundary are open. When `right_exclusive=true`,
+// it represents [left, right), of which right is exclusive.
 message KeyRange {
   bytes left = 1;
   bytes right = 2;
+  bool right_exclusive = 3;
 }
 
 message TableOption {

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -385,6 +385,7 @@ pub mod tests {
             key_range: Some(KeyRange {
                 left: iterator_test_key_of_epoch(table_prefix, left, epoch),
                 right: iterator_test_key_of_epoch(table_prefix, right, epoch),
+                right_exclusive: false,
             }),
             file_size: (right - left + 1) as u64,
             table_ids: vec![],
@@ -674,6 +675,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
                 level: 0,
@@ -701,6 +703,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
                 level: 0,
@@ -760,6 +763,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
                 level: 3,
@@ -789,6 +793,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
                 level: 4,

--- a/src/meta/src/hummock/compaction/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/manual_compaction_picker.rs
@@ -400,6 +400,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: iterator_test_key_of_epoch(1, 0, 1),
                     right: iterator_test_key_of_epoch(1, 201, 1),
+                    right_exclusive: false,
                 },
                 ..Default::default()
             };
@@ -486,6 +487,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: iterator_test_key_of_epoch(1, 101, 1),
                     right: iterator_test_key_of_epoch(1, 199, 1),
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::from([2]),
             };
@@ -614,6 +616,7 @@ pub mod tests {
             key_range: KeyRange {
                 left: vec![],
                 right: vec![],
+                right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
         };
@@ -633,6 +636,7 @@ pub mod tests {
             key_range: KeyRange {
                 left: vec![],
                 right: vec![],
+                right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
         };
@@ -674,6 +678,7 @@ pub mod tests {
             key_range: KeyRange {
                 left: iterator_test_key_of_epoch(1, 0, 2),
                 right: iterator_test_key_of_epoch(1, 200, 2),
+                right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
         };
@@ -721,6 +726,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
             };
@@ -758,6 +764,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // No matching internal table id.
                 internal_table_id: HashSet::from([100]),
@@ -777,6 +784,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // Include all sub level's table ids
                 internal_table_id: HashSet::from([1, 2, 3]),
@@ -818,6 +826,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // Only include bottom sub level's table id
                 internal_table_id: HashSet::from([3]),
@@ -858,6 +867,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // Only include partial top sub level's table id, but the whole top sub level is
                 // picked.
@@ -899,6 +909,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // Only include bottom sub level's table id
                 internal_table_id: HashSet::from([3]),
@@ -928,6 +939,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // No matching internal table id.
                 internal_table_id: HashSet::from([100]),
@@ -948,6 +960,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 // Only include partial input level's table id
                 internal_table_id: HashSet::from([1]),
@@ -996,6 +1009,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
             };
@@ -1039,6 +1053,7 @@ pub mod tests {
                 key_range: KeyRange {
                     left: vec![],
                     right: vec![],
+                    right_exclusive: false,
                 },
                 internal_table_id: HashSet::default(),
             };

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -271,6 +271,7 @@ impl Default for ManualCompactionOption {
             key_range: KeyRange {
                 left: vec![],
                 right: vec![],
+                right_exclusive: false,
             },
             internal_table_id: HashSet::default(),
             level: 1,

--- a/src/meta/src/hummock/compaction/overlap_strategy.rs
+++ b/src/meta/src/hummock/compaction/overlap_strategy.rs
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp;
+
 use itertools::Itertools;
-use risingwave_hummock_sdk::key::user_key;
 use risingwave_hummock_sdk::key_range::KeyRangeCommon;
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
@@ -76,15 +77,19 @@ impl OverlapInfo for RangeOverlapInfo {
             Some(key_range) => {
                 let mut tables = vec![];
                 let overlap_begin = others.partition_point(|table_status| {
-                    user_key(&table_status.key_range.as_ref().unwrap().right)
-                        < user_key(&key_range.left)
+                    table_status
+                        .key_range
+                        .as_ref()
+                        .unwrap()
+                        .compare_right_with(&key_range.left)
+                        == cmp::Ordering::Less
                 });
                 if overlap_begin >= others.len() {
                     return vec![];
                 }
                 for table in &others[overlap_begin..] {
-                    if user_key(&table.key_range.as_ref().unwrap().left)
-                        > user_key(&key_range.right)
+                    if key_range.compare_right_with(&table.key_range.as_ref().unwrap().left)
+                        == cmp::Ordering::Less
                     {
                         break;
                     }
@@ -122,5 +127,5 @@ impl OverlapStrategy for RangeOverlapStrategy {
 
 fn check_table_overlap(key_range: &KeyRange, table: &SstableInfo) -> bool {
     let other = table.key_range.as_ref().unwrap();
-    key_range.user_key_overlap(other)
+    key_range.sstable_overlap(other)
 }

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -146,6 +146,7 @@ pub fn generate_test_tables(epoch: u64, sst_ids: Vec<HummockSstableId>) -> Vec<S
             key_range: Some(KeyRange {
                 left: iterator_test_key_of_epoch(sst_id, i + 1, epoch),
                 right: iterator_test_key_of_epoch(sst_id, (i + 1) * 10, epoch),
+                right_exclusive: false,
             }),
             file_size: 2,
             table_ids: vec![(i + 1) as u32, (i + 2) as u32],

--- a/src/storage/hummock_sdk/src/key_range.rs
+++ b/src/storage/hummock_sdk/src/key_range.rs
@@ -16,24 +16,30 @@ use std::cmp;
 
 use bytes::Bytes;
 
-use super::key;
 use super::key_cmp::KeyComparator;
+use crate::user_key;
 
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct KeyRange {
     pub left: Bytes,
     pub right: Bytes,
+    pub right_exclusive: bool,
 }
 
 impl KeyRange {
     pub fn new(left: Bytes, right: Bytes) -> Self {
-        Self { left, right }
+        Self {
+            left,
+            right,
+            right_exclusive: false,
+        }
     }
 
     pub fn inf() -> Self {
         Self {
             left: Bytes::new(),
             right: Bytes::new(),
+            right_exclusive: false,
         }
     }
 
@@ -51,7 +57,11 @@ impl KeyRange {
 pub trait KeyRangeCommon {
     fn full_key_overlap(&self, other: &Self) -> bool;
     fn full_key_extend(&mut self, other: &Self);
-    fn user_key_overlap(&self, other: &Self) -> bool;
+    fn sstable_overlap(&self, other: &Self) -> bool;
+    fn compare_right_with(&self, full_key: &[u8]) -> std::cmp::Ordering {
+        self.compare_right_with_user_key(user_key(full_key))
+    }
+    fn compare_right_with_user_key(&self, ukey: &[u8]) -> std::cmp::Ordering;
 }
 
 #[macro_export]
@@ -83,16 +93,26 @@ macro_rules! impl_key_range_common {
                             == cmp::Ordering::Greater)
                 {
                     self.right = other.right.clone();
+                    self.right_exclusive = other.right_exclusive;
                 }
             }
 
-            fn user_key_overlap(&self, other: &Self) -> bool {
+            fn sstable_overlap(&self, other: &Self) -> bool {
                 (self.end_bound_inf()
                     || other.start_bound_inf()
-                    || key::user_key(&self.right) >= key::user_key(&other.left))
+                    || self.compare_right_with(&other.left) != std::cmp::Ordering::Less)
                     && (other.end_bound_inf()
                         || self.start_bound_inf()
-                        || key::user_key(&other.right) >= key::user_key(&self.left))
+                        || other.compare_right_with(&self.left) != std::cmp::Ordering::Less)
+            }
+
+            fn compare_right_with_user_key(&self, ukey: &[u8]) -> std::cmp::Ordering {
+                let ret = user_key(&self.right).cmp(ukey);
+                if ret == cmp::Ordering::Equal && self.right_exclusive {
+                    cmp::Ordering::Less
+                } else {
+                    ret
+                }
             }
         }
     };
@@ -144,16 +164,18 @@ impl From<KeyRange> for risingwave_pb::hummock::KeyRange {
         risingwave_pb::hummock::KeyRange {
             left: kr.left.to_vec(),
             right: kr.right.to_vec(),
+            right_exclusive: kr.right_exclusive,
         }
     }
 }
 
 impl From<&risingwave_pb::hummock::KeyRange> for KeyRange {
     fn from(kr: &risingwave_pb::hummock::KeyRange) -> Self {
-        KeyRange::new(
-            Bytes::copy_from_slice(&kr.left),
-            Bytes::copy_from_slice(&kr.right),
-        )
+        KeyRange {
+            left: Bytes::copy_from_slice(&kr.left),
+            right: Bytes::copy_from_slice(&kr.right),
+            right_exclusive: kr.right_exclusive,
+        }
     }
 }
 

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -33,6 +33,7 @@ use risingwave_pb::hummock::SstableInfo;
 
 use crate::compaction_group::StaticCompactionGroupId;
 use crate::key::user_key;
+use crate::key_range::KeyRangeCommon;
 use crate::table_stats::TableStats;
 
 pub mod compact;
@@ -153,9 +154,12 @@ impl SstIdRange {
 pub fn can_concat(ssts: &[impl Deref<Target = SstableInfo>]) -> bool {
     let len = ssts.len();
     for i in 0..len - 1 {
-        if user_key(&ssts[i].get_key_range().as_ref().unwrap().right).cmp(user_key(
-            &ssts[i + 1].get_key_range().as_ref().unwrap().left,
-        )) != Ordering::Less
+        if ssts[i]
+            .key_range
+            .as_ref()
+            .unwrap()
+            .compare_right_with(&ssts[i + 1].key_range.as_ref().unwrap().left)
+            != Ordering::Less
         {
             return false;
         }

--- a/src/storage/hummock_sdk/src/prost_key_range.rs
+++ b/src/storage/hummock_sdk/src/prost_key_range.rs
@@ -17,7 +17,7 @@ use std::cmp;
 use risingwave_pb::hummock::KeyRange;
 
 use crate::key_range::KeyRangeCommon;
-use crate::{impl_key_range_common, key, key_range_cmp, KeyComparator};
+use crate::{impl_key_range_common, key_range_cmp, user_key, KeyComparator};
 
 impl_key_range_common!(KeyRange);
 
@@ -34,11 +34,16 @@ impl KeyRangeExt for KeyRange {
         Self {
             left: vec![],
             right: vec![],
+            right_exclusive: false,
         }
     }
 
     fn new(left: Vec<u8>, right: Vec<u8>) -> Self {
-        Self { left, right }
+        Self {
+            left,
+            right,
+            right_exclusive: false,
+        }
     }
 
     fn compare(&self, other: &Self) -> cmp::Ordering {

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
 
     use std::collections::{BTreeSet, HashMap};
     use std::ops::Bound;
@@ -63,7 +63,7 @@ mod tests {
         HummockV2MixedStateStore as HummockStorage,
     };
 
-    async fn get_hummock_storage(
+    pub(crate) async fn get_hummock_storage(
         hummock_meta_client: Arc<dyn HummockMetaClient>,
         notification_client: impl NotificationClient,
     ) -> HummockStorage {
@@ -416,7 +416,7 @@ mod tests {
         assert!(compact_task.is_none());
     }
 
-    async fn flush_and_commit(
+    pub(crate) async fn flush_and_commit(
         hummock_meta_client: &Arc<dyn HummockMetaClient>,
         storage: &HummockStorage,
         epoch: u64,

--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -145,6 +145,7 @@ async fn test_read_version_basic() {
                     key_range: Some(KeyRange {
                         left: key_with_epoch(iterator_test_user_key_of(1).encode(), 1),
                         right: key_with_epoch(iterator_test_user_key_of(2).encode(), 2),
+                        right_exclusive: false,
                     }),
                     file_size: 1,
                     table_ids: vec![0],
@@ -158,6 +159,7 @@ async fn test_read_version_basic() {
                     key_range: Some(KeyRange {
                         left: key_with_epoch(iterator_test_user_key_of(3).encode(), 3),
                         right: key_with_epoch(iterator_test_user_key_of(3).encode(), 3),
+                        right_exclusive: false,
                     }),
                     file_size: 1,
                     table_ids: vec![0],

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -12,18 +12,40 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 
+use bytes::Bytes;
+use risingwave_common::catalog::hummock::CompactionFilterFlag;
+use risingwave_common::catalog::TableId;
+use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
-use risingwave_meta::hummock::test_utils::{add_ssts, setup_compute_env};
-use risingwave_meta::hummock::{start_local_notification_receiver, MockHummockMetaClient};
+use risingwave_hummock_sdk::key::{next_key, user_key};
+use risingwave_meta::hummock::compaction::compaction_config::CompactionConfigBuilder;
+use risingwave_meta::hummock::compaction::ManualCompactionOption;
+use risingwave_meta::hummock::test_utils::{
+    add_ssts, setup_compute_env, setup_compute_env_with_config,
+};
+use risingwave_meta::hummock::{
+    start_local_notification_receiver, HummockManagerRef, MockHummockMetaClient,
+};
 use risingwave_meta::manager::LocalNotification;
+use risingwave_meta::storage::MemStore;
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_rpc_client::HummockMetaClient;
+use risingwave_storage::hummock::compactor::{Compactor, CompactorContext};
 use risingwave_storage::hummock::SstableIdManager;
+use risingwave_storage::storage_value::StorageValue;
+use risingwave_storage::store::{ReadOptions, WriteOptions};
+use risingwave_storage::Keyspace;
 use serial_test::serial;
+
+use super::compactor_tests::tests::{
+    flush_and_commit, get_hummock_storage, prepare_compactor_and_filter,
+};
+use crate::test_utils::get_test_notification_client;
 
 #[tokio::test]
 #[serial]
@@ -176,4 +198,182 @@ async fn test_syncpoints_test_local_notification_receiver() {
 
     shutdown_sender.send(()).unwrap();
     join_handle.await.unwrap();
+}
+
+pub async fn compact_once(
+    hummock_manager_ref: HummockManagerRef<MemStore>,
+    compact_ctx: Arc<CompactorContext>,
+) {
+    // 2. get compact task
+    let manual_compcation_option = ManualCompactionOption {
+        level: 0,
+        ..Default::default()
+    };
+    // 2. get compact task
+    let mut compact_task = hummock_manager_ref
+        .manual_get_compact_task(
+            StaticCompactionGroupId::StateDefault.into(),
+            manual_compcation_option,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+    compact_task.gc_delete_keys = false;
+    let compactor = hummock_manager_ref.get_idle_compactor().await.unwrap();
+    hummock_manager_ref
+        .assign_compaction_task(&compact_task, compactor.context_id())
+        .await
+        .unwrap();
+
+    let compaction_filter_flag = CompactionFilterFlag::STATE_CLEAN;
+    compact_task.compaction_filter_mask = compaction_filter_flag.bits();
+    // 3. compact
+    let (_tx, rx) = tokio::sync::oneshot::channel();
+    Compactor::compact(compact_ctx, compact_task.clone(), rx).await;
+}
+
+#[tokio::test]
+#[cfg(feature = "sync_point")]
+#[serial]
+async fn test_syncpoints_get_in_delete_range_boundary() {
+    let config = CompactionConfigBuilder::new()
+        .level0_tier_compact_file_number(1)
+        .max_bytes_for_level_base(4096)
+        .build();
+    let (env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
+        setup_compute_env_with_config(8080, config).await;
+    let hummock_meta_client: Arc<dyn HummockMetaClient> = Arc::new(MockHummockMetaClient::new(
+        hummock_manager_ref.clone(),
+        worker_node.id,
+    ));
+    let storage = get_hummock_storage(
+        hummock_meta_client.clone(),
+        get_test_notification_client(env, hummock_manager_ref.clone(), worker_node.clone()),
+    )
+    .await;
+    let existing_table_id: u32 = 1;
+    let compact_ctx = Arc::new(
+        prepare_compactor_and_filter(
+            &storage,
+            &hummock_meta_client,
+            hummock_manager_ref.clone(),
+            existing_table_id,
+        )
+        .await,
+    );
+
+    let compactor_manager = hummock_manager_ref.compactor_manager_ref_for_test();
+    compactor_manager.add_compactor(worker_node.id, u64::MAX);
+
+    let keyspace = Keyspace::table_root(storage.clone(), TableId::new(existing_table_id));
+    // 1. add sstables
+    let val0 = Bytes::from(b"0"[..].repeat(1 << 10)); // 1024 Byte value
+    let val1 = Bytes::from(b"1"[..].repeat(1 << 10)); // 1024 Byte value
+    let mut local = keyspace.start_write_batch(WriteOptions {
+        epoch: 100,
+        table_id: existing_table_id.into(),
+    });
+    let mut start_key = b"aaa".to_vec();
+    for _ in 0..10 {
+        local.put(&start_key, StorageValue::new_put(val0.clone()));
+        start_key = next_key(&start_key);
+    }
+    local.put(b"ggg", StorageValue::new_put(val0.clone()));
+    local.put(b"hhh", StorageValue::new_put(val0.clone()));
+    local.put(b"kkk", StorageValue::new_put(val0.clone()));
+    local.ingest().await.unwrap();
+    flush_and_commit(&hummock_meta_client, &storage, 100).await;
+    compact_once(hummock_manager_ref.clone(), compact_ctx.clone()).await;
+    let mut local = keyspace.start_write_batch(WriteOptions {
+        epoch: 101,
+        table_id: existing_table_id.into(),
+    });
+    local.put(b"aaa", StorageValue::new_put(val1.clone()));
+    local.put(b"bbb", StorageValue::new_put(val1.clone()));
+    local.delete_range(b"ggg", b"hhh");
+    local.ingest().await.unwrap();
+    flush_and_commit(&hummock_meta_client, &storage, 101).await;
+    compact_once(hummock_manager_ref.clone(), compact_ctx.clone()).await;
+    let mut local = keyspace.start_write_batch(WriteOptions {
+        epoch: 102,
+        table_id: existing_table_id.into(),
+    });
+    local.put(b"hhh", StorageValue::new_put(val1.clone()));
+    local.put(b"iii", StorageValue::new_put(val1.clone()));
+    local.delete_range(b"jjj", b"kkk");
+    local.ingest().await.unwrap();
+    flush_and_commit(&hummock_meta_client, &storage, 102).await;
+    // move this two file to the same level.
+    compact_once(hummock_manager_ref.clone(), compact_ctx.clone()).await;
+
+    let mut local = keyspace.start_write_batch(WriteOptions {
+        epoch: 103,
+        table_id: existing_table_id.into(),
+    });
+    local.put(b"lll", StorageValue::new_put(val1.clone()));
+    local.put(b"mmm", StorageValue::new_put(val1.clone()));
+    local.ingest().await.unwrap();
+    flush_and_commit(&hummock_meta_client, &storage, 103).await;
+    // move this two file to the same level.
+    compact_once(hummock_manager_ref.clone(), compact_ctx.clone()).await;
+
+    // 4. get the latest version and check
+    let version = hummock_manager_ref.get_current_version().await;
+    let base_level = &version
+        .get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into())
+        .levels[4];
+    assert_eq!(base_level.table_infos.len(), 3);
+    assert!(
+        base_level.table_infos[0]
+            .key_range
+            .as_ref()
+            .unwrap()
+            .right_exclusive
+    );
+    assert_eq!(
+        user_key(&base_level.table_infos[0].key_range.as_ref().unwrap().right),
+        user_key(&base_level.table_infos[1].key_range.as_ref().unwrap().left),
+    );
+    storage.wait_version(version).await;
+    let read_options = ReadOptions {
+        ignore_range_tombstone: false,
+        check_bloom_filter: true,
+        prefix_hint: None,
+        table_id: TableId::from(existing_table_id),
+        retention_seconds: None,
+    };
+    let get_result = storage
+        .get(b"hhh", 120, read_options.clone())
+        .await
+        .unwrap();
+    assert_eq!(get_result.unwrap(), val1);
+    let get_result = storage
+        .get(b"ggg", 120, read_options.clone())
+        .await
+        .unwrap();
+    assert!(get_result.is_none());
+    let get_result = storage
+        .get(b"aaa", 120, read_options.clone())
+        .await
+        .unwrap();
+    assert_eq!(get_result.unwrap(), val1);
+    let get_result = storage
+        .get(b"aab", 120, read_options.clone())
+        .await
+        .unwrap();
+    assert_eq!(get_result.unwrap(), val0);
+    let skip_flag = Arc::new(AtomicBool::new(false));
+    let skip_flag_hook = skip_flag.clone();
+    sync_point::hook("HUMMOCK_V2::GET::SKIP_BY_NO_FILE", move || {
+        let flag = skip_flag_hook.clone();
+        async move {
+            flag.store(true, Ordering::Release);
+        }
+    });
+    let get_result = storage
+        .get(b"kkk", 120, read_options.clone())
+        .await
+        .unwrap();
+    assert_eq!(get_result.unwrap(), val0);
+    assert!(skip_flag.load(Ordering::Acquire));
 }

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -66,6 +66,7 @@ impl CompactorRunner {
         let key_range = KeyRange {
             left: Bytes::copy_from_slice(task.splits[split_index].get_left()),
             right: Bytes::copy_from_slice(task.splits[split_index].get_right()),
+            right_exclusive: true,
         };
         let compactor = Compactor::new(
             context.context.clone(),

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -169,6 +169,7 @@ impl Sstable {
             key_range: Some(KeyRange {
                 left: self.meta.smallest_key.clone(),
                 right: self.meta.largest_key.clone(),
+                right_exclusive: false,
             }),
             file_size: self.meta.estimated_size as u64,
             table_ids: vec![],

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -28,6 +28,7 @@ use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::key::{
     bound_table_key_range, user_key, FullKey, TableKey, TableKeyRange, UserKey,
 };
+use risingwave_hummock_sdk::key_range::KeyRangeCommon;
 use risingwave_hummock_sdk::{can_concat, HummockEpoch};
 use risingwave_pb::hummock::{HummockVersionDelta, LevelType, SstableInfo};
 
@@ -441,14 +442,11 @@ impl HummockVersionReader {
                         continue;
                     }
                     table_info_idx = table_info_idx.saturating_sub(1);
-                    let ord = user_key(
-                        &level.table_infos[table_info_idx]
-                            .key_range
-                            .as_ref()
-                            .unwrap()
-                            .right,
-                    )
-                    .cmp(encoded_user_key.as_ref());
+                    let ord = level.table_infos[table_info_idx]
+                        .key_range
+                        .as_ref()
+                        .unwrap()
+                        .compare_right_with_user_key(&encoded_user_key);
                     // the case that the key falls into the gap between two ssts
                     if ord == Ordering::Less {
                         continue;

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -31,6 +31,7 @@ use risingwave_hummock_sdk::key::{
 use risingwave_hummock_sdk::key_range::KeyRangeCommon;
 use risingwave_hummock_sdk::{can_concat, HummockEpoch};
 use risingwave_pb::hummock::{HummockVersionDelta, LevelType, SstableInfo};
+use sync_point::sync_point;
 
 use super::memtable::{ImmId, ImmutableMemtable};
 use super::state_store::StagingDataIterator;
@@ -449,6 +450,7 @@ impl HummockVersionReader {
                         .compare_right_with_user_key(&encoded_user_key);
                     // the case that the key falls into the gap between two ssts
                     if ord == Ordering::Less {
+                        sync_point!("HUMMOCK_V2::GET::SKIP_BY_NO_FILE");
                         continue;
                     }
 

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -101,6 +101,7 @@ pub fn gen_dummy_sst_info(
         key_range: Some(KeyRange {
             left: FullKey::for_test(table_id, min_table_key, epoch).encode(),
             right: FullKey::for_test(table_id, max_table_key, epoch).encode(),
+            right_exclusive: false,
         }),
         file_size,
         table_ids: vec![],
@@ -172,6 +173,7 @@ pub async fn put_sst(
         key_range: Some(KeyRange {
             left: meta.smallest_key.clone(),
             right: meta.largest_key.clone(),
+            right_exclusive: false,
         }),
         file_size: meta.estimated_size as u64,
         table_ids: vec![],


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Because https://github.com/risingwavelabs/risingwave/pull/6198 would make the user-key of two neighboring equal, and we need to check it by a special way, or it would cause an panic.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/5978