### PR TITLE
perf(dynamic filter): concurrently load from state table

### DIFF
--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -159,7 +159,7 @@ impl<S: StateStore> RangeCache<S> {
                 .map(|vnode| {
                     self.cache
                         .get_mut(&(vnode as VirtualNode))
-                        .map(|map| std::mem::take(map))
+                        .map(std::mem::take)
                         .unwrap_or_default()
                 })
                 .collect_vec();

--- a/src/stream/src/executor/managed_state/dynamic_filter.rs
+++ b/src/stream/src/executor/managed_state/dynamic_filter.rs
@@ -158,7 +158,8 @@ impl<S: StateStore> RangeCache<S> {
                 .ones()
                 .map(|vnode| {
                     self.cache
-                        .remove(&(vnode as VirtualNode))
+                        .get_mut(&(vnode as VirtualNode))
+                        .map(|map| std::mem::take(map))
                         .unwrap_or_default()
                 })
                 .collect_vec();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
concurrently load from state table
- How does this PR work? Need a brief introduction for the changed logic (optional)
parallel load by vnode to accelerate from state table in dynamic filter
a todo in current code:
https://github.com/risingwavelabs/risingwave/blob/4cfa252b5cc0e973c8fa146d66cfd3a52a0c08a0/src/stream/src/executor/managed_state/dynamic_filter.rs#L157
- Describe clearly one logical change and avoid lazy messages (optional)
buffer data loaded in each vnode with a `BTreeMap`
- Describe any limitations of the current code (optional)

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6489 