### PR TITLE
fix: notify ddl request with correct version to avoid stuck

### DIFF
--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -130,9 +130,13 @@ impl ObserverState for FrontendObserverNode {
 
         let snapshot_version = snapshot.version.unwrap();
         catalog_guard.set_version(snapshot_version.catalog_version);
-        self.catalog_updated_tx.send(snapshot_version.catalog_version).unwrap();
+        self.catalog_updated_tx
+            .send(snapshot_version.catalog_version)
+            .unwrap();
         user_guard.set_version(snapshot_version.catalog_version);
-        self.user_info_updated_tx.send(snapshot_version.catalog_version).unwrap();
+        self.user_info_updated_tx
+            .send(snapshot_version.catalog_version)
+            .unwrap();
     }
 }
 

--- a/src/frontend/src/observer/observer_manager.rs
+++ b/src/frontend/src/observer/observer_manager.rs
@@ -130,9 +130,9 @@ impl ObserverState for FrontendObserverNode {
 
         let snapshot_version = snapshot.version.unwrap();
         catalog_guard.set_version(snapshot_version.catalog_version);
-        self.catalog_updated_tx.send(resp.version).unwrap();
+        self.catalog_updated_tx.send(snapshot_version.catalog_version).unwrap();
         user_guard.set_version(snapshot_version.catalog_version);
-        self.user_info_updated_tx.send(resp.version).unwrap();
+        self.user_info_updated_tx.send(snapshot_version.catalog_version).unwrap();
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

As title, to fix the recovery stuck in https://buildkite.com/risingwavelabs/main-cron/builds/220#0184a1d9-64fe-4cfa-aef5-d9b898aa827a. 
The ddl operation will get stuck after refactoring in https://github.com/risingwavelabs/risingwave/pull/6378. This's because the observer manager in frontend notifies ddl request with an invalid version(0) after re-subscribing from meta.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
