### PR TITLE
fix: avoid zero parallelism in initialization of compute node

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -108,7 +108,12 @@ fn validate_opts(opts: &ComputeNodeOpts) {
         tracing::error!(error_msg);
         panic!("{}", error_msg);
     }
-    let total_cpu_available = total_cpu_available() as usize;
+    if opts.parallelism == 0 {
+        let error_msg = "parallelism should not be zero";
+        tracing::error!(error_msg);
+        panic!("{}", error_msg);
+    }
+    let total_cpu_available = total_cpu_available().ceil() as usize;
     if opts.parallelism > total_cpu_available {
         let error_msg = format!(
             "parallelism {} is larger than the total cpu available {} that can be acquired.",
@@ -160,5 +165,5 @@ fn default_total_memory_bytes() -> usize {
 }
 
 fn default_parallelism() -> usize {
-    total_cpu_available() as usize
+    total_cpu_available().ceil() as usize
 }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Avoid zero parallelism in initialization of compute node.

## Checklist

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
