### PR TITLE
refactor(type): introduce `Timestampz` type

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -94,6 +94,7 @@ enum ArrayType {
   STRUCT = 13;
   LIST = 14;
   BYTEA = 15;
+  TIMESTAMPZ = 16;
 }
 
 message Array {

--- a/src/common/src/array/chrono_array.rs
+++ b/src/common/src/array/chrono_array.rs
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 use super::{PrimitiveArray, PrimitiveArrayBuilder};
-use crate::types::{NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper};
+use crate::types::{NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, Timestampz};
 
 pub type NaiveDateArray = PrimitiveArray<NaiveDateWrapper>;
 pub type NaiveTimeArray = PrimitiveArray<NaiveTimeWrapper>;
 pub type NaiveDateTimeArray = PrimitiveArray<NaiveDateTimeWrapper>;
+pub type TimestampzArray = PrimitiveArray<Timestampz>;
 
 pub type NaiveDateArrayBuilder = PrimitiveArrayBuilder<NaiveDateWrapper>;
 pub type NaiveTimeArrayBuilder = PrimitiveArrayBuilder<NaiveTimeWrapper>;
 pub type NaiveDateTimeArrayBuilder = PrimitiveArrayBuilder<NaiveDateTimeWrapper>;
+pub type TimestampzArrayBuilder = PrimitiveArrayBuilder<Timestampz>;
 
 #[cfg(test)]
 mod tests {

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -521,13 +521,6 @@ impl ToText for ListRef<'_> {
             )
         })
     }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            DataType::List { .. } => self.write(f),
-            _ => unreachable!(),
-        }
-    }
 }
 
 impl Eq for ListRef<'_> {}

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -41,10 +41,7 @@ use std::sync::Arc;
 
 pub use bool_array::{BoolArray, BoolArrayBuilder};
 pub use bytes_array::*;
-pub use chrono_array::{
-    NaiveDateArray, NaiveDateArrayBuilder, NaiveDateTimeArray, NaiveDateTimeArrayBuilder,
-    NaiveTimeArray, NaiveTimeArrayBuilder,
-};
+pub use chrono_array::*;
 pub use column_proto_readers::*;
 pub use data_chunk::{DataChunk, DataChunkTestExt};
 pub use data_chunk_iter::RowRef;
@@ -334,8 +331,9 @@ macro_rules! for_all_variants {
             { Decimal, decimal, DecimalArray, DecimalArrayBuilder },
             { Interval, interval, IntervalArray, IntervalArrayBuilder },
             { NaiveDate, naivedate, NaiveDateArray, NaiveDateArrayBuilder },
-            { NaiveDateTime, naivedatetime, NaiveDateTimeArray, NaiveDateTimeArrayBuilder },
             { NaiveTime, naivetime, NaiveTimeArray, NaiveTimeArrayBuilder },
+            { NaiveDateTime, naivedatetime, NaiveDateTimeArray, NaiveDateTimeArrayBuilder },
+            { Timestampz, timestampz, TimestampzArray, TimestampzArrayBuilder },
             { Struct, struct, StructArray, StructArrayBuilder },
             { List, list, ListArray, ListArrayBuilder },
             { Bytea, bytea, BytesArray, BytesArrayBuilder}
@@ -666,6 +664,7 @@ impl ArrayImpl {
             ProstArrayType::Date => read_naive_date_array(array, cardinality)?,
             ProstArrayType::Time => read_naive_time_array(array, cardinality)?,
             ProstArrayType::Timestamp => read_naive_date_time_array(array, cardinality)?,
+            ProstArrayType::Timestampz => read_timestampz_array(array, cardinality)?,
             ProstArrayType::Interval => read_interval_unit_array(array, cardinality)?,
             ProstArrayType::Struct => StructArray::from_protobuf(array)?,
             ProstArrayType::List => ListArray::from_protobuf(array)?,

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -28,6 +28,7 @@ use crate::types::decimal::Decimal;
 use crate::types::interval::IntervalUnit;
 use crate::types::{
     NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, NativeType, Scalar, ScalarRef,
+    Timestampz,
 };
 
 /// Physical type of array items which have fixed size.
@@ -109,6 +110,7 @@ macro_rules! impl_primitive_for_others {
             impl PrimitiveArrayItemType for $scalar_type {
                 impl_array_methods!($scalar_type, $array_type_pb, $array_impl_variant);
 
+                #[deny(unconditional_recursion)]
                 fn to_protobuf<T: Write>(self, output: &mut T) -> ArrayResult<usize> {
                     <$scalar_type>::to_protobuf(self, output)
                 }
@@ -122,7 +124,8 @@ impl_primitive_for_others! {
     { IntervalUnit, Interval, Interval },
     { NaiveDateWrapper, Date, NaiveDate },
     { NaiveTimeWrapper, Time, NaiveTime },
-    { NaiveDateTimeWrapper, Timestamp, NaiveDateTime }
+    { NaiveDateTimeWrapper, Timestamp, NaiveDateTime },
+    { Timestampz, Timestampz, Timestampz }
 }
 
 /// `PrimitiveArray` is a collection of primitive types, such as `i32`, `f32`.

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -429,13 +429,6 @@ impl ToText for StructRef<'_> {
             write!(f, ")")
         })
     }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            DataType::Struct(_) => self.write(f),
-            _ => unreachable!(),
-        }
-    }
 }
 
 impl Eq for StructRef<'_> {}

