### PR TITLE
feat(array): generalize `**Array::from_slice` to `from_iter`

### DIFF
--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -287,7 +287,7 @@ mod tests {
                 .as_slice(),
         );
 
-        let visible_array = BoolArray::from_iter(&visible);
+        let visible_array = BoolArray::from_iter(visible.iter().cloned());
 
         let col1 = visible_array.into();
         let schema = Schema {

--- a/src/batch/src/executor/limit.rs
+++ b/src/batch/src/executor/limit.rs
@@ -155,7 +155,7 @@ mod tests {
     use crate::executor::test_utils::MockExecutor;
 
     fn create_column(vec: &[Option<i32>]) -> Column {
-        PrimitiveArray::from_slice(vec).into()
+        PrimitiveArray::from_iter(vec).into()
     }
 
     async fn test_limit_all_visible(
@@ -287,14 +287,7 @@ mod tests {
                 .as_slice(),
         );
 
-        let visible_array = BoolArray::from_slice(
-            visible
-                .clone()
-                .into_iter()
-                .map(Some)
-                .collect_vec()
-                .as_slice(),
-        );
+        let visible_array = BoolArray::from_iter(&visible);
 
         let col1 = visible_array.into();
         let schema = Schema {

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -30,16 +30,30 @@ impl BoolArray {
         Self { bitmap, data }
     }
 
-    pub fn from_slice(data: &[Option<bool>]) -> Self {
-        let mut builder = <Self as Array>::Builder::new(data.len());
-        for i in data {
-            builder.append(*i);
+    pub fn to_bitmap(&self) -> Bitmap {
+        &self.data & self.null_bitmap()
+    }
+}
+
+impl<'a> FromIterator<&'a bool> for BoolArray {
+    fn from_iter<I: IntoIterator<Item = &'a bool>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
+            builder.append(Some(*i));
         }
         builder.finish()
     }
+}
 
-    pub fn to_bitmap(&self) -> Bitmap {
-        &self.data & self.null_bitmap()
+impl<'a> FromIterator<&'a Option<bool>> for BoolArray {
+    fn from_iter<I: IntoIterator<Item = &'a Option<bool>>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
+            builder.append(*i);
+        }
+        builder.finish()
     }
 }
 

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -35,12 +35,12 @@ impl BoolArray {
     }
 }
 
-impl<'a> FromIterator<&'a bool> for BoolArray {
-    fn from_iter<I: IntoIterator<Item = &'a bool>>(iter: I) -> Self {
+impl FromIterator<Option<bool>> for BoolArray {
+    fn from_iter<I: IntoIterator<Item = Option<bool>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
         for i in iter {
-            builder.append(Some(*i));
+            builder.append(i);
         }
         builder.finish()
     }
@@ -48,12 +48,13 @@ impl<'a> FromIterator<&'a bool> for BoolArray {
 
 impl<'a> FromIterator<&'a Option<bool>> for BoolArray {
     fn from_iter<I: IntoIterator<Item = &'a Option<bool>>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
-        for i in iter {
-            builder.append(*i);
-        }
-        builder.finish()
+        iter.into_iter().cloned().collect()
+    }
+}
+
+impl FromIterator<bool> for BoolArray {
+    fn from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
+        iter.into_iter().map(Some).collect()
     }
 }
 

--- a/src/common/src/array/chrono_array.rs
+++ b/src/common/src/array/chrono_array.rs
@@ -53,7 +53,7 @@ mod tests {
             NaiveDateWrapper::with_days(67890).ok(),
         ];
 
-        let array = NaiveDateArray::from_slice(&input);
+        let array = NaiveDateArray::from_iter(&input);
         let buffers = array.to_protobuf().values;
 
         assert_eq!(buffers.len(), 1);

--- a/src/common/src/array/column.rs
+++ b/src/common/src/array/column.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use futures_async_stream::try_stream;
 use risingwave_pb::data::Column as ProstColumn;
 
-use super::{Array, ArrayError, ArrayResult, PrimitiveArray};
+use super::{Array, ArrayError, ArrayResult, I64Array};
 use crate::array::{ArrayImpl, ArrayRef};
 
 /// Column is owned by `DataChunk`. It consists of logic data type and physical array
@@ -88,10 +88,9 @@ impl Column {
                 new_columns[key] = columns[key].clone();
             }
             new_columns.extend(columns.iter().cloned());
-            let flags = Column::from(PrimitiveArray::<i64>::from_slice(&vec![
-                Some(i as i64);
-                cardinality
-            ]));
+            let flags = Column::from(I64Array::from_iter(
+                std::iter::repeat(i as i64).take(cardinality),
+            ));
             new_columns.push(flags);
             yield new_columns;
         }

