### PR TITLE
fix(planner-test): Show predicate pushdown in `LogicalHop` for non-trivial output indices

### DIFF
--- a/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
@@ -59,21 +59,22 @@
     LogicalFilter { predicate: (window_start >= '1997-07-02':Varchar::Date) AND (window_end >= '1997-07-03':Varchar::Date) AND (window_start >= (t.ts + '1 day':Interval)) AND (window_end > (t.ts + '4 days':Interval)) }
     └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: all }
       └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t.v4, t.ts], predicate: (t.v1 = 10:Int32) AND (t.v2 = 20:Int32) AND (t.v3 = 30:Int32) AND (t.ts >= '1997-07-01':Varchar::Date) }
-- name: filter hop transpose, window_start column
+- name: filter hop transpose with non-trivial output-indices
   sql: |
     create table t(v1 int, v2 int, v3 int, v4 int, ts date);
-    with cte as (select window_end from hop(t, ts, interval '1' day, interval '3' day))
-    select * from cte where window_end > date '2022-01-01'
+    with cte as (select window_end, v1, v2 from hop(t, ts, interval '1' day, interval '3' day))
+    select * from cte where window_end > date '2022-01-01' AND v1=10 AND v2 > 20
   logical_plan: |
-    LogicalProject { exprs: [window_end] }
-    └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) }
-      └─LogicalProject { exprs: [window_end] }
+    LogicalProject { exprs: [window_end, t.v1, t.v2] }
+    └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) AND (t.v1 = 10:Int32) AND (t.v2 > 20:Int32) }
+      └─LogicalProject { exprs: [window_end, t.v1, t.v2] }
         └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: all }
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t.v4, t.ts, t._row_id] }
   optimized_logical_plan: |
-    LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) }
-    └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: [window_end] }
-      └─LogicalScan { table: t, columns: [t.ts] }
+    LogicalProject { exprs: [window_end, t.v1, t.v2] }
+    └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) }
+      └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: [t.v1, t.v2, window_end] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.ts], predicate: (t.v1 = 10:Int32) AND (t.v2 > 20:Int32) }
 - name: filter union transpose
   sql: |
     create table t1 (v1 int, v2 int, v3 int);

--- a/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
@@ -62,19 +62,19 @@
 - name: filter hop transpose with non-trivial output-indices
   sql: |
     create table t(v1 int, v2 int, v3 int, v4 int, ts date);
-    with cte as (select window_end, v1, v2 from hop(t, ts, interval '1' day, interval '3' day))
-    select * from cte where window_end > date '2022-01-01' AND v1=10 AND v2 > 20
+    with cte as (select window_end, v4, v2 from hop(t, ts, interval '1' day, interval '3' day))
+    select * from cte where window_end > date '2022-01-01' AND v4=10 AND v2 > 20
   logical_plan: |
-    LogicalProject { exprs: [window_end, t.v1, t.v2] }
-    └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) AND (t.v1 = 10:Int32) AND (t.v2 > 20:Int32) }
-      └─LogicalProject { exprs: [window_end, t.v1, t.v2] }
+    LogicalProject { exprs: [window_end, t.v4, t.v2] }
+    └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) AND (t.v4 = 10:Int32) AND (t.v2 > 20:Int32) }
+      └─LogicalProject { exprs: [window_end, t.v4, t.v2] }
         └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: all }
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t.v4, t.ts, t._row_id] }
   optimized_logical_plan: |
-    LogicalProject { exprs: [window_end, t.v1, t.v2] }
+    LogicalProject { exprs: [window_end, t.v4, t.v2] }
     └─LogicalFilter { predicate: (window_end > '2022-01-01':Varchar::Date) }
-      └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: [t.v1, t.v2, window_end] }
-        └─LogicalScan { table: t, columns: [t.v1, t.v2, t.ts], predicate: (t.v1 = 10:Int32) AND (t.v2 > 20:Int32) }
+      └─LogicalHopWindow { time_col: t.ts, slide: 1 day, size: 3 days, output: [t.v2, t.v4, window_end] }
+        └─LogicalScan { table: t, columns: [t.v2, t.v4, t.ts], predicate: (t.v4 = 10:Int32) AND (t.v2 > 20:Int32) }
 - name: filter union transpose
   sql: |
     create table t1 (v1 int, v2 int, v3 int);


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Planner test introduced in https://github.com/risingwavelabs/risingwave/pull/6897 does not show predicate pushdown. We verify the correctness here.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Follow up: https://github.com/risingwavelabs/risingwave/pull/6897