### PR TITLE
fix(recovery): clear all senders on recovery

### DIFF
--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -149,13 +149,16 @@ impl LocalBarrierManager {
         };
 
         for actor_id in to_send {
-            let sender = self
-                .senders
-                .get(&actor_id)
-                .unwrap_or_else(|| panic!("sender for actor {} does not exist", actor_id));
-            if let Err(err) = sender.send(barrier.clone()) {
-                // return err to trigger recovery.
-                bail!("failed to send barrier to actor {}: {:?}", actor_id, err)
+            match self.senders.get(&actor_id) {
+                Some(sender) => {
+                    if let Err(err) = sender.send(barrier.clone()) {
+                        // return err to trigger recovery.
+                        bail!("failed to send barrier to actor {}: {:?}", actor_id, err)
+                    }
+                }
+                None => {
+                    bail!("sender for actor {} does not exist", actor_id)
+                }
             }
         }
 

--- a/src/stream/src/task/barrier_manager.rs
+++ b/src/stream/src/task/barrier_manager.rs
@@ -190,6 +190,11 @@ impl LocalBarrierManager {
             })
     }
 
+    // remove all senders
+    pub fn clear_senders(&mut self) {
+        self.senders.clear();
+    }
+
     /// remove all collect rx
     pub fn clear_collect_rx(&mut self) {
         self.collect_complete_receiver.clear();

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -221,9 +221,10 @@ impl LocalStreamManager {
         Ok(())
     }
 
-    /// Clear all collect rx in barrier manager.
-    pub fn clear_all_collect_rx(&self) {
+    /// Clear all senders and collect rx in barrier manager.
+    pub fn clear_all_senders_and_collect_rx(&self) {
         let mut barrier_manager = self.context.lock_barrier_manager();
+        barrier_manager.clear_senders();
         barrier_manager.clear_collect_rx();
     }
 
@@ -306,7 +307,7 @@ impl LocalStreamManager {
     pub async fn stop_all_actors(&self) -> StreamResult<()> {
         // Clear shared buffer in storage to release memory
         self.clear_storage_buffer().await;
-        self.clear_all_collect_rx();
+        self.clear_all_senders_and_collect_rx();
         self.core.lock().await.drop_all_actors();
 
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

clear all senders on recovery
During recovery, when `drop_all_actors` is called, only collect rx is cleared in `LocalBarrierManager`.
When `drop_all_actors` is called, `senders` should be cleared too.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6505 