### PR TITLE
feat(frontend): more pg_catalog support for DBeaver

### DIFF
--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -200,6 +200,7 @@ prepare_sys_catalog! {
     { PG_CATALOG, PG_ATTRDEF, vec![0], read_attrdef_info },
     { PG_CATALOG, PG_ROLES, vec![0], read_roles_info },
     { PG_CATALOG, PG_SHDESCRIPTION, vec![0], read_shdescription_info },
+    { PG_CATALOG, PG_TABLESPACE, vec![0], read_tablespace_info },
     { INFORMATION_SCHEMA, COLUMNS, vec![], read_columns_info },
     { INFORMATION_SCHEMA, TABLES, vec![], read_tables_info },
     { RW_CATALOG, RW_META_SNAPSHOT, vec![], read_meta_snapshot await },

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -29,10 +29,10 @@ pub mod pg_operator;
 pub mod pg_roles;
 pub mod pg_settings;
 pub mod pg_shdescription;
+pub mod pg_tablespace;
 pub mod pg_type;
 pub mod pg_user;
 pub mod pg_views;
-pub mod pg_tablespace;
 
 use std::collections::HashMap;
 
@@ -54,10 +54,10 @@ pub use pg_operator::*;
 pub use pg_roles::*;
 pub use pg_settings::*;
 pub use pg_shdescription::*;
+pub use pg_tablespace::*;
 pub use pg_type::*;
 pub use pg_user::*;
 pub use pg_views::*;
-pub use pg_tablespace::*;
 use risingwave_common::array::ListValue;
 use risingwave_common::error::Result;
 use risingwave_common::row::OwnedRow;
@@ -288,8 +288,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
                             Some(ScalarImpl::Utf8("r".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();
@@ -303,8 +303,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(mv.owner as i32)),
                             Some(ScalarImpl::Utf8("m".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();
@@ -318,8 +318,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(index.index_table.owner as i32)),
                             Some(ScalarImpl::Utf8("i".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();
@@ -333,8 +333,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(source.owner as i32)),
                             Some(ScalarImpl::Utf8("x".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();
@@ -348,8 +348,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
                             Some(ScalarImpl::Utf8("r".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();
@@ -363,8 +363,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(view.owner as i32)),
                             Some(ScalarImpl::Utf8("v".into())),
-                            Some(ScalarImpl::Int32(0 as i32)),
-                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
                         ])
                     })
                     .collect_vec();

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -32,6 +32,7 @@ pub mod pg_shdescription;
 pub mod pg_type;
 pub mod pg_user;
 pub mod pg_views;
+pub mod pg_tablespace;
 
 use std::collections::HashMap;
 
@@ -56,6 +57,7 @@ pub use pg_shdescription::*;
 pub use pg_type::*;
 pub use pg_user::*;
 pub use pg_views::*;
+pub use pg_tablespace::*;
 use risingwave_common::array::ListValue;
 use risingwave_common::error::Result;
 use risingwave_common::row::OwnedRow;
@@ -286,6 +288,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
                             Some(ScalarImpl::Utf8("r".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -299,6 +303,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(mv.owner as i32)),
                             Some(ScalarImpl::Utf8("m".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -312,6 +318,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(index.index_table.owner as i32)),
                             Some(ScalarImpl::Utf8("i".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -325,6 +333,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(source.owner as i32)),
                             Some(ScalarImpl::Utf8("x".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -338,6 +348,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(table.owner as i32)),
                             Some(ScalarImpl::Utf8("r".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -351,6 +363,8 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(schema_info.id as i32)),
                             Some(ScalarImpl::Int32(view.owner as i32)),
                             Some(ScalarImpl::Utf8("v".into())),
+                            Some(ScalarImpl::Int32(0 as i32)),
+                            Some(ScalarImpl::Int32(0 as i32)),
                         ])
                     })
                     .collect_vec();
@@ -384,6 +398,8 @@ impl SysCatalogReaderImpl {
                                 .map(|index| Some(ScalarImpl::Int16(index.get_id() as i16 + 1)))
                                 .collect_vec(),
                         ))),
+                        None,
+                        None,
                     ])
                 })
             })
