### PR TITLE
fix: precision not enough should not throw Error

### DIFF
--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -108,3 +108,9 @@ query TTTTTT
 select interval '1 year 1 month 1 day 1:1:1.009';
 ----
 1 year 1 mon 1 day 01:01:01.009
+
+# issue#7059, if we improve precision, then this should be removed.
+query TTTTTT
+select '1 mons 1 days 00:00:00.000001'::INTERVAL;
+----
+1 mon 1 day

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -994,17 +994,16 @@ impl IntervalUnit {
                     .ok_or_else(|| ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", s)))?;
                 }
                 (TimeStrToken::Second(second), TimeStrToken::TimeUnit(interval_unit)) => {
-                    result = result + (|| match interval_unit {
+                    result = result + match interval_unit {
                         Second => {
+                            // Currently our precision is millisecond, we should consider to refactor it to microseconds later (#4514).
+                            // If unsatisfied precision is passed as input, we should not return None (Error).
                             // TODO: IntervalUnit only support millisecond precision so the part smaller than millisecond will be truncated.
-                            if second > OrderedF64::from(0) && second < OrderedF64::from(0.001) {
-                                return None;
-                            }
                             let ms = (second.into_inner() * 1000_f64).round() as i64;
                             Some(IntervalUnit::from_millis(ms))
                         }
                         _ => None,
-                    })()
+                    }
                     .ok_or_else(|| ErrorCode::InvalidInputSyntax(format!("Invalid interval {}.", s)))?;
                 }
                 _ => {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Precision not enough should not throw Error.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
