### PR TITLE
feat(distinct on): Plan `DISTINCT ON` as `GroupTopN`

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -281,10 +281,9 @@
     create table t (v1 int, v2 int);
     select distinct on (v1) v1, v2 from t order by v1;
   logical_plan: |
-    LogicalProject { exprs: [t.v1, first_value(t.v2)] }
-    └─LogicalAgg { group_key: [t.v1], aggs: [first_value(t.v2)] }
-      └─LogicalProject { exprs: [t.v1, t.v2] }
-        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+    LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [0] }
+    └─LogicalProject { exprs: [t.v1, t.v2] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - name: arguments out-of-order
   sql: |
     create table t(v1 int, v2 int, v3 int);

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -284,6 +284,22 @@
     LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [0] }
     └─LogicalProject { exprs: [t.v1, t.v2] }
       └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+- name: distinct on
+  sql: |
+    create table t (v1 int, v2 int, v3 int);
+    select distinct on(v1) v2 + v3 from t order by v1;
+  logical_plan: |
+    LogicalProject { exprs: [(t.v2 + t.v3)] }
+    └─LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [1] }
+      └─LogicalProject { exprs: [(t.v2 + t.v3), t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+  batch_plan: |
+    BatchProject { exprs: [(t.v2 + t.v3)] }
+    └─BatchExchange { order: [t.v1 ASC], dist: Single }
+      └─BatchGroupTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [1] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1) }
+          └─BatchProject { exprs: [(t.v2 + t.v3), t.v1] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: arguments out-of-order
   sql: |
     create table t(v1 int, v2 int, v3 int);

--- a/src/frontend/src/planner/query.rs
+++ b/src/frontend/src/planner/query.rs
@@ -37,7 +37,7 @@ impl Planner {
         } = query;
 
         let extra_order_exprs_len = extra_order_exprs.len();
-        let mut plan = self.plan_set_expr(body, extra_order_exprs)?;
+        let mut plan = self.plan_set_expr(body, extra_order_exprs, &order)?;
         let order = Order { field_order: order };
         if limit.is_some() || offset.is_some() {
             let limit = limit.unwrap_or(LIMIT_ALL_COUNT);

--- a/src/frontend/src/planner/set_expr.rs
+++ b/src/frontend/src/planner/set_expr.rs
@@ -17,6 +17,7 @@ use risingwave_common::error::Result;
 use crate::binder::BoundSetExpr;
 use crate::expr::ExprImpl;
 use crate::optimizer::plan_node::PlanRef;
+use crate::optimizer::property::FieldOrder;
 use crate::planner::Planner;
 
 impl Planner {
@@ -24,9 +25,10 @@ impl Planner {
         &mut self,
         set_expr: BoundSetExpr,
         extra_order_exprs: Vec<ExprImpl>,
+        order: &[FieldOrder],
     ) -> Result<PlanRef> {
         match set_expr {
-            BoundSetExpr::Select(s) => self.plan_select(*s, extra_order_exprs),
+            BoundSetExpr::Select(s) => self.plan_select(*s, extra_order_exprs, order),
             BoundSetExpr::Values(v) => self.plan_values(*v),
             BoundSetExpr::Query(q) => Ok(self.plan_query(*q)?.into_subplan()),
             BoundSetExpr::SetOperation {

--- a/src/frontend/src/planner/set_operation.rs
+++ b/src/frontend/src/planner/set_operation.rs
@@ -28,8 +28,8 @@ impl Planner {
     ) -> Result<PlanRef> {
         match op {
             BoundSetOperation::Union => {
-                let left = self.plan_set_expr(left, vec![])?;
-                let right = self.plan_set_expr(right, vec![])?;
+                let left = self.plan_set_expr(left, vec![], &[])?;
+                let right = self.plan_set_expr(right, vec![], &[])?;
                 Ok(LogicalUnion::create(all, vec![left, right]))
             }
             BoundSetOperation::Except | BoundSetOperation::Intersect => {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Plan `DISTINCT ON` as `GroupTopN`. plz read #6146 for details.
- Describe clearly one logical change and avoid lazy messages (optional)
Seems that it can support streaming besides batch now :-)
- Describe any limitations of the current code (optional)
Unnecessary columns in `GroupTopN` cache.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6146 