### PR TITLE
fix: empty `docker/risingwave.toml`

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -44,34 +44,6 @@ RUN for component in "risingwave" "compute-node" "meta-node" "frontend" "compact
 FROM ubuntu:22.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
-FROM image-base as frontend-node
-LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
-RUN mkdir -p /risingwave/bin
-COPY --from=builder /risingwave/bin/frontend /risingwave/bin/frontend
-EXPOSE 4566
-ENTRYPOINT [ "/risingwave/bin/frontend" ]
-
-FROM image-base as compute-node
-LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
-RUN mkdir -p /risingwave/bin
-COPY --from=builder /risingwave/bin/compute-node /risingwave/bin/compute-node
-EXPOSE 5687
-ENTRYPOINT [ "/risingwave/bin/compute-node" ]
-
-FROM image-base as meta-node
-LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
-RUN mkdir -p /risingwave/bin
-COPY --from=builder /risingwave/bin/meta-node /risingwave/bin/meta-node
-EXPOSE 5690
-ENTRYPOINT [ "/risingwave/bin/meta-node" ]
-
-FROM image-base as compactor-node
-LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
-RUN mkdir -p /risingwave/bin
-COPY --from=builder /risingwave/bin/compactor /risingwave/bin/compactor
-EXPOSE 6660
-ENTRYPOINT [ "/risingwave/bin/compactor" ]
-
 FROM image-base as risingwave
 LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
 RUN mkdir -p /risingwave/bin

--- a/docker/risingwave.toml
+++ b/docker/risingwave.toml
@@ -1,21 +1,2 @@
-[server]
-heartbeat_interval_ms = 1000
-max_heartbeat_interval_secs = 600
-
-[meta]
-
-[batch]
-
-[streaming]
-barrier_interval_ms = 250
-checkpoint_frequency = 10
-
-[storage]
-shared_buffer_capacity_mb = 4096
-sstable_size_mb = 256
-block_size_kb = 1024
-bloom_false_positive = 0.01
-data_directory = "hummock_001"
-block_cache_capacity_mb = 4096
-meta_cache_capacity_mb = 1024
-object_store_use_batch_delete = true
+# RisingWave config file to be mounted into the Docker containers.
+# See src/config/example.toml for example


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

See background on #6814

By the way, remove images from Dockerfile except the "all-in-one" image, which are not used now.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

None