### PR TITLE
fix(ci): fix unused import in release build

### DIFF
--- a/src/storage/src/hummock/sstable/delete_range_aggregator.rs
+++ b/src/storage/src/hummock/sstable/delete_range_aggregator.rs
@@ -106,6 +106,7 @@ impl DeleteRangeAggregatorBuilder {
     }
 }
 
+#[cfg(debug_assertions)]
 fn check_sorted_tombstone(sorted_tombstones: &[DeleteRangeTombstone]) {
     for idx in 1..sorted_tombstones.len() {
         assert!(sorted_tombstones[idx]

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -17,13 +17,11 @@ use std::sync::Arc;
 
 use enum_as_inner::EnumAsInner;
 use risingwave_common::config::StorageConfig;
-use risingwave_common::util::env_var::env_var_is_true;
 use risingwave_common_service::observer_manager::RpcNotificationClient;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManagerRef;
 use risingwave_object_store::object::{
     parse_local_object_store, parse_remote_object_store, ObjectStoreImpl,
 };
-use tracing::info;
 
 use crate::error::StorageResult;
 use crate::hummock::hummock_meta_client::MonitoredHummockMetaClient;
@@ -35,7 +33,6 @@ use crate::hummock::{
 use crate::memory::sled::SledStateStore;
 use crate::memory::MemoryStateStore;
 use crate::monitor::{MonitoredStateStore as Monitored, ObjectStoreMetrics, StateStoreMetrics};
-use crate::store_impl::verify::VerifyStateStore;
 use crate::StateStore;
 
 pub type HummockStorageType = impl StateStore + AsHummockTrait;
@@ -85,6 +82,11 @@ fn may_verify(state_store: impl StateStore + AsHummockTrait) -> impl StateStore 
     }
     #[cfg(debug_assertions)]
     {
+        use risingwave_common::util::env_var::env_var_is_true;
+        use tracing::info;
+
+        use crate::store_impl::verify::VerifyStateStore;
+
         let expected = if env_var_is_true("ENABLE_STATE_STORE_VERIFY") {
             info!("enable verify state store");
             Some(SledStateStore::new_temp())


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

In https://github.com/risingwavelabs/risingwave/pull/6303, we accidentally added unused and unresolved import under release mode. In this PR we fix it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/pull/6303