### PR TITLE
feat: health check RPC for frontend node

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -413,15 +413,15 @@ risedev:
     - use: frontend
       port: 4565
       exporter-port: 2222
-      health_check_port: 6786
+      health-check-port: 6786
     - use: frontend
       port: 4566
       exporter-port: 2223
-      health_check_port: 6787
+      health-check-port: 6787
     - use: frontend
       port: 4567
       exporter-port: 2224
-      health_check_port: 6788
+      health-check-port: 6788
     - use: compactor
 
   ci-3cn-3fe-in-memory:
@@ -444,15 +444,15 @@ risedev:
     - use: frontend
       port: 4565
       exporter-port: 2222
-      health_check_port: 6786
+      health-check-port: 6786
     - use: frontend
       port: 4566
       exporter-port: 2223
-      health_check_port: 6787
+      health-check-port: 6787
     - use: frontend
       port: 4567
       exporter-port: 2224
-      health_check_port: 6788
+      health-check-port: 6788
 
   ci-kafka:
     - use: minio

--- a/risedev.yml
+++ b/risedev.yml
@@ -413,12 +413,15 @@ risedev:
     - use: frontend
       port: 4565
       exporter-port: 2222
+      health_check_port: 6786
     - use: frontend
       port: 4566
       exporter-port: 2223
+      health_check_port: 6787
     - use: frontend
       port: 4567
       exporter-port: 2224
+      health_check_port: 6788
     - use: compactor
 
   ci-3cn-3fe-in-memory:
@@ -441,12 +444,15 @@ risedev:
     - use: frontend
       port: 4565
       exporter-port: 2222
+      health_check_port: 6786
     - use: frontend
       port: 4566
       exporter-port: 2223
+      health_check_port: 6787
     - use: frontend
       port: 4567
       exporter-port: 2224
+      health_check_port: 6788
 
   ci-kafka:
     - use: minio
@@ -709,6 +715,9 @@ template:
 
     # Prometheus exporter listen port
     exporter-port: 2222
+
+    # Health check listen port
+    health-check-port: 6786
 
     # Id of this instance
     id: frontend-${port}

--- a/src/frontend/src/health_service.rs
+++ b/src/frontend/src/health_service.rs
@@ -1,0 +1,39 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::health::health_check_response::ServingStatus;
+use risingwave_pb::health::health_server::Health;
+use risingwave_pb::health::{HealthCheckRequest, HealthCheckResponse};
+use tonic::{Request, Response, Status};
+
+pub struct HealthServiceImpl {}
+
+impl HealthServiceImpl {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+#[async_trait::async_trait]
+impl Health for HealthServiceImpl {
+    async fn check(
+        &self,
+        _request: Request<HealthCheckRequest>,
+    ) -> Result<Response<HealthCheckResponse>, Status> {
+        // Reply serving as long as tonic service is started
+        Ok(Response::new(HealthCheckResponse {
+            status: ServingStatus::Serving as i32,
+        }))
+    }
+}

--- a/src/frontend/src/health_service.rs
+++ b/src/frontend/src/health_service.rs
@@ -20,6 +20,7 @@ use tonic::{Request, Response, Status};
 pub struct HealthServiceImpl {}
 
 impl HealthServiceImpl {
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         Self {}
     }

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -55,6 +55,7 @@ pub mod test_utils;
 mod user;
 
 mod monitor;
+pub mod health_service;
 
 use std::ffi::OsString;
 use std::iter;
@@ -88,6 +89,9 @@ pub struct FrontendOpts {
 
     #[clap(long, default_value = "127.0.0.1:2222")]
     pub prometheus_listener_addr: String,
+
+    #[clap(long, default_value = "127.0.0.1:4568")]
+    pub health_check_addr: String,
 
     /// Used for control the metrics level, similar to log level.
     /// 0 = close metrics

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -90,8 +90,8 @@ pub struct FrontendOpts {
     #[clap(long, default_value = "127.0.0.1:2222")]
     pub prometheus_listener_addr: String,
 
-    #[clap(long, default_value = "127.0.0.1:4568")]
-    pub health_check_addr: String,
+    #[clap(long, default_value = "127.0.0.1:6786")]
+    pub health_check_listener_addr: String,
 
     /// Used for control the metrics level, similar to log level.
     /// 0 = close metrics

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -54,8 +54,8 @@ mod meta_client;
 pub mod test_utils;
 mod user;
 
-mod monitor;
 pub mod health_service;
+mod monitor;
 
 use std::ffi::OsString;
 use std::iter;

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -40,6 +40,7 @@ use risingwave_common::util::addr::HostAddr;
 use risingwave_common_service::observer_manager::ObserverManager;
 use risingwave_common_service::MetricsManager;
 use risingwave_pb::common::WorkerType;
+use risingwave_pb::health::health_server::HealthServer;
 use risingwave_pb::user::auth_info::EncryptionType;
 use risingwave_pb::user::grant_privilege::{Action, Object};
 use risingwave_rpc_client::{ComputeClientPool, ComputeClientPoolRef, MetaClient};
@@ -57,6 +58,7 @@ use crate::expr::CorrelatedId;
 use crate::handler::handle;
 use crate::handler::privilege::{check_privileges, ObjectCheckItem};
 use crate::handler::util::to_pg_field;
+use crate::health_service::HealthServiceImpl;
 use crate::meta_client::{FrontendMetaClient, FrontendMetaClientImpl};
 use crate::monitor::FrontendMetrics;
 use crate::observer::FrontendObserverNode;
@@ -70,8 +72,6 @@ use crate::user::user_service::{UserInfoReader, UserInfoWriter, UserInfoWriterIm
 use crate::user::UserId;
 use crate::utils::WithOptions;
 use crate::{FrontendConfig, FrontendOpts, PgResponseStream, TableCatalog};
-use crate::health_service::HealthServiceImpl;
-use risingwave_pb::health::health_server::HealthServer;
 
 pub struct OptimizerContext {
     pub session_ctx: Arc<SessionImpl>,

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -352,7 +352,7 @@ impl FrontendEnv {
         }
 
         let health_srv = HealthServiceImpl::new();
-        let host = opts.health_check_addr.clone();
+        let host = opts.health_check_listener_addr.clone();
         tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(HealthServer::new(health_srv))
@@ -360,6 +360,10 @@ impl FrontendEnv {
                 .await
                 .unwrap();
         });
+        tracing::info!(
+            "Health Check RPC Listener is set up on {}",
+            opts.health_check_listener_addr.clone()
+        );
 
         Ok((
             Self {

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -84,6 +84,7 @@ pub struct FrontendConfig {
     pub port: u16,
     pub listen_address: String,
     pub exporter_port: u16,
+    pub health_check_port: u16,
 
     pub provide_meta_node: Option<Vec<MetaNodeConfig>>,
     pub user_managed: bool,

--- a/src/risedevtool/src/task/frontend_service.rs
+++ b/src/risedevtool/src/task/frontend_service.rs
@@ -51,6 +51,11 @@ impl FrontendService {
                 "{}:{}",
                 config.listen_address, config.exporter_port
             ))
+            .arg("--health-check-listener-addr")
+            .arg(format!(
+                "{}:{}",
+                config.listen_address, config.health_check_port
+            ))
             .arg("--metrics-level")
             .arg("1");
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Ref to this [issue](https://github.com/risingwavelabs/risingwave/issues/5072), add a health  check RPC service for frontend node at `127.0.0.1:4568`.



## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/5072

@skyzh 