--- a/src/common/src/array/decimal_array.rs
+++ b/src/common/src/array/decimal_array.rs
@@ -54,7 +54,7 @@ mod tests {
             Some(Decimal::NaN),
         ];
 
-        let array = DecimalArray::from_slice(&input);
+        let array = DecimalArray::from_iter(&input);
         let prost_array = array.to_protobuf();
 
         assert_eq!(prost_array.values.len(), 1);

--- a/src/common/src/array/interval_array.rs
+++ b/src/common/src/array/interval_array.rs
@@ -38,7 +38,7 @@ mod tests {
             assert_eq!(v.get_months(), 12);
             assert_eq!(v.get_days(), 0);
         }
-        let ret_arr = IntervalArray::from_iter(&[Some(IntervalUnit::from_ymd(1, 0, 0)), None]);
+        let ret_arr = IntervalArray::from_iter([Some(IntervalUnit::from_ymd(1, 0, 0)), None]);
         let v = ret_arr.value_at(0).unwrap();
         assert_eq!(v.get_years(), 1);
         assert_eq!(v.get_months(), 12);

--- a/src/common/src/array/interval_array.rs
+++ b/src/common/src/array/interval_array.rs
@@ -38,7 +38,7 @@ mod tests {
             assert_eq!(v.get_months(), 12);
             assert_eq!(v.get_days(), 0);
         }
-        let ret_arr = IntervalArray::from_slice(&[Some(IntervalUnit::from_ymd(1, 0, 0)), None]);
+        let ret_arr = IntervalArray::from_iter(&[Some(IntervalUnit::from_ymd(1, 0, 0)), None]);
         let v = ret_arr.value_at(0).unwrap();
         assert_eq!(v.get_years(), 1);
         assert_eq!(v.get_months(), 12);

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -132,10 +132,22 @@ pub struct PrimitiveArray<T: PrimitiveArrayItemType> {
     data: Vec<T>,
 }
 
-impl<T: PrimitiveArrayItemType> PrimitiveArray<T> {
-    pub fn from_slice(data: &[Option<T>]) -> Self {
-        let mut builder = <Self as Array>::Builder::new(data.len());
-        for i in data {
+impl<T: PrimitiveArrayItemType> FromIterator<T> for PrimitiveArray<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
+            builder.append(Some(i));
+        }
+        builder.finish()
+    }
+}
+
+impl<'a, T: PrimitiveArrayItemType> FromIterator<&'a Option<T>> for PrimitiveArray<T> {
+    fn from_iter<I: IntoIterator<Item = &'a Option<T>>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
             builder.append(*i);
         }
         builder.finish()

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -132,12 +132,12 @@ pub struct PrimitiveArray<T: PrimitiveArrayItemType> {
     data: Vec<T>,
 }
 
-impl<T: PrimitiveArrayItemType> FromIterator<T> for PrimitiveArray<T> {
-    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+impl<T: PrimitiveArrayItemType> FromIterator<Option<T>> for PrimitiveArray<T> {
+    fn from_iter<I: IntoIterator<Item = Option<T>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
         for i in iter {
-            builder.append(Some(i));
+            builder.append(i);
         }
         builder.finish()
     }
@@ -145,12 +145,13 @@ impl<T: PrimitiveArrayItemType> FromIterator<T> for PrimitiveArray<T> {
 
 impl<'a, T: PrimitiveArrayItemType> FromIterator<&'a Option<T>> for PrimitiveArray<T> {
     fn from_iter<I: IntoIterator<Item = &'a Option<T>>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
-        for i in iter {
-            builder.append(*i);
-        }
-        builder.finish()
+        iter.into_iter().cloned().collect()
+    }
+}
+
+impl<T: PrimitiveArrayItemType> FromIterator<T> for PrimitiveArray<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        iter.into_iter().map(Some).collect()
     }
 }
 

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -126,12 +126,12 @@ impl Array for Utf8Array {
     }
 }
 