--- a/src/common/src/hash/dispatcher.rs
+++ b/src/common/src/hash/dispatcher.rs
@@ -14,7 +14,7 @@
 
 use super::HashKey;
 use crate::hash;
-use crate::types::DataType;
+use crate::types::{DataType, Timestampz};
 
 /// An enum to help to dynamically dispatch [`HashKey`] template.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -96,7 +96,7 @@ fn hash_key_size(data_type: &DataType) -> HashKeySize {
         DataType::Date => HashKeySize::Fixed(size_of::<NaiveDateWrapper>()),
         DataType::Time => HashKeySize::Fixed(size_of::<NaiveTimeWrapper>()),
         DataType::Timestamp => HashKeySize::Fixed(size_of::<NaiveDateTimeWrapper>()),
-        DataType::Timestampz => HashKeySize::Fixed(size_of::<i64>()),
+        DataType::Timestampz => HashKeySize::Fixed(size_of::<Timestampz>()),
         DataType::Interval => HashKeySize::Fixed(size_of::<IntervalUnit>()),
 
         DataType::Varchar => HashKeySize::Variable,

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -40,7 +40,7 @@ use crate::hash::vnode::VirtualNode;
 use crate::row::{OwnedRow, RowDeserializer};
 use crate::types::{
     DataType, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
-    OrderedF32, OrderedF64, ScalarRef,
+    OrderedF32, OrderedF64, ScalarRef, Timestampz,
 };
 use crate::util::hash_util::Crc32FastBuilder;
 use crate::util::value_encoding::{deserialize_datum, serialize_datum_into};
@@ -460,6 +460,18 @@ impl HashKeySerDe<'_> for NaiveTimeWrapper {
         let secs = u32::from_ne_bytes(value[0..4].try_into().unwrap());
         let nano = u32::from_ne_bytes(value[4..8].try_into().unwrap());
         NaiveTimeWrapper::with_secs_nano(secs, nano).unwrap()
+    }
+}
+
+impl HashKeySerDe<'_> for Timestampz {
+    type S = [u8; 8];
+
+    fn serialize(self) -> Self::S {
+        self.0.serialize()
+    }
+
+    fn deserialize<R: Read>(source: &mut R) -> Self {
+        Timestampz(i64::deserialize(source))
     }
 }
 

