### PR TITLE
fix: potential scheduler bug in recovery test

### DIFF
--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -432,7 +432,11 @@ impl StageRunner {
                          } else {
                             // After processing all stream status, we must have sent signal (Either Scheduled or
                             // Failed) to Query Runner. If this is not true, query runner will stuck cuz it do not receive any signals.
-                            assert!(sent_signal_to_next);
+                            if !sent_signal_to_next {
+                                // For now, this kind of situation may come from recovery test: CN may get killed before reporting status, so sent signal flag is not set yet.
+                                // In this case, batch query is expected to fail. Client in simulation test should retry this query (w/o kill nodes).
+                                return Err(TaskExecutionError("compute node lose connection before response".to_string()));
+                            }
                             break;
                     }
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

To solve a bug listed in https://buildkite.com/risingwavelabs/main-cron/builds/229

Reason analysis:
Recovery test will kill nodes randomly, so it is possible that a CN crash before sending any status update. In this case, frontend should not panic, but report execution error to user (will abort remaining tasks). 

Verification:
Still on the way to verify it yet. Can not reproduce locally and is trying on EC2 but it's slow. Anyway this change is must better than before.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

