### PR TITLE
perf(array): optimize performance of literal expression

### DIFF
--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -54,7 +54,11 @@ impl<'a> FromIterator<&'a Option<bool>> for BoolArray {
 
 impl FromIterator<bool> for BoolArray {
     fn from_iter<I: IntoIterator<Item = bool>>(iter: I) -> Self {
-        iter.into_iter().map(Some).collect()
+        let data: Bitmap = iter.into_iter().collect();
+        BoolArray {
+            bitmap: Bitmap::all_high_bits(data.len()),
+            data,
+        }
     }
 }
 

--- a/src/common/src/array/bool_array.rs
+++ b/src/common/src/array/bool_array.rs
@@ -150,15 +150,15 @@ impl ArrayBuilder for BoolArrayBuilder {
         }
     }
 
-    fn append(&mut self, value: Option<bool>) {
+    fn append_n(&mut self, n: usize, value: Option<bool>) {
         match value {
             Some(x) => {
-                self.bitmap.append(true);
-                self.data.append(x);
+                self.bitmap.append_n(n, true);
+                self.data.append_n(n, x);
             }
             None => {
-                self.bitmap.append(false);
-                self.data.append(bool::default());
+                self.bitmap.append_n(n, false);
+                self.data.append_n(n, false);
             }
         }
     }

--- a/src/common/src/array/bytes_array.rs
+++ b/src/common/src/array/bytes_array.rs
@@ -211,16 +211,20 @@ impl ArrayBuilder for BytesArrayBuilder {
         }
     }
 
-    fn append<'a>(&'a mut self, value: Option<&'a [u8]>) {
+    fn append_n<'a>(&'a mut self, n: usize, value: Option<&'a [u8]>) {
         match value {
             Some(x) => {
-                self.bitmap.append(true);
-                self.data.extend_from_slice(x);
-                self.offset.push(self.data.len())
+                self.bitmap.append_n(n, true);
+                for _ in 0..n {
+                    self.data.extend_from_slice(x);
+                    self.offset.push(self.data.len());
+                }
             }
             None => {
-                self.bitmap.append(false);
-                self.offset.push(self.data.len())
+                self.bitmap.append_n(n, false);
+                for _ in 0..n {
+                    self.offset.push(self.data.len());
+                }
             }
         }
     }

--- a/src/common/src/array/iterator.rs
+++ b/src/common/src/array/iterator.rs
@@ -50,6 +50,38 @@ impl<'a, A: Array> Iterator for ArrayIterator<'a, A> {
     }
 }
 
+pub struct ArrayRawIter<'a, A: Array> {
+    data: &'a A,
+    pos: usize,
+}
+
+impl<'a, A: Array> ArrayRawIter<'a, A> {
+    pub fn new(data: &'a A) -> Self {
+        Self { data, pos: 0 }
+    }
+}
+
+unsafe impl<'a, A: Array> TrustedLen for ArrayRawIter<'a, A> {}
+
+impl<'a, A: Array> Iterator for ArrayRawIter<'a, A> {
+    type Item = A::RefItem<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.data.len() {
+            None
+        } else {
+            let item = self.data.value_at_raw(self.pos);
+            self.pos += 1;
+            Some(item)
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let size = self.data.len() - self.pos;
+        (size, Some(size))
+    }
+}
+
 pub struct ArrayImplIterator<'a> {
     data: &'a ArrayImpl,
     pos: usize,

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -78,24 +78,28 @@ impl ArrayBuilder for ListArrayBuilder {
         }
     }
 
