### PR TITLE
fix: remove the hazardous default.toml

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -387,7 +387,7 @@ cat <<\EOF > "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/risedev-profiles.user.ym
 # - develop the cluster with the new profiles by `./risedev dev <new-profile-name>`
 
 my-default-example:
-  config-path: src/config/default.toml
+  config-path: src/config/my_config.toml
   steps:
     - use: meta-node
     - use: compute-node

--- a/risedev.yml
+++ b/risedev.yml
@@ -16,7 +16,8 @@ profile:
 
   # The default configuration will start 1 compute node, 1 meta node and 1 frontend.
   default:
-    config-path: src/config/default.toml
+    # Specify a configuration file to override the default settings
+    # config-path: src/config/example.toml
     steps:
       # If you want to use the local s3 storage, enable the following line
       # - use: minio
@@ -68,7 +69,6 @@ profile:
 
   # The minimum config to use with risectl.
   for-ctl:
-    config-path: src/config/default.toml
     steps:
       - use: minio
       - use: meta-node
@@ -132,7 +132,6 @@ profile:
         persist-data: true
 
   3etcd-3meta-1cn-1fe:
-    config-path: src/config/default.toml
     steps:
       - use: etcd
         unsafe-no-fsync: true
@@ -194,7 +193,7 @@ profile:
       - use: compactor
 
   docker-playground:
-    config-path: src/config/default.toml
+    config-path: src/config/playground.toml
     steps:
       - use: meta-node
         listen-address: "0.0.0.0"

--- a/src/config/default.toml
+++ b/src/config/default.toml
@@ -1,3 +1,0 @@
-[meta]
-disable_recovery = true
-max_heartbeat_interval_secs = 600


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Remove the hazardous `default.toml` with `enable_recovery = false`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)
None