-impl<'a> FromIterator<&'a str> for Utf8Array {
-    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
+impl<'a> FromIterator<Option<&'a str>> for Utf8Array {
+    fn from_iter<I: IntoIterator<Item = Option<&'a str>>>(iter: I) -> Self {
         let iter = iter.into_iter();
         let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
         for i in iter {
-            builder.append(Some(i));
+            builder.append(i);
         }
         builder.finish()
     }
@@ -139,12 +139,13 @@ impl<'a> FromIterator<&'a str> for Utf8Array {
 
 impl<'a> FromIterator<&'a Option<&'a str>> for Utf8Array {
     fn from_iter<I: IntoIterator<Item = &'a Option<&'a str>>>(iter: I) -> Self {
-        let iter = iter.into_iter();
-        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
-        for i in iter {
-            builder.append(*i);
-        }
-        builder.finish()
+        iter.into_iter().cloned().collect()
+    }
+}
+
+impl<'a> FromIterator<&'a str> for Utf8Array {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
+        iter.into_iter().map(Some).collect()
     }
 }
 

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -126,15 +126,29 @@ impl Array for Utf8Array {
     }
 }
 
-impl Utf8Array {
-    pub fn from_slice(data: &[Option<&str>]) -> Self {
-        let mut builder = <Self as Array>::Builder::new(data.len());
-        for i in data {
+impl<'a> FromIterator<&'a str> for Utf8Array {
+    fn from_iter<I: IntoIterator<Item = &'a str>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
+            builder.append(Some(i));
+        }
+        builder.finish()
+    }
+}
+
+impl<'a> FromIterator<&'a Option<&'a str>> for Utf8Array {
+    fn from_iter<I: IntoIterator<Item = &'a Option<&'a str>>>(iter: I) -> Self {
+        let iter = iter.into_iter();
+        let mut builder = <Self as Array>::Builder::new(iter.size_hint().0);
+        for i in iter {
             builder.append(*i);
         }
         builder.finish()
     }
+}
 
+impl Utf8Array {
     /// Retrieve the ownership of the single string value. Panics if there're multiple or no values.
     pub fn into_single_value(self) -> Option<Box<str>> {
         assert_eq!(self.len(), 1);
@@ -394,7 +408,7 @@ mod tests {
             Some("666666"),
         ];
 
-        let array = Utf8Array::from_slice(&input);
+        let array = Utf8Array::from_iter(&input);
         assert_eq!(array.len(), input.len());
 
         assert_eq!(
@@ -416,7 +430,7 @@ mod tests {
             Some("666666"),
         ];
 
-        let array = Utf8Array::from_slice(&input);
+        let array = Utf8Array::from_iter(&input);
         let buffers = array.to_protobuf().values;
         assert!(buffers.len() >= 2);
     }
@@ -459,7 +473,7 @@ mod tests {
                 .collect_vec(),
         ];
 
-        let arrs = vecs.iter().map(|v| Utf8Array::from_slice(v)).collect_vec();
+        let arrs = vecs.iter().map(Utf8Array::from_iter).collect_vec();
 
         let hasher_builder = RandomXxHashBuilder64::default();
         let mut states = vec![hasher_builder.build_hasher(); ARR_LEN];

--- a/src/common/src/test_utils/test_stream_chunk.rs
+++ b/src/common/src/test_utils/test_stream_chunk.rs
@@ -83,11 +83,7 @@ impl BigStreamChunk {
             .collect();
 
         let col = {
-            let array = I32Array::from_slice(
-                &std::iter::repeat(Some(114_514))
-                    .take(capacity)
-                    .collect_vec(),
-            );
+            let array = I32Array::from_iter(std::iter::repeat(114_514).take(capacity));
             Column::from(array)
         };
 

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -324,7 +324,7 @@ mod tests {
         assert!(expr.is_ok());
 
         let res = expr.unwrap().eval(&DataChunk::new_dummy(1)).unwrap();
-        assert_eq!(*res, ArrayImpl::Utf8(Utf8Array::from_slice(&[Some("foo")])));
+        assert_eq!(*res, ArrayImpl::Utf8(Utf8Array::from_iter(["foo"])));
     }
 
     #[test]

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -761,8 +761,8 @@ mod tests {
             }
         }
 
-        let col1 = I32Array::from_slice(&lhs).into();
-        let col2 = I32Array::from_slice(&rhs).into();
+        let col1 = I32Array::from_iter(&lhs).into();
+        let col2 = I32Array::from_iter(&rhs).into();
         let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Int32, TypeName::Int32], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
@@ -809,8 +809,8 @@ mod tests {
             }
         }
 
