### PR TITLE
chore(ci): fix e2e fuzzing time

### DIFF
--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -15,7 +15,7 @@ mkdir -p ./test_data
 unzip -o test_data.zip -d .
 cd ../../
 
-export RUST_LOG=info
+export RUST_LOG="info,risingwave_sqlsmith=debug"
 export LOGDIR=.risingwave/log
 
 mkdir -p $LOGDIR

--- a/ci/scripts/pr.env.sh
+++ b/ci/scripts/pr.env.sh
@@ -7,6 +7,7 @@ set +e
 # Set features, depending on our workflow
 # If sqlsmith files are modified, we run tests with sqlsmith enabled.
 MATCHES="ci/scripts/pr.env.sh\
+\|ci/scripts/cron-fuzz-test.sh\
 \|ci/scripts/pr-fuzz-test.sh\
 \|ci/scripts/run-e2e-test.sh\
 \|ci/scripts/run-fuzz-test.sh\

--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -38,7 +38,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     cargo make pre-start-dev
     cargo make link-all-in-one-binaries
 
-    echo "+++ Run sqlsmith tests"
+    echo "--- frontend, fuzzing"
     NEXTEST_PROFILE=ci cargo nextest run run_sqlsmith_on_frontend --features "failpoints sync_point enable_sqlsmith_unit_test" 2> >(tee);
 
     echo "--- e2e, ci-3cn-1fe, fuzzing"
@@ -47,7 +47,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     chmod +x ./target/debug/sqlsmith
 
     cargo make ci-start ci-3cn-1fe
-    timeout 20m ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
+    timeout 20m RUST_LOG=info ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
 
     # Using `kill` instead of `ci-kill` avoids storing excess logs.
     # If there's errors, the failing query will be printed to stderr.

--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -47,7 +47,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     chmod +x ./target/debug/sqlsmith
 
     cargo make ci-start ci-3cn-1fe
-    timeout 20m RUST_LOG=info ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
+    RUST_LOG=info timeout 20m ./target/debug/sqlsmith test --count "$SQLSMITH_COUNT" --testdata ./src/tests/sqlsmith/tests/testdata
 
     # Using `kill` instead of `ci-kill` avoids storing excess logs.
     # If there's errors, the failing query will be printed to stderr.

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -22,6 +22,7 @@ use crate::{create_table_statement_to_table, mview_sql_gen, parse_sql, sql_gen, 
 
 /// e2e test runner for sqlsmith
 pub async fn run(client: &tokio_postgres::Client, testdata: &str, count: usize) {
+    tracing::info!("Running {} tests for stream and batch", count);
     let mut rng = rand::rngs::SmallRng::from_entropy();
     let (tables, mviews, setup_sql) = create_tables(&mut rng, testdata, client).await;
 
@@ -33,6 +34,7 @@ pub async fn run(client: &tokio_postgres::Client, testdata: &str, count: usize) 
     tracing::info!("Passed stream queries");
 
     drop_tables(&mviews, testdata, client).await;
+    tracing::info!("Sqlsmith e2e tests passed");
 }
 
 /// Sanity checks for sqlsmith

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -84,7 +84,7 @@ async fn test_batch_queries<R: Rng>(
     let mut skipped = 0;
     for _ in 0..sample_size {
         let sql = sql_gen(rng, tables.clone());
-        tracing::info!("Executing: {}", sql);
+        tracing::debug!("Executing: {}", sql);
         let response = client.query(sql.as_str(), &[]).await;
         skipped += validate_response(setup_sql, &format!("{};", sql), response);
     }
@@ -102,7 +102,7 @@ async fn test_stream_queries<R: Rng>(
     let mut skipped = 0;
     for _ in 0..sample_size {
         let (sql, table) = mview_sql_gen(rng, tables.clone(), "stream_query");
-        tracing::info!("Executing: {}", sql);
+        tracing::debug!("Executing: {}", sql);
         let response = client.execute(&sql, &[]).await;
         skipped += validate_response(setup_sql, &format!("{};", sql), response);
         drop_mview_table(&table, client).await;
@@ -123,7 +123,7 @@ async fn create_tables(
     testdata: &str,
     client: &tokio_postgres::Client,
 ) -> (Vec<Table>, Vec<Table>, String) {
-    tracing::info!("Preparing tables...");
+    tracing::debug!("Preparing tables...");
 
     let mut setup_sql = String::with_capacity(1000);
     let sql = get_seed_table_sql(testdata);
@@ -144,7 +144,7 @@ async fn create_tables(
     for i in 0..10 {
         let (create_sql, table) = mview_sql_gen(rng, tables.clone(), &format!("m{}", i));
         setup_sql.push_str(&format!("{};", &create_sql));
-        tracing::info!("Executing MView Setup: {}", &create_sql);
+        tracing::debug!("Executing MView Setup: {}", &create_sql);
         let response = client.execute(&create_sql, &[]).await;
         let skip_count = validate_response(&setup_sql, &create_sql, response);
         if skip_count == 0 {
@@ -168,7 +168,7 @@ async fn drop_mview_table(mview: &Table, client: &tokio_postgres::Client) {
 
 /// Drops mview tables and seed tables
 async fn drop_tables(mviews: &[Table], testdata: &str, client: &tokio_postgres::Client) {
-    tracing::info!("Cleaning tables...");
+    tracing::debug!("Cleaning tables...");
 
     for mview in mviews.iter().rev() {
         drop_mview_table(mview, client).await;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- Parallelize queries, so e2e runs faster.
- E2e test time shows up under `Kill cluster` step.

<img width="964" alt="Screenshot 2023-01-05 at 10 49 11 AM" src="https://user-images.githubusercontent.com/47273164/210690401-b7380735-7322-46a9-91c9-e8cd2dd705e4.png">

This PR fixes that. Also fix naming of frontend tests, add some logging.

<img width="964" alt="Screenshot 2023-01-05 at 12 43 05 PM" src="https://user-images.githubusercontent.com/47273164/210703326-f778e14f-5ad2-49d2-a729-fb9885263dc5.png">


## Checklist

- [ ] revert log level
- [ ] Parallelizing didn't do much because bottleneck is in frontend I believe. Perhaps change to 3fe?
- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
