### PR TITLE
feat(frontend): support CREATE TABLE IF NOT EXISTS

### DIFF
--- a/e2e_test/ddl/table.slt
+++ b/e2e_test/ddl/table.slt
@@ -9,6 +9,9 @@ explain select v1 from ddl_t;
 statement error
 create table ddl_t (v2 int);
 
+statement ok
+create table if not exists ddl_t (v2 int);
+
 # Drop the table.
 statement ok
 drop table ddl_t;

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -317,10 +317,17 @@ impl TestCase {
                     name,
                     columns,
                     constraints,
+                    if_not_exists,
                     ..
                 } => {
-                    create_table::handle_create_table(context, name, columns, constraints, false)
-                        .await?;
+                    create_table::handle_create_table(
+                        context,
+                        name,
+                        columns,
+                        constraints,
+                        if_not_exists,
+                    )
+                    .await?;
                 }
                 Statement::CreateSource {
                     is_materialized,
@@ -334,12 +341,13 @@ impl TestCase {
                     columns,
                     include,
                     distributed_by,
+                    if_not_exists,
                     // TODO: support unique and if_not_exist in planner test
                     ..
                 } => {
                     create_index::handle_create_index(
                         context,
-                        false,
+                        if_not_exists,
                         name,
                         table_name,
                         columns,

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -319,7 +319,8 @@ impl TestCase {
                     constraints,
                     ..
                 } => {
-                    create_table::handle_create_table(context, name, columns, constraints).await?;
+                    create_table::handle_create_table(context, name, columns, constraints, false)
+                        .await?;
                 }
                 Statement::CreateSource {
                     is_materialized,

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -264,7 +264,7 @@ pub async fn handle_create_table(
     table_name: ObjectName,
     columns: Vec<ColumnDef>,
     constraints: Vec<TableConstraint>,
-    if_not_exists: bool
+    if_not_exists: bool,
 ) -> Result<RwPgResponse> {
     let session = context.session_ctx.clone();
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -264,10 +264,20 @@ pub async fn handle_create_table(
     table_name: ObjectName,
     columns: Vec<ColumnDef>,
     constraints: Vec<TableConstraint>,
+    if_not_exists: bool
 ) -> Result<RwPgResponse> {
     let session = context.session_ctx.clone();
 
-    session.check_relation_name_duplicated(table_name.clone())?;
+    if let Err(e) = session.check_relation_name_duplicated(table_name.clone()) {
+        if if_not_exists {
+            return Ok(PgResponse::empty_result_with_notice(
+                StatementType::CREATE_TABLE,
+                format!("relation \"{}\" already exists, skipping", table_name),
+            ));
+        } else {
+            return Err(e);
+        }
+    }
 
     let (graph, source, table) = {
         let (plan, source, table) = gen_create_table_plan(

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -134,17 +134,10 @@ pub async fn handle(
                 )
                 .into());
             }
-            if if_not_exists {
-                return Err(ErrorCode::NotImplemented(
-                    "CREATE TABLE IF NOT EXISTS".to_string(),
-                    None.into(),
-                )
-                .into());
-            }
             if query.is_some() {
                 return Err(ErrorCode::NotImplemented("CREATE AS".to_string(), 6215.into()).into());
             }
-            create_table::handle_create_table(context, name, columns, constraints).await
+            create_table::handle_create_table(context, name, columns, constraints, if_not_exists).await
         }
         Statement::CreateDatabase {
             db_name,

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -137,7 +137,8 @@ pub async fn handle(
             if query.is_some() {
                 return Err(ErrorCode::NotImplemented("CREATE AS".to_string(), 6215.into()).into());
             }
-            create_table::handle_create_table(context, name, columns, constraints, if_not_exists).await
+            create_table::handle_create_table(context, name, columns, constraints, if_not_exists)
+                .await
         }
         Statement::CreateDatabase {
             db_name,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As titled

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes



* SQL commands, functions, and operators


### Release note
Support optional `IF NOT EXISTS` for CREATE TABLE statement.

[PG Doc](https://www.postgresql.org/docs/current/sql-createtable.html):
IF NOT EXISTS: Do not throw an error if a relation with the same name already exists. A notice is issued in this case. Note that there is no guarantee that the existing relation is anything like the one that would have been created.

table_name

## Refer to a related PR or issue link (optional)
