### PR TITLE
feat: config --max-request-bytes to 10m for etcd

### DIFF
--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -126,23 +126,24 @@ where
             let mut info = self.resolve_actor_info_for_recovery().await;
             let mut new_epoch = prev_epoch.next();
 
-            // Migrate expired actors to newly joined node by changing actor_map
-            let migrated = self.migrate_actors(&info).await?;
-            if migrated {
+            // Migrate actors in expired CN to newly joined one.
+            if self.migrate_actors(&info).await.inspect_err(|err| {
+                error!(err = ?err, "migrate actors failed");
+            })? {
                 info = self.resolve_actor_info_for_recovery().await;
             }
 
             // Reset all compute nodes, stop and drop existing actors.
-            self.reset_compute_nodes(&info).await.inspect_err(|e| {
-                error!("reset compute nodes failed: {}", e);
+            self.reset_compute_nodes(&info).await.inspect_err(|err| {
+                error!(err = ?err, "reset compute nodes failed");
             })?;
 
             // update and build all actors.
-            self.update_actors(&info).await.inspect_err(|e| {
-                error!("update actors failed: {}", e);
+            self.update_actors(&info).await.inspect_err(|err| {
+                error!(err = ?err, "update actors failed");
             })?;
-            self.build_actors(&info).await.inspect_err(|e| {
-                error!("build_actors failed: {}", e);
+            self.build_actors(&info).await.inspect_err(|err| {
+                error!(err = ?err, "build_actors failed");
             })?;
 
             // get split assignments for all actors
@@ -174,13 +175,13 @@ where
             match barrier_complete_rx.recv().await.unwrap() {
                 (_, Ok(response)) => {
                     if let Err(err) = command_ctx.post_collect().await {
-                        error!("post_collect failed: {}", err);
+                        error!(err = ?err, "post_collect failed");
                         return Err(err);
                     }
                     Ok((new_epoch, response))
                 }
                 (_, Err(err)) => {
-                    error!("inject_barrier failed: {}", err);
+                    error!(err = ?err, "inject_barrier failed");
                     Err(err)
                 }
             }
@@ -333,7 +334,7 @@ where
     async fn reset_compute_nodes(&self, info: &BarrierActorInfo) -> MetaResult<()> {
         let futures = info.node_map.iter().map(|(_, worker_node)| async move {
             let client = self.env.stream_client_pool().get(worker_node).await?;
-            debug!("force stop actors: {}", worker_node.id);
+            debug!(worker = ?worker_node.id, "force stop actors");
             client
                 .force_stop_actors(ForceStopActorsRequest {
                     request_id: Uuid::new_v4().to_string(),

--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -61,6 +61,8 @@ impl EtcdService {
             .arg("risedev-meta")
             .arg("--max-txn-ops")
             .arg("999999")
+            .arg("--max-request-bytes")
+            .arg("10485760")
             .arg("--auto-compaction-mode")
             .arg("periodic")
             .arg("--auto-compaction-retention")


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title, to partial fix #6726. The table fragment metadata sizes of all tpch MVs and tables are about 5M+ in a `ci-3cn-1fe` environment, however  the default config `--max-request-bytes` in etcd is 2M in our system. And it will getting larger if we increment the config number of PU for each CN or deploy more CNs.

The officially recommended configuration values for etcd is 10m, I changed the default config to 10M and I believe we might need to adjust it according to the actual production scenario. This can partial fix it as I test it locally, but I believe we still need some refactoring on how we update the table fragment metadata when migration.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Partial fix #6726 