### PR TITLE
refactor(meta): extract method for commit_epoch sanity check

### DIFF
--- a/src/meta/src/hummock/manager/context.rs
+++ b/src/meta/src/hummock/manager/context.rs
@@ -12,12 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::ops::DerefMut;
 
 use fail::fail_point;
 use function_name::named;
-use risingwave_hummock_sdk::HummockContextId;
+use itertools::Itertools;
+use risingwave_hummock_sdk::{HummockContextId, HummockEpoch, HummockSstableId, LocalSstableInfo};
+use risingwave_pb::hummock::subscribe_compact_tasks_response::Task;
+use risingwave_pb::hummock::{HummockVersion, ValidationTask};
 
 use crate::hummock::error::{Error, Result};
 use crate::hummock::manager::{
@@ -119,5 +122,67 @@ where
         self.release_contexts(&invalid_context_ids).await?;
 
         Ok(invalid_context_ids)
+    }
+
+    pub(crate) async fn commit_epoch_sanity_check(
+        &self,
+        epoch: HummockEpoch,
+        sstables: &Vec<LocalSstableInfo>,
+        sst_to_context: &HashMap<HummockSstableId, HummockContextId>,
+        current_version: &HummockVersion,
+    ) -> Result<()> {
+        for (sst_id, context_id) in sst_to_context {
+            #[cfg(test)]
+            {
+                if *context_id == crate::manager::META_NODE_ID {
+                    continue;
+                }
+            }
+            if !self.check_context(*context_id).await {
+                return Err(Error::InvalidSst(*sst_id));
+            }
+        }
+
+        if epoch <= current_version.max_committed_epoch {
+            return Err(anyhow::anyhow!(
+                "Epoch {} <= max_committed_epoch {}",
+                epoch,
+                current_version.max_committed_epoch
+            )
+            .into());
+        }
+
+        async {
+            if !self.env.opts.enable_committed_sst_sanity_check {
+                return;
+            }
+            if sstables.is_empty() {
+                return;
+            }
+            let compactor = match self.compactor_manager.next_compactor() {
+                None => {
+                    tracing::warn!("Skip committed SST sanity check due to no available worker");
+                    return;
+                }
+                Some(compactor) => compactor,
+            };
+            let sst_infos = sstables
+                .iter()
+                .map(|LocalSstableInfo { sst_info, .. }| sst_info.clone())
+                .collect_vec();
+            if compactor
+                .send_task(Task::ValidationTask(ValidationTask {
+                    sst_infos,
+                    sst_id_to_worker_id: sst_to_context.clone(),
+                    epoch,
+                }))
+                .await
+                .is_err()
+            {
+                tracing::warn!("Skip committed SST sanity check due to send failure");
+            }
+        }
+        .await;
+        Ok(())
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Extract `commit_epoch_sanity_check` to reduce length of `commit_epoch`.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
