### PR TITLE
refactor(optimizer): prevent optimizer context from being used across await points

### DIFF
--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -27,12 +27,13 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Result};
 pub use resolve_id::*;
 use risingwave_frontend::handler::{
-    create_index, create_mv, create_source, create_table, drop_table, variable,
+    create_index, create_mv, create_source, create_table, drop_table, variable, HandlerArgs,
 };
-use risingwave_frontend::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+use risingwave_frontend::session::SessionImpl;
 use risingwave_frontend::test_utils::{create_proto_file, get_explain_output, LocalFrontend};
 use risingwave_frontend::{
-    build_graph, explain_stream_graph, Binder, FrontendOpts, PlanRef, Planner, WithOptions,
+    build_graph, explain_stream_graph, Binder, FrontendOpts, OptimizerContext, OptimizerContextRef,
+    PlanRef, Planner, WithOptions,
 };
 use risingwave_sqlparser::ast::{ObjectName, Statement};
 use risingwave_sqlparser::parser::Parser;
@@ -293,12 +294,11 @@ impl TestCase {
     ) -> Result<Option<TestCaseResult>> {
         let statements = Parser::parse_sql(sql).unwrap();
         for stmt in statements {
-            let context = OptimizerContext::new(
-                session.clone(),
-                Arc::from(sql),
-                WithOptions::try_from(&stmt)?,
-            );
-            context.explain_verbose.store(true, Ordering::Relaxed); // use explain verbose in planner tests
+            let handler_args = HandlerArgs {
+                session: session.clone(),
+                sql: Arc::from(sql),
+                with_options: WithOptions::try_from(&stmt)?,
+            };
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }
@@ -307,6 +307,12 @@ impl TestCase {
                     if result.is_some() {
                         panic!("two queries in one test case");
                     }
+                    let context = OptimizerContext::new(
+                        session.clone(),
+                        Arc::from(sql),
+                        WithOptions::try_from(&stmt)?,
+                    );
+                    context.explain_verbose.store(true, Ordering::Relaxed); // use explain verbose in planner tests
                     let ret = self.apply_query(&stmt, context.into())?;
                     if do_check_result {
                         check_result(self, &ret)?;
@@ -321,7 +327,7 @@ impl TestCase {
                     ..
                 } => {
                     create_table::handle_create_table(
-                        context,
+                        handler_args,
                         name,
                         columns,
                         constraints,
@@ -333,7 +339,8 @@ impl TestCase {
                     is_materialized,
                     stmt,
                 } => {
-                    create_source::handle_create_source(context, is_materialized, stmt).await?;
+                    create_source::handle_create_source(handler_args, is_materialized, stmt)
+                        .await?;
                 }
                 Statement::CreateIndex {
                     name,
@@ -346,7 +353,7 @@ impl TestCase {
                     ..
                 } => {
                     create_index::handle_create_index(
-                        context,
+                        handler_args,
                         if_not_exists,
                         name,
                         table_name,
@@ -364,11 +371,11 @@ impl TestCase {
                     columns,
                     ..
                 } => {
-                    create_mv::handle_create_mv(context, name, *query, columns).await?;
+                    create_mv::handle_create_mv(handler_args, name, *query, columns).await?;
                 }
                 Statement::Drop(drop_statement) => {
                     drop_table::handle_drop_table(
-                        context,
+                        handler_args,
                         drop_statement.object_name,
                         drop_statement.if_exists,
                     )
@@ -379,7 +386,7 @@ impl TestCase {
                     variable,
                     value,
                 } => {
-                    variable::handle_set(context, variable, value).unwrap();
+                    variable::handle_set(handler_args, variable, value).unwrap();
                 }
                 Statement::Explain { .. } => {
                     let explain_output = get_explain_output(sql, session.clone()).await;

--- a/src/frontend/src/handler/alter_user.rs
+++ b/src/frontend/src/handler/alter_user.rs
@@ -22,7 +22,7 @@ use risingwave_sqlparser::ast::{AlterUserStatement, ObjectName, UserOption, User
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 use crate::user::user_authentication::encrypted_password;
 
 fn alter_prost_user_info(
@@ -142,10 +142,10 @@ fn alter_rename_prost_user_info(
 }
 
 pub async fn handle_alter_user(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: AlterUserStatement,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let (user_info, update_fields) = {
         let user_name = Binder::resolve_user_name(stmt.user_name.clone())?;
         let user_reader = session.env().user_info_reader().read_guard();

--- a/src/frontend/src/handler/create_database.rs
+++ b/src/frontend/src/handler/create_database.rs
@@ -20,14 +20,14 @@ use risingwave_sqlparser::ast::ObjectName;
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_create_database(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     database_name: ObjectName,
     if_not_exist: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let database_name = Binder::resolve_database_name(database_name)?;
 
     {

--- a/src/frontend/src/handler/create_schema.rs
+++ b/src/frontend/src/handler/create_schema.rs
@@ -23,14 +23,14 @@ use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
 use crate::handler::privilege::ObjectCheckItem;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_create_schema(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     schema_name: ObjectName,
     if_not_exist: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let database_name = session.database();
     let schema_name = Binder::resolve_schema_name(schema_name)?;
 

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -24,8 +24,9 @@ use risingwave_sqlparser::ast::{
 use super::create_mv::{check_column_names, get_column_names};
 use super::RwPgResponse;
 use crate::binder::Binder;
-use crate::optimizer::PlanRef;
-use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+use crate::handler::HandlerArgs;
+use crate::optimizer::{OptimizerContext, OptimizerContextRef, PlanRef};
+use crate::session::SessionImpl;
 use crate::stream_fragmenter::build_graph;
 use crate::Planner;
 
@@ -155,14 +156,15 @@ pub fn gen_sink_plan(
 }
 
 pub async fn handle_create_sink(
-    context: OptimizerContext,
+    handle_args: HandlerArgs,
     stmt: CreateSinkStatement,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx.clone();
+    let session = handle_args.session.clone();
 
     session.check_relation_name_duplicated(stmt.sink_name.clone())?;
 
     let (sink, graph) = {
+        let context = OptimizerContext::new_with_handler_args(handle_args);
         let (plan, sink) = gen_sink_plan(&session, context.into(), stmt)?;
 
         (sink, build_graph(plan))

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -31,7 +31,9 @@ use risingwave_sqlparser::ast::{
 use super::create_table::{bind_sql_columns, bind_sql_table_constraints, gen_materialize_plan};
 use super::RwPgResponse;
 use crate::binder::Binder;
-use crate::session::{OptimizerContext, SessionImpl};
+use crate::handler::HandlerArgs;
+use crate::optimizer::OptimizerContext;
+use crate::session::SessionImpl;
 use crate::stream_fragmenter::build_graph;
 
 pub(crate) fn make_prost_source(
@@ -108,7 +110,7 @@ async fn extract_protobuf_table_schema(
 
 // TODO(Yuanxin): Only create a source w/o materializing.
 pub async fn handle_create_source(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     is_materialized: bool,
     stmt: CreateSourceStatement,
 ) -> Result<RwPgResponse> {
@@ -121,7 +123,7 @@ pub async fn handle_create_source(
         )
         .into());
     }
-    let with_properties = context.with_options.inner().clone();
+    let with_properties = handler_args.with_options.inner().clone();
     const UPSTREAM_SOURCE_KEY: &str = "connector";
     // confluent schema registry must be used with kafka
     let is_kafka = with_properties
@@ -241,7 +243,7 @@ pub async fn handle_create_source(
     let row_id_index = row_id_index.map(|index| ProstColumnIndex { index: index as _ });
     let pk_column_ids = pk_column_ids.into_iter().map(Into::into).collect();
 
-    let session = context.session_ctx.clone();
+    let session = handler_args.session.clone();
 
     session.check_relation_name_duplicated(stmt.source_name.clone())?;
 
@@ -259,6 +261,7 @@ pub async fn handle_create_source(
     // TODO(Yuanxin): This should be removed after unifying table and materialized source.
     if is_materialized {
         let (graph, table) = {
+            let context = OptimizerContext::new_with_handler_args(handler_args);
             let (plan, table) =
                 gen_materialize_plan(context.into(), source.clone(), session.user_id())?;
             let graph = build_graph(plan);

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -34,10 +34,11 @@ use super::RwPgResponse;
 use crate::binder::{bind_data_type, bind_struct_field};
 use crate::catalog::column_catalog::ColumnCatalog;
 use crate::catalog::{check_valid_column_name, ColumnId};
+use crate::handler::HandlerArgs;
 use crate::optimizer::plan_node::LogicalSource;
 use crate::optimizer::property::{Order, RequiredDist};
-use crate::optimizer::{PlanRef, PlanRoot};
-use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+use crate::optimizer::{OptimizerContext, OptimizerContextRef, PlanRef, PlanRoot};
+use crate::session::SessionImpl;
 use crate::stream_fragmenter::build_graph;
 
 /// Binds the column schemas declared in CREATE statement into `ColumnDesc`.
@@ -269,13 +270,13 @@ pub(crate) fn gen_materialize_plan(
 }
 
 pub async fn handle_create_table(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     table_name: ObjectName,
     columns: Vec<ColumnDef>,
     constraints: Vec<TableConstraint>,
     if_not_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx.clone();
+    let session = handler_args.session.clone();
 
     if let Err(e) = session.check_relation_name_duplicated(table_name.clone()) {
         if if_not_exists {
@@ -289,6 +290,7 @@ pub async fn handle_create_table(
     }
 
     let (graph, source, table) = {
+        let context = OptimizerContext::new_with_handler_args(handler_args);
         let (plan, source, table) = gen_create_table_plan(
             &session,
             context.into(),

--- a/src/frontend/src/handler/create_user.rs
+++ b/src/frontend/src/handler/create_user.rs
@@ -21,7 +21,7 @@ use risingwave_sqlparser::ast::{CreateUserStatement, UserOption, UserOptions};
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 use crate::user::user_authentication::encrypted_password;
 
 fn make_prost_user_info(
@@ -81,10 +81,10 @@ fn make_prost_user_info(
 }
 
 pub async fn handle_create_user(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: CreateUserStatement,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let user_info = {
         let user_name = Binder::resolve_user_name(stmt.user_name)?;
         let user_reader = session.env().user_info_reader().read_guard();

--- a/src/frontend/src/handler/describe.rs
+++ b/src/frontend/src/handler/describe.rs
@@ -28,10 +28,10 @@ use super::RwPgResponse;
 use crate::binder::{Binder, Relation};
 use crate::catalog::{CatalogError, IndexCatalog};
 use crate::handler::util::col_descs_to_rows;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
-pub fn handle_describe(context: OptimizerContext, table_name: ObjectName) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+pub fn handle_describe(handler_args: HandlerArgs, table_name: ObjectName) -> Result<RwPgResponse> {
+    let session = handler_args.session;
     let mut binder = Binder::new(&session);
     let relation = binder.bind_relation_by_name(table_name.clone(), None)?;
     // For Source, it doesn't have table catalog so use get source to get column descs.

--- a/src/frontend/src/handler/drop_database.rs
+++ b/src/frontend/src/handler/drop_database.rs
@@ -18,15 +18,15 @@ use risingwave_sqlparser::ast::{DropMode, ObjectName};
 
 use super::RwPgResponse;
 use crate::binder::Binder;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_database(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     database_name: ObjectName,
     if_exists: bool,
     mode: Option<DropMode>,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let catalog_reader = session.env().catalog_reader();
     let database_name = Binder::resolve_database_name(database_name)?;
     if session.database() == database_name {

--- a/src/frontend/src/handler/drop_index.rs
+++ b/src/frontend/src/handler/drop_index.rs
@@ -23,14 +23,14 @@ use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableKind;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_index(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     index_name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, index_name) = Binder::resolve_schema_qualified_name(db_name, index_name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/drop_mv.rs
+++ b/src/frontend/src/handler/drop_mv.rs
@@ -25,14 +25,14 @@ use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableKind;
 use crate::catalog::CatalogError;
 use crate::handler::drop_table::check_source;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_mv(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     table_name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, table_name) = Binder::resolve_schema_qualified_name(db_name, table_name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/drop_schema.rs
+++ b/src/frontend/src/handler/drop_schema.rs
@@ -21,15 +21,15 @@ use risingwave_sqlparser::ast::{DropMode, ObjectName};
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_schema(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     schema_name: ObjectName,
     if_exist: bool,
     mode: Option<DropMode>,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let catalog_reader = session.env().catalog_reader();
     let schema_name = Binder::resolve_schema_name(schema_name)?;
 

--- a/src/frontend/src/handler/drop_sink.rs
+++ b/src/frontend/src/handler/drop_sink.rs
@@ -21,14 +21,14 @@ use super::privilege::check_super_user;
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_sink(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     sink_name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, sink_name) = Binder::resolve_schema_qualified_name(db_name, sink_name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/drop_source.rs
+++ b/src/frontend/src/handler/drop_source.rs
@@ -22,14 +22,14 @@ use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceKind;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_source(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, source_name) = Binder::resolve_schema_qualified_name(db_name, name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/drop_table.rs
+++ b/src/frontend/src/handler/drop_table.rs
@@ -24,7 +24,7 @@ use crate::catalog::catalog_service::CatalogReadGuard;
 use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::source_catalog::SourceKind;
 use crate::catalog::table_catalog::TableKind;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub fn check_source(
     reader: &CatalogReadGuard,
@@ -48,11 +48,11 @@ pub fn check_source(
 }
 
 pub async fn handle_drop_table(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     table_name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, table_name) = Binder::resolve_schema_qualified_name(db_name, table_name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -19,15 +19,15 @@ use risingwave_sqlparser::ast::{DropMode, ObjectName};
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::CatalogError;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_user(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     user_name: ObjectName,
     if_exists: bool,
     mode: Option<DropMode>,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     if mode.is_some() {
         return Err(ErrorCode::BindError("Drop user not support drop mode".to_string()).into());
     }

--- a/src/frontend/src/handler/drop_view.rs
+++ b/src/frontend/src/handler/drop_view.rs
@@ -21,14 +21,14 @@ use super::privilege::check_super_user;
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
 pub async fn handle_drop_view(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     table_name: ObjectName,
     if_exists: bool,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let db_name = session.database();
     let (schema_name, table_name) = Binder::resolve_schema_qualified_name(db_name, table_name)?;
     let search_path = session.config().get_search_path();

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -27,18 +27,21 @@ use super::create_sink::gen_sink_plan;
 use super::create_table::gen_create_table_plan;
 use super::query::gen_batch_query_plan;
 use super::RwPgResponse;
+use crate::handler::HandlerArgs;
 use crate::optimizer::plan_node::Convention;
+use crate::optimizer::OptimizerContext;
 use crate::scheduler::BatchPlanFragmenter;
-use crate::session::OptimizerContext;
 use crate::stream_fragmenter::build_graph;
 use crate::utils::explain_stream_graph;
 
 pub(super) fn handle_explain(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: Statement,
     options: ExplainOptions,
     analyze: bool,
 ) -> Result<RwPgResponse> {
+    let context = OptimizerContext::new_with_handler_args(handler_args);
+
     if analyze {
         return Err(ErrorCode::NotImplemented("explain analyze".to_string(), 4856.into()).into());
     }

--- a/src/frontend/src/handler/flush.rs
+++ b/src/frontend/src/handler/flush.rs
@@ -16,15 +16,15 @@ use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::Result;
 
 use super::RwPgResponse;
-use crate::session::OptimizerContext;
+use crate::handler::HandlerArgs;
 
-pub(super) async fn handle_flush(context: OptimizerContext) -> Result<RwPgResponse> {
-    let client = context.session_ctx.env().meta_client();
+pub(super) async fn handle_flush(handler_args: HandlerArgs) -> Result<RwPgResponse> {
+    let client = handler_args.session.env().meta_client();
     // The returned epoch >= epoch for flush, but it is okay.
     let snapshot = client.flush(true).await?;
     // Update max epoch to ensure read-after-write correctness.
-    context
-        .session_ctx
+    handler_args
+        .session
         .env()
         .hummock_snapshot_manager()
         .update_epoch(snapshot);

--- a/src/frontend/src/handler/handle_privilege.rs
+++ b/src/frontend/src/handler/handle_privilege.rs
@@ -21,7 +21,8 @@ use risingwave_sqlparser::ast::{GrantObjects, Privileges, Statement};
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::root_catalog::SchemaPath;
-use crate::session::{OptimizerContext, SessionImpl};
+use crate::handler::HandlerArgs;
+use crate::session::SessionImpl;
 use crate::user::user_privilege::{
     available_privilege_actions, check_privilege_type, get_prost_action,
 };
@@ -127,10 +128,10 @@ fn make_prost_privilege(
 }
 
 pub async fn handle_grant_privilege(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: Statement,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let Statement::Grant {
         privileges,
         objects,
@@ -166,10 +167,10 @@ pub async fn handle_grant_privilege(
 }
 
 pub async fn handle_revoke_privilege(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: Statement,
 ) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+    let session = handler_args.session;
     let Statement::Revoke {
         privileges,
         objects,

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -27,7 +27,7 @@ use risingwave_sqlparser::ast::{DropStatement, ObjectType, Statement};
 
 use self::util::DataChunkToRowSetAdapter;
 use crate::scheduler::{DistributedQueryStream, LocalQueryStream};
-use crate::session::{OptimizerContext, SessionImpl};
+use crate::session::SessionImpl;
 use crate::utils::WithOptions;
 
 pub mod alter_user;
@@ -86,28 +86,35 @@ impl From<Vec<Row>> for PgResponseStream {
     }
 }
 
+#[derive(Clone)]
+pub struct HandlerArgs {
+    pub session: Arc<SessionImpl>,
+    pub sql: Arc<str>,
+    pub with_options: WithOptions,
+}
+
 pub async fn handle(
     session: Arc<SessionImpl>,
     stmt: Statement,
     sql: &str,
     format: bool,
 ) -> Result<RwPgResponse> {
-    let context = OptimizerContext::new(
-        session.clone(),
-        Arc::from(sql),
-        WithOptions::try_from(&stmt)?,
-    );
+    let handler_args = HandlerArgs {
+        session,
+        sql: Arc::from(sql),
+        with_options: WithOptions::try_from(&stmt)?,
+    };
     match stmt {
         Statement::Explain {
             statement,
             analyze,
             options,
-        } => explain::handle_explain(context, *statement, options, analyze),
+        } => explain::handle_explain(handler_args, *statement, options, analyze),
         Statement::CreateSource {
             is_materialized,
             stmt,
-        } => create_source::handle_create_source(context, is_materialized, stmt).await,
-        Statement::CreateSink { stmt } => create_sink::handle_create_sink(context, stmt).await,
+        } => create_source::handle_create_source(handler_args, is_materialized, stmt).await,
+        Statement::CreateSink { stmt } => create_sink::handle_create_sink(handler_args, stmt).await,
         Statement::CreateTable {
             name,
             columns,
@@ -137,23 +144,33 @@ pub async fn handle(
             if query.is_some() {
                 return Err(ErrorCode::NotImplemented("CREATE AS".to_string(), 6215.into()).into());
             }
-            create_table::handle_create_table(context, name, columns, constraints, if_not_exists)
-                .await
+            create_table::handle_create_table(
+                handler_args,
+                name,
+                columns,
+                constraints,
+                if_not_exists,
+            )
+            .await
         }
         Statement::CreateDatabase {
             db_name,
             if_not_exists,
-        } => create_database::handle_create_database(context, db_name, if_not_exists).await,
+        } => create_database::handle_create_database(handler_args, db_name, if_not_exists).await,
         Statement::CreateSchema {
             schema_name,
             if_not_exists,
-        } => create_schema::handle_create_schema(context, schema_name, if_not_exists).await,
-        Statement::CreateUser(stmt) => create_user::handle_create_user(context, stmt).await,
-        Statement::AlterUser(stmt) => alter_user::handle_alter_user(context, stmt).await,
-        Statement::Grant { .. } => handle_privilege::handle_grant_privilege(context, stmt).await,
-        Statement::Revoke { .. } => handle_privilege::handle_revoke_privilege(context, stmt).await,
-        Statement::Describe { name } => describe::handle_describe(context, name),
-        Statement::ShowObjects(show_object) => show::handle_show_object(context, show_object),
+        } => create_schema::handle_create_schema(handler_args, schema_name, if_not_exists).await,
+        Statement::CreateUser(stmt) => create_user::handle_create_user(handler_args, stmt).await,
+        Statement::AlterUser(stmt) => alter_user::handle_alter_user(handler_args, stmt).await,
+        Statement::Grant { .. } => {
+            handle_privilege::handle_grant_privilege(handler_args, stmt).await
+        }
+        Statement::Revoke { .. } => {
+            handle_privilege::handle_revoke_privilege(handler_args, stmt).await
+        }
+        Statement::Describe { name } => describe::handle_describe(handler_args, name),
+        Statement::ShowObjects(show_object) => show::handle_show_object(handler_args, show_object),
         Statement::Drop(DropStatement {
             object_type,
             object_name,
@@ -161,21 +178,23 @@ pub async fn handle(
             drop_mode,
         }) => match object_type {
             ObjectType::Table => {
-                drop_table::handle_drop_table(context, object_name, if_exists).await
+                drop_table::handle_drop_table(handler_args, object_name, if_exists).await
             }
             ObjectType::MaterializedView => {
-                drop_mv::handle_drop_mv(context, object_name, if_exists).await
+                drop_mv::handle_drop_mv(handler_args, object_name, if_exists).await
             }
             ObjectType::Index => {
-                drop_index::handle_drop_index(context, object_name, if_exists).await
+                drop_index::handle_drop_index(handler_args, object_name, if_exists).await
             }
             ObjectType::Source => {
-                drop_source::handle_drop_source(context, object_name, if_exists).await
+                drop_source::handle_drop_source(handler_args, object_name, if_exists).await
             }
-            ObjectType::Sink => drop_sink::handle_drop_sink(context, object_name, if_exists).await,
+            ObjectType::Sink => {
+                drop_sink::handle_drop_sink(handler_args, object_name, if_exists).await
+            }
             ObjectType::Database => {
                 drop_database::handle_drop_database(
-                    context,
+                    handler_args,
                     object_name,
                     if_exists,
                     drop_mode.into(),
@@ -183,13 +202,21 @@ pub async fn handle(
                 .await
             }
             ObjectType::Schema => {
-                drop_schema::handle_drop_schema(context, object_name, if_exists, drop_mode.into())
-                    .await
+                drop_schema::handle_drop_schema(
+                    handler_args,
+                    object_name,
+                    if_exists,
+                    drop_mode.into(),
+                )
+                .await
             }
             ObjectType::User => {
-                drop_user::handle_drop_user(context, object_name, if_exists, drop_mode.into()).await
+                drop_user::handle_drop_user(handler_args, object_name, if_exists, drop_mode.into())
+                    .await
             }
-            ObjectType::View => drop_view::handle_drop_view(context, object_name, if_exists).await,
+            ObjectType::View => {
+                drop_view::handle_drop_view(handler_args, object_name, if_exists).await
+            }
             ObjectType::MaterializedSource => Err((ErrorCode::InvalidInputSyntax(
                 "Use `DROP SOURCE` to drop a materialized source.".to_owned(),
             ))
@@ -198,7 +225,7 @@ pub async fn handle(
         Statement::Query(_)
         | Statement::Insert { .. }
         | Statement::Delete { .. }
-        | Statement::Update { .. } => query::handle_query(context, stmt, format).await,
+        | Statement::Update { .. } => query::handle_query(handler_args, stmt, format).await,
         Statement::CreateView {
             materialized,
             name,
@@ -216,18 +243,18 @@ pub async fn handle(
                 .into());
             }
             if materialized {
-                create_mv::handle_create_mv(context, name, *query, columns).await
+                create_mv::handle_create_mv(handler_args, name, *query, columns).await
             } else {
-                create_view::handle_create_view(context, name, columns, *query).await
+                create_view::handle_create_view(handler_args, name, columns, *query).await
             }
         }
-        Statement::Flush => flush::handle_flush(context).await,
+        Statement::Flush => flush::handle_flush(handler_args).await,
         Statement::SetVariable {
             local: _,
             variable,
             value,
-        } => variable::handle_set(context, variable, value),
-        Statement::ShowVariable { variable } => variable::handle_show(context, variable),
+        } => variable::handle_set(handler_args, variable, value),
+        Statement::ShowVariable { variable } => variable::handle_show(handler_args, variable),
         Statement::CreateIndex {
             name,
             table_name,
@@ -244,7 +271,7 @@ pub async fn handle(
             }
 
             create_index::handle_create_index(
-                context,
+                handler_args,
                 if_not_exists,
                 name,
                 table_name,

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -29,13 +29,15 @@ use super::{PgResponseStream, RwPgResponse};
 use crate::binder::{Binder, BoundSetExpr, BoundStatement};
 use crate::handler::privilege::{check_privileges, resolve_privileges};
 use crate::handler::util::{to_pg_field, DataChunkToRowSetAdapter};
+use crate::handler::HandlerArgs;
+use crate::optimizer::{OptimizerContext, OptimizerContextRef};
 use crate::planner::Planner;
 use crate::scheduler::plan_fragmenter::Query;
 use crate::scheduler::{
     BatchPlanFragmenter, DistributedQueryStream, ExecutionContext, ExecutionContextRef,
     HummockSnapshotGuard, LocalQueryExecution, LocalQueryStream,
 };
-use crate::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+use crate::session::SessionImpl;
 use crate::PlanRef;
 
 pub fn gen_batch_query_plan(
@@ -88,16 +90,17 @@ pub fn gen_batch_query_plan(
 }
 
 pub async fn handle_query(
-    context: OptimizerContext,
+    handler_args: HandlerArgs,
     stmt: Statement,
     format: bool,
 ) -> Result<RwPgResponse> {
     let stmt_type = to_statement_type(&stmt)?;
-    let session = context.session_ctx.clone();
+    let session = handler_args.session.clone();
     let query_start_time = Instant::now();
 
     // Subblock to make sure PlanRef (an Rc) is dropped before `await` below.
     let (query, query_mode, output_schema) = {
+        let context = OptimizerContext::new_with_handler_args(handler_args);
         let (plan, query_mode, schema) = gen_batch_query_plan(&session, context.into(), stmt)?;
 
         tracing::trace!(

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -25,7 +25,8 @@ use super::RwPgResponse;
 use crate::binder::{Binder, Relation};
 use crate::catalog::CatalogError;
 use crate::handler::util::col_descs_to_rows;
-use crate::session::{OptimizerContext, SessionImpl};
+use crate::handler::HandlerArgs;
+use crate::session::SessionImpl;
 
 pub fn get_columns_from_table(
     session: &SessionImpl,
@@ -55,8 +56,8 @@ fn schema_or_default(schema: &Option<Ident>) -> String {
         .map_or_else(|| DEFAULT_SCHEMA_NAME.to_string(), |s| s.real_value())
 }
 
-pub fn handle_show_object(context: OptimizerContext, command: ShowObject) -> Result<RwPgResponse> {
-    let session = context.session_ctx;
+pub fn handle_show_object(handler_args: HandlerArgs, command: ShowObject) -> Result<RwPgResponse> {
+    let session = handler_args.session;
     let catalog_reader = session.env().catalog_reader().read_guard();
 
     let names = match command {

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -40,7 +40,7 @@ pub mod handler;
 pub use handler::PgResponseStream;
 mod observer;
 mod optimizer;
-pub use optimizer::PlanRef;
+pub use optimizer::{OptimizerContext, OptimizerContextRef, PlanRef};
 mod planner;
 pub use planner::Planner;
 #[expect(dead_code)]

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -23,10 +23,11 @@ mod plan_correlated_id_finder;
 mod plan_rewriter;
 mod plan_visitor;
 pub use plan_visitor::PlanVisitor;
+mod optimizer_context;
 mod rule;
-
 use fixedbitset::FixedBitSet;
 use itertools::Itertools as _;
+pub use optimizer_context::*;
 use property::Order;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result};
@@ -583,8 +584,8 @@ mod tests {
     use risingwave_common::types::DataType;
 
     use super::*;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     async fn test_as_subplan() {

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -1,0 +1,150 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use core::convert::{From, Into};
+use core::fmt::Formatter;
+use core::marker::Sync;
+use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
+use std::cell::RefCell;
+use std::sync::Arc;
+
+use crate::expr::CorrelatedId;
+use crate::handler::HandlerArgs;
+use crate::optimizer::plan_node::PlanNodeId;
+use crate::session::SessionImpl;
+use crate::WithOptions;
+
+pub struct OptimizerContext {
+    pub session_ctx: Arc<SessionImpl>,
+    // We use `AtomicI32` here because `Arc<T>` implements `Send` only when `T: Send + Sync`.
+    pub next_id: AtomicI32,
+    /// For debugging purposes, store the SQL string in Context
+    pub sql: Arc<str>,
+
+    /// it indicates whether the explain mode is verbose for explain statement
+    pub explain_verbose: AtomicBool,
+
+    /// it indicates whether the explain mode is trace for explain statement
+    pub explain_trace: AtomicBool,
+    /// Store the trace of optimizer
+    pub optimizer_trace: RefCell<Vec<String>>,
+    /// Store correlated id
+    pub next_correlated_id: AtomicU32,
+    /// Store options or properties from the `with` clause
+    pub with_options: WithOptions,
+}
+
+#[derive(Clone, Debug)]
+pub struct OptimizerContextRef {
+    inner: Arc<OptimizerContext>,
+}
+
+impl !Sync for OptimizerContextRef {}
+
+impl From<OptimizerContext> for OptimizerContextRef {
+    fn from(inner: OptimizerContext) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+}
+
+impl OptimizerContextRef {
+    pub fn inner(&self) -> &OptimizerContext {
+        &self.inner
+    }
+
+    pub fn next_plan_node_id(&self) -> PlanNodeId {
+        // It's safe to use `fetch_add` and `Relaxed` ordering since we have marked
+        // `QueryContextRef` not `Sync`.
+        let next_id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
+        PlanNodeId(next_id)
+    }
+
+    pub fn next_correlated_id(&self) -> CorrelatedId {
+        self.inner
+            .next_correlated_id
+            .fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn is_explain_verbose(&self) -> bool {
+        self.inner.explain_verbose.load(Ordering::Acquire)
+    }
+
+    pub fn is_explain_trace(&self) -> bool {
+        self.inner.explain_trace.load(Ordering::Acquire)
+    }
+
+    pub fn trace(&self, str: impl Into<String>) {
+        self.inner.optimizer_trace.borrow_mut().push(str.into());
+        self.inner
+            .optimizer_trace
+            .borrow_mut()
+            .push("\n".to_string());
+    }
+
+    pub fn take_trace(&self) -> Vec<String> {
+        self.inner.optimizer_trace.borrow_mut().drain(..).collect()
+    }
+}
+
+impl OptimizerContext {
+    pub fn new_with_handler_args(handler_args: HandlerArgs) -> Self {
+        Self::new(
+            handler_args.session,
+            handler_args.sql,
+            handler_args.with_options,
+        )
+    }
+
+    pub fn new(session_ctx: Arc<SessionImpl>, sql: Arc<str>, with_options: WithOptions) -> Self {
+        Self {
+            session_ctx,
+            next_id: AtomicI32::new(0),
+            sql,
+            explain_verbose: AtomicBool::new(false),
+            explain_trace: AtomicBool::new(false),
+            optimizer_trace: RefCell::new(vec![]),
+            next_correlated_id: AtomicU32::new(1),
+            with_options,
+        }
+    }
+
+    // TODO(TaoWu): Remove the async.
+    #[cfg(test)]
+    #[expect(clippy::unused_async)]
+    pub async fn mock() -> OptimizerContextRef {
+        Self {
+            session_ctx: Arc::new(SessionImpl::mock()),
+            next_id: AtomicI32::new(0),
+            sql: Arc::from(""),
+            explain_verbose: AtomicBool::new(false),
+            explain_trace: AtomicBool::new(false),
+            optimizer_trace: RefCell::new(vec![]),
+            next_correlated_id: AtomicU32::new(1),
+            with_options: Default::default(),
+        }
+        .into()
+    }
+}
+
+impl std::fmt::Debug for OptimizerContext {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "QueryContext {{ current id = {} }}",
+            self.next_id.load(Ordering::Relaxed)
+        )
+    }
+}

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -27,8 +27,8 @@ use risingwave_pb::stream_plan::{agg_call_state, AggCallState as AggCallStatePro
 use super::super::utils::TableCatalogBuilder;
 use super::{stream, GenericPlanNode, GenericPlanRef};
 use crate::expr::{Expr, ExprRewriter, InputRef, InputRefDisplay};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::Direction;
-use crate::session::OptimizerContextRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::utils::{ColIndexMapping, Condition, ConditionDisplay, IndexRewriter};
 use crate::TableCatalog;

--- a/src/frontend/src/optimizer/plan_node/generic/expand.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/expand.rs
@@ -17,7 +17,7 @@ use risingwave_common::catalog::{Field, FieldDisplay, Schema};
 use risingwave_common::types::DataType;
 
 use super::{GenericPlanNode, GenericPlanRef};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 
 /// [`Expand`] expand one row multiple times according to `column_subsets` and also keep
 /// original columns of input. It can be used to implement distinct aggregation and group set.

--- a/src/frontend/src/optimizer/plan_node/generic/filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/filter.rs
@@ -15,7 +15,7 @@
 use risingwave_common::catalog::Schema;
 
 use super::{GenericPlanNode, GenericPlanRef};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::utils::Condition;
 
 /// [`Filter`] iterates over its input and returns elements for which `predicate` evaluates to

--- a/src/frontend/src/optimizer/plan_node/generic/hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/hop_window.rs
@@ -21,7 +21,7 @@ use risingwave_common::types::{DataType, IntervalUnit};
 use super::super::utils::IndicesDisplay;
 use super::{GenericPlanNode, GenericPlanRef};
 use crate::expr::{InputRef, InputRefDisplay};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 
 /// [`HopWindow`] implements Hop Table Function.
 #[derive(Debug, Clone)]

--- a/src/frontend/src/optimizer/plan_node/generic/join.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/join.rs
@@ -16,7 +16,7 @@ use risingwave_common::catalog::Schema;
 use risingwave_pb::plan_common::JoinType;
 
 use super::{EqJoinPredicate, GenericPlanNode, GenericPlanRef};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::utils::{ColIndexMapping, Condition};
 
 /// [`Join`] combines two relations according to some condition.

--- a/src/frontend/src/optimizer/plan_node/generic/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/mod.rs
@@ -15,7 +15,7 @@
 use risingwave_common::catalog::Schema;
 
 use super::{stream, EqJoinPredicate};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 
 pub mod dynamic_filter;
 pub use dynamic_filter::*;

--- a/src/frontend/src/optimizer/plan_node/generic/project.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/project.rs
@@ -21,7 +21,7 @@ use risingwave_common::catalog::{Field, Schema};
 
 use super::{GenericPlanNode, GenericPlanRef};
 use crate::expr::{assert_input_ref, Expr, ExprDisplay, ExprImpl, InputRef};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::utils::ColIndexMapping;
 
 fn check_expr_type(expr: &ExprImpl) -> std::result::Result<(), &'static str> {

--- a/src/frontend/src/optimizer/plan_node/generic/project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/project_set.rs
@@ -17,7 +17,7 @@ use risingwave_common::types::DataType;
 
 use super::{GenericPlanNode, GenericPlanRef};
 use crate::expr::{Expr, ExprDisplay, ExprImpl};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::utils::ColIndexMapping;
 
 /// [`ProjectSet`] projects one row multiple times according to `select_list`.

--- a/src/frontend/src/optimizer/plan_node/generic/scan.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/scan.rs
@@ -19,7 +19,7 @@ use risingwave_common::catalog::{ColumnDesc, Field, Schema, TableDesc};
 
 use super::GenericPlanNode;
 use crate::catalog::{ColumnId, IndexCatalog};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::utils::Condition;
 
 /// [`Scan`] returns contents of a table or other equivalent object

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -22,7 +22,7 @@ use risingwave_common::util::sort_util::OrderType;
 use super::super::utils::TableCatalogBuilder;
 use super::{GenericPlanNode, GenericPlanRef};
 use crate::catalog::source_catalog::SourceCatalog;
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::TableCatalog;
 
 /// [`Source`] returns contents of a table or other equivalent object

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -19,8 +19,8 @@ use risingwave_common::util::sort_util::OrderType;
 
 use super::super::utils::TableCatalogBuilder;
 use super::{stream, GenericPlanNode, GenericPlanRef};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::Order;
-use crate::session::OptimizerContextRef;
 use crate::TableCatalog;
 /// `TopN` sorts the input data and fetches up to `limit` rows from `offset`
 #[derive(Debug, Clone)]

--- a/src/frontend/src/optimizer/plan_node/generic/union.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/union.rs
@@ -15,7 +15,7 @@
 use risingwave_common::catalog::Schema;
 
 use super::{GenericPlanNode, GenericPlanRef};
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 
 /// `Union` returns the union of the rows of its inputs.
 /// If `all` is false, it needs to eliminate duplicates.

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -942,8 +942,8 @@ mod tests {
     use crate::expr::{
         assert_eq_input_ref, input_ref_to_column_indices, AggCall, ExprType, FunctionCall, OrderBy,
     };
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     async fn test_create() {

--- a/src/frontend/src/optimizer/plan_node/logical_expand.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_expand.rs
@@ -193,8 +193,8 @@ mod tests {
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
 
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::{LogicalExpand, LogicalValues};
-    use crate::session::OptimizerContext;
 
     // TODO(Wenzhuo): change this test according to expand's new definition.
     #[tokio::test]

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -210,9 +210,9 @@ mod tests {
 
     use super::*;
     use crate::expr::{assert_eq_input_ref, FunctionCall, InputRef, Literal};
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
     use crate::optimizer::property::FunctionalDependency;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     /// Pruning

--- a/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_hop_window.rs
@@ -376,9 +376,9 @@ mod test {
 
     use super::*;
     use crate::expr::InputRef;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
     use crate::optimizer::property::FunctionalDependency;
-    use crate::session::OptimizerContext;
     #[tokio::test]
     /// Pruning
     /// ```text

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1212,9 +1212,9 @@ mod tests {
 
     use super::*;
     use crate::expr::{assert_eq_input_ref, FunctionCall, InputRef, Literal};
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::{LogicalValues, PlanTreeNodeUnary};
     use crate::optimizer::property::FunctionalDependency;
-    use crate::session::OptimizerContext;
 
     /// Pruning
     /// ```text

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -536,9 +536,9 @@ mod test {
 
     use super::*;
     use crate::expr::{FunctionCall, InputRef};
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
     use crate::optimizer::property::FunctionalDependency;
-    use crate::session::OptimizerContext;
     #[tokio::test]
     async fn fd_derivation_multi_join() {
         // t1: [v0, v1], t2: [v2, v3, v4], t3: [v5, v6]

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -323,8 +323,8 @@ mod tests {
 
     use super::*;
     use crate::expr::{assert_eq_input_ref, FunctionCall, InputRef, Literal};
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     /// Pruning

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -319,9 +319,9 @@ mod test {
 
     use super::*;
     use crate::expr::{ExprImpl, InputRef, TableFunction};
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::LogicalValues;
     use crate::optimizer::property::FunctionalDependency;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     async fn fd_derivation_project_set() {

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -29,11 +29,11 @@ use super::{
 };
 use crate::catalog::{ColumnId, IndexCatalog};
 use crate::expr::{CollectInputRef, Expr, ExprImpl, ExprRewriter, InputRef};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::{BatchSeqScan, LogicalFilter, LogicalProject, LogicalValues};
 use crate::optimizer::property::Direction::Asc;
 use crate::optimizer::property::{FieldOrder, FunctionalDependencySet, Order};
 use crate::optimizer::rule::IndexSelectionRule;
-use crate::session::OptimizerContextRef;
 use crate::utils::{ColIndexMapping, Condition, ConditionDisplay};
 
 /// `LogicalScan` returns contents of a table or other equivalent object

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -23,8 +23,8 @@ use super::{
     StreamSource, ToBatch, ToStream,
 };
 use crate::catalog::source_catalog::SourceCatalog;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::FunctionalDependencySet;
-use crate::session::OptimizerContextRef;
 use crate::utils::{ColIndexMapping, Condition};
 use crate::TableCatalog;
 

--- a/src/frontend/src/optimizer/plan_node/logical_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_table_function.rs
@@ -19,9 +19,9 @@ use risingwave_common::error::{ErrorCode, Result};
 
 use super::{ColPrunable, LogicalFilter, PlanBase, PlanRef, PredicatePushdown, ToBatch, ToStream};
 use crate::expr::{Expr, TableFunction};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::BatchTableFunction;
 use crate::optimizer::property::FunctionalDependencySet;
-use crate::session::OptimizerContextRef;
 use crate::utils::Condition;
 
 /// `LogicalGenerateSeries` implements Hop Table Function.

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -407,9 +407,9 @@ mod tests {
     use risingwave_common::types::DataType;
 
     use super::LogicalTopN;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::{ColPrunable, LogicalValues};
     use crate::optimizer::property::Order;
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     async fn test_prune_col() {

--- a/src/frontend/src/optimizer/plan_node/logical_union.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_union.rs
@@ -295,8 +295,8 @@ mod tests {
     use risingwave_common::types::DataType;
 
     use super::*;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::optimizer::plan_node::{LogicalValues, PlanTreeNodeUnary};
-    use crate::session::OptimizerContext;
 
     #[tokio::test]
     async fn test_prune_union() {

--- a/src/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_values.rs
@@ -23,8 +23,8 @@ use super::{
     ToStream,
 };
 use crate::expr::{Expr, ExprImpl};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::FunctionalDependencySet;
-use crate::session::OptimizerContextRef;
 use crate::utils::Condition;
 
 /// `LogicalValues` builds rows according to a list of expressions
@@ -124,7 +124,7 @@ mod tests {
 
     use super::*;
     use crate::expr::Literal;
-    use crate::session::OptimizerContext;
+    use crate::optimizer::optimizer_context::OptimizerContext;
 
     fn literal(val: i32) -> ExprImpl {
         Literal::new(Datum::Some(val.into()), DataType::Int32).into()

--- a/src/frontend/src/optimizer/plan_node/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/mod.rs
@@ -398,7 +398,7 @@ pub use stream_table_scan::StreamTableScan;
 pub use stream_topn::StreamTopN;
 pub use stream_union::StreamUnion;
 
-use crate::session::OptimizerContextRef;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
 /// `for_all_plan_nodes` includes all plan nodes. If you added a new plan node

--- a/src/frontend/src/optimizer/plan_node/plan_base.rs
+++ b/src/frontend/src/optimizer/plan_node/plan_base.rs
@@ -17,8 +17,8 @@ use risingwave_common::catalog::Schema;
 
 use super::*;
 use crate::for_all_plan_nodes;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::{Distribution, FunctionalDependencySet, Order};
-use crate::session::OptimizerContextRef;
 
 /// the common fields of all nodes, please make a field named `base` in
 /// every planNode and correctly valued it when construct the planNode.

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -25,9 +25,9 @@ use super::generic::{GenericPlanNode, GenericPlanRef};
 use super::utils::TableCatalogBuilder;
 use super::{generic, EqJoinPredicate, PlanNodeId};
 use crate::expr::{Expr, ExprImpl};
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::plan_tree_node_v2::PlanTreeNodeV2;
 use crate::optimizer::property::{Distribution, FieldOrder};
-use crate::session::OptimizerContextRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::TableCatalog;
 

--- a/src/frontend/src/optimizer/plan_node/stream_derive.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_derive.rs
@@ -16,8 +16,8 @@ use risingwave_common::catalog::Schema;
 
 use super::generic::GenericPlanNode;
 use super::stream::*;
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::property::Distribution;
-use crate::session::OptimizerContextRef;
 
 impl GenericPlanNode for DynamicFilter {
     fn schema(&self) -> Schema {

--- a/src/frontend/src/optimizer/rule/index_selection.rs
+++ b/src/frontend/src/optimizer/rule/index_selection.rs
@@ -64,11 +64,11 @@ use crate::expr::{
     to_conjunctions, to_disjunctions, Expr, ExprImpl, ExprRewriter, ExprType, ExprVisitor,
     FunctionCall, InputRef,
 };
+use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::{
     LogicalJoin, LogicalScan, LogicalUnion, PlanTreeNode, PlanTreeNodeBinary, PredicatePushdown,
 };
 use crate::optimizer::PlanRef;
-use crate::session::OptimizerContextRef;
 use crate::utils::Condition;
 
 const INDEX_MAX_LEN: usize = 5;

--- a/src/frontend/src/optimizer/rule/merge_multijoin.rs
+++ b/src/frontend/src/optimizer/rule/merge_multijoin.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use super::*;
     use crate::expr::{ExprImpl, FunctionCall, InputRef};
-    use crate::session::OptimizerContext;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::utils::Condition;
 
     #[tokio::test]

--- a/src/frontend/src/optimizer/rule/reorder_multijoin.rs
+++ b/src/frontend/src/optimizer/rule/reorder_multijoin.rs
@@ -45,7 +45,7 @@ mod tests {
 
     use super::*;
     use crate::expr::{ExprImpl, FunctionCall, InputRef};
-    use crate::session::OptimizerContext;
+    use crate::optimizer::optimizer_context::OptimizerContext;
     use crate::utils::Condition;
 
     #[tokio::test]

--- a/src/frontend/src/planner/mod.rs
+++ b/src/frontend/src/planner/mod.rs
@@ -15,8 +15,7 @@
 use risingwave_common::error::Result;
 
 use crate::binder::BoundStatement;
-use crate::optimizer::PlanRoot;
-use crate::session::OptimizerContextRef;
+use crate::optimizer::{OptimizerContextRef, PlanRoot};
 
 mod delete;
 mod insert;

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -394,12 +394,12 @@ pub(crate) mod tests {
         LogicalScan, ToBatch,
     };
     use crate::optimizer::property::{Distribution, Order};
-    use crate::optimizer::PlanRef;
+    use crate::optimizer::{OptimizerContext, PlanRef};
     use crate::scheduler::distributed::QueryExecution;
     use crate::scheduler::plan_fragmenter::{BatchPlanFragmenter, Query};
     use crate::scheduler::worker_node_manager::WorkerNodeManager;
     use crate::scheduler::{ExecutionContext, HummockSnapshotManager, QueryExecutionInfo};
-    use crate::session::{OptimizerContext, SessionImpl};
+    use crate::session::SessionImpl;
     use crate::test_utils::MockFrontendMetaClient;
     use crate::utils::Condition;
 

--- a/src/tests/sqlsmith/tests/frontend/mod.rs
+++ b/src/tests/sqlsmith/tests/frontend/mod.rs
@@ -19,9 +19,11 @@ use itertools::Itertools;
 use libtest_mimic::{Arguments, Failed, Trial};
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
-use risingwave_frontend::session::{OptimizerContext, OptimizerContextRef, SessionImpl};
+use risingwave_frontend::session::SessionImpl;
 use risingwave_frontend::test_utils::LocalFrontend;
-use risingwave_frontend::{handler, Binder, FrontendOpts, Planner, WithOptions};
+use risingwave_frontend::{
+    handler, Binder, FrontendOpts, OptimizerContext, OptimizerContextRef, Planner, WithOptions,
+};
 use risingwave_sqlparser::ast::Statement;
 use risingwave_sqlsmith::{
     create_table_statement_to_table, is_permissible_error, mview_sql_gen, parse_sql, sql_gen, Table,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Move `OptimizerContext` from `session` to `optimizer`.
- Use a new struct `HandlerArgs` instead of `OptimizerContext` for each frontend handler.
- Frontend handlers create `OptimizerContext` if they need, but `OptimizerContext` shouldn't be used across await points.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/6770