### PR TITLE
feat(optimizer): support join predicate reorder for lookup join

### DIFF
--- a/src/frontend/planner_test/tests/testdata/batch_index_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/batch_index_join.yaml
@@ -23,3 +23,38 @@
     └─BatchLookupJoin { type: Inner, predicate: t.a = idx2.c AND t.b = idx2.d, output: all }
       └─BatchExchange { order: [], dist: UpstreamHashShard(t.a, t.b) }
         └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+- sql: |
+    set rw_batch_enable_lookup_join = true;
+    create table t (a int, b int);
+    create table t2 (c int, d int);
+    create index idx on t2(d) include (c);
+    select * from t join t2 on t.b = t2.d;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchLookupJoin { type: Inner, predicate: t.b = idx.d, output: all }
+      └─BatchExchange { order: [], dist: UpstreamHashShard(t.b) }
+        └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+- name: test index join predicate reorder
+  sql: |
+    set rw_batch_enable_lookup_join = true;
+    create table t (a int, b int);
+    create table t2 (c int, d int);
+    create index idx on t2(c, d);
+    select * from t join t2 on t.b = t2.d and t.a = t2.c;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchLookupJoin { type: Inner, predicate: t.a = idx.c AND t.b = idx.d, output: all }
+      └─BatchExchange { order: [], dist: UpstreamHashShard(t.a, t.b) }
+        └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+- name: test index join prefix lookup
+  sql: |
+    set rw_batch_enable_lookup_join = true;
+    create table t (a int, b int);
+    create table t2 (c int, d int);
+    create index idx on t2(c, d) distributed by (c);
+    select * from t join t2 on t.a = t2.c;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchLookupJoin { type: Inner, predicate: t.a = idx.c, output: all }
+      └─BatchExchange { order: [], dist: UpstreamHashShard(t.a) }
+        └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }

--- a/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -200,6 +200,22 @@ impl EqJoinPredicate {
         }
         ColIndexMapping::new(map)
     }
+
+    /// Reorder the `eq_keys` according to the `reorder_idx`.
+    pub fn reorder(self, reorder_idx: &[usize]) -> Self {
+        assert!(reorder_idx.len() <= self.eq_keys.len());
+        let mut new_eq_keys = Vec::with_capacity(self.eq_keys.len());
+        for idx in reorder_idx {
+            new_eq_keys.push(self.eq_keys[*idx].clone());
+        }
+        for idx in 0..self.eq_keys.len() {
+            if !reorder_idx.contains(&idx) {
+                new_eq_keys.push(self.eq_keys[idx].clone());
+            }
+        }
+
+        Self::new(self.other_cond, new_eq_keys, self.left_cols_num)
+    }
 }
 
 pub struct EqJoinPredicateDisplay<'a> {

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -505,32 +505,21 @@ impl LogicalJoin {
             max_pos + 1
         };
 
-        if predicate.right_eq_indexes().len() < at_least_prefix_len {
-            // In Lookup Join, the right columns of the equality join predicates must contains the
-            // prefix of order key.
-            return None;
-        }
-
-        // Lookup prefix len is the prefix length of the order key.
-        let mut lookup_prefix_len = 0;
-        #[expect(clippy::disallowed_methods)]
-        for (i, (order_col_id, eq_idx)) in order_col_ids
-            .into_iter()
-            .zip(predicate.right_eq_indexes())
-            .enumerate()
-        {
-            if order_col_id != output_column_ids[eq_idx] {
-                if i < at_least_prefix_len {
-                    // In Lookup Join, the right columns of the equality join predicates must
-                    // contains the prefix of order key.
-                    return None;
-                } else {
+        // Reorder the join equal predicate to match the order key.
+        let mut reorder_idx = vec![];
+        for order_col_id in order_col_ids {
+            for (i, eq_idx) in predicate.right_eq_indexes().into_iter().enumerate() {
+                if order_col_id == output_column_ids[eq_idx] {
+                    reorder_idx.push(i);
                     break;
                 }
-            } else {
-                lookup_prefix_len = i + 1;
             }
         }
+        if reorder_idx.len() < at_least_prefix_len {
+            return None;
+        }
+        let lookup_prefix_len = reorder_idx.len();
+        let predicate = predicate.reorder(&reorder_idx);
 
         // Extract the predicate from logical scan. Only pure scan is supported.
         let (new_scan, scan_predicate, project_expr) = logical_scan.predicate_pull_up();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Reorder the predicate of `LogicalJoin` if they can be used by `BatchLookupJoin`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/6589