### PR TITLE
chore: enable row id gen executor to generate multiple row ids

### DIFF
--- a/dashboard/proto/gen/catalog.ts
+++ b/dashboard/proto/gen/catalog.ts
@@ -137,9 +137,7 @@ export interface Table {
    * An optional column index of row id. If the primary key is specified by users,
    * this will be `None`.
    */
-  rowIdIndex:
-    | ColumnIndex
-    | undefined;
+  rowIdIndices: number[];
   /**
    * The column indices which are stored in the state store's value with
    * row-encoding. Currently is not supported yet and expected to be
@@ -733,7 +731,7 @@ function createBaseTable(): Table {
     properties: {},
     fragmentId: 0,
     vnodeColIndex: undefined,
-    rowIdIndex: undefined,
+    rowIdIndices: [],
     valueIndices: [],
     definition: "",
     handlePkConflict: false,
@@ -771,7 +769,9 @@ export const Table = {
         : {},
       fragmentId: isSet(object.fragmentId) ? Number(object.fragmentId) : 0,
       vnodeColIndex: isSet(object.vnodeColIndex) ? ColumnIndex.fromJSON(object.vnodeColIndex) : undefined,
-      rowIdIndex: isSet(object.rowIdIndex) ? ColumnIndex.fromJSON(object.rowIdIndex) : undefined,
+      rowIdIndices: Array.isArray(object?.rowIdIndices)
+        ? object.rowIdIndices.map((e: any) => Number(e))
+        : [],
       valueIndices: Array.isArray(object?.valueIndices)
         ? object.valueIndices.map((e: any) => Number(e))
         : [],
@@ -826,8 +826,11 @@ export const Table = {
     message.fragmentId !== undefined && (obj.fragmentId = Math.round(message.fragmentId));
     message.vnodeColIndex !== undefined &&
       (obj.vnodeColIndex = message.vnodeColIndex ? ColumnIndex.toJSON(message.vnodeColIndex) : undefined);
-    message.rowIdIndex !== undefined &&
-      (obj.rowIdIndex = message.rowIdIndex ? ColumnIndex.toJSON(message.rowIdIndex) : undefined);
+    if (message.rowIdIndices) {
+      obj.rowIdIndices = message.rowIdIndices.map((e) => Math.round(e));
+    } else {
+      obj.rowIdIndices = [];
+    }
     if (message.valueIndices) {
       obj.valueIndices = message.valueIndices.map((e) => Math.round(e));
     } else {
@@ -876,9 +879,7 @@ export const Table = {
     message.vnodeColIndex = (object.vnodeColIndex !== undefined && object.vnodeColIndex !== null)
       ? ColumnIndex.fromPartial(object.vnodeColIndex)
       : undefined;
-    message.rowIdIndex = (object.rowIdIndex !== undefined && object.rowIdIndex !== null)
-      ? ColumnIndex.fromPartial(object.rowIdIndex)
-      : undefined;
+    message.rowIdIndices = object.rowIdIndices?.map((e) => e) || [];
     message.valueIndices = object.valueIndices?.map((e) => e) || [];
     message.definition = object.definition ?? "";
     message.handlePkConflict = object.handlePkConflict ?? false;

--- a/dashboard/proto/gen/hummock.ts
+++ b/dashboard/proto/gen/hummock.ts
@@ -683,7 +683,6 @@ export interface RiseCtlUpdateCompactionConfigRequest_MutableConfig {
     | { $case: "maxBytesForLevelMultiplier"; maxBytesForLevelMultiplier: number }
     | { $case: "maxCompactionBytes"; maxCompactionBytes: number }
     | { $case: "subLevelMaxCompactionBytes"; subLevelMaxCompactionBytes: number }
-    | { $case: "level0TriggerFileNumber"; level0TriggerFileNumber: number }
     | { $case: "level0TierCompactFileNumber"; level0TierCompactFileNumber: number }
     | { $case: "targetFileSizeBase"; targetFileSizeBase: number }
     | { $case: "compactionFilterMask"; compactionFilterMask: number }
@@ -708,7 +707,6 @@ export interface CompactionConfig {
   maxBytesForLevelMultiplier: number;
   maxCompactionBytes: number;
   subLevelMaxCompactionBytes: number;
-  level0TriggerFileNumber: number;
   level0TierCompactFileNumber: number;
   compactionMode: CompactionConfig_CompactionMode;
   compressionAlgorithm: string[];
@@ -3976,8 +3974,6 @@ export const RiseCtlUpdateCompactionConfigRequest_MutableConfig = {
         ? { $case: "maxCompactionBytes", maxCompactionBytes: Number(object.maxCompactionBytes) }
         : isSet(object.subLevelMaxCompactionBytes)
         ? { $case: "subLevelMaxCompactionBytes", subLevelMaxCompactionBytes: Number(object.subLevelMaxCompactionBytes) }
-        : isSet(object.level0TriggerFileNumber)
-        ? { $case: "level0TriggerFileNumber", level0TriggerFileNumber: Number(object.level0TriggerFileNumber) }
         : isSet(object.level0TierCompactFileNumber)
         ? {
           $case: "level0TierCompactFileNumber",
@@ -4003,8 +3999,6 @@ export const RiseCtlUpdateCompactionConfigRequest_MutableConfig = {
       (obj.maxCompactionBytes = Math.round(message.mutableConfig?.maxCompactionBytes));
     message.mutableConfig?.$case === "subLevelMaxCompactionBytes" &&
       (obj.subLevelMaxCompactionBytes = Math.round(message.mutableConfig?.subLevelMaxCompactionBytes));
-    message.mutableConfig?.$case === "level0TriggerFileNumber" &&
-      (obj.level0TriggerFileNumber = Math.round(message.mutableConfig?.level0TriggerFileNumber));
     message.mutableConfig?.$case === "level0TierCompactFileNumber" &&
       (obj.level0TierCompactFileNumber = Math.round(message.mutableConfig?.level0TierCompactFileNumber));
     message.mutableConfig?.$case === "targetFileSizeBase" &&
@@ -4058,16 +4052,6 @@ export const RiseCtlUpdateCompactionConfigRequest_MutableConfig = {
       message.mutableConfig = {
         $case: "subLevelMaxCompactionBytes",
         subLevelMaxCompactionBytes: object.mutableConfig.subLevelMaxCompactionBytes,
-      };
-    }
-    if (
-      object.mutableConfig?.$case === "level0TriggerFileNumber" &&
-      object.mutableConfig?.level0TriggerFileNumber !== undefined &&
-      object.mutableConfig?.level0TriggerFileNumber !== null
-    ) {
-      message.mutableConfig = {
-        $case: "level0TriggerFileNumber",
-        level0TriggerFileNumber: object.mutableConfig.level0TriggerFileNumber,
       };
     }
     if (
@@ -4198,7 +4182,6 @@ function createBaseCompactionConfig(): CompactionConfig {
     maxBytesForLevelMultiplier: 0,
     maxCompactionBytes: 0,
     subLevelMaxCompactionBytes: 0,
-    level0TriggerFileNumber: 0,
     level0TierCompactFileNumber: 0,
     compactionMode: CompactionConfig_CompactionMode.UNSPECIFIED,
     compressionAlgorithm: [],
@@ -4220,7 +4203,6 @@ export const CompactionConfig = {
       subLevelMaxCompactionBytes: isSet(object.subLevelMaxCompactionBytes)
         ? Number(object.subLevelMaxCompactionBytes)
         : 0,
-      level0TriggerFileNumber: isSet(object.level0TriggerFileNumber) ? Number(object.level0TriggerFileNumber) : 0,
       level0TierCompactFileNumber: isSet(object.level0TierCompactFileNumber)
         ? Number(object.level0TierCompactFileNumber)
         : 0,
@@ -4245,8 +4227,6 @@ export const CompactionConfig = {
     message.maxCompactionBytes !== undefined && (obj.maxCompactionBytes = Math.round(message.maxCompactionBytes));
     message.subLevelMaxCompactionBytes !== undefined &&
       (obj.subLevelMaxCompactionBytes = Math.round(message.subLevelMaxCompactionBytes));
-    message.level0TriggerFileNumber !== undefined &&
-      (obj.level0TriggerFileNumber = Math.round(message.level0TriggerFileNumber));
     message.level0TierCompactFileNumber !== undefined &&
       (obj.level0TierCompactFileNumber = Math.round(message.level0TierCompactFileNumber));
     message.compactionMode !== undefined &&
@@ -4269,7 +4249,6 @@ export const CompactionConfig = {
     message.maxBytesForLevelMultiplier = object.maxBytesForLevelMultiplier ?? 0;
     message.maxCompactionBytes = object.maxCompactionBytes ?? 0;
     message.subLevelMaxCompactionBytes = object.subLevelMaxCompactionBytes ?? 0;
-    message.level0TriggerFileNumber = object.level0TriggerFileNumber ?? 0;
     message.level0TierCompactFileNumber = object.level0TierCompactFileNumber ?? 0;
     message.compactionMode = object.compactionMode ?? CompactionConfig_CompactionMode.UNSPECIFIED;
     message.compressionAlgorithm = object.compressionAlgorithm?.map((e) => e) || [];

--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -699,7 +699,7 @@ export interface DmlNode {
 }
 
 export interface RowIdGenNode {
-  rowIdIndex: number;
+  rowIdIndices: number[];
 }
 
 export interface NowNode {
@@ -3078,23 +3078,27 @@ export const DmlNode = {
 };
 
 function createBaseRowIdGenNode(): RowIdGenNode {
-  return { rowIdIndex: 0 };
+  return { rowIdIndices: [] };
 }
 
 export const RowIdGenNode = {
   fromJSON(object: any): RowIdGenNode {
-    return { rowIdIndex: isSet(object.rowIdIndex) ? Number(object.rowIdIndex) : 0 };
+    return { rowIdIndices: Array.isArray(object?.rowIdIndices) ? object.rowIdIndices.map((e: any) => Number(e)) : [] };
   },
 
   toJSON(message: RowIdGenNode): unknown {
     const obj: any = {};
-    message.rowIdIndex !== undefined && (obj.rowIdIndex = Math.round(message.rowIdIndex));
+    if (message.rowIdIndices) {
+      obj.rowIdIndices = message.rowIdIndices.map((e) => Math.round(e));
+    } else {
+      obj.rowIdIndices = [];
+    }
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<RowIdGenNode>, I>>(object: I): RowIdGenNode {
     const message = createBaseRowIdGenNode();
-    message.rowIdIndex = object.rowIdIndex ?? 0;
+    message.rowIdIndices = object.rowIdIndices?.map((e) => e) || [];
     return message;
   },
 };

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -116,7 +116,7 @@ message Table {
   ColumnIndex vnode_col_index = 18;
   // An optional column index of row id. If the primary key is specified by users,
   // this will be `None`.
-  ColumnIndex row_id_index = 19;
+  repeated uint64 row_id_indices = 19;
   // The column indices which are stored in the state store's value with
   // row-encoding. Currently is not supported yet and expected to be
   // `[0..columns.len()]`.

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -439,7 +439,7 @@ message DmlNode {
 }
 
 message RowIdGenNode {
-  uint64 row_id_index = 1;
+  repeated uint64 row_id_indices = 1;
 }
 
 message NowNode {

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -98,9 +98,8 @@ pub struct TableCatalog {
     /// hash distribution
     pub vnode_col_index: Option<usize>,
 
-    /// An optional column index of row id. If the primary key is specified by users, this will be
-    /// `None`.
-    pub row_id_index: Option<usize>,
+    /// Column indices of row id. If the primary key is specified by users, this will be empty.
+    pub row_id_indices: Vec<usize>,
 
     /// The column indices which are stored in the state store's value with row-encoding. Currently
     /// is not supported yet and expected to be `[0..columns.len()]`
@@ -263,9 +262,7 @@ impl TableCatalog {
             vnode_col_index: self
                 .vnode_col_index
                 .map(|i| ProstColumnIndex { index: i as _ }),
-            row_id_index: self
-                .row_id_index
-                .map(|i| ProstColumnIndex { index: i as _ }),
+            row_id_indices: self.row_id_indices.iter().map(|i| *i as _).collect(),
             value_indices: self.value_indices.iter().map(|x| *x as _).collect(),
             definition: self.definition.clone(),
             handle_pk_conflict: self.handle_pk_conflict,
@@ -315,7 +312,7 @@ impl From<ProstTable> for TableCatalog {
             properties: WithOptions::new(tb.properties),
             fragment_id: tb.fragment_id,
             vnode_col_index: tb.vnode_col_index.map(|x| x.index as usize),
-            row_id_index: tb.row_id_index.map(|x| x.index as usize),
+            row_id_indices: tb.row_id_indices.iter().map(|x| *x as _).collect(),
             value_indices: tb.value_indices.iter().map(|x| *x as _).collect(),
             definition: tb.definition.clone(),
             handle_pk_conflict: tb.handle_pk_conflict,
@@ -406,7 +403,7 @@ mod tests {
             handle_pk_conflict: false,
             pk_prefix_len_hint: 0,
             vnode_col_index: None,
-            row_id_index: None,
+            row_id_indices: vec![],
         }
         .into();
 
@@ -462,7 +459,7 @@ mod tests {
                 )])),
                 fragment_id: 0,
                 vnode_col_index: None,
-                row_id_index: None,
+                row_id_indices: vec![],
                 value_indices: vec![0],
                 definition: "".into(),
                 handle_pk_conflict: false,

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -116,7 +116,7 @@ pub fn gen_create_mv_plan(
         col_names,
         false,
         false,
-        None,
+        vec![],
         TableType::MaterializedView,
     )?;
     let mut table = materialize.table().to_prost(schema_id, database_id);

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -277,8 +277,8 @@ pub(crate) fn gen_materialize_plan(
             "".into(),
             None,
             handle_pk_conflict,
-            false, // TODO(Yuanxin): true
-            None,  // TODO(Yuanxin): row_id_index
+            false,  // TODO(Yuanxin): true
+            vec![], // TODO(Yuanxin): row_id_index
             TableType::Table,
         )?
     };

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -503,7 +503,7 @@ impl PlanRoot {
         col_names: Option<Vec<String>>,
         handle_pk_conflict: bool,
         enable_dml: bool,
-        row_id_index: Option<usize>,
+        row_id_indices: Vec<usize>,
         table_type: TableType,
     ) -> Result<StreamMaterialize> {
         let out_names = if let Some(col_names) = col_names {
@@ -526,9 +526,9 @@ impl PlanRoot {
                 .collect_vec();
             stream_plan = StreamDml::new(stream_plan, column_descs).into();
         }
-        if let Some(row_id_index) = row_id_index {
+        if !row_id_indices.is_empty() {
             // Insert a row id gen eexecutor after the previous executor.
-            stream_plan = StreamRowIdGen::new(stream_plan, row_id_index).into();
+            stream_plan = StreamRowIdGen::new(stream_plan, row_id_indices.clone()).into();
         }
 
         StreamMaterialize::create(
@@ -541,7 +541,7 @@ impl PlanRoot {
             false,
             definition,
             handle_pk_conflict,
-            row_id_index,
+            row_id_indices,
             table_type,
         )
     }
@@ -559,7 +559,7 @@ impl PlanRoot {
             true,
             "".into(),
             false,
-            None,
+            vec![],
             TableType::Index,
         )
     }
@@ -583,7 +583,7 @@ impl PlanRoot {
             false,
             definition,
             false,
-            None,
+            vec![],
             // NOTE(Yuanxin): We set the table type as default here because this is irrelevant to
             // sink's plan generating.
             TableType::default(),

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -68,7 +68,7 @@ impl StreamMaterialize {
         is_index: bool,
         definition: String,
         handle_pk_conflict: bool,
-        row_id_index: Option<usize>,
+        row_id_indices: Vec<usize>,
         table_type: TableType,
     ) -> Result<Self> {
         let required_dist = match input.distribution() {
@@ -170,7 +170,7 @@ impl StreamMaterialize {
             // TODO(zehua): replace it with FragmentId::placeholder()
             fragment_id: FragmentId::MAX - 1,
             vnode_col_index: None,
-            row_id_index,
+            row_id_indices,
             value_indices,
             definition,
             handle_pk_conflict,

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -127,7 +127,7 @@ impl TableCatalogBuilder {
             // TODO(zehua): replace it with FragmentId::placeholder()
             fragment_id: FragmentId::MAX - 1,
             vnode_col_index: self.vnode_col_idx,
-            row_id_index: None,
+            row_id_indices: vec![],
             value_indices: self
                 .value_indices
                 .unwrap_or_else(|| (0..self.columns.len()).collect_vec()),

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -391,7 +391,7 @@ mod tests {
     use risingwave_common::util::ordered::OrderedRowSerde;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_pb::catalog::table::TableType;
-    use risingwave_pb::catalog::{ColumnIndex, Table as ProstTable};
+    use risingwave_pb::catalog::Table as ProstTable;
     use risingwave_pb::plan_common::{ColumnCatalog as ProstColumnCatalog, ColumnOrder};
     use tokio::task;
 
@@ -499,7 +499,7 @@ mod tests {
             )]),
             fragment_id: 0,
             vnode_col_index: None,
-            row_id_index: Some(ColumnIndex { index: 0 }),
+            row_id_indices: vec![0],
             value_indices: vec![0],
             definition: "".into(),
             handle_pk_conflict: false,

--- a/src/stream/src/from_proto/row_id_gen.rs
+++ b/src/stream/src/from_proto/row_id_gen.rs
@@ -42,7 +42,7 @@ impl ExecutorBuilder for RowIdGenExecutorBuilder {
             params.schema,
             params.pk_indices,
             params.executor_id,
-            node.row_id_index as _,
+            node.row_id_indices.iter().map(|i| *i as _).collect(),
             vnodes,
         );
         Ok(Box::new(executor))


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Enable row id gen executor to generate multiple row ids so that queries like

```SQL
create source s1 (v1 int) with (connector = 'datagen') row format json;
create source s2 (v2 int) with (connector = 'datagen') row format json;
create materialized view mv as select * from s1 join s2 on s1.v1 = s2.v2;
```

will get a correct result.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
