### PR TITLE
refactor(meta): unify hummock manager worker

### DIFF
--- a/src/meta/src/hummock/manager/worker.rs
+++ b/src/meta/src/hummock/manager/worker.rs
@@ -1,0 +1,154 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Duration;
+
+use sync_point::sync_point;
+use tokio::task::JoinHandle;
+use tokio_retry::strategy::{jitter, ExponentialBackoff};
+
+use crate::hummock::utils::RetryableError;
+use crate::hummock::{HummockManager, HummockManagerRef};
+use crate::manager::LocalNotification;
+use crate::storage::MetaStore;
+
+pub type HummockManagerEventSender = tokio::sync::mpsc::UnboundedSender<HummockManagerEvent>;
+pub type HummockManagerEventReceiver = tokio::sync::mpsc::UnboundedReceiver<HummockManagerEvent>;
+
+pub enum HummockManagerEvent {
+    Shutdown,
+}
+
+impl<S> HummockManager<S>
+where
+    S: MetaStore,
+{
+    pub(crate) async fn start_worker(
+        self: &HummockManagerRef<S>,
+        mut receiver: HummockManagerEventReceiver,
+    ) -> JoinHandle<()> {
+        let (local_notification_tx, mut local_notification_rx) =
+            tokio::sync::mpsc::unbounded_channel();
+        self.env
+            .notification_manager()
+            .insert_local_sender(local_notification_tx)
+            .await;
+        let hummock_manager = self.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    notification = local_notification_rx.recv() => {
+                        match notification {
+                            Some(notification) => {
+                                hummock_manager
+                                    .handle_local_notification(notification)
+                                    .await;
+                            }
+                            None => {
+                                return;
+                            }
+                        }
+                    }
+                    hummock_manager_event = receiver.recv() => {
+                        match hummock_manager_event {
+                            Some(hummock_manager_event) => {
+                                if !hummock_manager
+                                    .handle_hummock_manager_event(hummock_manager_event)
+                                    .await {
+                                    return;
+                                }
+                            }
+                            None => {
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        })
+    }
+
+    /// Returns false indicates to shutdown worker
+    #[expect(clippy::unused_async)]
+    async fn handle_hummock_manager_event(&self, event: HummockManagerEvent) -> bool {
+        match event {
+            HummockManagerEvent::Shutdown => {
+                tracing::info!("Hummock manager worker is stopped");
+                false
+            }
+        }
+    }
+
+    async fn handle_local_notification(&self, notification: LocalNotification) {
+        let retry_strategy = ExponentialBackoff::from_millis(10)
+            .max_delay(Duration::from_secs(60))
+            .map(jitter);
+        match notification {
+            LocalNotification::WorkerNodeIsDeleted(worker_node) => {
+                self.compactor_manager.remove_compactor(worker_node.id);
+                tokio_retry::RetryIf::spawn(
+                    retry_strategy.clone(),
+                    || async {
+                        if let Err(err) = self.release_contexts(vec![worker_node.id]).await {
+                            tracing::warn!(
+                                "Failed to release hummock context {}. {}. Will retry.",
+                                worker_node.id,
+                                err
+                            );
+                            return Err(err);
+                        }
+                        Ok(())
+                    },
+                    RetryableError::default(),
+                )
+                .await
+                .expect("retry until success");
+                tracing::info!("Released hummock context {}", worker_node.id);
+                sync_point!("AFTER_RELEASE_HUMMOCK_CONTEXTS_ASYNC");
+            }
+            // TODO move `CompactionTaskNeedCancel` to `handle_hummock_manager_event`
+            // TODO extract retry boilerplate code
+            LocalNotification::CompactionTaskNeedCancel(compact_task) => {
+                let task_id = compact_task.task_id;
+                tokio_retry::RetryIf::spawn(
+                    retry_strategy.clone(),
+                    || async {
+                        let mut compact_task_mut = compact_task.clone();
+                        if let Err(err) = self.cancel_compact_task_impl(&mut compact_task_mut).await
+                        {
+                            tracing::warn!(
+                                "Failed to cancel compaction task {}. {}. Will retry.",
+                                compact_task.task_id,
+                                err
+                            );
+                            return Err(err);
+                        }
+                        Ok(())
+                    },
+                    RetryableError::default(),
+                )
+                .await
+                .expect("retry until success");
+                tracing::info!("Cancelled compaction task {}", task_id);
+                sync_point!("AFTER_CANCEL_COMPACTION_TASK_ASYNC");
+            }
+        }
+    }
+
+    pub fn try_send_event(&self, event: HummockManagerEvent) {
+        if let Err(e) = self.event_sender.send(event) {
+            tracing::warn!("failed to send event to hummock manager {}", e);
+        }
+    }
+}

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -283,17 +283,15 @@ pub async fn setup_compute_env_with_config(
 
     let compactor_manager = Arc::new(CompactorManager::for_test());
 
-    let hummock_manager = Arc::new(
-        HummockManager::with_config(
-            env.clone(),
-            cluster_manager.clone(),
-            Arc::new(MetaMetrics::new()),
-            compactor_manager,
-            config,
-        )
-        .await
-        .unwrap(),
-    );
+    let hummock_manager = HummockManager::with_config(
+        env.clone(),
+        cluster_manager.clone(),
+        Arc::new(MetaMetrics::new()),
+        compactor_manager,
+        config,
+    )
+    .await
+    .unwrap();
     let fake_host_address = HostAddress {
         host: "127.0.0.1".to_string(),
         port,

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -324,16 +324,14 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             .await
             .unwrap(),
     );
-    let hummock_manager = Arc::new(
-        hummock::HummockManager::new(
-            env.clone(),
-            cluster_manager.clone(),
-            meta_metrics.clone(),
-            compactor_manager.clone(),
-        )
-        .await
-        .unwrap(),
-    );
+    let hummock_manager = hummock::HummockManager::new(
+        env.clone(),
+        cluster_manager.clone(),
+        meta_metrics.clone(),
+        compactor_manager.clone(),
+    )
+    .await
+    .unwrap();
 
     #[cfg(not(madsim))]
     if let Some(ref dashboard_addr) = address_info.dashboard_addr {
@@ -448,7 +446,6 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         vacuum_trigger.clone(),
         fragment_manager.clone(),
     );
-    let notification_manager = env.notification_manager_ref();
     let notification_srv = NotificationServiceImpl::new(
         env.clone(),
         catalog_manager,
@@ -471,15 +468,8 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
         hummock_manager.clone(),
         compactor_manager.clone(),
     ));
-    let mut sub_tasks = hummock::start_hummock_workers(
-        hummock_manager.clone(),
-        compactor_manager,
-        vacuum_trigger,
-        notification_manager,
-        compaction_scheduler,
-        &env.opts,
-    )
-    .await;
+    let mut sub_tasks =
+        hummock::start_hummock_workers(vacuum_trigger, compaction_scheduler, &env.opts);
     sub_tasks.push(
         ClusterManager::start_worker_num_monitor(
             cluster_manager.clone(),

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -933,15 +933,13 @@ mod tests {
             let compactor_manager =
                 Arc::new(CompactorManager::with_meta(env.clone(), 1).await.unwrap());
 
-            let hummock_manager = Arc::new(
-                HummockManager::new(
-                    env.clone(),
-                    cluster_manager.clone(),
-                    meta_metrics.clone(),
-                    compactor_manager.clone(),
-                )
-                .await?,
-            );
+            let hummock_manager = HummockManager::new(
+                env.clone(),
+                cluster_manager.clone(),
+                meta_metrics.clone(),
+                compactor_manager.clone(),
+            )
+            .await?;
 
             let (barrier_scheduler, scheduled_barriers) =
                 BarrierScheduler::new_pair(hummock_manager.clone(), env.opts.checkpoint_frequency);

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -27,9 +27,7 @@ use risingwave_meta::hummock::compaction::ManualCompactionOption;
 use risingwave_meta::hummock::test_utils::{
     add_ssts, setup_compute_env, setup_compute_env_with_config,
 };
-use risingwave_meta::hummock::{
-    start_local_notification_receiver, HummockManagerRef, MockHummockMetaClient,
-};
+use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::LocalNotification;
 use risingwave_meta::storage::MemStore;
 use risingwave_pb::common::WorkerNode;
@@ -154,12 +152,6 @@ async fn test_syncpoints_test_failpoints_fetch_ids() {
 async fn test_syncpoints_test_local_notification_receiver() {
     let (env, hummock_manager, _cluster_manager, worker_node) = setup_compute_env(80).await;
     let context_id = worker_node.id;
-    let (join_handle, shutdown_sender) = start_local_notification_receiver(
-        hummock_manager.clone(),
-        hummock_manager.compactor_manager_ref_for_test(),
-        env.notification_manager_ref(),
-    )
-    .await;
 
     // Test cancel compaction task
     let _sst_infos = add_ssts(1, hummock_manager.as_ref(), context_id).await;
@@ -194,9 +186,6 @@ async fn test_syncpoints_test_local_notification_receiver() {
     )
     .await
     .unwrap();
-
-    shutdown_sender.send(()).unwrap();
-    join_handle.await.unwrap();
 }
 
 pub async fn compact_once(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Add a dedicated worker for hummock manager. The use case is I need perform async hummock manager ops in drop method.

- Remove start_local_notification_receiver. It's replaced with this worker.
- Remove a non-deterministic test.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
