### PR TITLE
chore(meta): refine panic message when recovery disabled while using etcd

### DIFF
--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -533,6 +533,17 @@ where
                 .update_inflight_prev_epoch(self.env.meta_store())
                 .await
                 .unwrap();
+        } else {
+            if self
+                .fragment_manager
+                .has_any_table_fragments()
+                .await
+                .unwrap()
+            {
+                panic!(
+                    "Streaming jobs already exists in meta, please enable recovery to recover them"
+                );
+            }
         }
         self.set_status(BarrierManagerStatus::Running).await;
         let mut min_interval = tokio::time::interval(self.interval);

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -541,7 +541,7 @@ where
                 .unwrap()
             {
                 panic!(
-                    "Streaming jobs already exists in meta, please enable recovery to recover them"
+                    "Some streaming jobs already exist in meta, please start with recovery enabled"
                 );
             }
         }

--- a/src/meta/src/manager/catalog/fragment.rs
+++ b/src/meta/src/manager/catalog/fragment.rs
@@ -130,6 +130,12 @@ where
         Ok(map.values().cloned().collect())
     }
 
+    pub async fn has_any_table_fragments(&self) -> MetaResult<bool> {
+        let map = &self.core.read().await.table_fragments;
+
+        Ok(!map.is_empty())
+    }
+
     pub async fn batch_update_table_fragments(
         &self,
         table_fragments: &[TableFragments],


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Refine panic message when recovery disabled while using etcd. After that if we disable recovery and restart meta with any existing streaming jobs, it should panic as follows:
```
thread 'risingwave-main' panicked at 'Some streaming jobs already exist in meta, please start with recovery enabled', src/meta/src/barrier/mod.rs:543:17
```
## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
Fix #6991 