### PR TITLE
feat(frontend): support pg_stat_activity and an workaround of pg_cancel_backend/pg_terminate_backend

### DIFF
--- a/dashboard/proto/gen/catalog.ts
+++ b/dashboard/proto/gen/catalog.ts
@@ -1,4 +1,5 @@
 /* eslint-disable */
+import { DataType } from "./data";
 import { ExprNode } from "./expr";
 import {
   ColumnCatalog,
@@ -95,6 +96,18 @@ export interface Index {
    */
   indexItem: ExprNode[];
   originalColumns: number[];
+}
+
+export interface Function {
+  id: number;
+  schemaId: number;
+  databaseId: number;
+  name: string;
+  argTypes: DataType[];
+  returnType: DataType | undefined;
+  language: string;
+  path: string;
+  owner: number;
 }
 
 /** See `TableCatalog` struct in frontend crate for more information. */
@@ -636,6 +649,71 @@ export const Index = {
     message.primaryTableId = object.primaryTableId ?? 0;
     message.indexItem = object.indexItem?.map((e) => ExprNode.fromPartial(e)) || [];
     message.originalColumns = object.originalColumns?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBaseFunction(): Function {
+  return {
+    id: 0,
+    schemaId: 0,
+    databaseId: 0,
+    name: "",
+    argTypes: [],
+    returnType: undefined,
+    language: "",
+    path: "",
+    owner: 0,
+  };
+}
+
+export const Function = {
+  fromJSON(object: any): Function {
+    return {
+      id: isSet(object.id) ? Number(object.id) : 0,
+      schemaId: isSet(object.schemaId) ? Number(object.schemaId) : 0,
+      databaseId: isSet(object.databaseId) ? Number(object.databaseId) : 0,
+      name: isSet(object.name) ? String(object.name) : "",
+      argTypes: Array.isArray(object?.argTypes) ? object.argTypes.map((e: any) => DataType.fromJSON(e)) : [],
+      returnType: isSet(object.returnType) ? DataType.fromJSON(object.returnType) : undefined,
+      language: isSet(object.language) ? String(object.language) : "",
+      path: isSet(object.path) ? String(object.path) : "",
+      owner: isSet(object.owner) ? Number(object.owner) : 0,
+    };
+  },
+
+  toJSON(message: Function): unknown {
+    const obj: any = {};
+    message.id !== undefined && (obj.id = Math.round(message.id));
+    message.schemaId !== undefined && (obj.schemaId = Math.round(message.schemaId));
+    message.databaseId !== undefined && (obj.databaseId = Math.round(message.databaseId));
+    message.name !== undefined && (obj.name = message.name);
+    if (message.argTypes) {
+      obj.argTypes = message.argTypes.map((e) => e ? DataType.toJSON(e) : undefined);
+    } else {
+      obj.argTypes = [];
+    }
+    message.returnType !== undefined &&
+      (obj.returnType = message.returnType ? DataType.toJSON(message.returnType) : undefined);
+    message.language !== undefined && (obj.language = message.language);
+    message.path !== undefined && (obj.path = message.path);
+    message.owner !== undefined && (obj.owner = Math.round(message.owner));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<Function>, I>>(object: I): Function {
+    const message = createBaseFunction();
+    message.id = object.id ?? 0;
+    message.schemaId = object.schemaId ?? 0;
+    message.databaseId = object.databaseId ?? 0;
+    message.name = object.name ?? "";
+    message.argTypes = object.argTypes?.map((e) => DataType.fromPartial(e)) || [];
+    message.returnType = (object.returnType !== undefined && object.returnType !== null)
+      ? DataType.fromPartial(object.returnType)
+      : undefined;
+    message.language = object.language ?? "";
+    message.path = object.path ?? "";
+    message.owner = object.owner ?? 0;
     return message;
   },
 };

--- a/dashboard/proto/gen/ddl_service.ts
+++ b/dashboard/proto/gen/ddl_service.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-import { Database, Index, Schema, Sink, Source, Table, View } from "./catalog";
+import { Database, Function, Index, Schema, Sink, Source, Table, View } from "./catalog";
 import { Status } from "./common";
 import { StreamFragmentGraph } from "./stream_plan";
 
@@ -134,6 +134,25 @@ export interface CreateTableRequest {
 export interface CreateTableResponse {
   status: Status | undefined;
   tableId: number;
+  version: number;
+}
+
+export interface CreateFunctionRequest {
+  function: Function | undefined;
+}
+
+export interface CreateFunctionResponse {
+  status: Status | undefined;
+  functionId: number;
+  version: number;
+}
+
+export interface DropFunctionRequest {
+  functionId: number;
+}
+
+export interface DropFunctionResponse {
+  status: Status | undefined;
   version: number;
 }
 
@@ -920,6 +939,113 @@ export const CreateTableResponse = {
       ? Status.fromPartial(object.status)
       : undefined;
     message.tableId = object.tableId ?? 0;
+    message.version = object.version ?? 0;
+    return message;
+  },
+};
+
+function createBaseCreateFunctionRequest(): CreateFunctionRequest {
+  return { function: undefined };
+}
+
+export const CreateFunctionRequest = {
+  fromJSON(object: any): CreateFunctionRequest {
+    return { function: isSet(object.function) ? Function.fromJSON(object.function) : undefined };
+  },
+
+  toJSON(message: CreateFunctionRequest): unknown {
+    const obj: any = {};
+    message.function !== undefined && (obj.function = message.function ? Function.toJSON(message.function) : undefined);
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CreateFunctionRequest>, I>>(object: I): CreateFunctionRequest {
+    const message = createBaseCreateFunctionRequest();
+    message.function = (object.function !== undefined && object.function !== null)
+      ? Function.fromPartial(object.function)
+      : undefined;
+    return message;
+  },
+};
+
+function createBaseCreateFunctionResponse(): CreateFunctionResponse {
+  return { status: undefined, functionId: 0, version: 0 };
+}
+
+export const CreateFunctionResponse = {
+  fromJSON(object: any): CreateFunctionResponse {
+    return {
+      status: isSet(object.status) ? Status.fromJSON(object.status) : undefined,
+      functionId: isSet(object.functionId) ? Number(object.functionId) : 0,
+      version: isSet(object.version) ? Number(object.version) : 0,
+    };
+  },
+
+  toJSON(message: CreateFunctionResponse): unknown {
+    const obj: any = {};
+    message.status !== undefined && (obj.status = message.status ? Status.toJSON(message.status) : undefined);
+    message.functionId !== undefined && (obj.functionId = Math.round(message.functionId));
+    message.version !== undefined && (obj.version = Math.round(message.version));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<CreateFunctionResponse>, I>>(object: I): CreateFunctionResponse {
+    const message = createBaseCreateFunctionResponse();
+    message.status = (object.status !== undefined && object.status !== null)
+      ? Status.fromPartial(object.status)
+      : undefined;
+    message.functionId = object.functionId ?? 0;
+    message.version = object.version ?? 0;
+    return message;
+  },
+};
+
+function createBaseDropFunctionRequest(): DropFunctionRequest {
+  return { functionId: 0 };
+}
+
+export const DropFunctionRequest = {
+  fromJSON(object: any): DropFunctionRequest {
+    return { functionId: isSet(object.functionId) ? Number(object.functionId) : 0 };
+  },
+
+  toJSON(message: DropFunctionRequest): unknown {
+    const obj: any = {};
+    message.functionId !== undefined && (obj.functionId = Math.round(message.functionId));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DropFunctionRequest>, I>>(object: I): DropFunctionRequest {
+    const message = createBaseDropFunctionRequest();
+    message.functionId = object.functionId ?? 0;
+    return message;
+  },
+};
+
+function createBaseDropFunctionResponse(): DropFunctionResponse {
+  return { status: undefined, version: 0 };
+}
+
+export const DropFunctionResponse = {
+  fromJSON(object: any): DropFunctionResponse {
+    return {
+      status: isSet(object.status) ? Status.fromJSON(object.status) : undefined,
+      version: isSet(object.version) ? Number(object.version) : 0,
+    };
+  },
+
+  toJSON(message: DropFunctionResponse): unknown {
+    const obj: any = {};
+    message.status !== undefined && (obj.status = message.status ? Status.toJSON(message.status) : undefined);
+    message.version !== undefined && (obj.version = Math.round(message.version));
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<DropFunctionResponse>, I>>(object: I): DropFunctionResponse {
+    const message = createBaseDropFunctionResponse();
+    message.status = (object.status !== undefined && object.status !== null)
+      ? Status.fromPartial(object.status)
+      : undefined;
     message.version = object.version ?? 0;
     return message;
   },

--- a/dashboard/proto/gen/meta.ts
+++ b/dashboard/proto/gen/meta.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { MetaBackupManifestId } from "./backup_service";
-import { Database, Index, Schema, Sink, Source, Table, View } from "./catalog";
+import { Database, Function, Index, Schema, Sink, Source, Table, View } from "./catalog";
 import {
   HostAddress,
   ParallelUnit,
@@ -374,6 +374,7 @@ export interface MetaSnapshot {
   tables: Table[];
   indexes: Index[];
   views: View[];
+  functions: Function[];
   users: UserInfo[];
   parallelUnitMappings: ParallelUnitMapping[];
   nodes: WorkerNode[];
@@ -401,6 +402,7 @@ export interface SubscribeResponse {
     | { $case: "sink"; sink: Sink }
     | { $case: "index"; index: Index }
     | { $case: "view"; view: View }
+    | { $case: "function"; function: Function }
     | { $case: "user"; user: UserInfo }
     | { $case: "parallelUnitMapping"; parallelUnitMapping: ParallelUnitMapping }
     | { $case: "node"; node: WorkerNode }
@@ -1459,6 +1461,7 @@ function createBaseMetaSnapshot(): MetaSnapshot {
     tables: [],
     indexes: [],
     views: [],
+    functions: [],
     users: [],
     parallelUnitMappings: [],
     nodes: [],
@@ -1479,6 +1482,7 @@ export const MetaSnapshot = {
       tables: Array.isArray(object?.tables) ? object.tables.map((e: any) => Table.fromJSON(e)) : [],
       indexes: Array.isArray(object?.indexes) ? object.indexes.map((e: any) => Index.fromJSON(e)) : [],
       views: Array.isArray(object?.views) ? object.views.map((e: any) => View.fromJSON(e)) : [],
+      functions: Array.isArray(object?.functions) ? object.functions.map((e: any) => Function.fromJSON(e)) : [],
       users: Array.isArray(object?.users) ? object.users.map((e: any) => UserInfo.fromJSON(e)) : [],
       parallelUnitMappings: Array.isArray(object?.parallelUnitMappings)
         ? object.parallelUnitMappings.map((e: any) => ParallelUnitMapping.fromJSON(e))
@@ -1532,6 +1536,11 @@ export const MetaSnapshot = {
     } else {
       obj.views = [];
     }
+    if (message.functions) {
+      obj.functions = message.functions.map((e) => e ? Function.toJSON(e) : undefined);
+    } else {
+      obj.functions = [];
+    }
     if (message.users) {
       obj.users = message.users.map((e) => e ? UserInfo.toJSON(e) : undefined);
     } else {
@@ -1568,6 +1577,7 @@ export const MetaSnapshot = {
     message.tables = object.tables?.map((e) => Table.fromPartial(e)) || [];
     message.indexes = object.indexes?.map((e) => Index.fromPartial(e)) || [];
     message.views = object.views?.map((e) => View.fromPartial(e)) || [];
+    message.functions = object.functions?.map((e) => Function.fromPartial(e)) || [];
     message.users = object.users?.map((e) => UserInfo.fromPartial(e)) || [];
     message.parallelUnitMappings = object.parallelUnitMappings?.map((e) => ParallelUnitMapping.fromPartial(e)) || [];
     message.nodes = object.nodes?.map((e) => WorkerNode.fromPartial(e)) || [];
@@ -1646,6 +1656,8 @@ export const SubscribeResponse = {
         ? { $case: "index", index: Index.fromJSON(object.index) }
         : isSet(object.view)
         ? { $case: "view", view: View.fromJSON(object.view) }
+        : isSet(object.function)
+        ? { $case: "function", function: Function.fromJSON(object.function) }
         : isSet(object.user)
         ? { $case: "user", user: UserInfo.fromJSON(object.user) }
         : isSet(object.parallelUnitMapping)
@@ -1690,6 +1702,8 @@ export const SubscribeResponse = {
     message.info?.$case === "index" &&
       (obj.index = message.info?.index ? Index.toJSON(message.info?.index) : undefined);
     message.info?.$case === "view" && (obj.view = message.info?.view ? View.toJSON(message.info?.view) : undefined);
+    message.info?.$case === "function" &&
+      (obj.function = message.info?.function ? Function.toJSON(message.info?.function) : undefined);
     message.info?.$case === "user" && (obj.user = message.info?.user ? UserInfo.toJSON(message.info?.user) : undefined);
     message.info?.$case === "parallelUnitMapping" && (obj.parallelUnitMapping = message.info?.parallelUnitMapping
       ? ParallelUnitMapping.toJSON(message.info?.parallelUnitMapping)
@@ -1737,6 +1751,9 @@ export const SubscribeResponse = {
     }
     if (object.info?.$case === "view" && object.info?.view !== undefined && object.info?.view !== null) {
       message.info = { $case: "view", view: View.fromPartial(object.info.view) };
+    }
+    if (object.info?.$case === "function" && object.info?.function !== undefined && object.info?.function !== null) {
+      message.info = { $case: "function", function: Function.fromPartial(object.info.function) };
     }
     if (object.info?.$case === "user" && object.info?.user !== undefined && object.info?.user !== null) {
       message.info = { $case: "user", user: UserInfo.fromPartial(object.info.user) };

--- a/dashboard/proto/gen/user.ts
+++ b/dashboard/proto/gen/user.ts
@@ -80,6 +80,7 @@ export interface GrantPrivilege {
     | { $case: "sourceId"; sourceId: number }
     | { $case: "sinkId"; sinkId: number }
     | { $case: "viewId"; viewId: number }
+    | { $case: "functionId"; functionId: number }
     | { $case: "allTablesSchemaId"; allTablesSchemaId: number }
     | { $case: "allSourcesSchemaId"; allSourcesSchemaId: number };
   actionWithOpts: GrantPrivilege_ActionWithGrantOption[];
@@ -390,6 +391,8 @@ export const GrantPrivilege = {
         ? { $case: "sinkId", sinkId: Number(object.sinkId) }
         : isSet(object.viewId)
         ? { $case: "viewId", viewId: Number(object.viewId) }
+        : isSet(object.functionId)
+        ? { $case: "functionId", functionId: Number(object.functionId) }
         : isSet(object.allTablesSchemaId)
         ? { $case: "allTablesSchemaId", allTablesSchemaId: Number(object.allTablesSchemaId) }
         : isSet(object.allSourcesSchemaId)
@@ -409,6 +412,7 @@ export const GrantPrivilege = {
     message.object?.$case === "sourceId" && (obj.sourceId = Math.round(message.object?.sourceId));
     message.object?.$case === "sinkId" && (obj.sinkId = Math.round(message.object?.sinkId));
     message.object?.$case === "viewId" && (obj.viewId = Math.round(message.object?.viewId));
+    message.object?.$case === "functionId" && (obj.functionId = Math.round(message.object?.functionId));
     message.object?.$case === "allTablesSchemaId" &&
       (obj.allTablesSchemaId = Math.round(message.object?.allTablesSchemaId));
     message.object?.$case === "allSourcesSchemaId" &&
@@ -450,6 +454,13 @@ export const GrantPrivilege = {
     }
     if (object.object?.$case === "viewId" && object.object?.viewId !== undefined && object.object?.viewId !== null) {
       message.object = { $case: "viewId", viewId: object.object.viewId };
+    }
+    if (
+      object.object?.$case === "functionId" &&
+      object.object?.functionId !== undefined &&
+      object.object?.functionId !== null
+    ) {
+      message.object = { $case: "functionId", functionId: object.object.functionId };
     }
     if (
       object.object?.$case === "allTablesSchemaId" &&

--- a/e2e_test/batch/catalog/pg_stat_activity.slt.part
+++ b/e2e_test/batch/catalog/pg_stat_activity.slt.part
@@ -1,0 +1,11 @@
+query I
+SELECT pg_cancel_backend(pid)
+FROM pg_stat_activity
+WHERE pid=1024;
+----
+
+query I
+SELECT pg_terminate_backend(pid)
+FROM pg_stat_activity
+WHERE pid=1024;
+----

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -303,6 +303,10 @@ impl Binder {
             "pg_table_is_visible" => return Ok(ExprImpl::literal_bool(true)),
             "pg_encoding_to_char" => return Ok(ExprImpl::literal_varchar("UTF8".into())),
             "has_database_privilege" => return Ok(ExprImpl::literal_bool(true)),
+            "pg_backend_pid" if inputs.is_empty() => {
+                // FIXME: the session id is not global unique in multi-frontend env.
+                return Ok(ExprImpl::literal_int(self.session_id.0));
+            }
             "pg_cancel_backend" => {
                 return if inputs.len() == 1 {
                     // TODO: implement real cancel rather than just return false as an workaround.

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -303,6 +303,29 @@ impl Binder {
             "pg_table_is_visible" => return Ok(ExprImpl::literal_bool(true)),
             "pg_encoding_to_char" => return Ok(ExprImpl::literal_varchar("UTF8".into())),
             "has_database_privilege" => return Ok(ExprImpl::literal_bool(true)),
+            "pg_cancel_backend" => {
+                return if inputs.len() == 1 {
+                    // TODO: implement real cancel rather than just return false as an workaround.
+                    Ok(ExprImpl::literal_bool(false))
+                } else {
+                    Err(ErrorCode::ExprError(
+                        "Too many/few arguments for pg_cancel_backend()".into(),
+                    )
+                    .into())
+                };
+            }
+            "pg_terminate_backend" => {
+                return if inputs.len() == 1 {
+                    // TODO: implement real terminate rather than just return false as an
+                    // workaround.
+                    Ok(ExprImpl::literal_bool(false))
+                } else {
+                    Err(ErrorCode::ExprError(
+                        "Too many/few arguments for pg_terminate_backend()".into(),
+                    )
+                    .into())
+                };
+            }
             // internal
             "rw_vnode" => ExprType::Vnode,
             // TODO: include version/tag/commit_id

--- a/src/frontend/src/binder/mod.rs
+++ b/src/frontend/src/binder/mod.rs
@@ -35,6 +35,7 @@ pub use bind_context::{BindContext, LateralBindContext};
 pub use delete::BoundDelete;
 pub use expr::{bind_data_type, bind_struct_field};
 pub use insert::BoundInsert;
+use pgwire::pg_server::{Session, SessionId};
 pub use query::BoundQuery;
 pub use relation::{
     BoundBaseTable, BoundJoin, BoundSource, BoundSystemTable, BoundWatermark,
@@ -57,6 +58,7 @@ pub struct Binder {
     // TODO: maybe we can only lock the database, but not the whole catalog.
     catalog: CatalogReadGuard,
     db_name: String,
+    session_id: SessionId,
     context: BindContext,
     auth_context: Arc<AuthContext>,
     bind_timestamp_ms: u64,
@@ -92,6 +94,7 @@ impl Binder {
         Binder {
             catalog: session.env().catalog_reader().read_guard(),
             db_name: session.database().to_string(),
+            session_id: session.id(),
             context: BindContext::new(),
             auth_context: session.auth_context(),
             bind_timestamp_ms: now_ms,

--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -201,6 +201,7 @@ prepare_sys_catalog! {
     { PG_CATALOG, PG_ROLES, vec![0], read_roles_info },
     { PG_CATALOG, PG_SHDESCRIPTION, vec![0], read_shdescription_info },
     { PG_CATALOG, PG_TABLESPACE, vec![0], read_tablespace_info },
+    { PG_CATALOG, PG_STAT_ACTIVITY, vec![0], read_stat_activity },
     { INFORMATION_SCHEMA, COLUMNS, vec![], read_columns_info },
     { INFORMATION_SCHEMA, TABLES, vec![], read_tables_info },
     { RW_CATALOG, RW_META_SNAPSHOT, vec![], read_meta_snapshot await },

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -29,6 +29,7 @@ pub mod pg_operator;
 pub mod pg_roles;
 pub mod pg_settings;
 pub mod pg_shdescription;
+pub mod pg_stat_activity;
 pub mod pg_tablespace;
 pub mod pg_type;
 pub mod pg_user;
@@ -54,6 +55,7 @@ pub use pg_operator::*;
 pub use pg_roles::*;
 pub use pg_settings::*;
 pub use pg_shdescription::*;
+pub use pg_stat_activity::*;
 pub use pg_tablespace::*;
 pub use pg_type::*;
 pub use pg_user::*;
@@ -586,5 +588,9 @@ impl SysCatalogReaderImpl {
 
     pub(super) fn read_tablespace_info(&self) -> Result<Vec<OwnedRow>> {
         Ok(PG_TABLESPACE_DATA_ROWS.clone())
+    }
+
+    pub(super) fn read_stat_activity(&self) -> Result<Vec<OwnedRow>> {
+        Ok(vec![])
     }
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_stat_activity.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_stat_activity.rs
@@ -1,0 +1,40 @@
+// Copyright 2023 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::DataType;
+
+use crate::catalog::system_catalog::SystemCatalogColumnsDef;
+
+/// The pg_stat_activity view will have one row per server process, showing information related to
+/// the current activity of that process. Ref: [`https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW`]
+pub const PG_STAT_ACTIVITY_TABLE_NAME: &str = "pg_stat_activity";
+pub const PG_STAT_ACTIVITY_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
+    (DataType::Int32, "pid"),       // Process ID of this backend.
+    (DataType::Int32, "datid"),     // OID of the database this backend is connected to.
+    (DataType::Varchar, "datname"), // Name of the database this backend is connected to.
+    (DataType::Int32, "leader_pid"), /* Process ID of the parallel group leader, if this process
+                                     * is a parallel query worker. NULL if this process is a
+                                     * parallel group leader or does not participate in
+                                     * parallel query. */
+    (DataType::Int32, "usesysid"), // OID of the user logged into this backend.
+    (DataType::Varchar, "usename"), // Name of the user logged into this backend.
+    (DataType::Varchar, "application_name"), /* Name of the application that is connected to
+                                    * this backend. */
+    (DataType::Varchar, "client_addr"), // IP address of the client connected to this backend.
+    (DataType::Varchar, "client_hostname"), /* Host name of the connected client, as reported by a
+                                         * reverse DNS lookup of client_addr. */
+    (DataType::Int16, "client_port"), /* TCP port number that the client is using for
+                                       * communication with this backend, or -1 if a Unix socket
+                                       * is used. */
+];

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_stat_activity.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_stat_activity.rs
@@ -16,7 +16,7 @@ use risingwave_common::types::DataType;
 
 use crate::catalog::system_catalog::SystemCatalogColumnsDef;
 
-/// The pg_stat_activity view will have one row per server process, showing information related to
+/// The `pg_stat_activity` view will have one row per server process, showing information related to
 /// the current activity of that process. Ref: [`https://www.postgresql.org/docs/current/monitoring-stats.html#MONITORING-PG-STAT-ACTIVITY-VIEW`]
 pub const PG_STAT_ACTIVITY_TABLE_NAME: &str = "pg_stat_activity";
 pub const PG_STAT_ACTIVITY_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

To support superset, implement system table `pg_stat_activity` and a workaround of `pg_cancel_backend`/`pg_terminate_backend`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators

Introduced a system catalog `pg_stat_activity`.
Introduced some functions: 
- pg_cancel_backend: Cancel a backend's current query. You can execute this against another backend that has exactly the same role as the user calling the function. In all other cases, you must be a superuser.
- pg_terminate_backend: Terminate a backend. You can execute this against another backend that has exactly the same role as the user calling the function. In all other cases, you must be a superuser.
- pg_backend_pid: Process ID of the server process attached to the current session.

### Release note

Support system catalog `pg_stat_activity`, and some functions like: `pg_cancel_backend`, `pg_terminate_backend` and `pg_backend_pid`.

## Refer to a related PR or issue link (optional)
A workaround of #6891 