### PR TITLE
feat: meta-client with new election mechanism

### DIFF
--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -172,7 +172,7 @@ steps:
     retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
-    command: "TEST_NUM=16 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=12 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
     depends_on: "build-simulation"
     plugins:
       - gencer/cache#v2.4.10: *cargo-cache

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -247,7 +247,7 @@ steps:
     retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
-    command: "TEST_NUM=16 KILL_RATE=0.5 timeout 14m ci/scripts/deterministic-recovery-test.sh"
+    command: "TEST_NUM=8 KILL_RATE=0.5 timeout 14m ci/scripts/deterministic-recovery-test.sh"
     depends_on: "build-simulation"
     plugins:
       - gencer/cache#v2.4.10: *cargo-cache

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -137,6 +137,9 @@ pub mod monitor_service_serde;
 #[rustfmt::skip]
 #[path = "backup_service.serde.rs"]
 pub mod backup_service_serde;
+#[rustfmt::skip]
+#[path = "leader.serde.rs"]
+pub mod leader_serde;
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct ProstFieldNotFound(pub &'static str);

--- a/src/rpc_client/src/lib.rs
+++ b/src/rpc_client/src/lib.rs
@@ -159,3 +159,20 @@ macro_rules! rpc_client_method_impl {
         )*
     }
 }
+
+#[macro_export]
+macro_rules! meta_rpc_client_method_impl {
+    ($( { $client:tt, $fn_name:ident, $req:ty, $resp:ty }),*) => {
+        $(
+            pub async fn $fn_name(&self, request: $req) -> $crate::Result<$resp> {
+                let guard = self.core.lock().await;
+                Ok(guard
+                    .$client
+                    .to_owned()
+                    .$fn_name(request)
+                    .await?
+                    .into_inner())
+            }
+        )*
+    }
+}

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -1035,9 +1035,9 @@ impl GrpcMetaClient {
                     }
                 }
 
-                return Err(RpcError::Internal(anyhow!(
+                Err(RpcError::Internal(anyhow!(
                     "could not ensure meta node leader"
-                )));
+                )))
             }
         }
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use risingwave_common::catalog::{CatalogVersion, FunctionId, IndexId, TableId};
@@ -1233,7 +1233,7 @@ impl GrpcMetaClient {
                     tracing::error!("force refresh meta client failed {}", e);
                 }
             } else {
-                tracing::debug!("Skipping the current refresh, somewhere else is already doing it")
+                tracing::debug!("skipping the current refresh, somewhere else is already doing it")
             }
         }
     }

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Debug;
+use std::sync::Arc;
 use std::time::Duration;
 
+use anyhow::{anyhow, Context};
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use risingwave_common::catalog::{CatalogVersion, FunctionId, IndexId, TableId};
@@ -34,13 +36,15 @@ use risingwave_pb::catalog::{
     Schema as ProstSchema, Sink as ProstSink, Source as ProstSource, Table as ProstTable,
     View as ProstView,
 };
-use risingwave_pb::common::WorkerType;
+use risingwave_pb::common::{HostAddress, WorkerType};
 use risingwave_pb::ddl_service::ddl_service_client::DdlServiceClient;
 use risingwave_pb::ddl_service::drop_table_request::SourceId;
 use risingwave_pb::ddl_service::*;
 use risingwave_pb::hummock::hummock_manager_service_client::HummockManagerServiceClient;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
 use risingwave_pb::hummock::*;
+use risingwave_pb::leader::leader_service_client::LeaderServiceClient;
+use risingwave_pb::leader::{LeaderRequest, MembersRequest};
 use risingwave_pb::meta::cluster_service_client::ClusterServiceClient;
 use risingwave_pb::meta::heartbeat_request::{extra_info, ExtraInfo};
 use risingwave_pb::meta::heartbeat_service_client::HeartbeatServiceClient;
@@ -54,15 +58,18 @@ use risingwave_pb::stream_plan::StreamFragmentGraph;
 use risingwave_pb::user::update_user_request::UpdateField;
 use risingwave_pb::user::user_service_client::UserServiceClient;
 use risingwave_pb::user::*;
