### PR TITLE
refactor(meta_store): include keys in snapshot list response

### DIFF
--- a/src/meta/src/storage/mem_meta_store.rs
+++ b/src/meta/src/storage/mem_meta_store.rs
@@ -51,9 +51,9 @@ impl MemStoreInner {
 #[async_trait]
 impl Snapshot for MemSnapshot {
     #[inline(always)]
-    async fn list_cf(&self, cf: &str) -> MetaStoreResult<Vec<Value>> {
+    async fn list_cf(&self, cf: &str) -> MetaStoreResult<Vec<(Key, Value)>> {
         Ok(match self.0.cf_ref(cf) {
-            Some(cf) => cf.values().cloned().collect(),
+            Some(cf) => cf.iter().map(|(k, v)| (k.clone(), v.clone())).collect(),
             None => vec![],
         })
     }

--- a/src/meta/src/storage/meta_store.rs
+++ b/src/meta/src/storage/meta_store.rs
@@ -22,7 +22,7 @@ pub const DEFAULT_COLUMN_FAMILY: &str = "default";
 
 #[async_trait]
 pub trait Snapshot: Sync + Send + 'static {
-    async fn list_cf(&self, cf: &str) -> MetaStoreResult<Vec<Vec<u8>>>;
+    async fn list_cf(&self, cf: &str) -> MetaStoreResult<Vec<(Vec<u8>, Vec<u8>)>>;
     async fn get_cf(&self, cf: &str, key: &[u8]) -> MetaStoreResult<Vec<u8>>;
 }
 
@@ -38,7 +38,8 @@ pub trait MetaStore: Clone + Sync + Send + 'static {
     async fn txn(&self, trx: Transaction) -> MetaStoreResult<()>;
 
     async fn list_cf(&self, cf: &str) -> MetaStoreResult<Vec<Vec<u8>>> {
-        self.snapshot().await.list_cf(cf).await
+        let kvs = self.snapshot().await.list_cf(cf).await?;
+        Ok(kvs.into_iter().map(|(_k, v)| v).collect())
     }
 
     async fn get_cf(&self, cf: &str, key: &[u8]) -> MetaStoreResult<Vec<u8>> {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Previously meta_store snapshot list_cf only returns Vec\<Value\>. This PR makes it return Vec\<(Key, Value)\>.

The use case is I need list all KVs under DEFAULT_COLUMN_FAMILY, which are mostly simple single row data (e.g. various id generators, inflight barrier, notification version). Unlike MetadataModel that always contains Key in Value, these simple single row data doesn't impl MetadataModel, thus cannot get keys from list response.

list_cf is not in the critical path so I think performance impaction is acceptable.

## Checklist

~~- [] I have written necessary rustdoc comments~~
~~- [] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
