### PR TITLE
fix: quick fix for high barrier latency

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -521,7 +521,9 @@ mod default {
         }
 
         pub fn in_flight_barrier_nums() -> usize {
-            10
+            // quick fix
+            // TODO: remove this limitation from code
+            10000
         }
 
         pub fn checkpoint_frequency() -> usize {

--- a/src/stream/src/executor/exchange/permit.rs
+++ b/src/stream/src/executor/exchange/permit.rs
@@ -22,10 +22,10 @@ use crate::executor::Message;
 
 /// The initial permits that a channel holds, i.e., the maximum row count can be buffered in the
 /// channel.
-const INITIAL_PERMITS: usize = 32768;
+const INITIAL_PERMITS: usize = 8192;
 /// The permits that are batched to add back, for reducing the backward `AddPermits` messages in
 /// remote exchange.
-pub const BATCHED_PERMITS: usize = 4096;
+pub const BATCHED_PERMITS: usize = 1024;
 /// The maximum permits required by a chunk. If there're too many rows in a chunk, we only acquire
 /// these permits. [`BATCHED_PERMITS`] is subtracted to avoid deadlock with batching.
 const MAX_CHUNK_PERMITS: usize = INITIAL_PERMITS - BATCHED_PERMITS;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

See #6571 for background.

After some discussion with @BugenZhao @yezizp2012 @tabVersion, we realized that it's futile to attempt to "backpressure" the streaming jobs by limiting `in_flight_barrier_nums`. On the contrary, it makes things more tricky, such as the interval between barriers becoming much larger, which in turn results in uncontrolled memory consumption.

This PR removes the limit of `in_flight_barrier_nums` in a quick & dirty way, and reduces the permits of exchange channels to mitigate the high-latency issue. 

Of course, we must remove the related code. Just do this fix for the imminent version release.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

fix #6571