### PR TITLE
refactor(row): remove Ord for OwnedRow and introduce AscentRow

### DIFF
--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -12,25 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod chain;
-mod compacted_row;
-mod empty;
-mod once;
-mod owned_row;
-mod project;
-mod repeat_n;
-
 use std::borrow::Cow;
 use std::hash::{BuildHasher, Hasher};
 
 use bytes::{BufMut, Bytes, BytesMut};
-pub use chain::Chain;
-pub use compacted_row::CompactedRow;
-pub use empty::{empty, Empty};
-pub use once::{once, Once};
-pub use owned_row::{OwnedRow, RowDeserializer};
-pub use project::Project;
-pub use repeat_n::{repeat_n, RepeatN};
 
 use self::empty::EMPTY;
 use crate::hash::HashCode;
@@ -191,7 +176,7 @@ macro_rules! deref_forward_row {
             (**self).to_owned_row()
         }
 
-        fn value_serialize_into(&self, buf: impl BufMut) {
+        fn value_serialize_into(&self, buf: impl bytes::BufMut) {
             (**self).value_serialize_into(buf)
         }
 
@@ -199,25 +184,25 @@ macro_rules! deref_forward_row {
             (**self).value_serialize()
         }
 
-        fn memcmp_serialize_into(&self, serde: &OrderedRowSerde, buf: impl BufMut) {
+        fn memcmp_serialize_into(
+            &self,
+            serde: &$crate::util::ordered::OrderedRowSerde,
+            buf: impl bytes::BufMut,
+        ) {
             (**self).memcmp_serialize_into(serde, buf)
         }
 
-        fn memcmp_serialize(&self, serde: &OrderedRowSerde) -> Vec<u8> {
+        fn memcmp_serialize(&self, serde: &$crate::util::ordered::OrderedRowSerde) -> Vec<u8> {
             (**self).memcmp_serialize(serde)
         }
 
-        fn hash<H: BuildHasher>(&self, hash_builder: H) -> HashCode {
+        fn hash<H: std::hash::BuildHasher>(&self, hash_builder: H) -> $crate::hash::HashCode {
             (**self).hash(hash_builder)
         }
 
         fn eq(this: &Self, other: impl Row) -> bool {
             Row::eq(&(**this), other)
         }
-
-        // fn cmp(this: &Self, other: impl Row) -> Ordering {
-        //     Row::cmp(&(**this), other)
-        // }
     };
 }
 
@@ -359,3 +344,18 @@ impl<R: Row> Row for Option<R> {
         }
     }
 }
+
+mod chain;
+mod compacted_row;
+mod empty;
+mod once;
+mod owned_row;
+mod project;
+mod repeat_n;
+pub use chain::Chain;
+pub use compacted_row::CompactedRow;
+pub use empty::{empty, Empty};
+pub use once::{once, Once};
+pub use owned_row::{AscentOwnedRow, OwnedRow, RowDeserializer};
+pub use project::Project;
+pub use repeat_n::{repeat_n, RepeatN};

--- a/src/common/src/row/owned_row.rs
+++ b/src/common/src/row/owned_row.rs
@@ -162,7 +162,7 @@ impl<D: AsRef<[DataType]>> RowDeserializer<D> {
     }
 }
 
-/// A simple wrapper for `OwnedRow`, which assumes that all fields are defined as `ASC` order.
+/// A simple wrapper for [`OwnedRow`], which assumes that all fields are defined as `ASC` order.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AscentOwnedRow(OwnedRow);
 

--- a/src/common/src/row/owned_row.rs
+++ b/src/common/src/row/owned_row.rs
@@ -162,6 +162,7 @@ impl<D: AsRef<[DataType]>> RowDeserializer<D> {
     }
 }
 
+/// A simple wrapper for `OwnedRow`, which assumes that all fields are defined as `ASC` order.
 #[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub struct AscentOwnedRow(OwnedRow);
 

