### PR TITLE
feat(frontend): session timezone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,6 +5430,7 @@ dependencies = [
  "crc32fast",
  "criterion",
  "darwin-libproc",
+ "derivative",
  "either",
  "enum-as-inner",
  "fixedbitset",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,6 +5425,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "chrono-tz",
  "comfy-table",
  "crc32fast",
  "criterion",

--- a/e2e_test/database/timezone.slt
+++ b/e2e_test/database/timezone.slt
@@ -1,0 +1,32 @@
+
+query T
+show timezone;
+----
+UTC
+
+# Double quoted string
+statement ok
+set timezone = "America/Los_Angeles"
+
+query T
+show timezone;
+----
+America/Los_Angeles
+
+statement error
+set timezone = "Invalid"
+
+# timezone has not changed
+query T
+show timezone;
+----
+America/Los_Angeles
+
+# Single quoted string
+statement ok
+set timezone = 'GMT'
+
+query T
+show timezone;
+----
+GMT

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -18,6 +18,7 @@ bitflags = "1.3.2"
 byteorder = "1"
 bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
+chrono-tz = { version = "0.7", features = ["case-insensitive"] }
 comfy-table = "6"
 crc32fast = "1"
 either = "1"

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4", default-features = false, features = ["clock", "std"
 chrono-tz = { version = "0.7", features = ["case-insensitive"] }
 comfy-table = "6"
 crc32fast = "1"
+derivative = "2"
 either = "1"
 enum-as-inner = "0.5"
 fixedbitset = { version = "0.4", features = ["std"] }

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -19,10 +19,10 @@ mod visibility_mode;
 
 use std::ops::Deref;
 
+use chrono_tz::Tz;
 use itertools::Itertools;
 pub use query_mode::QueryMode;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
-use chrono_tz::Tz;
 
 use crate::error::{ErrorCode, RwError};
 use crate::session_config::transaction_isolation_level::IsolationLevel;
@@ -346,13 +346,10 @@ impl ConfigMap {
         } else if key.eq_ignore_ascii_case(Timezone::entry_name()) {
             let raw: Timezone = val.as_slice().try_into()?;
             // Check if the provided string is a valid timezone.
-            Tz::from_str_insensitive(&raw.0)
-                .map_err(|_e| {
-                    ErrorCode::InvalidConfigValue {
-                        config_entry: Timezone::entry_name().to_string(),
-                        config_value: raw.0.to_string(),
-                    }
-                })?;
+            Tz::from_str_insensitive(&raw.0).map_err(|_e| ErrorCode::InvalidConfigValue {
+                config_entry: Timezone::entry_name().to_string(),
+                config_value: raw.0.to_string(),
+            })?;
             self.timezone = raw;
         } else {
             return Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into());

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -20,6 +20,7 @@ mod visibility_mode;
 use std::ops::Deref;
 
 use chrono_tz::Tz;
+use derivative::{self, Derivative};
 use itertools::Itertools;
 pub use query_mode::QueryMode;
 pub use search_path::{SearchPath, USER_NAME_WILD_CARD};
@@ -259,7 +260,8 @@ type MaxSplitRangeGap = ConfigI32<MAX_SPLIT_RANGE_GAP, 8>;
 type QueryEpoch = ConfigU64<QUERY_EPOCH, 0>;
 type Timezone = ConfigString<TIMEZONE>;
 
-#[derive(Default)]
+#[derive(Derivative)]
+#[derivative(Default)]
 pub struct ConfigMap {
     /// If `RW_IMPLICIT_FLUSH` is on, then every INSERT/UPDATE/DELETE statement will block
     /// until the entire dataflow is refreshed. In other words, every related table & MV will
@@ -306,17 +308,11 @@ pub struct ConfigMap {
     query_epoch: QueryEpoch,
 
     /// Session timezone. Defaults to UTC.
+    #[derivative(Default(value = "ConfigString::<TIMEZONE>(String::from(\"UTC\"))"))]
     timezone: Timezone,
 }
 
 impl ConfigMap {
-    pub fn new() -> Self {
-        Self {
-            timezone: ConfigString::<TIMEZONE>("UTC".into()),
-            ..Default::default()
-        }
-    }
-
     pub fn set(&mut self, key: &str, val: Vec<String>) -> Result<(), RwError> {
         let val = val.iter().map(AsRef::as_ref).collect_vec();
         if key.eq_ignore_ascii_case(ImplicitFlush::entry_name()) {

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -29,15 +29,14 @@ pub fn handle_set(
     value: Vec<SetVariableValue>,
 ) -> Result<RwPgResponse> {
     // Strip double and single quotes
-    let string_vals = value.into_iter().map(|v|
-        match v {
-            SetVariableValue::Literal(Value::DoubleQuotedString(s)) |
-            SetVariableValue::Literal(Value::SingleQuotedString(s)) => {
-                s
-            },
-            _ => v.to_string()
-        }
-    ).collect_vec();
+    let string_vals = value
+        .into_iter()
+        .map(|v| match v {
+            SetVariableValue::Literal(Value::DoubleQuotedString(s))
+            | SetVariableValue::Literal(Value::SingleQuotedString(s)) => s,
+            _ => v.to_string(),
+        })
+        .collect_vec();
 
     // Currently store the config variable simply as String -> ConfigEntry(String).
     // In future we can add converter/parser to make the API more robust.

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -370,7 +370,7 @@ impl SessionImpl {
             env,
             auth_context,
             user_authenticator,
-            config_map: RwLock::new(ConfigMap::new()),
+            config_map: Default::default(),
             id,
         }
     }
@@ -385,7 +385,7 @@ impl SessionImpl {
                 DEFAULT_SUPER_USER_ID,
             )),
             user_authenticator: UserAuthenticator::None,
-            config_map: ConfigMap::new().into(),
+            config_map: Default::default(),
             // Mock session use non-sense id.
             id: (0, 0),
         }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -385,7 +385,7 @@ impl SessionImpl {
                 DEFAULT_SUPER_USER_ID,
             )),
             user_authenticator: UserAuthenticator::None,
-            config_map: ConfigMap::new(),
+            config_map: ConfigMap::new().into(),
             // Mock session use non-sense id.
             id: (0, 0),
         }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -370,7 +370,7 @@ impl SessionImpl {
             env,
             auth_context,
             user_authenticator,
-            config_map: RwLock::new(Default::default()),
+            config_map: RwLock::new(ConfigMap::new()),
             id,
         }
     }
@@ -385,7 +385,7 @@ impl SessionImpl {
                 DEFAULT_SUPER_USER_ID,
             )),
             user_authenticator: UserAuthenticator::None,
-            config_map: Default::default(),
+            config_map: ConfigMap::new(),
             // Mock session use non-sense id.
             id: (0, 0),
         }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Session timezone. Defaults to `UTC`. 

I believe defaulting to UTC is better than defaulting to server local timezone as default timezone for user timestamps is more likely to be UTC than server timezone.

We will warn users via pgwire notice whenever they make use of session timezone implicitly.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

### Types of user-facing changes
enabled `set timezone = [TimeZone]` and `show timezone`;

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/7175