### PR TITLE
feat(sqlsmith): investigate performance

### DIFF
--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -19,12 +19,15 @@ This test will be run as a unit test:
 
 In the second mode, it will test the entire query handling end-to-end. We provide a CLI tool that represents a Postgres client. You can run this tool via:
 
+Run sqlsmith:
 ```sh
-cargo build # Ensure CLI tool is up to date
-./risedev d # Start cluster
-# Run sqlsmith
+cargo build
+./risedev d
 ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
-# Or run sqlsmith with logs
+```
+
+Run sqlsmith with logs enabled:
+```sh
 RUST_LOG=info ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 ```
 

--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -22,7 +22,10 @@ In the second mode, it will test the entire query handling end-to-end. We provid
 ```sh
 cargo build # Ensure CLI tool is up to date
 ./risedev d # Start cluster
+# Run sqlsmith
 ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
+# Or run sqlsmith with logs
+RUST_LOG=info ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 ```
 
 Additionally, in some cases where you may want to debug whether we have defined some function/operator incorrectly,

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -25,32 +25,12 @@ pub async fn run(client: &tokio_postgres::Client, testdata: &str, count: usize) 
     let mut rng = rand::rngs::SmallRng::from_entropy();
     let (tables, mviews, setup_sql) = create_tables(&mut rng, testdata, client).await;
 
-    // Test sqlsmith first
     test_sqlsmith(client, &mut rng, tables.clone(), &setup_sql).await;
     tracing::info!("Passed sqlsmith tests");
-
-    // Test batch
-    // Queries we generate are complex, can cause overflow in
-    // local execution mode.
-    client
-        .query("SET query_mode TO distributed;", &[])
-        .await
-        .unwrap();
-    for _ in 0..count {
-        let sql = sql_gen(&mut rng, tables.clone());
-        tracing::info!("Executing: {}", sql);
-        let response = client.query(sql.as_str(), &[]).await;
-        validate_response(&setup_sql, &format!("{};", sql), response);
-    }
-
-    // Test stream
-    for _ in 0..count {
-        let (sql, table) = mview_sql_gen(&mut rng, tables.clone(), "stream_query");
-        tracing::info!("Executing: {}", sql);
-        let response = client.execute(&sql, &[]).await;
-        validate_response(&setup_sql, &format!("{};", sql), response);
-        drop_mview_table(&table, client).await;
-    }
+    test_batch_queries(client, &mut rng, tables.clone(), &setup_sql, count).await;
+    tracing::info!("Passed batch queries");
+    test_stream_queries(client, &mut rng, tables.clone(), &setup_sql, count).await;
+    tracing::info!("Passed stream queries");
 
     drop_tables(&mviews, testdata, client).await;
 }
