### PR TITLE
fix(planner): `order by` check using partial `order by` list

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -278,6 +278,16 @@
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - name: distinct on
   sql: |
+    create table t (v1 int, v2 int, v3 int);
+    select distinct on (v1, v3) v1, v2 from t order by v1, v3;
+  logical_plan: |
+    LogicalProject { exprs: [t.v1, first_value(t.v2)] }
+    └─LogicalProject { exprs: [t.v1, first_value(t.v2), t.v3] }
+      └─LogicalAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
+        └─LogicalProject { exprs: [t.v1, t.v3, t.v2] }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+- name: distinct on
+  sql: |
     create table t (v1 int, v2 int);
     select distinct on (v1) v1, v2 from t order by v1;
   logical_plan: |

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -281,39 +281,31 @@
     create table t (v1 int, v2 int, v3 int);
     select distinct on (v1, v3) v1, v2 from t order by v3, v1;
   logical_plan: |
-    LogicalProject { exprs: [t.v1, first_value(t.v2)] }
-    └─LogicalProject { exprs: [t.v1, first_value(t.v2), t.v3] }
-      └─LogicalAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
-        └─LogicalProject { exprs: [t.v1, t.v3, t.v2] }
-          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    LogicalProject { exprs: [t.v1, t.v2] }
+    └─LogicalTopN { order: "[t.v3 ASC, t.v1 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+      └─LogicalProject { exprs: [t.v1, t.v2, t.v3] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
-    BatchProject { exprs: [t.v1, first_value(t.v2)] }
+    BatchProject { exprs: [t.v1, t.v2] }
     └─BatchExchange { order: [t.v3 ASC, t.v1 ASC], dist: Single }
-      └─BatchProject { exprs: [t.v1, first_value(t.v2), t.v3] }
-        └─BatchSort { order: [t.v3 ASC, t.v1 ASC] }
-          └─BatchHashAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
-            └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
-              └─BatchProject { exprs: [t.v1, t.v3, t.v2] }
-                └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+      └─BatchGroupTopN { order: "[t.v3 ASC, t.v1 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int, v3 int);
     select distinct on (v1, v3) v1, v2 from t order by v1, v3;
   logical_plan: |
-    LogicalProject { exprs: [t.v1, first_value(t.v2)] }
-    └─LogicalProject { exprs: [t.v1, first_value(t.v2), t.v3] }
-      └─LogicalAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
-        └─LogicalProject { exprs: [t.v1, t.v3, t.v2] }
-          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+    LogicalProject { exprs: [t.v1, t.v2] }
+    └─LogicalTopN { order: "[t.v1 ASC, t.v3 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+      └─LogicalProject { exprs: [t.v1, t.v2, t.v3] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
-    BatchProject { exprs: [t.v1, first_value(t.v2)] }
+    BatchProject { exprs: [t.v1, t.v2] }
     └─BatchExchange { order: [t.v1 ASC, t.v3 ASC], dist: Single }
-      └─BatchProject { exprs: [t.v1, first_value(t.v2), t.v3] }
-        └─BatchSortAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
-          └─BatchExchange { order: [t.v1 ASC, t.v3 ASC], dist: HashShard(t.v1, t.v3) }
-            └─BatchProject { exprs: [t.v1, t.v3, t.v2] }
-              └─BatchSort { order: [t.v1 ASC, t.v3 ASC] }
-                └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+      └─BatchGroupTopN { order: "[t.v1 ASC, t.v3 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int);

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -286,6 +286,15 @@
       └─LogicalAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
         └─LogicalProject { exprs: [t.v1, t.v3, t.v2] }
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+  batch_plan: |
+    BatchProject { exprs: [t.v1, first_value(t.v2)] }
+    └─BatchExchange { order: [t.v1 ASC, t.v3 ASC], dist: Single }
+      └─BatchProject { exprs: [t.v1, first_value(t.v2), t.v3] }
+        └─BatchSortAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
+          └─BatchExchange { order: [t.v1 ASC, t.v3 ASC], dist: HashShard(t.v1, t.v3) }
+            └─BatchProject { exprs: [t.v1, t.v3, t.v2] }
+              └─BatchSort { order: [t.v1 ASC, t.v3 ASC] }
+                └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int);

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -279,6 +279,25 @@
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int, v3 int);
+    select distinct on (v1, v3) v1, v2 from t order by v3, v1;
+  logical_plan: |
+    LogicalProject { exprs: [t.v1, first_value(t.v2)] }
+    └─LogicalProject { exprs: [t.v1, first_value(t.v2), t.v3] }
+      └─LogicalAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
+        └─LogicalProject { exprs: [t.v1, t.v3, t.v2] }
+          └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
+  batch_plan: |
+    BatchProject { exprs: [t.v1, first_value(t.v2)] }
+    └─BatchExchange { order: [t.v3 ASC, t.v1 ASC], dist: Single }
+      └─BatchProject { exprs: [t.v1, first_value(t.v2), t.v3] }
+        └─BatchSort { order: [t.v3 ASC, t.v1 ASC] }
+          └─BatchHashAgg { group_key: [t.v1, t.v3], aggs: [first_value(t.v2)] }
+            └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
+              └─BatchProject { exprs: [t.v1, t.v3, t.v2] }
+                └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+- name: distinct on
+  sql: |
+    create table t (v1 int, v2 int, v3 int);
     select distinct on (v1, v3) v1, v2 from t order by v1, v3;
   logical_plan: |
     LogicalProject { exprs: [t.v1, first_value(t.v2)] }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Let `order by` check use complete order by list
- Describe any limitations of the current code (optional)
Should we force `order by` to include `distinct on`?
## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6597 