### PR TITLE
fix(planner test): now planner test should also use timestamptz

### DIFF
--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -353,7 +353,7 @@
     └─BatchValues { rows: [[]] }
 - name: now expression
   sql: |
-    create table t (v1 timestamp);
+    create table t (v1 timestamp with time zone);
     select * from t where v1 >= now();
   logical_plan: |
     LogicalProject { exprs: [t.v1] }
@@ -366,7 +366,7 @@
       └─StreamNow { output: [now] }
 - name: and of two now expression condition
   sql: |
-    create table t (v1 timestamp, v2 timestamp);
+    create table t (v1 timestamp with time zone, v2 timestamp with time zone);
     select * from t where v1 >= now() and v2 >= now();
   stream_plan: |
     StreamMaterialize { columns: [v1, v2, t._row_id(hidden)], pk_columns: [t._row_id] }
@@ -377,12 +377,12 @@
       └─StreamNow { output: [now] }
 - name: or of two now expression condition
   sql: |
-    create table t (v1 timestamp, v2 timestamp);
+    create table t (v1 timestamp with time zone, v2 timestamp with time zone);
     select * from t where v1 >= now() or v2 >= now();
   stream_error: 'Expr error: Invalid parameter now: now expression must be placed in a comparison'
 - name: now inside HAVING clause
   sql: |
-    create table t (v1 timestamp, v2 int);
+    create table t (v1 timestamp with time zone, v2 int);
     select max(v1) as max_time from t group by v2 having max(v1) >= now();
   stream_plan: |
     StreamMaterialize { columns: [max_time, t.v2(hidden)], pk_columns: [t.v2] }
@@ -395,16 +395,16 @@
         └─StreamNow { output: [now] }
 - name: forbid now in group by for stream
   sql: |
-    create table t (v1 timestamp, v2 int);
+    create table t (v1 timestamp with time zone, v2 int);
     select sum(v2) as sum_v2 from t group by v1 >= now();
   stream_error: 'Invalid input syntax: For creation of materialized views, `NOW()` function is only allowed in `WHERE` and `HAVING`. Found in clause: Some(GroupBy)'
 - name: forbid now in select for stream
   sql: |
-    create table t (v1 timestamp, v2 timestamp);
+    create table t (v1 timestamp with time zone, v2 timestamp with time zone);
     select now() as n, * from t where v1 >= now();
   stream_error: 'Invalid input syntax: For creation of materialized views, `NOW()` function is only allowed in `WHERE` and `HAVING`. Found in clause: None'
 - name: forbid now in agg filter for stream
   sql: |
-    create table t (v1 timestamp, v2 int);
+    create table t (v1 timestamp with time zone, v2 int);
     select sum(v2) filter (where v1 >= now()) as sum_v2 from t;
   stream_error: 'Invalid input syntax: For creation of materialized views, `NOW()` function is only allowed in `WHERE` and `HAVING`. Found in clause: Some(Filter)'

--- a/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/predicate_pushdown.yaml
@@ -238,8 +238,8 @@
     └─LogicalScan { table: t2, columns: [] }
 - name: now() pushdown with delta expression
   sql: |
-    create table t1(v1 timestamp);
-    create table t2(v2 timestamp);
+    create table t1(v1 timestamp with time zone);
+    create table t2(v2 timestamp with time zone);
     select * from t1 join t2 where v1 = v2 and v1 > now() + '1 hr';
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }
@@ -258,8 +258,8 @@
         └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: now() in a complex cmp expr does not get pushed down
   sql: |
-    create table t1(v1 timestamp);
-    create table t2(v2 timestamp, v3 interval);
+    create table t1(v1 timestamp with time zone);
+    create table t2(v2 timestamp with time zone, v3 interval);
     select * from t1, t2 where v1 = v2 and v1 > now() + v3;
   optimized_logical_plan: |
     LogicalFilter { predicate: (t1.v1 > (Now + t2.v3)) }
@@ -269,8 +269,8 @@
   stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form `col [cmp] now() +- [literal]`'
 - name: now() in complex cmp expr pushed onto join ON clause results in dynamic filter
   sql: |
-    create table t1(v1 timestamp);
-    create table t2(v2 timestamp, v3 interval);
+    create table t1(v1 timestamp with time zone);
+    create table t2(v2 timestamp with time zone, v3 interval);
     select * from t1 join t2 where v1 = v2 and v1 > now() + v3;
   optimized_logical_plan: |
     LogicalFilter { predicate: (t1.v1 > (Now + t2.v3)) }
@@ -280,7 +280,7 @@
   stream_error: 'Expr error: Invalid parameter now: expressions containing now must be of the form `col [cmp] now() +- [literal]`'
 - name: now() does not get pushed to scan, but others do
   sql: |
-    create table t1(v1 timestamp, v2 int);
+    create table t1(v1 timestamp with time zone, v2 int);
     select * from t1 where v1 > now() + '30 min' and v2 > 5;
   optimized_logical_plan: |
     LogicalFilter { predicate: (t1.v1 > (Now + '30 min':Varchar::Interval)) }
@@ -322,8 +322,8 @@
       └─LogicalScan { table: t2, columns: [t2.v1, t2.v2], predicate: IsNotNull((t2.v1 + 5:Int32)) }
 - name: eq-predicate derived condition is banned for impure function e.g. `now()`
   sql: |
-    create table t1(v1 timestamp);
-    create table t2(v2 timestamp);
+    create table t1(v1 timestamp with time zone);
+    create table t2(v2 timestamp with time zone);
     select * from t1 join t2 where v1 = v2 and v1 > now();
   optimized_logical_plan: |
     LogicalJoin { type: Inner, on: (t1.v1 = t2.v2), output: all }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

now planner test should also use timestamptz instead of timestamp

## Checklist

- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