-        let col1 = NaiveDateArray::from_slice(&lhs).into();
-        let col2 = IntervalArray::from_slice(&rhs).into();
+        let col1 = NaiveDateArray::from_iter(&lhs).into();
+        let col2 = IntervalArray::from_iter(&rhs).into();
         let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Date, TypeName::Interval], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();
@@ -862,8 +862,8 @@ mod tests {
             }
         }
 
-        let col1 = DecimalArray::from_slice(&lhs).into();
-        let col2 = DecimalArray::from_slice(&rhs).into();
+        let col1 = DecimalArray::from_iter(&lhs).into();
+        let col2 = DecimalArray::from_iter(&rhs).into();
         let data_chunk = DataChunk::new(vec![col1, col2], 100);
         let expr = make_expression(kind, &[TypeName::Decimal, TypeName::Decimal], &[0, 1]);
         let vec_executor = build_from_prost(&expr).unwrap();

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -356,7 +356,7 @@ mod tests {
                 target.push(None);
             }
         }
-        let col1 = I16Array::from_slice(&input).into();
+        let col1 = I16Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
@@ -399,7 +399,7 @@ mod tests {
         target.push(Some(0));
         target.push(Some(1));
 
-        let col1 = I32Array::from_slice(&input).into();
+        let col1 = I32Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 3);
         let return_type = DataType {
             type_name: TypeName::Int32 as i32,
@@ -449,7 +449,7 @@ mod tests {
             }
         }
         let col1_data = &input.iter().map(|x| x.as_ref().map(|x| &**x)).collect_vec();
-        let col1 = Utf8Array::from_slice(col1_data).into();
+        let col1 = Utf8Array::from_iter(col1_data).into();
         let data_chunk = DataChunk::new(vec![col1], 1);
         let return_type = DataType {
             type_name: TypeName::Int16 as i32,
@@ -504,7 +504,7 @@ mod tests {
             }
         }
 
-        let col1 = BoolArray::from_slice(&input).into();
+        let col1 = BoolArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
         let expr = make_expression(kind, &[TypeName::Boolean], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();
@@ -543,7 +543,7 @@ mod tests {
             }
         }
 
-        let col1 = NaiveDateArray::from_slice(&input).into();
+        let col1 = NaiveDateArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
         let expr = make_expression(kind, &[TypeName::Date], &[0]);
         let vec_executor = build_from_prost(&expr).unwrap();

--- a/src/expr/src/vector_op/agg/approx_count_distinct.rs
+++ b/src/expr/src/vector_op/agg/approx_count_distinct.rs
@@ -172,7 +172,7 @@ mod tests {
             lhs.push(Some(i));
         }
 
