### PR TITLE
refactor: dynamic filter plannode

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -45,8 +45,8 @@ impl<PlanRef: GenericPlanRef> DynamicFilter<PlanRef> {
                             self.left.schema().fields()[self.left_index].data_type(),
                         )),
                         ExprImpl::from(InputRef::new(
-                            self.left.schema().len() + 1,
-                            self.left.schema().fields()[0].data_type(),
+                            self.left.schema().len(),
+                            self.right.schema().fields()[0].data_type(),
                         )),
                     ],
                 )

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -38,7 +38,7 @@ impl<PlanRef: GenericPlanRef> DynamicFilter<PlanRef> {
         Condition {
             conjunctions: vec![ExprImpl::from(
                 FunctionCall::new(
-                    self.comparator.clone(),
+                    self.comparator,
                     vec![
                         ExprImpl::from(InputRef::new(
                             self.left_index,

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use risingwave_common::util::sort_util::OrderType;
+pub use risingwave_pb::expr::expr_node::Type as ExprType;
 
+use super::GenericPlanRef;
+use crate::expr::{ExprImpl, FunctionCall, InputRef};
 use crate::optimizer::plan_node::stream;
 use crate::optimizer::plan_node::utils::TableCatalogBuilder;
 use crate::utils::Condition;
@@ -22,11 +25,35 @@ use crate::TableCatalog;
 #[derive(Clone, Debug)]
 pub struct DynamicFilter<PlanRef> {
     /// The predicate (formed with exactly one of < , <=, >, >=)
-    pub predicate: Condition,
-    // dist_key_l: Distribution,
+    pub comparator: ExprType,
     pub left_index: usize,
     pub left: PlanRef,
+    /// The right input can only have one column.
     pub right: PlanRef,
+}
+
+impl<PlanRef: GenericPlanRef> DynamicFilter<PlanRef> {
+    /// normalize to the join predicate
+    pub fn predicate(&self) -> Condition {
+        Condition {
+            conjunctions: vec![ExprImpl::from(
+                FunctionCall::new(
+                    self.comparator.clone(),
+                    vec![
+                        ExprImpl::from(InputRef::new(
+                            self.left_index,
+                            self.left.schema().fields()[self.left_index].data_type(),
+                        )),
+                        ExprImpl::from(InputRef::new(
+                            self.left.schema().len() + 1,
+                            self.left.schema().fields()[0].data_type(),
+                        )),
+                    ],
+                )
+                .unwrap(),
+            )],
+        }
+    }
 }
 
 pub fn infer_left_internal_table_catalog(

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -307,21 +307,7 @@ impl ToStream for LogicalFilter {
                 });
                 cur_streaming = StreamDynamicFilter::new(
                     left_index,
-                    Condition {
-                        conjunctions: vec![ExprImpl::from(FunctionCall::new(
-                            now_cond.get_expr_type(),
-                            vec![
-                                ExprImpl::from(InputRef::new(
-                                    left_index,
-                                    self.schema().fields()[left_index].data_type(),
-                                )),
-                                ExprImpl::from(InputRef::new(
-                                    self.schema().len(),
-                                    rht.schema().fields()[0].data_type(),
-                                )),
-                            ],
-                        )?)],
-                    },
+                    now_cond.get_expr_type(),
                     cur_streaming,
                     rht,
                 )

--- a/src/frontend/src/optimizer/plan_node/logical_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_filter.rs
@@ -27,7 +27,7 @@ use super::{
     ColPrunable, CollectInputRef, LogicalProject, PlanBase, PlanRef, PlanTreeNodeUnary,
     PredicatePushdown, ToBatch, ToStream,
 };
-use crate::expr::{assert_input_ref, ExprImpl, FunctionCall, InputRef};
+use crate::expr::{assert_input_ref, ExprImpl, InputRef};
 use crate::optimizer::plan_node::stream_now::StreamNow;
 use crate::optimizer::plan_node::{
     BatchFilter, ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext,

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1108,10 +1108,6 @@ impl LogicalJoin {
             Some(v) => v,
             None => return Ok(None),
         };
-        let (left_ref, right_ref) = match left_ref.index < right_ref.index {
-            true => (left_ref, right_ref),
-            false => (right_ref, left_ref),
-        };
 
         let condition_cross_inputs = left_ref.index < self.left().schema().len()
             && right_ref.index == self.left().schema().len() /* right side has only one column */;
@@ -1121,7 +1117,9 @@ impl LogicalJoin {
         }
 
         // We align input types on all join predicates with cmp operator
-        if left_ref.data_type != right_ref.data_type {
+        if self.left().schema().fields()[left_ref.index].data_type
+            != self.right().schema().fields()[0].data_type
+        {
             return Ok(None);
         }
 

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -423,7 +423,7 @@ pub fn to_stream_prost_body(
             use generic::dynamic_filter::*;
             let me = &me.core;
             let condition = me
-                .predicate
+                .predicate()
                 .as_expr_unless_true()
                 .map(|x| x.to_expr_proto());
             let left_table = infer_left_internal_table_catalog(base, me.left_index)

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -22,11 +22,11 @@ use risingwave_pb::stream_plan::DynamicFilterNode;
 
 use super::generic;
 use super::utils::IndicesDisplay;
-use crate::expr::{Expr, ExprImpl, FunctionCall, InputRef};
+use crate::expr::{Expr};
 use crate::optimizer::plan_node::{PlanBase, PlanTreeNodeBinary, StreamNode};
 use crate::optimizer::PlanRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
-use crate::utils::{Condition, ConditionDisplay};
+use crate::utils::{ConditionDisplay};
 
 #[derive(Clone, Debug)]
 pub struct StreamDynamicFilter {
@@ -112,7 +112,7 @@ impl PlanTreeNodeBinary for StreamDynamicFilter {
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
         Self::new(
             self.core.left_index,
-            self.core.comparator.clone(),
+            self.core.comparator,
             left,
             right,
         )

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -16,12 +16,13 @@ use std::fmt;
 
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
+pub use risingwave_pb::expr::expr_node::Type as ExprType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::DynamicFilterNode;
 
 use super::generic;
 use super::utils::IndicesDisplay;
-use crate::expr::Expr;
+use crate::expr::{Expr, ExprImpl, FunctionCall, InputRef};
 use crate::optimizer::plan_node::{PlanBase, PlanTreeNodeBinary, StreamNode};
 use crate::optimizer::PlanRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -34,7 +35,9 @@ pub struct StreamDynamicFilter {
 }
 
 impl StreamDynamicFilter {
-    pub fn new(left_index: usize, predicate: Condition, left: PlanRef, right: PlanRef) -> Self {
+    pub fn new(left_index: usize, comparator: ExprType, left: PlanRef, right: PlanRef) -> Self {
+        assert_eq!(right.schema().len(), 1);
+
         // TODO: derive from input
         let base = PlanBase::new_stream(
             left.ctx(),
@@ -46,12 +49,20 @@ impl StreamDynamicFilter {
                     * in the future */
         );
         let core = generic::DynamicFilter {
-            predicate,
+            comparator,
             left_index,
             left,
             right,
         };
         Self { base, core }
+    }
+
+    pub fn left_index(&self) -> usize {
+        self.core.left_index
+    }
+
+    pub fn comparator(&self) -> &ExprType {
+        &self.core.comparator
     }
 }
 
@@ -64,10 +75,12 @@ impl fmt::Display for StreamDynamicFilter {
         concat_schema.extend(self.right().schema().fields.clone());
         let concat_schema = Schema::new(concat_schema);
 
+        let predicate = self.core.predicate();
+
         builder.field(
             "predicate",
             &ConditionDisplay {
-                condition: &self.core.predicate,
+                condition: &predicate,
                 input_schema: &concat_schema,
             },
         );
@@ -99,7 +112,7 @@ impl PlanTreeNodeBinary for StreamDynamicFilter {
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
         Self::new(
             self.core.left_index,
-            self.core.predicate.clone(),
+            self.core.comparator.clone(),
             left,
             right,
         )
@@ -113,7 +126,7 @@ impl StreamNode for StreamDynamicFilter {
         use generic::dynamic_filter::*;
         let condition = self
             .core
-            .predicate
+            .predicate()
             .as_expr_unless_true()
             .map(|x| x.to_expr_proto());
         let left_index = self.core.left_index;

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -22,11 +22,11 @@ use risingwave_pb::stream_plan::DynamicFilterNode;
 
 use super::generic;
 use super::utils::IndicesDisplay;
-use crate::expr::{Expr};
+use crate::expr::Expr;
 use crate::optimizer::plan_node::{PlanBase, PlanTreeNodeBinary, StreamNode};
 use crate::optimizer::PlanRef;
 use crate::stream_fragmenter::BuildFragmentGraphState;
-use crate::utils::{ConditionDisplay};
+use crate::utils::ConditionDisplay;
 
 #[derive(Clone, Debug)]
 pub struct StreamDynamicFilter {
@@ -110,12 +110,7 @@ impl PlanTreeNodeBinary for StreamDynamicFilter {
     }
 
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new(
-            self.core.left_index,
-            self.core.comparator,
-            left,
-            right,
-        )
+        Self::new(self.core.left_index, self.core.comparator, left, right)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Currently, the dynamic filter stores a whole `Condition` which contains many assumptions. In this PR, we just store the exprType and left key index, which is more type-safe and readable.