### PR TITLE
feat(test): support load/dump for etcd simulator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3152,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b32d93334a4030dad86dde50018e57ccd9e4c0f64a23e2a7be240e9d7d958c"
+checksum = "a5b15031e1ca7bb25f51c6ddb36f9ec8e10aa184e21987c49118e18a1141f7a8"
 dependencies = [
  "ahash",
  "async-channel",
@@ -3179,15 +3179,19 @@ dependencies = [
 
 [[package]]
 name = "madsim-etcd-client"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6c5383c2297a0a3306fbcc0475a6ab1decb5b49c3cd20adae6fd8d149dbde0"
+checksum = "f83388bf9b75da759e6ebc7470e8ab4911314504eb75e16946de66f56a5608ea"
 dependencies = [
  "etcd-client",
  "futures-util",
  "http",
  "madsim",
+ "serde",
+ "serde_with",
  "spin 0.9.4",
+ "thiserror",
+ "toml",
  "tonic",
  "tracing",
 ]

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -8,11 +8,11 @@ edition = "2021"
 anyhow = "1.0"
 async-trait = "0.1"
 clap = "3"
-etcd-client = { version = "0.2.8", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2.11", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"
-madsim = "0.2.10"
+madsim = "0.2.11"
 paste = "1"
 rand = "0.8"
 rdkafka = { package = "madsim-rdkafka", version = "=0.2.8-alpha", features = ["cmake-build"] }

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -14,6 +14,7 @@
 
 use std::future::Future;
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::LazyLock;
 use std::time::Duration;
 
@@ -58,6 +59,9 @@ pub struct Configuration {
 
     /// The probability of etcd request timeout.
     pub etcd_timeout_rate: f32,
+
+    /// Path to etcd data file.
+    pub etcd_data_path: Option<PathBuf>,
 }
 
 impl Configuration {
@@ -70,6 +74,7 @@ impl Configuration {
             compactor_nodes: 2,
             compute_node_cores: 2,
             etcd_timeout_rate: 0.0,
+            etcd_data_path: None,
         }
     }
 }
@@ -107,17 +112,22 @@ impl Cluster {
         println!("{:#?}", conf);
 
         // etcd node
+        let etcd_data = conf
+            .etcd_data_path
+            .as_ref()
+            .map(|path| std::fs::read_to_string(path).unwrap());
         handle
             .create_node()
             .name("etcd")
             .ip("192.168.10.1".parse().unwrap())
-            .init(move || async move {
+            .init(move || {
                 let addr = "0.0.0.0:2388".parse().unwrap();
-                etcd_client::SimServer::builder()
-                    .timeout_rate(conf.etcd_timeout_rate)
-                    .serve(addr)
-                    .await
-                    .unwrap();
+                let mut builder =
+                    etcd_client::SimServer::builder().timeout_rate(conf.etcd_timeout_rate);
+                if let Some(data) = &etcd_data {
+                    builder = builder.load(data.clone());
+                }
+                builder.serve(addr)
             })
             .build();
 

--- a/src/tests/simulation/src/main.rs
+++ b/src/tests/simulation/src/main.rs
@@ -107,11 +107,11 @@ pub struct Args {
     #[clap(long)]
     sqlsmith: Option<usize>,
 
-    /// Load etcd data from json file.
+    /// Load etcd data from toml file.
     #[clap(long)]
     etcd_data: Option<PathBuf>,
 
-    /// Dump etcd data into json file before exit.
+    /// Dump etcd data into toml file before exit.
     #[clap(long)]
     etcd_dump: Option<PathBuf>,
 }

--- a/src/tests/simulation/src/main.rs
+++ b/src/tests/simulation/src/main.rs
@@ -15,6 +15,8 @@
 #![cfg_attr(not(madsim), allow(dead_code))]
 #![feature(once_cell)]
 
+use std::path::PathBuf;
+
 use clap::Parser;
 
 #[cfg(not(madsim))]
@@ -104,6 +106,14 @@ pub struct Args {
     /// test data.
     #[clap(long)]
     sqlsmith: Option<usize>,
+
+    /// Load etcd data from json file.
+    #[clap(long)]
+    etcd_data: Option<PathBuf>,
+
+    /// Dump etcd data into json file before exit.
+    #[clap(long)]
+    etcd_dump: Option<PathBuf>,
 }
 
 #[cfg(madsim)]
@@ -123,6 +133,7 @@ async fn main() {
         compactor_nodes: args.compactor_nodes,
         compute_node_cores: args.compute_node_cores,
         etcd_timeout_rate: args.etcd_timeout_rate,
+        etcd_data_path: args.etcd_data,
     };
     let kill_opts = KillOpts {
         kill_meta: args.kill_meta || args.kill,
@@ -164,4 +175,16 @@ async fn main() {
             }
         })
         .await;
+
+    if let Some(path) = args.etcd_dump {
+        cluster
+            .run_on_client(async move {
+                let mut client = etcd_client::Client::connect(["192.168.10.1:2388"], None)
+                    .await
+                    .unwrap();
+                let dump = client.dump().await.unwrap();
+                std::fs::write(path, dump).unwrap();
+            })
+            .await;
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR adds support for loading and dumping etcd data in deterministic test.

You can use this feature with the following command:
```sh
# dump etcd data after a run
./risedev sslt -- --etcd-dump etcd.toml './e2e_test/streaming/*.slt'
# load etcd data before a run
./risedev sslt -- --etcd-data etcd.toml './e2e_test/streaming/*.slt'
```

The dumped data is in toml format, where keys and values are encoded in [Rust ascii escape format](https://doc.rust-lang.org/std/ascii/fn.escape_default.html#) to make it human-readable and editable:

```toml
# etcd.toml
revision = 515

[kv]
"cf/catalog_database/" = "\\x12\\x03dev\\x18\\x01"
"cf/catalog_schema/" = "\\x1a\\x06public \\x01"
"cf/catalog_schema/\\x08\\x01" = "\\x08\\x01\\x1a\\npg_catalog \\x01"
"cf/catalog_schema/\\x08\\x02" = "\\x08\\x02\\x1a\\x12information_schema \\x01"
# ...

[lease]

```

With this, you can get an overview of what is stored in the meta service.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/madsim-rs/madsim/pull/93
https://github.com/madsim-rs/madsim/pull/94