### PR TITLE
fix: Fix potential block in frontent.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5912,6 +5912,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror",
+ "tokio-stream",
  "tracing",
  "uuid",
  "workspace-hack",

--- a/src/frontend/Cargo.toml
+++ b/src/frontend/Cargo.toml
@@ -63,6 +63,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
     "signal",
     "fs",
 ] }
+tokio-stream = "0.1"
 tonic = { version = "0.2", package = "madsim-tonic" }
 tracing = "0.1"
 uuid = "1"

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -122,10 +122,12 @@ impl LocalQueryExecution {
                 }
             }
         };
-        #[cfg(madsim)]
-        spawn(future);
-        #[cfg(not(madsim))]
-        spawn_blocking(move || block_on(future));
+
+        if cfg!(madsim) {
+            tokio::spawn(future);
+        } else {
+            spawn_blocking(move || block_on(future));
+        }
 
         ReceiverStream::new(receiver)
     }

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -47,27 +47,6 @@ use crate::scheduler::task_context::FrontendBatchTaskContext;
 use crate::scheduler::{PinnedHummockSnapshot, SchedulerResult};
 use crate::session::{AuthContext, FrontendEnv};
 
-// pub struct LocalQueryStream {
-//     data_stream: BoxedDataChunkStream,
-// }
-//
-// impl Stream for LocalQueryStream {
-//     type Item = Result<DataChunk, BoxedError>;
-//
-//     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-//         match self.data_stream.as_mut().poll_next(cx) {
-//             Poll::Pending => Poll::Pending,
-//             Poll::Ready(chunk) => match chunk {
-//                 Some(chunk_result) => match chunk_result {
-//                     Ok(chunk) => Poll::Ready(Some(Ok(chunk))),
-//                     Err(err) => Poll::Ready(Some(Err(Box::new(err)))),
-//                 },
-//                 None => Poll::Ready(None),
-//             },
-//         }
-//     }
-// }
-
 pub type LocalQueryStream = ReceiverStream<Result<DataChunk, BoxedError>>;
 
 pub struct LocalQueryExecution {


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Currently local mode's root fragment is executed in frontend, if it maybe a blocking operation and block listener thread of frontend, so we move it to block pool.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)

#7285 
