### PR TITLE
fix: fix parser test of wildcard struct field with additional parentheses

### DIFF
--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -34,13 +34,13 @@
   formatted_sql: SELECT (foo).* FROM foo
 
 - input: SELECT ((foo.v1).v2).* FROM foo
-  formatted_sql: SELECT ((foo.v1).v2).* FROM foo
+  formatted_sql: SELECT (foo.v1).v2.* FROM foo
 
 - input: SELECT ((1,2,3)::foo).v1.*
   formatted_sql: SELECT (CAST(ROW(1, 2, 3) AS foo)).v1.*
 
 - input: SELECT (((((1,2,3)::foo).v1))).*
-  formatted_sql: SELECT ((CAST(ROW(1, 2, 3) AS foo)).v1).*
+  formatted_sql: SELECT (CAST(ROW(1, 2, 3) AS foo)).v1.*
 
 - input: SELECT * FROM generate_series('2'::INT,'10'::INT,'2'::INT)
   formatted_sql: SELECT * FROM generate_series(CAST('2' AS INT), CAST('10' AS INT), CAST('2' AS INT))


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Fix parser test of wildcard struct field with additional parentheses: https://buildkite.com/risingwavelabs/main-cron/builds/282#01854176-ffb0-4018-aa7b-fe128a411a41

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#7024 