### PR TITLE
refactor(common):add to_text_with_type && to_binary_with_type

### DIFF
--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -531,6 +531,13 @@ impl ToText for ListRef<'_> {
             )
         })
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::List { .. } => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Eq for ListRef<'_> {}

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -435,6 +435,13 @@ impl ToText for StructRef<'_> {
             )
         })
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::Struct(_) => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Eq for StructRef<'_> {}

--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -21,7 +21,7 @@ use postgres_types::{ToSql, Type};
 
 use super::to_binary::ToBinary;
 use super::to_text::ToText;
-use super::{CheckedAdd, IntervalUnit};
+use super::{CheckedAdd, DataType, IntervalUnit};
 use crate::array::ArrayResult;
 use crate::error::Result;
 use crate::util::value_encoding;
@@ -75,11 +75,25 @@ impl ToText for NaiveDateWrapper {
     fn to_text(&self) -> String {
         self.0.to_string()
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            super::DataType::Date => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl ToText for NaiveTimeWrapper {
     fn to_text(&self) -> String {
         self.0.to_string()
+    }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            super::DataType::Time => self.to_text(),
+            _ => unreachable!(),
+        }
     }
 }
 
@@ -87,29 +101,51 @@ impl ToText for NaiveDateTimeWrapper {
     fn to_text(&self) -> String {
         self.0.to_string()
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            super::DataType::Timestamp => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl ToBinary for NaiveDateWrapper {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
-        let mut output = BytesMut::new();
-        self.0.to_sql(&Type::ANY, &mut output).unwrap();
-        Ok(Some(output.freeze()))
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+        match ty {
+            super::DataType::Date => {
+                let mut output = BytesMut::new();
+                self.0.to_sql(&Type::ANY, &mut output).unwrap();
+                Ok(Some(output.freeze()))
+            }
+            _ => unreachable!(),
+        }
     }
 }
 
 impl ToBinary for NaiveTimeWrapper {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
-        let mut output = BytesMut::new();
-        self.0.to_sql(&Type::ANY, &mut output).unwrap();
-        Ok(Some(output.freeze()))
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+        match ty {
+            super::DataType::Time => {
+                let mut output = BytesMut::new();
+                self.0.to_sql(&Type::ANY, &mut output).unwrap();
+                Ok(Some(output.freeze()))
+            }
+            _ => unreachable!(),
+        }
     }
 }
 
 impl ToBinary for NaiveDateTimeWrapper {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
-        let mut output = BytesMut::new();
-        self.0.to_sql(&Type::ANY, &mut output).unwrap();
-        Ok(Some(output.freeze()))
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+        match ty {
+            super::DataType::Timestamp => {
+                let mut output = BytesMut::new();
+                self.0.to_sql(&Type::ANY, &mut output).unwrap();
+                Ok(Some(output.freeze()))
+            }
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -648,6 +648,13 @@ impl ToText for crate::types::IntervalUnit {
     fn to_text(&self) -> String {
         self.to_string()
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::Interval => self.to_string(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl Display for IntervalUnit {
@@ -728,10 +735,15 @@ impl<'a> FromSql<'a> for IntervalUnit {
 }
 
 impl ToBinary for IntervalUnit {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
-        let mut output = BytesMut::new();
-        self.to_sql(&Type::ANY, &mut output).unwrap();
-        Ok(Some(output.freeze()))
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+        match ty {
+            DataType::Interval => {
+                let mut output = BytesMut::new();
+                self.to_sql(&Type::ANY, &mut output).unwrap();
+                Ok(Some(output.freeze()))
+            }
+            _ => unreachable!(),
+        }
     }
 }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -823,12 +823,12 @@ pub fn hash_datum(datum: impl ToDatumRef, state: &mut impl std::hash::Hasher) {
 impl ScalarRefImpl<'_> {
     /// Encode the scalar to postgresql binary format.
     /// The encoder implements encoding using <https://docs.rs/postgres-types/0.2.3/postgres_types/trait.ToSql.html>
-    pub fn binary_format(&self) -> RwResult<Bytes> {
-        self.to_binary().transpose().unwrap()
+    pub fn binary_format(&self, data_type: &DataType) -> RwResult<Bytes> {
+        self.to_binary_with_type(data_type).transpose().unwrap()
     }
 
-    pub fn text_format(&self) -> String {
-        self.to_text()
+    pub fn text_format(&self, data_type: &DataType) -> String {
+        self.to_text_with_type(data_type)
     }
 
     /// Serialize the scalar.

--- a/src/common/src/types/to_binary.rs
+++ b/src/common/src/types/to_binary.rs
@@ -13,24 +13,30 @@
 // limitations under the License.
 
 use bytes::{Bytes, BytesMut};
+use chrono::{TimeZone, Utc};
 use postgres_types::{ToSql, Type};
 
-use super::{DatumRef, ScalarRefImpl};
+use super::{DataType, DatumRef, ScalarRefImpl};
 use crate::error::Result;
 // Used to convert ScalarRef to text format
 pub trait ToBinary {
-    fn to_binary(&self) -> Result<Option<Bytes>>;
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>>;
 }
 
 // implement use to_sql
 macro_rules! implement_using_to_sql {
-    ($({ $scalar_type:ty } ),*) => {
+    ($({ $scalar_type:ty , $data_type:ident} ),*) => {
         $(
             impl ToBinary for $scalar_type {
-                fn to_binary(&self) -> Result<Option<Bytes>> {
-                    let mut output = BytesMut::new();
-                    self.to_sql(&Type::ANY, &mut output).unwrap();
-                    Ok(Some(output.freeze()))
+                fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+                    match ty {
+                        DataType::$data_type => {
+                            let mut output = BytesMut::new();
+                            self.to_sql(&Type::ANY, &mut output).unwrap();
+                            Ok(Some(output.freeze()))
+                        },
+                        _ => unreachable!(),
+                    }
                 }
             }
         )*
@@ -38,42 +44,65 @@ macro_rules! implement_using_to_sql {
 }
 
 implement_using_to_sql! {
-    { i16  },
-    { i32  },
-    { i64  },
-    { &str },
-    { crate::types::OrderedF32 },
-    { crate::types::OrderedF64 },
-    { bool },
-    { &[u8] }
+    { i16,Int16  },
+    { i32,Int32  },
+    { &str,Varchar },
+    { crate::types::OrderedF32,Float32 },
+    { crate::types::OrderedF64,Float64 },
+    { bool,Boolean },
+    { &[u8],Bytea }
+}
+
+impl ToBinary for i64 {
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+        match ty {
+            DataType::Int64 => {
+                let mut output = BytesMut::new();
+                self.to_sql(&Type::ANY, &mut output).unwrap();
+                Ok(Some(output.freeze()))
+            }
+            DataType::Timestampz => {
+                let secs = self.div_euclid(1_000_000);
+                let nsecs = self.rem_euclid(1_000_000) * 1000;
+                let instant = Utc.timestamp_opt(secs, nsecs as u32).unwrap();
+                let mut out = BytesMut::new();
+                // postgres_types::Type::ANY is only used as a placeholder.
+                instant
+                    .to_sql(&postgres_types::Type::ANY, &mut out)
+                    .unwrap();
+                Ok(Some(out.freeze()))
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl ToBinary for ScalarRefImpl<'_> {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
         match self {
-            ScalarRefImpl::Int16(v) => v.to_binary(),
-            ScalarRefImpl::Int32(v) => v.to_binary(),
-            ScalarRefImpl::Int64(v) => v.to_binary(),
-            ScalarRefImpl::Float32(v) => v.to_binary(),
-            ScalarRefImpl::Float64(v) => v.to_binary(),
-            ScalarRefImpl::Utf8(v) => v.to_binary(),
-            ScalarRefImpl::Bool(v) => v.to_binary(),
-            ScalarRefImpl::Decimal(v) => v.to_binary(),
-            ScalarRefImpl::Interval(v) => v.to_binary(),
-            ScalarRefImpl::NaiveDate(v) => v.to_binary(),
-            ScalarRefImpl::NaiveDateTime(v) => v.to_binary(),
-            ScalarRefImpl::NaiveTime(v) => v.to_binary(),
+            ScalarRefImpl::Int16(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Int32(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Int64(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Float32(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Float64(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Utf8(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Bool(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Decimal(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Interval(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::NaiveDate(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::NaiveDateTime(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::NaiveTime(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Bytea(v) => v.to_binary_with_type(ty),
             ScalarRefImpl::Struct(_) => todo!(),
             ScalarRefImpl::List(_) => todo!(),
-            ScalarRefImpl::Bytea(v) => v.to_binary(),
         }
     }
 }
 
 impl ToBinary for DatumRef<'_> {
-    fn to_binary(&self) -> Result<Option<Bytes>> {
+    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
         match self {
-            Some(scalar) => scalar.to_binary(),
+            Some(scalar) => scalar.to_binary_with_type(ty),
             None => Ok(None),
         }
     }

--- a/src/common/src/types/to_text.rs
+++ b/src/common/src/types/to_text.rs
@@ -15,21 +15,52 @@
 use std::fmt::Write;
 use std::num::FpCategory;
 
+use chrono::{TimeZone, Utc};
 use num_traits::ToPrimitive;
 
-use super::{DatumRef, ScalarRefImpl};
+use super::{DataType, DatumRef, ScalarRefImpl};
 
 // Used to convert ScalarRef to text format
 pub trait ToText {
+    fn to_text_with_type(&self, ty: &DataType) -> String;
+    /// `to_text` is a special version of `to_text_with_type`, it convert the scalar to default type
+    /// text. E.g. for Int64, it will convert to text as a Int64 type.
+    /// We should prefer to use `to_text_with_type` because it's more clear and readable.
+    ///
+    /// Following is the relationship between scalar and default type:
+    /// - `ScalarRefImpl::Int16` -> `DataType::Int16`
+    /// - `ScalarRefImpl::Int32` -> `DataType::Int32`
+    /// - `ScalarRefImpl::Int64` -> `DataType::Int64`
+    /// - `ScalarRefImpl::Float32` -> `DataType::Float32`
+    /// - `ScalarRefImpl::Float64` -> `DataType::Float64`
+    /// - `ScalarRefImpl::Decimal` -> `DataType::Decimal`
+    /// - `ScalarRefImpl::Boolean` -> `DataType::Boolean`
+    /// - `ScalarRefImpl::Utf8` -> `DataType::Varchar`
+    /// - `ScalarRefImpl::Bytea` -> `DataType::Bytea`
+    /// - `ScalarRefImpl::NaiveDate` -> `DataType::Date`
+    /// - `ScalarRefImpl::NaiveTime` -> `DataType::Time`
+    /// - `ScalarRefImpl::NaiveDateTime` -> `DataType::Timestamp`
+    /// - `ScalarRefImpl::Interval` -> `DataType::Interval`
+    /// - `ScalarRefImpl::List` -> `DataType::List`
+    /// - `ScalarRefImpl::Struct` -> `DataType::Struct`
+    ///
+    /// Exception:
+    /// The scalar of `DataType::Timestampz` is the `ScalarRefImpl::Int64`.
     fn to_text(&self) -> String;
 }
 
 macro_rules! implement_using_to_string {
-    ($({ $scalar_type:ty } ),*) => {
+    ($({ $scalar_type:ty , $data_type:ident} ),*) => {
         $(
             impl ToText for $scalar_type {
                 fn to_text(&self) -> String {
                     self.to_string()
+                }
+                fn to_text_with_type(&self, ty: &DataType) -> String {
+                    match ty {
+                        DataType::$data_type => self.to_text(),
+                        _ => unreachable!(),
+                    }
                 }
             }
         )*
@@ -37,11 +68,17 @@ macro_rules! implement_using_to_string {
 }
 
 macro_rules! implement_using_itoa {
-    ($({ $scalar_type:ty } ),*) => {
+    ($({ $scalar_type:ty , $data_type:ident} ),*) => {
         $(
             impl ToText for $scalar_type {
                 fn to_text(&self) -> String {
                     itoa::Buffer::new().format(*self).to_owned()
+                }
+                fn to_text_with_type(&self, ty:&DataType) -> String {
+                    match ty {
+                        DataType::$data_type => self.to_text(),
+                        _ => unreachable!(),
+                    }
                 }
             }
         )*
@@ -49,18 +86,17 @@ macro_rules! implement_using_itoa {
 }
 
 implement_using_to_string! {
-    { String },
-    { &str }
+    { String ,Varchar },
+    { &str ,Varchar}
 }
 
 implement_using_itoa! {
-    { i16 },
-    { i32 },
-    { i64 }
+    { i16 ,Int16},
+    { i32 ,Int32}
 }
 
 macro_rules! implement_using_ryu {
-    ($({ $scalar_type:ty, $to_std_type:ident } ),*) => {
+    ($({ $scalar_type:ty, $to_std_type:ident, $data_type:ident } ),*) => {
             $(
             impl ToText for $scalar_type {
                 fn to_text(&self) -> String {
@@ -100,14 +136,43 @@ macro_rules! implement_using_ryu {
                         },
                     }
                 }
+                fn to_text_with_type(&self, ty: &DataType) -> String {
+                    match ty {
+                        DataType::$data_type => self.to_text(),
+                        _ => unreachable!(),
+                    }
+                }
             }
         )*
     };
 }
 
 implement_using_ryu! {
-    { crate::types::OrderedF32, to_f32 },
-    { crate::types::OrderedF64, to_f64 }
+    { crate::types::OrderedF32, to_f32,Float32 },
+    { crate::types::OrderedF64, to_f64,Float64 }
+}
+
+impl ToText for i64 {
+    fn to_text(&self) -> String {
+        self.to_string()
+    }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::Int64 => self.to_text(),
+            DataType::Timestampz => {
+                // Just a meaningful representation as placeholder. The real implementation depends
+                // on TimeZone from session. See #3552.
+                let secs = self.div_euclid(1_000_000);
+                let nsecs = self.rem_euclid(1_000_000) * 1000;
+                let instant = Utc.timestamp_opt(secs, nsecs as u32).unwrap();
+                // PostgreSQL uses a space rather than `T` to separate the date and time.
+                // https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
+                instant.format("%Y-%m-%d %H:%M:%S%.f%:z").to_string()
+            }
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl ToText for bool {
@@ -118,13 +183,28 @@ impl ToText for bool {
             "f".to_string()
         }
     }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::Boolean => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
-/// Convert bytes in `Bytea` type to String.
-pub fn format_bytes(bytes: &[u8]) -> String {
-    let mut s = String::with_capacity(2 * bytes.len());
-    write!(s, "\\x{}", hex::encode(bytes)).unwrap();
-    s
+impl ToText for &[u8] {
+    fn to_text(&self) -> String {
+        let mut s = String::with_capacity(2 + 2 * self.len());
+        write!(s, "\\x{}", hex::encode(self)).unwrap();
+        s
+    }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match ty {
+            DataType::Bytea => self.to_text(),
+            _ => unreachable!(),
+        }
+    }
 }
 
 impl ToText for ScalarRefImpl<'_> {
@@ -144,7 +224,27 @@ impl ToText for ScalarRefImpl<'_> {
             ScalarRefImpl::List(l) => l.to_text(),
             ScalarRefImpl::Struct(s) => s.to_text(),
             ScalarRefImpl::Utf8(v) => v.to_text(),
-            ScalarRefImpl::Bytea(v) => format_bytes(v),
+            ScalarRefImpl::Bytea(v) => v.to_text(),
+        }
+    }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match self {
+            ScalarRefImpl::Bool(b) => b.to_text_with_type(ty),
+            ScalarRefImpl::Int16(i) => i.to_text_with_type(ty),
+            ScalarRefImpl::Int32(i) => i.to_text_with_type(ty),
+            ScalarRefImpl::Int64(i) => i.to_text_with_type(ty),
+            ScalarRefImpl::Float32(f) => f.to_text_with_type(ty),
+            ScalarRefImpl::Float64(f) => f.to_text_with_type(ty),
+            ScalarRefImpl::Decimal(d) => d.to_text_with_type(ty),
+            ScalarRefImpl::Interval(i) => i.to_text_with_type(ty),
+            ScalarRefImpl::NaiveDate(d) => d.to_text_with_type(ty),
+            ScalarRefImpl::NaiveTime(t) => t.to_text_with_type(ty),
+            ScalarRefImpl::NaiveDateTime(dt) => dt.to_text_with_type(ty),
+            ScalarRefImpl::List(l) => l.to_text_with_type(ty),
+            ScalarRefImpl::Struct(s) => s.to_text_with_type(ty),
+            ScalarRefImpl::Utf8(v) => v.to_text_with_type(ty),
+            ScalarRefImpl::Bytea(v) => v.to_text_with_type(ty),
         }
     }
 }
@@ -153,6 +253,13 @@ impl ToText for DatumRef<'_> {
     fn to_text(&self) -> String {
         match self {
             Some(data) => data.to_text(),
+            None => "NULL".to_string(),
+        }
+    }
+
+    fn to_text_with_type(&self, ty: &DataType) -> String {
+        match self {
+            Some(data) => data.to_text_with_type(ty),
             None => "NULL".to_string(),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

The semantic of to_binary or to_text is to convert a 'inner data' into text or binary format. 
For 'inner data', it should be a scalar with a data type. But for now, to_text() ignore the data type, it assume a default type for the scalar. E.g the default data type of ScalarRef::Int64 is INT8, but actually the data type of ScalarRef::Int64 can be TIMESTAMPTZ. 
This PR add the to_text_with_type() && to_binary_with_type(). to_text && to_binary reserve as a default version of to_text_with_type && to_binary_with_type().

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
