### PR TITLE
fix(storage): update seal_epoch synchronously

### DIFF
--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -463,7 +463,6 @@ impl HummockEventHandler {
                             if is_checkpoint {
                                 self.uploader.start_sync_epoch(epoch);
                             }
-                            self.seal_epoch.store(epoch, Ordering::SeqCst);
                         }
                         #[cfg(any(test, feature = "test"))]
                         HummockEvent::FlushEvent(sender) => {

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -268,6 +268,9 @@ impl StateStore for HummockStorage {
             warn!("sealing invalid epoch");
             return;
         }
+        // Update `seal_epoch` synchronously,
+        // as `HummockEvent::SealEpoch` is handled asynchronously.
+        self.seal_epoch.store(epoch, MemOrdering::SeqCst);
         self.hummock_event_sender
             .send(HummockEvent::SealEpoch {
                 epoch,


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Before this PR, seal_epoch updating is handled by HummockEventHandler [asynchronously](https://github.com/risingwavelabs/risingwave/blob/12127933b945ba414e5a7329e04139c65f09f9c7/src/stream/src/task/barrier_manager/managed_state.rs#L133), which cannot ensure HummockEventHandler::seal_epoch is updated [before notifying barrier finishing ](https://github.com/risingwavelabs/risingwave/blob/12127933b945ba414e5a7329e04139c65f09f9c7/src/stream/src/task/barrier_manager/managed_state.rs#L144). It can lead to [current epoch can't read, because the epoch in storage is not updated](https://github.com/risingwavelabs/risingwave/issues/7169).

This PR fixes it by updating HummockStorage::seal_epoch synchronously, which shares the same underlying atomic var of HummockEventHandler::seal_epoch.


## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
fix https://github.com/risingwavelabs/risingwave/issues/7169