### PR TITLE
fix(frontend): save original sql for view

### DIFF
--- a/e2e_test/batch/basic/logical_view.slt.part
+++ b/e2e_test/batch/basic/logical_view.slt.part
@@ -70,10 +70,18 @@ create table t1 (s struct<v1 int, v2 VARCHAR>);
 statement ok
 create view v2 as select (s).v1, (s).v2 from t1;
 
+statement ok
+insert into t1 values ((114, '514'));
+
+query IT
+select v1, v2 from v2;
+----
+114 514
+
 query I
 select count(*) from v2;
 ----
-0
+1
 
 statement ok
 drop view v2;

--- a/e2e_test/batch/basic/logical_view.slt.part
+++ b/e2e_test/batch/basic/logical_view.slt.part
@@ -9,7 +9,7 @@ SELECT * FROM v1;
 ----
 1
 
-statement error 
+statement error
 CREATE VIEW v2(a, b) AS SELECT 1;
 
 statement ok
@@ -37,7 +37,7 @@ SELECT * FROM v3;
 
 # v3 depends on t. We can't drop t.
 
-statement error 
+statement error
 DROP TABLE t;
 
 # Currently it is allowed to drop a view even it is depended by another view.
@@ -45,13 +45,13 @@ DROP TABLE t;
 statement ok
 DROP VIEW v2;
 
-statement error 
+statement error
 SELECT * from v3;
 
 statement ok
 DROP VIEW v3;
 
-statement error 
+statement error
 SELECT * FROM v3;
 
 # We can drop t and v2 now
@@ -61,3 +61,22 @@ DROP TABLE t;
 
 statement ok
 DROP VIEW v1;
+
+# Test struct field accessing
+
+statement ok
+create table t1 (s struct<v1 int, v2 VARCHAR>);
+
+statement ok
+create view v2 as select (s).v1, (s).v2 from t1;
+
+query I
+select count(*) from v2;
+----
+0
+
+statement ok
+drop view v2;
+
+statement ok
+drop table t1;

--- a/src/frontend/src/handler/create_view.rs
+++ b/src/frontend/src/handler/create_view.rs
@@ -40,6 +40,7 @@ pub async fn handle_create_view(
     let (database_id, schema_id) = session.get_database_and_schema_id_for_create(schema_name)?;
 
     let properties = handler_args.with_options.clone();
+    let sql = handler_args.sql.clone();
 
     session.check_relation_name_duplicated(name.clone())?;
 
@@ -88,7 +89,9 @@ pub async fn handle_create_view(
         properties: properties.inner().clone(),
         owner: session.user_id(),
         dependent_relations,
-        sql: format!("{}", query),
+        // Here we save the original sql instead of the unparsed one from AST, in case there're
+        // uncovered cases in the unparsing implementation.
+        sql: sql.to_string(),
         columns: columns.into_iter().map(|f| f.to_prost()).collect(),
     };
 

--- a/src/frontend/src/handler/create_view.rs
+++ b/src/frontend/src/handler/create_view.rs
@@ -91,6 +91,7 @@ pub async fn handle_create_view(
         dependent_relations,
         // Here we save the original sql instead of the unparsed one from AST, in case there're
         // uncovered cases in the unparsing implementation.
+        // TODO: this includes the `CREATE VIEW` prefix, which can be removed if we have span info.
         sql: sql.to_string(),
         columns: columns.into_iter().map(|f| f.to_prost()).collect(),
     };


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Previously we saved the unparsed SQL for creating view, which is not well-covered and may lead to some incorrect results like #6801. A quick but thorough fix is to directly store the user's original query. 😅

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- Close #6801