### PR TITLE
fix(cron): make sqlsmith environment variables available

### DIFF
--- a/ci/scripts/cron-fuzz-test.sh
+++ b/ci/scripts/cron-fuzz-test.sh
@@ -4,4 +4,6 @@
 set -euo pipefail
 
 source ci/scripts/common.env.sh
+export RUN_SQLSMITH=1
+export SQLSMITH_COUNT=1000
 source ci/scripts/run-fuzz-test.sh

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -130,8 +130,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
           environment:
-            - RUN_SQLSMITH: 1
-            - SQLSMITH_COUNT: 1000
             - RW_RANDOM_SEED_SQLSMITH: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 20


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As per title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
