### PR TITLE
fix(build): Better shebang in scripts.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -75,7 +75,7 @@ alias = "logs"
 category = "Misc"
 description = "Open logs with VSCode and dump in console"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 code "${PREFIX_LOG}" || true
@@ -100,7 +100,7 @@ echo ""
 category = "Misc"
 description = "List all nodes in the cluster"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 tmux list-windows -t risedev | grep -v active | cut -d'(' -f1
 '''
 
@@ -108,7 +108,7 @@ tmux list-windows -t risedev | grep -v active | cut -d'(' -f1
 category = "Misc"
 description = "List --watch all nodes in the cluster"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 watch -n 1 "tmux list-windows -t risedev | grep -v active | cut -d'(' -f1"
 '''
 
@@ -119,7 +119,7 @@ alias = "delete"
 category = "Misc"
 description = "Delete a node in the cluster"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 risedev_ls () {
   tmux list-windows -t risedev | grep -v active | cut -d'(' -f1
@@ -151,7 +151,7 @@ alias = "follow"
 category = "misc"
 description = "Follows the end of the logs of a specific component"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 if [[ -z "$1" ]]; then 
@@ -175,7 +175,7 @@ tail -f -n 5 ${PREFIX_LOG}/$1
 category = "Misc"
 description = "Check if there is panic in log or significant log size issue"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 for out_file in ${PREFIX_LOG}/*.log
@@ -198,7 +198,7 @@ category = "Misc"
 description = "Open rustdoc for risingwave"
 dependencies = ["build-docs"]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 python -mwebbrowser file://$(pwd)/target/doc/index.html
@@ -209,7 +209,7 @@ category = "RiseDev - Build"
 description = "Link standalone cmds to RiseDev bin"
 condition = { env_not_set = ["ENABLE_ALL_IN_ONE"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 rm -f "${PREFIX_BIN}/compute-node"
 rm -f "${PREFIX_BIN}/meta-node"
@@ -226,7 +226,7 @@ category = "RiseDev - Build"
 description = "Link all-in-one cmds to RiseDev bin"
 condition = { env_set = ["ENABLE_ALL_IN_ONE"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 rm -rf "${PREFIX_BIN}/risingwave"
@@ -244,7 +244,7 @@ category = "RiseDev - Build"
 description = "Link all binaries to .bin"
 condition = { env_set = ["ENABLE_ALL_IN_ONE"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 rm -rf "${PREFIX_USR_BIN}"
@@ -277,7 +277,7 @@ category = "RiseDev - Build"
 description = "Extract dashboard artifact"
 condition = { env_not_set = ["ENABLE_BUILD_DASHBOARD_V2"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 # we allow this script to fail
 
@@ -293,7 +293,7 @@ category = "RiseDev - Build"
 description = "Build dashboard v2"
 condition = { env_set = ["ENABLE_BUILD_DASHBOARD_V2"] }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 rm -rf "${PREFIX_UI}"
@@ -306,7 +306,7 @@ category = "RiseDev - Build"
 description = "Build Rust components"
 condition = { env_set = ["ENABLE_BUILD_RUST"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 echo "$(tput setaf 4)$(tput bold)[Reminder]$(tput sgr0) risedev will only build $(tput setaf 4)risingwave_cmd(_all) and risedev$(tput sgr0) crates."
@@ -324,7 +324,7 @@ category = "RiseDev - Build"
 description = "Clean Rust targets"
 condition = { env_set = ["ENABLE_BUILD_RUST"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cargo clean
 '''
@@ -335,7 +335,7 @@ description = "Build Rust docs"
 condition = { env_set = ["ENABLE_BUILD_RUST"] }
 env = { RUSTDOCFLAGS = "--markdown-css ../../docs/rust.css --markdown-no-toc --index-page docs/index.md -Zunstable-options" }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -346,7 +346,7 @@ cargo doc --workspace --no-deps --document-private-items
 category = "RiseDev - Prepare"
 description = "Copy necessary configuration files to RiseDev"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -376,7 +376,7 @@ category = "RiseDev - Prepare"
 description = "Create user profiles file if not exists"
 condition = { files_not_exist = ["${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/risedev-profiles.user.yml"] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 cat <<\EOF > "${CARGO_MAKE_WORKSPACE_WORKING_DIRECTORY}/risedev-profiles.user.yml"
@@ -430,7 +430,7 @@ alias = "playground"
 category = "RiseDev - Start"
 description = "Start a lite RisingWave playground using risingwave all-in-one binary"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -ex
 
@@ -441,7 +441,7 @@ RUST_BACKTRACE=1 RW_NODE=playground cargo run --bin risingwave --profile "${RISI
 category = "RiseDev - Start"
 description = "Start RiseCtl"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 RC_ENV_FILE="${PREFIX_CONFIG}/risectl-env"
 
@@ -476,7 +476,7 @@ args = ["dev", "ci-kafka"]
 category = "RiseDev - Stop"
 description = "Kill RisingWave dev cluster"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 
 tmux list-windows -t risedev -F "#{pane_id}" | xargs -I {} tmux send-keys -t {} C-c C-d
 tmux kill-session -t risedev
@@ -497,7 +497,7 @@ dependencies = ["k", "clean-data"]
 [tasks.install-tools]
 category = "RiseDev - Check"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -540,7 +540,7 @@ echo "If any command is not found, run $(tput setaf 4)./risedev install-tools$(t
 category = "RiseDev - Test"
 dependencies = ["warn-on-missing-tools"]
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 export CARGO_TARGET_DIR=target/coverage
@@ -552,7 +552,7 @@ description = "Run unit tests and report coverage"
 category = "RiseDev - Test"
 dependencies = ["warn-on-missing-tools"]
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo nextest run "$@"
@@ -565,7 +565,7 @@ description = "Build in simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo build \
@@ -589,7 +589,7 @@ description = "Run unit tests in deterministic simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo nextest run \
@@ -613,7 +613,7 @@ description = "Run integration scaling tests in deterministic simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo nextest run \
@@ -627,7 +627,7 @@ description = "Archive integration scaling tests in deterministic simulation mod
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo nextest archive \
@@ -642,7 +642,7 @@ description = "Run cargo check in deterministic simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo check -p risingwave_simulation "$@"
@@ -654,7 +654,7 @@ description = "Run e2e tests in deterministic simulation mode"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo run -p risingwave_simulation "$@"
@@ -666,7 +666,7 @@ description = "Build deterministic simulation runner and tests"
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo build -p risingwave_simulation --tests "$@"
@@ -678,7 +678,7 @@ description = "Run e2e tests in deterministic simulation mode and report code co
 dependencies = ["warn-on-missing-tools"]
 env = { RUSTFLAGS = "-Ctarget-cpu=native --cfg tokio_unstable --cfg madsim", RUSTDOCFLAGS = "--cfg madsim", CARGO_TARGET_DIR = "target/sim-cov" }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo llvm-cov run -p risingwave_simulation --html "$@"
@@ -688,7 +688,7 @@ cargo llvm-cov run -p risingwave_simulation --html "$@"
 category = "RiseDev - Check"
 description = "Run cargo hakari check and attempt to fix"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running $(tput setaf 4)cargo hakari$(tput sgr0) checks and attempting to fix"
 
@@ -702,7 +702,7 @@ test $? -eq 0 || exit 1
 category = "RiseDev - Check"
 description = "Run cargo sort check and attempt to fix"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running $(tput setaf 4)cargo sort$(tput sgr0) checks and attempting to fix"
 
@@ -715,7 +715,7 @@ test $? -eq 0 || { echo "cargo sort check failed. You may run $(tput setaf 4)car
 category = "RiseDev - Check"
 description = "Run cargo fmt check and attempt to fix"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running $(tput setaf 4)cargo fmt$(tput sgr0) checks and attempting to fix"
 cargo fmt --all
@@ -726,7 +726,7 @@ test $? -eq 0 || exit 1
 category = "RiseDev - Check"
 description = "Run cargo clippy check"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Running $(tput setaf 4)cargo clippy$(tput sgr0) checks"
 cargo clippy --all-targets --all-features
@@ -737,7 +737,7 @@ echo "If cargo clippy check failed or generates warning, you may run $(tput seta
 category = "RiseDev - Check"
 description = "Run cargo typos-cli check"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 if ! [ -x "$(command -v typos)" ]; then
   echo "Error: 'typos-cli' is not installed, please run './risedev install-tools'." >&2
   exit 1
@@ -759,7 +759,7 @@ dependencies = [
   "check-typos",
 ]
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Good work! You may run $(tput setaf 4)./risedev test$(tput sgr0) or $(tput setaf 4)./risedev test-cov$(tput sgr0) to run unit tests."
 """
@@ -772,7 +772,7 @@ alias = "check"
 category = "RiseDev - Prepare"
 description = "Install RiseDev to user local"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 
@@ -788,7 +788,7 @@ then
 fi
 
 cat <<EOF > "${INSTALL_PATH}"
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd "$DIR"
 ./risedev "\\$@"
@@ -845,7 +845,7 @@ description = "Run all e2e tests"
 category = "RiseDev - SQLLogicTest"
 description = "Extract SQL examples written in SQLLogicTest syntax from Rust doc comments"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cargo run --bin risedev-docslt -- "$@"
 '''
@@ -854,7 +854,7 @@ cargo run --bin risedev-docslt -- "$@"
 category = "RiseDev - Compose"
 description = "Compose a docker-compose.yaml file"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 rm -rf ${PREFIX_DOCKER}/*
 mkdir -p "${PREFIX_DOCKER}"
@@ -866,7 +866,7 @@ echo docker-compose file generated in $(tput setaf 4)${PREFIX_DOCKER}$(tput sgr0
 category = "RiseDev - Compose"
 description = "Compose a docker-compose.yaml deploy directory"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 rm -rf "${PREFIX_DOCKER}"/*
 mkdir -p "${PREFIX_DOCKER}"
@@ -879,7 +879,7 @@ echo If you are ready, run $(tput setaf 4)./risedev apply-compose-deploy$(tput s
 category = "RiseDev - Compose"
 description = "Run deploy.sh"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 .risingwave/rw-docker/deploy.sh "$@"
@@ -894,7 +894,7 @@ cat .risingwave/rw-docker/_message.partial.sh
 category = "RiseDev - Compose"
 description = "Run deploy.sh"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cp -a .risingwave/rw-docker/* docker

--- a/ci/build-ci-image.sh
+++ b/ci/build-ci-image.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/ci/plugins/swapfile/hooks/pre-command
+++ b/ci/plugins/swapfile/hooks/pre-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/ci/plugins/upload-failure-logs/hooks/post-command
+++ b/ci/plugins/upload-failure-logs/hooks/post-command
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/ci/scripts/build-other.sh
+++ b/ci/scripts/build-other.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/build-simulation.sh
+++ b/ci/scripts/build-simulation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/check.sh
+++ b/ci/scripts/check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/cron-e2e-test.sh
+++ b/ci/scripts/cron-e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/cron-fuzz-test.sh
+++ b/ci/scripts/cron-fuzz-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/deterministic-recovery-test.sh
+++ b/ci/scripts/deterministic-recovery-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/deterministic-scale-test.sh
+++ b/ci/scripts/deterministic-scale-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/deterministic-unit-test.sh
+++ b/ci/scripts/deterministic-unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/docker.sh
+++ b/ci/scripts/docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/docslt.sh
+++ b/ci/scripts/docslt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/e2e-test-parallel-in-memory.sh
+++ b/ci/scripts/e2e-test-parallel-in-memory.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/e2e-test-parallel.sh
+++ b/ci/scripts/e2e-test-parallel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/e2e-test.sh
+++ b/ci/scripts/e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/misc-check.sh
+++ b/ci/scripts/misc-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/multi-arch-docker.sh
+++ b/ci/scripts/multi-arch-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/pr-fuzz-test.sh
+++ b/ci/scripts/pr-fuzz-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/pr-unit-test.sh
+++ b/ci/scripts/pr-unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/pr.env.sh
+++ b/ci/scripts/pr.env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/regress-test.sh
+++ b/ci/scripts/regress-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/run-unit-test.sh
+++ b/ci/scripts/run-unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/ci/scripts/unit-test.sh
+++ b/ci/scripts/unit-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -euo pipefail

--- a/dashboard/mock/fetch.sh
+++ b/dashboard/mock/fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/dashboard/scripts/generate_proto.sh
+++ b/dashboard/scripts/generate_proto.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/docker/aws/aws-build.sh
+++ b/docker/aws/aws-build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/grafana/generate.sh
+++ b/grafana/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/grafana/update.sh
+++ b/grafana/update.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/risedev
+++ b/risedev
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [ -z "$(which cargo-make)" ]; then
     echo "Installing cargo-make..."

--- a/scripts/cargo-config-disable-simd.sh
+++ b/scripts/cargo-config-disable-simd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 # set -e

--- a/scripts/source/prepare_ci_kafka.sh
+++ b/scripts/source/prepare_ci_kafka.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Exits as soon as any line fails.
 set -e

--- a/src/frontend/planner_test/planner_test.toml
+++ b/src/frontend/planner_test/planner_test.toml
@@ -3,7 +3,7 @@
 description = "Update planner test data"
 private = true
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cargo run --bin planner-test-apply
 '''
@@ -14,7 +14,7 @@ dependencies = [
   "update-planner-test"
 ]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd src/frontend/planner_test/tests/testdata/
 
@@ -33,7 +33,7 @@ dependencies = [
   "update-planner-test"
 ]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cd src/frontend/planner_test/tests/testdata/
 
@@ -60,7 +60,7 @@ description = "Run planner test"
 category = "RiseDev - Test"
 dependencies = ["warn-on-missing-tools"]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cargo nextest run -p risingwave_planner_test --retries 0 "$@"

--- a/src/java_binding/make-java-binding.toml
+++ b/src/java_binding/make-java-binding.toml
@@ -1,7 +1,7 @@
 [tasks.gen-java-binding-header]
 description = "Generate the java binding C header file"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 cd src/java_binding/java
 javac -h . -cp java-binding/src/main/java/ java-binding/src/main/java/com/risingwave/java/binding/Binding.java
@@ -10,7 +10,7 @@ javac -h . -cp java-binding/src/main/java/ java-binding/src/main/java/com/rising
 [tasks.build-java-binding-rust]
 description = "Build the java binding rust code"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 cargo build -p risingwave_java_binding
 '''
@@ -18,7 +18,7 @@ cargo build -p risingwave_java_binding
 [tasks.build-java-binding-java]
 description = "Build the java binding java code"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 cd src/java_binding/java
 mvn clean package
@@ -31,7 +31,7 @@ dependencies = [
     "build-java-binding-java"
 ]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -ex
 RISINGWAVE_ROOT=.
 JAVA_BINDING_ROOT=${RISINGWAVE_ROOT}/src/java_binding

--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -20,7 +20,7 @@ RISINGWAVE_BUILD_PROFILE = { source = "${ENABLE_RELEASE_PROFILE}", default_value
 [tasks.prepare-dir]
 private = true
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Using ${PREFIX} as base folder"
 mkdir -p "${PREFIX}" "${PREFIX_BIN}" "${PREFIX_TMP}" "${PREFIX_DATA}" "${PREFIX_CONFIG}" "${PREFIX_CONFIG}/mcli" "${PREFIX_LOG}" "${PREFIX_PROFILING}"
 '''
@@ -29,7 +29,7 @@ mkdir -p "${PREFIX}" "${PREFIX_BIN}" "${PREFIX_TMP}" "${PREFIX_DATA}" "${PREFIX_
 private = true
 condition = { env_not_set = [ "RISEDEV_CONFIGURED" ] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 echo "RiseDev is not configured, please run ./risedev configure"
 exit 1

--- a/src/risedevtool/connector.toml
+++ b/src/risedevtool/connector.toml
@@ -13,7 +13,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_RW_CONNECTOR" ] }
 description = "Download RisingWave Connector"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -f "${PREFIX_BIN}/risingwave-connector.jar" ]; then
     exit 0

--- a/src/risedevtool/etcd.toml
+++ b/src/risedevtool/etcd.toml
@@ -15,7 +15,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_ETCD" ] }
 description = "Download and extract Etcd"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/etcd" ]; then
     exit 0
@@ -41,7 +41,7 @@ category = "RiseDev - Components"
 description = "Clean etcd data"
 condition = { env_set = [ "PREFIX_DATA" ] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 rm -rf ${PREFIX_DATA}/etcd-*
 '''

--- a/src/risedevtool/gcloud-pubsub.toml
+++ b/src/risedevtool/gcloud-pubsub.toml
@@ -13,7 +13,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_PUBSUB" ] }
 description = "Download and enable Google Pubsub Emulator"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/gcloud" ]; then
     exit 0
@@ -26,7 +26,7 @@ echo "install the pubsub-emulator"
 mv "${PREFIX_TMP}/${GCLOUD_SDK_DIR}" "${PREFIX_BIN}/gcloud"
 # startup script for the emulator. bypasses gcloud because it detaches the java process from the runner
 cat <<EOF > "${PREFIX_BIN}/gcloud/start-pubsub-emulator.sh"
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ \$# -lt 1 ]; then
     echo "Usage: start-pubsub-emulator.sh <port>"

--- a/src/risedevtool/grafana.toml
+++ b/src/risedevtool/grafana.toml
@@ -13,7 +13,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_PROMETHEUS_GRAFANA" ] }
 description = "Download and extract Grafana"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/grafana" ]; then
     if [ -f "${PREFIX_BIN}/grafana/RISEDEV-VERSION-${GRAFANA_VERSION}" ]; then

--- a/src/risedevtool/jaeger.toml
+++ b/src/risedevtool/jaeger.toml
@@ -13,7 +13,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_COMPUTE_TRACING" ] }
 description = "Download and extract Jaeger"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/jaeger" ]; then
     if [ -f "${PREFIX_BIN}/jaeger/RISEDEV-VERSION-${JAEGER_VERSION}" ]; then

--- a/src/risedevtool/kafka.toml
+++ b/src/risedevtool/kafka.toml
@@ -13,7 +13,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_KAFKA" ] }
 description = "Download and extract Kafka"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/kafka" ]; then
     exit 0

--- a/src/risedevtool/minio.toml
+++ b/src/risedevtool/minio.toml
@@ -11,7 +11,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_MINIO" ] }
 description = "Download and extract MinIO"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -f "${PREFIX_BIN}/minio" ]; then
     exit 0
@@ -30,7 +30,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_MINIO" ] }
 description = "Download and extract MinIO Client"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -f "${PREFIX_BIN}/mcli" ]; then
     exit 0

--- a/src/risedevtool/prometheus.toml
+++ b/src/risedevtool/prometheus.toml
@@ -14,7 +14,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_PROMETHEUS_GRAFANA" ] }
 description = "Download and extract Prometheus"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/prometheus" ]; then
     exit 0

--- a/src/risedevtool/redis.toml
+++ b/src/risedevtool/redis.toml
@@ -12,7 +12,7 @@ dependencies = ["prepare"]
 condition = { env_set = [ "ENABLE_REDIS" ] }
 description = "Download and extract Redis"
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 if [ -d "${PREFIX_BIN}/redis" ]; then
     exit 0

--- a/src/risedevtool/risedev-components.toml
+++ b/src/risedevtool/risedev-components.toml
@@ -1,7 +1,7 @@
 [tasks.configure-if-not-configured]
 condition = { env_not_set = [ "RISEDEV_CONFIGURED" ] }
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ENV_PATH="$(pwd)/risedev-components.user.env"
 cargo run --bin risedev-config -- -f "${ENV_PATH}" default
@@ -9,7 +9,7 @@ cargo run --bin risedev-config -- -f "${ENV_PATH}" default
 
 [tasks.configure]
 script = '''
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 ENV_PATH="$(pwd)/risedev-components.user.env"
 cargo run --bin risedev-config -- -f "${ENV_PATH}" "$@"

--- a/src/risedevtool/run_command.sh
+++ b/src/risedevtool/run_command.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Usage: ./run_command.sh "log path" "status path" command
 

--- a/src/risedevtool/src/compose_deploy.rs
+++ b/src/risedevtool/src/compose_deploy.rs
@@ -61,7 +61,7 @@ pub fn compose_deploy(
         use std::fmt::Write;
         let ssh_extra_args = "-o \"UserKnownHostsFile=/dev/null\" -o \"StrictHostKeyChecking=no\" -o \"LogLevel=ERROR\"";
         let mut x = String::new();
-        writeln!(x, "#!/bin/bash -e")?;
+        writeln!(x, "#!/usr/bin/env bash -e")?;
         writeln!(x)?;
         writeln!(
             x,
@@ -117,7 +117,7 @@ fi
             let id = &instance.id;
             let base_folder = "~/risingwave-deploy";
             let mut y = String::new();
-            writeln!(y, "#!/bin/bash -e")?;
+            writeln!(y, "#!/usr/bin/env bash -e")?;
             writeln!(y)?;
             writeln!(
                 y,
@@ -152,7 +152,7 @@ fi
         for instance in ec2_instances {
             let id = &instance.id;
             let mut y = String::new();
-            writeln!(y, "#!/bin/bash -e")?;
+            writeln!(y, "#!/usr/bin/env bash -e")?;
             writeln!(
                 y,
                 r#"echo "{id}: $(tput setaf 2)stopping and pulling$(tput sgr0)""#,
@@ -226,7 +226,7 @@ fi
         for instance in ec2_instances {
             let id = &instance.id;
             let mut y = String::new();
-            writeln!(y, "#!/bin/bash -e")?;
+            writeln!(y, "#!/usr/bin/env bash -e")?;
             writeln!(y, r#"echo "{id}: $(tput setaf 2)check status$(tput sgr0)""#,)?;
             let public_ip = &instance.public_ip;
             let base_folder = "~/risingwave-deploy";

--- a/src/risedevtool/welcome.sh
+++ b/src/risedevtool/welcome.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 cat <<EOF
   _____  _          _____             

--- a/src/storage/backup/integration_tests/Makefile.toml
+++ b/src/storage/backup/integration_tests/Makefile.toml
@@ -4,7 +4,7 @@ dependencies = ["pre-start-dev"]
 description = "Run meta backup/restore test"
 condition = { env_set = [ "PREFIX_BIN", "PREFIX_DATA" ] }
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 BUILD_BIN="$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}"
 test_root="src/storage/backup/integration_tests"

--- a/src/storage/backup/integration_tests/common.sh
+++ b/src/storage/backup/integration_tests/common.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eo pipefail
 [ -n "${BACKUP_TEST_BACKUP_RESTORE}" ]
 [ -n "${BACKUP_TEST_MCLI}" ]

--- a/src/storage/backup/integration_tests/run_all.sh
+++ b/src/storage/backup/integration_tests/run_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/src/storage/backup/integration_tests/test_basic.sh
+++ b/src/storage/backup/integration_tests/test_basic.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "${DIR}/common.sh"

--- a/src/storage/backup/integration_tests/test_pin_sst.sh
+++ b/src/storage/backup/integration_tests/test_pin_sst.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "${DIR}/common.sh"

--- a/src/storage/backup/integration_tests/test_query_backup.sh
+++ b/src/storage/backup/integration_tests/test_query_backup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 . "${DIR}/common.sh"

--- a/src/tests/compaction_test/Makefile.toml
+++ b/src/tests/compaction_test/Makefile.toml
@@ -3,7 +3,7 @@
 category = "RiseDev - Test"
 description = "Run hummock compaction e2e deterministic test"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cargo run --bin compaction-test --profile "${RISINGWAVE_BUILD_PROFILE}" -- "$@"
 """
@@ -12,7 +12,7 @@ cargo run --bin compaction-test --profile "${RISINGWAVE_BUILD_PROFILE}" -- "$@"
 category = "RiseDev - Test"
 description = "Run hummock compaction delete-range for test"
 script = """
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 cargo run --bin delete-range-test --profile "${RISINGWAVE_BUILD_PROFILE}" -- "$@"
 """


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Change the hardcoded `/bin/bash` path to `/usr/bin/env bash`.
Some systems such as NixOS and BSDs don't have `/bin/bash`, and `/usr/bin/env bash` use that from the `PATH` instead.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

### Release note

Better OS compatibility for script shebang.
