### PR TITLE
fix(storage): loose the write stall condition and send flush event

### DIFF
--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -49,14 +49,16 @@ async fn test_read_version_basic() {
     {
         // single imm
         let kv_pairs = gen_dummy_batch(epoch);
+        let sorted_items = SharedBufferBatch::build_shared_buffer_item_batches(kv_pairs);
+        let size = SharedBufferBatch::measure_batch_size(&sorted_items);
         let imm = SharedBufferBatch::build_shared_buffer_batch(
             epoch,
-            kv_pairs,
+            sorted_items,
+            size,
             vec![],
             TableId::from(table_id),
             None,
-        )
-        .await;
+        );
 
         read_version.update(VersionUpdate::Staging(StagingData::ImmMem(imm)));
 
@@ -84,14 +86,16 @@ async fn test_read_version_basic() {
             // epoch from 1 to 6
             epoch += 1;
             let kv_pairs = gen_dummy_batch(epoch);
+            let sorted_items = SharedBufferBatch::build_shared_buffer_item_batches(kv_pairs);
+            let size = SharedBufferBatch::measure_batch_size(&sorted_items);
             let imm = SharedBufferBatch::build_shared_buffer_batch(
                 epoch,
-                kv_pairs,
+                sorted_items,
+                size,
                 vec![],
                 TableId::from(table_id),
                 None,
-            )
-            .await;
+            );
 
             read_version.update(VersionUpdate::Staging(StagingData::ImmMem(imm)));
         }
@@ -252,21 +256,23 @@ async fn test_read_filter_basic() {
     let (pinned_version, _, _) =
         prepare_first_valid_version(env, hummock_manager_ref, worker_node).await;
 
-    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(pinned_version.clone())));
+    let read_version = Arc::new(RwLock::new(HummockReadVersion::new(pinned_version)));
     let epoch = 1;
     let table_id = 0;
 
     {
         // single imm
         let kv_pairs = gen_dummy_batch(epoch);
+        let sorted_items = SharedBufferBatch::build_shared_buffer_item_batches(kv_pairs);
+        let size = SharedBufferBatch::measure_batch_size(&sorted_items);
         let imm = SharedBufferBatch::build_shared_buffer_batch(
             epoch,
-            kv_pairs,
+            sorted_items,
+            size,
             vec![],
             TableId::from(table_id),
             None,
-        )
-        .await;
+        );
 
         read_version
             .write()

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -38,14 +38,14 @@ use crate::hummock::local_version::upload_handle_manager::UploadHandleManager;
 use crate::hummock::local_version::SyncUncommittedDataStage;
 use crate::hummock::store::memtable::ImmutableMemtable;
 use crate::hummock::store::version::{HummockReadVersion, VersionUpdate};
-use crate::hummock::utils::validate_table_key_range;
-use crate::hummock::{HummockError, HummockResult, MemoryLimiter, SstableIdManagerRef, TrackerId};
+use crate::hummock::utils::{validate_table_key_range, LooseMemoryLimiter};
+use crate::hummock::{HummockError, HummockResult, SstableIdManagerRef, TrackerId};
 use crate::store::SyncResult;
 
 #[derive(Clone)]
 pub struct BufferTracker {
     flush_threshold: usize,
-    global_buffer: Arc<MemoryLimiter>,
+    global_buffer: Arc<LooseMemoryLimiter>,
     global_upload_task_size: Arc<AtomicUsize>,
 }
 
