### PR TITLE
fix(chore): fix mergify commit message

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,7 @@ I hereby agree to the terms of the [Singularity Data, Inc. Contributor License A
 
 ## What's changed and what's your intention?
 
-***PLEASE DO NOT LEAVE THIS EMPTY !!!***
+**This section will be used as the commit message. Please do not leave this empty!**
 
 Please explain **IN DETAIL** what the changes are in this PR and why they are needed:
 

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,13 +1,13 @@
 shared:
   - commit_message_template: &commit_message_template |
-      {{title}}
+      {{title}} (#{{number}})
       
       {{body | get_section("## What's changed and what's your intention?")}}
       
       {% for user in approved_reviews_by %}
       Approved-By: {{user}}
       {%- endfor %}
-      {% for commit in commits|unique(false, "email_author") %}
+      {% for commit in commits|unique(false, "email_author") if commit.author != "mergify[bot]" %}
       Co-Authored-By: {{ commit.author }} <{{ commit.email_author }}>
       {%- endfor %}
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Add the PR number in the commit message. See comments under #6829.
- Filter out `Co-Authored-By: mergify[bot]`
- Updated the PR template

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

https://github.com/risingwavelabs/risingwave/pull/6829#issuecomment-1348602849