### PR TITLE
feat: enable scaling for downstream fragment of multi-dispacher relations

### DIFF
--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -27,7 +27,9 @@ use risingwave_pb::meta::subscribe_response::{Info, Operation};
 use risingwave_pb::meta::table_fragments::actor_status::ActorState;
 use risingwave_pb::meta::table_fragments::{ActorStatus, State};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
-use risingwave_pb::stream_plan::{Dispatcher, FragmentType, StreamActor, StreamNode};
+use risingwave_pb::stream_plan::{
+    Dispatcher, DispatcherType, FragmentType, StreamActor, StreamNode,
+};
 use tokio::sync::{RwLock, RwLockReadGuard};
 
 use crate::barrier::Reschedule;
@@ -639,6 +641,7 @@ where
 
                 let mut table_fragment = table_fragments.get_mut(table_id).unwrap();
 
+                // First step, update self fragment
                 // Add actors to this fragment: set the state to `Running`.
                 for actor_id in &added_actors {
                     table_fragment
@@ -701,10 +704,13 @@ where
                     }
                 }
 
+                // Second step, update upstream fragments
                 // Update the dispatcher of the upstream fragments.
                 for (upstream_fragment_id, dispatcher_id) in upstream_fragment_dispatcher_ids {
-                    // TODO: here we assume the upstream fragment is in the same streaming job
-                    // as this fragment.
+                    // here we assume the upstream fragment is in the same streaming job as this
+                    // fragment. Cross-table references only occur in the case
+                    // of Chain fragment, and the scale of Chain fragment does not introduce updates
+                    // to the upstream Fragment (because of NoShuffle)
                     let upstream_fragment = table_fragment
                         .fragments
                         .get_mut(&upstream_fragment_id)
@@ -717,7 +723,14 @@ where
 
                         for dispatcher in &mut upstream_actor.dispatcher {
                             if dispatcher.dispatcher_id == dispatcher_id {
-                                dispatcher.hash_mapping = upstream_dispatcher_mapping.clone();
+                                match dispatcher.r#type() {
+                                    DispatcherType::Hash => {
+                                        dispatcher.hash_mapping =
+                                            upstream_dispatcher_mapping.clone();
+                                    }
+                                    _ => {}
+                                }
+
                                 update_actors(
                                     dispatcher.downstream_actor_id.as_mut(),
                                     &removed_actor_ids,

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -723,12 +723,8 @@ where
 
                         for dispatcher in &mut upstream_actor.dispatcher {
                             if dispatcher.dispatcher_id == dispatcher_id {
-                                match dispatcher.r#type() {
-                                    DispatcherType::Hash => {
-                                        dispatcher.hash_mapping =
-                                            upstream_dispatcher_mapping.clone();
-                                    }
-                                    _ => {}
+                                if let DispatcherType::Hash = dispatcher.r#type() {
+                                    dispatcher.hash_mapping = upstream_dispatcher_mapping.clone();
                                 }
 
                                 update_actors(

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -959,8 +959,30 @@ where
                         FragmentDistributionType::Unspecified => unreachable!(),
                     }
                 } else {
-                    let upstream_fragment_id =
-                        fragment.upstream_fragment_ids.iter().exactly_one().unwrap();
+
+                    // let test: &FragmentId =
+                    //     fragment.upstream_fragment_ids.iter().filter(|fragment_id| {
+                    //         !ctx.no_shuffle_source_fragment_ids.contains(*fragment_id)
+                    //     }).exactly_one().unwrap();
+                    //
+                    // let frag = ctx.fragment_map.get(test).cloned().unwrap();
+                    //
+                    // let x = frag.actors.iter().exactly_one().cloned().unwrap();
+                    //
+                    // println!("actor {} broad dispa {:#?}", x.actor_id, x.dispatcher);
+
+                    for fragment_id in &fragment.upstream_fragment_ids {
+                        let frag = ctx.fragment_map.get(fragment_id).cloned().unwrap();
+                        let x = frag.actors.first().unwrap();
+                        println!("actor {} broad dispa {:#?}", x.actor_id, x.dispatcher);
+                    }
+
+
+                    let upstream_fragment_id: &FragmentId =
+                        fragment.upstream_fragment_ids.iter().filter(|fragment_id| {
+                            ctx.no_shuffle_source_fragment_ids.contains(*fragment_id)
+                        }).exactly_one().unwrap();
+
                     let upstream_fragment = ctx.fragment_map.get(upstream_fragment_id).unwrap();
 
                     let upstream_fragment_dispatcher_types = upstream_fragment

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -1032,6 +1032,13 @@ where
                 }
             }
 
+            println!(
+                "frag {} ups ids {:?}, mapping {}",
+                fragment_id,
+                upstream_fragment_dispatcher_set,
+                upstream_dispatcher_mapping.is_some()
+            );
+
             let downstream_fragment_id = if let Some(downstream_fragment_ids) =
                 ctx.downstream_fragment_id_map.get(&fragment_id)
             {
@@ -1091,6 +1098,13 @@ where
                     actor_splits,
                 },
             );
+        }
+
+        for (a, b) in &reschedule_fragment {
+            println!("for fragment {}", a);
+            println!("\tadded   {:?}", b.added_actors);
+            println!("\tremoved {:?}", b.removed_actors);
+            println!("\tupstream ids {:?}", b.upstream_fragment_dispatcher_ids);
         }
 
         let mut fragment_created_actors = HashMap::new();

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -963,20 +963,6 @@ where
 
             let fragment = ctx.fragment_map.get(&fragment_id).unwrap();
 
