### PR TITLE
feat(now): frontend part of now expression

### DIFF
--- a/dashboard/proto/gen/expr.ts
+++ b/dashboard/proto/gen/expr.ts
@@ -113,6 +113,8 @@ export const ExprNode_Type = {
   SARG: "SARG",
   /** VNODE - Internal functions */
   VNODE: "VNODE",
+  /** NOW - Non-deterministic functions */
+  NOW: "NOW",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -360,6 +362,9 @@ export function exprNode_TypeFromJSON(object: any): ExprNode_Type {
     case 1101:
     case "VNODE":
       return ExprNode_Type.VNODE;
+    case 2022:
+    case "NOW":
+      return ExprNode_Type.NOW;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -529,6 +534,8 @@ export function exprNode_TypeToJSON(object: ExprNode_Type): string {
       return "SARG";
     case ExprNode_Type.VNODE:
       return "VNODE";
+    case ExprNode_Type.NOW:
+      return "NOW";
     case ExprNode_Type.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -107,6 +107,8 @@ message ExprNode {
     SARG = 999;
     // Internal functions
     VNODE = 1101;
+    // Non-deterministic functions
+    NOW = 2022;
   }
   Type expr_type = 1;
   data.DataType return_type = 3;

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -353,17 +353,15 @@
     └─BatchValues { rows: [[]] }
 - name: now expression
   sql: |
-    create table t (v1 datetime);
+    create table t (v1 timestamp);
     select * from t where v1 >= now();
   logical_plan: |
-    BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = min(min(t.v1))))] }
-    └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchSimpleAgg { aggs: [min(t.v1)] }
-          └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    LogicalProject { exprs: [t.v1] }
+    └─LogicalFilter { predicate: (t.v1 >= Now) }
+      └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |
-    BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = min(min(t.v1))))] }
-    └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
-      └─BatchExchange { order: [], dist: Single }
-        └─BatchSimpleAgg { aggs: [min(t.v1)] }
-          └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+    StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
+    └─StreamDynamicFilter { predicate: (t.v1 >= t.v1), output: [t.v1, t._row_id] }
+      ├─StreamFilter { predicate: true }
+      | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+      └─StreamNow { output: [now] }

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -362,8 +362,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
     └─StreamDynamicFilter { predicate: (t.v1 >= now), output: [t.v1, t._row_id] }
-      ├─StreamFilter { predicate: true }
-      | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+      ├─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamNow { output: [now] }
 - name: and of two now expression condition
   sql: |
@@ -373,8 +372,7 @@
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
     └─StreamDynamicFilter { predicate: (t.v2 >= now), output: [t.v1, t.v2, t._row_id] }
       ├─StreamDynamicFilter { predicate: (t.v1 >= now), output: [t.v1, t.v2, t._row_id] }
-      | ├─StreamFilter { predicate: true }
-      | | └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+      | ├─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       | └─StreamNow { output: [now] }
       └─StreamNow { output: [now] }
 - name: or of two now expression condition

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -365,3 +365,8 @@
       ├─StreamFilter { predicate: true }
       | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamNow { output: [now] }
+- name: invalid now expression
+  sql: |
+    create table t (v1 timestamp, v2 timestamp);
+    select * from t where v1 >= now() or v2 >= now();
+  stream_error: 'Expr error: Invalid parameter now: now expression must be placed in a comparison'

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -351,3 +351,19 @@
   batch_plan: |
     BatchProject { exprs: ['integer[][]':Varchar] }
     └─BatchValues { rows: [[]] }
