### PR TITLE
feat(expr): add struct to struct cast

### DIFF
--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -19,7 +19,8 @@ use bytes::{Bytes, BytesMut};
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};
 use num_traits::ToPrimitive;
 use postgres_types::ToSql;
-use risingwave_common::array::{Array, ListRef, ListValue};
+use risingwave_common::array::{Array, ListRef, ListValue, StructRef, StructValue};
+use risingwave_common::types::struct_type::StructType;
 use risingwave_common::types::to_text::ToText;
 use risingwave_common::types::{
     DataType, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
@@ -511,6 +512,26 @@ pub fn list_cast(
     ))
 }
 
+pub fn struct_cast(
+    input: StructRef<'_>,
+    source_elem_type: &StructType,
+    target_elem_type: &StructType,
+) -> Result<StructValue> {
+    Ok(StructValue::new(
+        input
+            .fields_ref()
+            .into_iter()
+            .zip(source_elem_type.fields.iter())
+            .zip(target_elem_type.fields.iter())
+            .map(|((datum_ref, source_elem_type), target_elem_type)| {
+                datum_ref
+                    .map(|scalar_ref| scalar_cast(scalar_ref, source_elem_type, target_elem_type))
+                    .transpose()
+            })
+            .try_collect()?,
+    ))
+}
+
 /// Cast scalar ref with `source_type` into owned scalar with `target_type`. This function forms a
 /// mutual recursion with `list_cast` so that we can cast nested lists (e.g., varchar[][] to
 /// int[][]).
@@ -522,6 +543,9 @@ fn scalar_cast(
     use crate::expr::data_types::*;
 
     match (source_type, target_type) {
+        (DataType::Struct(source_type), DataType::Struct(target_type)) => {
+            Ok(struct_cast(source.try_into()?, &*source_type, &*target_type)?.to_scalar_value())
+        }
         (
             DataType::List {
                 datatype: source_elem_type,
@@ -792,5 +816,31 @@ mod tests {
         assert!(str_to_list("{}}", &DataType::Int32).is_err());
         assert!(str_to_list("{{1, 2, 3}, {4, 5, 6}", &DataType::Int32).is_err());
         assert!(str_to_list("{{1, 2, 3}, 4, 5, 6}}", &DataType::Int32).is_err());
+    }
+
+    #[test]
+    fn test_struct_cast() {
+        assert_eq!(
+            struct_cast(
+                StructValue::new(vec![
+                    Some("1".to_string().to_scalar_value()),
+                    Some(OrderedF32::from(0.0).to_scalar_value()),
+                ])
+                .as_scalar_ref(),
+                &StructType::new(vec![
+                    (DataType::Varchar, "a".to_string()),
+                    (DataType::Float32, "b".to_string()),
+                ]),
+                &StructType::new(vec![
+                    (DataType::Int32, "a".to_string()),
+                    (DataType::Int32, "b".to_string()),
+                ])
+            )
+            .unwrap(),
+            StructValue::new(vec![
+                Some(1i32.to_scalar_value()),
+                Some(0i32.to_scalar_value()),
+            ])
+        );
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao 2 <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds support for struct-to-struct cast. Then we can add support on frontend to infer implicit casts when doing something like `select row(1) == row('1')`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

part of https://github.com/risingwavelabs/risingwave/issues/3692
