### PR TITLE
feat(frontend): `explain (logical)`

### DIFF
--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -26,8 +26,8 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Result};
 pub use resolve_id::*;
 use risingwave_frontend::handler::{
-    create_index, create_mv, create_schema, create_source, create_table, drop_table, variable,
-    HandlerArgs,
+    create_index, create_mv, create_schema, create_source, create_table, drop_table, explain,
+    variable, HandlerArgs,
 };
 use risingwave_frontend::session::SessionImpl;
 use risingwave_frontend::test_utils::{create_proto_file, get_explain_output, LocalFrontend};
@@ -392,11 +392,17 @@ impl TestCase {
                 } => {
                     variable::handle_set(handler_args, variable, value).unwrap();
                 }
-                Statement::Explain { .. } => {
-                    let explain_output = get_explain_output(sql, session.clone()).await;
+                Statement::Explain {
+                    analyze,
+                    statement,
+                    options,
+                } => {
                     if result.is_some() {
                         panic!("two queries in one test case");
                     }
+                    let rsp = explain::handle_explain(handler_args, *statement, options, analyze)?;
+
+                    let explain_output = get_explain_output(rsp).await;
                     let ret = TestCaseResult {
                         explain_output: Some(explain_output),
                         ..Default::default()

--- a/src/frontend/planner_test/tests/testdata/explain.yaml
+++ b/src/frontend/planner_test/tests/testdata/explain.yaml
@@ -86,3 +86,86 @@
         "0": []
       }
     }
+- sql: |
+    create table t1(v1 int);
+    create table t2(v2 int);
+    explain (logical) select * from t1 join t2 on v1=v2;
+  explain_output: |
+    LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+    ├─LogicalScan { table: t1, columns: [v1] }
+    └─LogicalScan { table: t2, columns: [v2] }
+- sql: |
+    create table t1(v1 int);
+    create table t2(v2 int);
+    explain (logical, trace) select * from t1 join t2 on v1=v2;
+  explain_output: |+
+    Begin:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Share Source:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Predicate Push Down:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Predicate Push Down:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Predicate Push Down:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Push Down the Calculation of Inputs of Join's Condition:
+
+    apply PushCalculationOfJoinRule 1 time(s)
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1, _row_id] }
+      └─LogicalScan { table: t2, columns: [v2, _row_id] }
+
+    Prune Columns:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1] }
+      └─LogicalScan { table: t2, columns: [v2] }
+
+    Predicate Push Down:
+
+    LogicalProject { exprs: [t1.v1, t2.v2] }
+    └─LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+      ├─LogicalScan { table: t1, columns: [v1] }
+      └─LogicalScan { table: t2, columns: [v2] }
+
+    Project Remove:
+
+    apply ProjectEliminateRule 1 time(s)
+
+    LogicalJoin { type: Inner, on: (t1.v1 = t2.v2) }
+    ├─LogicalScan { table: t1, columns: [v1] }
+    └─LogicalScan { table: t2, columns: [v2] }
+
+- sql: |
+    explain (logical) create table t1(v1 int);
+  explain_output: |
+    LogicalSource

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -32,7 +32,7 @@ use crate::scheduler::BatchPlanFragmenter;
 use crate::stream_fragmenter::build_graph;
 use crate::utils::explain_stream_graph;
 
