### PR TITLE
fix: enable async stack trace by default

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -32,8 +32,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, ArgEnum)]
 pub enum AsyncStackTraceOption {
     Off,
-    On,
-    Verbose,
+    On,      // default
+    Verbose, // `debug_assertions` off only
 }
 
 /// Command-line arguments for compute-node.
@@ -71,7 +71,7 @@ pub struct ComputeNodeOpts {
     pub enable_jaeger_tracing: bool,
 
     /// Enable async stack tracing for risectl.
-    #[clap(long, arg_enum, default_value_t = AsyncStackTraceOption::Off)]
+    #[clap(long, arg_enum, default_value_t = AsyncStackTraceOption::On)]
     pub async_stack_trace: AsyncStackTraceOption,
 
     /// Path to file cache data directory.

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -32,8 +32,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, ArgEnum)]
 pub enum AsyncStackTraceOption {
     Off,
-    On,      // default
-    Verbose, // `debug_assertions` off only
+    On, // default
+    Verbose,
 }
 
 /// Command-line arguments for compute-node.

--- a/src/stream/src/task/stream_manager.rs
+++ b/src/stream/src/task/stream_manager.rs
@@ -627,10 +627,10 @@ impl LocalStreamManagerCore {
             );
 
             let monitor = tokio_metrics::TaskMonitor::new();
-            let trace_reporter = self
+            let trace = self
                 .stack_trace_manager
                 .as_mut()
-                .map(|(m, _)| m.register(actor_id));
+                .map(|(m, c)| (m.register(actor_id), c.clone()));
 
             let handle = {
                 let context = self.context.clone();
@@ -642,15 +642,11 @@ impl LocalStreamManagerCore {
                     }
                 };
                 #[auto_enums::auto_enum(Future)]
-                let traced = match trace_reporter {
-                    Some(trace_reporter) => trace_reporter.trace(
+                let traced = match trace {
+                    Some((reporter, config)) => reporter.trace(
                         actor,
                         format!("Actor {actor_id}: `{}`", mview_definition),
-                        TraceConfig {
-                            report_detached: true,
-                            verbose: true,
-                            interval: Duration::from_secs(1),
-                        },
+                        config,
                     ),
                     None => actor,
                 };


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Previously the async stack trace is only enabled by default only if the user launches with `risedev`. This PR also enables it by default if no arg is specified, which is for production (cloud) deployment.

I've benched the release build with async stack trace = (verbose, on, off) and hardly found any performance regression. So I guess we're okay to enable it in production.

I'd also like to cherry pick this fix to the release branch. 🤔

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #5931 
- #6512