### PR TITLE
fix(compaction-test): prevent meta bump hummock version during version replay

### DIFF
--- a/dashboard/proto/gen/hummock.ts
+++ b/dashboard/proto/gen/hummock.ts
@@ -625,13 +625,6 @@ export interface RiseCtlGetPinnedSnapshotsSummaryResponse {
   summary: PinnedSnapshotsSummary | undefined;
 }
 
-export interface ResetCurrentVersionRequest {
-}
-
-export interface ResetCurrentVersionResponse {
-  oldVersion: HummockVersion | undefined;
-}
-
 export interface InitMetadataForReplayRequest {
   tables: Table[];
   compactionGroups: CompactionGroup[];
@@ -3584,51 +3577,6 @@ export const RiseCtlGetPinnedSnapshotsSummaryResponse = {
     const message = createBaseRiseCtlGetPinnedSnapshotsSummaryResponse();
     message.summary = (object.summary !== undefined && object.summary !== null)
       ? PinnedSnapshotsSummary.fromPartial(object.summary)
-      : undefined;
-    return message;
-  },
-};
-
-function createBaseResetCurrentVersionRequest(): ResetCurrentVersionRequest {
-  return {};
-}
-
-export const ResetCurrentVersionRequest = {
-  fromJSON(_: any): ResetCurrentVersionRequest {
-    return {};
-  },
-
-  toJSON(_: ResetCurrentVersionRequest): unknown {
-    const obj: any = {};
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<ResetCurrentVersionRequest>, I>>(_: I): ResetCurrentVersionRequest {
-    const message = createBaseResetCurrentVersionRequest();
-    return message;
-  },
-};
-
-function createBaseResetCurrentVersionResponse(): ResetCurrentVersionResponse {
-  return { oldVersion: undefined };
-}
-
-export const ResetCurrentVersionResponse = {
-  fromJSON(object: any): ResetCurrentVersionResponse {
-    return { oldVersion: isSet(object.oldVersion) ? HummockVersion.fromJSON(object.oldVersion) : undefined };
-  },
-
-  toJSON(message: ResetCurrentVersionResponse): unknown {
-    const obj: any = {};
-    message.oldVersion !== undefined &&
-      (obj.oldVersion = message.oldVersion ? HummockVersion.toJSON(message.oldVersion) : undefined);
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<ResetCurrentVersionResponse>, I>>(object: I): ResetCurrentVersionResponse {
-    const message = createBaseResetCurrentVersionResponse();
-    message.oldVersion = (object.oldVersion !== undefined && object.oldVersion !== null)
-      ? HummockVersion.fromPartial(object.oldVersion)
       : undefined;
     return message;
   },

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -449,12 +449,6 @@ message RiseCtlGetPinnedSnapshotsSummaryResponse {
   PinnedSnapshotsSummary summary = 1;
 }
 
-message ResetCurrentVersionRequest {}
-
-message ResetCurrentVersionResponse {
-  HummockVersion old_version = 1;
-}
-
 message InitMetadataForReplayRequest {
   repeated catalog.Table tables = 1;
   repeated CompactionGroup compaction_groups = 2;
@@ -522,7 +516,6 @@ message SetCompactorRuntimeConfigResponse {}
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);
   rpc GetCurrentVersion(GetCurrentVersionRequest) returns (GetCurrentVersionResponse);
-  rpc ResetCurrentVersion(ResetCurrentVersionRequest) returns (ResetCurrentVersionResponse);
   rpc ListVersionDeltas(ListVersionDeltasRequest) returns (ListVersionDeltasResponse);
   rpc ReplayVersionDelta(ReplayVersionDeltaRequest) returns (ReplayVersionDeltaResponse);
   rpc GetAssignedCompactTaskNum(GetAssignedCompactTaskNumRequest) returns (GetAssignedCompactTaskNumResponse);

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -100,7 +100,8 @@ pub struct MetaConfig {
     pub dangerous_max_idle_secs: Option<u64>,
 
     /// Whether to enable deterministic compaction scheduling, which
-    /// will disable all auto scheduling of compaction tasks
+    /// will disable all auto scheduling of compaction tasks.
+    /// Should only be used in e2e tests.
     #[serde(default)]
     pub enable_compaction_deterministic: bool,
 

--- a/src/config/ci-compaction-test-meta.toml
+++ b/src/config/ci-compaction-test-meta.toml
@@ -5,7 +5,9 @@ max_heartbeat_interval_secs = 600
 [streaming]
 barrier_interval_ms = 250
 in_flight_barrier_nums = 40
-checkpoint_frequency = 10
+# We set a large checkpoint frequency to prevent the embedded meta node
+# to commit new epochs to avoid bumping the hummock version during version log replay.
+checkpoint_frequency = 99999999
 
 [storage]
 shared_buffer_capacity_mb = 4096

--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -5,7 +5,9 @@ max_heartbeat_interval_secs = 600
 [streaming]
 barrier_interval_ms = 250
 in_flight_barrier_nums = 40
-checkpoint_frequency = 10
+# We set a large checkpoint frequency to prevent the embedded meta node
+# to commit new epochs to avoid bumping the hummock version
+checkpoint_frequency = 99999999
 
 [storage]
 shared_buffer_capacity_mb = 4096

--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -6,7 +6,8 @@ max_heartbeat_interval_secs = 600
 barrier_interval_ms = 250
 in_flight_barrier_nums = 40
 # We set a large checkpoint frequency to prevent the embedded meta node
-# to commit new epochs to avoid bumping the hummock version
+# to commit new epochs to avoid bumping the hummock version in other path
+# except the version replay.
 checkpoint_frequency = 99999999
 
 [storage]

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -868,27 +868,6 @@ async fn test_trigger_compaction_deterministic() {
         .expect("shutdown compaction scheduler error");
 }
 
-#[tokio::test]
-async fn test_reset_current_version() {
-    let (_env, hummock_manager, _, worker_node) = setup_compute_env(80).await;
-    let context_id = worker_node.id;
-
-    // Generate data for compaction task
-    let _ = add_test_tables(&hummock_manager, context_id).await;
-
-    let cur_version = hummock_manager.get_current_version().await;
-
-    let old_version = hummock_manager.reset_current_version().await.unwrap();
-    assert_eq!(cur_version.id, old_version.id);
-    assert_eq!(
-        cur_version.max_committed_epoch,
-        old_version.max_committed_epoch
-    );
-    let new_version = hummock_manager.get_current_version().await;
-    assert_eq!(new_version.id, FIRST_VERSION_ID);
-    assert_eq!(new_version.max_committed_epoch, INVALID_EPOCH);
-}
-
 // This is a non-deterministic test
 #[cfg(madsim)]
 #[tokio::test]

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -87,16 +87,6 @@ where
         }))
     }
 
