### PR TITLE
fix(optimizer): BatchSort can not maintain order when it has multiple scan range

### DIFF
--- a/src/frontend/planner_test/tests/testdata/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/order_by.yaml
@@ -186,6 +186,15 @@
   batch_plan: |
     BatchExchange { order: [mv.v DESC], dist: Single }
     └─BatchScan { table: mv, columns: [mv.v], distribution: SomeShard }
+- name: BatchSort needed, because our BatchScan can not get a ordered result when scan from ranges
+  sql: |
+    create table t(v int);
+    create materialized view mv as select * from t order by v asc;
+    select * from mv where v = 1 or v = 2 order by v asc;
+  batch_plan: |
+    BatchExchange { order: [mv.v ASC], dist: Single }
+    └─BatchSort { order: [mv.v ASC] }
+      └─BatchScan { table: mv, columns: [mv.v], scan_ranges: [mv.v = Int32(1) , mv.v = Int32(2)], distribution: SomeShard }
 - name: BatchSort needed, when input is sorted in wrong order
   sql: |
     create table t(v int);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Our BatchScan executor scans multiple ranges concurrently, so the order should be any now.
A flag in BatchScan will be introduced later to control if the BatchScan need to maintain the order.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
