### PR TITLE
feat(frontend): use function name as alias in select item 

### DIFF
--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -192,6 +192,9 @@ impl Binder {
                             self.bind_single_field_column(*field_expr.clone(), idents)?,
                             idents.last().map(|ident| ident.real_value()),
                         ),
+                        Expr::Function(func) => {
+                            (self.bind_expr(expr)?, Some(func.name.to_string()))
+                        }
                         _ => (self.bind_expr(expr)?, None),
                     };
                     select_list.push(select_expr);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

when use function, Postgres will use function name as column name
```
test_db=> select sum(id) from t;
 sum
-----

(1 row)

test_db=> select avg(id) from t;
 avg
-----

(1 row)
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