+use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot::Sender;
+use tokio::sync::{oneshot, Mutex};
 use tokio::task::JoinHandle;
+use tokio::time;
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
 use tonic::transport::{Channel, Endpoint};
 use tonic::Streaming;
 
-use crate::error::Result;
+use crate::error::{Result, RpcError};
 use crate::hummock_meta_client::{CompactTaskItem, HummockMetaClient};
-use crate::{rpc_client_method_impl, ExtraInfoSourceRef};
+use crate::{meta_rpc_client_method_impl, ExtraInfoSourceRef};
 
 type DatabaseId = u32;
 type SchemaId = u32;
@@ -851,12 +858,10 @@ impl HummockMetaClient for MetaClient {
     }
 }
 
-/// Client to meta server. Cloning the instance is lightweight.
-///
-/// It is a wrapper of tonic client. See [`rpc_client_method_impl`].
 #[derive(Debug, Clone)]
-struct GrpcMetaClient {
+struct GrpcMetaClientCore {
     cluster_client: ClusterServiceClient<Channel>,
+    election_client: LeaderServiceClient<Channel>,
     heartbeat_client: HeartbeatServiceClient<Channel>,
     ddl_client: DdlServiceClient<Channel>,
     hummock_client: HummockManagerServiceClient<Channel>,
@@ -865,6 +870,42 @@ struct GrpcMetaClient {
     user_client: UserServiceClient<Channel>,
     scale_client: ScaleServiceClient<Channel>,
     backup_client: BackupServiceClient<Channel>,
+}
+
+impl GrpcMetaClientCore {
+    pub(crate) fn new(channel: Channel) -> Self {
+        let cluster_client = ClusterServiceClient::new(channel.clone());
+        let election_client = LeaderServiceClient::new(channel.clone());
+        let heartbeat_client = HeartbeatServiceClient::new(channel.clone());
+        let ddl_client = DdlServiceClient::new(channel.clone());
+        let hummock_client = HummockManagerServiceClient::new(channel.clone());
+        let notification_client = NotificationServiceClient::new(channel.clone());
+        let stream_client = StreamManagerServiceClient::new(channel.clone());
+        let user_client = UserServiceClient::new(channel.clone());
+        let scale_client = ScaleServiceClient::new(channel.clone());
+        let backup_client = BackupServiceClient::new(channel);
+        GrpcMetaClientCore {
+            cluster_client,
+            election_client,
+            heartbeat_client,
+            ddl_client,
+            hummock_client,
+            notification_client,
+            stream_client,
+            user_client,
+            scale_client,
+            backup_client,
+        }
+    }
+}
+
+/// Client to meta server. Cloning the instance is lightweight.
+///
+/// It is a wrapper of tonic client. See [`rpc_client_method_impl`].
+#[derive(Debug, Clone)]
+struct GrpcMetaClient {
+    force_refresh: tokio::sync::mpsc::Sender<oneshot::Sender<Result<()>>>,
+    core: Arc<Mutex<GrpcMetaClientCore>>,
 }
 
 impl GrpcMetaClient {
@@ -883,8 +924,190 @@ impl GrpcMetaClient {
     // Max retry interval in ms for request to meta server.
     const REQUEST_RETRY_MAX_INTERVAL_MS: u64 = 5000;
 
+    async fn start_meta_election_monitor(
+        &self,
+        addr: &str,
+        force_refresh_receiver: Receiver<Sender<Result<()>>>,
+    ) -> Result<()> {
+        tracing::info!("using {} as initial leader", addr);
+        let core_ref = self.core.clone();
+        let current_leader = addr.to_string();
+        let mut members = HashMap::new();
+
+        // we use addr and election_client as default members
+        let init_election_client = core_ref.lock().await.election_client.clone();
+        members.insert(current_leader.clone(), init_election_client);
+
+        struct ElectionMemberManagement {
+            core_ref: Arc<Mutex<GrpcMetaClientCore>>,
+            members: HashMap<String, LeaderServiceClient<Channel>>,
+            current_leader: String,
+        }
+
+        impl ElectionMemberManagement {
+            fn host_address_to_url(addr: &HostAddress) -> String {
+                format!("http://{}:{}", addr.host, addr.port)
+            }
+
+            async fn recreate_core(&self, channel: Channel) {
+                let mut core = self.core_ref.lock().await;
+                *core = GrpcMetaClientCore::new(channel);
+            }
+
+            async fn tick(&mut self) -> Result<()> {
+                self.refresh_members()
+                    .await
+                    .context("error happened when refresh election members")?;
+                self.refresh_leader()
+                    .await
+                    .context("error happened when refresh election leader")?;
+                Ok(())
+            }
+
+            async fn refresh_members(&mut self) -> Result<()> {
+                let mut members = None;
+                for (addr, client) in &self.members {
+                    let members_resp = match client.to_owned().members(MembersRequest {}).await {
+                        Ok(resp) => resp.into_inner(),
+                        Err(e) => {
+                            tracing::warn!("failed to fetch members from {}, {}", addr, e);
+                            continue;
+                        }
+                    };
+
+                    let member_addrs: HashSet<_> = members_resp
+                        .members
+                        .iter()
+                        .cloned()
+                        .flat_map(|member| member.member_addr)
+                        .map(|addr| Self::host_address_to_url(&addr))
+                        .collect();
+
+                    members = Some(member_addrs);
+                    break;
+                }
+
+                let member_addrs = match members {
+                    None => return Err(RpcError::Internal(anyhow!("could not refresh members"))),
+                    Some(members) => members,
+                };
+
+                let mut new_members = HashMap::new();
+
+                for addr in member_addrs {
+                    if let Some(client) = self.members.remove(&addr) {
+                        new_members.insert(addr, client);
+                    } else {
+                        let channel = GrpcMetaClient::build_rpc_channel(addr.as_str()).await?;
+                        new_members.insert(addr, LeaderServiceClient::new(channel));
+                    }
+                }
+
+                self.members = new_members;
+
+                Ok(())
+            }
+
+            async fn refresh_leader(&mut self) -> Result<()> {
+                for (addr, client) in &self.members {
+                    let leader_resp = match client.to_owned().leader(LeaderRequest {}).await {
+                        Ok(resp) => resp.into_inner(),
+                        Err(e) => {
+                            tracing::warn!("failed to fetch leader from {}, {}", addr, e);
+                            continue;
+                        }
+                    };
+
+                    if let Some(leader_addr) = &leader_resp.leader_addr {
+                        let discovered_leader = Self::host_address_to_url(leader_addr);
+
+                        if discovered_leader != self.current_leader {
+                            tracing::info!("new meta leader {} discovered", discovered_leader);
+                            let channel =
+                                GrpcMetaClient::build_rpc_channel(discovered_leader.as_str())
+                                    .await?;
+
+                            self.recreate_core(channel).await;
+                            self.current_leader = discovered_leader;
+                        }
+
+                        return Ok(());
+                    }
+                }
+
+                return Err(RpcError::Internal(anyhow!(
+                    "could not ensure meta node leader"
+                )));
+            }
+        }
+
+        let member_management = ElectionMemberManagement {
+            core_ref,
+            members,
+            current_leader,
+        };
+
+        let mut force_refresh_receiver = force_refresh_receiver;
+
+        tokio::spawn(async move {
+            let mut member_management = member_management;
+            let mut ticker = time::interval(Duration::from_secs(1));
+
+            loop {
+                let result_sender: Option<oneshot::Sender<Result<()>>> = tokio::select! {
+                    _ = ticker.tick() => None,
+                    result_sender = force_refresh_receiver.recv() => result_sender,
+                };
+
+                let tick_result = member_management.tick().await;
+                if let Err(e) = tick_result.as_ref() {
+                    tracing::error!("refresh election client failed {}", e);
+                }
+
+                if let Some(sender) = result_sender {
+                    // ignore resp
+                    let _resp = sender.send(tick_result);
+                }
+            }
+        });
+
+        Ok(())
+    }
+
+    async fn force_refresh_leader(&self) -> Result<()> {
+        let (sender, receiver) = oneshot::channel();
+        self.force_refresh
+            .send(sender)
+            .await
+            .map_err(|e| anyhow!(e))?;
+        receiver.await.map_err(|e| anyhow!(e))?
+    }
+
     /// Connect to the meta server `addr`.
     pub async fn new(addr: &str) -> Result<Self> {
+        let channel = Self::build_rpc_channel(addr).await?;
+
+        let (force_refresh_sender, force_refresh_receiver) = tokio::sync::mpsc::channel(128);
+
+        let client = GrpcMetaClient {
+            force_refresh: force_refresh_sender,
+            core: Arc::new(Mutex::new(GrpcMetaClientCore::new(channel))),
+        };
+
+        client
+            .start_meta_election_monitor(addr, force_refresh_receiver)
+            .await?;
+
+        tracing::info!("force refresh leader of meta-node");
+
+        if let Err(e) = client.force_refresh_leader().await {
+            tracing::warn!("force refresh leader failed {}, init leader may failed", e);
+        }
+
+        Ok(client)
+    }
+
+    pub(crate) async fn build_rpc_channel(addr: &str) -> Result<Channel> {
         let endpoint = Endpoint::from_shared(addr.to_string())?
             .initial_connection_window_size(MAX_CONNECTION_WINDOW_SIZE);
         let retry_strategy = ExponentialBackoff::from_millis(Self::CONN_RETRY_BASE_INTERVAL_MS)
@@ -910,26 +1133,7 @@ impl GrpcMetaClient {
         })
         .await?;
 
-        let cluster_client = ClusterServiceClient::new(channel.clone());
-        let heartbeat_client = HeartbeatServiceClient::new(channel.clone());
-        let ddl_client = DdlServiceClient::new(channel.clone());
-        let hummock_client = HummockManagerServiceClient::new(channel.clone());
-        let notification_client = NotificationServiceClient::new(channel.clone());
-        let stream_client = StreamManagerServiceClient::new(channel.clone());
-        let user_client = UserServiceClient::new(channel.clone());
-        let scale_client = ScaleServiceClient::new(channel.clone());
-        let backup_client = BackupServiceClient::new(channel);
-        Ok(Self {
-            cluster_client,
-            heartbeat_client,
-            ddl_client,
-            hummock_client,
-            notification_client,
-            stream_client,
-            user_client,
-            scale_client,
-            backup_client,
-        })
+        Ok(channel)
     }
 
     /// Return retry strategy for retrying meta requests.
@@ -1016,5 +1220,5 @@ macro_rules! for_all_meta_rpc {
 }
 
 impl GrpcMetaClient {
-    for_all_meta_rpc! { rpc_client_method_impl }
+    for_all_meta_rpc! { meta_rpc_client_method_impl }
 }

--- a/src/tests/simulation/src/main.rs
+++ b/src/tests/simulation/src/main.rs
@@ -51,6 +51,10 @@ pub struct Args {
     #[clap(long, default_value = "2")]
     compactor_nodes: usize,
 
+    /// The number of meta nodes.
+    #[clap(long, default_value = "2")]
+    meta_nodes: usize,
+
     /// The number of CPU cores for each compute node.
     ///
     /// This determines worker_node_parallelism.
@@ -140,6 +144,7 @@ async fn main() {
         compute_nodes: args.compute_nodes,
         compactor_nodes: args.compactor_nodes,
         compute_node_cores: args.compute_node_cores,
+        meta_nodes: args.meta_nodes,
         etcd_timeout_rate: args.etcd_timeout_rate,
         etcd_data_path: args.etcd_data,
     };

--- a/src/tests/simulation/src/main.rs
+++ b/src/tests/simulation/src/main.rs
@@ -52,7 +52,7 @@ pub struct Args {
     compactor_nodes: usize,
 
     /// The number of meta nodes.
-    #[clap(long, default_value = "2")]
+    #[clap(long, default_value = "3")]
     meta_nodes: usize,
 
     /// The number of CPU cores for each compute node.


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

**This section will be used as the commit message. Please do not leave this empty!**

This PR is a follow-up to PR #7179 

This PR provides a meta client with an election client, and implements a sidecar rpc client update through the api of `members` and `leader` from LeaderService

But this also introduces a mutex, all meta client operations need to hold this lock

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
