### PR TITLE
refactor(plan, display): reorganize methods to have more private

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic.rs
+++ b/src/frontend/src/optimizer/plan_node/generic.rs
@@ -465,7 +465,16 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
         (self.agg_calls, self.group_key, self.input)
     }
 
-    pub fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
+    pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
+        let mut builder = f.debug_struct(name);
+        if !self.group_key.is_empty() {
+            builder.field("group_key", &self.group_key_display());
+        }
+        builder.field("aggs", &self.agg_calls_display());
+        builder.finish()
+    }
+
+    fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
         self.agg_calls
             .iter()
             .map(|plan_agg_call| PlanAggCallDisplay {
@@ -475,7 +484,7 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
             .collect_vec()
     }
 
-    pub fn group_key_display(&self) -> Vec<FieldDisplay<'_>> {
+    fn group_key_display(&self) -> Vec<FieldDisplay<'_>> {
         self.group_key
             .iter()
             .copied()

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -16,14 +16,12 @@ use std::{fmt, iter};
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use risingwave_common::catalog::FieldDisplay;
 use risingwave_common::error::{ErrorCode, Result, TrackingIssue};
 use risingwave_common::types::DataType;
 use risingwave_expr::expr::AggKind;
 
 use super::generic::{
-    self, AggCallState, GenericPlanNode, GenericPlanRef, PlanAggCall, PlanAggCallDisplay,
-    PlanAggOrderByField,
+    self, AggCallState, GenericPlanNode, GenericPlanRef, PlanAggCall, PlanAggOrderByField,
 };
 use super::{
     BatchHashAgg, BatchSimpleAgg, ColPrunable, LogicalProjectBuilder, PlanBase, PlanRef,

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -680,14 +680,6 @@ impl LogicalAgg {
         &self.core.agg_calls
     }
 
-    pub fn agg_calls_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
-        self.core.agg_calls_display()
-    }
-
-    pub fn group_key_display(&self) -> Vec<FieldDisplay<'_>> {
-        self.core.group_key_display()
-    }
-
     /// Get a reference to the logical agg's group key.
     pub fn group_key(&self) -> &Vec<usize> {
         &self.core.group_key
@@ -729,12 +721,7 @@ impl LogicalAgg {
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
-        let mut builder = f.debug_struct(name);
-        if !self.group_key().is_empty() {
-            builder.field("group_key", &self.group_key_display());
-        }
-        builder.field("aggs", &self.agg_calls_display());
-        builder.finish()
+        self.core.fmt_with_name(f, name)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
@@ -18,7 +18,6 @@ use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 
 use super::generic::PlanAggCall;
 use super::{LogicalAgg, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
-use crate::optimizer::plan_node::PlanAggCallDisplay;
 use crate::optimizer::property::Distribution;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
@@ -54,20 +53,18 @@ impl StreamGlobalSimpleAgg {
     pub fn agg_calls(&self) -> &[PlanAggCall] {
         self.logical.agg_calls()
     }
-
-    pub fn agg_calls_verbose_display(&self) -> Vec<PlanAggCallDisplay<'_>> {
-        self.logical.agg_calls_display()
-    }
 }
 
 impl fmt::Display for StreamGlobalSimpleAgg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if self.input().append_only() {
-            self.logical
-                .fmt_with_name(f, "StreamAppendOnlyGlobalSimpleAgg")
-        } else {
-            self.logical.fmt_with_name(f, "StreamGlobalSimpleAgg")
-        }
+        self.logical.fmt_with_name(
+            f,
+            if self.input().append_only() {
+                "StreamAppendOnlyGlobalSimpleAgg"
+            } else {
+                "StreamGlobalSimpleAgg"
+            },
+        )
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

+ Moved the impl of `fmt_with_name`
+ Made several methods private
+ Deleted some methods

For #6356 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

