### PR TITLE
feat(streaming): add watermark message variant in proto

### DIFF
--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import { ColumnIndex, StreamSourceInfo, Table, TableSourceInfo } from "./catalog";
 import { Buffer } from "./common";
-import { Datum, Epoch, IntervalUnit, StreamChunk } from "./data";
+import { DataType, Datum, Epoch, IntervalUnit, StreamChunk } from "./data";
 import { AggCall, ExprNode, InputRefExpr, ProjectSetSelectItem } from "./expr";
 import {
   ColumnCatalog,
@@ -292,14 +292,21 @@ export interface Barrier {
 }
 
 export interface Watermark {
-  /** the watermark column's index in the stream's schema */
+  /** The watermark column's index in the stream's schema. */
   colIdx: number;
-  /** the watermark value, there will be no record having a greater value in the watermark column */
+  /** The watermark type, used for deserialization of the watermark value. */
+  dataType:
+    | DataType
+    | undefined;
+  /** The watermark value, there will be no record having a greater value in the watermark column. */
   val: Datum | undefined;
 }
 
 export interface StreamMessage {
-  streamMessage?: { $case: "streamChunk"; streamChunk: StreamChunk } | { $case: "barrier"; barrier: Barrier };
+  streamMessage?: { $case: "streamChunk"; streamChunk: StreamChunk } | { $case: "barrier"; barrier: Barrier } | {
+    $case: "watermark";
+    watermark: Watermark;
+  };
 }
 
 /** Hash mapping for compute node. Stores mapping from virtual node to actor id. */
@@ -1468,13 +1475,14 @@ export const Barrier = {
 };
 
 function createBaseWatermark(): Watermark {
-  return { colIdx: 0, val: undefined };
+  return { colIdx: 0, dataType: undefined, val: undefined };
 }
 
 export const Watermark = {
   fromJSON(object: any): Watermark {
     return {
       colIdx: isSet(object.colIdx) ? Number(object.colIdx) : 0,
+      dataType: isSet(object.dataType) ? DataType.fromJSON(object.dataType) : undefined,
       val: isSet(object.val) ? Datum.fromJSON(object.val) : undefined,
     };
   },
@@ -1482,6 +1490,7 @@ export const Watermark = {
   toJSON(message: Watermark): unknown {
     const obj: any = {};
     message.colIdx !== undefined && (obj.colIdx = Math.round(message.colIdx));
+    message.dataType !== undefined && (obj.dataType = message.dataType ? DataType.toJSON(message.dataType) : undefined);
     message.val !== undefined && (obj.val = message.val ? Datum.toJSON(message.val) : undefined);
     return obj;
   },
@@ -1489,6 +1498,9 @@ export const Watermark = {
   fromPartial<I extends Exact<DeepPartial<Watermark>, I>>(object: I): Watermark {
     const message = createBaseWatermark();
     message.colIdx = object.colIdx ?? 0;
+    message.dataType = (object.dataType !== undefined && object.dataType !== null)
+      ? DataType.fromPartial(object.dataType)
+      : undefined;
     message.val = (object.val !== undefined && object.val !== null) ? Datum.fromPartial(object.val) : undefined;
     return message;
   },
@@ -1505,6 +1517,8 @@ export const StreamMessage = {
         ? { $case: "streamChunk", streamChunk: StreamChunk.fromJSON(object.streamChunk) }
         : isSet(object.barrier)
         ? { $case: "barrier", barrier: Barrier.fromJSON(object.barrier) }
+        : isSet(object.watermark)
+        ? { $case: "watermark", watermark: Watermark.fromJSON(object.watermark) }
         : undefined,
     };
   },
@@ -1516,6 +1530,10 @@ export const StreamMessage = {
       : undefined);
     message.streamMessage?.$case === "barrier" &&
       (obj.barrier = message.streamMessage?.barrier ? Barrier.toJSON(message.streamMessage?.barrier) : undefined);
+    message.streamMessage?.$case === "watermark" &&
+      (obj.watermark = message.streamMessage?.watermark
+        ? Watermark.toJSON(message.streamMessage?.watermark)
+        : undefined);
     return obj;
   },
 
@@ -1537,6 +1555,13 @@ export const StreamMessage = {
       object.streamMessage?.barrier !== null
     ) {
       message.streamMessage = { $case: "barrier", barrier: Barrier.fromPartial(object.streamMessage.barrier) };
+    }
+    if (
+      object.streamMessage?.$case === "watermark" &&
+      object.streamMessage?.watermark !== undefined &&
+      object.streamMessage?.watermark !== null
+    ) {
+      message.streamMessage = { $case: "watermark", watermark: Watermark.fromPartial(object.streamMessage.watermark) };
     }
     return message;
   },

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -95,10 +95,11 @@ message Barrier {
 }
 
 message Watermark {
-  // the watermark column's index in the stream's schema
+  // The watermark column's index in the stream's schema.
   uint32 col_idx = 1;
+  // The watermark type, used for deserialization of the watermark value.
   data.DataType data_type = 2;
-  // the watermark value, there will be no record having a greater value in the watermark column
+  // The watermark value, there will be no record having a greater value in the watermark column.
   data.Datum val = 3;
 }
 

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -97,14 +97,16 @@ message Barrier {
 message Watermark {
   // the watermark column's index in the stream's schema
   uint32 col_idx = 1;
+  data.DataType data_type = 2;
   // the watermark value, there will be no record having a greater value in the watermark column
-  data.Datum val = 2;
+  data.Datum val = 3;
 }
 
 message StreamMessage {
   oneof stream_message {
     data.StreamChunk stream_chunk = 1;
     Barrier barrier = 2;
+    Watermark watermark = 3;
   }
 }
 

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -466,6 +466,7 @@ mod tests {
                     } else {
                         tx.send(Message::Watermark(Watermark {
                             col_idx: (epoch as usize / 20 + tx_id) % CHANNEL_NUMBER,
+                            data_type: DataType::Int64,
                             val: ScalarImpl::Int64(epoch as i64),
                         }))
                         .await

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -566,12 +566,12 @@ impl Watermark {
 
     pub fn from_protobuf(prost: &ProstWatermark) -> StreamExecutorResult<Self> {
         let data_type = DataType::from(prost.get_data_type()?);
-        // Should never receive a Null watermark value here
-        let datum = deserialize_datum(prost.get_val()?.get_body().as_slice(), &data_type)?.unwrap();
+        let val = deserialize_datum(prost.get_val()?.get_body().as_slice(), &data_type)?
+            .expect("watermark value cannot be null");
         Ok(Watermark {
             col_idx: prost.col_idx as _,
             data_type,
-            val: datum,
+            val,
         })
     }
 }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -524,6 +524,7 @@ impl Barrier {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Watermark {
     col_idx: usize,
+    data_type: DataType,
     val: ScalarImpl,
 }
 
@@ -545,27 +546,32 @@ impl Ord for Watermark {
 }
 
 impl Watermark {
-    pub fn new(col_idx: usize, val: ScalarImpl) -> Self {
-        Self { col_idx, val }
+    pub fn new(col_idx: usize, data_type: DataType, val: ScalarImpl) -> Self {
+        Self {
+            col_idx,
+            data_type,
+            val,
+        }
     }
 
     pub fn to_protobuf(&self) -> ProstWatermark {
         ProstWatermark {
             col_idx: self.col_idx as _,
+            data_type: Some(self.data_type.to_protobuf()),
             val: Some(ProstDatum {
                 body: serialize_datum_to_bytes(Some(&self.val)),
             }),
         }
     }
 
-    pub fn from_protobuf(
-        prost: &ProstWatermark,
-        data_type: &DataType,
-    ) -> StreamExecutorResult<Self> {
+    pub fn from_protobuf(prost: &ProstWatermark) -> StreamExecutorResult<Self> {
+        let data_type = DataType::from(prost.get_data_type()?);
+        // Should never receive a Null watermark value here
+        let datum = deserialize_datum(prost.get_val()?.get_body().as_slice(), &data_type)?.unwrap();
         Ok(Watermark {
             col_idx: prost.col_idx as _,
-            // Should never receive a Null watermark value here
-            val: deserialize_datum(&*prost.get_val()?.body, data_type)?.unwrap(),
+            data_type,
+            val: datum,
         })
     }
 }
@@ -612,7 +618,7 @@ impl Message {
                 StreamMessage::StreamChunk(prost_stream_chunk)
             }
             Self::Barrier(barrier) => StreamMessage::Barrier(barrier.clone().to_protobuf()),
-            Self::Watermark(_) => todo!("https://github.com/risingwavelabs/risingwave/issues/6042"),
+            Self::Watermark(watermark) => StreamMessage::Watermark(watermark.to_protobuf()),
         };
         ProstStreamMessage {
             stream_message: Some(prost),
@@ -621,11 +627,10 @@ impl Message {
 
     pub fn from_protobuf(prost: &ProstStreamMessage) -> StreamExecutorResult<Self> {
         let res = match prost.get_stream_message()? {
-            StreamMessage::StreamChunk(ref stream_chunk) => {
-                Message::Chunk(StreamChunk::from_protobuf(stream_chunk)?)
-            }
-            StreamMessage::Barrier(ref barrier) => {
-                Message::Barrier(Barrier::from_protobuf(barrier)?)
+            StreamMessage::StreamChunk(chunk) => Message::Chunk(StreamChunk::from_protobuf(chunk)?),
+            StreamMessage::Barrier(barrier) => Message::Barrier(Barrier::from_protobuf(barrier)?),
+            StreamMessage::Watermark(watermark) => {
+                Message::Watermark(Watermark::from_protobuf(watermark)?)
             }
         };
         Ok(res)

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -49,14 +49,19 @@ impl MessageSender {
     }
 
     #[allow(dead_code)]
-    pub fn push_int64_watermark(&mut self, col_idx: usize, val: i64) {
+    pub fn push_watermark(&mut self, col_idx: usize, data_type: DataType, val: ScalarImpl) {
         self.0
             .send(Message::Watermark(Watermark {
                 col_idx,
-                data_type: DataType::Int64,
-                val: ScalarImpl::Int64(val),
+                data_type,
+                val,
             }))
             .unwrap();
+    }
+
+    #[allow(dead_code)]
+    pub fn push_int64_watermark(&mut self, col_idx: usize, val: i64) {
+        self.push_watermark(col_idx, DataType::Int64, ScalarImpl::Int64(val));
     }
 }
 

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -15,7 +15,7 @@
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::Schema;
-use risingwave_common::types::ScalarImpl;
+use risingwave_common::types::{DataType, ScalarImpl};
 use tokio::sync::mpsc;
 
 use super::error::StreamExecutorError;
@@ -49,9 +49,13 @@ impl MessageSender {
     }
 
     #[allow(dead_code)]
-    pub fn push_watermark(&mut self, col_idx: usize, val: ScalarImpl) {
+    pub fn push_int64_watermark(&mut self, col_idx: usize, val: i64) {
         self.0
-            .send(Message::Watermark(Watermark { col_idx, val }))
+            .send(Message::Watermark(Watermark {
+                col_idx,
+                data_type: DataType::Int64,
+                val: ScalarImpl::Int64(val),
+            }))
             .unwrap();
     }
 }

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -124,6 +124,7 @@ impl<S: StateStore> WatermarkFilterExecutor<S> {
 
         yield Message::Watermark(Watermark::new(
             event_time_col_idx,
+            watermark_type.clone(),
             current_watermark.clone(),
         ));
 
@@ -171,6 +172,7 @@ impl<S: StateStore> WatermarkFilterExecutor<S> {
 
                     yield Message::Watermark(Watermark::new(
                         event_time_col_idx,
+                        watermark_type.clone(),
                         current_watermark.clone(),
                     ));
                 }
@@ -182,6 +184,7 @@ impl<S: StateStore> WatermarkFilterExecutor<S> {
                             current_watermark = watermark;
                             yield Message::Watermark(Watermark::new(
                                 event_time_col_idx,
+                                watermark_type.clone(),
                                 current_watermark.clone(),
                             ));
                         }
@@ -401,7 +404,7 @@ mod tests {
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(1, WATERMARK_TYPE.min())
+            Watermark::new(1, WATERMARK_TYPE.clone(), WATERMARK_TYPE.min())
         );
 
         // push the 1st chunk
@@ -421,6 +424,7 @@ mod tests {
             watermark.into_watermark().unwrap(),
             Watermark::new(
                 1,
+                WATERMARK_TYPE.clone(),
                 ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
                     NaiveDate::from_ymd(2022, 11, 7).and_hms(0, 0, 0)
                 ))
@@ -447,6 +451,7 @@ mod tests {
             watermark.into_watermark().unwrap(),
             Watermark::new(
                 1,
+                WATERMARK_TYPE.clone(),
                 ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
                     NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
                 ))
@@ -474,6 +479,7 @@ mod tests {
             watermark.into_watermark().unwrap(),
             Watermark::new(
                 1,
+                WATERMARK_TYPE.clone(),
                 ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
                     NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
                 ))
@@ -496,6 +502,7 @@ mod tests {
             watermark.into_watermark().unwrap(),
             Watermark::new(
                 1,
+                WATERMARK_TYPE.clone(),
                 ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
                     NaiveDate::from_ymd(2022, 11, 13).and_hms(0, 0, 0)
                 ))

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -400,11 +400,17 @@ mod tests {
         tx.push_barrier(1, false);
         executor.next().await.unwrap().unwrap();
 
+        macro_rules! watermark {
+            ($scalar:expr) => {
+                Watermark::new(1, WATERMARK_TYPE.clone(), $scalar)
+            };
+        }
+
         // Init watermark
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(1, WATERMARK_TYPE.clone(), WATERMARK_TYPE.min())
+            watermark!(WATERMARK_TYPE.min()),
         );
 
         // push the 1st chunk
@@ -422,13 +428,9 @@ mod tests {
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(
-                1,
-                WATERMARK_TYPE.clone(),
-                ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
-                    NaiveDate::from_ymd(2022, 11, 7).and_hms(0, 0, 0)
-                ))
-            )
+            watermark!(ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
+                NaiveDate::from_ymd(2022, 11, 7).and_hms(0, 0, 0)
+            )))
         );
 
         // push the 2nd barrier
@@ -449,13 +451,9 @@ mod tests {
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(
-                1,
-                WATERMARK_TYPE.clone(),
-                ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
-                    NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
-                ))
-            )
+            watermark!(ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
+                NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
+            )))
         );
 
         // push the 3nd barrier
@@ -477,13 +475,9 @@ mod tests {
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(
-                1,
-                WATERMARK_TYPE.clone(),
-                ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
-                    NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
-                ))
-            )
+            watermark!(ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
+                NaiveDate::from_ymd(2022, 11, 9).and_hms(0, 0, 0)
+            )))
         );
 
         // push the 3rd chunk
@@ -500,13 +494,9 @@ mod tests {
         let watermark = executor.next().await.unwrap().unwrap();
         assert_eq!(
             watermark.into_watermark().unwrap(),
-            Watermark::new(
-                1,
-                WATERMARK_TYPE.clone(),
-                ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
-                    NaiveDate::from_ymd(2022, 11, 13).and_hms(0, 0, 0)
-                ))
-            )
+            watermark!(ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
+                NaiveDate::from_ymd(2022, 11, 13).and_hms(0, 0, 0)
+            )))
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As the `Datum` in prost erases the type of the scalar, we added the `DataType` into the `Watermark` message.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #6063 