### PR TITLE
fix(connector): fix start_offset and empty range 

### DIFF
--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -132,10 +132,15 @@ impl KafkaSplitEnumerator {
         // watermark as the start and end offset if the timestamp is provided, we will use
         // the watermark to narrow down the range
         let mut expect_start_offset = if let Some(ts) = expect_start_timestamp_millis {
-            Some(
-                self.fetch_offset_for_time(topic_partitions.as_ref(), ts)
-                    .await?,
-            )
+            let mut start_offset = self
+                .fetch_offset_for_time(topic_partitions.as_ref(), ts)
+                .await?;
+            start_offset.iter_mut().for_each(|(_, offset)| {
+                if let Some(v) = offset.as_mut() {
+                    *v -= 1;
+                }
+            });
+            Some(start_offset)
         } else {
             None
         };


### PR DESCRIPTION

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

fix:
- process start offset correctly
- check empty range correctly 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
