### PR TITLE
fix(frontend): add more details to cdc source error message

### DIFF
--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -166,7 +166,7 @@ pub(crate) async fn resolve_source_schema(
             // return err if user has not specified a pk
             if row_id_index.is_some() {
                 return Err(RwError::from(ProtocolError(
-                    "Primary key must be specified when creating source with row format debezium."
+                    "Primary key must be specified when creating source with row format maxwell."
                         .to_string(),
                 )));
             }

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -273,6 +273,9 @@ impl ParseTo for CreateSourceStatement {
             .find(|&opt| opt.name.real_value() == "connector");
         // row format for cdc source must be debezium json
         let source_schema = if let Some(opt) = option && opt.value.to_string().contains("-cdc") {
+            if p.peek_nth_any_of_keywords(0, &[Keyword::ROW]) && p.peek_nth_any_of_keywords(1, &[Keyword::FORMAT]) {
+                return Err(ParserError::ParserError("Row format for cdc connectors should not be set here because it is limited to debezium json".to_string()));
+            }
             SourceSchema::DebeziumJson
         } else {
             impl_parse_to!([Keyword::ROW, Keyword::FORMAT], p);

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -273,7 +273,9 @@ impl ParseTo for CreateSourceStatement {
             .find(|&opt| opt.name.real_value() == "connector");
         // row format for cdc source must be debezium json
         let source_schema = if let Some(opt) = option && opt.value.to_string().contains("-cdc") {
-            if p.peek_nth_any_of_keywords(0, &[Keyword::ROW]) && p.peek_nth_any_of_keywords(1, &[Keyword::FORMAT]) {
+            if p.peek_nth_any_of_keywords(0, &[Keyword::ROW])
+                && p.peek_nth_any_of_keywords(1, &[Keyword::FORMAT])
+            {
                 return Err(ParserError::ParserError("Row format for cdc connectors should not be set here because it is limited to debezium json".to_string()));
             }
             SourceSchema::DebeziumJson

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -23,7 +23,7 @@ use crate::ast::{
     display_comma_separated, display_separated, ColumnDef, ObjectName, SqlOption, TableConstraint,
 };
 use crate::keywords::Keyword;
-use crate::parser::{IsOptional, Parser, ParserError};
+use crate::parser::{IsOptional, Parser, ParserError, UPSTREAM_SOURCE_KEY};
 use crate::tokenizer::Token;
 
 /// Consumes token from the parser into an AST node.
@@ -270,7 +270,7 @@ impl ParseTo for CreateSourceStatement {
         let option = with_properties
             .0
             .iter()
-            .find(|&opt| opt.name.real_value() == "connector");
+            .find(|&opt| opt.name.real_value() == UPSTREAM_SOURCE_KEY);
         // row format for cdc source must be debezium json
         let source_schema = if let Some(opt) = option && opt.value.to_string().contains("-cdc") {
             if p.peek_nth_any_of_keywords(0, &[Keyword::ROW])

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -28,6 +28,8 @@ use crate::ast::{ParseTo, *};
 use crate::keywords::{self, Keyword};
 use crate::tokenizer::*;
 
+pub(crate) const UPSTREAM_SOURCE_KEY: &str = "connector";
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ParserError {
     TokenizerError(String),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Before:

```SQL
dev=> create source products (
 ...
) with (
 connector = 'mysql-cdc',
 ...
) row format debezium json;
ERROR:  QueryError: sql parser error: Expected end of statement, found: row
```

After:

```SQL
dev=> create source products (
 ...
) with (
 connector = 'mysql-cdc',
 ...
) row format debezium json;
ERROR:  QueryError: sql parser error: Row format for cdc connectors should not be set here because it is limited to debezium json
```

Also fixed a typo in maxwell error message.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* SQL commands, functions, and operators