-    fn append(&mut self, value: Option<ListRef<'_>>) {
+    fn append_n(&mut self, n: usize, value: Option<ListRef<'_>>) {
         match value {
             None => {
-                self.bitmap.append(false);
+                self.bitmap.append_n(n, false);
                 let last = *self.offsets.last().unwrap();
-                self.offsets.push(last);
+                for _ in 0..n {
+                    self.offsets.push(last);
+                }
             }
             Some(v) => {
-                self.bitmap.append(true);
-                let last = *self.offsets.last().unwrap();
-                let values_ref = v.values_ref();
-                self.offsets.push(last + values_ref.len());
-                for f in values_ref {
-                    self.value.append_datum(f);
+                self.bitmap.append_n(n, true);
+                for _ in 0..n {
+                    let last = *self.offsets.last().unwrap();
+                    let values_ref = v.values_ref();
+                    self.offsets.push(last + values_ref.len());
+                    for f in values_ref {
+                        self.value.append_datum(f);
+                    }
                 }
             }
         }
-        self.len += 1;
+        self.len += n;
     }
 
     fn append_array(&mut self, other: &ListArray) {

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -23,6 +23,7 @@ use itertools::Itertools;
 use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, ListArrayData};
 use serde::{Deserializer, Serializer};
 
+use super::iterator::ArrayRawIter;
 use super::{
     Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, ArrayResult, RowRef,
 };
@@ -158,7 +159,12 @@ impl Array for ListArray {
     type Builder = ListArrayBuilder;
     type Iter<'a> = ArrayIterator<'a, Self>;
     type OwnedItem = ListValue;
+    type RawIter<'a> = ArrayRawIter<'a, Self>;
     type RefItem<'a> = ListRef<'a>;
+
+    fn value_at_raw(&self, idx: usize) -> Self::RefItem<'_> {
+        ListRef::Indexed { arr: self, idx }
+    }
 
     fn value_at(&self, idx: usize) -> Option<ListRef<'_>> {
         if !self.is_null(idx) {
@@ -182,6 +188,10 @@ impl Array for ListArray {
 
     fn iter(&self) -> Self::Iter<'_> {
         ArrayIterator::new(self)
+    }
+
+    fn raw_iter(&self) -> Self::RawIter<'_> {
+        ArrayRawIter::new(self)
     }
 
     fn to_protobuf(&self) -> ProstArray {

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -112,6 +112,19 @@ pub trait ArrayBuilder: Send + Sync + Sized + 'static {
         self.append(None)
     }
 
+    /// Append a value multiple times.
+    ///
+    /// This may be more efficient than calling `append` multiple times.
+    fn append_n(
+        &mut self,
+        n: usize,
+        value: Option<<<Self as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>,
+    ) {
+        for _ in 0..n {
+            self.append(value);
+        }
+    }
+
     /// Append an array to builder.
     fn append_array(&mut self, other: &Self::ArrayType);
 

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -164,6 +164,16 @@ pub trait Array: std::fmt::Debug + Send + Sync + Sized + 'static + Into<ArrayImp
     where
         Self: 'a;
 
+    /// Raw iterator type of this array.
+    type RawIter<'a>: Iterator<Item = Self::RefItem<'a>>
+    where
+        Self: 'a;
+
+    /// Retrieve a reference to value regardless of whether it is null.
+    ///
+    /// The returned value for NULL values is undefined.
+    fn value_at_raw(&self, idx: usize) -> Self::RefItem<'_>;
+
     /// Retrieve a reference to value.
     fn value_at(&self, idx: usize) -> Option<Self::RefItem<'_>>;
 
@@ -177,6 +187,12 @@ pub trait Array: std::fmt::Debug + Send + Sync + Sized + 'static + Into<ArrayImp
 
     /// Get iterator of current array.
     fn iter(&self) -> Self::Iter<'_>;
+
+    /// Get raw iterator of current array.
+    ///
+    /// The raw iterator simply iterates values without checking the null bitmap.
+    /// The returned value for NULL values is undefined.
+    fn raw_iter(&self) -> Self::RawIter<'_>;
 
     /// Serialize to protobuf
     fn to_protobuf(&self) -> ProstArray;

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -105,24 +105,18 @@ pub trait ArrayBuilder: Send + Sync + Sized + 'static {
     /// Panics if `meta`'s type mismatches with the array type.
     fn with_meta(capacity: usize, meta: ArrayMeta) -> Self;
 
+    /// Append a value multiple times.
+    ///
+    /// This should be more efficient than calling `append` multiple times.
+    fn append_n(&mut self, n: usize, value: Option<<Self::ArrayType as Array>::RefItem<'_>>);
+
     /// Append a value to builder.
-    fn append(&mut self, value: Option<<<Self as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>);
+    fn append(&mut self, value: Option<<Self::ArrayType as Array>::RefItem<'_>>) {
+        self.append_n(1, value);
+    }
 
     fn append_null(&mut self) {
         self.append(None)
-    }
-
-    /// Append a value multiple times.
-    ///
-    /// This may be more efficient than calling `append` multiple times.
-    fn append_n(
-        &mut self,
-        n: usize,
-        value: Option<<<Self as ArrayBuilder>::ArrayType as Array>::RefItem<'_>>,
-    ) {
-        for _ in 0..n {
-            self.append(value);
-        }
     }
 
     /// Append an array to builder.
@@ -470,12 +464,14 @@ macro_rules! impl_array_builder {
                 }
             }
 
-            /// Append a [`Datum`] or [`DatumRef`], return error while type not match.
-            pub fn append_datum(&mut self, datum: impl ToDatumRef) {
+            /// Append a [`Datum`] or [`DatumRef`] multiple times, return error while type not match.
+            pub fn append_datum_n(&mut self, n: usize, datum: impl ToDatumRef) {
                 match datum.to_datum_ref() {
-                    None => self.append_null(),
+                    None => match self {
+                        $( Self::$variant_name(inner) => inner.append_n(n, None), )*
+                    }
                     Some(scalar_ref) => match (self, scalar_ref) {
-                        $( (Self::$variant_name(inner), ScalarRefImpl::$variant_name(v)) => inner.append(Some(v)), )*
+                        $( (Self::$variant_name(inner), ScalarRefImpl::$variant_name(v)) => inner.append_n(n, Some(v)), )*
                         (this_builder, this_scalar_ref) => panic!(
                             "Failed to append datum, array builder type: {}, scalar type: {}",
                             this_builder.get_ident(),
@@ -483,6 +479,11 @@ macro_rules! impl_array_builder {
                         ),
                     },
                 }
+            }
+
+            /// Append a [`Datum`] or [`DatumRef`], return error while type not match.
+            pub fn append_datum(&mut self, datum: impl ToDatumRef) {
+                self.append_datum_n(1, datum);
             }
 
             pub fn append_array_element(&mut self, other: &ArrayImpl, idx: usize) {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -270,6 +270,19 @@ impl<T: PrimitiveArrayItemType> ArrayBuilder for PrimitiveArrayBuilder<T> {
         }
     }
 
+    fn append_n(&mut self, n: usize, value: Option<T>) {
+        match value {
+            Some(x) => {
+                self.bitmap.append_n(n, true);
+                self.data.extend(std::iter::repeat(x).take(n));
+            }
+            None => {
+                self.bitmap.append_n(n, false);
+                self.data.extend(std::iter::repeat(T::default()).take(n));
+            }
+        }
+    }
+
     fn append_array(&mut self, other: &PrimitiveArray<T>) {
         for bit in other.bitmap.iter() {
             self.bitmap.append(bit);

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -159,7 +159,12 @@ impl<T: PrimitiveArrayItemType> Array for PrimitiveArray<T> {
     type Builder = PrimitiveArrayBuilder<T>;
     type Iter<'a> = ArrayIterator<'a, Self>;
     type OwnedItem = T;
+    type RawIter<'a> = std::iter::Cloned<std::slice::Iter<'a, T>>;
     type RefItem<'a> = T;
+
+    fn value_at_raw(&self, idx: usize) -> Self::RefItem<'_> {
+        self.data[idx]
+    }
 
     fn value_at(&self, idx: usize) -> Option<T> {
         if self.is_null(idx) {
@@ -187,6 +192,10 @@ impl<T: PrimitiveArrayItemType> Array for PrimitiveArray<T> {
 
     fn iter(&self) -> Self::Iter<'_> {
         ArrayIterator::new(self)
+    }
+
+    fn raw_iter(&self) -> Self::RawIter<'_> {
+        self.data.iter().cloned()
     }
 
     fn to_protobuf(&self) -> ProstArray {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -257,19 +257,6 @@ impl<T: PrimitiveArrayItemType> ArrayBuilder for PrimitiveArrayBuilder<T> {
         }
     }
 
-    fn append(&mut self, value: Option<T>) {
-        match value {
-            Some(x) => {
-                self.bitmap.append(true);
-                self.data.push(x);
-            }
-            None => {
-                self.bitmap.append(false);
-                self.data.push(T::default());
-            }
-        }
-    }
-
     fn append_n(&mut self, n: usize, value: Option<T>) {
         match value {
             Some(x) => {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -151,7 +151,11 @@ impl<'a, T: PrimitiveArrayItemType> FromIterator<&'a Option<T>> for PrimitiveArr
 
 impl<T: PrimitiveArrayItemType> FromIterator<T> for PrimitiveArray<T> {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
-        iter.into_iter().map(Some).collect()
+        let data: Vec<T> = iter.into_iter().collect();
+        PrimitiveArray {
+            bitmap: Bitmap::all_high_bits(data.len()),
+            data,
+        }
     }
 }
 

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -22,6 +22,7 @@ use bytes::{Buf, BufMut};
 use itertools::Itertools;
 use risingwave_pb::data::{Array as ProstArray, ArrayType as ProstArrayType, StructArrayData};
 
+use super::iterator::ArrayRawIter;
 use super::{
     Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayIterator, ArrayMeta, ArrayResult,
 };
@@ -156,7 +157,12 @@ impl Array for StructArray {
     type Builder = StructArrayBuilder;
     type Iter<'a> = ArrayIterator<'a, Self>;
     type OwnedItem = StructValue;
+    type RawIter<'a> = ArrayRawIter<'a, Self>;
     type RefItem<'a> = StructRef<'a>;
+
+    fn value_at_raw(&self, idx: usize) -> StructRef<'_> {
+        StructRef::Indexed { arr: self, idx }
+    }
 
     fn value_at(&self, idx: usize) -> Option<StructRef<'_>> {
         if !self.is_null(idx) {
@@ -180,6 +186,10 @@ impl Array for StructArray {
 
     fn iter(&self) -> Self::Iter<'_> {
         ArrayIterator::new(self)
+    }
+
+    fn raw_iter(&self) -> Self::RawIter<'_> {
+        ArrayRawIter::new(self)
     }
 
     fn to_protobuf(&self) -> ProstArray {

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -77,24 +77,24 @@ impl ArrayBuilder for StructArrayBuilder {
         }
     }
 
-    fn append(&mut self, value: Option<StructRef<'_>>) {
+    fn append_n(&mut self, n: usize, value: Option<StructRef<'_>>) {
         match value {
             None => {
-                self.bitmap.append(false);
+                self.bitmap.append_n(n, false);
                 for child in &mut self.children_array {
-                    child.append_datum(Datum::None);
+                    child.append_datum_n(n, Datum::None);
                 }
             }
             Some(v) => {
-                self.bitmap.append(true);
+                self.bitmap.append_n(n, true);
                 let fields = v.fields_ref();
                 assert_eq!(fields.len(), self.children_array.len());
-                for (field_idx, f) in fields.into_iter().enumerate() {
-                    self.children_array[field_idx].append_datum(f);
+                for (child, f) in self.children_array.iter_mut().zip_eq(fields) {
+                    child.append_datum_n(n, f);
                 }
             }
         }
-        self.len += 1;
+        self.len += n;
     }
 
     fn append_array(&mut self, other: &StructArray) {

--- a/src/common/src/array/utf8_array.rs
+++ b/src/common/src/array/utf8_array.rs
@@ -138,8 +138,8 @@ impl ArrayBuilder for Utf8ArrayBuilder {
     }
 
     #[inline]
-    fn append<'a>(&'a mut self, value: Option<&'a str>) {
-        self.bytes.append(value.map(|v| v.as_bytes()));
+    fn append_n<'a>(&'a mut self, n: usize, value: Option<&'a str>) {
+        self.bytes.append_n(n, value.map(|v| v.as_bytes()));
     }
 
     #[inline]

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -404,7 +404,8 @@ impl Not for Bitmap {
 
 impl FromIterator<bool> for Bitmap {
     fn from_iter<T: IntoIterator<Item = bool>>(iter: T) -> Self {
-        let mut builder = BitmapBuilder::default();
+        let iter = iter.into_iter();
+        let mut builder = BitmapBuilder::with_capacity(iter.size_hint().0);
         for b in iter {
             builder.append(b);
         }
@@ -414,7 +415,8 @@ impl FromIterator<bool> for Bitmap {
 
 impl FromIterator<Option<bool>> for Bitmap {
     fn from_iter<T: IntoIterator<Item = Option<bool>>>(iter: T) -> Self {
-        let mut builder = BitmapBuilder::default();
+        let iter = iter.into_iter();
+        let mut builder = BitmapBuilder::with_capacity(iter.size_hint().0);
         for b in iter {
             builder.append(b.unwrap_or(false));
         }

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -281,8 +281,8 @@ macro_rules! gen_binary_expr_bitwise {
             { int32, int16, int32, $general_f },
             { int32, int32, int32, $general_f },
             { int32, int64, int64, $general_f },
-            { int64, int16,int64, $general_f },
-            { int64, int32,int64, $general_f },
+            { int64, int16, int64, $general_f },
+            { int64, int32, int64, $general_f },
             { int64, int64, int64, $general_f },
             $(
                 { $i1, $i2, $rt, $func },


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- introduce `Array::raw_iter` to efficiently iterate over raw values regardless of null.
- introduce `ArrayBuilder::append_n` to efficiently append the same value multiple times.
- remove the `head` from `Bitmap`

With these optimizations, the evaluation time of literal expressions dropped from 2.2us to 150ns.

This PR also adds an optimized version of `i32 + i32` using raw iterator in the bench, reducing time from 3.3us to 350us.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#6868