### PR TITLE
test(regress): enable more int4 queries blocked by TypedString parsing

### DIFF
--- a/src/tests/regress/data/expected/float8.out
+++ b/src/tests/regress/data/expected/float8.out
@@ -332,13 +332,13 @@ select sign(f1) as sign_f1 from float8_tbl f;
 -- avoid bit-exact output here because operations may not be bit-exact.
 SET extra_float_digits = 0;
 -- square root
-SELECT sqrt(float8 '64') AS eight;
+SELECT sqrt(double precision '64') AS eight;
  eight 
 -------
      8
 (1 row)
 
-SELECT |/ float8 '64' AS eight;
+SELECT |/ double precision '64' AS eight;
  eight 
 -------
      8
@@ -355,159 +355,159 @@ SELECT f.f1, |/f.f1 AS sqrt_f1
 (3 rows)
 
 -- power
-SELECT power(float8 '144', float8 '0.5');
+SELECT power(double precision '144', double precision '0.5');
  power 
 -------
     12
 (1 row)
 
-SELECT power(float8 'NaN', float8 '0.5');
+SELECT power(double precision 'NaN', double precision '0.5');
  power 
 -------
    NaN
 (1 row)
 
-SELECT power(float8 '144', float8 'NaN');
+SELECT power(double precision '144', double precision 'NaN');
  power 
 -------
    NaN
 (1 row)
 
-SELECT power(float8 'NaN', float8 'NaN');
+SELECT power(double precision 'NaN', double precision 'NaN');
  power 
 -------
    NaN
 (1 row)
 
-SELECT power(float8 '-1', float8 'NaN');
+SELECT power(double precision '-1', double precision 'NaN');
  power 
 -------
    NaN
 (1 row)
 
-SELECT power(float8 '1', float8 'NaN');
+SELECT power(double precision '1', double precision 'NaN');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 'NaN', float8 '0');
+SELECT power(double precision 'NaN', double precision '0');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 'inf', float8 '0');
+SELECT power(double precision 'inf', double precision '0');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '-inf', float8 '0');
+SELECT power(double precision '-inf', double precision '0');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '0', float8 'inf');
+SELECT power(double precision '0', double precision 'inf');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 '0', float8 '-inf');
+SELECT power(double precision '0', double precision '-inf');
 ERROR:  zero raised to a negative power is undefined
-SELECT power(float8 '1', float8 'inf');
+SELECT power(double precision '1', double precision 'inf');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '1', float8 '-inf');
+SELECT power(double precision '1', double precision '-inf');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '-1', float8 'inf');
+SELECT power(double precision '-1', double precision 'inf');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '-1', float8 '-inf');
+SELECT power(double precision '-1', double precision '-inf');
  power 
 -------
      1
 (1 row)
 
