### PR TITLE
fix(frontend): Bug in pushdown of `now()`

### DIFF
--- a/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
@@ -246,20 +246,27 @@
     ├─LogicalFilter { predicate: (t1.v1 > (Now + '1 hr':Varchar::Interval)) }
     | └─LogicalScan { table: t1, columns: [t1.v1] }
     └─LogicalScan { table: t2, columns: [t2.v2] }
-  stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form col [cmp] now() +- [literal]'
+  stream_plan: |
+    StreamMaterialize { columns: [v1, v2, t1._row_id(hidden), t2._row_id(hidden)], pk_columns: [t1._row_id, t2._row_id, v1, v2] }
+    └─StreamHashJoin { type: Inner, predicate: t1.v1 = t2.v2, output: [t1.v1, t2.v2, t1._row_id, t2._row_id] }
+      ├─StreamExchange { dist: HashShard(t1.v1) }
+      | └─StreamDynamicFilter { predicate: (t1.v1 > (now + '1 hr':Varchar::Interval)), output: [t1.v1, t1._row_id] }
+      |   ├─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
+      |   └─StreamProject { exprs: [(now + '1 hr':Varchar::Interval)] }
+      |     └─StreamNow { output: [now] }
+      └─StreamExchange { dist: HashShard(t2.v2) }
+        └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: now() in a complex cmp expr does not get pushed down
   sql: |
     create table t1(v1 timestamp);
-    create table t2(v2 timestamp);
-    create table t3(v3 interval);
-    select * from t1, t2, t3 where v1 = v2 and v1 > now() + v3;
+    create table t2(v2 timestamp, v3 interval);
+    select * from t1, t2 where v1 = v2 and v1 > now() + v3;
   optimized_logical_plan: |
-    LogicalFilter { predicate: (t1.v1 > (Now + t3.v3)) }
-    └─LogicalJoin { type: Inner, on: true, output: all }
-      ├─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
-      | ├─LogicalScan { table: t1, columns: [t1.v1] }
-      | └─LogicalScan { table: t2, columns: [t2.v2] }
-      └─LogicalScan { table: t3, columns: [t3.v3] }
+    LogicalFilter { predicate: (t1.v1 > (Now + t2.v3)) }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
+      ├─LogicalScan { table: t1, columns: [t1.v1] }
+      └─LogicalScan { table: t2, columns: [t2.v2, t2.v3] }
+  stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form `col [cmp] now() +- [literal]`'
 - name: now() in complex cmp expr pushed onto join ON clause results in dynamic filter
   sql: |
     create table t1(v1 timestamp);
@@ -270,7 +277,7 @@
     └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
       ├─LogicalScan { table: t1, columns: [t1.v1] }
       └─LogicalScan { table: t2, columns: [t2.v2, t2.v3] }
-  stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form col [cmp] now() +- [literal]'
+  stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form `col [cmp] now() +- [literal]`'
 - name: now() does not get pushed to scan, but others do
   sql: |
     create table t1(v1 timestamp, v2 int);
@@ -278,4 +285,10 @@
   optimized_logical_plan: |
     LogicalFilter { predicate: (t1.v1 > (Now + '30 min':Varchar::Interval)) }
     └─LogicalScan { table: t1, columns: [t1.v1, t1.v2], predicate: (t1.v2 > 5:Int32) }
-  stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form col [cmp] now() +- [literal]'
+  stream_plan: |
+    StreamMaterialize { columns: [v1, v2, t1._row_id(hidden)], pk_columns: [t1._row_id] }
+    └─StreamDynamicFilter { predicate: (t1.v1 > (now + '30 min':Varchar::Interval)), output: [t1.v1, t1.v2, t1._row_id] }
+      ├─StreamFilter { predicate: (t1.v2 > 5:Int32) }
+      | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
+      └─StreamProject { exprs: [(now + '30 min':Varchar::Interval)] }
+        └─StreamNow { output: [now] }

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -236,9 +236,11 @@ impl ToStream for LogicalFilter {
                             if try_match_expand!(&now_expr.inputs()[0], ExprImpl::FunctionCall)?
                                 .get_expr_type()
                                 != Type::Now
-                                || !matches!(&now_expr.inputs()[1], ExprImpl::Literal(_) | ExprImpl::FunctionCall(_))
+                                || !matches!(
+                                    &now_expr.inputs()[1],
+                                    ExprImpl::Literal(_) | ExprImpl::FunctionCall(_)
+                                )
                                 || now_expr.inputs()[1].has_input_ref()
-                                
                             {
                                 return Err(ExprError::InvalidParam {
                                     name: "now",

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -236,7 +236,9 @@ impl ToStream for LogicalFilter {
                             if try_match_expand!(&now_expr.inputs()[0], ExprImpl::FunctionCall)?
                                 .get_expr_type()
                                 != Type::Now
-                                || !matches!(&now_expr.inputs()[1], ExprImpl::Literal(_))
+                                || !matches!(&now_expr.inputs()[1], ExprImpl::Literal(_) | ExprImpl::FunctionCall(_))
+                                || now_expr.inputs()[1].has_input_ref()
+                                
                             {
                                 return Err(ExprError::InvalidParam {
                                     name: "now",


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Sorry, noticed mistakes in https://github.com/risingwavelabs/risingwave/pull/6964 but it got merged before I fixed it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/pull/6964