### PR TITLE
test(storage): remove `table id == 0` hack in filter key extractor

### DIFF
--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -307,14 +307,6 @@ impl FilterKeyExtractorManagerInner {
             return FilterKeyExtractorImpl::FullKey(FullKeyFilterKeyExtractor::default());
         }
 
-        #[cfg(debug_assertions)]
-        {
-            // for some unit-test not config table_id_set
-            if table_id_set.iter().any(|table_id| *table_id == 0) {
-                return FilterKeyExtractorImpl::FullKey(FullKeyFilterKeyExtractor::default());
-            }
-        }
-
         let mut multi_filter_key_extractor = MultiFilterKeyExtractor::default();
         while !table_id_set.is_empty() {
             let notified = self.notify.notified();

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -23,7 +23,9 @@ use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::key::{map_table_key_range, FullKey};
 use risingwave_hummock_sdk::HummockEpoch;
-use risingwave_meta::hummock::test_utils::setup_compute_env;
+use risingwave_meta::hummock::test_utils::{
+    setup_compute_env, update_filter_key_extractor_for_table_ids,
+};
 use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::MetaSrvEnv;
 use risingwave_meta::storage::MemStore;
@@ -64,13 +66,16 @@ pub async fn prepare_hummock_event_handler(
         worker_node.id,
     ));
 
+    let filter_key_extractor_manager = Arc::new(FilterKeyExtractorManager::default());
+    update_filter_key_extractor_for_table_ids(filter_key_extractor_manager.clone(), &[0]);
+
     let compactor_context = Arc::new(Context::new_local_compact_context(
         opt.clone(),
         sstable_store_ref,
         hummock_meta_client,
         Arc::new(StateStoreMetrics::unused()),
         sstable_id_manager,
-        Arc::new(FilterKeyExtractorManager::default()),
+        filter_key_extractor_manager,
     ));
 
     let hummock_event_handler = HummockEventHandler::new(

--- a/src/storage/hummock_test/src/local_version_manager_tests.rs
+++ b/src/storage/hummock_test/src/local_version_manager_tests.rs
@@ -20,7 +20,9 @@ use risingwave_common::catalog::TableId;
 use risingwave_common::config::StorageConfig;
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::HummockSstableId;
-use risingwave_meta::hummock::test_utils::setup_compute_env;
+use risingwave_meta::hummock::test_utils::{
+    setup_compute_env, update_filter_key_extractor_for_table_ids,
+};
 use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::MetaSrvEnv;
 use risingwave_meta::storage::MemStore;
@@ -65,6 +67,9 @@ pub async fn prepare_local_version_manager(
         opt.sstable_id_remote_fetch_number,
     ));
 
+    let filter_key_extractor_manager = Arc::new(FilterKeyExtractorManager::default());
+    update_filter_key_extractor_for_table_ids(filter_key_extractor_manager.clone(), &[0]);
+
     let buffer_tracker = BufferTracker::from_storage_config(&opt);
     let compactor_context = Arc::new(Context::new_local_compact_context(
         opt.clone(),
@@ -72,7 +77,7 @@ pub async fn prepare_local_version_manager(
         hummock_meta_client,
         Arc::new(StateStoreMetrics::unused()),
         sstable_id_manager,
-        Arc::new(FilterKeyExtractorManager::default()),
+        filter_key_extractor_manager,
     ));
 
     LocalVersionManager::new(pinned_version, compactor_context, buffer_tracker)

--- a/src/storage/hummock_test/src/state_store_tests.rs
+++ b/src/storage/hummock_test/src/state_store_tests.rs
@@ -1211,25 +1211,7 @@ async fn test_multiple_epoch_sync_inner(
 
 #[tokio::test]
 async fn test_gc_watermark_and_clear_shared_buffer() {
-    let sstable_store = mock_sstable_store();
-    let hummock_options = Arc::new(default_config_for_test());
-    let (env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
-        setup_compute_env(8080).await;
-    let meta_client = Arc::new(MockHummockMetaClient::new(
-        hummock_manager_ref.clone(),
-        worker_node.id,
-    ));
-
-    let hummock_storage = HummockStorage::for_test(
-        hummock_options,
-        sstable_store,
-        meta_client.clone(),
-        get_test_notification_client(env, hummock_manager_ref, worker_node),
-    )
-    .await
-    .unwrap();
-
-    let hummock_storage = HummockV2MixedStateStore::new(hummock_storage, Default::default()).await;
+    let (hummock_storage, meta_client) = with_hummock_storage_v2(Default::default()).await;
 
     assert_eq!(
         hummock_storage

--- a/src/storage/hummock_test/src/test_utils.rs
+++ b/src/storage/hummock_test/src/test_utils.rs
@@ -27,7 +27,9 @@ use risingwave_common::util::addr::HostAddr;
 use risingwave_common_service::observer_manager::{Channel, NotificationClient, ObserverManager};
 use risingwave_hummock_sdk::filter_key_extractor::FilterKeyExtractorManager;
 use risingwave_hummock_sdk::HummockReadEpoch;
-use risingwave_meta::hummock::test_utils::setup_compute_env;
+use risingwave_meta::hummock::test_utils::{
+    setup_compute_env, update_filter_key_extractor_for_table_ids,
+};
 use risingwave_meta::hummock::{HummockManager, HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::{MessageStatus, MetaSrvEnv, NotificationManagerRef, WorkerKey};
 use risingwave_meta::storage::{MemStore, MetaStore};
@@ -361,6 +363,11 @@ pub async fn with_hummock_storage_v1() -> (HummockStorageV1, Arc<MockHummockMeta
     .await
     .unwrap();
 
+    update_filter_key_extractor_for_table_ids(
+        hummock_storage.filter_key_extractor_manager().clone(),
+        &[0],
+    );
+
     (hummock_storage, meta_client)
 }
 
@@ -384,6 +391,11 @@ pub async fn with_hummock_storage_v2(
     )
     .await
     .unwrap();
+
+    update_filter_key_extractor_for_table_ids(
+        hummock_storage.filter_key_extractor_manager().clone(),
+        &[0],
+    );
 
     (
         HummockV2MixedStateStore::new(hummock_storage, table_id).await,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title