### PR TITLE
fix(stream): fix backfill comparison with pk order

### DIFF
--- a/src/stream/src/executor/backfill.rs
+++ b/src/stream/src/executor/backfill.rs
@@ -20,10 +20,12 @@ use either::Either;
 use futures::stream::select_with_strategy;
 use futures::{pin_mut, stream, StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
+use itertools::Itertools;
 use risingwave_common::array::{Op, StreamChunk};
 use risingwave_common::buffer::BitmapBuilder;
 use risingwave_common::catalog::Schema;
 use risingwave_common::row::{self, OwnedRow, Row, RowExt};
+use risingwave_common::util::sort_util::OrderType;
 use risingwave_hummock_sdk::HummockReadEpoch;
 use risingwave_storage::table::batch_table::storage_table::StorageTable;
 use risingwave_storage::table::TableIter;
@@ -103,6 +105,7 @@ where
     async fn execute_inner(mut self) {
         // Table storage primary key.
         let table_pk_indices = self.table.pk_indices();
+        let pk_order = self.table.pk_serializer().get_order_types();
         let upstream_indices = self.upstream_indices;
 
         let mut upstream = self.upstream.execute();
@@ -203,7 +206,12 @@ where
                                 for chunk in upstream_chunk_buffer.drain(..) {
                                     if let Some(current_pos) = &current_pos {
                                         yield Message::Chunk(Self::mapping_chunk(
-                                            Self::mark_chunk(chunk, current_pos, table_pk_indices),
+                                            Self::mark_chunk(
+                                                chunk,
+                                                current_pos,
+                                                table_pk_indices,
+                                                pk_order,
+                                            ),
                                             &upstream_indices,
                                         ));
                                     }
@@ -337,13 +345,21 @@ where
         chunk: StreamChunk,
         current_pos: &OwnedRow,
         table_pk_indices: PkIndicesRef<'_>,
+        pk_order: &[OrderType],
     ) -> StreamChunk {
         let chunk = chunk.compact();
         let (data, ops) = chunk.into_parts();
         let mut new_visibility = BitmapBuilder::with_capacity(ops.len());
         // Use project to avoid allocation.
         for v in data.rows().map(|row| {
-            match row.project(table_pk_indices).iter().cmp(current_pos.iter()) {
+            match row
+                .project(table_pk_indices)
+                .iter()
+                .zip_eq(pk_order.iter())
+                .cmp_by(current_pos.iter(), |(x, order), y| match order {
+                    OrderType::Ascending => x.cmp(&y),
+                    OrderType::Descending => y.cmp(&x),
+                }) {
                 Ordering::Less | Ordering::Equal => true,
                 Ordering::Greater => false,
             }

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -37,6 +37,7 @@
 #![feature(provide_any)]
 #![feature(btree_drain_filter)]
 #![feature(bound_map)]
+#![feature(iter_order_by)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Since storage `pk_serializer` will encode the primary key based on the order type, we need to handle the comparison between `current_pos` and upstream message storage order key properly.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/pull/7395