### PR TITLE
fix(storage): fix wrong parameter of hit_sstable_bloom_filter

### DIFF
--- a/src/storage/src/hummock/state_store_v1.rs
+++ b/src/storage/src/hummock/state_store_v1.rs
@@ -124,7 +124,7 @@ impl HummockStorageV1 {
 
         // Because SST meta records encoded key range,
         // the filter key needs to be encoded as well.
-        let encoded_user_key = UserKey::for_test(read_options.table_id, table_key).encode();
+        let encoded_user_key = UserKey::new(read_options.table_id, table_key).encode();
         // See comments in HummockStorage::iter_inner for details about using compaction_group_id in
         // read/write path.
         assert!(pinned_version.is_valid());
@@ -298,6 +298,12 @@ impl HummockStorageV1 {
             user_key_range.1.as_ref().map(UserKey::encode),
         );
         assert!(pinned_version.is_valid());
+        // encode once
+        let bloom_filter_key = if let Some(prefix) = read_options.prefix_hint.as_ref() {
+            UserKey::new(read_options.table_id, TableKey(prefix)).encode()
+        } else {
+            vec![]
+        };
         for level in pinned_version.levels(table_id) {
             let table_infos = prune_ssts(level.table_infos.iter(), table_id, &table_key_range);
             if table_infos.is_empty() {
@@ -323,7 +329,7 @@ impl HummockStorageV1 {
 
                 let mut sstables = vec![];
                 for sstable_info in pruned_sstables {
-                    if let Some(bloom_filter_key) = read_options.prefix_hint.as_ref() {
+                    if !bloom_filter_key.is_empty() {
                         let sstable = self
                             .sstable_store
                             .sstable(sstable_info, &mut local_stats)
@@ -332,9 +338,7 @@ impl HummockStorageV1 {
 
                         if hit_sstable_bloom_filter(
                             sstable.value(),
-                            UserKey::for_test(read_options.table_id, bloom_filter_key)
-                                .encode()
-                                .as_slice(),
+                            bloom_filter_key.as_slice(),
                             &mut local_stats,
                         ) {
                             sstables.push((*sstable_info).clone());
@@ -358,14 +362,14 @@ impl HummockStorageV1 {
                         .sstable(table_info, &mut local_stats)
                         .in_span(Span::enter_with_local_parent("get_sstable"))
                         .await?;
-                    if let Some(bloom_filter_key) = read_options.prefix_hint.as_ref() {
-                        if !hit_sstable_bloom_filter(
+                    if !bloom_filter_key.is_empty()
+                        && !hit_sstable_bloom_filter(
                             sstable.value(),
-                            bloom_filter_key,
+                            bloom_filter_key.as_slice(),
                             &mut local_stats,
-                        ) {
-                            continue;
-                        }
+                        )
+                    {
+                        continue;
                     }
 
                     overlapped_iters.push(HummockIteratorUnion::Fourth(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After merge https://github.com/risingwavelabs/risingwave/pull/6130, we found some wrong when using state_store_v1 backend. 

This PR fix wrong parameter of `hit_sstable_bloom_filter` and reduce `UserKey::encode` times

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- fix wrong parameter of `hit_sstable_bloom_filter`
- remove `UserKey::for_test` in state_store 
- reduce `UserKey::encode` times

## Checklist

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- https://github.com/risingwavelabs/risingwave/issues/6353