### PR TITLE
fix(ci): set config path for compaction test

### DIFF
--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -100,7 +100,9 @@ if [[ "$RUN_COMPACTION" -eq "1" ]]; then
     buildkite-agent artifact download compaction-test-"$profile" target/debug/
     mv target/debug/compaction-test-"$profile" target/debug/compaction-test
     chmod +x ./target/debug/compaction-test
-    ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001
+    # Use the config of ci-compaction-test for replay.
+    config_path=".risingwave/config/risingwave.toml"
+    ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 --config-path "${config_path}"
 
     echo "--- Kill cluster"
     cargo make ci-kill

--- a/src/tests/compaction_test/src/runner.rs
+++ b/src/tests/compaction_test/src/runner.rs
@@ -131,6 +131,11 @@ async fn start_meta_node(listen_addr: String, config_path: String) {
         "--config-path",
         &config_path,
     ]);
+    let config = load_config(&opts.config_path);
+    assert!(
+        config.meta.enable_compaction_deterministic,
+        "enable_compaction_deterministic should be set"
+    );
     risingwave_meta::start(opts).await
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
After recent refactor, `enable_compaction_deterministic` is no longer a cli options. 
This fix set it via config file for ci compaction test.


## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
