### PR TITLE
fix(ci): limit in-flight barrier nums

### DIFF
--- a/src/config/ci-recovery.toml
+++ b/src/config/ci-recovery.toml
@@ -5,4 +5,5 @@ max_heartbeat_interval_secs = 600
 
 [streaming]
 barrier_interval_ms = 250
+in_flight_barrier_nums = 10
 checkpoint_frequency = 5

--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -5,4 +5,5 @@ max_heartbeat_interval_secs = 600
 
 [streaming]
 barrier_interval_ms = 250
+in_flight_barrier_nums = 10
 checkpoint_frequency = 5


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR set back the limit for in-flight barrier nums after #6943, so that the time cost for e2e tests in CI is normal. Guess the overhead is caused by more periodical checkpoints. Still investigating. 🤔

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

## Refer to a related PR or issue link (optional)
- #6943