### PR TITLE
refactor(source): refine some code of source executor

### DIFF
--- a/src/stream/src/executor/source/source_executor_v2.rs
+++ b/src/stream/src/executor/source/source_executor_v2.rs
@@ -51,7 +51,7 @@ pub struct StreamSourceCore<S: StateStore> {
 
     /// Split info for stream source. A source executor might read data from several splits of
     /// external connector.
-    stream_source_splits: Vec<SplitImpl>,
+    stream_source_splits: HashMap<SplitId, SplitImpl>,
 
     /// Stores information of the splits.
     split_state_store: SourceStateTableHandler<S>,
@@ -77,7 +77,7 @@ where
             column_ids,
             source_identify: "Table_".to_string() + &source_id.table_id().to_string(),
             source_desc_builder: Some(source_desc_builder),
-            stream_source_splits: Vec::new(),
+            stream_source_splits: HashMap::new(),
             split_state_store,
             state_cache: HashMap::new(),
         }
@@ -234,7 +234,10 @@ impl<S: StateStore> SourceExecutorV2<S> {
         self.stream_source_core
             .as_mut()
             .unwrap()
-            .stream_source_splits = target_state;
+            .stream_source_splits = target_state
+            .into_iter()
+            .map(|split| (split.id(), split))
+            .collect();
 
         Ok(())
     }
@@ -293,16 +296,16 @@ impl<S: StateStore> SourceExecutorV2<S> {
             .await
             .map_err(StreamExecutorError::connector_error)?;
 
+        let mut boot_state = Vec::default();
         if let Some(mutation) = barrier.mutation.as_ref() {
             match mutation.as_ref() {
-                Mutation::Add { splits, .. } => {
+                Mutation::Add { splits, .. }
+                | Mutation::Update {
+                    actor_splits: splits,
+                    ..
+                } => {
                     if let Some(splits) = splits.get(&self.ctx.id) {
-                        core.stream_source_splits = splits.clone();
-                    }
-                }
-                Mutation::Update { actor_splits, .. } => {
-                    if let Some(splits) = actor_splits.get(&self.ctx.id) {
-                        core.stream_source_splits = splits.clone();
+                        boot_state = splits.clone();
                     }
                 }
                 _ => {}
@@ -311,7 +314,12 @@ impl<S: StateStore> SourceExecutorV2<S> {
 
         core.split_state_store.init_epoch(barrier.epoch);
 
-        let mut boot_state = core.stream_source_splits.clone();
+        core.stream_source_splits = boot_state
+            .clone()
+            .into_iter()
+            .map(|split| (split.id(), split))
+            .collect();
+
         for ele in &mut boot_state {
             if let Some(recover_state) = core
                 .split_state_store
@@ -396,21 +404,16 @@ impl<S: StateStore> SourceExecutorV2<S> {
                     if let Some(mapping) = split_offset_mapping {
                         let state: HashMap<_, _> = mapping
                             .iter()
-                            .flat_map(|(split, offset)| {
+                            .flat_map(|(split_id, offset)| {
                                 let origin_split_impl = self
                                     .stream_source_core
                                     .as_ref()
                                     .unwrap()
                                     .stream_source_splits
-                                    .iter()
-                                    .filter(|origin_split| &origin_split.id() == split)
-                                    .at_most_one()
-                                    .unwrap_or_else(|_| {
-                                        panic!("multiple splits with same id `{split}`")
-                                    });
+                                    .get(split_id);
 
                                 origin_split_impl.map(|split_impl| {
-                                    (split.clone(), split_impl.update(offset.clone()))
+                                    (split_id.clone(), split_impl.update(offset.clone()))
                                 })
                             })
                             .collect();
@@ -575,7 +578,7 @@ mod tests {
             column_ids,
             source_identify: "Table_".to_string() + &table_id.table_id().to_string(),
             source_desc_builder: Some(source_desc_builder),
-            stream_source_splits: vec![],
+            stream_source_splits: HashMap::new(),
             split_state_store,
             state_cache: HashMap::new(),
             source_name: MOCK_SOURCE_NAME.to_string(),
@@ -667,7 +670,7 @@ mod tests {
             column_ids: column_ids.clone(),
             source_identify: "Table_".to_string() + &table_id.table_id().to_string(),
             source_desc_builder: Some(source_desc_builder),
-            stream_source_splits: vec![],
+            stream_source_splits: HashMap::new(),
             split_state_store,
             state_cache: HashMap::new(),
             source_name: MOCK_SOURCE_NAME.to_string(),


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

- refine some code of source executor

## Checklist

~- [] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

