### PR TITLE
feat(sink): add blackhole sink

### DIFF
--- a/e2e_test/sink/blackhole_sink.slt
+++ b/e2e_test/sink/blackhole_sink.slt
@@ -1,0 +1,39 @@
+statement ok
+CREATE TABLE t5 (v1 int, v2 int);
+
+statement ok
+CREATE MATERIALIZED VIEW mv5 AS SELECT * FROM t5;
+
+statement ok
+CREATE SINK s5 AS select * from t5 WITH (
+    connector = 'blackhole'
+);
+
+statement ok
+CREATE SINK s5mv AS select mv5.v1 as v1, mv5.v2 as v2 from mv5 WITH (
+    connector = 'blackhole'
+);
+
+statement ok
+INSERT INTO t5 VALUES (101, 102), (101, 102), (102, 102), (103, 102), (105, 102), (108, 102), (113, 102), (121, 102);
+
+statement error
+DROP TABLE t5;
+
+statement ok
+DROP SINK s5;
+
+statement error
+DROP MATERIALIZED VIEW mv5;
+
+statement ok
+DROP SINK s5mv;
+
+statement ok
+DROP MATERIALIZED VIEW mv5;
+
+statement ok
+DROP TABLE t5;
+
+statement ok
+FLUSH;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Blackhole sink does nothing, purely for performance test purposes. 
So that branch https://github.com/risingwavelabs/risingwave/tree/disable_mv can be deleted.
Partially(?) unlock #5678, and performance test for stateless ETL cases.

## Checklist

- [x] ~I have written necessary rustdoc comments~
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Connector (sources & sinks)
* SQL commands, functions, and operators

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

Users can now create a sink with `blackhole` being the connector. It does nothing. It is helpful when we want to create a streaming query without a materialized view or a sink whose writes may affect the end-to-end performance.

## Refer to a related PR or issue link (optional)
