### PR TITLE
fix(sqlsmith): handle broken channel errors

### DIFF
--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -36,6 +36,13 @@ fn not_unique_error(db_error: &str) -> bool {
     db_error.contains("Bind error") && db_error.contains("is not unique")
 }
 
+/// Ignore broken channel error, since this can be triggered by upstream error,
+/// e.g. ExprError::NumericOutofRange.
+/// TODO(Noel): Should further verify logs to see that the upstream error type is one which is acceptable.
+fn is_broken_chan_error(db_error: &str) -> bool {
+    db_error.contains("broken") && db_error.contains("channel");
+}
+
 /// Certain errors are permitted to occur. This is because:
 /// 1. It is more complex to generate queries without these errors.
 /// 2. These errors seldom occur, skipping them won't affect overall effectiveness of sqlsmith.
@@ -44,4 +51,5 @@ pub fn is_permissible_error(db_error: &str) -> bool {
         || is_division_by_zero_err(db_error)
         || is_unimplemented_error(db_error)
         || not_unique_error(db_error)
+        || is_broken_chan_error(db_error)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Fix broken channel errors.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