--- a/src/common/src/test_utils/rand_array.rs
+++ b/src/common/src/test_utils/rand_array.rs
@@ -28,7 +28,7 @@ use rand::{Rng, SeedableRng};
 use crate::array::{Array, ArrayBuilder, ArrayRef, ListValue, StructValue};
 use crate::types::{
     Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, NativeType,
-    Scalar,
+    Scalar, Timestampz,
 };
 
 pub trait RandValue {
@@ -108,6 +108,12 @@ impl RandValue for NaiveDateTimeWrapper {
                 .0
                 .and_time(NaiveTimeWrapper::rand_value(rand).0),
         )
+    }
+}
+
+impl RandValue for Timestampz {
+    fn rand_value<R: Rng>(rand: &mut R) -> Self {
+        Timestampz(i64::rand_value(rand))
     }
 }
 

--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -20,8 +20,7 @@ use chrono::{Datelike, Duration, NaiveDate, NaiveDateTime, NaiveTime, Timelike, 
 use postgres_types::{ToSql, Type};
 
 use super::to_binary::ToBinary;
-use super::to_text::ToText;
-use super::{CheckedAdd, DataType, IntervalUnit};
+use super::{CheckedAdd, IntervalUnit};
 use crate::array::ArrayResult;
 use crate::error::Result;
 use crate::util::value_encoding;
@@ -71,81 +70,27 @@ impl Default for NaiveDateTimeWrapper {
     }
 }
 
