### PR TITLE
fix(ci): explicitly set barrier config for compaction test

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -55,11 +55,11 @@ echo "--- e2e, ci-1cn-1fe, cdc source"
 apt-get -y install mysql-client
 # import data to mysql
 mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc.sql
-# start risingwave cluster
-cargo make ci-start ci-1cn-1fe-with-recovery
 # start cdc connector node
 nohup java -jar ./connector-service.jar --port 60061 > .risingwave/log/connector-node.log 2>&1 &
-sleep 1
+# start risingwave cluster
+cargo make ci-start ci-1cn-1fe-with-recovery
+sleep 2
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.load.slt'
 # wait for cdc loading
 sleep 10

--- a/risedev.yml
+++ b/risedev.yml
@@ -112,23 +112,6 @@ risedev:
       - use: kafka
         persist-data: true
 
-  full-compaction-test:
-    config-path: src/config/compaction-test.toml
-    steps:
-      - use: aws-s3
-        bucket: some-bucket # configure a valid bucket name
-      - use: etcd
-      - use: meta-node
-      - use: compute-node
-      - use: frontend
-      - use: compactor
-      - use: prometheus
-      - use: grafana
-      - use: zookeeper
-        persist-data: true
-      - use: kafka
-        persist-data: true
-
   full-benchmark:
     steps:
       - use: minio

--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -1,3 +1,7 @@
 [meta]
 enable_compaction_deterministic = true
 max_heartbeat_interval_secs = 600
+
+[streaming]
+barrier_interval_ms = 250
+checkpoint_frequency = 5

--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -4,4 +4,5 @@ max_heartbeat_interval_secs = 600
 
 [streaming]
 barrier_interval_ms = 250
-checkpoint_frequency = 5
+in_flight_barrier_nums = 40
+checkpoint_frequency = 10

--- a/src/config/compaction-test.toml
+++ b/src/config/compaction-test.toml
@@ -1,8 +1,0 @@
-[meta]
-enable_compaction_deterministic = true
-max_heartbeat_interval_secs = 600
-
-[streaming]
-barrier_interval_ms = 250
-in_flight_barrier_nums = 40
-checkpoint_frequency = 10

--- a/src/config/compaction-test.toml
+++ b/src/config/compaction-test.toml
@@ -1,3 +1,7 @@
 [meta]
 enable_compaction_deterministic = true
 max_heartbeat_interval_secs = 600
+
+[streaming]
+barrier_interval_ms = 250
+checkpoint_frequency = 5

--- a/src/config/compaction-test.toml
+++ b/src/config/compaction-test.toml
@@ -4,4 +4,5 @@ max_heartbeat_interval_secs = 600
 
 [streaming]
 barrier_interval_ms = 250
-checkpoint_frequency = 5
+in_flight_barrier_nums = 40
+checkpoint_frequency = 10


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Previously it relies on default values, and we encounter CI timeout due to recent default value changing.

## Checklist

~~- [] I have written necessary rustdoc comments~~
~~- [] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