@@ -55,7 +55,7 @@ impl BufferTracker {
         let flush_threshold = capacity * 4 / 5;
         Self {
             flush_threshold,
-            global_buffer: Arc::new(MemoryLimiter::new(capacity as u64)),
+            global_buffer: Arc::new(LooseMemoryLimiter::new(capacity as u64)),
             global_upload_task_size: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -64,7 +64,7 @@ impl BufferTracker {
         self.global_buffer.get_memory_usage() as usize
     }
 
-    pub fn get_memory_limiter(&self) -> &Arc<MemoryLimiter> {
+    pub fn get_memory_limiter(&self) -> &Arc<LooseMemoryLimiter> {
         &self.global_buffer
     }
 

--- a/src/storage/src/hummock/local_version/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version/local_version_manager.rs
@@ -149,14 +149,21 @@ impl LocalVersionManager {
         delete_ranges: Vec<(Bytes, Bytes)>,
         table_id: TableId,
     ) -> HummockResult<usize> {
+        let sorted_items = SharedBufferBatch::build_shared_buffer_item_batches(kv_pairs);
+        let size = SharedBufferBatch::measure_batch_size(&sorted_items);
         let batch = SharedBufferBatch::build_shared_buffer_batch(
             epoch,
-            kv_pairs,
+            sorted_items,
+            size,
             delete_ranges,
             table_id,
-            Some(self.buffer_tracker.get_memory_limiter().as_ref()),
-        )
-        .await;
+            Some(
+                self.buffer_tracker
+                    .get_memory_limiter()
+                    .require_memory(size as u64)
+                    .await,
+            ),
+        );
         let batch_size = batch.size();
         self.write_shared_buffer_inner(batch.epoch(), batch);
         Ok(batch_size)

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -94,6 +94,7 @@ use crate::hummock::shared_buffer::{OrderSortedUncommittedData, UncommittedData}
 use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::{SstableStoreRef, TableHolder};
 use crate::hummock::store::version::{HummockReadVersion, HummockVersionReader};
+use crate::hummock::utils::LooseMemoryLimiter;
 use crate::monitor::StoreLocalStatistic;
 use crate::store::ReadOptions;
 
@@ -239,7 +240,7 @@ impl HummockStorage {
         &self.context.filter_key_extractor_manager
     }
 
-    pub fn get_memory_limiter(&self) -> Arc<MemoryLimiter> {
+    pub fn get_memory_limiter(&self) -> Arc<LooseMemoryLimiter> {
         self.buffer_tracker.get_memory_limiter().clone()
     }
 
@@ -570,7 +571,7 @@ impl HummockStorageV1 {
         &self.filter_key_extractor_manager
     }
 
-    pub fn get_memory_limiter(&self) -> Arc<MemoryLimiter> {
+    pub fn get_memory_limiter(&self) -> Arc<LooseMemoryLimiter> {
         self.local_version_manager
             .buffer_tracker()
             .get_memory_limiter()

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -35,9 +35,8 @@ use super::{
     TieredCacheValue,
 };
 use crate::hummock::multi_builder::UploadJoinHandle;
-use crate::hummock::{
-    BlockHolder, CacheableEntry, HummockError, HummockResult, LruCache, MemoryLimiter,
-};
+use crate::hummock::utils::LooseMemoryLimiter;
+use crate::hummock::{BlockHolder, CacheableEntry, HummockError, HummockResult, LruCache};
 use crate::monitor::{MemoryCollector, StoreLocalStatistic};
 
 const MAX_META_CACHE_SHARD_BITS: usize = 2;
@@ -395,11 +394,11 @@ pub type SstableStoreRef = Arc<SstableStore>;
 
 pub struct HummockMemoryCollector {
     sstable_store: SstableStoreRef,
-    limiter: Arc<MemoryLimiter>,
+    limiter: Arc<LooseMemoryLimiter>,
 }
 
 impl HummockMemoryCollector {
-    pub fn new(sstable_store: SstableStoreRef, limiter: Arc<MemoryLimiter>) -> Self {
+    pub fn new(sstable_store: SstableStoreRef, limiter: Arc<LooseMemoryLimiter>) -> Self {
         Self {
             sstable_store,
             limiter,

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -26,9 +26,10 @@ use risingwave_object_store::object::{
 use crate::error::StorageResult;
 use crate::hummock::hummock_meta_client::MonitoredHummockMetaClient;
 use crate::hummock::sstable_store::SstableStoreRef;
+use crate::hummock::utils::LooseMemoryLimiter;
 use crate::hummock::{
-    HummockStorage, HummockStorageV1, MemoryLimiter, SstableIdManagerRef, SstableStore,
-    TieredCache, TieredCacheMetricsBuilder,
+    HummockStorage, HummockStorageV1, SstableIdManagerRef, SstableStore, TieredCache,
+    TieredCacheMetricsBuilder,
 };
 use crate::memory::MemoryStateStore;
 use crate::monitor::{MonitoredStateStore as Monitored, ObjectStoreMetrics, StateStoreMetrics};
@@ -292,7 +293,7 @@ pub trait HummockTrait {
     fn sstable_id_manager(&self) -> &SstableIdManagerRef;
     fn sstable_store(&self) -> SstableStoreRef;
     fn filter_key_extractor_manager(&self) -> &FilterKeyExtractorManagerRef;
-    fn get_memory_limiter(&self) -> Arc<MemoryLimiter>;
+    fn get_memory_limiter(&self) -> Arc<LooseMemoryLimiter>;
     fn as_hummock(&self) -> Option<&HummockStorage>;
 }
 
@@ -309,7 +310,7 @@ impl HummockTrait for HummockStorage {
         self.filter_key_extractor_manager()
     }
 
-    fn get_memory_limiter(&self) -> Arc<MemoryLimiter> {
+    fn get_memory_limiter(&self) -> Arc<LooseMemoryLimiter> {
         self.get_memory_limiter()
     }
 
@@ -330,7 +331,7 @@ impl HummockTrait for HummockStorageV1 {
         self.filter_key_extractor_manager()
     }
 
-    fn get_memory_limiter(&self) -> Arc<MemoryLimiter> {
+    fn get_memory_limiter(&self) -> Arc<LooseMemoryLimiter> {
         self.get_memory_limiter()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Currently in our `ingest_batch`, we blocking-wait on memory limiter to acquire memory quota so that we can limit the memory usage of shared buffer. However, the current logic can easily cause endless blocking. 

First, when we get blocked on acquiring quota, we didn't send an event to notify the event handler to flush some in memory data to release the quota. 

Second, even if we send an event for the event handler to flush, it may not really do the flushing. For example, let's assume that the flush threshold is 800MB, and the total memory limit is 1000MB. If the current memory usage is 750MB, and we request for 300MB quota, we get blocked because after our request is granted, the total usage will exceed the memory limiter. However, the current memory usage is still under the flush threshold, and therefore no data will be flushed, and then the memory quota will not be released.

In this PR, we make introduce two changes. 
1. we loosen the criterion to stall the write. After this PR, we will get blocked when the current memory usage has exceeded the total limit rather than the current usage + the requested quota. In the above example, the request for 300MB quota will be granted, because the current usage is less than the total limit. After this request is granted, any future request will not be granted, because the total usage has reached 750+300=1050MB, which is greater than the total limit. 
2. before we await on the memory limiter, we will first try to acquire the memory. If we fail the attempt, we will send an `BufferMayFlush` event to event handler, and then wait on the memory limiter.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6684