### PR TITLE
refactor(logging): be aware of RUST_LOG env

### DIFF
--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -134,7 +134,7 @@ if [[ "$RUN_COMPACTION" -eq "1" ]]; then
     chmod +x ./target/debug/compaction-test
     # Use the config of ci-compaction-test for replay.
     config_path=".risingwave/config/risingwave.toml"
-    ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 --config-path "${config_path}"
+    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 --config-path "${config_path}"
 
     echo "--- Kill cluster"
     cargo make ci-kill

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -217,12 +217,16 @@ fn to_env_filter(filter: Targets) -> EnvFilter {
     if let Some(g) = filter.default_level() {
         env_filter = env_filter.add_directive(g.into());
     }
-    let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
-    let directives = rust_log
-        .split(',')
-        .map(|s: &str| s.parse::<Directive>().expect("failed to parse RUST_LOG"));
-    for directive in directives {
-        env_filter = env_filter.add_directive(directive);
+    if let Ok(rust_log) = env::var(EnvFilter::DEFAULT_ENV) {
+        if rust_log.is_empty() {
+            return env_filter;
+        }
+        let directives = rust_log
+            .split(',')
+            .map(|s: &str| s.parse::<Directive>().expect("failed to parse RUST_LOG"));
+        for directive in directives {
+            env_filter = env_filter.add_directive(directive);
+        }
     }
     env_filter
 }

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -16,14 +16,16 @@
 
 #![feature(panic_update_hook)]
 
+use std::env;
 use std::path::PathBuf;
 use std::time::Duration;
 
 use futures::Future;
 use tracing::Level;
-use tracing_subscriber::filter;
+use tracing_subscriber::filter::{Directive, Targets};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::prelude::*;
+use tracing_subscriber::{filter, EnvFilter};
 
 // ============================================================================
 // BEGIN SECTION: frequently used log configurations for debugging
@@ -138,7 +140,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
         #[cfg(debug_assertions)]
         let filter = filter.with_default(Level::DEBUG);
 
-        layers.push(fmt_layer.with_filter(filter).boxed());
+        layers.push(fmt_layer.with_filter(to_env_filter(filter)).boxed());
     };
 
     if ENABLE_QUERY_LOG_FILE {
@@ -204,6 +206,25 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
     tracing_subscriber::registry().with(layers).init();
 
     // TODO: add file-appender tracing subscriber in the future
+}
+
+fn to_env_filter(filter: Targets) -> EnvFilter {
+    let mut env_filter = EnvFilter::new("");
+    for (target, level) in filter.iter() {
+        let directive = format!("{}={}", target, level).parse().unwrap();
+        env_filter = env_filter.add_directive(directive);
+    }
+    if let Some(g) = filter.default_level() {
+        env_filter = env_filter.add_directive(g.into());
+    }
+    let rust_log = env::var(EnvFilter::DEFAULT_ENV).unwrap_or_default();
+    let directives = rust_log
+        .split(',')
+        .map(|s: &str| s.parse::<Directive>().expect("failed to parse RUST_LOG"));
+    for directive in directives {
+        env_filter = env_filter.add_directive(directive);
+    }
+    env_filter
 }
 
 /// Enable parking lot's deadlock detection.

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -208,6 +208,11 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
     // TODO: add file-appender tracing subscriber in the future
 }
 
+/// Returns a `EnvFilter` that
+/// 1. inherits given `filter`'s target-LevelFilter pairs and default-LevelFilter.
+/// 2. parses RUST_LOG environment variable and adds these filters.
+///
+/// Filters from step 1 will be overwritten by filters from step 2 that matches.
 fn to_env_filter(filter: Targets) -> EnvFilter {
     let mut env_filter = EnvFilter::new("");
     for (target, level) in filter.iter() {

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -210,7 +210,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
 
 /// Returns a `EnvFilter` that
 /// 1. inherits given `filter`'s target-LevelFilter pairs and default-LevelFilter.
-/// 2. parses RUST_LOG environment variable and adds these filters.
+/// 2. parses `RUST_LOG` environment variable and adds these filters.
 ///
 /// Filters from step 1 will be overwritten by filters from step 2 that matches.
 fn to_env_filter(filter: Targets) -> EnvFilter {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
This PR supports overwriting log filters predefined in `init_risingwave_logger`, by specifying RUST_LOG environment variable.
One use case is I want to suppress certain logs in CI, to avoid large log size.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
