### PR TITLE
fix: gh create release notes too long

### DIFF
--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -24,7 +24,7 @@ yum install -y llvm-toolset-7.0-lld
 source /opt/rh/llvm-toolset-7.0/enable
 
 echo "--- Release create"
-gh release create "${BUILDKITE_TAG}" --generate-notes -d -p
+gh release create "${BUILDKITE_TAG}" --notes "release ${BUILDKITE_TAG}" -d -p
 
 echo "--- Build release asset"
 cargo build -p risingwave_cmd_all --features "static-link static-log-level" --profile release


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

as the title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)