### PR TITLE
fix: skip empty `ingest_batch`

### DIFF
--- a/src/storage/src/write_batch.rs
+++ b/src/storage/src/write_batch.rs
@@ -89,10 +89,6 @@ impl<'a, S: StateStoreWrite> WriteBatch<'a, S> {
 
     /// Preprocesses the batch to make it sorted. It returns `false` if duplicate keys are found.
     pub fn preprocess(&mut self) -> StorageResult<()> {
-        if self.is_empty() {
-            return Ok(());
-        }
-
         let original_length = self.batch.len();
         self.batch.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
         self.batch.dedup_by(|(k1, _), (k2, _)| k1 == k2);
@@ -106,15 +102,17 @@ impl<'a, S: StateStoreWrite> WriteBatch<'a, S> {
 
     /// Returns `true` if the batch contains no key-value pairs.
     pub fn is_empty(&self) -> bool {
-        self.batch.is_empty()
+        self.batch.is_empty() && self.delete_ranges.is_empty()
     }
 
     /// Ingests this batch into the associated state store.
     pub async fn ingest(mut self) -> StorageResult<()> {
-        self.preprocess()?;
-        self.store
-            .ingest_batch(self.batch, self.delete_ranges, self.write_options)
-            .await?;
+        if !self.is_empty() {
+            self.preprocess()?;
+            self.store
+                .ingest_batch(self.batch, self.delete_ranges, self.write_options)
+                .await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

When I read the monitoring the "Write Ops" is always non-zero even when source throughput is zero. This should fix that.

BTW, also fixed the `is_empty()`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)
None