### PR TITLE
fix(ci): separate e2e fuzzing workflow

### DIFF
--- a/ci/scripts/cron-fuzz-test.sh
+++ b/ci/scripts/cron-fuzz-test.sh
@@ -4,6 +4,4 @@
 set -euo pipefail
 
 source ci/scripts/common.env.sh
-export RUN_COMPACTION=1;
-export RUN_META_BACKUP=1;
-source ci/scripts/run-e2e-test.sh
+source ci/scripts/run-fuzz-test.sh

--- a/ci/scripts/fuzz-test.sh
+++ b/ci/scripts/fuzz-test.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-# Exits as soon as any line fails.
-set -euo pipefail
-
-source ci/scripts/common.env.sh
-export RUN_SQLSMITH=1; # fuzz tests
-source ci/scripts/run-fuzz-test.sh

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -124,19 +124,3 @@ if [[ "$RUN_COMPACTION" -eq "1" ]]; then
     echo "--- Kill cluster"
     cargo make ci-kill
 fi
-
-if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
-    echo "--- e2e, ci-3cn-1fe, fuzzing"
-    buildkite-agent artifact download sqlsmith-"$profile" target/debug/
-    mv target/debug/sqlsmith-"$profile" target/debug/sqlsmith
-    chmod +x ./target/debug/sqlsmith
-
-    cargo make ci-start ci-3cn-1fe
-    timeout 20m ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
-
-    # Using `kill` instead of `ci-kill` avoids storing excess logs.
-    # If there's errors, the failing query will be printed to stderr.
-    # Use that to reproduce logs on local machine.
-    echo "--- Kill cluster"
-    cargo make kill
-fi

--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -2,6 +2,55 @@
 set -euo pipefail
 
 if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
+    while getopts 'p:' opt; do
+        case ${opt} in
+            p )
+                profile=$OPTARG
+                ;;
+            \? )
+                echo "Invalid Option: -$OPTARG" 1>&2
+                exit 1
+                ;;
+            : )
+                echo "Invalid option: $OPTARG requires an argument" 1>&2
+                ;;
+        esac
+    done
+    shift $((OPTIND -1))
+
+    echo "--- Download artifacts"
+    mkdir -p target/debug
+    buildkite-agent artifact download risingwave-"$profile" target/debug/
+    buildkite-agent artifact download risedev-dev-"$profile" target/debug/
+    # buildkite-agent artifact download "e2e_test/generated/*" ./
+    mv target/debug/risingwave-"$profile" target/debug/risingwave
+    mv target/debug/risedev-dev-"$profile" target/debug/risedev-dev
+
+    echo "--- Adjust permission"
+    chmod +x ./target/debug/risingwave
+    chmod +x ./target/debug/risedev-dev
+
+    echo "--- Generate RiseDev CI config"
+    cp ci/risedev-components.ci.env risedev-components.user.env
+
+    echo "--- Prepare RiseDev dev cluster"
+    cargo make pre-start-dev
+    cargo make link-all-in-one-binaries
+
     echo "+++ Run sqlsmith tests"
     NEXTEST_PROFILE=ci cargo nextest run run_sqlsmith_on_frontend --features "failpoints sync_point enable_sqlsmith_unit_test" 2> >(tee);
+
+    echo "--- e2e, ci-3cn-1fe, fuzzing"
+    buildkite-agent artifact download sqlsmith-"$profile" target/debug/
+    mv target/debug/sqlsmith-"$profile" target/debug/sqlsmith
+    chmod +x ./target/debug/sqlsmith
+
+    cargo make ci-start ci-3cn-1fe
+    timeout 20m ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
+
+    # Using `kill` instead of `ci-kill` avoids storing excess logs.
+    # If there's errors, the failing query will be printed to stderr.
+    # Use that to reproduce logs on local machine.
+    echo "--- Kill cluster"
+    cargo make kill
 fi

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -119,7 +119,9 @@ steps:
     retry: *auto-retry
 
   - label: "fuzz test"
-    command: "ci/scripts/fuzz-test.sh"
+    command: "ci/scripts/cron-fuzz-test.sh -p ci-release"
+    depends_on:
+      - "build"
     plugins:
       - ./ci/plugins/swapfile
       - gencer/cache#v2.4.10: *cargo-cache
@@ -128,8 +130,10 @@ steps:
           config: ci/docker-compose.yml
           environment:
             - RUN_SQLSMITH: 1
+            - SQLSMITH_COUNT: 1000
             - RW_RANDOM_SEED_SQLSMITH: true
-    timeout_in_minutes: 10
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 20
     retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -203,14 +203,17 @@ steps:
     retry: *auto-retry
 
   - label: "fuzz test"
-    command: "ci/scripts/pr-fuzz-test.sh"
+    command: "ci/scripts/pr-fuzz-test.sh -p ci-dev"
+    depends_on:
+      - "build"
     plugins:
       - ./ci/plugins/swapfile
       - gencer/cache#v2.4.10: *cargo-cache
       - docker-compose#v3.9.0:
           run: rw-build-env
           config: ci/docker-compose.yml
-    timeout_in_minutes: 10
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "end-to-end sink test (release mode)"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -186,14 +186,17 @@ steps:
     retry: *auto-retry
 
   - label: "fuzz test"
-    command: "ci/scripts/pr-fuzz-test.sh"
+    command: "ci/scripts/pr-fuzz-test.sh -p ci-dev"
+    depends_on:
+      - "build"
     plugins:
       - ./ci/plugins/swapfile
       - gencer/cache#v2.4.10: *cargo-cache
       - docker-compose#v3.9.0:
           run: rw-build-env
           config: ci/docker-compose.yml
-    timeout_in_minutes: 10
+      - ./ci/plugins/upload-failure-logs
+    timeout_in_minutes: 15
     retry: *auto-retry
 
   - label: "check"


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Similar to what was done for frontend fuzzing tests https://github.com/risingwavelabs/risingwave/issues/6941, 
e2e fuzzing should be separated too.

See:
- Workflow with sqlsmith changes timeout: https://buildkite.com/risingwavelabs/main/builds/2548#01852a1c-e63a-4c9b-9317-b36aa72b640d
- Workflow without sqlsmith changes no timeout: https://buildkite.com/risingwavelabs/main/builds/2549#01852a6e-82a9-4a8d-8c53-283e5d19c4e5

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
