### PR TITLE
chore(ci): suppress debug log for compaction-test

### DIFF
--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -83,6 +83,7 @@ if [[ "$RUN_META_BACKUP" -eq "1" ]]; then
     BACKUP_TEST_RW_ALL_IN_ONE="target/debug/risingwave" \
     RW_HUMMOCK_URL="hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001" \
     RW_META_ADDR="http://127.0.0.1:5690" \
+    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
     bash "${test_root}/run_all.sh"
     echo "--- Kill cluster"
     cargo make kill
@@ -91,6 +92,7 @@ fi
 if [[ "$RUN_DELETE_RANGE" -eq "1" ]]; then
     echo "--- e2e, ci-delete-range-test"
     cargo make clean-data
+    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
     cargo make ci-start ci-delete-range-test
     buildkite-agent artifact download delete-range-test-"$profile" target/debug/
     mv target/debug/delete-range-test-"$profile" target/debug/delete-range-test
@@ -105,6 +107,7 @@ fi
 
 if [[ "$RUN_COMPACTION" -eq "1" ]]; then
     echo "--- e2e, ci-compaction-test, nexmark_q7"
+    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
     cargo make ci-start ci-compaction-test
     # Please make sure the regression is expected before increasing the timeout.
     sqllogictest -p 4566 -d dev './e2e_test/compaction/ingest_rows.slt'
@@ -134,7 +137,8 @@ if [[ "$RUN_COMPACTION" -eq "1" ]]; then
     chmod +x ./target/debug/compaction-test
     # Use the config of ci-compaction-test for replay.
     config_path=".risingwave/config/risingwave.toml"
-    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 --config-path "${config_path}"
+    RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
+    ./target/debug/compaction-test --ci-mode true --state-store hummock+minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001 --config-path "${config_path}"
 
     echo "--- Kill cluster"
     cargo make ci-kill

--- a/src/frontend/planner_test/tests/testdata/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery.yaml
@@ -182,7 +182,7 @@
     └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
       ├─LogicalFilter { predicate: In(pg_class.relkind, 'r':Varchar, 'p':Varchar, 'v':Varchar, 'm':Varchar, 'S':Varchar, 'f':Varchar, '':Varchar) AND (pg_namespace.nspname <> 'pg_catalog':Varchar) AND IsNull(RegexpMatch(pg_namespace.nspname, '^pg_toast':Varchar)) AND (pg_namespace.nspname <> 'information_schema':Varchar) }
       | └─LogicalJoin { type: LeftOuter, on: (pg_namespace.oid = pg_class.relnamespace), output: all }
-      |   ├─LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind] }
+      |   ├─LogicalScan { table: pg_class, columns: [pg_class.oid, pg_class.relname, pg_class.relnamespace, pg_class.relowner, pg_class.relkind, pg_class.relam, pg_class.reltablespace] }
       |   └─LogicalScan { table: pg_namespace, columns: [pg_namespace.oid, pg_namespace.nspname, pg_namespace.nspowner, pg_namespace.nspacl] }
       └─LogicalProject { exprs: [pg_user.name] }
         └─LogicalFilter { predicate: (CorrelatedInputRef { index: 3, correlated_id: 1 } = pg_user.usesysid) }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Suppress debug logs in ci-compaction-test, to avoid too large log size.
- Also fix a failing planner test's expected result, because two new columns has been added in pg_class previously.


## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
