### PR TITLE
fix(streaming): handle scaling for row id gen executor

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -159,9 +159,11 @@ async fn test_table_materialize() -> StreamResult<()> {
     let (barrier_tx, barrier_rx) = unbounded_channel();
     let vnodes = Bitmap::from_bytes(&[0b11111111]);
 
+    let actor_ctx = ActorContext::create(0x3f3f3f);
+
     // Create a `SourceExecutor` to read the changes.
     let source_executor = SourceExecutorV2::<PanicStateStore>::new(
-        ActorContext::create(0x3f3f3f),
+        actor_ctx.clone(),
         all_schema.clone(),
         pk_indices.clone(),
         None, // There is no external stream source.
@@ -183,6 +185,7 @@ async fn test_table_materialize() -> StreamResult<()> {
     );
 
     let row_id_gen_executor = RowIdGenExecutor::new(
+        actor_ctx,
         Box::new(dml_executor),
         all_schema.clone(),
         pk_indices.clone(),

--- a/src/stream/src/executor/row_id_gen.rs
+++ b/src/stream/src/executor/row_id_gen.rs
@@ -112,8 +112,8 @@ impl RowIdGenExecutor {
                     yield Message::Chunk(StreamChunk::new(ops, columns, bitmap));
                 }
                 Message::Barrier(barrier) => {
-                    // Update row id generator if vnode mapping is changed.
-                    // Note that: since update barrier will only occurs between pause and resume
+                    // Update row id generator if vnode mapping changes.
+                    // Note that: since `Update` barrier only exists between `Pause` and `Resume`
                     // barrier, duplicated row id won't be generated.
                     if let Some(vnodes) = barrier.as_update_vnode_bitmap(self.ctx.id) {
                         self.row_id_generator = Self::new_generator(&vnodes);

--- a/src/stream/src/from_proto/row_id_gen.rs
+++ b/src/stream/src/from_proto/row_id_gen.rs
@@ -38,6 +38,7 @@ impl ExecutorBuilder for RowIdGenExecutorBuilder {
             .vnode_bitmap
             .expect("vnodes not set for row id gen executor");
         let executor = RowIdGenExecutor::new(
+            params.actor_context,
             upstream,
             params.schema,
             params.pk_indices,

--- a/src/tests/simulation/tests/nexmark_source.rs
+++ b/src/tests/simulation/tests/nexmark_source.rs
@@ -23,17 +23,20 @@ use risingwave_simulation::ctl_ext::predicate::identity_contains;
 use risingwave_simulation::nexmark::{NexmarkCluster, THROUGHPUT};
 use risingwave_simulation::utils::AssertResult;
 
-/// Check that the number of generated events is correct after scaling of source executor.
+/// Check that everything works well after scaling of source-related executor.
 #[madsim::test]
 async fn nexmark_source() -> Result<()> {
     let events = 20 * THROUGHPUT;
 
     let mut cluster = NexmarkCluster::new(Configuration::for_scale(), 6, Some(events)).await?;
 
+    // Materialize all sources so that we can also check whether the row id generator is working
+    // correctly after scaling.
+    // https://github.com/risingwavelabs/risingwave/issues/7103
     for table in ["person", "auction", "bid"] {
         cluster
             .run(&format!(
-                "create materialized view count_{table} as select count(*) count_{table} from {table};"
+                "create materialized view materialized_{table} as select * from {table};"
             ))
             .await?;
     }
@@ -57,9 +60,15 @@ async fn nexmark_source() -> Result<()> {
     reschedule!();
 
     sleep(Duration::from_secs(30)).await;
+
+    // Check the total number of events.
     cluster
         .run(
-            "select count_person + count_auction + count_bid from count_person, count_auction, count_bid;",
+            r#"
+with count_p as (select count(*) count_p from materialized_person),
+     count_a as (select count(*) count_a from materialized_auction),
+     count_b as (select count(*) count_b from materialized_bid)
+select count_p + count_a + count_b from count_p, count_a, count_b;"#,
         )
         .await?
         .assert_result_eq(events.to_string());


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Correctly handle the scaling for RowIdGen executor. The logic used to work fine, but was lost in the refactoring in #6529.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- #6529
- #6836
- #7103