### PR TITLE
fix(sqlsmith): disable implicit cast

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -77,6 +77,7 @@ pub(crate) struct SqlGeneratorContext {
     inside_explicit_cast: bool,
 }
 
+#[allow(dead_code)]
 impl SqlGeneratorContext {
     pub fn new() -> Self {
         SqlGeneratorContext {

--- a/src/tests/sqlsmith/tests/frontend/mod.rs
+++ b/src/tests/sqlsmith/tests/frontend/mod.rs
@@ -249,7 +249,7 @@ pub fn run() {
     let args = Arguments::from_args();
     let env = Arc::new(setup_sqlsmith_with_seed(0).unwrap());
 
-    let num_tests = 512;
+    let num_tests = 256;
     let tests = (0..num_tests)
         .map(|i| {
             let env = env.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

After implicit cast introduced, following bugs occurred:
- https://buildkite.com/risingwavelabs/pull-request/builds/14104#01851aae-4290-4fb1-85f1-a9214d5e1951
- https://buildkite.com/risingwavelabs/pull-request/builds/14089#01851a3d-b8eb-4822-a66a-9dacf9f05571

Per conversation below, I think I would just disable `implicit_cast` for now. Probably have to implement just for a subset of functions, which we know won't be too ambiguous in their evaluation result.

Full explanation (mouse-over and scroll through):
https://github.com/risingwavelabs/risingwave/blob/5a71857e17e1eb5c8fd04379643cd0dad99bae85/src/tests/sqlsmith/src/sql_gen/expr.rs#L143-L164

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
