### PR TITLE
Refactor(optimizer): refactor optimizer context to use refcell instead of atomic

### DIFF
--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -21,7 +21,6 @@ mod resolve_id;
 
 use std::collections::BTreeMap;
 use std::path::Path;
-use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
@@ -311,8 +310,9 @@ impl TestCase {
                         session.clone(),
                         Arc::from(sql),
                         WithOptions::try_from(&stmt)?,
+                        true, // use explain verbose in planner tests
+                        false,
                     );
-                    context.explain_verbose.store(true, Ordering::Relaxed); // use explain verbose in planner tests
                     let ret = self.apply_query(&stmt, context.into())?;
                     if do_check_result {
                         check_result(self, &ret)?;
@@ -413,7 +413,7 @@ impl TestCase {
         stmt: &Statement,
         context: OptimizerContextRef,
     ) -> Result<TestCaseResult> {
-        let session = context.inner().session_ctx.clone();
+        let session = context.session_ctx().clone();
         let mut ret = TestCaseResult::default();
 
         let bound = {

--- a/src/frontend/planner_test/tests/testdata/explain.yaml
+++ b/src/frontend/planner_test/tests/testdata/explain.yaml
@@ -46,7 +46,7 @@
       "stages": {
         "0": {
           "root": {
-            "plan_node_id": 23,
+            "plan_node_id": 24,
             "plan_node_type": "BatchProject",
             "schema": [
               {
@@ -59,7 +59,7 @@
             ],
             "children": [
               {
-                "plan_node_id": 21,
+                "plan_node_id": 22,
                 "plan_node_type": "BatchValues",
                 "schema": [],
                 "children": [],

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -99,7 +99,7 @@ pub fn gen_sink_plan(
     // If colume names not specified, use the name in materialized view.
     let col_names = get_column_names(&bound, session, stmt.columns)?;
 
-    let properties = context.inner().with_options.clone();
+    let properties = context.with_options().clone();
 
     let mut plan_root = Planner::new(context).plan_query(bound)?;
     let col_names = if let Some(col_names) = col_names {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -208,7 +208,7 @@ pub(crate) fn gen_create_table_plan(
         bind_sql_table_constraints(column_descs, pk_column_id_from_columns, constraints)?;
     let row_id_index = row_id_index.map(|index| ProstColumnIndex { index: index as _ });
     let pk_column_ids = pk_column_ids.into_iter().map(Into::into).collect();
-    let properties = context.inner().with_options.inner().clone();
+    let properties = context.with_options().inner().clone();
 
     // TODO(Yuanxin): Detect if there is an external source based on `properties` (WITH CONNECTOR)
     // and make prost source accordingly.

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use core::convert::{From, Into};
+use core::convert::Into;
 use core::fmt::Formatter;
-use core::marker::Sync;
-use core::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
 use std::cell::RefCell;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use crate::expr::CorrelatedId;
@@ -26,78 +25,23 @@ use crate::session::SessionImpl;
 use crate::WithOptions;
 
 pub struct OptimizerContext {
-    pub session_ctx: Arc<SessionImpl>,
-    // We use `AtomicI32` here because `Arc<T>` implements `Send` only when `T: Send + Sync`.
-    pub next_id: AtomicI32,
+    session_ctx: Arc<SessionImpl>,
+    /// Store plan node id
+    next_plan_node_id: RefCell<i32>,
     /// For debugging purposes, store the SQL string in Context
-    pub sql: Arc<str>,
-
-    /// it indicates whether the explain mode is verbose for explain statement
-    pub explain_verbose: AtomicBool,
-
-    /// it indicates whether the explain mode is trace for explain statement
-    pub explain_trace: AtomicBool,
+    sql: Arc<str>,
+    /// It indicates whether the explain mode is verbose for explain statement
+    explain_verbose: bool,
+    /// It indicates whether the explain mode is trace for explain statement
+    explain_trace: bool,
     /// Store the trace of optimizer
-    pub optimizer_trace: RefCell<Vec<String>>,
+    optimizer_trace: RefCell<Vec<String>>,
     /// Store correlated id
-    pub next_correlated_id: AtomicU32,
+    next_correlated_id: RefCell<u32>,
     /// Store options or properties from the `with` clause
-    pub with_options: WithOptions,
+    with_options: WithOptions,
 }
-
-#[derive(Clone, Debug)]
-pub struct OptimizerContextRef {
-    inner: Arc<OptimizerContext>,
-}
-
-impl !Sync for OptimizerContextRef {}
-
-impl From<OptimizerContext> for OptimizerContextRef {
-    fn from(inner: OptimizerContext) -> Self {
-        Self {
-            inner: Arc::new(inner),
-        }
-    }
-}
-
-impl OptimizerContextRef {
-    pub fn inner(&self) -> &OptimizerContext {
-        &self.inner
-    }
-
-    pub fn next_plan_node_id(&self) -> PlanNodeId {
-        // It's safe to use `fetch_add` and `Relaxed` ordering since we have marked
-        // `QueryContextRef` not `Sync`.
-        let next_id = self.inner.next_id.fetch_add(1, Ordering::Relaxed);
-        PlanNodeId(next_id)
-    }
-
-    pub fn next_correlated_id(&self) -> CorrelatedId {
-        self.inner
-            .next_correlated_id
-            .fetch_add(1, Ordering::Relaxed)
-    }
-
-    pub fn is_explain_verbose(&self) -> bool {
-        self.inner.explain_verbose.load(Ordering::Acquire)
-    }
-
-    pub fn is_explain_trace(&self) -> bool {
-        self.inner.explain_trace.load(Ordering::Acquire)
-    }
-
-    pub fn trace(&self, str: impl Into<String>) {
-        self.inner.optimizer_trace.borrow_mut().push(str.into());
-        self.inner
-            .optimizer_trace
-            .borrow_mut()
-            .push("\n".to_string());
-    }
-
-    pub fn take_trace(&self) -> Vec<String> {
-        self.inner.optimizer_trace.borrow_mut().drain(..).collect()
-    }
-}
+pub type OptimizerContextRef = Rc<OptimizerContext>;
 
 impl OptimizerContext {
     pub fn new_with_handler_args(handler_args: HandlerArgs) -> Self {
@@ -105,18 +49,26 @@ impl OptimizerContext {
             handler_args.session,
             handler_args.sql,
             handler_args.with_options,
+            false,
+            false,
         )
     }
 
-    pub fn new(session_ctx: Arc<SessionImpl>, sql: Arc<str>, with_options: WithOptions) -> Self {
+    pub fn new(
+        session_ctx: Arc<SessionImpl>,
+        sql: Arc<str>,
+        with_options: WithOptions,
+        explain_verbose: bool,
+        explain_trace: bool,
+    ) -> Self {
         Self {
             session_ctx,
-            next_id: AtomicI32::new(0),
+            next_plan_node_id: RefCell::new(0),
             sql,
-            explain_verbose: AtomicBool::new(false),
-            explain_trace: AtomicBool::new(false),
+            explain_verbose,
+            explain_trace,
             optimizer_trace: RefCell::new(vec![]),
-            next_correlated_id: AtomicU32::new(1),
+            next_correlated_id: RefCell::new(0),
             with_options,
         }
     }
@@ -127,15 +79,50 @@ impl OptimizerContext {
     pub async fn mock() -> OptimizerContextRef {
         Self {
             session_ctx: Arc::new(SessionImpl::mock()),
-            next_id: AtomicI32::new(0),
+            next_plan_node_id: RefCell::new(0),
             sql: Arc::from(""),
-            explain_verbose: AtomicBool::new(false),
-            explain_trace: AtomicBool::new(false),
+            explain_verbose: false,
+            explain_trace: false,
             optimizer_trace: RefCell::new(vec![]),
-            next_correlated_id: AtomicU32::new(1),
+            next_correlated_id: RefCell::new(0),
             with_options: Default::default(),
         }
         .into()
+    }
+
+    pub fn next_plan_node_id(&self) -> PlanNodeId {
+        *self.next_plan_node_id.borrow_mut() += 1;
+        PlanNodeId(*self.next_plan_node_id.borrow())
+    }
+
+    pub fn next_correlated_id(&self) -> CorrelatedId {
+        *self.next_correlated_id.borrow_mut() += 1;
+        *self.next_correlated_id.borrow()
+    }
+
+    pub fn is_explain_verbose(&self) -> bool {
+        self.explain_verbose
+    }
+
+    pub fn is_explain_trace(&self) -> bool {
+        self.explain_trace
+    }
+
+    pub fn trace(&self, str: impl Into<String>) {
+        self.optimizer_trace.borrow_mut().push(str.into());
+        self.optimizer_trace.borrow_mut().push("\n".to_string());
+    }
+
+    pub fn take_trace(&self) -> Vec<String> {
+        self.optimizer_trace.borrow_mut().drain(..).collect()
+    }
+
+    pub fn with_options(&self) -> &WithOptions {
+        &self.with_options
+    }
+
+    pub fn session_ctx(&self) -> &Arc<SessionImpl> {
+        &self.session_ctx
     }
 }
 
@@ -143,8 +130,13 @@ impl std::fmt::Debug for OptimizerContext {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "QueryContext {{ current id = {} }}",
-            self.next_id.load(Ordering::Relaxed)
+            "QueryContext {{ next_plan_node_id = {}, sql = {}, explain_verbose = {}, explain_trace = {}, next_correlated_id = {}, with_options = {:?} }}",
+            self.next_plan_node_id.borrow(),
+            self.sql,
+            self.explain_verbose,
+            self.explain_trace,
+            self.next_correlated_id.borrow(),
+            &self.with_options
         )
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -148,7 +148,7 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
                                             include_keys: Vec<usize>|
          -> MaterializedInputState {
             let mut internal_table_catalog_builder =
-                TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+                TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
 
             let mut included_upstream_indices = vec![]; // all upstream indices that are included in the state table
             let mut column_mapping = BTreeMap::new(); // key: upstream col idx, value: table col idx
@@ -202,7 +202,7 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
 
         let gen_table_state = |agg_kind: AggKind| -> TableState {
             let mut internal_table_catalog_builder =
-                TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+                TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
 
             let mut included_upstream_indices = vec![];
             for &idx in &self.group_key {
@@ -325,7 +325,7 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
         let out_fields = me.schema().fields();
         let in_dist_key = self.input.distribution().dist_column_indices().to_vec();
         let mut internal_table_catalog_builder =
-            TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+            TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
         for field in out_fields.iter() {
             let tb_column_idx = internal_table_catalog_builder.add_column(field);
             if tb_column_idx < self.group_key.len() {

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -43,7 +43,7 @@ pub fn infer_left_internal_table_catalog(
     pk_indices.extend(me.logical_pk());
 
     let mut internal_table_catalog_builder =
-        TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+        TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
 
     schema.fields().iter().for_each(|field| {
         internal_table_catalog_builder.add_column(field);
@@ -66,7 +66,7 @@ pub fn infer_right_internal_table_catalog(input: &impl stream::StreamPlanRef) ->
     );
 
     let mut internal_table_catalog_builder =
-        TableCatalogBuilder::new(input.ctx().inner().with_options.internal_table_subset());
+        TableCatalogBuilder::new(input.ctx().with_options().internal_table_subset());
 
     schema.fields().iter().for_each(|field| {
         internal_table_catalog_builder.add_column(field);

--- a/src/frontend/src/optimizer/plan_node/generic/source.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/source.rs
@@ -67,8 +67,7 @@ impl Source {
     pub fn infer_internal_table_catalog(me: &impl GenericPlanRef) -> TableCatalog {
         // note that source's internal table is to store partition_id -> offset mapping and its
         // schema is irrelevant to input schema
-        let mut builder =
-            TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+        let mut builder = TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
 
         let key = Field {
             data_type: DataType::Varchar,

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -45,7 +45,7 @@ impl<PlanRef: stream::StreamPlanRef> TopN<PlanRef> {
         let columns_fields = schema.fields().to_vec();
         let field_order = &self.order.field_order;
         let mut internal_table_catalog_builder =
-            TableCatalogBuilder::new(me.ctx().inner().with_options.internal_table_subset());
+            TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());
 
         columns_fields.iter().for_each(|field| {
             internal_table_catalog_builder.add_column(field);

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -1232,12 +1232,12 @@ mod tests {
         let project = plan.as_logical_project().unwrap();
         assert_eq!(project.exprs().len(), 1);
         assert_eq_input_ref!(&project.exprs()[0], 1);
-        assert_eq!(project.id().0, 4);
+        assert_eq!(project.id().0, 5);
 
         let agg_new = project.input();
         let agg_new = agg_new.as_logical_agg().unwrap();
         assert_eq!(agg_new.group_key(), &vec![0]);
-        assert_eq!(agg_new.id().0, 3);
+        assert_eq!(agg_new.id().0, 4);
 
         assert_eq!(agg_new.agg_calls().len(), 1);
         let agg_call_new = agg_new.agg_calls()[0].clone();

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -267,7 +267,7 @@ mod tests {
         assert_eq!(filter.schema().fields().len(), 2);
         assert_eq!(filter.schema().fields()[0], fields[1]);
         assert_eq!(filter.schema().fields()[1], fields[2]);
-        assert_eq!(filter.id().0, 3);
+        assert_eq!(filter.id().0, 4);
 
         let expr: ExprImpl = filter.predicate().clone().into();
         let call = expr.as_function_call().unwrap();

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1090,7 +1090,7 @@ impl ToBatch for LogicalJoin {
         let right = self.right().to_batch()?;
         let logical_join = self.clone_with_left_right(left, right);
 
-        let config = self.base.ctx.inner().session_ctx.config();
+        let config = self.base.ctx.session_ctx().config();
 
         if predicate.has_eq() {
             if config.get_batch_enable_lookup_join() {

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -473,8 +473,7 @@ impl LogicalScan {
                 self.core.table_desc.clone(),
                 self.base
                     .ctx
-                    .inner()
-                    .session_ctx
+                    .session_ctx()
                     .config()
                     .get_max_split_range_gap(),
             )?;

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -245,7 +245,7 @@ impl HashJoin {
 
         // Build internal table
         let mut internal_table_catalog_builder =
-            TableCatalogBuilder::new(input.ctx().inner().with_options.internal_table_subset());
+            TableCatalogBuilder::new(input.ctx().with_options().internal_table_subset());
         let internal_columns_fields = schema.fields().to_vec();
 
         internal_columns_fields.iter().for_each(|field| {
@@ -258,7 +258,7 @@ impl HashJoin {
 
         // Build degree table.
         let mut degree_table_catalog_builder =
-            TableCatalogBuilder::new(input.ctx().inner().with_options.internal_table_subset());
+            TableCatalogBuilder::new(input.ctx().with_options().internal_table_subset());
 
         let degree_column_field = Field::with_name(DataType::Int64, "_degree");
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -150,7 +150,7 @@ impl StreamMaterialize {
         }
 
         let ctx = input.ctx();
-        let properties = ctx.inner().with_options.internal_table_subset();
+        let properties = ctx.with_options().internal_table_subset();
         let table = TableCatalog {
             id: TableId::placeholder(),
             associated_source_id: None,

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -795,8 +795,14 @@ impl Session<PgResponseStream> for SessionImpl {
 
 /// Returns row description of the statement
 fn infer(session: Arc<SessionImpl>, stmt: Statement, sql: &str) -> Result<Vec<PgFieldDescriptor>> {
-    let context = OptimizerContext::new(session, Arc::from(sql), WithOptions::try_from(&stmt)?);
-    let session = context.session_ctx.clone();
+    let context = OptimizerContext::new(
+        session,
+        Arc::from(sql),
+        WithOptions::try_from(&stmt)?,
+        false,
+        false,
+    );
+    let session = context.session_ctx().clone();
 
     let bound = {
         let mut binder = Binder::new(&session);

--- a/src/tests/sqlsmith/tests/frontend/mod.rs
+++ b/src/tests/sqlsmith/tests/frontend/mod.rs
@@ -159,6 +159,8 @@ fn test_batch_query(
         session.clone(),
         Arc::from(sql),
         WithOptions::try_from(&stmt)?,
+        false,
+        false,
     )
     .into();
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

***PLEASE DO NOT LEAVE THIS EMPTY !!!***

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Use `RefCell` instead of `Atomic`.
- Make all fields of `OptimizerContext` private.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