-impl ToText for NaiveDateWrapper {
-    fn write<W: std::fmt::Write>(&self, f: &mut W) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            super::DataType::Date => self.write(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl ToText for NaiveTimeWrapper {
-    fn write<W: std::fmt::Write>(&self, f: &mut W) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            super::DataType::Time => self.write(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl ToText for NaiveDateTimeWrapper {
-    fn write<W: std::fmt::Write>(&self, f: &mut W) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            super::DataType::Timestamp => self.write(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
 impl ToBinary for NaiveDateWrapper {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-        match ty {
-            super::DataType::Date => {
-                let mut output = BytesMut::new();
-                self.0.to_sql(&Type::ANY, &mut output).unwrap();
-                Ok(Some(output.freeze()))
-            }
-            _ => unreachable!(),
-        }
+    fn to_binary(&self) -> Result<Option<Bytes>> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Ok(Some(output.freeze()))
     }
 }
 
 impl ToBinary for NaiveTimeWrapper {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-        match ty {
-            super::DataType::Time => {
-                let mut output = BytesMut::new();
-                self.0.to_sql(&Type::ANY, &mut output).unwrap();
-                Ok(Some(output.freeze()))
-            }
-            _ => unreachable!(),
-        }
+    fn to_binary(&self) -> Result<Option<Bytes>> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Ok(Some(output.freeze()))
     }
 }
 
 impl ToBinary for NaiveDateTimeWrapper {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-        match ty {
-            super::DataType::Timestamp => {
-                let mut output = BytesMut::new();
-                self.0.to_sql(&Type::ANY, &mut output).unwrap();
-                Ok(Some(output.freeze()))
-            }
-            _ => unreachable!(),
-        }
+    fn to_binary(&self) -> Result<Option<Bytes>> {
+        let mut output = BytesMut::new();
+        self.0.to_sql(&Type::ANY, &mut output).unwrap();
+        Ok(Some(output.freeze()))
     }
 }
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -643,19 +643,6 @@ impl Neg for IntervalUnit {
     }
 }
 
-impl ToText for crate::types::IntervalUnit {
-    fn write<W: std::fmt::Write>(&self, f: &mut W) -> std::fmt::Result {
-        write!(f, "{self}")
-    }
-
-    fn write_with_type<W: std::fmt::Write>(&self, ty: &DataType, f: &mut W) -> std::fmt::Result {
-        match ty {
-            DataType::Interval => self.write(f),
-            _ => unreachable!(),
-        }
-    }
-}
-
 impl Display for IntervalUnit {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let years = self.months / 12;
@@ -744,15 +731,10 @@ impl<'a> FromSql<'a> for IntervalUnit {
 }
 
 impl ToBinary for IntervalUnit {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-        match ty {
-            DataType::Interval => {
-                let mut output = BytesMut::new();
-                self.to_sql(&Type::ANY, &mut output).unwrap();
-                Ok(Some(output.freeze()))
-            }
-            _ => unreachable!(),
-        }
+    fn to_binary(&self) -> Result<Option<Bytes>> {
+        let mut output = BytesMut::new();
+        self.to_sql(&Type::ANY, &mut output).unwrap();
+        Ok(Some(output.freeze()))
     }
 }
 

--- a/src/common/src/types/scalar_impl.rs
+++ b/src/common/src/types/scalar_impl.rs
@@ -313,6 +313,32 @@ impl<'a> ScalarRef<'a> for NaiveTimeWrapper {
     }
 }
 
+/// Implement `Scalar` for `Timestampz`.
+impl Scalar for Timestampz {
+    type ScalarRefType<'a> = Timestampz;
+
+    fn as_scalar_ref(&self) -> Timestampz {
+        *self
+    }
+
+    fn to_scalar_value(self) -> ScalarImpl {
+        ScalarImpl::Timestampz(self)
+    }
+}
+
+/// Implement `ScalarRef` for `Timestampz`.
+impl<'a> ScalarRef<'a> for Timestampz {
+    type ScalarType = Timestampz;
+
+    fn to_owned_scalar(&self) -> Timestampz {
+        *self
+    }
+
+    fn hash_scalar<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.hash(state)
+    }
+}
+
 /// Implement `Scalar` for `StructValue`.
 impl<'a> ScalarRef<'a> for StructRef<'a> {
     type ScalarType = StructValue;

--- a/src/common/src/types/timestampz.rs
+++ b/src/common/src/types/timestampz.rs
@@ -1,3 +1,17 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::Write;
 
 use bytes::{Bytes, BytesMut};

--- a/src/common/src/types/timestampz.rs
+++ b/src/common/src/types/timestampz.rs
@@ -1,0 +1,64 @@
+use std::io::Write;
+
+use bytes::{Bytes, BytesMut};
+use chrono::{TimeZone, Utc};
+use postgres_types::ToSql;
+use serde::{Deserialize, Serialize};
+
+use super::to_binary::ToBinary;
+use super::to_text::ToText;
+use crate::array::ArrayResult;
+use crate::error::Result;
+
+#[derive(
+    Default,
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    parse_display::Display,
+    Serialize,
+    Deserialize,
+)]
+#[repr(transparent)]
+pub struct Timestampz(pub i64);
+
+impl ToBinary for Timestampz {
+    fn to_binary(&self) -> Result<Option<Bytes>> {
+        let instant = Utc.timestamp_nanos(self.0 * 1000);
+        let mut out = BytesMut::new();
+        // postgres_types::Type::ANY is only used as a placeholder.
+        instant
+            .to_sql(&postgres_types::Type::ANY, &mut out)
+            .unwrap();
+        Ok(Some(out.freeze()))
+    }
+}
+
+impl ToText for Timestampz {
+    fn write<W: std::fmt::Write>(&self, f: &mut W) -> std::fmt::Result {
+        // Just a meaningful representation as placeholder. The real implementation depends
+        // on TimeZone from session. See #3552.
+        let instant = Utc.timestamp_nanos(self.0 * 1000);
+        // PostgreSQL uses a space rather than `T` to separate the date and time.
+        // https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-DATETIME-OUTPUT
+        // same as `instant.format("%Y-%m-%d %H:%M:%S%.f%:z")` but faster
+        write!(f, "{}+00:00", instant.naive_local())
+    }
+}
+
+impl Timestampz {
+    pub const MIN: Self = Self(i64::MIN);
+
+    pub fn from_protobuf(timestamp_micros: i64) -> ArrayResult<Self> {
+        Ok(Self(timestamp_micros))
+    }
+
+    pub fn to_protobuf(self, output: &mut impl Write) -> ArrayResult<usize> {
+        output.write(&self.0.to_be_bytes()).map_err(Into::into)
+    }
+}

