### PR TITLE
fix(nexmark): change the partitioning strategy for each split and fix spin loop

### DIFF
--- a/src/connector/src/source/nexmark/mod.rs
+++ b/src/connector/src/source/nexmark/mod.rs
@@ -51,7 +51,7 @@ pub struct NexmarkPropertiesInner {
     /// The total event count of Bid + Auction + Person
     #[serde_as(as = "DisplayFromStr")]
     #[serde(rename = "nexmark.event.num", default = "default_event_num")]
-    pub event_num: i64,
+    pub event_num: u64,
 
     #[serde(rename = "nexmark.table.type", default = "default_event_type")]
     pub table_type: EventType,
@@ -217,8 +217,8 @@ pub struct NexmarkPropertiesInner {
     pub threads: Option<usize>,
 }
 
-fn default_event_num() -> i64 {
-    -1
+fn default_event_num() -> u64 {
+    u64::MAX
 }
 
 fn default_event_type() -> EventType {

--- a/src/connector/src/source/nexmark/source/reader.rs
+++ b/src/connector/src/source/nexmark/source/reader.rs
@@ -54,7 +54,6 @@ impl SplitReader for NexmarkSplitReader {
     ) -> Result<Self> {
         let mut assigned_split = NexmarkSplit::default();
         let mut split_id = "".into();
-        let mut split_index = 0;
         let mut split_num = 1;
         let mut offset = 0;
 
@@ -65,7 +64,7 @@ impl SplitReader for NexmarkSplitReader {
             split_id = split.id();
             let split = split.into_nexmark().unwrap();
 
-            split_index = split.split_index as u64;
+            let split_index = split.split_index as u64;
             split_num = split.split_num as u64;
             offset = split.start_offset.unwrap_or(split_index);
             assigned_split = split;

--- a/src/tests/simulation_scale/src/nexmark.rs
+++ b/src/tests/simulation_scale/src/nexmark.rs
@@ -145,7 +145,7 @@ pub mod queries {
     use std::time::Duration;
 
     const DEFAULT_INITIAL_INTERVAL: Duration = Duration::from_secs(1);
-    const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(10);
+    const DEFAULT_INITIAL_TIMEOUT: Duration = Duration::from_secs(20);
 
     pub mod q3 {
         use super::*;

--- a/src/tests/simulation_scale/tests/nexmark_chaos.rs
+++ b/src/tests/simulation_scale/tests/nexmark_chaos.rs
@@ -113,7 +113,7 @@ fn nexmark_chaos_common(
 
 macro_rules! test {
     ($query:ident) => {
-        test!($query, Duration::from_secs(5));
+        test!($query, Duration::from_secs(1));
     };
     ($query:ident, $after_scale_duration:expr) => {
         paste::paste! {
@@ -156,6 +156,6 @@ test!(q4);
 test!(q5);
 // q6: cannot plan
 test!(q7);
-test!(q8, Duration::from_secs(2));
+test!(q8);
 test!(q9);
 // TODO: extended queries from q10

--- a/src/tests/simulation_scale/tests/nexmark_source.rs
+++ b/src/tests/simulation_scale/tests/nexmark_source.rs
@@ -56,7 +56,7 @@ async fn nexmark_source() -> Result<()> {
     sleep(Duration::from_secs(5)).await;
     reschedule!();
 
-    sleep(Duration::from_secs(20)).await;
+    sleep(Duration::from_secs(30)).await;
     cluster
         .run(
             "select count_person + count_auction + count_bid from count_person, count_auction, count_bid;",

--- a/src/utils/nexmark/src/generator.rs
+++ b/src/utils/nexmark/src/generator.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Duration;
-
 use crate::config::{GeneratorConfig, NexmarkConfig};
 use crate::event::*;
 
@@ -21,10 +19,12 @@ use crate::event::*;
 #[derive(Default, Clone, Debug)]
 pub struct EventGenerator {
     cfg: GeneratorConfig,
-    events_so_far: u64,
+    /// The current offset of event.
+    offset: u64,
+    /// Each iteration the offset is incremented by this step.
+    step: u64,
     /// If Some, only the specified type of events will be generated.
     type_filter: Option<EventType>,
-    elapsed_ms: u64,
 }
 
 impl EventGenerator {
@@ -32,50 +32,58 @@ impl EventGenerator {
     pub fn new(config: NexmarkConfig) -> Self {
         EventGenerator {
             cfg: config.into(),
-            events_so_far: 0,
+            offset: 0,
+            step: 1,
             type_filter: None,
-            elapsed_ms: 0,
         }
     }
 
-    /// Set the start event offset.
-    pub fn with_events_so_far(mut self, events_so_far: u64) -> Self {
-        self.events_so_far = events_so_far;
+    /// Set the start event offset. Default: 0.
+    pub fn with_offset(mut self, offset: u64) -> Self {
+        self.offset = offset;
         self
     }
 
-    /// Set the type of events to generate.
+    /// Set the step. Default: 1.
+    pub fn with_step(mut self, step: u64) -> Self {
+        assert_ne!(step, 0);
+        self.step = step;
+        self
+    }
+
+    /// Set the type of events to generate. Default: all.
     pub fn with_type_filter(mut self, type_: EventType) -> Self {
         self.type_filter = Some(type_);
         self
     }
 
-    /// Return the number of events so far.
-    pub fn events_so_far(&self) -> u64 {
-        self.events_so_far
+    /// Return the current offset of the generator.
+    pub fn offset(&self) -> u64 {
+        self.offset
     }
 
-    /// Returns the amount of time elapsed since the base time to the last event timestamp.
-    pub fn elapsed(&self) -> Duration {
-        Duration::from_millis(self.elapsed_ms)
+    /// Return the timestamp of current offset event.
+    pub fn timestamp(&self) -> u64 {
+        let event_number = self.cfg.next_adjusted_event(self.offset as usize);
+        self.cfg.event_timestamp(event_number)
     }
 }
 
 impl Iterator for EventGenerator {
-    type Item = Event;
+    type Item = (u64, Event);
 
-    fn next(&mut self) -> Option<Event> {
+    fn next(&mut self) -> Option<(u64, Event)> {
         loop {
-            let event_number = self.cfg.next_adjusted_event(self.events_so_far as usize);
+            let offset = self.offset;
+            let event_number = self.cfg.next_adjusted_event(offset as usize);
             let event_type = self.cfg.event_type(event_number);
-            self.events_so_far += 1;
+            self.offset += self.step;
 
             if matches!(self.type_filter, Some(t) if t != event_type) {
                 continue;
             }
             let event = Event::new(event_number, &self.cfg);
-            self.elapsed_ms = event.timestamp() - self.cfg.base_time;
-            return Some(event);
+            return Some((offset, event));
         }
     }
 }

--- a/src/utils/nexmark/src/main.rs
+++ b/src/utils/nexmark/src/main.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use clap::{Parser, ValueEnum};
 use nexmark::event::{Event, EventType};
@@ -29,6 +29,14 @@ pub struct Args {
     /// If not specified, generate events forever.
     #[clap(short, long)]
     number: Option<usize>,
+
+    /// The start event offset.
+    #[clap(long, default_value = "0")]
+    offset: u64,
+
+    /// The step for each iteration.
+    #[clap(long, default_value = "1")]
+    step: u64,
 
     /// Print format.
     #[clap(long, value_enum, default_value = "json")]
@@ -59,19 +67,22 @@ fn main() {
     let opts = Args::parse();
     let number = opts.number.unwrap_or(usize::MAX);
 
-    let iter = EventGenerator::default();
-    let mut iter = match opts.type_ {
+    let iter = EventGenerator::default()
+        .with_offset(opts.offset)
+        .with_step(opts.step);
+    let iter = match opts.type_ {
         Type::All => iter,
         Type::Person => iter.with_type_filter(EventType::Person),
         Type::Auction => iter.with_type_filter(EventType::Auction),
         Type::Bid => iter.with_type_filter(EventType::Bid),
     };
     let start_time = Instant::now();
-    let mut i = 0;
-    while let Some(event) = iter.next() {
+    let start_ts = iter.timestamp();
+    for (_, event) in iter.take(number) {
         if !opts.no_wait {
+            let emit_time = start_time + Duration::from_millis(event.timestamp() - start_ts);
             // sleep until the timestamp of the event
-            if let Some(t) = (start_time + iter.elapsed()).checked_duration_since(Instant::now()) {
+            if let Some(t) = emit_time.checked_duration_since(Instant::now()) {
                 std::thread::sleep(t);
             }
         }
@@ -82,10 +93,6 @@ fn main() {
                 Event::Auction(e) => println!("{e:?}"),
                 Event::Bid(e) => println!("{e:?}"),
             },
-        }
-        i += 1;
-        if i >= number {
-            break;
         }
     }
 }

--- a/src/utils/nexmark/src/main.rs
+++ b/src/utils/nexmark/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
     };
     let start_time = Instant::now();
     let start_ts = iter.timestamp();
-    for (_, event) in iter.take(number) {
+    for event in iter.take(number) {
         if !opts.no_wait {
             let emit_time = start_time + Duration::from_millis(event.timestamp() - start_ts);
             // sleep until the timestamp of the event


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As mentioned in #6450, the current partitioning strategy in nexmark makes some splits have no events and fall in a spin loop. This PR fixes it by changing the partitioning strategy. For each split, it no longer maintains the global offset of all events, but a local offset of its own type. This way, we can make sure each split is assigned to an even number of events for a certain type.

```
Global  Offset: 0 1 2 3 4 5 ... 49 50 51 52 53 54 55 ... 99
Person  Offset: 0                   1
Auction Offset:   0 1 2                3  4  5
Bid     Offset:         0 1 ... 45             46 47 ... 91

Person  Offset: 0 1 2 ... 7 8 9 10 ... 15
Person  Split:  0 1 2 ... 7 0 1  2 ...  7
```

After this PR, the performance of simulation test `./risedev sslt --release -- ./e2e_test/source/nexmark_endless.slt` has been further improved. The execution time dropped from 1.1s to 0.5s, and the percentage of overhead dropped from 20% to 9%.

I also noticed that previous nexmark generator would sleep based on the relative time inside a chunk, instead of elapsed time from the beginning. This would result in lower throughput than we set. This PR corrects this behavior, and adjusts the corresponding sleep time in the scale test.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
fix #6450