### PR TITLE
fix: broken channel reciever

### DIFF
--- a/src/batch/src/task/broadcast_channel.rs
+++ b/src/batch/src/task/broadcast_channel.rs
@@ -28,6 +28,7 @@ use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSende
 use crate::task::data_chunk_in_channel::DataChunkInChannel;
 
 /// `BroadcastSender` sends the same chunk to a number of `BroadcastReceiver`s.
+#[derive(Clone)]
 pub struct BroadcastSender {
     senders: Vec<mpsc::Sender<Option<DataChunkInChannel>>>,
     broadcast_info: BroadcastInfo,

--- a/src/batch/src/task/channel.rs
+++ b/src/batch/src/task/channel.rs
@@ -40,7 +40,7 @@ pub(super) trait ChanSender: Send {
     fn send(&mut self, chunk: Option<DataChunk>) -> Self::SendFuture<'_>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ChanSenderImpl {
     HashShuffle(HashShuffleSender),
     ConsistentHashShuffle(ConsistentHashShuffleSender),

--- a/src/batch/src/task/consistent_hash_shuffle_channel.rs
+++ b/src/batch/src/task/consistent_hash_shuffle_channel.rs
@@ -32,6 +32,7 @@ use crate::error::Result as BatchResult;
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 use crate::task::data_chunk_in_channel::DataChunkInChannel;
 
+#[derive(Clone)]
 pub struct ConsistentHashShuffleSender {
     senders: Vec<mpsc::Sender<Option<DataChunkInChannel>>>,
     consistent_hash_info: ConsistentHashInfo,

--- a/src/batch/src/task/fifo_channel.rs
+++ b/src/batch/src/task/fifo_channel.rs
@@ -24,6 +24,7 @@ use crate::error::BatchError::SenderError;
 use crate::error::Result as BatchResult;
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 use crate::task::data_chunk_in_channel::DataChunkInChannel;
+#[derive(Clone)]
 pub struct FifoSender {
     sender: mpsc::Sender<Option<DataChunkInChannel>>,
 }

--- a/src/batch/src/task/hash_shuffle_channel.rs
+++ b/src/batch/src/task/hash_shuffle_channel.rs
@@ -30,7 +30,7 @@ use crate::error::BatchError::SenderError;
 use crate::error::Result as BatchResult;
 use crate::task::channel::{ChanReceiver, ChanReceiverImpl, ChanSender, ChanSenderImpl};
 use crate::task::data_chunk_in_channel::DataChunkInChannel;
-
+#[derive(Clone)]
 pub struct HashShuffleSender {
     senders: Vec<mpsc::Sender<Option<DataChunkInChannel>>>,
     hash_info: HashInfo,

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -247,6 +247,8 @@ pub struct BatchTaskExecution<C> {
     /// Receivers data of the task.
     receivers: Mutex<Vec<Option<ChanReceiverImpl>>>,
 
+    sender: ChanSenderImpl,
+
     /// Context for task execution
     context: C,
 
@@ -275,17 +277,27 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         runtime: &'static Runtime,
     ) -> Result<Self> {
         let task_id = TaskId::from(prost_tid);
+
+        let (sender, receivers) = create_output_channel(
+            plan.get_exchange_info()?,
+            context.get_config().developer.batch_output_channel_size,
+        )?;
+
+        let mut rts = Vec::new();
+        rts.extend(receivers.into_iter().map(Some));
+
         Ok(Self {
             task_id,
             plan,
             state: Mutex::new(TaskStatus::Pending),
-            receivers: Mutex::new(Vec::new()),
+            receivers: Mutex::new(rts),
             failure: Arc::new(Mutex::new(None)),
             epoch,
             shutdown_tx: Mutex::new(None),
             state_rx: Mutex::new(None),
             context,
             runtime,
+            sender,
         })
     }
 
@@ -316,18 +328,9 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         .await?;
 
         // Init shutdown channel and data receivers.
-        let (sender, receivers) = create_output_channel(
-            self.plan.get_exchange_info()?,
-            self.context
-                .get_config()
-                .developer
-                .batch_output_channel_size,
-        )?;
+        let sender = self.sender.clone();
         let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<u64>();
         *self.shutdown_tx.lock() = Some(shutdown_tx);
-        self.receivers
-            .lock()
-            .extend(receivers.into_iter().map(Some));
         let failure = self.failure.clone();
         let task_id = self.task_id.clone();
 

--- a/src/tests/regress/src/schedule.rs
+++ b/src/tests/regress/src/schedule.rs
@@ -222,6 +222,9 @@ impl TestCase {
                 vec![
                     "SET RW_IMPLICIT_FLUSH TO true;\n",
                     "SET CREATE_COMPACTION_GROUP_FOR_MV TO true;\n",
+                    // TODO: There is some problem in failure propagate for local mode, so we
+                    // temporarily use distributed now.
+                    "SET QUERY_MODE TO distributed;\n",
                 ]
             }
             DatabaseMode::Postgres => vec![],


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Basically the idea is store sender inside TaskExecution. And clone it out when we need to mut it.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

#7219 #7324
