### PR TITLE
feat: collect batch task mem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2700,6 +2709,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hytra"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7ee43a7d27a202506374a5afb36b89c3be719ace2082e492dabb2034028124"
+dependencies = [
+ "atomic",
+ "crossbeam-utils",
+ "num-traits",
+ "rayon",
+ "thread_local",
 ]
 
 [[package]]
@@ -5106,6 +5128,7 @@ dependencies = [
  "fixedbitset",
  "futures",
  "futures-async-stream",
+ "hytra",
  "itertools",
  "madsim-tokio",
  "madsim-tonic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,6 +5129,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "static_assertions",
+ "task_stats_alloc",
  "tempfile",
  "thiserror",
  "tikv-jemallocator",

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -56,6 +56,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tokio-metrics = "0.1.0"
 tokio-stream = "0.1"
 tonic = { version = "0.2", package = "madsim-tonic" }
+task_stats_alloc = { path = "../utils/task_stats_alloc" }
 tracing = "0.1"
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -22,6 +22,7 @@ farmhash = "1"
 fixedbitset = { version = "0.4", features = ["std"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-async-stream = "0.2"
+hytra = "0.1.2"
 itertools = "0.10"
 minitrace = "0.4"
 num-traits = "0.2"

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -42,6 +42,7 @@ serde-value = "0.7"
 serde_json = "1"
 smallvec = "1"
 static_assertions = "1"
+task_stats_alloc = { path = "../utils/task_stats_alloc" }
 tempfile = "3"
 thiserror = "1"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
@@ -56,7 +57,6 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tokio-metrics = "0.1.0"
 tokio-stream = "0.1"
 tonic = { version = "0.2", package = "madsim-tonic" }
-task_stats_alloc = { path = "../utils/task_stats_alloc" }
 tracing = "0.1"
 tracing-futures = "0.2"
 twox-hash = "1"

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -60,7 +60,7 @@ pub trait BatchTaskContext: Clone + Send + Sync + 'static {
 
     fn source_metrics(&self) -> Arc<SourceMetrics>;
 
-    fn record_mem_usage(&self, val: usize);
+    fn store_mem_usage(&self, val: usize);
 
     fn get_mem_usage(&self) -> usize;
 }
@@ -72,9 +72,10 @@ pub struct ComputeNodeContext {
     // None: Local mode don't record metrics.
     task_metrics: Option<BatchTaskMetricsWithTaskLabels>,
 
-    // Last mem usage value.
+    // Last mem usage value. Init to be 0. Should be the last value of `cur_mem_val`.
     last_mem_val: Arc<AtomicUsize>,
-    // Record how many memory bytes have been used in this task,
+    // How many memory bytes have been used in this task for the latest report value. Will be moved
+    // to `last_mem_val` if new value comes in.
     cur_mem_val: Arc<AtomicUsize>,
 }
 
@@ -117,7 +118,7 @@ impl BatchTaskContext for ComputeNodeContext {
         self.env.source_metrics()
     }
 
-    fn record_mem_usage(&self, val: usize) {
+    fn store_mem_usage(&self, val: usize) {
         // Record the last mem val.
         // Calculate the difference between old val and new value, and apply the diff to total
         // memory usage value.

--- a/src/batch/src/task/context.rs
+++ b/src/batch/src/task/context.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use risingwave_common::catalog::SysCatalogReaderRef;
@@ -130,6 +130,7 @@ impl ComputeNodeContext {
         Self {
             env: BatchEnvironment::for_test(),
             task_metrics: None,
+            mem_usage_value: Arc::new(0.into()),
         }
     }
 

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -596,6 +596,12 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
     pub fn get_mem_usage(&self) -> usize {
         self.context.get_mem_usage()
     }
+
+    /// Check the task status: whether has ended.
+    pub fn is_end(&self) -> bool {
+        let guard = self.state.lock();
+        !(*guard == TaskStatus::Running || *guard == TaskStatus::Pending)
+    }
 }
 
 #[cfg(test)]

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -593,7 +593,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
             .expect("The state receivers must have been inited!")
     }
 
-    pub fn report_mem_usage(&self) -> usize {
+    pub fn get_mem_usage(&self) -> usize {
         self.context.get_mem_usage()
     }
 }

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -47,7 +47,8 @@ pub struct BatchManager {
     config: BatchConfig,
 
     /// Total batch mem usage.
-    /// When each task context report their own usage, it will apply the diff into this total mem value for all tasks.
+    /// When each task context report their own usage, it will apply the diff into this total mem
+    /// value for all tasks.
     mem_val: Arc<TrAdder<i64>>,
 }
 
@@ -217,6 +218,9 @@ impl BatchManager {
         let guard = self.tasks.lock();
         for (t_id, t) in guard.iter() {
             // If the task has been stopped, we should not count this.
+            if t.is_end() {
+                continue;
+            }
             // Alternatively, we can use a bool flag to indicate end of execution.
             // Now we use only store 0 bytes in Context after execution ends.
             let mem_usage = t.get_mem_usage();
@@ -231,7 +235,8 @@ impl BatchManager {
         }
     }
 
-    /// Called by global memory manager for total usage of batch tasks. This op is designed to be light-weight
+    /// Called by global memory manager for total usage of batch tasks. This op is designed to be
+    /// light-weight
     pub fn get_all_memory_usage(&self) -> usize {
         self.mem_val.get() as usize
     }

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -221,12 +221,9 @@ impl BatchManager {
         let mut max_mem = usize::MIN;
         let guard = self.tasks.lock();
         for (k, v) in guard.iter() {
-            if v.is_end() {
-                // println!("End");
-                continue;
-            }
-
-            // println!("No End");
+            // If the task has been stopped, we should not count this.
+            // Alternatively, we can use a bool flag to indicate end of execution.
+            // Now we use only store 0 bytes in Context after execution ends.
             let mem_usage = v.report_mem_usage();
             if mem_usage > max_mem {
                 max_mem = mem_usage;
@@ -235,7 +232,10 @@ impl BatchManager {
             all += mem_usage;
         }
 
-        let guard = self.max_mem_task.lock();
+        // Store the max memory task for future potential kill queries.
+        let mut guard = self.max_mem_task.lock();
+        *guard = max_mem_task_id;
+
         all
     }
 }

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -46,10 +46,10 @@ pub struct BatchManager {
     /// Batch configuration
     config: BatchConfig,
 
-    /// Total batch mem usage.
+    /// Total batch memory usage in this CN.
     /// When each task context report their own usage, it will apply the diff into this total mem
     /// value for all tasks.
-    mem_val: Arc<TrAdder<i64>>,
+    total_mem_val: Arc<TrAdder<i64>>,
 }
 
 impl BatchManager {
@@ -72,7 +72,7 @@ impl BatchManager {
             // stream manager.
             runtime: Box::leak(Box::new(runtime)),
             config,
-            mem_val: TrAdder::new().into(),
+            total_mem_val: TrAdder::new().into(),
         }
     }
 
@@ -238,11 +238,13 @@ impl BatchManager {
     /// Called by global memory manager for total usage of batch tasks. This op is designed to be
     /// light-weight
     pub fn get_all_memory_usage(&self) -> usize {
-        self.mem_val.get() as usize
+        self.total_mem_val.get() as usize
     }
 
+    /// Calculate the diff between this time and last time memory usage report, apply the diff for
+    /// the global counter. Due to the limitation of hytra, we need to use i64 type here.
     pub fn apply_mem_diff(&self, diff: i64) {
-        self.mem_val.inc(diff)
+        self.total_mem_val.inc(diff)
     }
 }
 

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -81,4 +81,20 @@ impl BatchTaskContext for FrontendBatchTaskContext {
     fn source_metrics(&self) -> Arc<SourceMetrics> {
         self.env.source_metrics()
     }
+
+    fn record_mem_usage(&self, val: usize) {
+        todo!()
+    }
+
+    fn get_mem_usage(&self) -> usize {
+        todo!()
+    }
+
+    fn set_task_end(&self) {
+        todo!()
+    }
+
+    fn is_end(&self) -> bool {
+        todo!()
+    }
 }

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -82,7 +82,7 @@ impl BatchTaskContext for FrontendBatchTaskContext {
         self.env.source_metrics()
     }
 
-    fn record_mem_usage(&self, val: usize) {
+    fn record_mem_usage(&self, _val: usize) {
         todo!()
     }
 

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -89,12 +89,4 @@ impl BatchTaskContext for FrontendBatchTaskContext {
     fn get_mem_usage(&self) -> usize {
         todo!()
     }
-
-    fn set_task_end(&self) {
-        todo!()
-    }
-
-    fn is_end(&self) -> bool {
-        todo!()
-    }
 }

--- a/src/frontend/src/scheduler/task_context.rs
+++ b/src/frontend/src/scheduler/task_context.rs
@@ -82,7 +82,7 @@ impl BatchTaskContext for FrontendBatchTaskContext {
         self.env.source_metrics()
     }
 
-    fn record_mem_usage(&self, _val: usize) {
+    fn store_mem_usage(&self, _val: usize) {
         todo!()
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Collect batch task mem usage by store the value in Task Context and sum it up in BatchManager.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
