### PR TITLE
chore: remove deprecated expr in proto

### DIFF
--- a/dashboard/proto/gen/expr.ts
+++ b/dashboard/proto/gen/expr.ts
@@ -122,10 +122,11 @@ export const ExprNode_Type = {
   ARRAY_CAT: "ARRAY_CAT",
   ARRAY_APPEND: "ARRAY_APPEND",
   ARRAY_PREPEND: "ARRAY_PREPEND",
-  /** SEARCH - Search operator and Search ARGument */
-  SEARCH: "SEARCH",
-  SARG: "SARG",
-  /** VNODE - Internal functions */
+  /**
+   * VNODE - Non-pure functions below (> 600)
+   * ------------------------
+   * Internal functions
+   */
   VNODE: "VNODE",
   /** NOW - Non-deterministic functions */
   NOW: "NOW",
@@ -370,12 +371,6 @@ export function exprNode_TypeFromJSON(object: any): ExprNode_Type {
     case 533:
     case "ARRAY_PREPEND":
       return ExprNode_Type.ARRAY_PREPEND;
-    case 998:
-    case "SEARCH":
-      return ExprNode_Type.SEARCH;
-    case 999:
-    case "SARG":
-      return ExprNode_Type.SARG;
     case 1101:
     case "VNODE":
       return ExprNode_Type.VNODE;
@@ -547,10 +542,6 @@ export function exprNode_TypeToJSON(object: ExprNode_Type): string {
       return "ARRAY_APPEND";
     case ExprNode_Type.ARRAY_PREPEND:
       return "ARRAY_PREPEND";
-    case ExprNode_Type.SEARCH:
-      return "SEARCH";
-    case ExprNode_Type.SARG:
-      return "SARG";
     case ExprNode_Type.VNODE:
       return "VNODE";
     case ExprNode_Type.NOW:

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -110,9 +110,9 @@ message ExprNode {
     ARRAY_CAT = 531;
     ARRAY_APPEND = 532;
     ARRAY_PREPEND = 533;
-    // Search operator and Search ARGument
-    SEARCH = 998;
-    SARG = 999;
+
+    // Non-pure functions below (> 600)
+    // ------------------------
     // Internal functions
     VNODE = 1101;
     // Non-deterministic functions

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -208,8 +208,8 @@ impl FunctionCall {
         self.func_type
     }
 
+    /// Refer to [`ExprType`] for details.
     pub fn is_pure(&self) -> bool {
-        // See proto for details
         0 < self.func_type as i32 && self.func_type as i32 <= 600
     }
 

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -41,23 +41,21 @@ mod utils;
 
 pub use agg_call::AggCall;
 pub use correlated_input_ref::{CorrelatedId, CorrelatedInputRef, Depth};
-pub use function_call::{is_row_function, FunctionCall, FunctionCallDisplay};
-pub use input_ref::{input_ref_to_column_indices, InputRef, InputRefDisplay};
-pub use literal::Literal;
-pub use subquery::{Subquery, SubqueryKind};
-pub use table_function::{TableFunction, TableFunctionType};
-pub use window_function::{WindowFunction, WindowFunctionType};
-
-pub type ExprType = risingwave_pb::expr::expr_node::Type;
-
 pub use expr_mutator::ExprMutator;
 pub use expr_rewriter::ExprRewriter;
 pub use expr_visitor::ExprVisitor;
+pub use function_call::{is_row_function, FunctionCall, FunctionCallDisplay};
+pub use input_ref::{input_ref_to_column_indices, InputRef, InputRefDisplay};
+pub use literal::Literal;
+pub use risingwave_pb::expr::expr_node::Type as ExprType;
+pub use subquery::{Subquery, SubqueryKind};
+pub use table_function::{TableFunction, TableFunctionType};
 pub use type_inference::{
     agg_func_sigs, align_types, cast_map_array, cast_ok, cast_sigs, func_sigs, infer_type,
     least_restrictive, AggFuncSig, CastContext, CastSig, FuncSign,
 };
 pub use utils::*;
+pub use window_function::{WindowFunction, WindowFunctionType};
 
 /// the trait of bound expressions
 pub trait Expr: Into<ExprImpl> {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
was not used after #411