### PR TITLE
fix(ci): explicitly set config for compaction-test 

### DIFF
--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -6,3 +6,20 @@ max_heartbeat_interval_secs = 600
 barrier_interval_ms = 250
 in_flight_barrier_nums = 40
 checkpoint_frequency = 10
+
+[storage]
+shared_buffer_capacity_mb = 4096
+sstable_size_mb = 256
+block_size_kb = 1024
+bloom_false_positive = 0.01
+data_directory = "hummock_001"
+block_cache_capacity_mb = 4096
+meta_cache_capacity_mb = 1024
+compactor_memory_limit_mb = 5120
+
+[storage.file_cache]
+capacity_mb = 1024
+total_buffer_capacity_mb = 128
+cache_file_fallocate_unit_mb = 512
+cache_meta_fallocate_unit_mb = 16
+cache_file_max_write_size_mb = 4


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Same as https://github.com/risingwavelabs/risingwave/pull/6812 (some default values have been changed by other commit)

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
