### PR TITLE
feat: Implement `range` table function

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -123,6 +123,7 @@ message TableFunction {
     GENERATE = 1;
     UNNEST = 2;
     REGEXP_MATCHES = 3;
+    RANGE = 4;
   }
   Type function_type = 1;
   repeated expr.ExprNode args = 2;

--- a/src/expr/src/table_function/generate_series.rs
+++ b/src/expr/src/table_function/generate_series.rs
@@ -32,6 +32,8 @@ pub struct GenerateSeries<T: Array, S: Array> {
     stop: BoxedExpression,
     step: BoxedExpression,
     chunk_size: usize,
+    /// `_stop_inclusive` is required to be `true` for `GenerateSeries`, while `false` for `Range`.
+    /// This is guaranteed by the only pub entry point `new_range` and `new_generate_series`.
     _stop_inclusive: bool,
     _phantom: std::marker::PhantomData<(T, S)>,
 }

--- a/src/expr/src/table_function/mod.rs
+++ b/src/expr/src/table_function/mod.rs
@@ -28,6 +28,8 @@ use crate::expr::{build_from_prost as expr_build_from_prost, BoxedExpression};
 
 mod generate_series;
 use generate_series::*;
+mod range;
+use range::*;
 mod unnest;
 use unnest::*;
 mod regexp_matches;
@@ -62,6 +64,7 @@ pub fn build_from_prost(
         Generate => new_generate_series(prost, chunk_size),
         Unnest => new_unnest(prost, chunk_size),
         RegexpMatches => new_regexp_matches(prost, chunk_size),
+        Range => new_range(prost, chunk_size),
         Unspecified => unreachable!(),
     }
 }

--- a/src/expr/src/table_function/range.rs
+++ b/src/expr/src/table_function/range.rs
@@ -12,137 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use anyhow::anyhow;
-use itertools::multizip;
-use num_traits::Zero;
-use risingwave_common::array::{
-    Array, ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, I32Array, IntervalArray,
-    NaiveDateTimeArray,
-};
-use risingwave_common::types::{CheckedAdd, IsNegative, Scalar, ScalarRef};
+use risingwave_common::array::{I32Array, IntervalArray, NaiveDateTimeArray};
+
+type Range<T, S> = GenerateSeries<T, S>;
 
 use super::*;
 use crate::ExprError;
