### PR TITLE
fix(frontend): report error instead of panicking for invalid CREATE SOURCE

### DIFF
--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -150,9 +150,11 @@ pub async fn handle_create_source(
     }
     let (columns, source_info) = match &stmt.source_schema {
         SourceSchema::Protobuf(protobuf_schema) => {
-            assert_eq!(columns.len(), 1);
-            assert_eq!(pk_column_ids, vec![0.into()]);
-            assert_eq!(row_id_index, Some(0));
+            if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
+                return Err(RwError::from(ProtocolError(
+                    "User-defined schema is not allowed with row format protobuf.".to_string(),
+                )));
+            }
 
             columns.extend(
                 extract_protobuf_table_schema(protobuf_schema, with_properties.clone()).await?,
@@ -169,9 +171,11 @@ pub async fn handle_create_source(
             )
         }
         SourceSchema::Avro(avro_schema) => {
-            assert_eq!(columns.len(), 1);
-            assert_eq!(pk_column_ids, vec![0.into()]);
-            assert_eq!(row_id_index, Some(0));
+            if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
+                return Err(RwError::from(ProtocolError(
+                    "User-defined schema is not allowed with row format avro.".to_string(),
+                )));
+            }
             columns.extend(extract_avro_table_schema(avro_schema, with_properties.clone()).await?);
             (
                 columns,

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -152,7 +152,7 @@ pub async fn handle_create_source(
         SourceSchema::Protobuf(protobuf_schema) => {
             if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
                 return Err(RwError::from(ProtocolError(
-                    "User-defined schema is not allowed with row format protobuf.".to_string(),
+                    "User-defined schema is not allowed with row format protobuf. Please refer to https://www.risingwave.dev/docs/latest/sql-create-source/#protobuf for more information.".to_string(),
                 )));
             }
 
@@ -173,7 +173,7 @@ pub async fn handle_create_source(
         SourceSchema::Avro(avro_schema) => {
             if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
                 return Err(RwError::from(ProtocolError(
-                    "User-defined schema is not allowed with row format avro.".to_string(),
+                    "User-defined schema is not allowed with row format avro. Please refer to https://www.risingwave.dev/docs/latest/sql-create-source/#avro for more information.".to_string(),
                 )));
             }
             columns.extend(extract_avro_table_schema(avro_schema, with_properties.clone()).await?);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

See below.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

When the user creates a source like 

```SQL
CREATE MATERIALIZED SOURCE s (
    v int
) WITH (
    connector = 'kafka',
    ......
) 
ROW FORMAT AVRO 
MESSAGE 'main_message' 
ROW SCHEMA LOCATION 'location';
```

RisingWave will report an error `User-defined schema is not allowed with row format avro.` instead of panicking.

The same for `protobuf`.

Also, we might have to update [our document (column `Limitations` here)](https://www.risingwave.dev/docs/latest/sql-create-source/#supported-sources) for reminding.
