### PR TITLE
feat(stream): implement framework of now executor

### DIFF
--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -701,6 +701,11 @@ export interface RowIdGenNode {
   rowIdIndex: number;
 }
 
+export interface NowNode {
+  /** Persists emitted 'now'. */
+  stateTable: Table | undefined;
+}
+
 export interface StreamNode {
   nodeBody?:
     | { $case: "source"; source: SourceNode }
@@ -731,7 +736,8 @@ export interface StreamNode {
     | { $case: "sort"; sort: SortNode }
     | { $case: "watermarkFilter"; watermarkFilter: WatermarkFilterNode }
     | { $case: "dml"; dml: DmlNode }
-    | { $case: "rowIdGen"; rowIdGen: RowIdGenNode };
+    | { $case: "rowIdGen"; rowIdGen: RowIdGenNode }
+    | { $case: "now"; now: NowNode };
   /**
    * The id for the operator. This is local per mview.
    * TODO: should better be a uint32.
@@ -3085,6 +3091,31 @@ export const RowIdGenNode = {
   },
 };
 
+function createBaseNowNode(): NowNode {
+  return { stateTable: undefined };
+}
+
+export const NowNode = {
+  fromJSON(object: any): NowNode {
+    return { stateTable: isSet(object.stateTable) ? Table.fromJSON(object.stateTable) : undefined };
+  },
+
+  toJSON(message: NowNode): unknown {
+    const obj: any = {};
+    message.stateTable !== undefined &&
+      (obj.stateTable = message.stateTable ? Table.toJSON(message.stateTable) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<NowNode>, I>>(object: I): NowNode {
+    const message = createBaseNowNode();
+    message.stateTable = (object.stateTable !== undefined && object.stateTable !== null)
+      ? Table.fromPartial(object.stateTable)
+      : undefined;
+    return message;
+  },
+};
+
 function createBaseStreamNode(): StreamNode {
   return { nodeBody: undefined, operatorId: 0, input: [], streamKey: [], appendOnly: false, identity: "", fields: [] };
 }
@@ -3150,6 +3181,8 @@ export const StreamNode = {
         ? { $case: "dml", dml: DmlNode.fromJSON(object.dml) }
         : isSet(object.rowIdGen)
         ? { $case: "rowIdGen", rowIdGen: RowIdGenNode.fromJSON(object.rowIdGen) }
+        : isSet(object.now)
+        ? { $case: "now", now: NowNode.fromJSON(object.now) }
         : undefined,
       operatorId: isSet(object.operatorId) ? Number(object.operatorId) : 0,
       input: Array.isArray(object?.input)
@@ -3230,6 +3263,8 @@ export const StreamNode = {
       (obj.dml = message.nodeBody?.dml ? DmlNode.toJSON(message.nodeBody?.dml) : undefined);
     message.nodeBody?.$case === "rowIdGen" &&
       (obj.rowIdGen = message.nodeBody?.rowIdGen ? RowIdGenNode.toJSON(message.nodeBody?.rowIdGen) : undefined);
+    message.nodeBody?.$case === "now" &&
+      (obj.now = message.nodeBody?.now ? NowNode.toJSON(message.nodeBody?.now) : undefined);
     message.operatorId !== undefined && (obj.operatorId = Math.round(message.operatorId));
     if (message.input) {
       obj.input = message.input.map((e) =>
@@ -3447,6 +3482,9 @@ export const StreamNode = {
       object.nodeBody?.rowIdGen !== null
     ) {
       message.nodeBody = { $case: "rowIdGen", rowIdGen: RowIdGenNode.fromPartial(object.nodeBody.rowIdGen) };
+    }
+    if (object.nodeBody?.$case === "now" && object.nodeBody?.now !== undefined && object.nodeBody?.now !== null) {
+      message.nodeBody = { $case: "now", now: NowNode.fromPartial(object.nodeBody.now) };
     }
     message.operatorId = object.operatorId ?? 0;
     message.input = object.input?.map((e) => StreamNode.fromPartial(e)) || [];

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -440,6 +440,11 @@ message RowIdGenNode {
   uint64 row_id_index = 1;
 }
 
+message NowNode {
+  // Persists emitted 'now'.
+  catalog.Table state_table = 1;
+}
+
 message StreamNode {
   oneof node_body {
     SourceNode source = 100;
@@ -471,6 +476,7 @@ message StreamNode {
     WatermarkFilterNode watermark_filter = 126;
     DmlNode dml = 127;
     RowIdGenNode row_id_gen = 128;
+    NowNode now = 129;
   }
   // The id for the operator. This is local per mview.
   // TODO: should better be a uint32.

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -237,15 +237,6 @@ impl Barrier {
         }
     }
 
-    pub fn with_prev_epoch_for_test(epoch: u64, prev_epoch: u64) -> Self {
-        Self {
-            epoch: EpochPair::new(epoch, prev_epoch),
-            checkpoint: true,
-            mutation: Default::default(),
-            passed_actors: Default::default(),
-        }
-    }
-
     #[must_use]
     pub fn with_mutation(self, mutation: Mutation) -> Self {
         Self {
@@ -290,20 +281,9 @@ impl Barrier {
         )
     }
 
-    /// Whether this barrier is for pause.
-    pub fn is_pause(&self) -> bool {
-        matches!(self.mutation.as_deref(), Some(Mutation::Pause))
-    }
-
     /// Whether this barrier is for configuration change. Used for source executor initialization.
     pub fn is_update(&self) -> bool {
         matches!(self.mutation.as_deref(), Some(Mutation::Update { .. }))
-    }
-
-    /// Whether this barrier is for resume. Used for now executor to determine whether to yield a
-    /// chunk and a watermark before this barrier.
-    pub fn is_resume(&self) -> bool {
-        matches!(self.mutation.as_deref(), Some(Mutation::Resume))
     }
 
     /// Returns the [`MergeUpdate`] if this barrier is to update the merge executors for the actor

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -1,0 +1,88 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::StreamExt;
+use futures_async_stream::try_stream;
+use risingwave_common::catalog::{Field, Schema};
+use risingwave_common::types::DataType;
+use risingwave_storage::StateStore;
+use tokio::sync::mpsc::UnboundedReceiver;
+
+use super::{
+    Barrier, BoxedMessageStream, Executor, Message, PkIndices, PkIndicesRef, StreamExecutorError,
+};
+use crate::common::table::state_table::StateTable;
+
+pub struct NowExecutor<S: StateStore> {
+    /// Receiver of barrier channel.
+    barrier_receiver: UnboundedReceiver<Barrier>,
+
+    pk_indices: PkIndices,
+    identity: String,
+    schema: Schema,
+    state_table: StateTable<S>,
+}
+
+impl<S: StateStore> NowExecutor<S> {
+    pub fn new(
+        barrier_receiver: UnboundedReceiver<Barrier>,
+        executor_id: u64,
+        state_table: StateTable<S>,
+    ) -> Self {
+        let schema = Schema::new(vec![Field {
+            data_type: DataType::Timestamp,
+            name: String::from("now"),
+            sub_fields: vec![],
+            type_name: String::default(),
+        }]);
+        Self {
+            barrier_receiver,
+            pk_indices: vec![],
+            identity: format!("NowExecutor {:X}", executor_id),
+            schema,
+            state_table,
+        }
+    }
+
+    #[try_stream(ok = Message, error = StreamExecutorError)]
+    async fn into_stream(self) {
+        #[allow(unused_variables)]
+        let Self {
+            barrier_receiver,
+            state_table,
+            schema,
+            ..
+        } = self;
+
+        todo!("https://github.com/risingwavelabs/risingwave/pull/6408");
+    }
+}
+
+impl<S: StateStore> Executor for NowExecutor<S> {
+    fn execute(self: Box<Self>) -> BoxedMessageStream {
+        self.into_stream().boxed()
+    }
+
+    fn schema(&self) -> &Schema {
+        &self.schema
+    }
+
+    fn pk_indices(&self) -> PkIndicesRef<'_> {
+        &self.pk_indices
+    }
+
+    fn identity(&self) -> &str {
+        self.identity.as_str()
+    }
+}

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -31,6 +31,7 @@ mod lookup;
 mod lookup_union;
 mod merge;
 mod mview;
+mod now;
 mod project;
 mod project_set;
 mod row_id_gen;
@@ -64,6 +65,7 @@ use self::lookup::*;
 use self::lookup_union::*;
 use self::merge::*;
 use self::mview::*;
+use self::now::NowExecutorBuilder;
 use self::project::*;
 use self::project_set::*;
 use self::row_id_gen::RowIdGenExecutorBuilder;
@@ -143,5 +145,6 @@ pub async fn create_executor(
         NodeBody::WatermarkFilter => WatermarkFilterBuilder,
         NodeBody::Dml => DmlExecutorBuilder,
         NodeBody::RowIdGen => RowIdGenExecutorBuilder,
+        NodeBody::Now => NowExecutorBuilder,
     }
 }

--- a/src/stream/src/from_proto/now.rs
+++ b/src/stream/src/from_proto/now.rs
@@ -1,0 +1,52 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_pb::stream_plan::NowNode;
+use risingwave_storage::StateStore;
+use tokio::sync::mpsc::unbounded_channel;
+
+use super::ExecutorBuilder;
+use crate::common::table::state_table::StateTable;
+use crate::error::StreamResult;
+use crate::executor::{BoxedExecutor, NowExecutor};
+use crate::task::{ExecutorParams, LocalStreamManagerCore};
+
+pub struct NowExecutorBuilder;
+
+#[async_trait::async_trait]
+impl ExecutorBuilder for NowExecutorBuilder {
+    type Node = NowNode;
+
+    async fn new_boxed_executor(
+        params: ExecutorParams,
+        node: &NowNode,
+        store: impl StateStore,
+        stream: &mut LocalStreamManagerCore,
+    ) -> StreamResult<BoxedExecutor> {
+        let (sender, barrier_receiver) = unbounded_channel();
+        stream
+            .context
+            .lock_barrier_manager()
+            .register_sender(params.actor_context.id, sender);
+
+        let state_table =
+            StateTable::from_table_catalog(node.get_state_table()?, store, None).await;
+
+        Ok(Box::new(NowExecutor::new(
+            barrier_receiver,
+            params.executor_id,
+            state_table,
+        )))
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This is framework of `Now` executor.
Here defines interface of `Now` executor and builder.
Frontend part, backend part and barrier part of now executor will be based on this.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6408 