### PR TITLE
feat: dedup group and order key for group top n

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -335,36 +335,38 @@
     select distinct on (v1, v3) v1, v2 from t order by v3, v1;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
-    └─LogicalTopN { order: "[t.v3 ASC, t.v1 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+    └─LogicalTopN { order: "[]", limit: 1, offset: 0, group_key: [0, 2] }
       └─LogicalProject { exprs: [t.v1, t.v2, t.v3] }
         └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
     BatchProject { exprs: [t.v1, t.v2] }
     └─BatchExchange { order: [t.v3 ASC, t.v1 ASC], dist: Single }
-      └─BatchGroupTopN { order: "[t.v3 ASC, t.v1 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
-          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+      └─BatchSort { order: [t.v3 ASC, t.v1 ASC] }
+        └─BatchGroupTopN { order: "[]", limit: 1, offset: 0, group_key: [0, 2] }
+          └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int, v3 int);
     select distinct on (v1, v3) v1, v2 from t order by v1, v3;
   logical_plan: |
     LogicalProject { exprs: [t.v1, t.v2] }
-    └─LogicalTopN { order: "[t.v1 ASC, t.v3 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
+    └─LogicalTopN { order: "[]", limit: 1, offset: 0, group_key: [0, 2] }
       └─LogicalProject { exprs: [t.v1, t.v2, t.v3] }
         └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
     BatchProject { exprs: [t.v1, t.v2] }
     └─BatchExchange { order: [t.v1 ASC, t.v3 ASC], dist: Single }
-      └─BatchGroupTopN { order: "[t.v1 ASC, t.v3 ASC]", limit: 1, offset: 0, group_key: [0, 2] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
-          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+      └─BatchSort { order: [t.v1 ASC, t.v3 ASC] }
+        └─BatchGroupTopN { order: "[]", limit: 1, offset: 0, group_key: [0, 2] }
+          └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3) }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: distinct on
   sql: |
     create table t (v1 int, v2 int);
     select distinct on (v1) v1, v2 from t order by v1;
   logical_plan: |
-    LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [0] }
+    LogicalTopN { order: "[]", limit: 1, offset: 0, group_key: [0] }
     └─LogicalProject { exprs: [t.v1, t.v2] }
       └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - name: distinct on
@@ -373,16 +375,17 @@
     select distinct on(v1) v2 + v3 from t order by v1;
   logical_plan: |
     LogicalProject { exprs: [(t.v2 + t.v3)] }
-    └─LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [1] }
+    └─LogicalTopN { order: "[]", limit: 1, offset: 0, group_key: [1] }
       └─LogicalProject { exprs: [(t.v2 + t.v3), t.v1] }
         └─LogicalScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id] }
   batch_plan: |
     BatchProject { exprs: [(t.v2 + t.v3)] }
     └─BatchExchange { order: [t.v1 ASC], dist: Single }
-      └─BatchGroupTopN { order: "[t.v1 ASC]", limit: 1, offset: 0, group_key: [1] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1) }
-          └─BatchProject { exprs: [(t.v2 + t.v3), t.v1] }
-            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+      └─BatchSort { order: [t.v1 ASC] }
+        └─BatchGroupTopN { order: "[]", limit: 1, offset: 0, group_key: [1] }
+          └─BatchExchange { order: [], dist: HashShard(t.v1) }
+            └─BatchProject { exprs: [(t.v2 + t.v3), t.v1] }
+              └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
 - name: arguments out-of-order
   sql: |
     create table t(v1 int, v2 int, v3 int);

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
@@ -74,7 +75,19 @@ impl LogicalTopN {
         group_key: Vec<usize>,
     ) -> Self {
         let mut topn = Self::new(input, limit, offset, with_ties, order);
-        topn.core.group_key = group_key;
+        // deduplicate group key and order
+        let mut indices = HashSet::new();
+        topn.core.group_key = group_key
+            .into_iter()
+            .filter(|k| indices.insert(*k))
+            .collect();
+        topn.core.order.field_order = topn
+            .core
+            .order
+            .field_order
+            .into_iter()
+            .filter(|f| indices.insert(f.index))
+            .collect();
         topn
     }
 

--- a/src/stream/src/executor/top_n/utils.rs
+++ b/src/stream/src/executor/top_n/utils.rs
@@ -195,16 +195,26 @@ pub fn create_cache_key_serde(
     {
         // validate storage_key = group_by + order_by + additional_pk
         for i in 0..group_by.len() {
-            assert_eq!(storage_key[i].column_idx, group_by[i]);
+            assert_eq!(
+                storage_key[i].column_idx, group_by[i],
+                "\nstorage_key = {:?}\ngroup_by = {:?}",
+                storage_key, group_by
+            );
         }
         for i in group_by.len()..(group_by.len() + order_by.len()) {
-            assert_eq!(storage_key[i], order_by[i - group_by.len()]);
+            assert_eq!(
+                storage_key[i],
+                order_by[i - group_by.len()],
+                "\nstorage_key = {:?}\norder_by = {:?}",
+                storage_key,
+                order_by
+            );
         }
         let pk_indices = pk_indices.iter().copied().collect::<HashSet<_>>();
         for i in (group_by.len() + order_by.len())..storage_key.len() {
             assert!(
                 pk_indices.contains(&storage_key[i].column_idx),
-                "storage_key = {:?}, pk_indices = {:?}",
+                "\nstorage_key = {:?}\npk_indices = {:?}",
                 storage_key,
                 pk_indices
             );


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

e.g., `partition by x,y,x,y order by x,y,x,y,z` is equivalent to `partition by x,y order by z`



## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fix https://github.com/risingwavelabs/risingwave/issues/7322