### PR TITLE
fix: remove abused `join_all`

### DIFF
--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::convert::identity;
+
 use anyhow::anyhow;
-use futures::future::try_join_all;
+use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::column::Column;
@@ -137,13 +139,11 @@ impl UpdateExecutor {
         }
 
         // Wait for all chunks to be taken / written.
-        let rows_updated = try_join_all(notifiers)
-            .await
-            .map_err(|_| {
-                BatchError::Internal(anyhow!("failed to wait chunks to be written".to_owned(),))
-            })?
-            .into_iter()
-            .sum::<usize>()
+        let rows_updated = futures::stream::iter(notifiers)
+            .then(identity)
+            .map_err(|_| BatchError::Internal(anyhow!("failed to wait chunks to be written")))
+            .try_fold(0_usize, |acc, x| async move { Ok(acc + x) })
+            .await?
             / 2;
 
         // Create ret value

--- a/src/stream/src/executor/aggregation/agg_group.rs
+++ b/src/stream/src/executor/aggregation/agg_group.rs
@@ -96,6 +96,8 @@ impl<S: StateStore> AggGroup<S> {
             })
             .unwrap_or(0);
 
+        // Note: we assume there won't be too many agg calls, so `join_all` without limiting the
+        // concurrency is fine.
         let states =
             futures::future::try_join_all(agg_calls.iter().enumerate().map(|(idx, agg_call)| {
                 AggState::create(
@@ -157,6 +159,8 @@ impl<S: StateStore> AggGroup<S> {
         &self,
         storages: &mut [AggStateStorage<S>],
     ) -> StreamExecutorResult<()> {
+        // Note: we assume there won't be too many agg calls, so `join_all` without limiting the
+        // concurrency is fine.
         futures::future::try_join_all(self.states.iter().zip_eq(storages).filter_map(
             |(state, storage)| match state {
                 AggState::Table(state) => Some(state.flush_state_if_needed(
@@ -176,6 +180,8 @@ impl<S: StateStore> AggGroup<S> {
         &mut self,
         storages: &[AggStateStorage<S>],
     ) -> StreamExecutorResult<Vec<Datum>> {
+        // Note: we assume there won't be too many agg calls, so `join_all` without limiting the
+        // concurrency is fine.
         futures::future::try_join_all(
             self.states
                 .iter_mut()

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -214,6 +214,8 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
             agg_group.flush_state_if_needed(storages).await?;
 
             // Commit all state tables except for result table.
+            // Note: we assume there won't be too many agg calls, so `join_all` without limiting the
+            // concurrency is fine.
             futures::future::try_join_all(
                 iter_table_storage(storages).map(|state_table| state_table.commit(epoch)),
             )

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -466,6 +466,8 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
             }
 
             // Commit all state tables.
+            // Note: we assume there won't be too many agg calls, so `join_all` without limiting the
+            // concurrency is fine.
             futures::future::try_join_all(
                 iter_table_storage(storages).map(|state_table| state_table.commit(epoch)),
             )


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As explained in https://github.com/risingwavelabs/risingwave/pull/6490#discussion_r1027832394. `join_all` with a large concurrency will lead to extra overhead if every `Future` is lightweight. This PR removes some abused `join_all`s in the codebase.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #6117