-SELECT power(float8 '0.1', float8 'inf');
+SELECT power(double precision '0.1', double precision 'inf');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 '-0.1', float8 'inf');
+SELECT power(double precision '-0.1', double precision 'inf');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 '1.1', float8 'inf');
+SELECT power(double precision '1.1', double precision 'inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '-1.1', float8 'inf');
+SELECT power(double precision '-1.1', double precision 'inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '0.1', float8 '-inf');
+SELECT power(double precision '0.1', double precision '-inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '-0.1', float8 '-inf');
+SELECT power(double precision '-0.1', double precision '-inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '1.1', float8 '-inf');
+SELECT power(double precision '1.1', double precision '-inf');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 '-1.1', float8 '-inf');
+SELECT power(double precision '-1.1', double precision '-inf');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 'inf', float8 '-2');
+SELECT power(double precision 'inf', double precision '-2');
  power 
 -------
      0
 (1 row)
 
-SELECT power(float8 'inf', float8 '2');
+SELECT power(double precision 'inf', double precision '2');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 'inf', float8 'inf');
+SELECT power(double precision 'inf', double precision 'inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 'inf', float8 '-inf');
+SELECT power(double precision 'inf', double precision '-inf');
  power 
 -------
      0
@@ -515,39 +515,39 @@ SELECT power(float8 'inf', float8 '-inf');
 
 -- Intel's icc misoptimizes the code that controls the sign of this result,
 -- even with -mp1.  Pending a fix for that, only test for "is it zero".
-SELECT power(float8 '-inf', float8 '-2') = '0';
+SELECT power(double precision '-inf', double precision '-2') = '0';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT power(float8 '-inf', float8 '-3');
+SELECT power(double precision '-inf', double precision '-3');
  power 
 -------
     -0
 (1 row)
 
-SELECT power(float8 '-inf', float8 '2');
+SELECT power(double precision '-inf', double precision '2');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '-inf', float8 '3');
+SELECT power(double precision '-inf', double precision '3');
    power   
 -----------
  -Infinity
 (1 row)
 
-SELECT power(float8 '-inf', float8 '3.5');
+SELECT power(double precision '-inf', double precision '3.5');
 ERROR:  a negative number raised to a non-integer power yields a complex result
-SELECT power(float8 '-inf', float8 'inf');
+SELECT power(double precision '-inf', double precision 'inf');
   power   
 ----------
  Infinity
 (1 row)
 
-SELECT power(float8 '-inf', float8 '-inf');
+SELECT power(double precision '-inf', double precision '-inf');
  power 
 -------
      0
@@ -572,7 +572,7 @@ SELECT exp('inf'::float8), exp('-inf'::float8), exp('nan'::float8);
 (1 row)
 
 -- cube root
-SELECT ||/ float8 '27' AS three;
+SELECT ||/ double precision '27' AS three;
  three 
 -------
      3
@@ -632,130 +632,130 @@ SELECT * FROM FLOAT8_TBL;
 -- hyperbolic functions
 -- we run these with extra_float_digits = 0 too, since different platforms
 -- tend to produce results that vary in the last place.
-SELECT sinh(float8 '1');
+SELECT sinh(double precision '1');
       sinh       
 -----------------
  1.1752011936438
 (1 row)
 
-SELECT cosh(float8 '1');
+SELECT cosh(double precision '1');
        cosh       
 ------------------
  1.54308063481524
 (1 row)
 
-SELECT tanh(float8 '1');
+SELECT tanh(double precision '1');
        tanh        
 -------------------
  0.761594155955765
 (1 row)
 
-SELECT asinh(float8 '1');
+SELECT asinh(double precision '1');
        asinh       
 -------------------
  0.881373587019543
 (1 row)
 
-SELECT acosh(float8 '2');
+SELECT acosh(double precision '2');
       acosh       
 ------------------
  1.31695789692482
 (1 row)
 
-SELECT atanh(float8 '0.5');
+SELECT atanh(double precision '0.5');
        atanh       
 -------------------
  0.549306144334055
 (1 row)
 
 -- test Inf/NaN cases for hyperbolic functions
-SELECT sinh(float8 'infinity');
+SELECT sinh(double precision 'infinity');
    sinh   
 ----------
  Infinity
 (1 row)
 
-SELECT sinh(float8 '-infinity');
+SELECT sinh(double precision '-infinity');
    sinh    
 -----------
  -Infinity
 (1 row)
 
-SELECT sinh(float8 'nan');
+SELECT sinh(double precision 'nan');
  sinh 
 ------
   NaN
 (1 row)
 
-SELECT cosh(float8 'infinity');
+SELECT cosh(double precision 'infinity');
    cosh   
 ----------
  Infinity
 (1 row)
 
-SELECT cosh(float8 '-infinity');
+SELECT cosh(double precision '-infinity');
    cosh   
 ----------
  Infinity
 (1 row)
 
-SELECT cosh(float8 'nan');
+SELECT cosh(double precision 'nan');
  cosh 
 ------
   NaN
 (1 row)
 
-SELECT tanh(float8 'infinity');
+SELECT tanh(double precision 'infinity');
  tanh 
 ------
     1
 (1 row)
 
-SELECT tanh(float8 '-infinity');
+SELECT tanh(double precision '-infinity');
  tanh 
 ------
    -1
 (1 row)
 
-SELECT tanh(float8 'nan');
+SELECT tanh(double precision 'nan');
  tanh 
 ------
   NaN
 (1 row)
 
-SELECT asinh(float8 'infinity');
+SELECT asinh(double precision 'infinity');
   asinh   
 ----------
  Infinity
 (1 row)
 
-SELECT asinh(float8 '-infinity');
+SELECT asinh(double precision '-infinity');
    asinh   
 -----------
  -Infinity
 (1 row)
 
-SELECT asinh(float8 'nan');
+SELECT asinh(double precision 'nan');
  asinh 
 -------
    NaN
 (1 row)
 
 -- acosh(Inf) should be Inf, but some mingw versions produce NaN, so skip test
--- SELECT acosh(float8 'infinity');
-SELECT acosh(float8 '-infinity');
+-- SELECT acosh(double precision 'infinity');
+SELECT acosh(double precision '-infinity');
 ERROR:  input is out of range
-SELECT acosh(float8 'nan');
+SELECT acosh(double precision 'nan');
  acosh 
 -------
    NaN
 (1 row)
 
-SELECT atanh(float8 'infinity');
+SELECT atanh(double precision 'infinity');
 ERROR:  input is out of range
-SELECT atanh(float8 '-infinity');
+SELECT atanh(double precision '-infinity');
 ERROR:  input is out of range
-SELECT atanh(float8 'nan');
+SELECT atanh(double precision 'nan');
  atanh 
 -------
    NaN

--- a/src/tests/regress/data/expected/int4.out
+++ b/src/tests/regress/data/expected/int4.out
@@ -51,7 +51,7 @@ SELECT * FROM INT4_TBL;
  -2147483647
 (5 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <> smallint '0';
      f1      
 -------------
       123456
@@ -60,7 +60,7 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int2 '0';
  -2147483647
 (4 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int '0';
      f1      
 -------------
       123456
@@ -69,33 +69,33 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int4 '0';
  -2147483647
 (4 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 = int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 = smallint '0';
  f1 
 ----
   0
 (1 row)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 = int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 = int '0';
  f1 
 ----
   0
 (1 row)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 < int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 < smallint '0';
      f1      
 -------------
      -123456
  -2147483647
 (2 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 < int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 < int '0';
      f1      
 -------------
      -123456
  -2147483647
 (2 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <= smallint '0';
      f1      
 -------------
            0
@@ -103,7 +103,7 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int2 '0';
  -2147483647
 (3 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int '0';
      f1      
 -------------
            0
@@ -111,21 +111,21 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int4 '0';
  -2147483647
 (3 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 > int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 > smallint '0';
      f1     
 ------------
      123456
  2147483647
 (2 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 > int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 > int '0';
      f1     
 ------------
      123456
  2147483647
 (2 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 >= smallint '0';
      f1     
 ------------
           0
@@ -133,7 +133,7 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int2 '0';
  2147483647
 (3 rows)
 
-SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int '0';
      f1     
 ------------
           0
@@ -142,14 +142,14 @@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int4 '0';
 (3 rows)
 
 -- positive odds
-SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int2 '2') = int2 '1';
+SELECT i.* FROM INT4_TBL i WHERE (i.f1 % smallint '2') = smallint '1';
      f1     
 ------------
  2147483647
 (1 row)
 
 -- any evens
-SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int4 '2') = int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int '2') = smallint '0';
    f1    
 ---------
        0
@@ -157,9 +157,9 @@ SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int4 '2') = int2 '0';
  -123456
 (3 rows)
 
-SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 * smallint '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 * smallint '2' AS x FROM INT4_TBL i
 WHERE abs(f1) < 1073741824;
    f1    |    x    
 ---------+---------
@@ -168,9 +168,9 @@ WHERE abs(f1) < 1073741824;
  -123456 | -246912
 (3 rows)
 
-SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 * int '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 * int '2' AS x FROM INT4_TBL i
 WHERE abs(f1) < 1073741824;
    f1    |    x    
 ---------+---------
@@ -179,9 +179,9 @@ WHERE abs(f1) < 1073741824;
  -123456 | -246912
 (3 rows)
 
-SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 + smallint '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 + smallint '2' AS x FROM INT4_TBL i
 WHERE f1 < 2147483646;
      f1      |      x      
 -------------+-------------
@@ -191,9 +191,9 @@ WHERE f1 < 2147483646;
  -2147483647 | -2147483645
 (4 rows)
 
-SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 + int '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 + int '2' AS x FROM INT4_TBL i
 WHERE f1 < 2147483646;
      f1      |      x      
 -------------+-------------
@@ -203,9 +203,9 @@ WHERE f1 < 2147483646;
  -2147483647 | -2147483645
 (4 rows)
 
-SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 - smallint '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 - smallint '2' AS x FROM INT4_TBL i
 WHERE f1 > -2147483647;
      f1     |     x      
 ------------+------------
@@ -215,9 +215,9 @@ WHERE f1 > -2147483647;
  2147483647 | 2147483645
 (4 rows)
 
-SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 - int '2' AS x FROM INT4_TBL i;
 ERROR:  integer out of range
-SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i
+SELECT i.f1, i.f1 - int '2' AS x FROM INT4_TBL i
 WHERE f1 > -2147483647;
      f1     |     x      
 ------------+------------
@@ -227,7 +227,7 @@ WHERE f1 > -2147483647;
  2147483647 | 2147483645
 (4 rows)
 
-SELECT i.f1, i.f1 / int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 / smallint '2' AS x FROM INT4_TBL i;
      f1      |      x      
 -------------+-------------
            0 |           0
@@ -237,7 +237,7 @@ SELECT i.f1, i.f1 / int2 '2' AS x FROM INT4_TBL i;
  -2147483647 | -1073741823
 (5 rows)
 
-SELECT i.f1, i.f1 / int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 / int '2' AS x FROM INT4_TBL i;
      f1      |      x      
 -------------+-------------
            0 |           0
@@ -275,25 +275,25 @@ SELECT 2 - -2 AS four;
     4
 (1 row)
 
-SELECT int2 '2' * int2 '2' = int2 '16' / int2 '4' AS true;
+SELECT smallint '2' * smallint '2' = smallint '16' / smallint '4' AS true;
  true 
 ------
  t
 (1 row)
 
-SELECT int4 '2' * int2 '2' = int2 '16' / int4 '4' AS true;
+SELECT int '2' * smallint '2' = smallint '16' / int '4' AS true;
  true 
 ------
  t
 (1 row)
 
-SELECT int2 '2' * int4 '2' = int4 '16' / int2 '4' AS true;
+SELECT smallint '2' * int '2' = int '16' / smallint '4' AS true;
  true 
 ------
  t
 (1 row)
 
-SELECT int4 '1000' < int4 '999' AS false;
+SELECT int '1000' < int '999' AS false;
  false 
 -------
  f

--- a/src/tests/regress/data/sql/float4.sql
+++ b/src/tests/regress/data/sql/float4.sql
@@ -352,3 +352,5 @@ SELECT '-9223380000000000000'::float4::int8;
 
 -- clean up, lest opr_sanity complain
 --@ drop type xfloat4 cascade;
+
+DROP TABLE FLOAT4_TBL;

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -106,51 +106,51 @@ select sign(f1) as sign_f1 from float8_tbl f;
 SET extra_float_digits = 0;
 
 -- square root
-SELECT sqrt(float8 '64') AS eight;
+SELECT sqrt(double precision '64') AS eight;
 
-SELECT |/ float8 '64' AS eight;
+SELECT |/ double precision '64' AS eight;
 
 SELECT f.f1, |/f.f1 AS sqrt_f1
    FROM FLOAT8_TBL f
    WHERE f.f1 > '0.0';
 
 -- power
-SELECT power(float8 '144', float8 '0.5');
-SELECT power(float8 'NaN', float8 '0.5');
-SELECT power(float8 '144', float8 'NaN');
-SELECT power(float8 'NaN', float8 'NaN');
-SELECT power(float8 '-1', float8 'NaN');
-SELECT power(float8 '1', float8 'NaN');
-SELECT power(float8 'NaN', float8 '0');
-SELECT power(float8 'inf', float8 '0');
-SELECT power(float8 '-inf', float8 '0');
-SELECT power(float8 '0', float8 'inf');
-SELECT power(float8 '0', float8 '-inf');
-SELECT power(float8 '1', float8 'inf');
-SELECT power(float8 '1', float8 '-inf');
-SELECT power(float8 '-1', float8 'inf');
-SELECT power(float8 '-1', float8 '-inf');
-SELECT power(float8 '0.1', float8 'inf');
-SELECT power(float8 '-0.1', float8 'inf');
-SELECT power(float8 '1.1', float8 'inf');
-SELECT power(float8 '-1.1', float8 'inf');
-SELECT power(float8 '0.1', float8 '-inf');
-SELECT power(float8 '-0.1', float8 '-inf');
-SELECT power(float8 '1.1', float8 '-inf');
-SELECT power(float8 '-1.1', float8 '-inf');
-SELECT power(float8 'inf', float8 '-2');
-SELECT power(float8 'inf', float8 '2');
-SELECT power(float8 'inf', float8 'inf');
-SELECT power(float8 'inf', float8 '-inf');
+SELECT power(double precision '144', double precision '0.5');
+SELECT power(double precision 'NaN', double precision '0.5');
+SELECT power(double precision '144', double precision 'NaN');
+SELECT power(double precision 'NaN', double precision 'NaN');
+SELECT power(double precision '-1', double precision 'NaN');
+SELECT power(double precision '1', double precision 'NaN');
+SELECT power(double precision 'NaN', double precision '0');
+SELECT power(double precision 'inf', double precision '0');
+SELECT power(double precision '-inf', double precision '0');
+SELECT power(double precision '0', double precision 'inf');
+SELECT power(double precision '0', double precision '-inf');
+SELECT power(double precision '1', double precision 'inf');
+SELECT power(double precision '1', double precision '-inf');
+SELECT power(double precision '-1', double precision 'inf');
+SELECT power(double precision '-1', double precision '-inf');
+SELECT power(double precision '0.1', double precision 'inf');
+SELECT power(double precision '-0.1', double precision 'inf');
+SELECT power(double precision '1.1', double precision 'inf');
+SELECT power(double precision '-1.1', double precision 'inf');
+SELECT power(double precision '0.1', double precision '-inf');
+SELECT power(double precision '-0.1', double precision '-inf');
+SELECT power(double precision '1.1', double precision '-inf');
+SELECT power(double precision '-1.1', double precision '-inf');
+SELECT power(double precision 'inf', double precision '-2');
+SELECT power(double precision 'inf', double precision '2');
+SELECT power(double precision 'inf', double precision 'inf');
+SELECT power(double precision 'inf', double precision '-inf');
 -- Intel's icc misoptimizes the code that controls the sign of this result,
 -- even with -mp1.  Pending a fix for that, only test for "is it zero".
-SELECT power(float8 '-inf', float8 '-2') = '0';
-SELECT power(float8 '-inf', float8 '-3');
-SELECT power(float8 '-inf', float8 '2');
-SELECT power(float8 '-inf', float8 '3');
-SELECT power(float8 '-inf', float8 '3.5');
-SELECT power(float8 '-inf', float8 'inf');
-SELECT power(float8 '-inf', float8 '-inf');
+SELECT power(double precision '-inf', double precision '-2') = '0';
+SELECT power(double precision '-inf', double precision '-3');
+SELECT power(double precision '-inf', double precision '2');
+SELECT power(double precision '-inf', double precision '3');
+SELECT power(double precision '-inf', double precision '3.5');
+SELECT power(double precision '-inf', double precision 'inf');
+SELECT power(double precision '-inf', double precision '-inf');
 
 -- take exp of ln(f.f1)
 SELECT f.f1, exp(ln(f.f1)) AS exp_ln_f1
@@ -161,7 +161,7 @@ SELECT f.f1, exp(ln(f.f1)) AS exp_ln_f1
 SELECT exp('inf'::float8), exp('-inf'::float8), exp('nan'::float8);
 
 -- cube root
-SELECT ||/ float8 '27' AS three;
+SELECT ||/ double precision '27' AS three;
 
 SELECT f.f1, ||/f.f1 AS cbrt_f1 FROM FLOAT8_TBL f;
 
@@ -191,32 +191,32 @@ SELECT * FROM FLOAT8_TBL;
 -- hyperbolic functions
 -- we run these with extra_float_digits = 0 too, since different platforms
 -- tend to produce results that vary in the last place.
-SELECT sinh(float8 '1');
-SELECT cosh(float8 '1');
-SELECT tanh(float8 '1');
-SELECT asinh(float8 '1');
-SELECT acosh(float8 '2');
-SELECT atanh(float8 '0.5');
+SELECT sinh(double precision '1');
+SELECT cosh(double precision '1');
+SELECT tanh(double precision '1');
+SELECT asinh(double precision '1');
+SELECT acosh(double precision '2');
+SELECT atanh(double precision '0.5');
 -- test Inf/NaN cases for hyperbolic functions
-SELECT sinh(float8 'infinity');
-SELECT sinh(float8 '-infinity');
-SELECT sinh(float8 'nan');
-SELECT cosh(float8 'infinity');
-SELECT cosh(float8 '-infinity');
-SELECT cosh(float8 'nan');
-SELECT tanh(float8 'infinity');
-SELECT tanh(float8 '-infinity');
-SELECT tanh(float8 'nan');
-SELECT asinh(float8 'infinity');
-SELECT asinh(float8 '-infinity');
-SELECT asinh(float8 'nan');
+SELECT sinh(double precision 'infinity');
+SELECT sinh(double precision '-infinity');
+SELECT sinh(double precision 'nan');
+SELECT cosh(double precision 'infinity');
+SELECT cosh(double precision '-infinity');
+SELECT cosh(double precision 'nan');
+SELECT tanh(double precision 'infinity');
+SELECT tanh(double precision '-infinity');
+SELECT tanh(double precision 'nan');
+SELECT asinh(double precision 'infinity');
+SELECT asinh(double precision '-infinity');
+SELECT asinh(double precision 'nan');
 -- acosh(Inf) should be Inf, but some mingw versions produce NaN, so skip test
--- SELECT acosh(float8 'infinity');
-SELECT acosh(float8 '-infinity');
-SELECT acosh(float8 'nan');
-SELECT atanh(float8 'infinity');
-SELECT atanh(float8 '-infinity');
-SELECT atanh(float8 'nan');
+-- SELECT acosh(double precision 'infinity');
+SELECT acosh(double precision '-infinity');
+SELECT acosh(double precision 'nan');
+SELECT atanh(double precision 'infinity');
+SELECT atanh(double precision '-infinity');
+SELECT atanh(double precision 'nan');
 
 RESET extra_float_digits;
 

--- a/src/tests/regress/data/sql/int4.sql
+++ b/src/tests/regress/data/sql/int4.sql
@@ -29,69 +29,69 @@ INSERT INTO INT4_TBL(f1) VALUES ('');
 
 SELECT * FROM INT4_TBL;
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <> smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <> int '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 = int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 = smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 = int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 = int '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 < int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 < smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 < int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 < int '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <= smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 <= int '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 > int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 > smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 > int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 > int '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 >= smallint '0';
 
---@ SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int4 '0';
+SELECT i.* FROM INT4_TBL i WHERE i.f1 >= int '0';
 
 -- positive odds
---@ SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int2 '2') = int2 '1';
+SELECT i.* FROM INT4_TBL i WHERE (i.f1 % smallint '2') = smallint '1';
 
 -- any evens
---@ SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int4 '2') = int2 '0';
+SELECT i.* FROM INT4_TBL i WHERE (i.f1 % int '2') = smallint '0';
 
-SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 * smallint '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 * int2 '2' AS x FROM INT4_TBL i
---@ WHERE abs(f1) < 1073741824;
+SELECT i.f1, i.f1 * smallint '2' AS x FROM INT4_TBL i
+WHERE abs(f1) < 1073741824;
 
-SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 * int '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 * int4 '2' AS x FROM INT4_TBL i
---@ WHERE abs(f1) < 1073741824;
+SELECT i.f1, i.f1 * int '2' AS x FROM INT4_TBL i
+WHERE abs(f1) < 1073741824;
 
-SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 + smallint '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 + int2 '2' AS x FROM INT4_TBL i
---@ WHERE f1 < 2147483646;
+SELECT i.f1, i.f1 + smallint '2' AS x FROM INT4_TBL i
+WHERE f1 < 2147483646;
 
-SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 + int '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 + int4 '2' AS x FROM INT4_TBL i
---@ WHERE f1 < 2147483646;
+SELECT i.f1, i.f1 + int '2' AS x FROM INT4_TBL i
+WHERE f1 < 2147483646;
 
-SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 - smallint '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 - int2 '2' AS x FROM INT4_TBL i
---@ WHERE f1 > -2147483647;
+SELECT i.f1, i.f1 - smallint '2' AS x FROM INT4_TBL i
+WHERE f1 > -2147483647;
 
-SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 - int '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 - int4 '2' AS x FROM INT4_TBL i
---@ WHERE f1 > -2147483647;
+SELECT i.f1, i.f1 - int '2' AS x FROM INT4_TBL i
+WHERE f1 > -2147483647;
 
---@ SELECT i.f1, i.f1 / int2 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 / smallint '2' AS x FROM INT4_TBL i;
 
---@ SELECT i.f1, i.f1 / int4 '2' AS x FROM INT4_TBL i;
+SELECT i.f1, i.f1 / int '2' AS x FROM INT4_TBL i;
 
 --
 -- more complex expressions
@@ -106,13 +106,13 @@ SELECT 2- -1 AS three;
 
 SELECT 2 - -2 AS four;
 
---@ SELECT int2 '2' * int2 '2' = int2 '16' / int2 '4' AS true;
+SELECT smallint '2' * smallint '2' = smallint '16' / smallint '4' AS true;
 
---@ SELECT int4 '2' * int2 '2' = int2 '16' / int4 '4' AS true;
+SELECT int '2' * smallint '2' = smallint '16' / int '4' AS true;
 
---@ SELECT int2 '2' * int4 '2' = int4 '16' / int2 '4' AS true;
+SELECT smallint '2' * int '2' = int '16' / smallint '4' AS true;
 
---@ SELECT int4 '1000' < int4 '999' AS false;
+SELECT int '1000' < int '999' AS false;
 
 SELECT 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 + 1 AS ten;
 

--- a/src/tests/regress/data/sql/int4.sql
+++ b/src/tests/regress/data/sql/int4.sql
@@ -176,3 +176,5 @@ SELECT gcd((-2147483648)::int4, (-2147483648)::int4); -- overflow
 
 SELECT lcm((-2147483648)::int4, 1::int4); -- overflow
 SELECT lcm(2147483647::int4, 2147483646::int4); -- overflow
+
+DROP TABLE INT4_TBL;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

The [TypeString](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS-GENERIC) syntax (`date '2022-01-01'`) of [sqlparser-rs](https://github.com/risingwavelabs/risingwave/blob/8b9a74556e9e00a3ddd55bb65af8eb76396a666b/src/sqlparser/src/parser.rs#L369-L375) only supports standard types (`smallint`, `real`, `timestamp with time zone`) but not PostgreSQL-internal names (`int2`, `float4`, `timestamptz`). Given these are not user-facing, we update the test cases rather than enhancing the parser.

Also adds `drop table` at end of tests to make repeated run easier.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
