### PR TITLE
fix(sqlsmith): skip division by zero error

### DIFF
--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -138,10 +138,9 @@ fn is_broken_chan_err(db_error: &DbError) -> bool {
 
 fn is_permissible_error(db_error: &DbError) -> bool {
     let is_internal_error = *db_error.code() == SqlState::INTERNAL_ERROR;
-    is_internal_error
-        && (is_numeric_out_of_range_err(db_error)
-            || is_broken_chan_err(db_error)
-            || is_division_by_zero_err(db_error))
+    (is_internal_error && is_broken_chan_err(db_error))
+        || is_numeric_out_of_range_err(db_error)
+        || is_division_by_zero_err(db_error)
 }
 
 /// Validate client responses


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As per title, division by zero error may not necessarily be wrapped by `internal error`.

Also added sqlsmith test to ensure we don't skip too many queries.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests.
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