-            // scale upstream
-
-            // hash - (ids, mapping)
-            // simple - (ids)?
-            // no_shuffle - _
-            // broadcast - (ids)
-
-            // hash - hash    -> Some(xxx)
-            // hash - single  -> None
-            // no_shuffle - _ -> None
-            // broadcast - _  -> None
-
-            // fragment.upstream_fragment_ids.
-
             let in_degree_types: HashSet<_> = fragment
                 .upstream_fragment_ids
                 .iter()
@@ -1031,13 +1017,6 @@ where
                     }
                 }
             }
-
-            println!(
-                "frag {} ups ids {:?}, mapping {}",
-                fragment_id,
-                upstream_fragment_dispatcher_set,
-                upstream_dispatcher_mapping.is_some()
-            );
 
             let downstream_fragment_id = if let Some(downstream_fragment_ids) =
                 ctx.downstream_fragment_id_map.get(&fragment_id)
@@ -1098,13 +1077,6 @@ where
                     actor_splits,
                 },
             );
-        }
-
-        for (a, b) in &reschedule_fragment {
-            println!("for fragment {}", a);
-            println!("\tadded   {:?}", b.added_actors);
-            println!("\tremoved {:?}", b.removed_actors);
-            println!("\tupstream ids {:?}", b.upstream_fragment_dispatcher_ids);
         }
 
         let mut fragment_created_actors = HashMap::new();

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -492,7 +492,6 @@ mod tests {
             comparator,
             mem_state_l,
             mem_state_r,
-            true,
             Arc::new(StreamingMetrics::unused()),
             1024,
             fallback.vnodes,

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -134,6 +134,7 @@ impl<S: StateStore> RangeCache<S> {
             ranges_to_fetch
         } else {
             self.range = Some(range.clone());
+            self.cache = HashMap::new();
             vec![range.clone()]
         };
 
@@ -194,6 +195,7 @@ impl<S: StateStore> RangeCache<S> {
             }
         }
         self.vnodes = new_vnodes;
+        self.range = None;
         old_vnodes
     }
 

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -27,6 +27,7 @@ use risingwave_common::types::{ScalarImpl, VIRTUAL_NODE_SIZE};
 use risingwave_common::util::epoch::EpochPair;
 use risingwave_storage::StateStore;
 
+use crate::cache::cache_may_stale;
 use crate::common::table::state_table::{prefix_range_to_memcomparable, StateTable};
 use crate::executor::error::StreamExecutorError;
 use crate::executor::StreamExecutorResult;
@@ -134,7 +135,6 @@ impl<S: StateStore> RangeCache<S> {
             ranges_to_fetch
         } else {
             self.range = Some(range.clone());
-            self.cache = HashMap::new();
             vec![range.clone()]
         };
 
