### PR TITLE
feat(watermark): Clean state in DynamicFilter by watermark in right side

### DIFF
--- a/src/stream/src/executor/barrier_align.rs
+++ b/src/stream/src/executor/barrier_align.rs
@@ -23,7 +23,7 @@ use futures_async_stream::try_stream;
 use risingwave_common::bail;
 
 use super::error::StreamExecutorError;
-use super::{Barrier, BoxedMessageStream, Message, StreamChunk, StreamExecutorResult};
+use super::{Barrier, BoxedMessageStream, Message, StreamChunk, StreamExecutorResult, Watermark};
 use crate::executor::monitor::StreamingMetrics;
 use crate::task::ActorId;
 
@@ -33,6 +33,8 @@ pub trait AlignedMessageStream = futures::Stream<Item = AlignedMessageStreamItem
 #[derive(Debug, EnumAsInner, PartialEq)]
 pub enum AlignedMessage {
     Barrier(Barrier),
+    WatermarkLeft(Watermark),
+    WatermarkRight(Watermark),
     Left(StreamChunk),
     Right(StreamChunk),
 }
@@ -60,8 +62,8 @@ pub async fn barrier_align(
                 // left stream end, passthrough right chunks
                 while let Some(msg) = right.next().await {
                     match msg? {
-                        Message::Watermark(_) => {
-                            todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                        Message::Watermark(watermark) => {
+                            yield AlignedMessage::WatermarkRight(watermark)
                         }
                         Message::Chunk(chunk) => yield AlignedMessage::Right(chunk),
                         Message::Barrier(_) => {
@@ -75,8 +77,8 @@ pub async fn barrier_align(
                 // right stream end, passthrough left chunks
                 while let Some(msg) = left.next().await {
                     match msg? {
-                        Message::Watermark(_) => {
-                            todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                        Message::Watermark(watermark) => {
+                            yield AlignedMessage::WatermarkLeft(watermark)
                         }
                         Message::Chunk(chunk) => yield AlignedMessage::Left(chunk),
                         Message::Barrier(_) => {
@@ -87,9 +89,7 @@ pub async fn barrier_align(
                 break;
             }
             Either::Left((Some(msg), _)) => match msg? {
-                Message::Watermark(_) => {
-                    todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
-                }
+                Message::Watermark(watermark) => yield AlignedMessage::WatermarkLeft(watermark),
                 Message::Chunk(chunk) => yield AlignedMessage::Left(chunk),
                 Message::Barrier(_) => loop {
                     let start_time = Instant::now();
@@ -99,8 +99,8 @@ pub async fn barrier_align(
                         .await
                         .context("failed to poll right message, stream closed unexpectedly")??
                     {
-                        Message::Watermark(_) => {
-                            todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                        Message::Watermark(watermark) => {
+                            yield AlignedMessage::WatermarkRight(watermark)
                         }
                         Message::Chunk(chunk) => yield AlignedMessage::Right(chunk),
                         Message::Barrier(barrier) => {
@@ -115,9 +115,7 @@ pub async fn barrier_align(
                 },
             },
             Either::Right((Some(msg), _)) => match msg? {
-                Message::Watermark(_) => {
-                    todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
-                }
+                Message::Watermark(watermark) => yield AlignedMessage::WatermarkRight(watermark),
                 Message::Chunk(chunk) => yield AlignedMessage::Right(chunk),
                 Message::Barrier(_) => loop {
                     let start_time = Instant::now();
@@ -127,8 +125,8 @@ pub async fn barrier_align(
                         .await
                         .context("failed to poll left message, stream closed unexpectedly")??
                     {
-                        Message::Watermark(_) => {
-                            todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                        Message::Watermark(watermark) => {
+                            yield AlignedMessage::WatermarkLeft(watermark)
                         }
                         Message::Chunk(chunk) => yield AlignedMessage::Left(chunk),
                         Message::Barrier(barrier) => {

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -300,7 +300,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
             left_to_output,
         );
 
-        let is_watermark_direct_accord = !matches!(self.comparator, LessThan | LessThanOrEqual);
+        let watermark_can_clean_state = !matches!(self.comparator, LessThan | LessThanOrEqual);
         let mut unused_clean_hint = None;
 
         #[for_await]
@@ -361,7 +361,7 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                     // Do nothing.
                 }
                 AlignedMessage::WatermarkRight(watermark) => {
-                    if is_watermark_direct_accord {
+                    if watermark_can_clean_state {
                         unused_clean_hint = Some(watermark);
                     }
                 }

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -300,6 +300,9 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
             left_to_output,
         );
 
+        let is_watermark_direct_accord = !matches!(self.comparator, LessThan | LessThanOrEqual);
+        let mut unused_clean_hint = None;
+
         #[for_await]
         for msg in aligned_stream {
             match msg? {
@@ -354,6 +357,14 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                         }
                     }
                 }
+                AlignedMessage::WatermarkLeft(_) => {
+                    // Do nothing.
+                }
+                AlignedMessage::WatermarkRight(watermark) => {
+                    if is_watermark_direct_accord {
+                        unused_clean_hint = Some(watermark);
+                    }
+                }
                 AlignedMessage::Barrier(barrier) => {
                     // Flush the difference between the `prev_value` and `current_value`
                     //
@@ -382,6 +393,12 @@ impl<S: StateStore> DynamicFilterExecutor<S> {
                             yield Message::Chunk(chunk);
                         }
                     }
+
+                    if let Some(mut watermark) = unused_clean_hint.take() {
+                        self.range_cache.shrink(watermark.val.clone());
+                        watermark.col_idx = self.key_l;
+                        yield Message::Watermark(watermark);
+                    };
 
                     // Update the committed value on RHS if it has changed.
                     if last_committed_epoch_row != current_epoch_row {

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -619,6 +619,9 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 .with_label_values(&[&actor_id_str])
                 .inc_by(start_time.elapsed().as_nanos() as u64);
             match msg? {
+                AlignedMessage::WatermarkLeft(_) | AlignedMessage::WatermarkRight(_) => {
+                    todo!("https://github.com/risingwavelabs/risingwave/issues/6042")
+                }
                 AlignedMessage::Left(chunk) => {
                     #[for_await]
                     for chunk in Self::eq_join_oneside::<{ SideType::Left }>(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Clean state in `DynamicFilter` by watermark **in right side**
- How does this PR work? Need a brief introduction for the changed logic (optional)
Do range delete by cached watermark among corresponding vnodes on barrier
- Describe clearly one logical change and avoid lazy messages (optional)
Buffer and state table will both be cleaned
`BarrierAlign` is modified
- Describe any limitations of the current code (optional)
If comparator is `LessThan`, it will not be cleaned

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6472 