### PR TITLE
fix(sqlsmith): handle expected frontend errors

### DIFF
--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -30,6 +30,8 @@ use risingwave_sqlparser::parser::Parser;
 
 mod expr;
 pub use expr::print_function_table;
+use risingwave_expr::ExprError;
+
 mod relation;
 pub mod runner;
 mod scalar;
@@ -460,4 +462,26 @@ pub fn create_table_statement_to_table(statement: &Statement) -> Table {
         },
         _ => panic!("Unexpected statement: {}", statement),
     }
+}
+
+fn is_division_by_zero_err(db_error: &str) -> bool {
+    db_error.contains(&ExprError::DivisionByZero.to_string())
+}
+
+fn is_numeric_out_of_range_err(db_error: &str) -> bool {
+    db_error.contains(&ExprError::NumericOutOfRange.to_string())
+}
+
+/// Skip queries with unimplemented features
+fn is_unimplemented_error(db_error: &str) -> bool {
+    db_error.contains("Feature is not yet implemented")
+}
+
+/// Certain errors are permitted to occur. This is because:
+/// 1. It is more complex to generate queries without these errors.
+/// 2. These errors seldom occur, skipping them won't affect overall effectiveness of sqlsmith.
+pub fn is_permissible_error(db_error: &str) -> bool {
+    is_numeric_out_of_range_err(db_error)
+        || is_division_by_zero_err(db_error)
+        || is_unimplemented_error(db_error)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Permit some errors in frontend as well, not just in e2e.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes https://github.com/risingwavelabs/risingwave/issues/6546