--- a/src/compute/src/memory_management/memory_manager.rs
+++ b/src/compute/src/memory_management/memory_manager.rs
@@ -82,6 +82,7 @@ impl GlobalMemoryManager {
     /// Jemalloc is not supported on Windows, because of tikv-jemalloc's own reasons.
     /// See the comments for the macro `enable_jemalloc_on_linux!()`
     #[cfg(not(target_os = "linux"))]
+    #[expect(clippy::unused_async)]
     pub async fn run(self: Arc<Self>, _: Arc<BatchManager>, _: Arc<LocalStreamManager>) {}
 
     /// Memory manager will get memory usage from batch and streaming, and do some actions.

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -633,7 +633,7 @@ mod tests {
     use risingwave_common::array::{Op, StreamChunk};
     use risingwave_common::catalog::{Field, Schema, TableId};
     use risingwave_common::hash::SerializedKey;
-    use risingwave_common::row::{OwnedRow, Row};
+    use risingwave_common::row::{AscentOwnedRow, OwnedRow, Row};
     use risingwave_common::types::DataType;
     use risingwave_expr::expr::*;
     use risingwave_storage::memory::MemoryStateStore;
@@ -1118,8 +1118,14 @@ mod tests {
         fn sorted_rows(self) -> Vec<(Op, OwnedRow)> {
             let (chunk, ops) = self.into_parts();
             ops.into_iter()
-                .zip_eq(chunk.rows().map(Row::into_owned_row))
+                .zip_eq(
+                    chunk
+                        .rows()
+                        .map(Row::into_owned_row)
+                        .map(AscentOwnedRow::from),
+                )
                 .sorted()
+                .map(|(op, row)| (op, row.into_inner()))
                 .collect_vec()
         }
     }

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeSet;
+use std::collections::HashSet;
 
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::row::{OwnedRow, Row, RowExt};
@@ -22,12 +22,12 @@ use crate::task::AtomicU64Ref;
 
 /// A cache for lookup's arrangement side.
 pub struct LookupCache {
-    data: ExecutorCache<OwnedRow, BTreeSet<OwnedRow>>,
+    data: ExecutorCache<OwnedRow, HashSet<OwnedRow>>,
 }
 
 impl LookupCache {
     /// Lookup a row in cache. If not found, return `None`.
-    pub fn lookup(&mut self, key: &OwnedRow) -> Option<&BTreeSet<OwnedRow>> {
+    pub fn lookup(&mut self, key: &OwnedRow) -> Option<&HashSet<OwnedRow>> {
         self.data.get(key)
     }
 

--- a/src/stream/src/executor/sort.rs
+++ b/src/stream/src/executor/sort.rs
@@ -21,7 +21,7 @@ use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
 use risingwave_common::hash::VirtualNode;
-use risingwave_common::row::{self, OwnedRow, Row, RowExt};
+use risingwave_common::row::{self, AscentOwnedRow, OwnedRow, Row, RowExt};
 use risingwave_common::types::{ScalarImpl, ToOwnedDatum};
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::select_all;
@@ -35,7 +35,7 @@ use super::{
 use crate::common::table::state_table::StateTable;
 
 /// [`SortBufferKey`] contains a record's timestamp and pk.
-type SortBufferKey = (ScalarImpl, OwnedRow);
+type SortBufferKey = (ScalarImpl, AscentOwnedRow);
 
 /// [`SortBufferValue`] contains a record's value and a flag indicating whether the record has been
 /// persisted to storage.
@@ -186,7 +186,7 @@ impl<S: StateStore> SortExecutor<S> {
                                 let row = row_ref.into_owned_row();
                                 // Null event time should not exist in the row since the `WatermarkFilter`
                                 // before the `Sort` will filter out the Null event time.
-                                self.buffer.insert((timestamp_datum, pk), (row, false));
+                                self.buffer.insert((timestamp_datum, pk.into()), (row, false));
                             },
                             // Other operations are not supported currently.
                             _ => unimplemented!("operations other than insert currently are not supported by sort executor")
@@ -285,7 +285,8 @@ impl<S: StateStore> SortExecutor<S> {
                 let pk = (&row).project(&self.pk_indices).into_owned_row();
                 // Null event time should not exist in the row since the `WatermarkFilter` before
                 // the `Sort` will filter out the Null event time.
-                self.buffer.insert((timestamp_datum, pk), (row, true));
+                self.buffer
+                    .insert((timestamp_datum, pk.into()), (row, true));
             }
         }
         Ok(())


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

`impl Ord for OwnedRow` is error-prone.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recxmmended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

## Refer to a related PR or issue link (optional)

Close #7392 