@@ -566,5 +582,9 @@ impl SysCatalogReaderImpl {
 
     pub(super) fn read_keywords_info(&self) -> Result<Vec<OwnedRow>> {
         Ok(PG_KEYWORDS_DATA_ROWS.clone())
+    }
+
+    pub(super) fn read_tablespace_info(&self) -> Result<Vec<OwnedRow>> {
+        Ok(PG_TABLESPACE_DATA_ROWS.clone())
     }
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_class.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_class.rs
@@ -25,4 +25,8 @@ pub const PG_CLASS_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "relnamespace"),
     (DataType::Int32, "relowner"),
     (DataType::Varchar, "relkind"),
+    // 0
+    (DataType::Int32, "relam"),
+    // 0
+    (DataType::Int32, "reltablespace"),
 ];

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_index.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_index.rs
@@ -32,5 +32,9 @@ pub static PG_INDEX_COLUMNS: LazyLock<Vec<SystemCatalogColumnsDef<'_>>> = LazyLo
             },
             "indkey",
         ),
+        // None. We don't have `pg_node_tree` type yet, so we use `text` instead.
+        (DataType::Varchar, "indexprs"),
+        // None. We don't have `pg_node_tree` type yet, so we use `text` instead.
+        (DataType::Varchar, "indpred"),
     ]
 });

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
@@ -18,7 +18,7 @@ use risingwave_common::{row::OwnedRow, types::DataType};
 
 use crate::catalog::system_catalog::SystemCatalogColumnsDef;
 
-/// The catalog pg_tablespace stores information about the available tablespaces. 
+/// The catalog `pg_tablespace` stores information about the available tablespaces. 
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-tablespace.html`]
 /// This is introduced only for pg compatibility and is not used in our system. 
 pub const PG_TABLESPACE_TABLE_NAME: &str = "pg_tablespace";

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
@@ -1,0 +1,33 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::LazyLock;
+
+use risingwave_common::{row::OwnedRow, types::DataType};
+
+use crate::catalog::system_catalog::SystemCatalogColumnsDef;
+
+/// The catalog pg_tablespace stores information about the available tablespaces. 
+/// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-tablespace.html`]
+/// This is introduced only for pg compatibility and is not used in our system. 
+pub const PG_TABLESPACE_TABLE_NAME: &str = "pg_tablespace";
+pub const PG_TABLESPACE_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
+    (DataType::Int32, "oid"),
+    (DataType::Varchar, "spcname"),
+    (DataType::Int32, "spcowner"),
+    (DataType::Varchar, "spcacl"),
+    (DataType::Varchar, "spcoptions"),
+];
+
+pub static PG_TABLESPACE_DATA_ROWS: LazyLock<Vec<OwnedRow>> = LazyLock::new(Vec::new);

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tablespace.rs
@@ -14,13 +14,14 @@
 
 use std::sync::LazyLock;
 
-use risingwave_common::{row::OwnedRow, types::DataType};
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::DataType;
 
 use crate::catalog::system_catalog::SystemCatalogColumnsDef;
 
-/// The catalog `pg_tablespace` stores information about the available tablespaces. 
+/// The catalog `pg_tablespace` stores information about the available tablespaces.
 /// Ref: [`https://www.postgresql.org/docs/current/catalog-pg-tablespace.html`]
-/// This is introduced only for pg compatibility and is not used in our system. 
+/// This is introduced only for pg compatibility and is not used in our system.
 pub const PG_TABLESPACE_TABLE_NAME: &str = "pg_tablespace";
 pub const PG_TABLESPACE_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "oid"),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Add `pg_tablespace`
- Add more columns in `pg_class` and `pg_index`

This should be the last piece of work in the kernel side to support DBeaver. Tested against DBeaver.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#6878 