### PR TITLE
perf(connector): generate native Row when datagen to avoid json deser

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,7 +21,6 @@
         "d3-selection": "^3.0.0",
         "fabric": "^5.2.1",
         "framer-motion": "^6.5.1",
-        "gen-proto": "^0.0.1",
         "lodash": "^4.17.21",
         "next": "^12.0.9",
         "react": "^18.2.0",
@@ -6076,14 +6075,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/gen-proto": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/gen-proto/-/gen-proto-0.0.1.tgz",
-      "integrity": "sha512-Jl1wXOPnOiWCColXbtdc3YmbJVrZpfmUIX8/qWnEV7SZFVLXsMdU16+2anu1SMUyNcFP2e9zSh6d0WwxyrtuFw==",
-      "bin": {
-        "gen-proto": "bin/index.js"
       }
     },
     "node_modules/gensync": {
@@ -14691,11 +14682,6 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
-    },
-    "gen-proto": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/gen-proto/-/gen-proto-0.0.1.tgz",
-      "integrity": "sha512-Jl1wXOPnOiWCColXbtdc3YmbJVrZpfmUIX8/qWnEV7SZFVLXsMdU16+2anu1SMUyNcFP2e9zSh6d0WwxyrtuFw=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -21,6 +21,7 @@
         "d3-selection": "^3.0.0",
         "fabric": "^5.2.1",
         "framer-motion": "^6.5.1",
+        "gen-proto": "^0.0.1",
         "lodash": "^4.17.21",
         "next": "^12.0.9",
         "react": "^18.2.0",
@@ -6075,6 +6076,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gen-proto": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gen-proto/-/gen-proto-0.0.1.tgz",
+      "integrity": "sha512-Jl1wXOPnOiWCColXbtdc3YmbJVrZpfmUIX8/qWnEV7SZFVLXsMdU16+2anu1SMUyNcFP2e9zSh6d0WwxyrtuFw==",
+      "bin": {
+        "gen-proto": "bin/index.js"
       }
     },
     "node_modules/gensync": {
@@ -14682,6 +14691,11 @@
         "strip-ansi": "^6.0.1",
         "wide-align": "^1.1.2"
       }
+    },
+    "gen-proto": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/gen-proto/-/gen-proto-0.0.1.tgz",
+      "integrity": "sha512-Jl1wXOPnOiWCColXbtdc3YmbJVrZpfmUIX8/qWnEV7SZFVLXsMdU16+2anu1SMUyNcFP2e9zSh6d0WwxyrtuFw=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -27,7 +27,6 @@
     "d3-selection": "^3.0.0",
     "fabric": "^5.2.1",
     "framer-motion": "^6.5.1",
-    "gen-proto": "^0.0.1",
     "lodash": "^4.17.21",
     "next": "^12.0.9",
     "react": "^18.2.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -27,6 +27,7 @@
     "d3-selection": "^3.0.0",
     "fabric": "^5.2.1",
     "framer-motion": "^6.5.1",
+    "gen-proto": "^0.0.1",
     "lodash": "^4.17.21",
     "next": "^12.0.9",
     "react": "^18.2.0",

