### PR TITLE
refactor(storage):  batch read be aware of value_indices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6214,6 +6214,7 @@ dependencies = [
  "lz4",
  "madsim-tokio",
  "madsim-tonic",
+ "memcomparable",
  "minitrace",
  "minstant",
  "moka",

--- a/src/common/src/util/ordered/serde.rs
+++ b/src/common/src/util/ordered/serde.rs
@@ -17,7 +17,6 @@ use std::borrow::Cow;
 use bytes::BufMut;
 use itertools::Itertools;
 
-use crate::error::Result;
 use crate::row::{OwnedRow, Row};
 use crate::types::{
     memcmp_deserialize_datum_from, memcmp_serialize_datum_into, DataType, ToDatumRef,
@@ -72,7 +71,7 @@ impl OrderedRowSerde {
         }
     }
 
-    pub fn deserialize(&self, data: &[u8]) -> Result<OwnedRow> {
+    pub fn deserialize(&self, data: &[u8]) -> memcomparable::Result<OwnedRow> {
         let mut values = Vec::with_capacity(self.schema.len());
         let mut deserializer = memcomparable::Deserializer::new(data);
         for (data_type, order_type) in self.schema.iter().zip_eq(self.order_types.iter()) {

--- a/src/ctl/src/cmd_impl/table/scan.rs
+++ b/src/ctl/src/cmd_impl/table/scan.rs
@@ -88,7 +88,7 @@ pub fn make_storage_table<S: StateStore>(hummock: S, table: &TableCatalog) -> St
         table.pk().iter().map(|x| x.index).collect(),
         Distribution::all_vnodes(table.distribution_key().to_vec()),
         TableOption::build_table_option(&HashMap::new()),
-        (0..table.columns().len()).collect(),
+        table.value_indices.clone(),
         table.read_prefix_len_hint,
     )
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -34,6 +34,7 @@ hyper = "0.14"
 itertools = "0.10"
 libc = "0.2"
 lz4 = "1.23.1"
+memcomparable = "0.1"
 minitrace = "0.4"
 minstant = "0.1"
 nix = { version = "0.25", features = ["fs", "mman"] }

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -32,6 +32,9 @@ pub enum StorageError {
     #[error("Deserialize row error {0}.")]
     DeserializeRow(ValueEncodingError),
 
+    #[error("Deserialize pk error {0}.")]
+    DeserializeOrderedRow(RwError),
+
     #[error("Sled error: {0}")]
     Sled(
         #[backtrace]
@@ -51,6 +54,12 @@ impl From<ValueEncodingError> for StorageError {
 impl From<StorageError> for RwError {
     fn from(s: StorageError) -> Self {
         ErrorCode::StorageError(Box::new(s)).into()
+    }
+}
+
+impl From<RwError> for StorageError {
+    fn from(s: RwError) -> Self {
+        StorageError::DeserializeOrderedRow(s)
     }
 }
 

--- a/src/storage/src/error.rs
+++ b/src/storage/src/error.rs
@@ -32,8 +32,8 @@ pub enum StorageError {
     #[error("Deserialize row error {0}.")]
     DeserializeRow(ValueEncodingError),
 
-    #[error("Deserialize pk error {0}.")]
-    DeserializeOrderedRow(RwError),
+    #[error("Serialize/deserialize error: {0}")]
+    SerdeError(memcomparable::Error),
 
     #[error("Sled error: {0}")]
     Sled(
@@ -51,15 +51,15 @@ impl From<ValueEncodingError> for StorageError {
     }
 }
 
-impl From<StorageError> for RwError {
-    fn from(s: StorageError) -> Self {
-        ErrorCode::StorageError(Box::new(s)).into()
+impl From<memcomparable::Error> for StorageError {
+    fn from(m: memcomparable::Error) -> Self {
+        StorageError::SerdeError(m)
     }
 }
 
-impl From<RwError> for StorageError {
-    fn from(s: RwError) -> Self {
-        StorageError::DeserializeOrderedRow(s)
+impl From<StorageError> for RwError {
+    fn from(s: StorageError) -> Self {
+        ErrorCode::StorageError(Box::new(s)).into()
     }
 }
 

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -475,8 +475,7 @@ impl<S: StateStore> StorageTable<S> {
             };
             let prefix_len = self
                 .pk_serializer
-                .deserialize_prefix_len(encoded_prefix, self.read_prefix_len_hint)
-                .unwrap();
+                .deserialize_prefix_len(encoded_prefix, self.read_prefix_len_hint)?;
             Some(encoded_prefix[..prefix_len].to_vec())
         } else {
             trace!(
@@ -579,7 +578,6 @@ impl<S: StateStore> StorageTableIterInner<S> {
             row_deserializer,
             pk_serializer,
             output_indices_in_key,
-
         };
         Ok(iter)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
As title, when `output_indices` is not the subset of `value_indices`, storage table need to deserialize result from both key and value. For example, `output_indices = [0, 1, 2]` and `value_indices = [2]`.
## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
close https://github.com/risingwavelabs/risingwave/issues/7303  https://github.com/risingwavelabs/risingwave/issues/7313