### PR TITLE
fix(frontend): fix source check on protobuf and avro based on `_rw_kafka_timestamp` column

### DIFF
--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -225,6 +225,23 @@ create materialized source s16 (v1 int, v2 varchar) with (
 ) row format json
 
 statement ok
+create source s17 with (
+  connector = 'kafka', 
+  topic = 'proto_c_bin',
+  properties.bootstrap.server = '127.0.0.1:29092',
+  scan.startup.mode = 'earliest',
+  proto.message = 'test.User'
+) row format protobuf message 'test.User' row schema location 'file:///risingwave/proto-complex-schema'
+
+statement ok
+create source s18 with (
+  connector = 'kafka', 
+  topic = 'avro_c_bin',
+  properties.bootstrap.server = '127.0.0.1:29092',
+  scan.startup.mode = 'earliest'
+) row format avro message 'user' row schema location 'file:///risingwave/avro-complex-schema.avsc'
+
+statement ok
 flush;
 
 # Wait enough time to ensure SourceExecutor consumes all Kafka data.
@@ -425,3 +442,9 @@ drop source s15
 
 statement ok
 drop source s16
+
+statement ok
+drop source s17
+
+statement ok
+drop source s18

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -292,7 +292,7 @@ pub async fn handle_create_source(
         &with_properties,
         row_id_index,
         &pk_column_ids,
-        false,
+        is_materialized,
     )
     .await?;
 

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -32,7 +32,7 @@ use super::create_table::{bind_sql_table_constraints, gen_materialize_plan};
 use super::RwPgResponse;
 use crate::binder::Binder;
 use crate::catalog::column_catalog::ColumnCatalog;
-use crate::catalog::ColumnId;
+use crate::catalog::{ColumnId, ROW_ID_COLUMN_ID};
 use crate::handler::create_table::{bind_sql_columns, ColumnIdGenerator};
 use crate::handler::HandlerArgs;
 use crate::optimizer::plan_node::KAFKA_TIMESTAMP_COLUMN_NAME;
@@ -85,6 +85,7 @@ async fn extract_protobuf_table_schema(
         .collect_vec())
 }
 
+#[inline(always)]
 pub(crate) fn is_kafka_source(with_properties: &HashMap<String, String>) -> bool {
     with_properties
         .get(UPSTREAM_SOURCE_KEY)
@@ -99,8 +100,10 @@ pub(crate) async fn resolve_source_schema(
     with_properties: &HashMap<String, String>,
     row_id_index: Option<usize>,
     pk_column_ids: &[ColumnId],
+    is_materialized: bool,
 ) -> Result<StreamSourceInfo> {
-    if !is_kafka_source(with_properties)
+    let is_kafka = is_kafka_source(with_properties);
+    if !is_kafka
         && matches!(
             &source_schema,
             SourceSchema::Protobuf(ProtobufSchema {
@@ -120,7 +123,16 @@ pub(crate) async fn resolve_source_schema(
 
     let source_info = match &source_schema {
         SourceSchema::Protobuf(protobuf_schema) => {
-            if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
+            let (expected_column_len, expected_row_id_index) = if is_kafka && !is_materialized {
+                // The first column is `_rw_kafka_timestamp`.
+                (2, 1)
+            } else {
+                (1, 0)
+            };
+            if columns.len() != expected_column_len
+                || pk_column_ids != vec![ROW_ID_COLUMN_ID]
+                || row_id_index != Some(expected_row_id_index)
+            {
                 return Err(RwError::from(ProtocolError(
                     "User-defined schema is not allowed with row format protobuf. Please refer to https://www.risingwave.dev/docs/current/sql-create-source/#protobuf for more information.".to_string(),
                 )));
@@ -140,7 +152,16 @@ pub(crate) async fn resolve_source_schema(
         }
 
         SourceSchema::Avro(avro_schema) => {
-            if columns.len() != 1 || pk_column_ids != vec![0.into()] || row_id_index != Some(0) {
+            let (expected_column_len, expected_row_id_index) = if is_kafka && !is_materialized {
+                // The first column is `_rw_kafka_timestamp`.
+                (2, 1)
+            } else {
+                (1, 0)
+            };
+            if columns.len() != expected_column_len
+                || pk_column_ids != vec![ROW_ID_COLUMN_ID]
+                || row_id_index != Some(expected_row_id_index)
+            {
                 return Err(RwError::from(ProtocolError(
                     "User-defined schema is not allowed with row format avro. Please refer to https://www.risingwave.dev/docs/current/sql-create-source/#avro for more information.".to_string(),
                 )));
@@ -271,6 +292,7 @@ pub async fn handle_create_source(
         &with_properties,
         row_id_index,
         &pk_column_ids,
+        false,
     )
     .await?;
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -310,6 +310,7 @@ pub(crate) async fn gen_create_table_plan_with_source(
         properties,
         row_id_index,
         &pk_column_ids,
+        true,
     )
     .await?;
 


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Fix the bug that users cannot create non-materialized kafka source with row format of protobuf and avro.

Before:
```SQL
create source s with (
  connector = 'kafka', 
  ...
) row format protobuf message xxxxx row schema location file://yyyyy;

ERROR:  QueryError: Protocol error: User-defined schema is not allowed with row format protobuf. Please refer to https://www.risingwave.dev/docs/current/sql-create-source/#protobuf for more information.
```

After:
```SQL
create source s with (
  connector = 'kafka', 
  ...
) row format protobuf message xxxxx row schema location file://yyyyy;

CREATE_SOURCE
```

Also add corresponding e2e tests.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Connector (sources & sinks)