+- name: now expression
+  sql: |
+    create table t (v1 datetime);
+    select * from t where v1 >= now();
+  logical_plan: |
+    BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = min(min(t.v1))))] }
+    └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [min(t.v1)] }
+          └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
+  stream_plan: |
+    BatchProject { exprs: [(In(1:Int32::Decimal, 3:Int32::Decimal, (0.5:Decimal * 2:Int32)) OR (1:Int32 = min(min(t.v1))))] }
+    └─BatchSimpleAgg { aggs: [min(min(t.v1))] }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchSimpleAgg { aggs: [min(t.v1)] }
+          └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -365,7 +365,19 @@
       ├─StreamFilter { predicate: true }
       | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamNow { output: [now] }
-- name: invalid now expression
+- name: and of two now expression condition
+  sql: |
+    create table t (v1 timestamp, v2 timestamp);
+    select * from t where v1 >= now() and v2 >= now();
+  stream_plan: |
+    StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
+    └─StreamDynamicFilter { predicate: (t.v2 >= t.v1), output: [t.v1, t.v2, t._row_id] }
+      ├─StreamDynamicFilter { predicate: (t.v1 >= t.v1), output: [t.v1, t.v2, t._row_id] }
+      | ├─StreamFilter { predicate: true }
+      | | └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+      | └─StreamNow { output: [now] }
+      └─StreamNow { output: [now] }
+- name: or of two now expression condition
   sql: |
     create table t (v1 timestamp, v2 timestamp);
     select * from t where v1 >= now() or v2 >= now();

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -361,7 +361,7 @@
       └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [v1, t._row_id(hidden)], pk_columns: [t._row_id] }
-    └─StreamDynamicFilter { predicate: (t.v1 >= t.v1), output: [t.v1, t._row_id] }
+    └─StreamDynamicFilter { predicate: (t.v1 >= now), output: [t.v1, t._row_id] }
       ├─StreamFilter { predicate: true }
       | └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamNow { output: [now] }
