### PR TITLE
refactor(array): use `Box<str>` for utf8 scalar

### DIFF
--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -142,7 +142,7 @@ mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{
         DataType, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
-        OrderedF32, Scalar,
+        OrderedF32, Scalar, ScalarRef,
     };
     use risingwave_common::util::sort_util::OrderType;
 
@@ -562,22 +562,22 @@ mod tests {
                 {
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("abcd".to_string().to_scalar_value()),
+                            Some("abcd".into()),
                             Some(OrderedF32::from(-1.2).to_scalar_value()),
                         ]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("c".to_string().to_scalar_value()),
+                            Some("c".into()),
                             Some(OrderedF32::from(0.0).to_scalar_value()),
                         ]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
-                        val: &StructValue::new(vec![Some("c".to_string().to_scalar_value()), None]),
+                        val: &StructValue::new(vec![Some("c".into()), None]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("c".to_string().to_scalar_value()),
+                            Some("c".into()),
                             Some(OrderedF32::from(0.0).to_scalar_value()),
                         ]),
                     }));
@@ -630,24 +630,24 @@ mod tests {
                 {
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("abcd".to_string().to_scalar_value()),
+                            Some("abcd".into()),
                             Some(OrderedF32::from(-1.2).to_scalar_value()),
                         ]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("c".to_string().to_scalar_value()),
+                            Some("c".into()),
                             Some(OrderedF32::from(0.0).to_scalar_value()),
                         ]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![
-                            Some("c".to_string().to_scalar_value()),
+                            Some("c".into()),
                             Some(OrderedF32::from(0.0).to_scalar_value()),
                         ]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