--- a/dashboard/proto/gen/plan_common.ts
+++ b/dashboard/proto/gen/plan_common.ts
@@ -134,6 +134,7 @@ export const RowFormatType = {
   MAXWELL: "MAXWELL",
   CANAL_JSON: "CANAL_JSON",
   CSV: "CSV",
+  NATIVE: "NATIVE",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -165,6 +166,9 @@ export function rowFormatTypeFromJSON(object: any): RowFormatType {
     case 7:
     case "CSV":
       return RowFormatType.CSV;
+    case 8:
+    case "NATIVE":
+      return RowFormatType.NATIVE;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -190,6 +194,8 @@ export function rowFormatTypeToJSON(object: RowFormatType): string {
       return "CANAL_JSON";
     case RowFormatType.CSV:
       return "CSV";
+    case RowFormatType.NATIVE:
+      return "NATIVE";
     case RowFormatType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/e2e_test/ddl/invalid_operation.slt
+++ b/e2e_test/ddl/invalid_operation.slt
@@ -137,7 +137,7 @@ create materialized source msrc (v int) with (
     fields.v.end  = '10',
     datagen.rows.per.second='15',
     datagen.split.num = '1'
-) row format json;
+) row format native;
 
 statement error Use `DROP SOURCE`
 drop table msrc;
@@ -165,7 +165,7 @@ create source src (v int) with (
     fields.v.end  = '10',
     datagen.rows.per.second='15',
     datagen.split.num = '1'
-) row format json;
+) row format native;
 
 # FIXME: improve the error message
 statement error not found

--- a/e2e_test/source/basic/datagen.slt
+++ b/e2e_test/source/basic/datagen.slt
@@ -9,7 +9,7 @@ create materialized source s1 (v1 int, v2 float) with (
     fields.v2.end = '20',
     datagen.rows.per.second='15',
     datagen.split.num = '1'
-) row format json;
+) row format native;
 
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s
@@ -43,7 +43,7 @@ create materialized source s1 (v1 int)  with (
     fields.v1.end = '100',
     datagen.rows.per.second = '10',
     datagen.split.num = '5'
-) row format json;
+) row format native;
 
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s
@@ -76,7 +76,7 @@ create materialized source s1 (v1 struct<v2 int>)  with (
     fields.v1.v2.end = '100',
     datagen.rows.per.second = '10',
     datagen.split.num = '5'
-) row format json;
+) row format native;
 
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s
@@ -117,7 +117,7 @@ create materialized source s1 (v1 struct<v2 int>, t1 timestamp, c1 varchar) with
     fields.c1.seed = '3',
     datagen.rows.per.second = '10',
     datagen.split.num = '5'
