### PR TITLE
refactor(Bitmap): use Bitmap::ones as much as possible

### DIFF
--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -308,12 +308,7 @@ impl<S: StateStore> StorageTable<S> {
             // If `vnode_hint` is set, we can only access this single vnode.
             Some(vnode) => std::iter::once(vnode),
             // Otherwise, we need to access all vnodes of this table.
-            None => self
-                .vnodes
-                .iter()
-                .enumerate()
-                .filter(|&(_, set)| set)
-                .map(|(i, _)| VirtualNode::from_index(i)),
+            None => self.vnodes.ones().map(VirtualNode::from_index),
         };
 
         // For each vnode, construct an iterator.

--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -258,11 +258,7 @@ impl<S: StateStore> SortExecutor<S> {
             curr_vnode_bitmap.to_owned()
         };
         let mut values_per_vnode = Vec::new();
-        for (owned_vnode, _) in newly_owned_vnodes
-            .iter()
-            .enumerate()
-            .filter(|(_, is_set)| *is_set)
-        {
+        for owned_vnode in newly_owned_vnodes.ones() {
             let value_iter = self
                 .state_table
                 .iter_with_pk_range(


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Find the pattern `\.enumerate\(\)[ \n]*\.filter`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