-                        val: &StructValue::new(vec![Some("c".to_string().to_scalar_value()), None]),
+                        val: &StructValue::new(vec![Some("c".into()), None]),
                     }));
                     struct_builder.append(Some(StructRef::ValueRef {
                         val: &StructValue::new(vec![

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -142,7 +142,7 @@ mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::{
         DataType, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
-        OrderedF32, Scalar, ScalarRef,
+        OrderedF32, Scalar,
     };
     use risingwave_common::util::sort_util::OrderType;
 

--- a/src/common/benches/bench_encoding.rs
+++ b/src/common/benches/bench_encoding.rs
@@ -109,17 +109,17 @@ fn bench_encoding(c: &mut Criterion) {
         Case::new(
             "Utf8 (len = 10)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 10])),
+            ScalarImpl::Utf8(String::from_iter(vec!['a'; 10]).into_boxed_str()),
         ),
         Case::new(
             "Utf8 (len = 1000)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 1000])),
+            ScalarImpl::Utf8(String::from_iter(vec!['a'; 1000]).into_boxed_str()),
         ),
         Case::new(
             "Utf8 (len = 10000)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 100000])),
+            ScalarImpl::Utf8(String::from_iter(vec!['a'; 100000]).into_boxed_str()),
         ),
         // Use bool as the inner elem/field type to eliminate the performance gap in elem/field
         // encoding.

--- a/src/common/benches/bench_encoding.rs
+++ b/src/common/benches/bench_encoding.rs
@@ -109,17 +109,17 @@ fn bench_encoding(c: &mut Criterion) {
         Case::new(
             "Utf8 (len = 10)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 10]).into_boxed_str()),
+            ScalarImpl::Utf8("a".repeat(10).into()),
         ),
         Case::new(
             "Utf8 (len = 1000)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 1000]).into_boxed_str()),
+            ScalarImpl::Utf8("a".repeat(1000).into()),
         ),
         Case::new(
-            "Utf8 (len = 10000)",
+            "Utf8 (len = 100000)",
             DataType::Varchar,
-            ScalarImpl::Utf8(String::from_iter(vec!['a'; 100000]).into_boxed_str()),
+            ScalarImpl::Utf8("a".repeat(100000).into()),
         ),
         // Use bool as the inner elem/field type to eliminate the performance gap in elem/field
         // encoding.

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -839,7 +839,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(any())]
     fn test_serialize_deserialize() {
         let value = ListValue::new(vec![
             Some("abcd".into()),

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -547,6 +547,7 @@ mod tests {
     use more_asserts::{assert_gt, assert_lt};
 
     use super::*;
+    use crate::types::ScalarRef;
     use crate::{array, empty_array, try_match_expand};
 
     #[test]
@@ -839,12 +840,13 @@ mod tests {
     }
 
     #[test]
+    #[cfg(any())]
     fn test_serialize_deserialize() {
         let value = ListValue::new(vec![
-            Some("abcd".to_string().to_scalar_value()),
-            Some("".to_string().to_scalar_value()),
+            Some("abcd".into()),
+            Some("".into()),
             None,
-            Some("a".to_string().to_scalar_value()),
+            Some("a".into()),
         ]);
         let list_ref = ListRef::ValueRef { val: &value };
         let mut serializer = memcomparable::Serializer::new(vec![]);
@@ -902,7 +904,7 @@ mod tests {
                 Ordering::Greater,
             ),
             (
-                ListValue::new(vec![None, Some("".to_string().to_scalar_value())]),
+                ListValue::new(vec![None, Some("".into())]),
                 ListValue::new(vec![None, None]),
                 DataType::Varchar,
                 Ordering::Less,

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -547,7 +547,6 @@ mod tests {
     use more_asserts::{assert_gt, assert_lt};
 
     use super::*;
-    use crate::types::ScalarRef;
     use crate::{array, empty_array, try_match_expand};
 
     #[test]

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -451,7 +451,7 @@ mod tests {
     use more_asserts::assert_gt;
 
     use super::*;
-    use crate::types::{OrderedF32, OrderedF64};
+    use crate::types::{OrderedF32, OrderedF64, ScalarRef};
     use crate::{array, try_match_expand};
 
     // Empty struct is allowed in postgres.
@@ -553,18 +553,18 @@ mod tests {
     fn test_serialize_deserialize() {
         let value = StructValue::new(vec![
             Some(OrderedF32::from(3.2).to_scalar_value()),
-            Some("abcde".to_string().to_scalar_value()),
+            Some("abcde".into()),
             Some(
                 StructValue::new(vec![
                     Some(OrderedF64::from(1.3).to_scalar_value()),
-                    Some("a".to_string().to_scalar_value()),
+                    Some("a".into()),
                     None,
                     Some(StructValue::new(vec![]).to_scalar_value()),
                 ])
                 .to_scalar_value(),
             ),
             None,
-            Some("".to_string().to_scalar_value()),
+            Some("".into()),
             None,
             Some(StructValue::new(vec![]).to_scalar_value()),
             Some(12345.to_scalar_value()),
@@ -644,19 +644,16 @@ mod tests {
                 Ordering::Greater,
             ),
             (
-                StructValue::new(vec![Some("".to_string().to_scalar_value())]),
+                StructValue::new(vec![Some("".into())]),
                 StructValue::new(vec![None]),
                 vec![DataType::Varchar],
                 Ordering::Less,
             ),
             (
-                StructValue::new(vec![Some("abcd".to_string().to_scalar_value()), None]),
+                StructValue::new(vec![Some("abcd".into()), None]),
                 StructValue::new(vec![
-                    Some("abcd".to_string().to_scalar_value()),
-                    Some(
-                        StructValue::new(vec![Some("abcdef".to_string().to_scalar_value())])
-                            .to_scalar_value(),
-                    ),
+                    Some("abcd".into()),
+                    Some(StructValue::new(vec![Some("abcdef".into())]).to_scalar_value()),
                 ]),
                 vec![
                     DataType::Varchar,
@@ -666,18 +663,12 @@ mod tests {
             ),
             (
                 StructValue::new(vec![
-                    Some("abcd".to_string().to_scalar_value()),
-                    Some(
-                        StructValue::new(vec![Some("abcdef".to_string().to_scalar_value())])
-                            .to_scalar_value(),
-                    ),
+                    Some("abcd".into()),
+                    Some(StructValue::new(vec![Some("abcdef".into())]).to_scalar_value()),
                 ]),
                 StructValue::new(vec![
-                    Some("abcd".to_string().to_scalar_value()),
-                    Some(
-                        StructValue::new(vec![Some("abcdef".to_string().to_scalar_value())])
-                            .to_scalar_value(),
-                    ),
+                    Some("abcd".into()),
+                    Some(StructValue::new(vec![Some("abcdef".into())]).to_scalar_value()),
                 ]),
                 vec![
                     DataType::Varchar,

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -451,7 +451,7 @@ mod tests {
     use more_asserts::assert_gt;
 
     use super::*;
-    use crate::types::{OrderedF32, OrderedF64, ScalarRef};
+    use crate::types::{OrderedF32, OrderedF64};
     use crate::{array, try_match_expand};
 
     // Empty struct is allowed in postgres.

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -35,7 +35,7 @@ pub struct Utf8Array {
 impl Array for Utf8Array {
     type Builder = Utf8ArrayBuilder;
     type Iter<'a> = ArrayIterator<'a, Self>;
-    type OwnedItem = String;
+    type OwnedItem = Box<str>;
     type RefItem<'a> = &'a str;
 
     fn value_at(&self, idx: usize) -> Option<&str> {
@@ -136,10 +136,10 @@ impl Utf8Array {
     }
 
     /// Retrieve the ownership of the single string value. Panics if there're multiple or no values.
-    pub fn into_single_value(self) -> Option<String> {
+    pub fn into_single_value(self) -> Option<Box<str>> {
         assert_eq!(self.len(), 1);
         if !self.is_null(0) {
-            Some(unsafe { String::from_utf8_unchecked(self.data) })
+            Some(unsafe { String::from_utf8_unchecked(self.data).into_boxed_str() })
         } else {
             None
         }

--- a/src/common/src/field_generator/varchar.rs
+++ b/src/common/src/field_generator/varchar.rs
@@ -51,6 +51,6 @@ impl VarcharField {
             .take(self.length)
             .map(char::from)
             .collect();
-        Some(s.to_scalar_value())
+        Some(s.into_boxed_str().to_scalar_value())
     }
 }

--- a/src/common/src/test_utils/rand_array.rs
+++ b/src/common/src/test_utils/rand_array.rs
@@ -45,11 +45,14 @@ where
     }
 }
 
-impl RandValue for String {
+impl RandValue for Box<str> {
     fn rand_value<R: Rng>(rand: &mut R) -> Self {
         let len = rand.gen_range(1..=10);
         // `rand.gen:::<char>` create a random Unicode scalar value.
-        (0..len).map(|_| rand.gen::<char>()).collect()
+        (0..len)
+            .map(|_| rand.gen::<char>())
+            .collect::<String>()
+            .into_boxed_str()
     }
 }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -1065,12 +1065,14 @@ mod tests {
 
     #[test]
     fn test_size() {
-        assert_eq!(std::mem::size_of::<StructValue>(), 16);
-        assert_eq!(std::mem::size_of::<ListValue>(), 16);
+        use static_assertions::const_assert_eq;
+
+        const_assert_eq!(std::mem::size_of::<StructValue>(), 16);
+        const_assert_eq!(std::mem::size_of::<ListValue>(), 16);
         // TODO: try to reduce the memory usage of `Decimal`, `ScalarImpl` and `Datum`.
-        assert_eq!(std::mem::size_of::<Decimal>(), 20);
-        assert_eq!(std::mem::size_of::<ScalarImpl>(), 32);
-        assert_eq!(std::mem::size_of::<Datum>(), 32);
+        const_assert_eq!(std::mem::size_of::<Decimal>(), 20);
+        const_assert_eq!(std::mem::size_of::<ScalarImpl>(), 24);
+        const_assert_eq!(std::mem::size_of::<Datum>(), 24);
     }
 
     #[test]

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -713,7 +713,7 @@ macro_rules! impl_convert {
 
 for_all_scalar_variants! { impl_convert }
 
-// Implement `From<raw float>` for `ScalarImpl` manually
+// Implement `From<raw float>` for `ScalarImpl::Float` as a sugar.
 impl From<f32> for ScalarImpl {
     fn from(f: f32) -> Self {
         Self::Float32(f.into())
@@ -725,6 +725,7 @@ impl From<f64> for ScalarImpl {
     }
 }
 
+// Implement `From<string like>` for `ScalarImpl::Utf8` as a sugar.
 impl From<String> for ScalarImpl {
     fn from(s: String) -> Self {
         Self::Utf8(s.into_boxed_str())

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -364,7 +364,7 @@ impl DataType {
             DataType::Float32 => ScalarImpl::Float32(OrderedF32::neg_infinity()),
             DataType::Float64 => ScalarImpl::Float64(OrderedF64::neg_infinity()),
             DataType::Boolean => ScalarImpl::Bool(false),
-            DataType::Varchar => ScalarImpl::Utf8("".to_string()),
+            DataType::Varchar => ScalarImpl::Utf8("".into()),
             DataType::Date => ScalarImpl::NaiveDate(NaiveDateWrapper(NaiveDate::MIN)),
             DataType::Time => ScalarImpl::NaiveTime(NaiveTimeWrapper::from_hms_uncheck(0, 0, 0)),
             DataType::Timestamp => {
@@ -462,7 +462,7 @@ macro_rules! for_all_scalar_variants {
             { Int64, int64, i64, i64 },
             { Float32, float32, OrderedF32, OrderedF32 },
             { Float64, float64, OrderedF64, OrderedF64 },
-            { Utf8, utf8, String, &'scalar str },
+            { Utf8, utf8, Box<str>, &'scalar str },
             { Bool, bool, bool, bool },
             { Decimal, decimal, Decimal, Decimal  },
             { Interval, interval, IntervalUnit, IntervalUnit },
@@ -719,10 +719,25 @@ impl From<f32> for ScalarImpl {
         Self::Float32(f.into())
     }
 }
-
 impl From<f64> for ScalarImpl {
     fn from(f: f64) -> Self {
         Self::Float64(f.into())
+    }
+}
+
+impl From<String> for ScalarImpl {
+    fn from(s: String) -> Self {
+        Self::Utf8(s.into_boxed_str())
+    }
+}
+impl From<&str> for ScalarImpl {
+    fn from(s: &str) -> Self {
+        Self::Utf8(s.into())
+    }
+}
+impl From<&String> for ScalarImpl {
+    fn from(s: &String) -> Self {
+        Self::Utf8(s.as_str().into())
     }
 }
 
@@ -857,7 +872,7 @@ impl ScalarImpl {
             Ty::Int64 => Self::Int64(i64::deserialize(de)?),
             Ty::Float32 => Self::Float32(f32::deserialize(de)?.into()),
             Ty::Float64 => Self::Float64(f64::deserialize(de)?.into()),
-            Ty::Varchar => Self::Utf8(String::deserialize(de)?),
+            Ty::Varchar => Self::Utf8(Box::<str>::deserialize(de)?),
             Ty::Boolean => Self::Bool(bool::deserialize(de)?),
             Ty::Decimal => Self::Decimal(de.deserialize_decimal()?.into()),
             Ty::Interval => Self::Interval(IntervalUnit::deserialize(de)?),
@@ -1119,7 +1134,7 @@ mod tests {
                     ScalarImpl::NaiveDate(NaiveDateWrapper::from_ymd_uncheck(2333, 3, 3)),
                     DataType::Date,
                 ),
-                DataTypeName::Varchar => (ScalarImpl::Utf8("233".to_string()), DataType::Varchar),
+                DataTypeName::Varchar => (ScalarImpl::Utf8("233".into()), DataType::Varchar),
                 DataTypeName::Time => (
                     ScalarImpl::NaiveTime(NaiveTimeWrapper::from_hms_uncheck(2, 3, 3)),
                     DataType::Time,

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -1067,10 +1067,23 @@ mod tests {
     fn test_size() {
         use static_assertions::const_assert_eq;
 
-        const_assert_eq!(std::mem::size_of::<StructValue>(), 16);
-        const_assert_eq!(std::mem::size_of::<ListValue>(), 16);
+        use crate::array::*;
+
+        macro_rules! assert_item_size_eq {
+            ($array:ty, $size:literal) => {
+                const_assert_eq!(std::mem::size_of::<<$array as Array>::OwnedItem>(), $size);
+            };
+        }
+
+        assert_item_size_eq!(StructArray, 16); // Box<[Datum]>
+        assert_item_size_eq!(ListArray, 16); // Box<[Datum]>
+        assert_item_size_eq!(Utf8Array, 16); // Box<str>
+        assert_item_size_eq!(IntervalArray, 16);
+        assert_item_size_eq!(NaiveDateTimeArray, 12);
+
         // TODO: try to reduce the memory usage of `Decimal`, `ScalarImpl` and `Datum`.
-        const_assert_eq!(std::mem::size_of::<Decimal>(), 20);
+        assert_item_size_eq!(DecimalArray, 20);
+
         const_assert_eq!(std::mem::size_of::<ScalarImpl>(), 24);
         const_assert_eq!(std::mem::size_of::<Datum>(), 24);
     }

--- a/src/common/src/types/scalar_impl.rs
+++ b/src/common/src/types/scalar_impl.rs
@@ -60,11 +60,11 @@ for_all_native_types! { impl_all_native_scalar }
 
 /// Implement `Scalar` for `String`.
 /// `String` could be converted to `&str`.
-impl Scalar for String {
+impl Scalar for Box<str> {
     type ScalarRefType<'a> = &'a str;
 
     fn as_scalar_ref(&self) -> &str {
-        self.as_str()
+        self.as_ref()
     }
 
     fn to_scalar_value(self) -> ScalarImpl {
@@ -101,10 +101,10 @@ impl Scalar for ListValue {
 /// Implement `ScalarRef` for `String`.
 /// `String` could be converted to `&str`.
 impl<'a> ScalarRef<'a> for &'a str {
-    type ScalarType = String;
+    type ScalarType = Box<str>;
 
-    fn to_owned_scalar(&self) -> String {
-        self.to_string()
+    fn to_owned_scalar(&self) -> Box<str> {
+        (*self).into()
     }
 
     fn hash_scalar<H: std::hash::Hasher>(&self, state: &mut H) {
@@ -112,9 +112,9 @@ impl<'a> ScalarRef<'a> for &'a str {
     }
 }
 
-impl ScalarPartialOrd for String {
+impl ScalarPartialOrd for Box<str> {
     fn scalar_cmp(&self, other: &str) -> Option<std::cmp::Ordering> {
-        self.as_str().partial_cmp(other)
+        self.as_ref().partial_cmp(other)
     }
 }
 

--- a/src/common/src/types/scalar_impl.rs
+++ b/src/common/src/types/scalar_impl.rs
@@ -58,8 +58,8 @@ macro_rules! impl_all_native_scalar {
 
 for_all_native_types! { impl_all_native_scalar }
 
-/// Implement `Scalar` for `String`.
-/// `String` could be converted to `&str`.
+/// Implement `Scalar` for `Box<str>`.
+/// `Box<str>` could be converted to `&str`.
 impl Scalar for Box<str> {
     type ScalarRefType<'a> = &'a str;
 
@@ -98,8 +98,8 @@ impl Scalar for ListValue {
     }
 }
 
-/// Implement `ScalarRef` for `String`.
-/// `String` could be converted to `&str`.
+/// Implement `ScalarRef` for `Box<str>`.
+/// `Box<str>` could be converted to `&str`.
 impl<'a> ScalarRef<'a> for &'a str {
     type ScalarType = Box<str>;
 
@@ -143,8 +143,7 @@ impl Scalar for bool {
     }
 }
 
-/// Implement `Scalar` and `ScalarRef` for `String`.
-/// `String` could be converted to `&str`.
+/// Implement `ScalarRef` for `bool`.
 impl<'a> ScalarRef<'a> for bool {
     type ScalarType = bool;
 

--- a/src/common/src/util/encoding_for_comparison.rs
+++ b/src/common/src/util/encoding_for_comparison.rs
@@ -95,11 +95,11 @@ mod tests {
     fn test_encode_row() {
         let v10 = Some(ScalarImpl::Int32(42));
         let v10_cloned = v10.clone();
-        let v11 = Some(ScalarImpl::Utf8("hello".to_string()));
+        let v11 = Some(ScalarImpl::Utf8("hello".into()));
         let v11_cloned = v11.clone();
         let v12 = Some(ScalarImpl::Float32(4.0.into()));
         let v20 = Some(ScalarImpl::Int32(42));
-        let v21 = Some(ScalarImpl::Utf8("hell".to_string()));
+        let v21 = Some(ScalarImpl::Utf8("hell".into()));
         let v22 = Some(ScalarImpl::Float32(3.0.into()));
 
         let row1 = Row::new(vec![v10, v11, v12]);
@@ -133,10 +133,10 @@ mod tests {
     #[test]
     fn test_encode_chunk() {
         let v10 = Some(ScalarImpl::Int32(42));
-        let v11 = Some(ScalarImpl::Utf8("hello".to_string()));
+        let v11 = Some(ScalarImpl::Utf8("hello".into()));
         let v12 = Some(ScalarImpl::Float32(4.0.into()));
         let v20 = Some(ScalarImpl::Int32(42));
-        let v21 = Some(ScalarImpl::Utf8("hell".to_string()));
+        let v21 = Some(ScalarImpl::Utf8("hell".into()));
         let v22 = Some(ScalarImpl::Float32(3.0.into()));
 
         let row1 = Row::new(vec![v10, v11, v12]);

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -120,9 +120,9 @@ mod tests {
         let orders = vec![OrderType::Descending, OrderType::Ascending];
         let data_types = vec![DataType::Int16, DataType::Varchar];
         let serializer = OrderedRowSerde::new(data_types, orders);
-        let row1 = Row::new(vec![Some(Int16(5)), Some(Utf8("abc".to_string()))]);
-        let row2 = Row::new(vec![Some(Int16(5)), Some(Utf8("abd".to_string()))]);
-        let row3 = Row::new(vec![Some(Int16(6)), Some(Utf8("abc".to_string()))]);
+        let row1 = Row::new(vec![Some(Int16(5)), Some(Utf8("abc".into()))]);
+        let row2 = Row::new(vec![Some(Int16(5)), Some(Utf8("abd".into()))]);
+        let row3 = Row::new(vec![Some(Int16(6)), Some(Utf8("abc".into()))]);
         let rows = vec![row1, row2, row3];
         let mut array = vec![];
         for row in &rows {
@@ -147,9 +147,9 @@ mod tests {
 
             let schema = vec![DataType::Varchar, DataType::Int16];
             let serde = OrderedRowSerde::new(schema, order_types);
-            let row1 = Row::new(vec![Some(Utf8("abc".to_string())), Some(Int16(5))]);
-            let row2 = Row::new(vec![Some(Utf8("abd".to_string())), Some(Int16(5))]);
-            let row3 = Row::new(vec![Some(Utf8("abc".to_string())), Some(Int16(6))]);
+            let row1 = Row::new(vec![Some(Utf8("abc".into())), Some(Int16(5))]);
+            let row2 = Row::new(vec![Some(Utf8("abd".into())), Some(Int16(5))]);
+            let row3 = Row::new(vec![Some(Utf8("abc".into())), Some(Int16(6))]);
             let rows = vec![row1.clone(), row2.clone(), row3.clone()];
             let mut array = vec![];
             for row in &rows {
@@ -170,15 +170,15 @@ mod tests {
             let schema = vec![DataType::Varchar, DataType::Decimal];
             let serde = OrderedRowSerde::new(schema, order_types);
             let row1 = Row::new(vec![
-                Some(Utf8("abc".to_string())),
+                Some(Utf8("abc".into())),
                 Some(ScalarImpl::Decimal(Decimal::NaN)),
             ]);
             let row2 = Row::new(vec![
-                Some(Utf8("abd".to_string())),
+                Some(Utf8("abd".into())),
                 Some(ScalarImpl::Decimal(Decimal::PositiveInf)),
             ]);
             let row3 = Row::new(vec![
-                Some(Utf8("abc".to_string())),
+                Some(Utf8("abc".into())),
                 Some(ScalarImpl::Decimal(Decimal::NegativeInf)),
             ]);
             let rows = vec![row1.clone(), row2.clone(), row3.clone()];
@@ -200,7 +200,7 @@ mod tests {
 
         let schema = vec![DataType::Varchar, DataType::Int16];
         let serde = OrderedRowSerde::new(schema, order_types);
-        let row1 = Row::new(vec![Some(Utf8("abc".to_string())), Some(Int16(5))]);
+        let row1 = Row::new(vec![Some(Utf8("abc".into())), Some(Int16(5))]);
         let rows = vec![row1.clone()];
         let mut array = vec![];
         for row in &rows {
@@ -220,7 +220,7 @@ mod tests {
             let prefix_slice = &array[0][0..row_0_idx_0_len];
             assert_eq!(
                 deserde.deserialize(prefix_slice).unwrap(),
-                Row::new(vec![Some(Utf8("abc".to_string()))])
+                Row::new(vec![Some(Utf8("abc".into()))])
             );
         }
 
@@ -398,7 +398,7 @@ mod tests {
                 {
                     // test varchar
                     let varchar = "abcdefghijklmn";
-                    let row = Row::new(vec![Some(Utf8(varchar.to_string()))]);
+                    let row = Row::new(vec![Some(Utf8(varchar.into()))]);
                     let mut row_bytes = vec![];
                     serde.serialize(&row, &mut row_bytes);
                     let mut deserializer = memcomparable::Deserializer::new(&row_bytes[..]);
@@ -417,7 +417,7 @@ mod tests {
                         let schema = vec![DataType::Varchar];
                         let serde = OrderedRowSerde::new(schema, order_types);
                         let varchar = "abcdefghijklmnopq";
-                        let row = Row::new(vec![Some(Utf8(varchar.to_string()))]);
+                        let row = Row::new(vec![Some(Utf8(varchar.into()))]);
                         let mut row_bytes = vec![];
                         serde.serialize(&row, &mut row_bytes);
                         let mut deserializer = memcomparable::Deserializer::new(&row_bytes[..]);

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -267,10 +267,10 @@ mod tests {
     #[test]
     fn test_compare_rows() {
         let v10 = Some(ScalarImpl::Int32(42));
-        let v11 = Some(ScalarImpl::Utf8("hello".to_string()));
+        let v11 = Some(ScalarImpl::Utf8("hello".into()));
         let v12 = Some(ScalarImpl::Float32(4.0.into()));
         let v20 = Some(ScalarImpl::Int32(42));
-        let v21 = Some(ScalarImpl::Utf8("hell".to_string()));
+        let v21 = Some(ScalarImpl::Utf8("hell".into()));
         let v22 = Some(ScalarImpl::Float32(3.0.into()));
 
         let row1 = Row::new(vec![v10, v11, v12]);
@@ -293,10 +293,10 @@ mod tests {
     #[test]
     fn test_compare_rows_in_chunk() {
         let v10 = Some(ScalarImpl::Int32(42));
-        let v11 = Some(ScalarImpl::Utf8("hello".to_string()));
+        let v11 = Some(ScalarImpl::Utf8("hello".into()));
         let v12 = Some(ScalarImpl::Float32(4.0.into()));
         let v20 = Some(ScalarImpl::Int32(42));
-        let v21 = Some(ScalarImpl::Utf8("hell".to_string()));
+        let v21 = Some(ScalarImpl::Utf8("hell".into()));
         let v22 = Some(ScalarImpl::Float32(3.0.into()));
 
         let row1 = Row::new(vec![v10, v11, v12]);
@@ -328,7 +328,7 @@ mod tests {
             Some(ScalarImpl::Int64(64)),
             Some(ScalarImpl::Float32(3.2.into())),
             Some(ScalarImpl::Float64(6.4.into())),
-            Some(ScalarImpl::Utf8("hello".to_string())),
+            Some(ScalarImpl::Utf8("hello".into())),
             Some(ScalarImpl::Bool(true)),
             Some(ScalarImpl::Decimal(10.into())),
             Some(ScalarImpl::Interval(Default::default())),
@@ -350,7 +350,7 @@ mod tests {
             Some(ScalarImpl::Int64(64)),
             Some(ScalarImpl::Float32(3.2.into())),
             Some(ScalarImpl::Float64(6.4.into())),
-            Some(ScalarImpl::Utf8("hello".to_string())),
+            Some(ScalarImpl::Utf8("hello".into())),
             Some(ScalarImpl::Bool(true)),
             Some(ScalarImpl::Decimal(10.into())),
             Some(ScalarImpl::Interval(Default::default())),

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -179,11 +179,13 @@ fn deserialize_list(item_type: &DataType, data: &mut impl Buf) -> Result<ScalarI
     Ok(ScalarImpl::List(ListValue::new(values)))
 }
 
-fn deserialize_str(data: &mut impl Buf) -> Result<String> {
+fn deserialize_str(data: &mut impl Buf) -> Result<Box<str>> {
     let len = data.get_u32_le();
     let mut bytes = vec![0; len as usize];
     data.copy_to_slice(&mut bytes);
-    String::from_utf8(bytes).map_err(ValueEncodingError::InvalidUtf8)
+    String::from_utf8(bytes)
+        .map(String::into_boxed_str)
+        .map_err(ValueEncodingError::InvalidUtf8)
 }
 
 fn deserialize_bool(data: &mut impl Buf) -> Result<bool> {

--- a/src/connector/src/sink/mysql.rs
+++ b/src/connector/src/sink/mysql.rs
@@ -157,7 +157,7 @@ impl TryFrom<Datum> for MySqlValue {
                 ScalarImpl::Bool(v) => Ok(MySqlValue(v.into())),
                 ScalarImpl::Decimal(Decimal::Normalized(v)) => Ok(MySqlValue(v.into())),
                 ScalarImpl::Decimal(_) => panic!("NaN, -inf, +inf are not supported by MySQL"),
-                ScalarImpl::Utf8(v) => Ok(MySqlValue(v.into())),
+                ScalarImpl::Utf8(v) => Ok(MySqlValue(String::from(v).into())),
                 ScalarImpl::NaiveDate(v) => Ok(MySqlValue(format!("{}", v).into())),
                 ScalarImpl::NaiveTime(v) => Ok(MySqlValue(format!("{}", v).into())),
                 ScalarImpl::NaiveDateTime(v) => Ok(MySqlValue(format!("{}", v).into())),

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -251,7 +251,7 @@ mod tests {
     use std::vec;
 
     use risingwave_common::array::{ArrayImpl, DataChunk, Utf8Array};
-    use risingwave_common::types::{Scalar, ScalarRef};
+    use risingwave_common::types::Scalar;
     use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::{DataType as ProstDataType, Datum as ProstDatum};

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -251,7 +251,7 @@ mod tests {
     use std::vec;
 
     use risingwave_common::array::{ArrayImpl, DataChunk, Utf8Array};
-    use risingwave_common::types::Scalar;
+    use risingwave_common::types::{Scalar, ScalarRef};
     use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::{DataType as ProstDataType, Datum as ProstDatum};
@@ -271,9 +271,7 @@ mod tests {
                         ..Default::default()
                     }),
                     rex_node: Some(RexNode::Constant(ProstDatum {
-                        body: serialize_datum_to_bytes(
-                            Some("foo".to_owned().to_scalar_value()).as_ref(),
-                        ),
+                        body: serialize_datum_to_bytes(Some("foo".into()).as_ref()),
                     })),
                 },
                 ExprNode {
@@ -283,9 +281,7 @@ mod tests {
                         ..Default::default()
                     }),
                     rex_node: Some(RexNode::Constant(ProstDatum {
-                        body: serialize_datum_to_bytes(
-                            Some("bar".to_owned().to_scalar_value()).as_ref(),
-                        ),
+                        body: serialize_datum_to_bytes(Some("bar".into()).as_ref()),
                     })),
                 },
             ],
@@ -341,7 +337,7 @@ mod tests {
                 ..Default::default()
             }),
             rex_node: Some(RexNode::Constant(ProstDatum {
-                body: serialize_datum_to_bytes(Some("DAY".to_string().to_scalar_value()).as_ref()),
+                body: serialize_datum_to_bytes(Some("DAY".into()).as_ref()),
             })),
         };
         let right_date = ExprNode {

--- a/src/expr/src/expr/expr_concat_ws.rs
+++ b/src/expr/src/expr/expr_concat_ws.rs
@@ -19,7 +19,7 @@ use risingwave_common::array::{
     Array, ArrayBuilder, ArrayImpl, ArrayRef, DataChunk, Utf8ArrayBuilder,
 };
 use risingwave_common::row::Row;
-use risingwave_common::types::{DataType, Datum, Scalar};
+use risingwave_common::types::{DataType, Datum};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
 
@@ -115,7 +115,7 @@ impl Expression for ConcatWsExpression {
             final_string.push_str(string.as_utf8());
         }
 
-        Ok(Some(final_string.to_scalar_value()))
+        Ok(Some(final_string.into()))
     }
 }
 
@@ -160,7 +160,7 @@ mod tests {
     use itertools::Itertools;
     use risingwave_common::array::{DataChunk, DataChunkTestExt};
     use risingwave_common::row::Row;
-    use risingwave_common::types::{Datum, Scalar};
+    use risingwave_common::types::{Datum, Scalar, ScalarRef};
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
     use risingwave_pb::expr::expr_node::RexNode;
@@ -238,14 +238,11 @@ mod tests {
         let expected = vec![Some("a,b,c"), None, Some("b,c"), Some(""), None];
 
         for (i, row_input) in row_inputs.iter().enumerate() {
-            let datum_vec: Vec<Datum> = row_input
-                .iter()
-                .map(|e| e.map(|s| s.to_string().to_scalar_value()))
-                .collect();
+            let datum_vec: Vec<Datum> = row_input.iter().map(|e| e.map(|s| s.into())).collect();
             let row = Row::new(datum_vec);
 
             let result = concat_ws_expr.eval_row(&row).unwrap();
-            let expected = expected[i].map(|s| s.to_string().to_scalar_value());
+            let expected = expected[i].map(|s| s.into());
 
             assert_eq!(result, expected);
         }

--- a/src/expr/src/expr/expr_concat_ws.rs
+++ b/src/expr/src/expr/expr_concat_ws.rs
@@ -160,7 +160,7 @@ mod tests {
     use itertools::Itertools;
     use risingwave_common::array::{DataChunk, DataChunkTestExt};
     use risingwave_common::row::Row;
-    use risingwave_common::types::{Datum, Scalar, ScalarRef};
+    use risingwave_common::types::Datum;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
     use risingwave_pb::expr::expr_node::RexNode;

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -124,7 +124,7 @@ mod tests {
     use risingwave_common::array::DataChunk;
     use risingwave_common::row::Row;
     use risingwave_common::test_prelude::DataChunkTestExt;
-    use risingwave_common::types::{DataType, Scalar, ScalarImpl};
+    use risingwave_common::types::{DataType, Scalar, ScalarImpl, ScalarRef};
     use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::{DataType as ProstDataType, Datum as ProstDatum};
@@ -153,9 +153,7 @@ mod tests {
                     ..Default::default()
                 }),
                 rex_node: Some(RexNode::Constant(ProstDatum {
-                    body: serialize_datum_to_bytes(
-                        Some("ABC".to_string().to_scalar_value()).as_ref(),
-                    ),
+                    body: serialize_datum_to_bytes(Some("ABC".into()).as_ref()),
                 })),
             },
             ExprNode {
@@ -165,9 +163,7 @@ mod tests {
                     ..Default::default()
                 }),
                 rex_node: Some(RexNode::Constant(ProstDatum {
-                    body: serialize_datum_to_bytes(
-                        Some("def".to_string().to_scalar_value()).as_ref(),
-                    ),
+                    body: serialize_datum_to_bytes(Some("def".into()).as_ref()),
                 })),
             },
         ];
@@ -195,10 +191,10 @@ mod tests {
         ];
         let data = [
             vec![
-                Some(ScalarImpl::Utf8("abc".to_string())),
-                Some(ScalarImpl::Utf8("def".to_string())),
+                Some(ScalarImpl::Utf8("abc".into())),
+                Some(ScalarImpl::Utf8("def".into())),
             ],
-            vec![None, Some(ScalarImpl::Utf8("abc".to_string()))],
+            vec![None, Some(ScalarImpl::Utf8("abc".into()))],
         ];
 
         let data_chunks = [
@@ -249,10 +245,10 @@ mod tests {
 
         let data = [
             vec![
-                Some(ScalarImpl::Utf8("abc".to_string())),
-                Some(ScalarImpl::Utf8("def".to_string())),
+                Some(ScalarImpl::Utf8("abc".into())),
+                Some(ScalarImpl::Utf8("def".into())),
             ],
-            vec![None, Some(ScalarImpl::Utf8("abc".to_string()))],
+            vec![None, Some(ScalarImpl::Utf8("abc".into()))],
         ];
 
         let row_inputs = vec![
@@ -270,7 +266,7 @@ mod tests {
                 InExpression::new(input_ref, data[i].clone().into_iter(), DataType::Boolean);
 
             for (j, row_input) in row_inputs[i].iter().enumerate() {
-                let row_input = vec![row_input.map(|s| s.to_string().to_scalar_value())];
+                let row_input = vec![row_input.map(|s| s.into())];
                 let row = Row::new(row_input);
                 let result = search_expr.eval_row(&row).unwrap();
                 assert_eq!(result, expected[i][j].map(ScalarImpl::Bool));

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -124,7 +124,7 @@ mod tests {
     use risingwave_common::array::DataChunk;
     use risingwave_common::row::Row;
     use risingwave_common::test_prelude::DataChunkTestExt;
-    use risingwave_common::types::{DataType, Scalar, ScalarImpl, ScalarRef};
+    use risingwave_common::types::{DataType, ScalarImpl};
     use risingwave_common::util::value_encoding::serialize_datum_to_bytes;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::{DataType as ProstDataType, Datum as ProstDatum};

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -146,7 +146,7 @@ mod tests {
     #[test]
     fn test_struct_expr_literal_from() {
         let value = StructValue::new(vec![
-            Some(ScalarImpl::Utf8("12222".to_string())),
+            Some(ScalarImpl::Utf8("12222".into())),
             Some(2.into()),
             None,
         ]);
@@ -222,7 +222,7 @@ mod tests {
         let expr = LiteralExpression::try_from(&make_expression(None, t)).unwrap();
         assert_eq!(v, expr.literal());
 
-        let v = String::from("varchar");
+        let v = String::from("varchar").into_boxed_str();
         let t = TypeName::Varchar;
         let bytes = serialize_datum_to_bytes(Some(v.clone().to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -222,7 +222,7 @@ mod tests {
         let expr = LiteralExpression::try_from(&make_expression(None, t)).unwrap();
         assert_eq!(v, expr.literal());
 
-        let v = String::from("varchar").into_boxed_str();
+        let v: Box<str> = "varchar".into();
         let t = TypeName::Varchar;
         let bytes = serialize_datum_to_bytes(Some(v.clone().to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -21,7 +21,7 @@ use risingwave_common::array::{
     Utf8Array,
 };
 use risingwave_common::row::Row;
-use risingwave_common::types::{DataType, Datum, Scalar, ScalarImpl};
+use risingwave_common::types::{DataType, Datum, Scalar, ScalarImpl, ScalarRef};
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
@@ -103,7 +103,7 @@ impl RegexpMatchExpression {
                         }
                     })
                     .flatten()
-                    .map(|mat| Some(mat.as_str().to_string().to_scalar_value()))
+                    .map(|mat| Some(mat.as_str().into()))
                     .collect_vec();
                 let list = ListValue::new(list);
                 Some(list)

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -21,7 +21,7 @@ use risingwave_common::array::{
     Utf8Array,
 };
 use risingwave_common::row::Row;
-use risingwave_common::types::{DataType, Datum, Scalar, ScalarImpl, ScalarRef};
+use risingwave_common::types::{DataType, Datum, ScalarImpl};
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -436,11 +436,11 @@ mod tests {
         for<'a> <A as Array>::RefItem<'a>: PartialEq,
         F: Fn(&str) -> <A as Array>::OwnedItem,
     {
-        let mut input = Vec::<Option<String>>::new();
+        let mut input = Vec::<Option<Box<str>>>::new();
         let mut target = Vec::<Option<<A as Array>::OwnedItem>>::new();
         for i in 0..1u32 {
             if i % 2 == 0 {
-                let s = i.to_string();
+                let s = i.to_string().into_boxed_str();
                 target.push(Some(f(&s)));
                 input.push(Some(s));
             } else {

--- a/src/expr/src/table_function/regexp_matches.rs
+++ b/src/expr/src/table_function/regexp_matches.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use regex::Regex;
 use risingwave_common::array::{Array, ArrayRef, DataChunk, ListValue, Utf8Array};
-use risingwave_common::types::{Scalar, ScalarImpl};
+use risingwave_common::types::{Scalar, ScalarImpl, ScalarRef};
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_common::{bail, ensure};
 use risingwave_pb::expr::expr_node::RexNode;
@@ -64,7 +64,7 @@ impl RegexpMatches {
                     }
                 })
                 .flatten()
-                .map(|mat| Some(mat.as_str().to_string().to_scalar_value()))
+                .map(|mat| Some(mat.as_str().into()))
                 .collect_vec();
             let list = ListValue::new(list);
             builder.append_datum(&Some(list.into()));

--- a/src/expr/src/table_function/regexp_matches.rs
+++ b/src/expr/src/table_function/regexp_matches.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 
 use regex::Regex;
 use risingwave_common::array::{Array, ArrayRef, DataChunk, ListValue, Utf8Array};
-use risingwave_common::types::{Scalar, ScalarImpl, ScalarRef};
+use risingwave_common::types::ScalarImpl;
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_common::{bail, ensure};
 use risingwave_pb::expr::expr_node::RexNode;

--- a/src/expr/src/vector_op/agg/string_agg.rs
+++ b/src/expr/src/vector_op/agg/string_agg.rs
@@ -17,7 +17,7 @@ use risingwave_common::array::{
     Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk, RowRef,
 };
 use risingwave_common::bail;
-use risingwave_common::types::{DataType, Scalar};
+use risingwave_common::types::DataType;
 use risingwave_common::util::ordered::OrderedRow;
 use risingwave_common::util::sort_util::{OrderPair, OrderType};
 
@@ -103,7 +103,7 @@ impl Aggregator for StringAggUnordered {
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         if let ArrayBuilderImpl::Utf8(builder) = builder {
             let res = self.get_result_and_reset();
-            builder.append(res.as_ref().map(|x| x.as_str()));
+            builder.append(res.as_deref());
             Ok(())
         } else {
             bail!("Builder fail to match {}.", stringify!(Utf8))
@@ -225,7 +225,7 @@ impl Aggregator for StringAggOrdered {
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         if let ArrayBuilderImpl::Utf8(builder) = builder {
             let res = self.get_result_and_reset();
-            builder.append(res.as_ref().map(|x| x.as_str()));
+            builder.append(res.as_deref());
             Ok(())
         } else {
             bail!("Builder fail to match {}.", stringify!(Utf8))

--- a/src/expr/src/vector_op/agg/string_agg.rs
+++ b/src/expr/src/vector_op/agg/string_agg.rs
@@ -103,7 +103,7 @@ impl Aggregator for StringAggUnordered {
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         if let ArrayBuilderImpl::Utf8(builder) = builder {
             let res = self.get_result_and_reset();
-            builder.append(res.as_ref().map(|x| x.as_scalar_ref()));
+            builder.append(res.as_ref().map(|x| x.as_str()));
             Ok(())
         } else {
             bail!("Builder fail to match {}.", stringify!(Utf8))
@@ -225,7 +225,7 @@ impl Aggregator for StringAggOrdered {
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
         if let ArrayBuilderImpl::Utf8(builder) = builder {
             let res = self.get_result_and_reset();
-            builder.append(res.as_ref().map(|x| x.as_scalar_ref()));
+            builder.append(res.as_ref().map(|x| x.as_str()));
             Ok(())
         } else {
             bail!("Builder fail to match {}.", stringify!(Utf8))

--- a/src/expr/src/vector_op/array_access.rs
+++ b/src/expr/src/vector_op/array_access.rs
@@ -75,15 +75,15 @@ mod tests {
         let l3 = ListRef::ValueRef { val: &v3 };
 
         assert_eq!(
-            array_access::<String>(Some(l1), Some(1)).unwrap(),
+            array_access::<Box<str>>(Some(l1), Some(1)).unwrap(),
             Some("来自".into())
         );
         assert_eq!(
-            array_access::<String>(Some(l2), Some(2)).unwrap(),
+            array_access::<Box<str>>(Some(l2), Some(2)).unwrap(),
             Some("荷兰".into())
         );
         assert_eq!(
-            array_access::<String>(Some(l3), Some(3)).unwrap(),
+            array_access::<Box<str>>(Some(l3), Some(3)).unwrap(),
             Some("的爱".into())
         );
     }

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -593,7 +593,6 @@ fn scalar_cast(
 #[cfg(test)]
 mod tests {
     use num_traits::FromPrimitive;
-    use risingwave_common::types::ScalarRef;
 
     use super::*;
 

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -222,7 +222,7 @@ impl Binder {
                         .get_schema_by_name(&self.db_name, schema_name)
                         .is_ok()
                     {
-                        schema_names.push(Some(schema_name.clone().to_scalar_value()));
+                        schema_names.push(Some(schema_name.into()));
                     }
                 }
 

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -20,7 +20,7 @@ use risingwave_common::array::ListValue;
 use risingwave_common::catalog::PG_CATALOG_SCHEMA_NAME;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::session_config::USER_NAME_WILD_CARD;
-use risingwave_common::types::{DataType, Scalar};
+use risingwave_common::types::DataType;
 use risingwave_expr::expr::AggKind;
 use risingwave_sqlparser::ast::{Function, FunctionArg, FunctionArgExpr, WindowSpec};
 

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -43,7 +43,10 @@ impl Binder {
     }
 
     pub(super) fn bind_string(&mut self, s: String) -> Result<Literal> {
-        Ok(Literal::new(Some(ScalarImpl::Utf8(s)), DataType::Varchar))
+        Ok(Literal::new(
+            Some(ScalarImpl::Utf8(s.into())),
+            DataType::Varchar,
+        ))
     }
 
     fn bind_bool(&mut self, b: bool) -> Result<Literal> {

--- a/src/frontend/src/catalog/system_catalog/information_schema/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/information_schema/mod.rs
@@ -42,14 +42,14 @@ impl SysCatalogReaderImpl {
                 let view_rows = schema.iter_view().flat_map(|view| {
                     view.columns.iter().enumerate().map(|(index, column)| {
                         Row::new(vec![
-                            Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                            Some(ScalarImpl::Utf8(schema.name())),
-                            Some(ScalarImpl::Utf8(view.name().to_string())),
-                            Some(ScalarImpl::Utf8(column.name.clone())),
+                            Some(ScalarImpl::Utf8(self.auth_context.database.clone().into())),
+                            Some(ScalarImpl::Utf8(schema.name().into())),
+                            Some(ScalarImpl::Utf8(view.name().into())),
+                            Some(ScalarImpl::Utf8(column.name.clone().into())),
                             Some(ScalarImpl::Int32(index as i32 + 1)),
                             // TODO: refactor when we support "NOT NULL".
-                            Some(ScalarImpl::Utf8("YES".to_string())),
-                            Some(ScalarImpl::Utf8(column.data_type().to_string())),
+                            Some(ScalarImpl::Utf8("YES".into())),
+                            Some(ScalarImpl::Utf8(column.data_type().to_string().into())),
                         ])
                     })
                 });
@@ -64,14 +64,16 @@ impl SysCatalogReaderImpl {
                             .filter(|(_, column)| !column.is_hidden())
                             .map(|(index, column)| {
                                 Row::new(vec![
-                                    Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                                    Some(ScalarImpl::Utf8(schema.name())),
-                                    Some(ScalarImpl::Utf8(table_name.to_string())),
-                                    Some(ScalarImpl::Utf8(column.name().to_string())),
+                                    Some(ScalarImpl::Utf8(
+                                        self.auth_context.database.clone().into(),
+                                    )),
+                                    Some(ScalarImpl::Utf8(schema.name().into())),
+                                    Some(ScalarImpl::Utf8(table_name.into())),
+                                    Some(ScalarImpl::Utf8(column.name().into())),
                                     Some(ScalarImpl::Int32(index as i32 + 1)),
                                     // TODO: refactor when we support "NOT NULL".
-                                    Some(ScalarImpl::Utf8("YES".to_string())),
-                                    Some(ScalarImpl::Utf8(column.data_type().to_string())),
+                                    Some(ScalarImpl::Utf8("YES".into())),
+                                    Some(ScalarImpl::Utf8(column.data_type().to_string().into())),
                                 ])
                             })
                     })
@@ -88,38 +90,38 @@ impl SysCatalogReaderImpl {
             .flat_map(|schema| {
                 let table_rows = schema.iter_table().map(|table| {
                     Row::new(vec![
-                        Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                        Some(ScalarImpl::Utf8(schema.name())),
-                        Some(ScalarImpl::Utf8(table.name().to_string())),
-                        Some(ScalarImpl::Utf8("BASE TABLE".to_string())),
-                        Some(ScalarImpl::Utf8("YES".to_string())),
+                        Some(ScalarImpl::Utf8(self.auth_context.database.clone().into())),
+                        Some(ScalarImpl::Utf8(schema.name().into())),
+                        Some(ScalarImpl::Utf8(table.name().into())),
+                        Some(ScalarImpl::Utf8("BASE TABLE".into())),
+                        Some(ScalarImpl::Utf8("YES".into())),
                     ])
                 });
                 let sys_table_rows = schema.iter_system_tables().map(|table| {
                     Row::new(vec![
-                        Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                        Some(ScalarImpl::Utf8(schema.name())),
-                        Some(ScalarImpl::Utf8(table.name().to_string())),
-                        Some(ScalarImpl::Utf8("SYSTEM TABLE".to_string())),
-                        Some(ScalarImpl::Utf8("NO".to_string())),
+                        Some(ScalarImpl::Utf8(self.auth_context.database.clone().into())),
+                        Some(ScalarImpl::Utf8(schema.name().into())),
+                        Some(ScalarImpl::Utf8(table.name().into())),
+                        Some(ScalarImpl::Utf8("SYSTEM TABLE".into())),
+                        Some(ScalarImpl::Utf8("NO".into())),
                     ])
                 });
                 let mv_rows = schema.iter_mv().map(|mv| {
                     Row::new(vec![
-                        Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                        Some(ScalarImpl::Utf8(schema.name())),
-                        Some(ScalarImpl::Utf8(mv.name().to_string())),
-                        Some(ScalarImpl::Utf8("MATERIALIZED VIEW".to_string())),
-                        Some(ScalarImpl::Utf8("NO".to_string())),
+                        Some(ScalarImpl::Utf8(self.auth_context.database.clone().into())),
+                        Some(ScalarImpl::Utf8(schema.name().into())),
+                        Some(ScalarImpl::Utf8(mv.name().into())),
+                        Some(ScalarImpl::Utf8("MATERIALIZED VIEW".into())),
+                        Some(ScalarImpl::Utf8("NO".into())),
                     ])
                 });
                 let view_rows = schema.iter_view().map(|view| {
                     Row::new(vec![
-                        Some(ScalarImpl::Utf8(self.auth_context.database.clone())),
-                        Some(ScalarImpl::Utf8(schema.name())),
-                        Some(ScalarImpl::Utf8(view.name().to_string())),
-                        Some(ScalarImpl::Utf8("VIEW".to_string())),
-                        Some(ScalarImpl::Utf8("NO".to_string())),
+                        Some(ScalarImpl::Utf8(self.auth_context.database.clone().into())),
+                        Some(ScalarImpl::Utf8(schema.name().into())),
+                        Some(ScalarImpl::Utf8(view.name().into())),
+                        Some(ScalarImpl::Utf8("VIEW".into())),
+                        Some(ScalarImpl::Utf8("NO".into())),
                     ])
                 });
 

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -143,13 +143,11 @@ impl SysCatalogReaderImpl {
             .map(|schema| {
                 Row::new(vec![
                     Some(ScalarImpl::Int32(schema.id as i32)),
-                    Some(ScalarImpl::Utf8(schema.name.clone())),
+                    Some(ScalarImpl::Utf8(schema.name.clone().into())),
                     Some(ScalarImpl::Int32(schema.owner as i32)),
-                    Some(ScalarImpl::Utf8(get_acl_items(
-                        &Object::SchemaId(schema.id),
-                        &users,
-                        username_map,
-                    ))),
+                    Some(ScalarImpl::Utf8(
+                        get_acl_items(&Object::SchemaId(schema.id), &users, username_map).into(),
+                    )),
                 ])
             })
             .collect_vec())
@@ -163,11 +161,11 @@ impl SysCatalogReaderImpl {
             .map(|user| {
                 Row::new(vec![
                     Some(ScalarImpl::Int32(user.id as i32)),
-                    Some(ScalarImpl::Utf8(user.name.clone())),
+                    Some(ScalarImpl::Utf8(user.name.clone().into())),
                     Some(ScalarImpl::Bool(user.can_create_db)),
                     Some(ScalarImpl::Bool(user.is_super)),
                     // compatible with PG.
-                    Some(ScalarImpl::Utf8("********".to_string())),
+                    Some(ScalarImpl::Utf8("********".into())),
                 ])
             })
             .collect_vec())
@@ -206,10 +204,10 @@ impl SysCatalogReaderImpl {
                     .map(|table| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(table.id.table_id() as i32)),
-                            Some(ScalarImpl::Utf8(table.name.clone())),
+                            Some(ScalarImpl::Utf8(table.name.clone().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
-                            Some(ScalarImpl::Utf8("r".to_string())),
+                            Some(ScalarImpl::Utf8("r".into())),
                         ])
                     })
                     .collect_vec();
@@ -219,10 +217,10 @@ impl SysCatalogReaderImpl {
                     .map(|mv| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(mv.id.table_id() as i32)),
-                            Some(ScalarImpl::Utf8(mv.name.clone())),
+                            Some(ScalarImpl::Utf8(mv.name.clone().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(mv.owner as i32)),
-                            Some(ScalarImpl::Utf8("m".to_string())),
+                            Some(ScalarImpl::Utf8("m".into())),
                         ])
                     })
                     .collect_vec();
@@ -232,10 +230,10 @@ impl SysCatalogReaderImpl {
                     .map(|index| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(index.index_table.id.table_id as i32)),
-                            Some(ScalarImpl::Utf8(index.name.clone())),
+                            Some(ScalarImpl::Utf8(index.name.clone().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(index.index_table.owner as i32)),
-                            Some(ScalarImpl::Utf8("i".to_string())),
+                            Some(ScalarImpl::Utf8("i".into())),
                         ])
                     })
                     .collect_vec();
@@ -245,10 +243,10 @@ impl SysCatalogReaderImpl {
                     .map(|source| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(source.id as i32)),
-                            Some(ScalarImpl::Utf8(source.name.clone())),
+                            Some(ScalarImpl::Utf8(source.name.clone().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(source.owner as i32)),
-                            Some(ScalarImpl::Utf8("x".to_string())),
+                            Some(ScalarImpl::Utf8("x".into())),
                         ])
                     })
                     .collect_vec();
@@ -258,10 +256,10 @@ impl SysCatalogReaderImpl {
                     .map(|table| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(table.id.table_id() as i32)),
-                            Some(ScalarImpl::Utf8(table.name.clone())),
+                            Some(ScalarImpl::Utf8(table.name.clone().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
-                            Some(ScalarImpl::Utf8("r".to_string())),
+                            Some(ScalarImpl::Utf8("r".into())),
                         ])
                     })
                     .collect_vec();
@@ -271,10 +269,10 @@ impl SysCatalogReaderImpl {
                     .map(|view| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(view.id as i32)),
-                            Some(ScalarImpl::Utf8(view.name().to_string())),
+                            Some(ScalarImpl::Utf8(view.name().into())),
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(view.owner as i32)),
-                            Some(ScalarImpl::Utf8("v".to_string())),
+                            Some(ScalarImpl::Utf8("v".into())),
                         ])
                     })
                     .collect_vec();
@@ -340,12 +338,12 @@ impl SysCatalogReaderImpl {
                 .for_each(|t| {
                     if let Some(fragments) = table_fragments.get(&t.id.table_id) {
                         rows.push(Row::new(vec![
-                            Some(ScalarImpl::Utf8(schema.clone())),
-                            Some(ScalarImpl::Utf8(t.name.clone())),
+                            Some(ScalarImpl::Utf8(schema.clone().into())),
+                            Some(ScalarImpl::Utf8(t.name.clone().into())),
                             Some(ScalarImpl::Int32(t.owner as i32)),
-                            Some(ScalarImpl::Utf8(t.definition.clone())),
+                            Some(ScalarImpl::Utf8(t.definition.clone().into())),
                             Some(ScalarImpl::Int32(t.id.table_id as i32)),
-                            Some(ScalarImpl::Utf8(json!(fragments).to_string())),
+                            Some(ScalarImpl::Utf8(json!(fragments).to_string().into())),
                         ]));
                     }
                 });
@@ -366,13 +364,16 @@ impl SysCatalogReaderImpl {
             .flat_map(|schema| {
                 schema.iter_view().map(|view| {
                     Row::new(vec![
-                        Some(ScalarImpl::Utf8(schema.name())),
-                        Some(ScalarImpl::Utf8(view.name().to_string())),
+                        Some(ScalarImpl::Utf8(schema.name().into())),
+                        Some(ScalarImpl::Utf8(view.name().into())),
                         Some(ScalarImpl::Utf8(
-                            user_info_reader.get_user_name_by_id(view.owner).unwrap(),
+                            user_info_reader
+                                .get_user_name_by_id(view.owner)
+                                .unwrap()
+                                .into(),
                         )),
                         // TODO(zehua): may be not same as postgresql's "definition" column.
-                        Some(ScalarImpl::Utf8(view.sql.clone())),
+                        Some(ScalarImpl::Utf8(view.sql.clone().into())),
                     ])
                 })
             })
@@ -389,7 +390,7 @@ impl SysCatalogReaderImpl {
                     view.columns.iter().enumerate().map(|(index, column)| {
                         Row::new(vec![
                             Some(ScalarImpl::Int32(view.id as i32)),
-                            Some(ScalarImpl::Utf8(column.name.clone())),
+                            Some(ScalarImpl::Utf8(column.name.clone().into())),
                             Some(ScalarImpl::Int32(column.data_type().to_oid())),
                             Some(ScalarImpl::Int16(column.data_type().type_len())),
                             Some(ScalarImpl::Int16(index as i16 + 1)),
@@ -409,7 +410,7 @@ impl SysCatalogReaderImpl {
                             .map(|(index, column)| {
                                 Row::new(vec![
                                     Some(ScalarImpl::Int32(table.id.table_id() as i32)),
-                                    Some(ScalarImpl::Utf8(column.name().to_string())),
+                                    Some(ScalarImpl::Utf8(column.name().into())),
                                     Some(ScalarImpl::Int32(column.data_type().to_oid())),
                                     Some(ScalarImpl::Int16(column.data_type().type_len())),
                                     Some(ScalarImpl::Int16(index as i16 + 1)),

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_cast.rs
@@ -42,7 +42,7 @@ pub static PG_CAST_DATA_ROWS: LazyLock<Vec<Row>> = LazyLock::new(|| {
                 Some(ScalarImpl::Int32(idx as i32)),
                 Some(ScalarImpl::Int32(DataType::from(*src).to_oid())),
                 Some(ScalarImpl::Int32(DataType::from(*target).to_oid())),
-                Some(ScalarImpl::Utf8(ctx.into())),
+                Some(ScalarImpl::Utf8(ctx.to_string().into())),
             ])
         })
         .collect_vec()

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_type.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_type.rs
@@ -49,7 +49,7 @@ pub static PG_TYPE_DATA_ROWS: LazyLock<Vec<Row>> = LazyLock::new(|| {
         .map(|(oid, name)| {
             Row::new(vec![
                 Some(ScalarImpl::Int32(*oid)),
-                Some(ScalarImpl::Utf8(name.to_string())),
+                Some(ScalarImpl::Utf8((*name).into())),
             ])
         })
         .collect_vec()

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -101,7 +101,7 @@ mod tests {
     #[test]
     fn test_struct_to_value_encoding() {
         let value = StructValue::new(vec![
-            Some(ScalarImpl::Utf8("".to_string())),
+            Some(ScalarImpl::Utf8("".into())),
             Some(2.into()),
             Some(3.into()),
         ]);
@@ -124,9 +124,9 @@ mod tests {
     #[test]
     fn test_list_to_value_encoding() {
         let value = ListValue::new(vec![
-            Some(ScalarImpl::Utf8("1".to_owned())),
-            Some(ScalarImpl::Utf8("2".to_owned())),
-            Some(ScalarImpl::Utf8("".to_owned())),
+            Some(ScalarImpl::Utf8("1".into())),
+            Some(ScalarImpl::Utf8("2".into())),
+            Some(ScalarImpl::Utf8("".into())),
         ]);
         let data = Some(ScalarImpl::List(value.clone()));
         let node = literal_to_value_encoding(&data);

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -111,7 +111,7 @@ impl ExprImpl {
     /// A literal varchar value.
     #[inline(always)]
     pub fn literal_varchar(v: String) -> Self {
-        Literal::new(Some(v.to_scalar_value()), DataType::Varchar).into()
+        Literal::new(Some(v.into()), DataType::Varchar).into()
     }
 
     /// A literal null value.

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -159,7 +159,7 @@ impl TableFunction {
                 if let Some(flag) = args.get(2) {
                     if let ExprImpl::Literal(lit) = flag &&
                       let Some(ScalarImpl::Utf8(flag)) = lit.get_data() {
-                        if flag != "g" {
+                        if flag.as_ref() != "g" {
                             return Err(ErrorCode::NotImplemented(
                                 "flag in regexp_matches".to_string(),
                                 4545.into()

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -143,9 +143,9 @@ pub enum CastContext {
 
 pub type CastMap = BTreeMap<(DataTypeName, DataTypeName), CastContext>;
 
-impl From<&CastContext> for String {
-    fn from(c: &CastContext) -> Self {
-        match c {
+impl ToString for CastContext {
+    fn to_string(&self) -> String {
+        match self {
             CastContext::Implicit => "IMPLICIT".to_string(),
             CastContext::Assign => "ASSIGN".to_string(),
             CastContext::Explicit => "EXPLICIT".to_string(),

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -90,7 +90,7 @@ fn pg_value_format(data_type: &DataType, d: ScalarRefImpl<'_>, format: bool) -> 
     if !format {
         match (data_type, d) {
             (DataType::Timestampz, ScalarRefImpl::Int64(us)) => {
-                Ok(timestampz_to_utc_string(us).into())
+                Ok(timestampz_to_utc_string(us).into_boxed_bytes().into())
             }
             _ => Ok(d.text_format().into()),
         }

--- a/src/source/src/parser/avro/parser.rs
+++ b/src/source/src/parser/avro/parser.rs
@@ -237,7 +237,7 @@ impl AvroParser {
 fn from_avro_value(value: Value) -> Result<Datum> {
     let v = match value {
         Value::Boolean(b) => ScalarImpl::Bool(b),
-        Value::String(s) => ScalarImpl::Utf8(s),
+        Value::String(s) => ScalarImpl::Utf8(s.into_boxed_str()),
         Value::Int(i) => ScalarImpl::Int32(i),
         Value::Long(i) => ScalarImpl::Int64(i),
         Value::Float(f) => ScalarImpl::Float32(OrderedF32::from(f)),
@@ -280,7 +280,7 @@ fn from_avro_value(value: Value) -> Result<Datum> {
             let millis = u32::from(duration.millis()) as i64;
             ScalarImpl::Interval(IntervalUnit::new(months, days, millis))
         }
-        Value::Enum(_, symbol) => ScalarImpl::Utf8(symbol),
+        Value::Enum(_, symbol) => ScalarImpl::Utf8(symbol.into_boxed_str()),
         Value::Record(descs) => {
             let rw_values = descs
                 .into_iter()
@@ -425,7 +425,7 @@ mod test {
             let value = field.clone().1;
             match value {
                 Value::String(str) => {
-                    assert_eq!(row[i], Some(ScalarImpl::Utf8(str)));
+                    assert_eq!(row[i], Some(ScalarImpl::Utf8(str.into_boxed_str())));
                 }
                 Value::Boolean(bool_val) => {
                     assert_eq!(row[i], Some(ScalarImpl::Bool(bool_val)));

--- a/src/source/src/parser/canal/mod.rs
+++ b/src/source/src/parser/canal/mod.rs
@@ -86,7 +86,7 @@ mod tests {
             assert_eq!(row.value_at(0).to_owned_datum(), Some(ScalarImpl::Int64(1)));
             assert_eq!(
                 row.value_at(1).to_owned_datum(),
-                (Some(ScalarImpl::Utf8("mike".to_owned())))
+                (Some(ScalarImpl::Utf8("mike".into())))
             );
             assert_eq!(
                 row.value_at(2).to_owned_datum(),
@@ -114,7 +114,7 @@ mod tests {
             assert_eq!(row.value_at(0).to_owned_datum(), Some(ScalarImpl::Int64(1)));
             assert_eq!(
                 row.value_at(1).to_owned_datum(),
-                (Some(ScalarImpl::Utf8("mike".to_owned())))
+                (Some(ScalarImpl::Utf8("mike".into())))
             );
             assert_eq!(
                 row.value_at(2).to_owned_datum(),

--- a/src/source/src/parser/debezium/mod.rs
+++ b/src/source/src/parser/debezium/mod.rs
@@ -124,8 +124,8 @@ mod test {
         let [(_op, row)]: [_; 1] = parse_one(parser, columns, data).await.try_into().unwrap();
 
         assert!(row[0].eq(&Some(ScalarImpl::Int32(101))));
-        assert!(row[1].eq(&Some(ScalarImpl::Utf8("scooter".to_string()))));
-        assert!(row[2].eq(&Some(ScalarImpl::Utf8("Small 2-wheel scooter".to_string()))));
+        assert!(row[1].eq(&Some(ScalarImpl::Utf8("scooter".into()))));
+        assert!(row[2].eq(&Some(ScalarImpl::Utf8("Small 2-wheel scooter".into()))));
         assert!(row[3].eq(&Some(ScalarImpl::Float64(1.234.into()))));
     }
 
@@ -145,8 +145,8 @@ mod test {
         assert_eq!(op, Op::Insert);
 
         assert!(row[0].eq(&Some(ScalarImpl::Int32(102))));
-        assert!(row[1].eq(&Some(ScalarImpl::Utf8("car battery".to_string()))));
-        assert!(row[2].eq(&Some(ScalarImpl::Utf8("12V car battery".to_string()))));
+        assert!(row[1].eq(&Some(ScalarImpl::Utf8("car battery".into()))));
+        assert!(row[2].eq(&Some(ScalarImpl::Utf8("12V car battery".into()))));
         assert!(row[3].eq(&Some(ScalarImpl::Float64(8.1.into()))));
     }
 
@@ -167,8 +167,8 @@ mod test {
         assert_eq!(op, Op::Delete);
 
         assert!(row[0].eq(&Some(ScalarImpl::Int32(101))));
-        assert!(row[1].eq(&Some(ScalarImpl::Utf8("scooter".to_string()))));
-        assert!(row[2].eq(&Some(ScalarImpl::Utf8("Small 2-wheel scooter".to_string()))));
+        assert!(row[1].eq(&Some(ScalarImpl::Utf8("scooter".into()))));
+        assert!(row[2].eq(&Some(ScalarImpl::Utf8("Small 2-wheel scooter".into()))));
         assert!(row[3].eq(&Some(ScalarImpl::Float64(1.234.into()))));
     }
 
@@ -197,13 +197,13 @@ mod test {
         assert_eq!(op2, Op::UpdateInsert);
 
         assert!(row1[0].eq(&Some(ScalarImpl::Int32(102))));
-        assert!(row1[1].eq(&Some(ScalarImpl::Utf8("car battery".to_string()))));
-        assert!(row1[2].eq(&Some(ScalarImpl::Utf8("12V car battery".to_string()))));
+        assert!(row1[1].eq(&Some(ScalarImpl::Utf8("car battery".into()))));
+        assert!(row1[2].eq(&Some(ScalarImpl::Utf8("12V car battery".into()))));
         assert!(row1[3].eq(&Some(ScalarImpl::Float64(8.1.into()))));
 
         assert!(row2[0].eq(&Some(ScalarImpl::Int32(102))));
-        assert!(row2[1].eq(&Some(ScalarImpl::Utf8("car battery".to_string()))));
-        assert!(row2[2].eq(&Some(ScalarImpl::Utf8("24V car battery".to_string()))));
+        assert!(row2[1].eq(&Some(ScalarImpl::Utf8("car battery".into()))));
+        assert!(row2[2].eq(&Some(ScalarImpl::Utf8("24V car battery".into()))));
         assert!(row2[3].eq(&Some(ScalarImpl::Float64(9.1.into()))));
     }
 

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -202,7 +202,7 @@ mod tests {
             );
             assert_eq!(
                 row.value_at(6).to_owned_datum(),
-                (Some(ScalarImpl::Utf8("varchar".to_string())))
+                (Some(ScalarImpl::Utf8("varchar".into())))
             );
             assert_eq!(
                 row.value_at(7).to_owned_datum(),
@@ -345,17 +345,17 @@ mod tests {
                 Some(ScalarImpl::NaiveDateTime(
                     str_to_timestamp("2022-07-13 20:48:37.07").unwrap()
                 )),
-                Some(ScalarImpl::Utf8("1732524418112319151".to_string())),
-                Some(ScalarImpl::Utf8("Here man favor ourselves mysteriously most her sigh in straightaway for afterwards.".to_string())),
-                Some(ScalarImpl::Utf8("English".to_string())),
+                Some(ScalarImpl::Utf8("1732524418112319151".into())),
+                Some(ScalarImpl::Utf8("Here man favor ourselves mysteriously most her sigh in straightaway for afterwards.".into())),
+                Some(ScalarImpl::Utf8("English".into())),
             ]))),
             Some(ScalarImpl::Struct(StructValue::new(vec![
                 Some(ScalarImpl::NaiveDateTime(
                     str_to_timestamp("2018-01-29 12:19:11.07").unwrap()
                 )),
-                Some(ScalarImpl::Utf8("7772634297".to_string())),
-                Some(ScalarImpl::Utf8("Lily Frami yet".to_string())),
-                Some(ScalarImpl::Utf8("Dooley5659".to_string())),
+                Some(ScalarImpl::Utf8("7772634297".into())),
+                Some(ScalarImpl::Utf8("Lily Frami yet".into())),
+                Some(ScalarImpl::Utf8("Dooley5659".into())),
             ]) ))
         ];
         assert_eq!(row, expected);

--- a/src/source/src/parser/protobuf/parser.rs
+++ b/src/source/src/parser/protobuf/parser.rs
@@ -197,7 +197,7 @@ fn from_protobuf_value(field_desc: &FieldDescriptor, value: &Value) -> Result<Da
         Value::U64(i) => ScalarImpl::Decimal(Decimal::from(*i)),
         Value::F32(f) => ScalarImpl::Float32(OrderedF32::from(*f)),
         Value::F64(f) => ScalarImpl::Float64(OrderedF64::from(*f)),
-        Value::String(s) => ScalarImpl::Utf8(s.to_owned()),
+        Value::String(s) => ScalarImpl::Utf8(s.as_str().into()),
         Value::EnumNumber(idx) => {
             let kind = field_desc.kind();
             let enum_desc = kind.as_enum().ok_or_else(|| {
@@ -211,7 +211,7 @@ fn from_protobuf_value(field_desc: &FieldDescriptor, value: &Value) -> Result<Da
                 );
                 RwError::from(ProtocolError(err_msg))
             })?;
-            ScalarImpl::Utf8(enum_symbol.name().to_owned())
+            ScalarImpl::Utf8(enum_symbol.name().into())
         }
         Value::Message(dyn_msg) => {
             let mut rw_values = Vec::with_capacity(dyn_msg.descriptor().fields().len());

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -491,7 +491,7 @@ mod tests {
         let serializer = OrderedRowSerde::new(schema, order_types);
         let row = Row::new(vec![
             Some(ScalarImpl::Int64(100)),
-            Some(ScalarImpl::Utf8("abc".to_string())),
+            Some(ScalarImpl::Utf8("abc".into())),
         ]);
         let mut row_bytes = vec![];
         serializer.serialize(&row, &mut row_bytes);
@@ -529,7 +529,7 @@ mod tests {
             let serializer = OrderedRowSerde::new(schema, order_types);
             let row = Row::new(vec![
                 Some(ScalarImpl::Int64(100)),
-                Some(ScalarImpl::Utf8("abc".to_string())),
+                Some(ScalarImpl::Utf8("abc".into())),
             ]);
             let mut row_bytes = vec![];
             serializer.serialize(&row, &mut row_bytes);
@@ -572,7 +572,7 @@ mod tests {
             let serializer = OrderedRowSerde::new(schema, order_types);
             let row = Row::new(vec![
                 Some(ScalarImpl::Int64(100)),
-                Some(ScalarImpl::Utf8("abc".to_string())),
+                Some(ScalarImpl::Utf8("abc".into())),
             ]);
             let mut row_bytes = vec![];
             serializer.serialize(&row, &mut row_bytes);

--- a/src/stream/src/executor/aggregation/minput.rs
+++ b/src/stream/src/executor/aggregation/minput.rs
@@ -685,7 +685,7 @@ mod tests {
 
             match state_1.get_output(&table_1, group_key.as_ref()).await? {
                 Some(ScalarImpl::Utf8(s)) => {
-                    assert_eq!(&s, "a");
+                    assert_eq!(s.as_ref(), "a");
                 }
                 _ => panic!("unexpected output"),
             }
@@ -1120,7 +1120,7 @@ mod tests {
             let res = state.get_output(&table, group_key.as_ref()).await?;
             match res {
                 Some(ScalarImpl::Utf8(s)) => {
-                    assert_eq!(s, "c,a".to_string());
+                    assert_eq!(s.as_ref(), "c,a".to_string());
                 }
                 _ => panic!("unexpected output"),
             }
@@ -1143,7 +1143,7 @@ mod tests {
             let res = state.get_output(&table, group_key.as_ref()).await?;
             match res {
                 Some(ScalarImpl::Utf8(s)) => {
-                    assert_eq!(s, "d_c,a+e".to_string());
+                    assert_eq!(s.as_ref(), "d_c,a+e".to_string());
                 }
                 _ => panic!("unexpected output"),
             }

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -344,10 +344,10 @@ mod tests {
         let cache_key_serde = (first_key_serde, second_key_serde);
         let mut managed_state = ManagedTopNState::new(state_table, &data_types, &order_types, 1);
 
-        let row1 = row_nonnull!["abc".to_string(), 2i64];
-        let row2 = row_nonnull!["abc".to_string(), 3i64];
-        let row3 = row_nonnull!["abd".to_string(), 3i64];
-        let row4 = row_nonnull!["ab".to_string(), 4i64];
+        let row1 = row_nonnull!["abc", 2i64];
+        let row2 = row_nonnull!["abc", 3i64];
+        let row3 = row_nonnull!["abd", 3i64];
+        let row4 = row_nonnull!["ab", 4i64];
 
         let row1_bytes = serialize_row_to_cache_key(row1.clone(), 1, &cache_key_serde);
         let row2_bytes = serialize_row_to_cache_key(row2.clone(), 1, &cache_key_serde);
@@ -424,11 +424,11 @@ mod tests {
         let cache_key_serde = (first_key_serde, second_key_serde);
         let mut managed_state = ManagedTopNState::new(state_table, &data_types, &order_types, 1);
 
-        let row1 = row_nonnull!["abc".to_string(), 2i64];
-        let row2 = row_nonnull!["abc".to_string(), 3i64];
-        let row3 = row_nonnull!["abd".to_string(), 3i64];
-        let row4 = row_nonnull!["ab".to_string(), 4i64];
-        let row5 = row_nonnull!["abcd".to_string(), 5i64];
+        let row1 = row_nonnull!["abc", 2i64];
+        let row2 = row_nonnull!["abc", 3i64];
+        let row3 = row_nonnull!["abd", 3i64];
+        let row4 = row_nonnull!["ab", 4i64];
+        let row5 = row_nonnull!["abcd", 5i64];
 
         let row1_bytes = serialize_row_to_cache_key(row1.clone(), 1, &cache_key_serde);
         let row2_bytes = serialize_row_to_cache_key(row2.clone(), 1, &cache_key_serde);

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -47,7 +47,7 @@ impl<S: StateStore> SourceStateTableHandler<S> {
     }
 
     fn string_to_scalar(rhs: impl Into<String>) -> ScalarImpl {
-        ScalarImpl::Utf8(rhs.into())
+        ScalarImpl::Utf8(rhs.into().into_boxed_str())
     }
 
     pub(crate) async fn get(&self, key: SplitId) -> StreamExecutorResult<Option<Row>> {

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -152,9 +152,8 @@ impl Executor for MockSource {
 macro_rules! row_nonnull {
     [$( $value:expr ),*] => {
         {
-            use risingwave_common::types::Scalar;
             use risingwave_common::array::Row;
-            Row::new(vec![$(Some($value.to_scalar_value()), )*])
+            Row::new(vec![$(Some($value.into()), )*])
         }
     };
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`Scalar` should always be immutable, so the capacity for growing makes no sense. We have used `Box<[Datum]>` for the list and struct array. This PR uses `Box<str>` for the UTF8 array.

Note that `String` does not support specifying an allocator for now, while `Box` does. This also makes it possible to add `Allocator` generic for `Datum`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
