### PR TITLE
ci(mergify): update commit message template

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,13 @@
+shared:
+  - commit_message_template: &commit_message_template |
+      {{title}}
+      
+      {{body}}
+      
+      {% for user in approved_reviews_by %}
+      Approved-By: {{user}}
+      {% endfor %}
+
 queue_rules:
   - name: default
     conditions:
@@ -22,6 +32,7 @@ pull_request_rules:
         name: default
         method: squash
         priority: high
+        commit_message_template: *commit_message_template
 
   - name: Automatic merge on approval
     conditions:
@@ -37,6 +48,7 @@ pull_request_rules:
         name: default
         method: squash
         priority: medium
+        commit_message_template: *commit_message_template
 
   - name: Notify author on queue failure
     conditions:

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,13 +4,12 @@ shared:
       
       {{body | get_section("## What's changed and what's your intention?")}}
       
-      {% for user in approved_reviews_by -%}
+      {% for user in approved_reviews_by %}
       Approved-By: {{user}}
-      {% endfor %}
-      
-      {% for commit in commits|unique(false, "email_author") -%}
+      {%- endfor %}
+      {% for commit in commits|unique(false, "email_author") %}
       Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
-      {% endfor %}
+      {%- endfor %}
 
 queue_rules:
   - name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ shared:
   - commit_message_template: &commit_message_template |
       {{title}}
       
-      {{body}}
+      {{body | get_section("## What's changed and what's your intention?")}}
       
       {% for user in approved_reviews_by %}
       Approved-By: {{user}}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -4,8 +4,12 @@ shared:
       
       {{body | get_section("## What's changed and what's your intention?")}}
       
-      {% for user in approved_reviews_by %}
+      {% for user in approved_reviews_by -%}
       Approved-By: {{user}}
+      {% endfor %}
+      
+      {% for commit in commits|unique(false, "email_author") -%}
+      Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
       {% endfor %}
 
 queue_rules:


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Update Mergify's commit message template to use the "What's changed and what's your intention?" section in the PR description as the message of the squashed commit.

This change has been made by @fuyufjh from Mergify config editor.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

closes #6791