-
-#[derive(Debug)]
-pub struct Range<T: Array, S: Array> {
-    start: BoxedExpression,
-    stop: BoxedExpression,
-    step: BoxedExpression,
-    chunk_size: usize,
-    _phantom: std::marker::PhantomData<(T, S)>,
-}
-
-impl<T: Array, S: Array> Range<T, S>
-where
-    T::OwnedItem: for<'a> PartialOrd<T::RefItem<'a>>,
-    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>, Output = T::OwnedItem>,
-    for<'a> S::RefItem<'a>: IsNegative,
-{
-    fn new(
-        start: BoxedExpression,
-        stop: BoxedExpression,
-        step: BoxedExpression,
-        chunk_size: usize,
-    ) -> Self {
-        Self {
-            start,
-            stop,
-            step,
-            chunk_size,
-            _phantom: Default::default(),
-        }
-    }
-
-    fn eval_row(
-        &self,
-        start: T::RefItem<'_>,
-        stop: T::RefItem<'_>,
-        step: S::RefItem<'_>,
-    ) -> Result<ArrayRef> {
-        if step.is_zero() {
-            return Err(ExprError::InvalidParam {
-                name: "step",
-                reason: "must be non-zero".to_string(),
-            });
-        }
-
-        let mut builder = T::Builder::new(self.chunk_size);
-
-        let mut cur: T::OwnedItem = start.to_owned_scalar();
-
-        while if step.is_negative() {
-            cur > stop
-        } else {
-            cur < stop
-        } {
-            builder.append(Some(cur.as_scalar_ref()));
-            cur = cur.checked_add(step).ok_or(ExprError::NumericOutOfRange)?;
-        }
-
-        Ok(Arc::new(builder.finish().into()))
-    }
-}
-
-impl<T: Array, S: Array> TableFunction for Range<T, S>
-where
-    T::OwnedItem: for<'a> PartialOrd<T::RefItem<'a>>,
-    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>, Output = T::OwnedItem>,
-    for<'a> S::RefItem<'a>: IsNegative,
-    for<'a> &'a T: From<&'a ArrayImpl>,
-    for<'a> &'a S: From<&'a ArrayImpl>,
-{
-    fn return_type(&self) -> DataType {
-        self.start.return_type()
-    }
-
-    fn eval(&self, input: &DataChunk) -> Result<Vec<ArrayRef>> {
-        let ret_start = self.start.eval_checked(input)?;
-        let arr_start: &T = ret_start.as_ref().into();
-        let ret_stop = self.stop.eval_checked(input)?;
-        let arr_stop: &T = ret_stop.as_ref().into();
-
-        let ret_step = self.step.eval_checked(input)?;
-        let arr_step: &S = ret_step.as_ref().into();
-
-        let bitmap = input.get_visibility_ref();
-        let mut output_arrays: Vec<ArrayRef> = vec![];
-
-        match bitmap {
-            Some(bitmap) => {
-                for ((start, stop, step), visible) in
-                    multizip((arr_start.iter(), arr_stop.iter(), arr_step.iter()))
-                        .zip_eq(bitmap.iter())
-                {
-                    let array = if !visible {
-                        empty_array(self.return_type())
-                    } else if let (Some(start), Some(stop), Some(step)) = (start, stop, step) {
-                        self.eval_row(start, stop, step)?
-                    } else {
-                        empty_array(self.return_type())
-                    };
-                    output_arrays.push(array);
-                }
-            }
-            None => {
-                for (start, stop, step) in
-                    multizip((arr_start.iter(), arr_stop.iter(), arr_step.iter()))
-                {
-                    let array = if let (Some(start), Some(stop), Some(step)) = (start, stop, step) {
-                        self.eval_row(start, stop, step)?
-                    } else {
-                        empty_array(self.return_type())
-                    };
-                    output_arrays.push(array);
-                }
-            }
-        }
-
-        Ok(output_arrays)
-    }
-}
 
 pub fn new_range(prost: &TableFunctionProst, chunk_size: usize) -> Result<BoxedTableFunction> {
     let return_type = DataType::from(prost.get_return_type().unwrap());
@@ -151,11 +27,11 @@ pub fn new_range(prost: &TableFunctionProst, chunk_size: usize) -> Result<BoxedT
 
     match return_type {
         DataType::Timestamp => Ok(Range::<NaiveDateTimeArray, IntervalArray>::new(
-            start, stop, step, chunk_size,
+            start, stop, step, chunk_size, false,
         )
         .boxed()),
         DataType::Int32 => {
-            Ok(Range::<I32Array, I32Array>::new(start, stop, step, chunk_size).boxed())
+            Ok(Range::<I32Array, I32Array>::new(start, stop, step, chunk_size, false).boxed())
         }
         _ => Err(ExprError::Internal(anyhow!(
             "the return type of Range Function is incorrect".to_string(),
@@ -186,13 +62,13 @@ mod tests {
             LiteralExpression::new(DataType::Int32, Some(v.into())).boxed()
         }
 
-        let function = Range::<I32Array, I32Array> {
-            start: to_lit_expr(start),
-            stop: to_lit_expr(stop),
-            step: to_lit_expr(step),
-            chunk_size: CHUNK_SIZE,
-            _phantom: Default::default(),
-        }
+        let function = Range::<I32Array, I32Array>::new(
+            to_lit_expr(start),
+            to_lit_expr(stop),
+            to_lit_expr(step),
+            CHUNK_SIZE,
+            false,
+        )
         .boxed();
         let expect_cnt = ((stop - start - step.signum()) / step + 1) as usize;
 
@@ -226,13 +102,13 @@ mod tests {
             LiteralExpression::new(ty, Some(v)).boxed()
         }
 
-        let function = Range::<NaiveDateTimeArray, IntervalArray> {
-            start: to_lit_expr(DataType::Timestamp, start.into()),
-            stop: to_lit_expr(DataType::Timestamp, stop.into()),
-            step: to_lit_expr(DataType::Interval, step.into()),
-            chunk_size: CHUNK_SIZE,
-            _phantom: Default::default(),
-        };
+        let function = Range::<NaiveDateTimeArray, IntervalArray>::new(
+            to_lit_expr(DataType::Timestamp, start.into()),
+            to_lit_expr(DataType::Timestamp, stop.into()),
+            to_lit_expr(DataType::Interval, step.into()),
+            CHUNK_SIZE,
+            false,
+        );
 
         let dummy_chunk = DataChunk::new_dummy(1);
         let arrays = function.eval(&dummy_chunk).unwrap();

--- a/src/expr/src/table_function/range.rs
+++ b/src/expr/src/table_function/range.rs
@@ -1,0 +1,243 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use anyhow::anyhow;
+use itertools::multizip;
+use num_traits::Zero;
+use risingwave_common::array::{
+    Array, ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, I32Array, IntervalArray,
+    NaiveDateTimeArray,
+};
+use risingwave_common::types::{CheckedAdd, IsNegative, Scalar, ScalarRef};
+
+use super::*;
+use crate::ExprError;
+
+#[derive(Debug)]
+pub struct Range<T: Array, S: Array> {
+    start: BoxedExpression,
+    stop: BoxedExpression,
+    step: BoxedExpression,
+    chunk_size: usize,
+    _phantom: std::marker::PhantomData<(T, S)>,
+}
+
+impl<T: Array, S: Array> Range<T, S>
+where
+    T::OwnedItem: for<'a> PartialOrd<T::RefItem<'a>>,
+    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>, Output = T::OwnedItem>,
+    for<'a> S::RefItem<'a>: IsNegative,
+{
+    fn new(
+        start: BoxedExpression,
+        stop: BoxedExpression,
+        step: BoxedExpression,
+        chunk_size: usize,
+    ) -> Self {
+        Self {
+            start,
+            stop,
+            step,
+            chunk_size,
+            _phantom: Default::default(),
+        }
+    }
+
+    fn eval_row(
+        &self,
+        start: T::RefItem<'_>,
+        stop: T::RefItem<'_>,
+        step: S::RefItem<'_>,
+    ) -> Result<ArrayRef> {
+        if step.is_zero() {
+            return Err(ExprError::InvalidParam {
+                name: "step",
+                reason: "must be non-zero".to_string(),
+            });
+        }
+
+        let mut builder = T::Builder::new(self.chunk_size);
+
+        let mut cur: T::OwnedItem = start.to_owned_scalar();
+
+        while if step.is_negative() {
+            cur > stop
+        } else {
+            cur < stop
+        } {
+            builder.append(Some(cur.as_scalar_ref()));
+            cur = cur.checked_add(step).ok_or(ExprError::NumericOutOfRange)?;
+        }
+
+        Ok(Arc::new(builder.finish().into()))
+    }
+}
+
+impl<T: Array, S: Array> TableFunction for Range<T, S>
+where
+    T::OwnedItem: for<'a> PartialOrd<T::RefItem<'a>>,
+    T::OwnedItem: for<'a> CheckedAdd<S::RefItem<'a>, Output = T::OwnedItem>,
+    for<'a> S::RefItem<'a>: IsNegative,
+    for<'a> &'a T: From<&'a ArrayImpl>,
+    for<'a> &'a S: From<&'a ArrayImpl>,
+{
+    fn return_type(&self) -> DataType {
+        self.start.return_type()
+    }
+
+    fn eval(&self, input: &DataChunk) -> Result<Vec<ArrayRef>> {
+        let ret_start = self.start.eval_checked(input)?;
+        let arr_start: &T = ret_start.as_ref().into();
+        let ret_stop = self.stop.eval_checked(input)?;
+        let arr_stop: &T = ret_stop.as_ref().into();
+
+        let ret_step = self.step.eval_checked(input)?;
+        let arr_step: &S = ret_step.as_ref().into();
+
+        let bitmap = input.get_visibility_ref();
+        let mut output_arrays: Vec<ArrayRef> = vec![];
+
+        match bitmap {
+            Some(bitmap) => {
+                for ((start, stop, step), visible) in
+                    multizip((arr_start.iter(), arr_stop.iter(), arr_step.iter()))
+                        .zip_eq(bitmap.iter())
+                {
+                    let array = if !visible {
+                        empty_array(self.return_type())
+                    } else if let (Some(start), Some(stop), Some(step)) = (start, stop, step) {
+                        self.eval_row(start, stop, step)?
+                    } else {
+                        empty_array(self.return_type())
+                    };
+                    output_arrays.push(array);
+                }
+            }
+            None => {
+                for (start, stop, step) in
+                    multizip((arr_start.iter(), arr_stop.iter(), arr_step.iter()))
+                {
+                    let array = if let (Some(start), Some(stop), Some(step)) = (start, stop, step) {
+                        self.eval_row(start, stop, step)?
+                    } else {
+                        empty_array(self.return_type())
+                    };
+                    output_arrays.push(array);
+                }
+            }
+        }
+
+        Ok(output_arrays)
+    }
+}
+
+pub fn new_range(prost: &TableFunctionProst, chunk_size: usize) -> Result<BoxedTableFunction> {
+    let return_type = DataType::from(prost.get_return_type().unwrap());
+    let args: Vec<_> = prost.args.iter().map(expr_build_from_prost).try_collect()?;
+    let [start, stop, step]: [_; 3] = args.try_into().unwrap();
+
+    match return_type {
+        DataType::Timestamp => Ok(Range::<NaiveDateTimeArray, IntervalArray>::new(
+            start, stop, step, chunk_size,
+        )
+        .boxed()),
+        DataType::Int32 => {
+            Ok(Range::<I32Array, I32Array>::new(start, stop, step, chunk_size).boxed())
+        }
+        _ => Err(ExprError::Internal(anyhow!(
+            "the return type of Range Function is incorrect".to_string(),
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::types::{DataType, IntervalUnit, NaiveDateTimeWrapper, ScalarImpl};
+
+    use super::*;
+    use crate::expr::{Expression, LiteralExpression};
+    use crate::vector_op::cast::str_to_timestamp;
+
+    const CHUNK_SIZE: usize = 1024;
+
+    #[test]
+    fn test_i32_range() {
+        range_test_case(2, 4, 1);
+        range_test_case(4, 2, -1);
+        range_test_case(0, 9, 2);
+        range_test_case(0, (CHUNK_SIZE * 2 + 3) as i32, 1);
+    }
+
+    fn range_test_case(start: i32, stop: i32, step: i32) {
+        fn to_lit_expr(v: i32) -> BoxedExpression {
+            LiteralExpression::new(DataType::Int32, Some(v.into())).boxed()
+        }
+
+        let function = Range::<I32Array, I32Array> {
+            start: to_lit_expr(start),
+            stop: to_lit_expr(stop),
+            step: to_lit_expr(step),
+            chunk_size: CHUNK_SIZE,
+            _phantom: Default::default(),
+        }
+        .boxed();
+        let expect_cnt = ((stop - start - step.signum()) / step + 1) as usize;
+
+        let dummy_chunk = DataChunk::new_dummy(1);
+        let arrays = function.eval(&dummy_chunk).unwrap();
+
+        let cnt: usize = arrays.iter().map(|a| a.len()).sum();
+        assert_eq!(cnt, expect_cnt);
+    }
+
+    #[test]
+    fn test_time_range() {
+        let start_time = str_to_timestamp("2008-03-01 00:00:00").unwrap();
+        let stop_time = str_to_timestamp("2008-03-09 00:00:00").unwrap();
+        let one_minute_step = IntervalUnit::from_minutes(1);
+        let one_hour_step = IntervalUnit::from_minutes(60);
+        let one_day_step = IntervalUnit::from_days(1);
+        time_range_test_case(start_time, stop_time, one_minute_step, 60 * 24 * 8);
+        time_range_test_case(start_time, stop_time, one_hour_step, 24 * 8);
+        time_range_test_case(start_time, stop_time, one_day_step, 8);
+        time_range_test_case(stop_time, start_time, -one_day_step, 8);
+    }
+
+    fn time_range_test_case(
+        start: NaiveDateTimeWrapper,
+        stop: NaiveDateTimeWrapper,
+        step: IntervalUnit,
+        expect_cnt: usize,
+    ) {
+        fn to_lit_expr(ty: DataType, v: ScalarImpl) -> BoxedExpression {
+            LiteralExpression::new(ty, Some(v)).boxed()
+        }
+
+        let function = Range::<NaiveDateTimeArray, IntervalArray> {
+            start: to_lit_expr(DataType::Timestamp, start.into()),
+            stop: to_lit_expr(DataType::Timestamp, stop.into()),
+            step: to_lit_expr(DataType::Interval, step.into()),
+            chunk_size: CHUNK_SIZE,
+            _phantom: Default::default(),
+        };
+
+        let dummy_chunk = DataChunk::new_dummy(1);
+        let arrays = function.eval(&dummy_chunk).unwrap();
+
+        let cnt: usize = arrays.iter().map(|a| a.len()).sum();
+        assert_eq!(cnt, expect_cnt);
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- add `new_range()` entry point in `src/expr/src/table_function/mod.rs`
- add the `Range` test cases according to `GenerateSeries`
- add `_stop_inclusive` property to `GenerateSeries`, to control whether the `stop` is inclusive or exclusive, making it to be `true` for `GenerateSeries`
- use `GenerateSeries` with `_stop_inclusive` as `false` to be the `Range`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

* SQL commands, functions, and operators

### Release note

Support `range` function described in https://duckdb.org/docs/sql/functions/nested#range-functions .

## Refer to a related PR or issue link (optional)

#6570 