--- a/src/common/src/types/to_binary.rs
+++ b/src/common/src/types/to_binary.rs
@@ -13,30 +13,24 @@
 // limitations under the License.
 
 use bytes::{Bytes, BytesMut};
-use chrono::{TimeZone, Utc};
 use postgres_types::{ToSql, Type};
 
-use super::{DataType, DatumRef, ScalarRefImpl};
+use super::{DatumRef, OrderedF32, OrderedF64, ScalarRefImpl};
 use crate::error::Result;
 // Used to convert ScalarRef to text format
 pub trait ToBinary {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>>;
+    fn to_binary(&self) -> Result<Option<Bytes>>;
 }
 
 // implement use to_sql
 macro_rules! implement_using_to_sql {
-    ($({ $scalar_type:ty , $data_type:ident} ),*) => {
+    ($($scalar_type:ty),*) => {
         $(
             impl ToBinary for $scalar_type {
-                fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-                    match ty {
-                        DataType::$data_type => {
-                            let mut output = BytesMut::new();
-                            self.to_sql(&Type::ANY, &mut output).unwrap();
-                            Ok(Some(output.freeze()))
-                        },
-                        _ => unreachable!(),
-                    }
+                fn to_binary(&self) -> Result<Option<Bytes>> {
+                    let mut output = BytesMut::new();
+                    self.to_sql(&Type::ANY, &mut output).unwrap();
+                    Ok(Some(output.freeze()))
                 }
             }
         )*
@@ -44,55 +38,33 @@ macro_rules! implement_using_to_sql {
 }
 
 implement_using_to_sql! {
-    { i16,Int16  },
-    { i32,Int32  },
-    { &str,Varchar },
-    { crate::types::OrderedF32,Float32 },
-    { crate::types::OrderedF64,Float64 },
-    { bool,Boolean },
-    { &[u8],Bytea }
-}
-
-impl ToBinary for i64 {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
-        match ty {
-            DataType::Int64 => {
-                let mut output = BytesMut::new();
-                self.to_sql(&Type::ANY, &mut output).unwrap();
-                Ok(Some(output.freeze()))
-            }
-            DataType::Timestampz => {
-                let secs = self.div_euclid(1_000_000);
-                let nsecs = self.rem_euclid(1_000_000) * 1000;
-                let instant = Utc.timestamp_opt(secs, nsecs as u32).unwrap();
-                let mut out = BytesMut::new();
-                // postgres_types::Type::ANY is only used as a placeholder.
-                instant
-                    .to_sql(&postgres_types::Type::ANY, &mut out)
-                    .unwrap();
-                Ok(Some(out.freeze()))
-            }
-            _ => unreachable!(),
-        }
-    }
+    i16,
+    i32,
+    i64,
+    &str,
+    OrderedF32,
+    OrderedF64,
+    bool,
+    &[u8]
 }
 
 impl ToBinary for ScalarRefImpl<'_> {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+    fn to_binary(&self) -> Result<Option<Bytes>> {
         match self {
-            ScalarRefImpl::Int16(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Int32(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Int64(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Float32(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Float64(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Utf8(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Bool(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Decimal(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Interval(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::NaiveDate(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::NaiveDateTime(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::NaiveTime(v) => v.to_binary_with_type(ty),
-            ScalarRefImpl::Bytea(v) => v.to_binary_with_type(ty),
+            ScalarRefImpl::Int16(v) => v.to_binary(),
+            ScalarRefImpl::Int32(v) => v.to_binary(),
+            ScalarRefImpl::Int64(v) => v.to_binary(),
+            ScalarRefImpl::Float32(v) => v.to_binary(),
+            ScalarRefImpl::Float64(v) => v.to_binary(),
+            ScalarRefImpl::Utf8(v) => v.to_binary(),
+            ScalarRefImpl::Bool(v) => v.to_binary(),
+            ScalarRefImpl::Decimal(v) => v.to_binary(),
+            ScalarRefImpl::Interval(v) => v.to_binary(),
+            ScalarRefImpl::NaiveDate(v) => v.to_binary(),
+            ScalarRefImpl::NaiveTime(v) => v.to_binary(),
+            ScalarRefImpl::NaiveDateTime(v) => v.to_binary(),
+            ScalarRefImpl::Timestampz(v) => v.to_binary(),
+            ScalarRefImpl::Bytea(v) => v.to_binary(),
             ScalarRefImpl::Struct(_) => todo!(),
             ScalarRefImpl::List(_) => todo!(),
         }
@@ -100,9 +72,9 @@ impl ToBinary for ScalarRefImpl<'_> {
 }
 
 impl ToBinary for DatumRef<'_> {
-    fn to_binary_with_type(&self, ty: &DataType) -> Result<Option<Bytes>> {
+    fn to_binary(&self) -> Result<Option<Bytes>> {
         match self {
-            Some(scalar) => scalar.to_binary_with_type(ty),
+            Some(scalar) => scalar.to_binary(),
             None => Ok(None),
         }
     }

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -177,8 +177,9 @@ pub fn compare_rows(lhs: &OwnedRow, rhs: &OwnedRow, order_pairs: &[OrderPair]) -
                 Decimal,
                 Interval,
                 NaiveDate,
-                NaiveDateTime,
                 NaiveTime,
+                NaiveDateTime,
+                Timestampz,
                 Struct,
                 List,
                 Bytea

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -347,15 +347,15 @@ fn datum_to_json_object(field: &Field, datum: DatumRef<'_>) -> ArrayResult<Value
             json!(v.to_text())
         }
         (
-            dt @ DataType::Date
-            | dt @ DataType::Time
-            | dt @ DataType::Timestamp
-            | dt @ DataType::Timestampz
-            | dt @ DataType::Interval
-            | dt @ DataType::Bytea,
+            DataType::Date
+            | DataType::Time
+            | DataType::Timestamp
+            | DataType::Timestampz
+            | DataType::Interval
+            | DataType::Bytea,
             scalar,
         ) => {
-            json!(scalar.to_text_with_type(&dt))
+            json!(scalar.to_text())
         }
         (DataType::List { .. }, ScalarRefImpl::List(list_ref)) => {
             let mut vec = Vec::with_capacity(field.sub_fields.len());

--- a/src/expr/benches/expr.rs
+++ b/src/expr/benches/expr.rs
@@ -23,7 +23,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_common::array::*;
 use risingwave_common::types::{
     DataType, DataTypeName, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper,
-    NaiveTimeWrapper, OrderedF32, OrderedF64,
+    NaiveTimeWrapper, OrderedF32, OrderedF64, Timestampz,
 };
 use risingwave_expr::expr::expr_unary::new_unary_expr;
 use risingwave_expr::expr::*;
@@ -57,7 +57,7 @@ fn bench_expr(c: &mut Criterion) {
                 (1..=CHUNK_SIZE).map(|_| NaiveDateTimeWrapper::default()),
             )
             .into(),
-            I64Array::from_iter(1..=CHUNK_SIZE as i64).into(),
+            TimestampzArray::from_iter((1..=CHUNK_SIZE).map(|i| Timestampz(i as i64))).into(),
             IntervalArray::from_iter((1..=CHUNK_SIZE).map(|i| IntervalUnit::from_days(i as _)))
                 .into(),
             Utf8Array::from_iter_display((1..=CHUNK_SIZE).map(Some)).into(),

--- a/src/expr/src/expr/data_types.rs
+++ b/src/expr/src/expr/data_types.rs
@@ -208,7 +208,7 @@ macro_rules! timestampz {
     ($macro:ident) => {
         $macro! {
             risingwave_common::types::DataType::Timestampz,
-            risingwave_common::array::I64Array
+            risingwave_common::array::TimestampzArray
         }
     };
 }

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -207,7 +207,7 @@ fn build_array_access_expr(
         DataType::Bytea => array_access_expression!(BytesArray),
         DataType::Time => array_access_expression!(NaiveTimeArray),
         DataType::Timestamp => array_access_expression!(NaiveDateTimeArray),
-        DataType::Timestampz => array_access_expression!(PrimitiveArray::<i64>),
+        DataType::Timestampz => array_access_expression!(TimestampzArray),
         DataType::Interval => array_access_expression!(IntervalArray),
         DataType::Struct { .. } => array_access_expression!(StructArray),
         DataType::List { .. } => array_access_expression!(ListArray),

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -294,7 +294,7 @@ pub fn new_unary_expr(
             gen_round_expr! {"Ceil", child_expr, return_type, round_f64, round_decimal}
         }
         (ProstType::ToTimestamp, DataType::Timestampz, DataType::Float64) => {
-            Box::new(UnaryExpression::<F64Array, I64Array, _>::new(
+            Box::new(UnaryExpression::<F64Array, TimestampzArray, _>::new(
                 child_expr,
                 return_type,
                 f64_sec_to_timestampz,

--- a/src/expr/src/vector_op/extract.rs
+++ b/src/expr/src/vector_op/extract.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use chrono::{Datelike, Timelike};
-use risingwave_common::types::{Decimal, NaiveDateTimeWrapper, NaiveDateWrapper};
+use risingwave_common::types::{Decimal, NaiveDateTimeWrapper, NaiveDateWrapper, Timestampz};
 
 use crate::{bail, Result};
 
@@ -57,9 +57,9 @@ pub fn extract_from_timestamp(time_unit: &str, timestamp: NaiveDateTimeWrapper) 
     res
 }
 
-pub fn extract_from_timestampz(time_unit: &str, usecs: i64) -> Result<Decimal> {
+pub fn extract_from_timestampz(time_unit: &str, tz: Timestampz) -> Result<Decimal> {
     match time_unit {
-        "EPOCH" => Ok(Decimal::from(usecs) / 1_000_000.into()),
+        "EPOCH" => Ok(Decimal::from(tz.0) / 1_000_000.into()),
         // TODO(#5826): all other units depend on implicit session TimeZone
         _ => bail!(
             "Unsupported timestamp with time zone unit {} in extract function",

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -55,6 +55,7 @@ use itertools::Itertools;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::{
     DataType, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
+    Timestampz,
 };
 use risingwave_pb::plan_common::JoinType;
 
@@ -707,7 +708,7 @@ impl<'a> TableScanIoEstimator<'a> {
             DataType::Date => size_of::<NaiveDateWrapper>(),
             DataType::Time => size_of::<NaiveTimeWrapper>(),
             DataType::Timestamp => size_of::<NaiveDateTimeWrapper>(),
-            DataType::Timestampz => size_of::<i64>(),
+            DataType::Timestampz => size_of::<Timestampz>(),
             DataType::Interval => size_of::<IntervalUnit>(),
             DataType::Varchar => 20,
             DataType::Bytea => 20,

--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -407,6 +407,7 @@ impl_fold_agg! { I64Array, Int64, IntervalArray }
 impl_fold_agg! { I64Array, Int64, NaiveTimeArray }
 impl_fold_agg! { I64Array, Int64, NaiveDateArray }
 impl_fold_agg! { I64Array, Int64, NaiveDateTimeArray }
+impl_fold_agg! { I64Array, Int64, TimestampzArray }
 // max/min
 impl_fold_agg! { I16Array, Int16, I16Array }
 impl_fold_agg! { I32Array, Int32, I32Array }
@@ -420,6 +421,7 @@ impl_fold_agg! { IntervalArray, Interval, IntervalArray }
 impl_fold_agg! { NaiveTimeArray, NaiveTime, NaiveTimeArray }
 impl_fold_agg! { NaiveDateArray, NaiveDate, NaiveDateArray }
 impl_fold_agg! { NaiveDateTimeArray, NaiveDateTime, NaiveDateTimeArray }
+impl_fold_agg! { TimestampzArray, Timestampz, TimestampzArray }
 // sum
 impl_fold_agg! { DecimalArray, Decimal, I64Array }
 // avg

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -26,7 +26,7 @@ use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::{
     Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, BoolArray, BytesArray, DecimalArray,
     F32Array, F64Array, I16Array, I32Array, I64Array, IntervalArray, ListArray, NaiveDateArray,
-    NaiveDateTimeArray, NaiveTimeArray, StructArray, Utf8Array,
+    NaiveDateTimeArray, NaiveTimeArray, StructArray, TimestampzArray, Utf8Array,
 };
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::types::{DataType, Datum};
@@ -165,13 +165,19 @@ pub fn create_streaming_agg_impl(
                     (Count, varchar, int64, StreamingCountAgg::<Utf8Array>),
                     (Count, interval, int64, StreamingCountAgg::<IntervalArray>),
                     (Count, date, int64, StreamingCountAgg::<NaiveDateArray>),
+                    (Count, time, int64, StreamingCountAgg::<NaiveTimeArray>),
                     (
                         Count,
                         timestamp,
                         int64,
                         StreamingCountAgg::<NaiveDateTimeArray>
                     ),
-                    (Count, time, int64, StreamingCountAgg::<NaiveTimeArray>),
+                    (
+                        Count,
+                        timestampz,
+                        int64,
+                        StreamingCountAgg::<TimestampzArray>
+                    ),
                     (Count, struct_type, int64, StreamingCountAgg::<StructArray>),
                     (Count, list, int64, StreamingCountAgg::<ListArray>),
                     // Sum0
@@ -219,7 +225,12 @@ pub fn create_streaming_agg_impl(
                         timestamp,
                         StreamingMinAgg::<NaiveDateTimeArray>
                     ),
-                    (Min, timestampz, timestampz, StreamingMinAgg::<I64Array>),
+                    (
+                        Min,
+                        timestampz,
+                        timestampz,
+                        StreamingMinAgg::<TimestampzArray>
+                    ),
                     (Min, varchar, varchar, StreamingMinAgg::<Utf8Array>),
                     (Min, bytea, bytea, StreamingMinAgg::<BytesArray>),
                     // Max
@@ -238,7 +249,12 @@ pub fn create_streaming_agg_impl(
                         timestamp,
                         StreamingMaxAgg::<NaiveDateTimeArray>
                     ),
-                    (Max, timestampz, timestampz, StreamingMaxAgg::<I64Array>),
+                    (
+                        Max,
+                        timestampz,
+                        timestampz,
+                        StreamingMaxAgg::<TimestampzArray>
+                    ),
                     (Max, varchar, varchar, StreamingMaxAgg::<Utf8Array>),
                     (Max, bytea, bytea, StreamingMaxAgg::<BytesArray>),
                 ]


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

This PR introduces `Timestampz` type as a wrapper over the original `i64`, as well as the corresponding `TimestampzArray` and `TimestampzArrayBuilder`. It makes a 1-1 mapping between SQL data types and Rust types, removes the ambiguity of i64 value -> int64 or timestampz. Thus `ToText` and `ToBinary` can be called without specifying the data type.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