@@ -371,8 +371,8 @@
     select * from t where v1 >= now() and v2 >= now();
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
-    └─StreamDynamicFilter { predicate: (t.v2 >= t.v1), output: [t.v1, t.v2, t._row_id] }
-      ├─StreamDynamicFilter { predicate: (t.v1 >= t.v1), output: [t.v1, t.v2, t._row_id] }
+    └─StreamDynamicFilter { predicate: (t.v2 >= now), output: [t.v1, t.v2, t._row_id] }
+      ├─StreamDynamicFilter { predicate: (t.v1 >= now), output: [t.v1, t.v2, t._row_id] }
       | ├─StreamFilter { predicate: true }
       | | └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       | └─StreamNow { output: [now] }

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -276,6 +276,16 @@ impl Binder {
             // TODO: include version/tag/commit_id
             // TODO: choose which pg version we should return.
             "version" => return Ok(ExprImpl::literal_varchar("PostgreSQL 13.9-RW".to_string())),
+            // non-deterministic
+            "now" => {
+                if !inputs.is_empty() {
+                    return Err(ErrorCode::BindError(
+                        "function now() must not contain any arguments".to_string(),
+                    )
+                    .into());
+                }
+                ExprType::Now
+            }
             _ => {
                 return Err(ErrorCode::NotImplemented(
                     format!("unsupported function: {:?}", function_name),

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -277,15 +277,7 @@ impl Binder {
             // TODO: choose which pg version we should return.
             "version" => return Ok(ExprImpl::literal_varchar("PostgreSQL 13.9-RW".to_string())),
             // non-deterministic
-            "now" => {
-                if !inputs.is_empty() {
-                    return Err(ErrorCode::BindError(
-                        "function now() must not contain any arguments".to_string(),
-                    )
-                    .into());
-                }
-                ExprType::Now
-            }
+            "now" => ExprType::Now,
             _ => {
                 return Err(ErrorCode::NotImplemented(
                     format!("unsupported function: {:?}", function_name),

--- a/src/frontend/src/expr/expr_visitor.rs
+++ b/src/frontend/src/expr/expr_visitor.rs
@@ -43,16 +43,13 @@ pub trait ExprVisitor<R: Default> {
             ExprImpl::WindowFunction(inner) => self.visit_window_function(inner),
         }
     }
-    fn visit_function_call_general(&mut self, func_call: &FunctionCall) -> R {
+    fn visit_function_call(&mut self, func_call: &FunctionCall) -> R {
         func_call
             .inputs()
             .iter()
             .map(|expr| self.visit_expr(expr))
             .reduce(Self::merge)
             .unwrap_or_default()
-    }
-    fn visit_function_call(&mut self, func_call: &FunctionCall) -> R {
-        self.visit_function_call_general(func_call)
     }
     fn visit_agg_call(&mut self, agg_call: &AggCall) -> R {
         let mut r = agg_call

--- a/src/frontend/src/expr/expr_visitor.rs
+++ b/src/frontend/src/expr/expr_visitor.rs
@@ -43,13 +43,16 @@ pub trait ExprVisitor<R: Default> {
             ExprImpl::WindowFunction(inner) => self.visit_window_function(inner),
         }
     }
-    fn visit_function_call(&mut self, func_call: &FunctionCall) -> R {
+    fn visit_function_call_general(&mut self, func_call: &FunctionCall) -> R {
         func_call
             .inputs()
             .iter()
             .map(|expr| self.visit_expr(expr))
             .reduce(Self::merge)
             .unwrap_or_default()
+    }
+    fn visit_function_call(&mut self, func_call: &FunctionCall) -> R {
+        self.visit_function_call_general(func_call)
     }
     fn visit_agg_call(&mut self, agg_call: &AggCall) -> R {
         let mut r = agg_call

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -159,8 +159,7 @@ impl ExprImpl {
     /// Count `Now`s in the expression.
     pub fn count_nows(&self) -> usize {
         let mut visitor = CountNow::default();
-        visitor.visit_expr(self);
-        visitor.into()
+        visitor.visit_expr(self)
     }
 
     /// Check whether self is literal NULL.

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -158,7 +158,7 @@ impl ExprImpl {
 
     /// Count `Now`s in the expression.
     pub fn count_nows(&self) -> usize {
-        let mut visitor = CountNow::new();
+        let mut visitor = CountNow::default();
         visitor.visit_expr(self);
         visitor.into()
     }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -156,6 +156,13 @@ impl ExprImpl {
         visitor.into()
     }
 
+    /// Count `Now`s in the expression.
+    pub fn count_nows(&self) -> usize {
+        let mut visitor = CountNow::new();
+        visitor.visit_expr(self);
+        visitor.into()
+    }
+
     /// Check whether self is literal NULL.
     pub fn is_null(&self) -> bool {
         matches!(self, ExprImpl::Literal(literal) if literal.get_data().is_none())

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -294,7 +294,10 @@ fn infer_type_for_special(
             ensure_arity!("vnode", 1 <= | inputs |);
             Ok(Some(DataType::Int16))
         }
-        ExprType::Now => Ok(Some(DataType::Timestamp)),
+        ExprType::Now => {
+            ensure_arity!("now", | inputs | == 0);
+            Ok(Some(DataType::Timestamp))
+        }
         _ => Ok(None),
     }
 }

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -294,6 +294,7 @@ fn infer_type_for_special(
             ensure_arity!("vnode", 1 <= | inputs |);
             Ok(Some(DataType::Int16))
         }
+        ExprType::Now => Ok(Some(DataType::Timestamp)),
         _ => Ok(None),
     }
 }

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -390,7 +390,7 @@ impl Extend<usize> for CollectInputRef {
 }
 
 /// Count `Now`s in the expression.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CountNow {
     now_cnt: usize,
 }
@@ -406,12 +406,6 @@ impl ExprVisitor<usize> for CountNow {
         } else {
             ExprVisitor::<usize>::visit_function_call(self, func_call)
         }
-    }
-}
-
-impl CountNow {
-    pub fn new() -> Self {
-        CountNow { now_cnt: 0 }
     }
 }
 

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -389,6 +389,38 @@ impl Extend<usize> for CollectInputRef {
     }
 }
 
+/// Count `Now`s in the expression.
+#[derive(Clone)]
+pub struct CountNow {
+    now_cnt: usize,
+}
+
+impl ExprVisitor<usize> for CountNow {
+    fn merge(a: usize, b: usize) -> usize {
+        a + b
+    }
+
+    fn visit_function_call(&mut self, func_call: &FunctionCall) -> usize {
+        if func_call.get_expr_type() == ExprType::Now {
+            1
+        } else {
+            ExprVisitor::<usize>::visit_function_call(self, func_call)
+        }
+    }
+}
+
+impl CountNow {
+    pub fn new() -> Self {
+        CountNow { now_cnt: 0 }
+    }
+}
+
+impl From<CountNow> for usize {
+    fn from(s: CountNow) -> Self {
+        s.now_cnt
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use risingwave_common::types::{DataType, ScalarImpl};

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -404,7 +404,12 @@ impl ExprVisitor<usize> for CountNow {
         if func_call.get_expr_type() == ExprType::Now {
             1
         } else {
-            self.visit_function_call_general(func_call)
+            func_call
+                .inputs()
+                .iter()
+                .map(|expr| self.visit_expr(expr))
+                .reduce(Self::merge)
+                .unwrap_or_default()
         }
     }
 }

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -404,7 +404,7 @@ impl ExprVisitor<usize> for CountNow {
         if func_call.get_expr_type() == ExprType::Now {
             1
         } else {
-            ExprVisitor::<usize>::visit_function_call(self, func_call)
+            self.visit_function_call_general(func_call)
         }
     }
 }

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -391,9 +391,7 @@ impl Extend<usize> for CollectInputRef {
 
 /// Count `Now`s in the expression.
 #[derive(Clone, Default)]
-pub struct CountNow {
-    now_cnt: usize,
-}
+pub struct CountNow {}
 
 impl ExprVisitor<usize> for CountNow {
     fn merge(a: usize, b: usize) -> usize {
@@ -411,12 +409,6 @@ impl ExprVisitor<usize> for CountNow {
                 .reduce(Self::merge)
                 .unwrap_or_default()
         }
-    }
-}
-
-impl From<CountNow> for usize {
-    fn from(s: CountNow) -> Self {
-        s.now_cnt
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -269,6 +269,8 @@ impl ToStream for LogicalFilter {
             let mut cur_streaming = PlanRef::from(StreamFilter::new(
                 simple_logical.clone_with_input(new_input),
             ));
+            // Rewrite each now condition. Replace `NowExpr` with `StreamNow` and replace
+            // `LogicalFilter` with `DynamicFilter`.
             for (_, now_cond) in now_conds {
                 let left_index = must_match!(now_cond.inputs()[0], ExprImpl::InputRef(box ref input_ref) => input_ref.index());
                 let rht = must_match!(now_cond.inputs()[1], ExprImpl::FunctionCall(box ref function_call) => {

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -277,6 +277,7 @@ impl ToStream for LogicalFilter {
                             now_delta_expr.inputs_mut()[0] = ExprImpl::from(InputRef::new(0, DataType::Timestamp));
                             StreamProject::new(LogicalProject::new(StreamNow::new(self.ctx()).into(), vec![ExprImpl::from(now_delta_expr)])).into()
                         },
+                        // We can panic here because we have checked above
                         _ => panic!(),
                     }
                 });

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -279,6 +279,7 @@ impl ToStream for LogicalFilter {
                         Type::Add | Type::Subtract => {
                             let mut now_delta_expr = function_call.clone();
                             now_delta_expr.inputs_mut()[0] = ExprImpl::from(InputRef::new(0, DataType::Timestamp));
+                            // We cannot call `LogicalProject::to_stream()` here, because its input is already a stream.
                             StreamProject::new(LogicalProject::new(StreamNow::new(self.ctx()).into(), vec![ExprImpl::from(now_delta_expr)])).into()
                         },
                         // We can panic here because we have checked above

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -263,6 +263,8 @@ impl ToStream for LogicalFilter {
                 })
                 .collect_vec();
             now_conds.sort_by_key(|(comparator_priority, _)| *comparator_priority);
+            // We do simple logical filters first because it can reduce size of dynamic filter's
+            // cache.
             let simple_logical = LogicalFilter::new(self.input(), Condition { conjunctions });
             let mut cur_streaming = PlanRef::from(StreamFilter::new(
                 simple_logical.clone_with_input(new_input),

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -259,6 +259,9 @@ impl ToStream for LogicalFilter {
                     })
                 })
                 .collect_vec();
+            // Apply filters by selectivity and then applicabiliy of watermark - equality condition
+            // first, then conditions of the form T > now() - Y (the timestamp needs to be greater
+            // than a watermark), then conditions similar to T < now() - Y
             now_conds.sort_by_key(|(comparator_priority, _)| *comparator_priority);
             let simple_logical = LogicalFilter::new(self.input(), Condition { conjunctions });
             let mut cur_streaming = PlanRef::from(StreamFilter::new(

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -104,10 +104,6 @@ impl LogicalFilter {
             }
         )
     }
-
-    fn clone_with_predicate(&self, predicate: Condition) -> Self {
-        Self::new(self.input(), predicate)
-    }
 }
 
 impl PlanTreeNodeUnary for LogicalFilter {
@@ -264,7 +260,7 @@ impl ToStream for LogicalFilter {
                 })
                 .collect_vec();
             now_conds.sort_by_key(|(comparator_priority, _)| *comparator_priority);
-            let simple_logical = self.clone_with_predicate(Condition { conjunctions });
+            let simple_logical = LogicalFilter::new(self.input(), Condition { conjunctions });
             let mut cur_streaming = PlanRef::from(StreamFilter::new(
                 simple_logical.clone_with_input(new_input),
             ));

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -190,6 +190,9 @@ impl ToBatch for LogicalFilter {
     }
 }
 
+/// Apply filters by selectivity and then applicabiliy of watermark - equality condition
+/// first, then conditions of the form T > now() - Y (the timestamp needs to be greater
+/// than a watermark), then conditions similar to T < now() - Y
 fn convert_comparator_to_priority(comparator: Type) -> i32 {
     match comparator {
         Type::Equal => 0,
@@ -259,9 +262,6 @@ impl ToStream for LogicalFilter {
                     })
                 })
                 .collect_vec();
-            // Apply filters by selectivity and then applicabiliy of watermark - equality condition
-            // first, then conditions of the form T > now() - Y (the timestamp needs to be greater
-            // than a watermark), then conditions similar to T < now() - Y
             now_conds.sort_by_key(|(comparator_priority, _)| *comparator_priority);
             let simple_logical = LogicalFilter::new(self.input(), Condition { conjunctions });
             let mut cur_streaming = PlanRef::from(StreamFilter::new(

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -297,7 +297,7 @@ impl ToStream for LogicalFilter {
                                     self.schema().fields()[left_index].data_type(),
                                 )),
                                 ExprImpl::from(InputRef::new(
-                                    0,
+                                    self.schema().len(),
                                     rht.schema().fields()[0].data_type(),
                                 )),
                             ],

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -218,6 +218,7 @@ impl ToStream for LogicalFilter {
                 if conjunction.count_nows() > 0 {
                     let comparator_expr = try_match_expand!(conjunction, ExprImpl::FunctionCall)?;
                     if convert_comparator_to_priority(comparator_expr.get_expr_type()) < 0 {
+                        // TODO: We should avoid using `ExprError` in frontend, same 2 below.
                         return Err(ExprError::InvalidParam {
                             name: "now",
                             reason: String::from("now expression must be placed in a comparison"),

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -285,11 +285,13 @@ impl LogicalJoin {
         push_right: bool,
         push_on: bool,
     ) -> (Condition, Condition, Condition) {
-        let conjunctions = std::mem::take(&mut predicate.conjunctions);
+        let mut conjunctions = std::mem::take(&mut predicate.conjunctions);
+
+        let mut cannot_push = conjunctions
+            .drain_filter(|expr| expr.count_nows() > 0)
+            .collect_vec();
         let (mut left, right, mut others) =
             Condition { conjunctions }.split(left_col_num, right_col_num);
-
-        let mut cannot_push = vec![];
 
         if !push_left {
             cannot_push.extend(left);

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -29,7 +29,8 @@ use super::{
 };
 use crate::catalog::{ColumnId, IndexCatalog};
 use crate::expr::{
-    CollectInputRef, CorrelatedInputRef, Expr, ExprImpl, ExprRewriter, ExprVisitor, InputRef,
+    CollectInputRef, CorrelatedInputRef, CountNow, Expr, ExprImpl, ExprRewriter, ExprVisitor,
+    InputRef,
 };
 use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::{BatchSeqScan, LogicalFilter, LogicalProject, LogicalValues};
@@ -448,7 +449,9 @@ impl PredicatePushdown for LogicalScan {
             }
         }
         let mut has_correlated_visitor = HasCorrelated {};
-        if predicate.visit_expr(&mut has_correlated_visitor) {
+        if predicate.visit_expr(&mut has_correlated_visitor)
+            || predicate.visit_expr(&mut CountNow::default()) > 0
+        {
             return LogicalFilter::create(
                 self.clone_with_predicate(self.predicate().clone()).into(),
                 predicate,

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -436,7 +436,7 @@ impl ColPrunable for LogicalScan {
 
 impl PredicatePushdown for LogicalScan {
     fn predicate_pushdown(&self, predicate: Condition) -> PlanRef {
-        // If the predicate contains `CorrelatedInputRef`. We don't push down.
+        // If the predicate contains `CorrelatedInputRef` or `now()`. We don't push down.
         // This case could come from the predicate push down before the subquery unnesting.
         struct HasCorrelated {}
         impl ExprVisitor<bool> for HasCorrelated {

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -320,6 +320,7 @@ mod stream_hop_window;
 mod stream_index_scan;
 mod stream_local_simple_agg;
 mod stream_materialize;
+mod stream_now;
 mod stream_project;
 mod stream_project_set;
 mod stream_row_id_gen;
@@ -389,6 +390,7 @@ pub use stream_hop_window::StreamHopWindow;
 pub use stream_index_scan::StreamIndexScan;
 pub use stream_local_simple_agg::StreamLocalSimpleAgg;
 pub use stream_materialize::StreamMaterialize;
+pub use stream_now::StreamNow;
 pub use stream_project::StreamProject;
 pub use stream_project_set::StreamProjectSet;
 pub use stream_row_id_gen::StreamRowIdGen;
@@ -484,6 +486,7 @@ macro_rules! for_all_plan_nodes {
             , { Stream, Union }
             , { Stream, RowIdGen }
             , { Stream, Dml }
+            , { Stream, Now }
         }
     };
 }
@@ -579,6 +582,7 @@ macro_rules! for_stream_plan_nodes {
             , { Stream, Union }
             , { Stream, RowIdGen }
             , { Stream, Dml }
+            , { Stream, Now }
         }
     };
 }

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -80,7 +80,7 @@ impl StreamNode for StreamNow {
         let schema = self.base.schema();
         let dist_keys = self.base.distribution().dist_column_indices().to_vec();
         let mut internal_table_catalog_builder =
-            TableCatalogBuilder::new(self.base.ctx().inner().with_options.internal_table_subset());
+            TableCatalogBuilder::new(self.base.ctx().with_options().internal_table_subset());
         schema.fields().iter().for_each(|field| {
             internal_table_catalog_builder.add_column(field);
         });

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -1,0 +1,95 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt;
+
+use itertools::Itertools;
+use risingwave_common::catalog::{Field, Schema};
+use risingwave_common::types::DataType;
+use risingwave_pb::stream_plan::stream_node::NodeBody;
+use risingwave_pb::stream_plan::NowNode;
+
+use super::generic::GenericPlanRef;
+use super::stream::StreamPlanRef;
+use super::utils::{IndicesDisplay, TableCatalogBuilder};
+use super::{PlanBase, StreamNode};
+use crate::optimizer::property::{Distribution, FunctionalDependencySet};
+use crate::session::OptimizerContextRef;
+use crate::stream_fragmenter::BuildFragmentGraphState;
+
+#[derive(Clone, Debug)]
+pub struct StreamNow {
+    pub base: PlanBase,
+}
+
+impl StreamNow {
+    pub fn new(ctx: OptimizerContextRef) -> Self {
+        let schema = Schema::new(vec![Field {
+            data_type: DataType::Timestamp,
+            name: String::from("now"),
+            sub_fields: vec![],
+            type_name: String::default(),
+        }]);
+        let base = PlanBase::new_stream(
+            ctx,
+            schema,
+            vec![],
+            FunctionalDependencySet::default(),
+            Distribution::Single,
+            false,
+        );
+        Self { base }
+    }
+}
+
+impl fmt::Display for StreamNow {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let verbose = self.base.ctx.is_explain_verbose();
+        let mut builder = f.debug_struct("StreamNow");
+
+        if verbose {
+            // For now, output all columns from the left side. Make it explicit here.
+            builder.field(
+                "output",
+                &IndicesDisplay {
+                    indices: &(0..self.schema().fields.len()).collect_vec(),
+                    input_schema: self.schema(),
+                },
+            );
+        }
+
+        builder.finish()
+    }
+}
+
+impl_plan_tree_node_for_leaf! { StreamNow }
+
+impl StreamNode for StreamNow {
+    fn to_stream_prost_body(&self, state: &mut BuildFragmentGraphState) -> NodeBody {
+        let schema = self.base.schema();
+        let dist_keys = self.base.distribution().dist_column_indices().to_vec();
+        let mut internal_table_catalog_builder =
+            TableCatalogBuilder::new(self.base.ctx().inner().with_options.internal_table_subset());
+        schema.fields().iter().for_each(|field| {
+            internal_table_catalog_builder.add_column(field);
+        });
+
+        let table_catalog = internal_table_catalog_builder
+            .build(dist_keys)
+            .with_id(state.gen_table_id_wrapped());
+        NodeBody::Now(NowNode {
+            state_table: Some(table_catalog.to_internal_table_prost()),
+        })
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -25,8 +25,8 @@ use super::stream::StreamPlanRef;
 use super::utils::{IndicesDisplay, TableCatalogBuilder};
 use super::{PlanBase, StreamNode};
 use crate::optimizer::property::{Distribution, FunctionalDependencySet};
-use crate::session::OptimizerContextRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
+use crate::OptimizerContextRef;
 
 #[derive(Clone, Debug)]
 pub struct StreamNow {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Implement happy path of frontend part of now expression in order that optimizer can generate `NowExecutor` node.
- How does this PR work? Need a brief introduction for the changed logic (optional)
We modify `to_stream` method of `LogicalFilter`. It will convert `NowExpr` in filter expression into `NowNode` and convert the `LogicalFIlter` into a `DynamicFilter`.
- Describe clearly one logical change and avoid lazy messages (optional)
`LogicalFilter` with `now()` in filter expression will be replaced with a `DynamicFilter` with a `NowNode`.
- Describe any limitations of the current code (optional)
We haven't limited `now()` expression format.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6669 