### PR TITLE
chore: don't overwrite the millestone if it has been set

### DIFF
--- a/.github/workflows/assign-issue-milestone.yml
+++ b/.github/workflows/assign-issue-milestone.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Add issue to the latest milestone
-      uses: cgetc/automatically-set-milestone-to-issue@v0.1.2
+      uses: fuyufjh/automatically-set-milestone-to-issue@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         version-prefix: 'release-'

--- a/.github/workflows/assign-issue-milestone.yml
+++ b/.github/workflows/assign-issue-milestone.yml
@@ -14,6 +14,7 @@ jobs:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         version-prefix: 'release-'
         version-separator: '.'
+        overwrite: false
     - name: Add issue to project
       uses: actions/add-to-project@v0.3.0
       with:


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title. See details in https://github.com/fuyufjh/automatically-set-milestone-to-issue/pull/4

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

None