### PR TITLE
feat(batch): lookup join supports lookup inner side table's prefix of the order key

### DIFF
--- a/e2e_test/batch/basic/lookup_join.slt.part
+++ b/e2e_test/batch/basic/lookup_join.slt.part
@@ -221,4 +221,35 @@ statement ok
 drop table t2;
 
 statement ok
+create table t1(a int, b int);
+
+statement ok
+create table t2(c int, d int);
+
+statement ok
+create index idx on t2(c) include(d);
+
+statement ok
+insert into t1 values (1,222);
+
+statement ok
+insert into t2 values (1,222);
+
+query IIII
+select * from t1 join idx on t1.a = idx.c;
+----
+1 222 1 222
+
+query IIII
+select * from t1 join idx on t1.a = idx.c and t1.b = idx.d;
+----
+1 222 1 222
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+statement ok
 set rw_batch_enable_lookup_join to false;

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -217,14 +217,17 @@ message LocalLookupJoinNode {
   plan_common.JoinType join_type = 1;
   expr.ExprNode condition = 2;
   repeated uint32 outer_side_key = 3;
-  plan_common.StorageTableDesc inner_side_table_desc = 4;
-  repeated uint32 inner_side_vnode_mapping = 5;
-  repeated int32 inner_side_column_ids = 6;
-  repeated uint32 output_indices = 7;
-  repeated common.WorkerNode worker_nodes = 8;
+  repeated uint32 inner_side_key = 4;
+  uint32 lookup_prefix_len = 5;
+  plan_common.StorageTableDesc inner_side_table_desc = 6;
+  repeated uint32 inner_side_vnode_mapping = 7;
+  repeated int32 inner_side_column_ids = 8;
+  repeated uint32 output_indices = 9;
+  repeated common.WorkerNode worker_nodes = 10;
   // Null safe means it treats `null = null` as true.
   // Each key pair can be null safe independently. (left_key, right_key, null_safe)
-  repeated bool null_safe = 9;
+  repeated bool null_safe = 11;
+
 }
 
 // RFC: A new schedule way for distributed lookup join
@@ -233,12 +236,14 @@ message DistributedLookupJoinNode {
   plan_common.JoinType join_type = 1;
   expr.ExprNode condition = 2;
   repeated uint32 outer_side_key = 3;
-  plan_common.StorageTableDesc inner_side_table_desc = 4;
-  repeated int32 inner_side_column_ids = 5;
-  repeated uint32 output_indices = 6;
+  repeated uint32 inner_side_key = 4;
+  uint32 lookup_prefix_len = 5;
+  plan_common.StorageTableDesc inner_side_table_desc = 6;
+  repeated int32 inner_side_column_ids = 7;
+  repeated uint32 output_indices = 8;
   // Null safe means it treats `null = null` as true.
   // Each key pair can be null safe independently. (left_key, right_key, null_safe)
-  repeated bool null_safe = 7;
+  repeated bool null_safe = 9;
 }
 
 message UnionNode {}

--- a/src/batch/src/executor/join/lookup_join_base.rs
+++ b/src/batch/src/executor/join/lookup_join_base.rs
@@ -44,6 +44,7 @@ pub struct LookupJoinBase<K> {
     pub inner_side_key_types: Vec<DataType>, // Data types only of key columns of inner side table
     pub inner_side_key_idxs: Vec<usize>,
     pub null_safe: Vec<bool>,
+    pub lookup_prefix_len: usize,
     pub chunk_builder: DataChunkBuilder,
     pub schema: Schema,
     pub output_indices: Vec<usize>,
@@ -86,6 +87,7 @@ impl<K: HashKey> LookupJoinBase<K> {
                     chunk.rows().map(|row| {
                         self.outer_side_key_idxs
                             .iter()
+                            .take(self.lookup_prefix_len)
                             .map(|&idx| row.value_at(idx).to_owned_datum())
                             .collect_vec()
                     })

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -43,6 +43,9 @@ pub struct BatchLookupJoin {
     /// Output column ids of the right side table
     right_output_column_ids: Vec<ColumnId>,
 
+    /// The prefix length of the order key of right side table.
+    lookup_prefix_len: usize,
+
     /// If `distributed_lookup` is true, it will generate `DistributedLookupJoinNode` for
     /// `ToBatchProst`. Otherwise, it will generate `LookupJoinNode`.
     distributed_lookup: bool,
@@ -54,6 +57,7 @@ impl BatchLookupJoin {
         eq_join_predicate: EqJoinPredicate,
         right_table_desc: TableDesc,
         right_output_column_ids: Vec<ColumnId>,
+        lookup_prefix_len: usize,
         distributed_lookup: bool,
     ) -> Self {
         let ctx = logical.base.ctx.clone();
@@ -65,6 +69,7 @@ impl BatchLookupJoin {
             eq_join_predicate,
             right_table_desc,
             right_output_column_ids,
+            lookup_prefix_len,
             distributed_lookup,
         }
     }
@@ -148,6 +153,7 @@ impl PlanTreeNodeUnary for BatchLookupJoin {
             self.eq_join_predicate.clone(),
             self.right_table_desc.clone(),
             self.right_output_column_ids.clone(),
+            self.lookup_prefix_len,
             self.distributed_lookup,
         )
     }
@@ -184,6 +190,12 @@ impl ToBatchProst for BatchLookupJoin {
                     .into_iter()
                     .map(|a| a as _)
                     .collect(),
+                inner_side_key: self
+                    .eq_join_predicate
+                    .right_eq_indexes()
+                    .into_iter()
+                    .map(|a| a as _)
+                    .collect(),
                 inner_side_table_desc: Some(self.right_table_desc.to_protobuf()),
                 inner_side_column_ids: self
                     .right_output_column_ids
@@ -197,6 +209,7 @@ impl ToBatchProst for BatchLookupJoin {
                     .map(|&x| x as u32)
                     .collect(),
                 null_safe: self.eq_join_predicate.null_safes(),
+                lookup_prefix_len: self.lookup_prefix_len as u32,
             })
         } else {
             NodeBody::LocalLookupJoin(LocalLookupJoinNode {
@@ -209,6 +222,12 @@ impl ToBatchProst for BatchLookupJoin {
                 outer_side_key: self
                     .eq_join_predicate
                     .left_eq_indexes()
+                    .into_iter()
+                    .map(|a| a as _)
+                    .collect(),
+                inner_side_key: self
+                    .eq_join_predicate
+                    .right_eq_indexes()
                     .into_iter()
                     .map(|a| a as _)
                     .collect(),
@@ -227,6 +246,7 @@ impl ToBatchProst for BatchLookupJoin {
                     .collect(),
                 worker_nodes: vec![], // To be filled in at local.rs
                 null_safe: self.eq_join_predicate.null_safes(),
+                lookup_prefix_len: self.lookup_prefix_len as u32,
             })
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Previously we only supported lookup join if the join key matches the whole order key of the inner side table. This PR let lookup join support lookup the prefix of the order key.
- This is a preparation for index selection for index join.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