-    async fn reset_current_version(
-        &self,
-        _request: Request<ResetCurrentVersionRequest>,
-    ) -> Result<Response<ResetCurrentVersionResponse>, Status> {
-        let old_version = self.hummock_manager.reset_current_version().await?;
-        Ok(Response::new(ResetCurrentVersionResponse {
-            old_version: Some(old_version),
-        }))
-    }
-
     async fn replay_version_delta(
         &self,
         request: Request<ReplayVersionDeltaRequest>,
@@ -499,7 +489,7 @@ where
         } = request.into_inner();
 
         self.hummock_manager
-            .init_metadata_for_replay(tables, compaction_groups)
+            .init_metadata_for_version_replay(tables, compaction_groups)
             .await?;
         Ok(Response::new(InitMetadataForReplayResponse {}))
     }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -525,16 +525,6 @@ impl MetaClient {
             .await
     }
 
-    pub async fn reset_current_version(&self) -> Result<HummockVersion> {
-        let req = ResetCurrentVersionRequest {};
-        Ok(self
-            .inner
-            .reset_current_version(req)
-            .await?
-            .old_version
-            .unwrap())
-    }
-
     pub async fn init_metadata_for_replay(
         &self,
         tables: Vec<ProstTable>,
@@ -960,7 +950,6 @@ macro_rules! for_all_meta_rpc {
             ,{ ddl_client, risectl_list_state_tables, RisectlListStateTablesRequest, RisectlListStateTablesResponse }
             ,{ hummock_client, unpin_version_before, UnpinVersionBeforeRequest, UnpinVersionBeforeResponse }
             ,{ hummock_client, get_current_version, GetCurrentVersionRequest, GetCurrentVersionResponse }
-            ,{ hummock_client, reset_current_version, ResetCurrentVersionRequest, ResetCurrentVersionResponse }
             ,{ hummock_client, replay_version_delta, ReplayVersionDeltaRequest, ReplayVersionDeltaResponse }
             ,{ hummock_client, list_version_deltas, ListVersionDeltasRequest, ListVersionDeltasResponse }
             ,{ hummock_client, get_assigned_compact_task_num, GetAssignedCompactTaskNumRequest, GetAssignedCompactTaskNumResponse }

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -139,7 +139,8 @@ pub async fn start_meta_node(listen_addr: String, config_path: String) {
     );
 
     // We set a large checkpoint frequency to prevent the embedded meta node
-    // to commit new epochs to avoid bumping the hummock version
+    // to commit new epochs to avoid bumping the hummock version in other path
+    // except the version replay.
     assert_eq!(
         CHECKPOINT_FREQ_FOR_REPLAY,
         config.streaming.checkpoint_frequency

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -332,7 +332,7 @@ async fn start_replay(
     let latest_version = meta_client.disable_commit_epoch().await?;
     assert_eq!(FIRST_VERSION_ID, latest_version.id);
     // The new meta should not have any data at this time
-    for (_, level) in latest_version.levels.iter() {
+    for level in latest_version.levels.values() {
         level.levels.iter().for_each(|lvl| {
             assert!(lvl.table_infos.is_empty());
             assert_eq!(0, lvl.total_file_size);

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -165,7 +165,7 @@ async fn compaction_test(
         },
     );
     hummock_manager_ref
-        .init_metadata_for_replay(
+        .init_metadata_for_version_replay(
             vec![delete_key_table, delete_range_table],
             vec![group1, group2],
         )

--- a/src/tests/compaction_test/src/lib.rs
+++ b/src/tests/compaction_test/src/lib.rs
@@ -24,13 +24,13 @@
 #![warn(clippy::await_holding_lock)]
 #![deny(rustdoc::broken_intra_doc_links)]
 
+mod compaction_test_runner;
 mod delete_range_runner;
-mod runner;
 
 use clap::Parser;
 pub use delete_range_runner::start_delete_range;
 
-use crate::runner::compaction_test_main;
+use crate::compaction_test_runner::compaction_test_main;
 
 /// Command-line arguments for compute-node.
 #[derive(Parser, Debug)]
@@ -73,6 +73,10 @@ pub struct CompactionTestOpts {
     /// [`risingwave_common::config`] instead of command line arguments.
     #[clap(long, default_value = "")]
     pub config_path: String,
+
+    /// The path to the configuration file used for version delta replay.
+    #[clap(long, default_value = "src/config/ci-compaction-test.toml")]
+    pub config_path_for_replay: String,
 }
 
 use std::future::Future;

--- a/src/tests/compaction_test/src/lib.rs
+++ b/src/tests/compaction_test/src/lib.rs
@@ -74,9 +74,9 @@ pub struct CompactionTestOpts {
     #[clap(long, default_value = "")]
     pub config_path: String,
 
-    /// The path to the configuration file used for version delta replay.
-    #[clap(long, default_value = "src/config/ci-compaction-test.toml")]
-    pub config_path_for_replay: String,
+    /// The path to the configuration file used for the embedded meta node.
+    #[clap(long, default_value = "src/config/ci-compaction-test-meta.toml")]
+    pub config_path_for_meta: String,
 }
 
 use std::future::Future;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
We sleep for 2 seconds in the `init_metadata_for_replay()`, the embedded meta node will commit an epoch during this period. So the version will be accidentally bumped.

- Prevent meta bump hummock version during version replay
- Remove unused interface from hummock manager

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fix #7251 
