### PR TITLE
feat(compaction): clean stale tables in `report_compact_task`

### DIFF
--- a/src/meta/src/hummock/level_handler.rs
+++ b/src/meta/src/hummock/level_handler.rs
@@ -91,6 +91,10 @@ impl LevelHandler {
         self.compacting_files.len()
     }
 
+    pub fn get_pending_file_ids(&self) -> Vec<HummockSstableId> {
+        self.compacting_files.keys().cloned().collect_vec()
+    }
+
     pub fn get_pending_file_size(&self) -> u64 {
         self.pending_tasks
             .iter()

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -2259,18 +2259,15 @@ fn gen_version_delta<'a>(
                     .iter()
                     .filter_map(|table_info| {
                         let id = table_info.get_id();
-                        if compacting_ssts.contains(&id) {
-                            None
-                        } else {
-                            if table_info
+                        if compacting_ssts.contains(&id)
+                            || table_info
                                 .get_table_ids()
                                 .iter()
                                 .any(|table_id| all_state_tables.contains(table_id))
-                            {
-                                None
-                            } else {
-                                Some(id)
-                            }
+                        {
+                            None
+                        } else {
+                            Some(id)
                         }
                     })
                     .collect_vec();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

clean stale tables in `report_compact_task`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