-pub(super) fn handle_explain(
+pub fn handle_explain(
     handler_args: HandlerArgs,
     stmt: Statement,
     options: ExplainOptions,
@@ -47,9 +47,6 @@ pub(super) fn handle_explain(
 
     if analyze {
         return Err(ErrorCode::NotImplemented("explain analyze".to_string(), 4856.into()).into());
-    }
-    if options.explain_type == ExplainType::Logical {
-        return Err(ErrorCode::NotImplemented("explain logical".to_string(), 4856.into()).into());
     }
 
     let session = context.session_ctx().clone();
@@ -119,8 +116,8 @@ pub(super) fn handle_explain(
         vec![]
     };
 
-    if options.explain_type == ExplainType::DistSql {
-        match plan.convention() {
+    match options.explain_type {
+        ExplainType::DistSql => match plan.convention() {
             Convention::Logical => unreachable!(),
             Convention::Batch => {
                 let plan_fragmenter = BatchPlanFragmenter::new(
@@ -144,16 +141,30 @@ pub(super) fn handle_explain(
                         .map(|s| Row::new(vec![Some(s.to_string().into())])),
                 );
             }
+        },
+        ExplainType::Physical => {
+            // if explain trace is open, the plan has been in the rows
+            if !explain_trace {
+                let output = plan.explain_to_string()?;
+                rows.extend(
+                    output
+                        .lines()
+                        .map(|s| Row::new(vec![Some(s.to_string().into())])),
+                );
+            }
         }
-    } else {
-        // if explain trace is open, the plan has been in the rows
-        if !explain_trace {
-            let output = plan.explain_to_string()?;
-            rows.extend(
-                output
-                    .lines()
-                    .map(|s| Row::new(vec![Some(s.to_string().into())])),
-            );
+        ExplainType::Logical => {
+            // if explain trace is open, the plan has been in the rows
+            if !explain_trace {
+                let output = plan.ctx().take_logical().ok_or_else(|| {
+                    ErrorCode::InternalError("Logical plan not found for query".into())
+                })?;
+                rows.extend(
+                    output
+                        .lines()
+                        .map(|s| Row::new(vec![Some(s.to_string().into())])),
+                );
+            }
         }
     }
 

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -51,7 +51,7 @@ pub mod drop_source;
 pub mod drop_table;
 pub mod drop_user;
 mod drop_view;
-mod explain;
+pub mod explain;
 mod flush;
 pub mod handle_privilege;
 pub mod privilege;

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -417,6 +417,8 @@ impl PlanRoot {
             ApplyOrder::TopDown,
         );
 
+        ctx.store_logical(plan.explain_to_string().unwrap());
+
         Ok(plan)
     }
 

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -18,7 +18,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
 
-use risingwave_sqlparser::ast::ExplainOptions;
+use risingwave_sqlparser::ast::{ExplainOptions, ExplainType};
 
 use crate::expr::CorrelatedId;
 use crate::handler::HandlerArgs;
@@ -36,6 +36,8 @@ pub struct OptimizerContext {
     explain_options: ExplainOptions,
     /// Store the trace of optimizer
     optimizer_trace: RefCell<Vec<String>>,
+    /// Store the optimized logical plan of optimizer
+    logical_explain: RefCell<Option<String>>,
     /// Store correlated id
     next_correlated_id: RefCell<u32>,
     /// Store options or properties from the `with` clause
@@ -65,6 +67,7 @@ impl OptimizerContext {
             sql,
             explain_options,
             optimizer_trace: RefCell::new(vec![]),
+            logical_explain: RefCell::new(None),
             next_correlated_id: RefCell::new(0),
             with_options,
         }
@@ -80,6 +83,7 @@ impl OptimizerContext {
             sql: Arc::from(""),
             explain_options: ExplainOptions::default(),
             optimizer_trace: RefCell::new(vec![]),
+            logical_explain: RefCell::new(None),
             next_correlated_id: RefCell::new(0),
             with_options: Default::default(),
         }
@@ -105,9 +109,23 @@ impl OptimizerContext {
     }
 
     pub fn trace(&self, str: impl Into<String>) {
+        // If explain type is logical, do not store the trace for any optimizations beyond logical.
+        if self.explain_options.explain_type == ExplainType::Logical
+            && self.logical_explain.borrow().is_some()
+        {
+            return;
+        }
         let mut optimizer_trace = self.optimizer_trace.borrow_mut();
         optimizer_trace.push(str.into());
         optimizer_trace.push("\n".to_string());
+    }
+
+    pub fn store_logical(&self, str: impl Into<String>) {
+        *self.logical_explain.borrow_mut() = Some(str.into())
+    }
+
+    pub fn take_logical(&self) -> Option<String> {
+        self.logical_explain.borrow_mut().take()
     }
 
     pub fn take_trace(&self) -> Vec<String> {

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -158,9 +158,10 @@ impl LocalFrontend {
     }
 }
 
-pub async fn get_explain_output(sql: &str, session: Arc<SessionImpl>) -> String {
-    let mut rsp = session.run_statement(sql, false).await.unwrap();
-    assert_eq!(rsp.get_stmt_type(), StatementType::EXPLAIN);
+pub async fn get_explain_output(mut rsp: RwPgResponse) -> String {
+    if rsp.get_stmt_type() != StatementType::EXPLAIN {
+        panic!("RESPONSE INVALID: {rsp:?}");
+    }
     let mut res = String::new();
     #[for_await]
     for row_set in rsp.values_stream() {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Implement `explain logical`. 

It can be useful to some users who want to understand the logical plan of their query, but not the physical plan or look through the trace.

Usage combinations:
1. `explain (logical) [stmt]`: show the optimized logical plan
2. `explain (logical, trace) [stmt]`: only show the optimizer trace up to optimized logical plan
3. `explain (logical, verbose) [stmt]`: no change with 1

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation
The documentation for `EXPLAIN` should be updated (we can merge it after release)

### Release note
Enabled `explain (logical)` and `explain (logical, trace)`.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/4856