@@ -188,14 +188,22 @@ impl<S: StateStore> RangeCache<S> {
     /// owned.
     pub fn update_vnodes(&mut self, new_vnodes: Arc<Bitmap>) -> Arc<Bitmap> {
         let old_vnodes = self.state_table.update_vnode_bitmap(new_vnodes.clone());
-        for (vnode, (old, new)) in old_vnodes.iter().zip_eq(new_vnodes.iter()).enumerate() {
-            if old && !new {
-                let vnode = vnode.try_into().unwrap();
-                self.cache.remove(&vnode);
+
+        // if new vnodes is not subset of old vnodes, clear cache and range, else delete the stale
+        // vnodes
+        if cache_may_stale(old_vnodes.as_ref(), new_vnodes.as_ref()) {
+            self.range = None;
+            self.cache = HashMap::new();
+        } else {
+            for (vnode, (old, new)) in old_vnodes.iter().zip_eq(new_vnodes.iter()).enumerate() {
+                if old && !new {
+                    let vnode = vnode.try_into().unwrap();
+                    self.cache.remove(&vnode);
+                }
             }
         }
         self.vnodes = new_vnodes;
-        self.range = None;
+
         old_vnodes
     }
 

--- a/src/stream/src/from_proto/dynamic_filter.rs
+++ b/src/stream/src/from_proto/dynamic_filter.rs
@@ -52,9 +52,6 @@ impl ExecutorBuilder for DynamicFilterExecutorBuilder {
             );
         }
 
-        // Only write the RHS value if this actor is in charge of vnode 0
-        let is_right_table_writer = vnodes.is_set(0);
-
         let state_table_l = StateTable::from_table_catalog(
             node.get_left_table()?,
             store.clone(),
@@ -75,7 +72,6 @@ impl ExecutorBuilder for DynamicFilterExecutorBuilder {
             comparator,
             state_table_l,
             state_table_r,
-            is_right_table_writer,
             params.executor_stats,
             params.env.config().developer.stream_chunk_size,
             vnodes,

--- a/src/tests/simulation_scale/tests/dynamic_filter.rs
+++ b/src/tests/simulation_scale/tests/dynamic_filter.rs
@@ -57,8 +57,8 @@ async fn test_dynamic_filter() -> Result<()> {
         .unwrap();
 
     let id = fragment.id();
-    //
-    // cluster.reschedule(format!("{id}-[1,2,3]")).await?;
+
+    cluster.reschedule(format!("{id}-[1,2,3]")).await?;
     sleep(Duration::from_secs(3)).await;
 
     cluster.run(SELECT).await?.assert_result_eq("");
@@ -70,7 +70,7 @@ async fn test_dynamic_filter() -> Result<()> {
     // 2
     // 3
 
-    // cluster.reschedule(format!("{id}-[4,5]+[1,2,3]")).await?;
+    cluster.reschedule(format!("{id}-[4,5]+[1,2,3]")).await?;
     sleep(Duration::from_secs(3)).await;
     cluster.run(SELECT).await?.assert_result_eq("1\n2\n3");
 
@@ -80,7 +80,7 @@ async fn test_dynamic_filter() -> Result<()> {
     cluster.run(SELECT).await?.assert_result_eq("3");
     // 3
 
-    // cluster.reschedule(format!("{id}-[1,2,3]+[4,5]")).await?;
+    cluster.reschedule(format!("{id}-[1,2,3]+[4,5]")).await?;
     sleep(Duration::from_secs(3)).await;
     cluster.run(SELECT).await?.assert_result_eq("3");
 
@@ -91,7 +91,7 @@ async fn test_dynamic_filter() -> Result<()> {
     // 2
     // 3
     //
-    // cluster.reschedule(format!("{id}+[1,2,3]")).await?;
+    cluster.reschedule(format!("{id}+[1,2,3]")).await?;
     sleep(Duration::from_secs(3)).await;
     cluster.run(SELECT).await?.assert_result_eq("2\n3");
 

--- a/src/tests/simulation_scale/tests/dynamic_filter.rs
+++ b/src/tests/simulation_scale/tests/dynamic_filter.rs
@@ -1,0 +1,113 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![cfg(madsim)]
+
+use std::collections::HashSet;
+use std::time::Duration;
+
+use anyhow::Result;
+use itertools::Itertools;
+use madsim::time::sleep;
+use risingwave_simulation_scale::cluster::{Cluster, Configuration};
+use risingwave_simulation_scale::ctl_ext::predicate::{identity_contains, no_identity_contains};
+use risingwave_simulation_scale::utils::AssertResult;
+
+const SELECT: &str = "select * from mv1 order by v1;";
+
+#[madsim::test]
+async fn test_dynamic_filter() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::default()).await?;
+
+    cluster.run("create table t1 (v1 int);").await?;
+    cluster.run("create table t2 (v2 int);").await?;
+    cluster.run("create materialized view mv1 as with max_v2 as (select max(v2) max from t2) select v1 from t1, max_v2 where v1 > max;").await?;
+    cluster.run("insert into t1 values (1), (2), (3)").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+
+    let dynamic_filter_fragment = cluster
+        .locate_one_fragment(vec![identity_contains("dynamicFilter")])
+        .await?;
+
+    let materialize_fragments = cluster
+        .locate_fragments(vec![identity_contains("materialize")])
+        .await?;
+
+    let upstream_fragment_ids: HashSet<_> = dynamic_filter_fragment
+        .inner
+        .upstream_fragment_ids
+        .iter()
+        .collect();
+
+    let fragment = materialize_fragments
+        .iter()
+        .find(|fragment| upstream_fragment_ids.contains(&fragment.id()))
+        .unwrap();
+
+    let id = fragment.id();
+    //
+    // cluster.reschedule(format!("{id}-[1,2,3]")).await?;
+    sleep(Duration::from_secs(3)).await;
+
+    cluster.run(SELECT).await?.assert_result_eq("");
+    cluster.run("insert into t2 values (0)").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+    cluster.run(SELECT).await?.assert_result_eq("1\n2\n3");
+    // 1
+    // 2
+    // 3
+
+    // cluster.reschedule(format!("{id}-[4,5]+[1,2,3]")).await?;
+    sleep(Duration::from_secs(3)).await;
+    cluster.run(SELECT).await?.assert_result_eq("1\n2\n3");
+
+    cluster.run("insert into t2 values (2)").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+    cluster.run(SELECT).await?.assert_result_eq("3");
+    // 3
+
+    // cluster.reschedule(format!("{id}-[1,2,3]+[4,5]")).await?;
+    sleep(Duration::from_secs(3)).await;
+    cluster.run(SELECT).await?.assert_result_eq("3");
+
+    cluster.run("update t2 set v2 = 1 where v2 = 2").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+    cluster.run(SELECT).await?.assert_result_eq("2\n3");
+    // 2
+    // 3
+    //
+    // cluster.reschedule(format!("{id}+[1,2,3]")).await?;
+    sleep(Duration::from_secs(3)).await;
+    cluster.run(SELECT).await?.assert_result_eq("2\n3");
+
+    cluster.run("delete from t2 where true").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+    cluster.run(SELECT).await?.assert_result_eq("");
+
+    cluster.reschedule(format!("{id}-[1]")).await?;
+    sleep(Duration::from_secs(3)).await;
+    cluster.run(SELECT).await?.assert_result_eq("");
+
+    cluster.run("insert into t2 values (1)").await?;
+    cluster.run("flush").await?;
+    sleep(Duration::from_secs(5)).await;
+    cluster.run(SELECT).await?.assert_result_eq("2\n3");
+
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After the introduction of `DynamicFilter`, there is a type of fragment which has multiple upstream fragments, but the dispatcher types of these fragments are not the same. For example the fragment of `DynamicFilter` has both `NoShuffle` and `Broadcast` upstream fragments, the processing in the current scaling logic is wrong.

This PR avoids these problems by modifying each of the multiple upstreams, ~but adds an index `fragment_dispatcher_map`, which will be refactored in a later PR~

Also, DynamicFilter has some bugs in scaling scenario like #6414 , this PR tries to fix them
 


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6414 #6292 