### PR TITLE
fix(dynamic_filter): let executor write correct data upon scaling change

### DIFF
--- a/src/source/src/parser/common.rs
+++ b/src/source/src/parser/common.rs
@@ -70,12 +70,12 @@ fn do_parse_json_value(dtype: &DataType, v: &Value) -> Result<ScalarImpl> {
         DataType::Time => str_to_time(ensure_str!(v, "time"))?.into(),
         DataType::Timestamp => match v {
             Value::String(s) => str_to_timestamp(s)?.into(),
-            Value::Number(n) => i64_to_timestamp(ensure_int!(v, i64))?.into(),
+            Value::Number(_n) => i64_to_timestamp(ensure_int!(v, i64))?.into(),
             _ => anyhow::bail!("expect timestamp, but found {v}"),
         },
         DataType::Timestampz => match v {
             Value::String(s) => str_to_timestampz(s)?.into(),
-            Value::Number(n) => i64_to_timestampz(ensure_int!(v, i64))?.into(),
+            Value::Number(_n) => i64_to_timestampz(ensure_int!(v, i64))?.into(),
             _ => anyhow::bail!("expect timestampz, but found {v}"),
         },
         DataType::Struct(struct_type_info) => {

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -356,6 +356,11 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                 }
                 AlignedMessage::Barrier(barrier) => {
                     // Flush the difference between the `prev_value` and `current_value`
+                    //
+                    // This block is guaranteed to be idempotent even if we may encounter multiple barriers
+                    // since `prev_epoch_value` is always be reset to the equivalent of `current_epoch_value` 
+                    // at the end of this block. Likewise, `last_commited_epoch_row` will always be equal to 
+                    // `current_epoch_row`.
                     let curr: Datum = current_epoch_value.clone().flatten();
                     let prev: Datum = prev_epoch_value.flatten();
                     let row_deserializer = RowDeserializer::new(self.schema.data_types());
@@ -375,9 +380,11 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         }
                     }
 
-                    // Only write the RHS value if this actor is in charge of vnode 0
-                    if self.range_cache.state_table.vnode_bitmap().is_set(0) {
-                        if last_committed_epoch_row != current_epoch_row {
+                    // Update the commited value on RHS if it has changed.
+                    if last_committed_epoch_row != current_epoch_row {
+                        // Only write the RHS value if this actor is in charge of vnode 0
+                        // Otherwise, we only actively replicate the changes.
+                        if self.range_cache.state_table.vnode_bitmap().is_set(0) {
                             // If both `None`, then this branch is inactive.
                             // Hence, at least one is `Some`, hence at least one update.
                             if let Some(old_row) = last_committed_epoch_row.take() {
@@ -385,19 +392,22 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                             }
                             if let Some(row) = &current_epoch_row {
                                 self.right_table.insert(row.clone());
-                                last_committed_epoch_row = Some(row.clone());
                             }
                             self.right_table.commit(barrier.epoch).await?;
                         } else {
                             self.right_table.commit_no_data_expected(barrier.epoch);
                         }
+                        // Update the last commited row since it has changed
+                        last_commited_epoch_row = current_epoch_row.clone();
                     } else {
-                        last_committed_epoch_row = current_epoch_row.clone();
+                        self.right_table.commit_no_data_expected(barrier.epoch);
                     }
 
                     self.range_cache.flush(barrier.epoch).await?;
 
                     prev_epoch_value = Some(curr);
+
+                    debug_assert_eq!(last_commited_epoch_row, current_epoch_row);
 
                     // Update the vnode bitmap for the left state table if asked.
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -362,6 +362,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                     // the equivalent of `current_epoch_value` at the end of
                     // this block. Likewise, `last_committed_epoch_row` will always be equal to
                     // `current_epoch_row`.
+                    // It is thus guaranteed not to commit state or produce chunks as long as
+                    // no new chunks have arrived since the previous barrier.
                     let curr: Datum = current_epoch_value.clone().flatten();
                     let prev: Datum = prev_epoch_value.flatten();
                     let row_deserializer = RowDeserializer::new(self.schema.data_types());

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -391,6 +391,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         } else {
                             self.right_table.commit_no_data_expected(barrier.epoch);
                         }
+                    } else {
+                        last_committed_epoch_row = current_epoch_row.clone();
                     }
 
                     self.range_cache.flush(barrier.epoch).await?;

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -360,7 +360,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                     // This block is guaranteed to be idempotent even if we may encounter multiple
                     // barriers since `prev_epoch_value` is always be reset to
                     // the equivalent of `current_epoch_value` at the end of
-                    // this block. Likewise, `last_commited_epoch_row` will always be equal to
+                    // this block. Likewise, `last_committed_epoch_row` will always be equal to
                     // `current_epoch_row`.
                     let curr: Datum = current_epoch_value.clone().flatten();
                     let prev: Datum = prev_epoch_value.flatten();
@@ -381,7 +381,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         }
                     }
 
-                    // Update the commited value on RHS if it has changed.
+                    // Update the committed value on RHS if it has changed.
                     if last_committed_epoch_row != current_epoch_row {
                         // Only write the RHS value if this actor is in charge of vnode 0
                         // Otherwise, we only actively replicate the changes.
@@ -398,8 +398,8 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         } else {
                             self.right_table.commit_no_data_expected(barrier.epoch);
                         }
-                        // Update the last commited row since it has changed
-                        last_commited_epoch_row = current_epoch_row.clone();
+                        // Update the last committed row since it has changed
+                        last_committed_epoch_row = current_epoch_row.clone();
                     } else {
                         self.right_table.commit_no_data_expected(barrier.epoch);
                     }
@@ -408,7 +408,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
 
                     prev_epoch_value = Some(curr);
 
-                    debug_assert_eq!(last_commited_epoch_row, current_epoch_row);
+                    debug_assert_eq!(last_committed_epoch_row, current_epoch_row);
 
                     // Update the vnode bitmap for the left state table if asked.
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -357,9 +357,10 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                 AlignedMessage::Barrier(barrier) => {
                     // Flush the difference between the `prev_value` and `current_value`
                     //
-                    // This block is guaranteed to be idempotent even if we may encounter multiple barriers
-                    // since `prev_epoch_value` is always be reset to the equivalent of `current_epoch_value` 
-                    // at the end of this block. Likewise, `last_commited_epoch_row` will always be equal to 
+                    // This block is guaranteed to be idempotent even if we may encounter multiple
+                    // barriers since `prev_epoch_value` is always be reset to
+                    // the equivalent of `current_epoch_value` at the end of
+                    // this block. Likewise, `last_commited_epoch_row` will always be equal to
                     // `current_epoch_row`.
                     let curr: Datum = current_epoch_value.clone().flatten();
                     let prev: Datum = prev_epoch_value.flatten();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
let executor write correct data upon change in dynamic filter
- How does this PR work? Need a brief introduction for the changed logic (optional)
maintain `last_comitted_row`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6470 