### PR TITLE
feat(fragment): add new fragment type `Now` and send barriers to now …

### DIFF
--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -138,6 +138,7 @@ export const FragmentTypeFlag = {
   SOURCE: "SOURCE",
   MVIEW: "MVIEW",
   SINK: "SINK",
+  NOW: "NOW",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -157,6 +158,9 @@ export function fragmentTypeFlagFromJSON(object: any): FragmentTypeFlag {
     case 4:
     case "SINK":
       return FragmentTypeFlag.SINK;
+    case 8:
+    case "NOW":
+      return FragmentTypeFlag.NOW;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -174,6 +178,8 @@ export function fragmentTypeFlagToJSON(object: FragmentTypeFlag): string {
       return "MVIEW";
     case FragmentTypeFlag.SINK:
       return "SINK";
+    case FragmentTypeFlag.NOW:
+      return "NOW";
     case FragmentTypeFlag.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -557,6 +557,7 @@ enum FragmentTypeFlag {
   SOURCE = 1;
   MVIEW = 2;
   SINK = 4;
+  NOW = 8;
 }
 
 message StreamFragmentGraph {

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -201,11 +201,11 @@ fn build_fragment(
     // Update current fragment based on the node we're visiting.
     match stream_node.get_node_body()? {
         NodeBody::Source(_) => {
-            current_fragment.fragment_type_mask |= FragmentTypeFlag::Source as u32
+            current_fragment.fragment_type_mask |= FragmentTypeFlag::Source as u32;
         }
 
         NodeBody::Materialize(_) => {
-            current_fragment.fragment_type_mask |= FragmentTypeFlag::Mview as u32
+            current_fragment.fragment_type_mask |= FragmentTypeFlag::Mview as u32;
         }
 
         NodeBody::Sink(_) => current_fragment.fragment_type_mask |= FragmentTypeFlag::Sink as u32,
@@ -222,6 +222,8 @@ fn build_fragment(
             current_fragment.upstream_table_ids.push(node.table_id);
             current_fragment.is_singleton = node.is_singleton;
         }
+
+        NodeBody::Now(_) => current_fragment.fragment_type_mask |= FragmentTypeFlag::Now as u32,
 
         _ => {}
     };

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -28,7 +28,7 @@ pub struct BarrierActorInfo {
     /// node_id => actors
     pub actor_map: HashMap<WorkerId, Vec<ActorId>>,
 
-    /// node_id => source and now actors
+    /// node_id => barrier inject actors
     pub actor_map_to_send: HashMap<WorkerId, Vec<ActorId>>,
 }
 
@@ -47,7 +47,7 @@ impl BarrierActorInfo {
         Self {
             node_map,
             actor_map: actor_infos.actor_maps,
-            actor_map_to_send: actor_infos.source_now_actor_maps,
+            actor_map_to_send: actor_infos.barrier_inject_actor_maps,
         }
     }
 

--- a/src/meta/src/barrier/info.rs
+++ b/src/meta/src/barrier/info.rs
@@ -28,7 +28,7 @@ pub struct BarrierActorInfo {
     /// node_id => actors
     pub actor_map: HashMap<WorkerId, Vec<ActorId>>,
 
-    /// node_id => source actors
+    /// node_id => source and now actors
     pub actor_map_to_send: HashMap<WorkerId, Vec<ActorId>>,
 }
 
@@ -47,7 +47,7 @@ impl BarrierActorInfo {
         Self {
             node_map,
             actor_map: actor_infos.actor_maps,
-            actor_map_to_send: actor_infos.source_actor_maps,
+            actor_map_to_send: actor_infos.source_now_actor_maps,
         }
     }
 

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -79,8 +79,8 @@ pub struct ActorInfos {
     /// node_id => actor_ids
     pub actor_maps: HashMap<WorkerId, Vec<ActorId>>,
 
-    /// all reachable source actors
-    pub source_actor_maps: HashMap<WorkerId, Vec<ActorId>>,
+    /// all reachable source and now actors
+    pub source_now_actor_maps: HashMap<WorkerId, Vec<ActorId>>,
 }
 
 pub struct FragmentVNodeInfo {
@@ -339,7 +339,7 @@ where
         check_state: impl Fn(ActorState, TableId, ActorId) -> bool,
     ) -> ActorInfos {
         let mut actor_maps = HashMap::new();
-        let mut source_actor_maps = HashMap::new();
+        let mut source_now_actor_maps = HashMap::new();
 
         let map = &self.core.read().await.table_fragments;
         for fragments in map.values() {
@@ -354,11 +354,11 @@ where
                 }
             }
 
-            let source_actors = fragments.worker_source_actor_states();
-            for (worker_id, actor_states) in source_actors {
+            let source_now_actors = fragments.worker_source_now_actor_states();
+            for (worker_id, actor_states) in source_now_actors {
                 for (actor_id, actor_state) in actor_states {
                     if check_state(actor_state, fragments.table_id(), actor_id) {
-                        source_actor_maps
+                        source_now_actor_maps
                             .entry(worker_id)
                             .or_insert_with(Vec::new)
                             .push(actor_id);
@@ -369,7 +369,7 @@ where
 
         ActorInfos {
             actor_maps,
-            source_actor_maps,
+            source_now_actor_maps,
         }
     }
 

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -79,8 +79,8 @@ pub struct ActorInfos {
     /// node_id => actor_ids
     pub actor_maps: HashMap<WorkerId, Vec<ActorId>>,
 
-    /// all reachable source and now actors
-    pub source_now_actor_maps: HashMap<WorkerId, Vec<ActorId>>,
+    /// all reachable barrier inject actors
+    pub barrier_inject_actor_maps: HashMap<WorkerId, Vec<ActorId>>,
 }
 
 pub struct FragmentVNodeInfo {
@@ -339,7 +339,7 @@ where
         check_state: impl Fn(ActorState, TableId, ActorId) -> bool,
     ) -> ActorInfos {
         let mut actor_maps = HashMap::new();
-        let mut source_now_actor_maps = HashMap::new();
+        let mut barrier_inject_actor_maps = HashMap::new();
 
         let map = &self.core.read().await.table_fragments;
         for fragments in map.values() {
@@ -354,11 +354,11 @@ where
                 }
             }
 
-            let source_now_actors = fragments.worker_source_now_actor_states();
-            for (worker_id, actor_states) in source_now_actors {
+            let barrier_inject_actors = fragments.worker_barrier_inject_actor_states();
+            for (worker_id, actor_states) in barrier_inject_actors {
                 for (actor_id, actor_state) in actor_states {
                     if check_state(actor_state, fragments.table_id(), actor_id) {
-                        source_now_actor_maps
+                        barrier_inject_actor_maps
                             .entry(worker_id)
                             .or_insert_with(Vec::new)
                             .push(actor_id);
@@ -369,7 +369,7 @@ where
 
         ActorInfos {
             actor_maps,
-            source_now_actor_maps,
+            barrier_inject_actor_maps,
         }
     }
 

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -182,8 +182,8 @@ impl TableFragments {
             .collect()
     }
 
-    /// Returns source and now actor ids.
-    pub fn source_now_actor_ids(&self) -> Vec<ActorId> {
+    /// Returns barrier inject actor ids.
+    pub fn barrier_inject_actor_ids(&self) -> Vec<ActorId> {
         Self::filter_actor_ids(self, |fragment_type_mask| {
             (fragment_type_mask & (FragmentTypeFlag::Source as u32 | FragmentTypeFlag::Now as u32))
                 != 0
@@ -373,10 +373,12 @@ impl TableFragments {
         actors
     }
 
-    pub fn worker_source_now_actor_states(&self) -> BTreeMap<WorkerId, Vec<(ActorId, ActorState)>> {
+    pub fn worker_barrier_inject_actor_states(
+        &self,
+    ) -> BTreeMap<WorkerId, Vec<(ActorId, ActorState)>> {
         let mut map = BTreeMap::default();
-        let source_now_actor_ids = self.source_now_actor_ids();
-        for &actor_id in &source_now_actor_ids {
+        let barrier_inject_actor_ids = self.barrier_inject_actor_ids();
+        for &actor_id in &barrier_inject_actor_ids {
             let actor_status = &self.actor_status[&actor_id];
             map.entry(actor_status.get_parallel_unit().unwrap().worker_node_id as WorkerId)
                 .or_insert_with(Vec::new)

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -182,10 +182,11 @@ impl TableFragments {
             .collect()
     }
 
-    /// Returns source actor ids.
-    pub fn source_actor_ids(&self) -> Vec<ActorId> {
+    /// Returns source and now actor ids.
+    pub fn source_now_actor_ids(&self) -> Vec<ActorId> {
         Self::filter_actor_ids(self, |fragment_type_mask| {
-            (fragment_type_mask & FragmentTypeFlag::Source as u32) != 0
+            (fragment_type_mask & (FragmentTypeFlag::Source as u32 | FragmentTypeFlag::Now as u32))
+                != 0
         })
     }
 
@@ -372,10 +373,10 @@ impl TableFragments {
         actors
     }
 
-    pub fn worker_source_actor_states(&self) -> BTreeMap<WorkerId, Vec<(ActorId, ActorState)>> {
+    pub fn worker_source_now_actor_states(&self) -> BTreeMap<WorkerId, Vec<(ActorId, ActorState)>> {
         let mut map = BTreeMap::default();
-        let source_actor_ids = self.source_actor_ids();
-        for &actor_id in &source_actor_ids {
+        let source_now_actor_ids = self.source_now_actor_ids();
+        for &actor_id in &source_now_actor_ids {
             let actor_status = &self.actor_status[&actor_id];
             map.entry(actor_status.get_parallel_unit().unwrap().worker_node_id as WorkerId)
                 .or_insert_with(Vec::new)

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -408,11 +408,11 @@ async fn test_fragmenter() -> MetaResult<()> {
 
     let table_fragments = TableFragments::new(TableId::default(), graph);
     let actors = table_fragments.actors();
-    let source_now_actor_ids = table_fragments.source_now_actor_ids();
+    let barrier_inject_actor_ids = table_fragments.barrier_inject_actor_ids();
     let sink_actor_ids = table_fragments.mview_actor_ids();
     let internal_table_ids = ctx.internal_table_ids();
     assert_eq!(actors.len(), 9);
-    assert_eq!(source_now_actor_ids, vec![6, 7, 8, 9]);
+    assert_eq!(barrier_inject_actor_ids, vec![6, 7, 8, 9]);
     assert_eq!(sink_actor_ids, vec![1]);
     assert_eq!(2, internal_table_ids.len());
 

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -408,11 +408,11 @@ async fn test_fragmenter() -> MetaResult<()> {
 
     let table_fragments = TableFragments::new(TableId::default(), graph);
     let actors = table_fragments.actors();
-    let source_actor_ids = table_fragments.source_actor_ids();
+    let source_now_actor_ids = table_fragments.source_now_actor_ids();
     let sink_actor_ids = table_fragments.mview_actor_ids();
     let internal_table_ids = ctx.internal_table_ids();
     assert_eq!(actors.len(), 9);
-    assert_eq!(source_actor_ids, vec![6, 7, 8, 9]);
+    assert_eq!(source_now_actor_ids, vec![6, 7, 8, 9]);
     assert_eq!(sink_actor_ids, vec![1]);
     assert_eq!(2, internal_table_ids.len());
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Summarize your change (**mandatory**)
Add a new fragment type `Now` (i.e., has now) in order that we can send barriers to actors who have `NowExecutor` .
- Describe clearly one logical change and avoid lazy messages (optional)
After this PR, we will send barriers to actors who have either `NowExecutor` or `SourceExecutor`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6889 