### PR TITLE
fix: fix some panics in recovery

### DIFF
--- a/src/meta/src/storage/etcd_retry_client.rs
+++ b/src/meta/src/storage/etcd_retry_client.rs
@@ -48,7 +48,9 @@ impl EtcdRetryClient {
     #[inline(always)]
     fn should_retry(err: &Error) -> bool {
         match err {
-            Error::GRpcStatus(status) => status.code() == tonic::Code::Unavailable,
+            Error::GRpcStatus(status) => {
+                status.code() == tonic::Code::Unavailable || status.code() == tonic::Code::Unknown
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

As title:
1. add retry logic for unknown error in etcd. #6683 
2. add retry logic for calling `new_register` to meta, which was found by @wangrunji0408 , when meta exits between client connection and sending request.
## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Resolve #6683 