-) row format json;
+) row format native;
 
 # Wait enough time to ensure Datagen connector generate data
 sleep 2s

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -78,4 +78,5 @@ enum RowFormatType {
   MAXWELL = 5;
   CANAL_JSON = 6;
   CSV = 7;
+  NATIVE = 8;
 }

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -71,6 +71,9 @@ impl DatagenEventGenerator {
                         .iter_mut()
                         .map(|field_generator| field_generator.generate_datum(self.offset))
                         .collect();
+                    // Leak the memory.
+                    // We will reclaim the ownership of this piece of memory during parsing.
+                    // see `NativeParser`
                     let value = unsafe {
                         let row = OwnedRow::new(data);
                         let row = Box::new(row);

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -108,31 +108,25 @@ mod tests {
         expected_length: usize,
     ) {
         let split_id = format!("{}-{}", split_num, split_index).into();
-        let mut fields_vec = vec![];
-        fields_vec.push(
-            FieldGeneratorImpl::with_number_sequence(
-                risingwave_common::types::DataType::Int32,
-                Some("1".to_string()),
-                Some("10".to_string()),
-                split_index,
-                split_num,
-            )
-            .unwrap(),
-        );
-
-        fields_vec.push(
-            FieldGeneratorImpl::with_number_sequence(
-                risingwave_common::types::DataType::Float32,
-                Some("1".to_string()),
-                Some("10".to_string()),
-                split_index,
-                split_num,
-            )
-            .unwrap(),
-        );
+        let generator1 = FieldGeneratorImpl::with_number_sequence(
+            risingwave_common::types::DataType::Int32,
+            Some("1".to_string()),
+            Some("10".to_string()),
+            split_index,
+            split_num,
+        )
+        .unwrap();
+        let generator2 = FieldGeneratorImpl::with_number_sequence(
+            risingwave_common::types::DataType::Float32,
+            Some("1".to_string()),
+            Some("10".to_string()),
+            split_index,
+            split_num,
+        )
+        .unwrap();
 
         let generator = DatagenEventGenerator::new(
-            fields_vec,
+            vec![generator1, generator2],
             rows_per_second,
             0,
             split_id,

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -67,7 +67,6 @@ impl SplitReader for DatagenSplitReader {
 
         let rows_per_second = properties.rows_per_second;
         let fields_option_map = properties.fields;
-        let mut fields_map = HashMap::<String, FieldGeneratorImpl>::new();
 
         // check columns
         assert!(columns.as_ref().is_some());
@@ -90,21 +89,20 @@ impl SplitReader for DatagenSplitReader {
 
         // 'fields.f_random_str.length'='10'
         // )
-
+        let mut fields_vec = vec![];
         for column in columns {
             let name = column.name.clone();
             let gen = generator_from_data_type(
-                column.data_type,
+                column.data_type.clone(),
                 &fields_option_map,
                 &name,
                 split_index,
                 split_num,
             )?;
-            fields_map.insert(name, gen);
+            fields_vec.push(gen);
         }
-
         let generator = DatagenEventGenerator::new(
-            fields_map,
+            fields_vec,
             rows_per_second,
             events_so_far,
             split_id,

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -231,6 +231,7 @@ mod tests {
         unsafe { Box::from_raw(payload.as_ptr() as *mut OwnedRow) }
     }
 
+    #[allow(clippy::excessive_precision)]
     #[tokio::test]
     async fn test_generator() -> Result<()> {
         let mock_datum = vec![
@@ -285,8 +286,8 @@ mod tests {
             .await?
             .into_stream();
         let random_float = Some(ScalarImpl::Float32(533.1488647460938.into()));
-        let random_int = Some(ScalarImpl::Int32(533.into()));
-        let sequence_int = Some(ScalarImpl::Int32(1.into()));
+        let random_int = Some(ScalarImpl::Int32(533));
+        let sequence_int = Some(ScalarImpl::Int32(1));
         let struct_int = Some(ScalarImpl::Struct(StructValue::new(vec![
             ScalarImpl::Int32(1533).into(),
         ])));

--- a/src/frontend/planner_test/tests/testdata/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery.yaml
@@ -182,7 +182,7 @@
     └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
       ├─LogicalFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) AND (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
       | └─LogicalJoin { type: LeftOuter, on: (pg_namespace.oid = pg_class.relnamespace), output: all }
-      |   ├─LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind] }
+      |   ├─LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind, pg_class.relam, pg_class.reltablespace] }
       |   └─LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
       └─LogicalProject { exprs: [pg_user.name] }
         └─LogicalFilter { predicate: (CorrelatedInputRef { index: 3, correlated_id: 1 } = pg_user.usesysid) }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -253,6 +253,13 @@ pub async fn handle_create_source(
                 ..Default::default()
             },
         ),
+        SourceSchema::Native => (
+            columns,
+            StreamSourceInfo {
+                row_format: RowFormatType::Native as i32,
+                ..Default::default()
+            },
+        ),
     };
 
     let row_id_index = row_id_index.map(|index| ProstColumnIndex { index: index as _ });

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -334,6 +334,7 @@ impl SourceDescBuilderV2 {
             ProstRowFormatType::Maxwell => SourceFormat::Maxwell,
             ProstRowFormatType::CanalJson => SourceFormat::CanalJson,
             ProstRowFormatType::Csv => SourceFormat::Csv,
+            ProstRowFormatType::Native => SourceFormat::Native,
             ProstRowFormatType::RowUnspecified => unreachable!(),
         };
 

--- a/src/source/src/lib.rs
+++ b/src/source/src/lib.rs
@@ -62,6 +62,7 @@ pub enum SourceFormat {
     Maxwell,
     CanalJson,
     Csv,
+    Native,
 }
 
 #[derive(Debug, EnumAsInner)]

--- a/src/source/src/manager.rs
+++ b/src/source/src/manager.rs
@@ -299,6 +299,7 @@ impl SourceDescBuilder {
             RowFormatType::Avro => SourceFormat::Avro,
             RowFormatType::Maxwell => SourceFormat::Maxwell,
             RowFormatType::CanalJson => SourceFormat::CanalJson,
+            RowFormatType::Native => SourceFormat::Native,
             _ => unreachable!(),
         };
 

--- a/src/source/src/parser/avro/parser.rs
+++ b/src/source/src/parser/avro/parser.rs
@@ -205,7 +205,7 @@ impl AvroParser {
         };
         // parse the valur to rw value
         if let Value::Record(fields) = avro_value {
-            writer.insert(|column| {
+            writer.insert(|_idx, column| {
                 let tuple = fields.iter().find(|val| column.name.eq(&val.0)).unwrap();
                 from_avro_value(tuple.1.clone()).map_err(|e| {
                     tracing::error!(

--- a/src/source/src/parser/canal/json_parser.rs
+++ b/src/source/src/parser/canal/json_parser.rs
@@ -76,7 +76,7 @@ impl CanalJsonParser {
 
                 let results = inserted
                     .map(|v| {
-                        writer.insert(|columns| {
+                        writer.insert(|_idx, columns| {
                             canal_json_parse_value(&columns.data_type, v.get(&columns.name))
                                 .map_err(Into::into)
                         })
@@ -106,7 +106,7 @@ impl CanalJsonParser {
                 let results = before
                     .zip(after)
                     .map(|(before, after)| {
-                        writer.update(|column| {
+                        writer.update(|_idx, column| {
                             // in origin canal, old only contains the changed columns but data
                             // contains all columns.
                             // in ticdc, old contains all fields
@@ -133,7 +133,7 @@ impl CanalJsonParser {
                     })?;
                 let results = deleted
                     .map(|v| {
-                        writer.delete(|columns| {
+                        writer.delete(|_idx, columns| {
                             canal_json_parse_value(&columns.data_type, v.get(&columns.name))
                                 .map_err(Into::into)
                         })

--- a/src/source/src/parser/canal/simd_json_parser.rs
+++ b/src/source/src/parser/canal/simd_json_parser.rs
@@ -79,7 +79,7 @@ impl CanalJsonParser {
                 let results = inserted
                     .into_iter()
                     .map(|v| {
-                        writer.insert(|column| {
+                        writer.insert(|_idx, column| {
                             cannal_simd_json_parse_value(
                                 &column.data_type,
                                 v.get(column.name.as_str()),
@@ -117,7 +117,7 @@ impl CanalJsonParser {
                 let results = before
                     .zip_eq(after)
                     .map(|(before, after)| {
-                        writer.update(|column| {
+                        writer.update(|_idx, column| {
                             // in origin canal, old only contains the changed columns but data
                             // contains all columns.
                             // in ticdc, old contains all fields
@@ -151,7 +151,7 @@ impl CanalJsonParser {
                 let results = deleted
                     .into_iter()
                     .map(|v| {
-                        writer.delete(|column| {
+                        writer.delete(|_idx, column| {
                             cannal_simd_json_parse_value(
                                 &column.data_type,
                                 v.get(column.name.as_str()),

--- a/src/source/src/parser/csv_parser.rs
+++ b/src/source/src/parser/csv_parser.rs
@@ -130,7 +130,7 @@ impl CsvParser {
             Some(strings) => strings,
         };
         writer
-            .insert(move |desc| {
+            .insert(move |_idx, desc| {
                 let column_id = desc.column_id.get_id();
                 let column_type = &desc.data_type;
                 let v = match columns_string.get(column_id as usize) {

--- a/src/source/src/parser/debezium/json_parser.rs
+++ b/src/source/src/parser/debezium/json_parser.rs
@@ -65,7 +65,7 @@ impl DebeziumJsonParser {
                     ))
                 })?;
 
-                writer.update(|column| {
+                writer.update(|_idx, column| {
                     let before = json_parse_value(&column.data_type, before.get(&column.name))?;
                     let after = json_parse_value(&column.data_type, after.get(&column.name))?;
 
@@ -79,7 +79,7 @@ impl DebeziumJsonParser {
                     ))
                 })?;
 
-                writer.insert(|column| {
+                writer.insert(|_idx, column| {
                     json_parse_value(&column.data_type, after.get(&column.name)).map_err(Into::into)
                 })
             }
@@ -90,7 +90,7 @@ impl DebeziumJsonParser {
                     ))
                 })?;
 
-                writer.delete(|column| {
+                writer.delete(|_idx, column| {
                     json_parse_value(&column.data_type, before.get(&column.name))
                         .map_err(Into::into)
                 })

--- a/src/source/src/parser/debezium/simd_json_parser.rs
+++ b/src/source/src/parser/debezium/simd_json_parser.rs
@@ -79,7 +79,7 @@ impl DebeziumJsonParser {
                         ))
                     })?;
 
-                writer.update(|column| {
+                writer.update(|_idx, column| {
                     let before =
                         simd_json_parse_value(&column.data_type, before.get(column.name.as_str()))?;
                     let after =
@@ -98,7 +98,7 @@ impl DebeziumJsonParser {
                         ))
                     })?;
 
-                writer.insert(|column| {
+                writer.insert(|_idx, column| {
                     simd_json_parse_value(&column.data_type, after.get(column.name.as_str()))
                         .map_err(Into::into)
                 })
@@ -113,7 +113,7 @@ impl DebeziumJsonParser {
                         ))
                     })?;
 
-                writer.delete(|column| {
+                writer.delete(|_idx, column| {
                     simd_json_parse_value(&column.data_type, before.get(column.name.as_str()))
                         .map_err(Into::into)
                 })

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -97,7 +97,7 @@ impl JsonParser {
         let value: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
-        writer.insert(|desc| {
+        writer.insert(|_idx, desc| {
             simd_json_parse_value(&desc.data_type, value.get(desc.name.as_str())).map_err(|e| {
                 tracing::error!(
                     "failed to process value ({}): {}",

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 use futures::future::ready;
-use risingwave_common::error::Result;
-use risingwave_common::row::{OwnedRow, Row};
-use risingwave_common::types::ToOwnedDatum;
+use risingwave_common::error::ErrorCode::ProtocolError;
+use risingwave_common::error::{Result, RwError};
 
 use crate::{ParseFuture, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
 
@@ -89,12 +88,24 @@ impl JsonParser {
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let boxed_row: Box<OwnedRow> = unsafe { Box::from_raw(payload.as_ptr() as *mut OwnedRow) };
-        let mut idx = 0;
-        writer.insert(|_desc| {
-            let datum = boxed_row.datum_at(idx).to_owned_datum();
-            idx += 1;
-            Ok(datum)
+        use simd_json::{BorrowedValue, ValueAccess};
+
+        use crate::parser::common::simd_json_parse_value;
+
+        let mut payload_mut = payload.to_vec();
+
+        let value: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
+            .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
+
+        writer.insert(|desc| {
+            simd_json_parse_value(&desc.data_type, value.get(desc.name.as_str())).map_err(|e| {
+                tracing::error!(
+                    "failed to process value ({}): {}",
+                    String::from_utf8_lossy(payload),
+                    e
+                );
+                e.into()
+            })
         })
     }
 }

--- a/src/source/src/parser/json_parser.rs
+++ b/src/source/src/parser/json_parser.rs
@@ -41,7 +41,7 @@ impl JsonParser {
         let value: Value = serde_json::from_slice(payload)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
-        writer.insert(|desc| {
+        writer.insert(|_idx, desc| {
             json_parse_value(&desc.data_type, value.get(&desc.name)).map_err(|e| {
                 tracing::error!(
                     "failed to process value ({}): {}",

--- a/src/source/src/parser/maxwell/json_parser.rs
+++ b/src/source/src/parser/maxwell/json_parser.rs
@@ -54,7 +54,7 @@ impl MaxwellParser {
                         "data is missing for creating event".to_string(),
                     ))
                 })?;
-                writer.insert(|column| {
+                writer.insert(|_idx, column| {
                     json_parse_value(&column.data_type, after.get(&column.name)).map_err(Into::into)
                 })
             }
@@ -70,7 +70,7 @@ impl MaxwellParser {
                     ))
                 })?;
 
-                writer.update(|column| {
+                writer.update(|_idx, column| {
                     // old only contains the changed columns but data contains all columns.
                     let before_value = before
                         .get(column.name.as_str())
@@ -84,7 +84,7 @@ impl MaxwellParser {
                 let before = event.after.as_ref().ok_or_else(|| {
                     RwError::from(ProtocolError("old is missing for delete event".to_string()))
                 })?;
-                writer.delete(|column| {
+                writer.delete(|_idx, column| {
                     json_parse_value(&column.data_type, before.get(&column.name))
                         .map_err(Into::into)
                 })

--- a/src/source/src/parser/maxwell/simd_json_parser.rs
+++ b/src/source/src/parser/maxwell/simd_json_parser.rs
@@ -53,7 +53,7 @@ impl MaxwellParser {
                         "data is missing for creating event".to_string(),
                     ))
                 })?;
-                writer.insert(|column| {
+                writer.insert(|_idx, column| {
                     simd_json_parse_value(&column.data_type, after.get(column.name.as_str()))
                         .map_err(Into::into)
                 })
@@ -70,7 +70,7 @@ impl MaxwellParser {
                     ))
                 })?;
 
-                writer.update(|column| {
+                writer.update(|_idx, column| {
                     // old only contains the changed columns but data contains all columns.
                     let before_value = before
                         .get(column.name.as_str())
@@ -85,7 +85,7 @@ impl MaxwellParser {
                 let before = event.get(AFTER).ok_or_else(|| {
                     RwError::from(ProtocolError("old is missing for delete event".to_string()))
                 })?;
-                writer.delete(|column| {
+                writer.delete(|_idx, column| {
                     simd_json_parse_value(&column.data_type, before.get(column.name.as_str()))
                         .map_err(Into::into)
                 })

--- a/src/source/src/parser/mod.rs
+++ b/src/source/src/parser/mod.rs
@@ -189,7 +189,7 @@ impl OpAction for OpActionUpdate {
 impl SourceStreamChunkRowWriter<'_> {
     fn do_action<A: OpAction>(
         &mut self,
-        mut f: impl FnMut(&SourceColumnDesc) -> Result<A::Output>,
+        mut f: impl FnMut(usize, &SourceColumnDesc) -> Result<A::Output>,
     ) -> Result<WriteGuard> {
         // The closure `f` may fail so that a part of builders were appended incompletely.
         // Loop invariant: `builders[0..appended_idx)` has been appended on every iter ended or loop
@@ -204,7 +204,7 @@ impl SourceStreamChunkRowWriter<'_> {
                 let output = if desc.skip_parse {
                     A::DEFAULT_OUTPUT
                 } else {
-                    f(desc)?
+                    f(idx, desc)?
                 };
                 A::apply(builder, output);
                 appended_idx = idx + 1;
@@ -231,7 +231,7 @@ impl SourceStreamChunkRowWriter<'_> {
     /// * `f`: A failable closure that produced one [`Datum`] by corresponding [`SourceColumnDesc`].
     pub fn insert(
         &mut self,
-        f: impl FnMut(&SourceColumnDesc) -> Result<Datum>,
+        f: impl FnMut(usize, &SourceColumnDesc) -> Result<Datum>,
     ) -> Result<WriteGuard> {
         self.do_action::<OpActionInsert>(f)
     }
@@ -244,7 +244,7 @@ impl SourceStreamChunkRowWriter<'_> {
     /// * `f`: A failable closure that produced one [`Datum`] by corresponding [`SourceColumnDesc`].
     pub fn delete(
         &mut self,
-        f: impl FnMut(&SourceColumnDesc) -> Result<Datum>,
+        f: impl FnMut(usize, &SourceColumnDesc) -> Result<Datum>,
     ) -> Result<WriteGuard> {
         self.do_action::<OpActionDelete>(f)
     }
@@ -258,7 +258,7 @@ impl SourceStreamChunkRowWriter<'_> {
     ///   [`SourceColumnDesc`].
     pub fn update(
         &mut self,
-        f: impl FnMut(&SourceColumnDesc) -> Result<(Datum, Datum)>,
+        f: impl FnMut(usize, &SourceColumnDesc) -> Result<(Datum, Datum)>,
     ) -> Result<WriteGuard> {
         self.do_action::<OpActionUpdate>(f)
     }

--- a/src/source/src/parser/mod.rs
+++ b/src/source/src/parser/mod.rs
@@ -24,6 +24,7 @@ use enum_as_inner::EnumAsInner;
 use futures::Future;
 use itertools::Itertools;
 pub use json_parser::*;
+use native_parser::NativeParser;
 pub use protobuf::*;
 use risingwave_common::array::{ArrayBuilderImpl, Op, StreamChunk};
 use risingwave_common::error::ErrorCode::ProtocolError;
@@ -42,6 +43,7 @@ mod debezium;
 mod json_parser;
 mod macros;
 mod maxwell;
+mod native_parser;
 mod protobuf;
 mod schema_registry;
 mod util;
@@ -300,6 +302,7 @@ pub enum SourceParserImpl {
     Avro(AvroParser),
     Maxwell(MaxwellParser),
     CanalJson(CanalJsonParser),
+    Native(NativeParser),
 }
 
 impl SourceParserImpl {
@@ -315,6 +318,7 @@ impl SourceParserImpl {
             Self::Avro(avro_parser) => avro_parser.parse(payload, writer).await,
             Self::Maxwell(maxwell_parser) => maxwell_parser.parse(payload, writer).await,
             Self::CanalJson(parser) => parser.parse(payload, writer).await,
+            Self::Native(parser) => parser.parse(payload, writer).await,
         }
     }
 
@@ -344,6 +348,7 @@ impl SourceParserImpl {
             ),
             SourceFormat::Maxwell => SourceParserImpl::Maxwell(MaxwellParser),
             SourceFormat::CanalJson => SourceParserImpl::CanalJson(CanalJsonParser),
+            SourceFormat::Native => SourceParserImpl::Native(NativeParser),
             _ => {
                 return Err(RwError::from(ProtocolError(
                     "format not support".to_string(),

--- a/src/source/src/parser/native_parser.rs
+++ b/src/source/src/parser/native_parser.rs
@@ -1,0 +1,55 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::future::ready;
+use risingwave_common::error::Result;
+use risingwave_common::row::{OwnedRow, Row};
+use risingwave_common::types::ToOwnedDatum;
+
+use crate::{ParseFuture, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
+
+#[derive(Debug)]
+pub struct NativeParser;
+
+impl NativeParser {
+    fn parse_inner(
+        &self,
+        payload: &[u8],
+        mut writer: SourceStreamChunkRowWriter<'_>,
+    ) -> Result<WriteGuard> {
+        let boxed_row: Box<OwnedRow> = unsafe { Box::from_raw(payload.as_ptr() as *mut OwnedRow) };
+        let mut idx = 0;
+        writer.insert(|_desc| {
+            let datum = boxed_row.datum_at(idx).to_owned_datum();
+            idx += 1;
+            Ok(datum)
+        })
+    }
+}
+
+impl SourceParser for NativeParser {
+    type ParseResult<'a> = impl ParseFuture<'a, Result<WriteGuard>>;
+
+    fn parse<'a, 'b, 'c>(
+        &'a self,
+        payload: &'b [u8],
+        writer: SourceStreamChunkRowWriter<'c>,
+    ) -> Self::ParseResult<'a>
+    where
+        'b: 'a,
+        'c: 'a,
+    {
+        ready(self.parse_inner(payload, writer))
+    }
+}

--- a/src/source/src/parser/native_parser.rs
+++ b/src/source/src/parser/native_parser.rs
@@ -28,6 +28,8 @@ impl NativeParser {
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
+        // Reclaim the ownership of the memory.
+        // Previously leak the memory in `DatagenEventGenerator`.
         let boxed_row: Box<OwnedRow> = unsafe { Box::from_raw(payload.as_ptr() as *mut OwnedRow) };
         let mut idx = 0;
         writer.insert(|_desc| {

--- a/src/source/src/parser/native_parser.rs
+++ b/src/source/src/parser/native_parser.rs
@@ -31,10 +31,8 @@ impl NativeParser {
         // Reclaim the ownership of the memory.
         // Previously leak the memory in `DatagenEventGenerator`.
         let boxed_row: Box<OwnedRow> = unsafe { Box::from_raw(payload.as_ptr() as *mut OwnedRow) };
-        let mut idx = 0;
-        writer.insert(|_desc| {
+        writer.insert(|idx, _desc| {
             let datum = boxed_row.datum_at(idx).to_owned_datum();
-            idx += 1;
             Ok(datum)
         })
     }

--- a/src/source/src/parser/protobuf/parser.rs
+++ b/src/source/src/parser/protobuf/parser.rs
@@ -166,7 +166,7 @@ impl ProtobufParser {
 
         let message = DynamicMessage::decode(self.message_descriptor.clone(), payload)
             .map_err(|e| ProtocolError(format!("parse message failed: {}", e)))?;
-        writer.insert(|column_desc| {
+        writer.insert(|_idx, column_desc| {
             let field_desc = message
                 .descriptor()
                 .get_field_by_name(&column_desc.name)

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -91,6 +91,7 @@ pub enum SourceSchema {
     Maxwell,          // Keyword::MAXWELL
     CanalJson,        // Keyword::CANAL_JSON
     CSV(CsvInfo),     // Keyword::CSV
+    Native,
 }
 
 impl ParseTo for SourceSchema {
@@ -112,6 +113,8 @@ impl ParseTo for SourceSchema {
         } else if p.parse_keywords(&[Keyword::CSV]) {
             impl_parse_to!(csv_info: CsvInfo, p);
             SourceSchema::CSV(csv_info)
+        } else if p.parse_keywords(&[Keyword::NATIVE]) {
+            SourceSchema::Native
         } else {
             return Err(ParserError::ParserError(
                 "expected JSON | PROTOBUF | DEBEZIUM_JSON | AVRO | MAXWELL | CANAL_JSON after ROW FORMAT".to_string(),
@@ -131,6 +134,7 @@ impl fmt::Display for SourceSchema {
             SourceSchema::Avro(avro_schema) => write!(f, "AVRO {}", avro_schema),
             SourceSchema::CanalJson => write!(f, "CANAL JSON"),
             SourceSchema::CSV(csv_ingo) => write!(f, "CSV {}", csv_ingo),
+            SourceSchema::Native => write!(f, "NATIVE"),
         }
     }
 }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -305,6 +305,7 @@ define_keywords!(
     MONTH,
     MULTISET,
     NATIONAL,
+    NATIVE,
     NATURAL,
     NCHAR,
     NCLOB,

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -781,7 +781,7 @@ mod tests {
         let row_id_index = Some(ProstColumnIndex { index: 0 });
         let pk_column_ids = vec![0];
         let stream_source_info = StreamSourceInfo {
-            row_format: ProstRowFormatType::Json as i32,
+            row_format: ProstRowFormatType::Native as i32,
             ..Default::default()
         };
         let source_manager = Arc::new(TableSourceManager::default());

--- a/src/stream/src/executor/source/source_executor_v2.rs
+++ b/src/stream/src/executor/source/source_executor_v2.rs
@@ -511,7 +511,7 @@ mod tests {
         let pk_column_ids = vec![0];
         let pk_indices = vec![0];
         let source_info = StreamSourceInfo {
-            row_format: ProstRowFormatType::Json as i32,
+            row_format: ProstRowFormatType::Native as i32,
             ..Default::default()
         };
         let (barrier_tx, barrier_rx) = unbounded_channel::<Barrier>();
@@ -602,7 +602,7 @@ mod tests {
         let pk_column_ids = vec![0];
         let pk_indices = vec![0_usize];
         let source_info = StreamSourceInfo {
-            row_format: ProstRowFormatType::Json as i32,
+            row_format: ProstRowFormatType::Native as i32,
             ..Default::default()
         };
         let properties = convert_args!(hashmap!(


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

#4555  #4961 

Use `Box::into_raw` to leak the memory, and then `Box::from_raw` to reclaim the ownership of that piece of memory.

introduce keywords NATIVE 
```
create source ... with ( connector = 'datagen' ) ROW FORMAT NATIVE
```
and create a special `native` parser for that.

I guess creating individual rows and then sending them row by row is still suboptimal, compared to creating columns (column by column, so create, e.g. 1024, the same types of data each time) to compose a `StreamChunk`.

This is unsafe but limited to a small scope.
No reason to free the memory twice as it requires using the `Bytes` twice, which itself would suggest it's a suboptimal implementation.


Comparison on c5.4xLarge EC2.
Query:
```
create source t1 (
    v1 BIGINT, 
    v2 BIGINT, 
    t1 timestamp, 
    t2 timestamp,
    c1 varchar,
    c2 varchar
) with ( 
    connector = 'datagen', 
    datagen.split.num = '8',
    datagen.rows.per.second = '1000000000'
) ROW FORMAT JSON;

create sink s1 as select * from t1 with ( connector = 'blackhole' );
```
risedev.yml:
```
parallelism: 8
```

This pr:
![native 8-8](https://user-images.githubusercontent.com/5791930/208887259-f401ead7-a973-4d12-8928-6a7f68f4e474.png)

commit: 94d508ac34ee05cc4279ffec0ed45a54850c24e3:
![json 8-8](https://user-images.githubusercontent.com/5791930/208887535-23921c84-2da6-4a18-bea9-8ea8e8fc5510.png)


So more than 2X improvement.

Guess the improvement can be artificially increased by specifying more and longer column names, and more and larger column values.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