-        let col1 = I32Array::from_slice(&lhs).into();
+        let col1 = I32Array::from_iter(&lhs).into();
         DataChunk::new(vec![col1], size)
     }
 

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn vec_sum_int32() -> Result<()> {
-        let input = I32Array::from_slice(&[Some(1), Some(2), Some(3)]);
+        let input = I32Array::from_iter([1, 2, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int32;
         let return_type = DataType::Int64;
@@ -223,7 +223,7 @@ mod tests {
 
     #[test]
     fn vec_sum_int64() -> Result<()> {
-        let input = I64Array::from_slice(&[Some(1), Some(2), Some(3)]);
+        let input = I64Array::from_iter([1, 2, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int64;
         let return_type = DataType::Decimal;
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn vec_min_float32() -> Result<()> {
-        let input = F32Array::from_slice(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
+        let input = F32Array::from_iter(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Float32;
         let return_type = DataType::Float32;
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn vec_min_char() -> Result<()> {
-        let input = Utf8Array::from_slice(&[Some("b"), Some("aa")]);
+        let input = Utf8Array::from_iter(["b", "aa"]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Varchar;
         let return_type = DataType::Varchar;
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn vec_max_char() -> Result<()> {
-        let input = Utf8Array::from_slice(&[Some("b"), Some("aa")]);
+        let input = Utf8Array::from_iter(["b", "aa"]);
         let agg_kind = AggKind::Max;
         let input_type = DataType::Varchar;
         let return_type = DataType::Varchar;
@@ -357,13 +357,13 @@ mod tests {
             assert_eq!(actual, expected);
             Ok(())
         };
-        let input = I32Array::from_slice(&[Some(1), Some(2), Some(3)]);
+        let input = I32Array::from_iter([1, 2, 3]);
         let expected = &[Some(3)];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_slice(&[]);
+        let input = I32Array::from_iter(&[]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_slice(&[None]);
+        let input = I32Array::from_iter(&[None]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)
     }

--- a/src/expr/src/vector_op/agg/general_agg.rs
+++ b/src/expr/src/vector_op/agg/general_agg.rs
@@ -242,7 +242,7 @@ mod tests {
 
     #[test]
     fn vec_min_float32() -> Result<()> {
-        let input = F32Array::from_iter(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
+        let input = F32Array::from_iter([Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Float32;
         let return_type = DataType::Float32;
@@ -360,10 +360,11 @@ mod tests {
         let input = I32Array::from_iter([1, 2, 3]);
         let expected = &[Some(3)];
         test_case(input.into(), expected)?;
+        #[allow(clippy::needless_borrow)]
         let input = I32Array::from_iter(&[]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_iter(&[None]);
+        let input = I32Array::from_iter([None]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)
     }

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_sum_int32() -> Result<()> {
-        let input = I32Array::from_slice(&[Some(1), Some(1), Some(3)]);
+        let input = I32Array::from_iter([1, 2, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int32;
         let return_type = DataType::Int64;
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_sum_int64() -> Result<()> {
-        let input = I64Array::from_slice(&[Some(1), Some(1), Some(3)]);
+        let input = I64Array::from_iter([1, 2, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int64;
         let return_type = DataType::Decimal;
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_min_float32() -> Result<()> {
-        let input = F32Array::from_slice(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
+        let input = F32Array::from_iter(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Float32;
         let return_type = DataType::Float32;
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_min_char() -> Result<()> {
-        let input = Utf8Array::from_slice(&[Some("b"), Some("aa")]);
+        let input = Utf8Array::from_iter(["b", "aa"]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Varchar;
         let return_type = DataType::Varchar;
@@ -291,7 +291,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_max_char() -> Result<()> {
-        let input = Utf8Array::from_slice(&[Some("b"), Some("aa")]);
+        let input = Utf8Array::from_iter(["b", "aa"]);
         let agg_kind = AggKind::Max;
         let input_type = DataType::Varchar;
         let return_type = DataType::Varchar;
@@ -326,13 +326,13 @@ mod tests {
             assert_eq!(actual, expected);
             Ok(())
         };
-        let input = I32Array::from_slice(&[Some(1), Some(1), Some(3)]);
+        let input = I32Array::from_iter([1, 2, 3]);
         let expected = &[Some(2)];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_slice(&[]);
+        let input = I32Array::from_iter(&[]);
         let expected = &[None];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_slice(&[None]);
+        let input = I32Array::from_iter(&[None]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)
     }

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_min_float32() -> Result<()> {
-        let input = F32Array::from_iter(&[Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
+        let input = F32Array::from_iter([Some(1.0.into()), Some(2.0.into()), Some(3.0.into())]);
         let agg_kind = AggKind::Min;
         let input_type = DataType::Float32;
         let return_type = DataType::Float32;
@@ -329,10 +329,11 @@ mod tests {
         let input = I32Array::from_iter([1, 2, 3]);
         let expected = &[Some(2)];
         test_case(input.into(), expected)?;
+        #[allow(clippy::needless_borrow)]
         let input = I32Array::from_iter(&[]);
         let expected = &[None];
         test_case(input.into(), expected)?;
-        let input = I32Array::from_iter(&[None]);
+        let input = I32Array::from_iter([None]);
         let expected = &[Some(0)];
         test_case(input.into(), expected)
     }

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_sum_int32() -> Result<()> {
-        let input = I32Array::from_iter([1, 2, 3]);
+        let input = I32Array::from_iter([1, 1, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int32;
         let return_type = DataType::Int64;
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn vec_distinct_sum_int64() -> Result<()> {
-        let input = I64Array::from_iter([1, 2, 3]);
+        let input = I64Array::from_iter([1, 1, 3]);
         let agg_kind = AggKind::Sum;
         let input_type = DataType::Int64;
         let return_type = DataType::Decimal;
@@ -326,7 +326,7 @@ mod tests {
             assert_eq!(actual, expected);
             Ok(())
         };
-        let input = I32Array::from_iter([1, 2, 3]);
+        let input = I32Array::from_iter([1, 1, 3]);
         let expected = &[Some(2)];
         test_case(input.into(), expected)?;
         #[allow(clippy::needless_borrow)]

--- a/src/expr/src/vector_op/agg/general_sorted_grouper.rs
+++ b/src/expr/src/vector_op/agg/general_sorted_grouper.rs
@@ -215,14 +215,14 @@ mod tests {
         };
         let mut builder = I32ArrayBuilder::new(0);
 
-        let input = I32Array::from_slice(&[Some(1), Some(1), Some(3)]);
+        let input = I32Array::from_iter([1, 1, 3]);
         let eq = g.detect_groups_concrete(&input)?;
         assert_eq!(eq.indices, vec![2]);
         g.update_concrete(&input, 0, *eq.indices.first().unwrap())?;
         g.output_concrete(&mut builder)?;
         g.update_concrete(&input, *eq.indices.first().unwrap(), input.len())?;
 
-        let input = I32Array::from_slice(&[Some(3), Some(4), Some(4)]);
+        let input = I32Array::from_iter([3, 4, 4]);
         let eq = g.detect_groups_concrete(&input)?;
         assert_eq!(eq.indices, vec![1]);
         g.update_concrete(&input, 0, *eq.indices.first().unwrap())?;

--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -508,7 +508,7 @@ mod tests {
             agg.apply_batch(
                 &ops,
                 None,
-                &[&ArrayImpl::Float64(F64Array::from_slice(&data))],
+                &[&ArrayImpl::Float64(F64Array::from_iter(&data))],
             )
             .unwrap();
             assert_eq!(

--- a/src/stream/src/executor/aggregation/value.rs
+++ b/src/stream/src/executor/aggregation/value.rs
@@ -106,7 +106,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Insert, Op::Insert],
                 None,
-                &[&I64Array::from_iter(&[Some(0), Some(1), Some(2), None]).into()],
+                &[&I64Array::from_iter([Some(0), Some(1), Some(2), None]).into()],
             )
             .unwrap();
 
@@ -121,7 +121,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Delete, Op::Insert],
                 None,
-                &[&I64Array::from_iter(&[Some(42), None, Some(2), Some(8)]).into()],
+                &[&I64Array::from_iter([Some(42), None, Some(2), Some(8)]).into()],
             )
             .unwrap();
         assert_eq!(state.get_output(), Some(ScalarImpl::Int64(4)));
@@ -148,7 +148,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Insert, Op::Insert, Op::Insert],
                 None,
-                &[&I64Array::from_iter(&[Some(-1), Some(0), Some(2), Some(1), None]).into()],
+                &[&I64Array::from_iter([Some(-1), Some(0), Some(2), Some(1), None]).into()],
             )
             .unwrap();
 

--- a/src/stream/src/executor/aggregation/value.rs
+++ b/src/stream/src/executor/aggregation/value.rs
@@ -106,7 +106,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Insert, Op::Insert],
                 None,
-                &[&I64Array::from_slice(&[Some(0), Some(1), Some(2), None]).into()],
+                &[&I64Array::from_iter(&[Some(0), Some(1), Some(2), None]).into()],
             )
             .unwrap();
 
@@ -121,7 +121,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Delete, Op::Insert],
                 None,
-                &[&I64Array::from_slice(&[Some(42), None, Some(2), Some(8)]).into()],
+                &[&I64Array::from_iter(&[Some(42), None, Some(2), Some(8)]).into()],
             )
             .unwrap();
         assert_eq!(state.get_output(), Some(ScalarImpl::Int64(4)));
@@ -148,7 +148,7 @@ mod tests {
             .apply_chunk(
                 &[Op::Insert, Op::Insert, Op::Insert, Op::Insert, Op::Insert],
                 None,
-                &[&I64Array::from_slice(&[Some(-1), Some(0), Some(2), Some(1), None]).into()],
+                &[&I64Array::from_iter(&[Some(-1), Some(0), Some(2), Some(1), None]).into()],
             )
             .unwrap();
 

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -203,7 +203,7 @@ async fn test_merger_sum_aggr() {
         for i in 0..10 {
             let chunk = StreamChunk::new(
                 vec![op; i],
-                vec![I64Array::from_slice(vec![Some(1); i].as_slice()).into()],
+                vec![I64Array::from_iter(vec![1; i]).into()],
                 None,
             );
             input.send(Message::Chunk(chunk)).await.unwrap();


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR generalizes array's `from_slice` function to `FromIterator` trait, so that we can build an array from iterator.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
