### PR TITLE
perf(expr): reduce format parsing in to_char

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "Inflector"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
+
+[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -42,6 +48,12 @@ checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "aliasable"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
 name = "android_system_properties"
@@ -3952,6 +3964,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5bf27447411e9ee3ff51186bf7a08e16c341efdde93f4d823e8844429bed7e"
 
 [[package]]
+name = "ouroboros"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbb50b356159620db6ac971c6d5c9ab788c9cc38a6f49619fca2a27acb062ca"
+dependencies = [
+ "aliasable",
+ "ouroboros_macro",
+]
+
+[[package]]
+name = "ouroboros_macro"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0d9d1a6191c4f391f87219d1ea42b23f09ee84d64763cd05ee6ea88d9f384d"
+dependencies = [
+ "Inflector",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "output_vt100"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5519,6 +5554,7 @@ dependencies = [
  "madsim-tonic",
  "md5",
  "num-traits",
+ "ouroboros",
  "parse-display",
  "paste",
  "postgres-types",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -24,6 +24,7 @@ hex = "0.4.3"
 itertools = "0.10"
 md5 = "0.7.0"
 num-traits = "0.2"
+ouroboros = "0.15"
 parse-display = "0.6"
 paste = "1"
 postgres-types = { version = "0.2.4", features = ["derive","with-chrono-0_4"] }

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -236,7 +236,7 @@ pub fn build_to_char_expr(prost: &ExprNode) -> Result<BoxedExpression> {
 
         Ok(ExprToCharConstTmpl {
             ctx: ExprToCharConstTmplContext {
-                chrono_tmpl: pattern,
+                chrono_pattern: pattern,
             },
             child: data_expr,
         }.boxed())

--- a/src/expr/src/expr/expr_to_char_const_tmpl.rs
+++ b/src/expr/src/expr/expr_to_char_const_tmpl.rs
@@ -20,10 +20,11 @@ use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
 
 use super::Expression;
+use crate::vector_op::to_char::ChronoPattern;
 
 #[derive(Debug)]
 pub(crate) struct ExprToCharConstTmplContext {
-    pub(crate) chrono_tmpl: String,
+    pub(crate) chrono_pattern: ChronoPattern,
 }
 
 #[derive(Debug)]
@@ -48,7 +49,7 @@ impl Expression for ExprToCharConstTmpl {
             if !vis {
                 output.append_null();
             } else if let Some(data) = data {
-                let res = data.0.format(&self.ctx.chrono_tmpl).to_string();
+                let res = data.0.format_with_items(self.ctx.chrono_pattern.borrow_items().iter()).to_string();
                 output.append(Some(res.as_str()));
             } else {
                 output.append_null();
@@ -61,7 +62,7 @@ impl Expression for ExprToCharConstTmpl {
     fn eval_row(&self, input: &OwnedRow) -> crate::Result<Datum> {
         let data = self.child.eval_row(input)?;
         Ok(if let Some(ScalarImpl::NaiveDateTime(data)) = data {
-            Some(data.0.format(&self.ctx.chrono_tmpl).to_string().into())
+            Some(data.0.format_with_items(self.ctx.chrono_pattern.borrow_items().iter()).to_string().into())
         } else {
             None
         })

--- a/src/expr/src/expr/expr_to_char_const_tmpl.rs
+++ b/src/expr/src/expr/expr_to_char_const_tmpl.rs
@@ -49,7 +49,10 @@ impl Expression for ExprToCharConstTmpl {
             if !vis {
                 output.append_null();
             } else if let Some(data) = data {
-                let res = data.0.format_with_items(self.ctx.chrono_pattern.borrow_items().iter()).to_string();
+                let res = data
+                    .0
+                    .format_with_items(self.ctx.chrono_pattern.borrow_items().iter())
+                    .to_string();
                 output.append(Some(res.as_str()));
             } else {
                 output.append_null();
@@ -62,7 +65,12 @@ impl Expression for ExprToCharConstTmpl {
     fn eval_row(&self, input: &OwnedRow) -> crate::Result<Datum> {
         let data = self.child.eval_row(input)?;
         Ok(if let Some(ScalarImpl::NaiveDateTime(data)) = data {
-            Some(data.0.format_with_items(self.ctx.chrono_pattern.borrow_items().iter()).to_string().into())
+            Some(
+                data.0
+                    .format_with_items(self.ctx.chrono_pattern.borrow_items().iter())
+                    .to_string()
+                    .into(),
+            )
         } else {
             None
         })

--- a/src/expr/src/vector_op/to_char.rs
+++ b/src/expr/src/vector_op/to_char.rs
@@ -64,13 +64,11 @@ pub fn compile_pattern_to_chrono(tmpl: &str) -> ChronoPattern {
         dst.push_str(CHRONO_PATTERNS[mat.pattern()]);
         true
     });
-    let pattern = ChronoPatternBuilder {
+    ChronoPatternBuilder {
         tmpl: chrono_tmpl,
         items_builder: |tmpl| StrftimeItems::new(tmpl).into_iter().collect::<Vec<_>>(),
     }
-    .build();
-
-    pattern
+    .build()
 }
 
 #[inline(always)]

--- a/src/expr/src/vector_op/to_char.rs
+++ b/src/expr/src/vector_op/to_char.rs
@@ -12,17 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt::Debug;
 use std::sync::LazyLock;
 
 use aho_corasick::{AhoCorasick, AhoCorasickBuilder};
+use chrono::format::StrftimeItems;
+use ouroboros::self_referencing;
 use risingwave_common::array::{StringWriter, WrittenGuard};
 use risingwave_common::types::NaiveDateTimeWrapper;
 
 use crate::Result;
 
+#[self_referencing]
+pub struct ChronoPattern {
+    pub(crate) tmpl: String,
+    #[borrows(tmpl)]
+    #[covariant]
+    pub(crate) items: Vec<chrono::format::Item<'this>>,
+}
+
+impl Debug for ChronoPattern {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ChronoPattern")
+            .field("tmpl", self.borrow_tmpl())
+            .finish()
+    }
+}
+
 /// Compile the pg pattern to chrono pattern.
 // TODO: Chrono can not fully support the pg format, so consider using other implementations later.
-pub fn compile_pattern_to_chrono(tmpl: &str) -> String {
+pub fn compile_pattern_to_chrono(tmpl: &str) -> ChronoPattern {
     // https://www.postgresql.org/docs/current/functions-formatting.html
     static PG_PATTERNS: &[&str] = &[
         "HH24", "hh24", "HH12", "hh12", "HH", "hh", "MI", "mi", "SS", "ss", "YYYY", "yyyy", "YY",
@@ -45,15 +64,25 @@ pub fn compile_pattern_to_chrono(tmpl: &str) -> String {
         dst.push_str(CHRONO_PATTERNS[mat.pattern()]);
         true
     });
-    chrono_tmpl
+    let pattern = ChronoPatternBuilder {
+        tmpl: chrono_tmpl,
+        items_builder: |tmpl| StrftimeItems::new(tmpl).into_iter().collect::<Vec<_>>(),
+    }
+    .build();
+
+    pattern
 }
 
+#[inline(always)]
 pub fn to_char_timestamp(
     data: NaiveDateTimeWrapper,
     tmpl: &str,
     writer: StringWriter<'_>,
 ) -> Result<WrittenGuard> {
-    let chrono_tmpl = compile_pattern_to_chrono(tmpl);
-    let res = data.0.format(&chrono_tmpl).to_string();
+    let pattern = compile_pattern_to_chrono(tmpl);
+    let res = data
+        .0
+        .format_with_items(pattern.borrow_items().iter())
+        .to_string();
     Ok(writer.write_ref(&res))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Reduce duplicated format parsing during evaluation of `to_char`.

The perf improve by about 20% with a constant format string "YYYY/MM/DD HH24:MI:SS", but downgraded with the current benchmark framework due to #7050 .

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
