### PR TITLE
fix(compute): fix clippy lint warning in macos

### DIFF
--- a/src/compute/src/memory_management/fake_global_memory_manager.rs
+++ b/src/compute/src/memory_management/fake_global_memory_manager.rs
@@ -1,0 +1,47 @@
+// Copyright 2023 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::atomic::AtomicU64;
+use std::sync::Arc;
+
+use risingwave_batch::task::BatchManager;
+use risingwave_stream::executor::monitor::StreamingMetrics;
+use risingwave_stream::task::LocalStreamManager;
+
+/// When `enable_managed_cache` is set, compute node will launch a [`GlobalMemoryManager`] to limit
+/// the memory usage.
+#[cfg(not(target_os = "linux"))]
+pub struct GlobalMemoryManager {
+    /// All cached data before the watermark should be evicted.
+    watermark_epoch: Arc<AtomicU64>,
+}
+
+impl GlobalMemoryManager {
+    pub fn new(
+        _total_memory_available_bytes: usize,
+        _barrier_interval_ms: u32,
+        _metrics: Arc<StreamingMetrics>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            watermark_epoch: Arc::new(0.into()),
+        })
+    }
+
+    pub fn get_watermark_epoch(&self) -> Arc<AtomicU64> {
+        self.watermark_epoch.clone()
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn run(self: Arc<Self>, _: Arc<BatchManager>, _: Arc<LocalStreamManager>) {}
+}

--- a/src/compute/src/memory_management/memory_manager.rs
+++ b/src/compute/src/memory_management/memory_manager.rs
@@ -20,7 +20,6 @@ use risingwave_batch::task::BatchManager;
 use risingwave_common::util::epoch::Epoch;
 use risingwave_stream::executor::monitor::StreamingMetrics;
 use risingwave_stream::task::LocalStreamManager;
-#[cfg(target_os = "linux")]
 use tikv_jemalloc_ctl::{epoch as jemalloc_epoch, stats as jemalloc_stats};
 use tracing;
 
@@ -69,16 +68,9 @@ impl GlobalMemoryManager {
         watermark_epoch.store(epoch, Ordering::Relaxed);
     }
 
-    // FIXME: remove such limitation after #7180
-    /// Jemalloc is not supported on Windows, because of tikv-jemalloc's own reasons.
-    /// See the comments for the macro `enable_jemalloc_on_linux!()`
-    #[cfg(not(target_os = "linux"))]
-    pub async fn run(self: Arc<Self>, _: Arc<BatchManager>, _: Arc<LocalStreamManager>) {}
-
     /// Memory manager will get memory usage from batch and streaming, and do some actions.
     /// 1. if batch exceeds, kill running query.
     /// 2. if streaming exceeds, evict cache by watermark.
-    #[cfg(target_os = "linux")]
     pub async fn run(
         self: Arc<Self>,
         _batch_mgr: Arc<BatchManager>,

--- a/src/compute/src/memory_management/mod.rs
+++ b/src/compute/src/memory_management/mod.rs
@@ -12,4 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod memory_manager;
+#[cfg(target_os = "linux")]
+mod memory_manager;
+
+// FIXME: remove such limitation after #7180
+/// Jemalloc is not supported on Windows, because of tikv-jemalloc's own reasons.
+/// See the comments for the macro `enable_jemalloc_on_linux!()`
+#[cfg(not(target_os = "linux"))]
+mod fake_global_memory_manager;
+#[cfg(not(target_os = "linux"))]
+pub use fake_global_memory_manager::GlobalMemoryManager;
+#[cfg(target_os = "linux")]
+use memory_manager::{GlobalMemoryManager, GlobalMemoryManagerRef};

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -52,7 +52,7 @@ use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
-use crate::memory_management::memory_manager::GlobalMemoryManager;
+use crate::memory_management::GlobalMemoryManager;
 use crate::rpc::service::config_service::ConfigServiceImpl;
 use crate::rpc::service::exchange_metrics::ExchangeServiceMetrics;
 use crate::rpc::service::exchange_service::ExchangeServiceImpl;


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

If we use MacOS to compile risingwave, there would be lint warning since variables would not be used. So I port an independent fake MemoryManager for os except linux.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

* Installation and deployment 
* Connector (sources & sinks)
* SQL commands, functions, and operators
* RisingWave cluster configuration changes
* Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