@@ -64,45 +44,68 @@ pub async fn test_sqlsmith<R: Rng>(
 ) {
     // Test percentage of skipped queries <=5% of sample size.
     let threshold = 0.20; // permit at most 20% of queries to be skipped.
-    let mut batch_skipped = 0;
-    let batch_sample_size = 50;
+    let sample_size = 50;
+
+    let skipped_percentage =
+        test_batch_queries(client, rng, tables.clone(), setup_sql, sample_size).await;
+    if skipped_percentage > threshold {
+        panic!(
+            "percentage of skipped batch queries = {}, threshold: {}",
+            skipped_percentage, threshold
+        );
+    }
+
+    let skipped_percentage =
+        test_stream_queries(client, rng, tables.clone(), setup_sql, sample_size).await;
+    if skipped_percentage > threshold {
+        panic!(
+            "percentage of skipped stream queries = {}, threshold: {}",
+            skipped_percentage, threshold
+        );
+    }
+}
+
+/// Test batch queries, returns skipped query statistics
+/// Runs in distributed mode, since queries can be complex and cause overflow in local execution
+/// mode.
+async fn test_batch_queries<R: Rng>(
+    client: &tokio_postgres::Client,
+    rng: &mut R,
+    tables: Vec<Table>,
+    setup_sql: &str,
+    sample_size: usize,
+) -> f64 {
     client
         .query("SET query_mode TO distributed;", &[])
         .await
         .unwrap();
-    for _ in 0..batch_sample_size {
+    let mut skipped = 0;
+    for _ in 0..sample_size {
         let sql = sql_gen(rng, tables.clone());
         tracing::info!("Executing: {}", sql);
         let response = client.query(sql.as_str(), &[]).await;
-        batch_skipped +=
-            validate_response_with_skip_count(setup_sql, &format!("{};", sql), response);
+        skipped += validate_response(setup_sql, &format!("{};", sql), response);
     }
-    let skipped_percentage = batch_skipped as f64 / batch_sample_size as f64;
-    if skipped_percentage > threshold {
-        panic!(
-            "percentage of skipped batch queries = {}, threshold: {}",
-            skipped_percentage, threshold
-        );
-    }
+    skipped as f64 / sample_size as f64
+}
 
-    let mut stream_skipped = 0;
-    let stream_sample_size = 50;
-    for _ in 0..stream_sample_size {
+/// Test stream queries, returns skipped query statistics
+async fn test_stream_queries<R: Rng>(
+    client: &tokio_postgres::Client,
+    rng: &mut R,
+    tables: Vec<Table>,
+    setup_sql: &str,
+    sample_size: usize,
+) -> f64 {
+    let mut skipped = 0;
+    for _ in 0..sample_size {
         let (sql, table) = mview_sql_gen(rng, tables.clone(), "stream_query");
         tracing::info!("Executing: {}", sql);
         let response = client.execute(&sql, &[]).await;
-        stream_skipped +=
-            validate_response_with_skip_count(setup_sql, &format!("{};", sql), response);
+        skipped += validate_response(setup_sql, &format!("{};", sql), response);
         drop_mview_table(&table, client).await;
     }
-
-    let skipped_percentage = stream_skipped as f64 / stream_sample_size as f64;
-    if skipped_percentage > threshold {
-        panic!(
-            "percentage of skipped batch queries = {}, threshold: {}",
-            skipped_percentage, threshold
-        );
-    }
+    skipped as f64 / sample_size as f64
 }
 
 fn get_seed_table_sql(testdata: &str) -> String {
@@ -172,17 +175,8 @@ async fn drop_tables(mviews: &[Table], testdata: &str, client: &tokio_postgres::
     }
 }
 
-/// Validate client responses
-fn validate_response<_Row>(setup_sql: &str, query: &str, response: Result<_Row, PgError>) {
-    validate_response_with_skip_count(setup_sql, query, response);
-}
-
 /// Validate client responses, returning a count of skipped queries.
-fn validate_response_with_skip_count<_Row>(
-    setup_sql: &str,
-    query: &str,
-    response: Result<_Row, PgError>,
-) -> i64 {
+fn validate_response<_Row>(setup_sql: &str, query: &str, response: Result<_Row, PgError>) -> i64 {
     match response {
         Ok(_) => 0,
         Err(e) => {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Testing locally:
```sh
cargo build
./risedev d
time RUST_LOG=info ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata --count 100 | grep "Finished" | sed 's/^.*Fin/Fin/'

```

Seems that bottleneck is in **running the queries**:
```
Finished create table in 5s
Finished generating batch queries in 0s
Finished executing batch queries in 26s
Finished validating batch queries in 0s
Finished generating stream queries in 0s
Finished testing sqlsmith in 52s
Finished generating batch queries in 0s
Finished executing batch queries in 42s
Finished validating batch queries in 0s
Finished testing batch queries in 42s
Finished generating stream queries in 0s
Finished testing stream queries in 51s
Finished cleanup in 0s
RUST_LOG=info ./target/debug/sqlsmith test --testdata  --count 100  0.37s user 0.08s system 0% cpu 2:31.85 total
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
