### PR TITLE
chore: rename `TableSource` to `TableDmlHandle`

### DIFF
--- a/dashboard/proto/gen/catalog.ts
+++ b/dashboard/proto/gen/catalog.ts
@@ -14,8 +14,8 @@ export const protobufPackage = "catalog";
 
 /**
  * The rust prost library always treats uint64 as required and message as
- * optional. In order to allow `row_id_index` as optional field in
- * `StreamSourceInfo` and `TableSourceInfo`, we wrap uint64 inside this message.
+ * optional. In order to allow `row_id_index` as an optional field, we wrap
+ * uint64 inside this message.
  */
 export interface ColumnIndex {
   index: number;

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -10,7 +10,7 @@ option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
 // The rust prost library always treats uint64 as required and message as
-// optional. In order to allow `row_id_index` as an optional field, we wrap 
+// optional. In order to allow `row_id_index` as an optional field, we wrap
 // uint64 inside this message.
 message ColumnIndex {
   uint64 index = 1;

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -10,8 +10,8 @@ option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
 // The rust prost library always treats uint64 as required and message as
-// optional. In order to allow `row_id_index` as optional field in
-// `StreamSourceInfo` and `TableSourceInfo`, we wrap uint64 inside this message.
+// optional. In order to allow `row_id_index` as an optional field, we wrap 
+// uint64 inside this message.
 message ColumnIndex {
   uint64 index = 1;
 }

--- a/src/batch/src/executor/delete.rs
+++ b/src/batch/src/executor/delete.rs
@@ -207,8 +207,8 @@ mod tests {
             .enumerate()
             .map(|(i, field)| ColumnDesc::unnamed(ColumnId::new(i as _), field.data_type.clone()))
             .collect_vec();
-        // We must create a variable to hold this `Arc<TableSource>` here, or it will be dropped due
-        // to the `Weak` reference in `DmlManager`.
+        // We must create a variable to hold this `Arc<TableDmlHandle>` here, or it will be dropped
+        // due to the `Weak` reference in `DmlManager`.
         let reader = dml_manager
             .register_reader(table_id, &column_descs)
             .unwrap();

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -271,8 +271,8 @@ mod tests {
             .enumerate()
             .map(|(i, field)| ColumnDesc::unnamed(ColumnId::new(i as _), field.data_type.clone()))
             .collect_vec();
-        // We must create a variable to hold this `Arc<TableSource>` here, or it will be dropped due
-        // to the `Weak` reference in `DmlManager`.
+        // We must create a variable to hold this `Arc<TableDmlHandle>` here, or it will be dropped
+        // due to the `Weak` reference in `DmlManager`.
         let reader = dml_manager
             .register_reader(table_id, &column_descs)
             .unwrap();

--- a/src/batch/src/executor/update.rs
+++ b/src/batch/src/executor/update.rs
@@ -260,8 +260,8 @@ mod tests {
             .enumerate()
             .map(|(i, field)| ColumnDesc::unnamed(ColumnId::new(i as _), field.data_type.clone()))
             .collect_vec();
-        // We must create a variable to hold this `Arc<TableSource>` here, or it will be dropped due
-        // to the `Weak` reference in `DmlManager`.
+        // We must create a variable to hold this `Arc<TableDmlHandle>` here, or it will be dropped
+        // due to the `Weak` reference in `DmlManager`.
         let reader = dml_manager
             .register_reader(table_id, &column_descs)
             .unwrap();

--- a/src/frontend/src/binder/insert.rs
+++ b/src/frontend/src/binder/insert.rs
@@ -47,8 +47,9 @@ pub struct BoundInsert {
 
     pub source: BoundQuery,
 
-    /// Used as part of an extra `Project` when the column types of `source` query does not match
-    /// `table_source`. This does not include a simple `VALUE`. See comments in code for details.
+    /// Used as part of an extra `Project` when the column types of the query does not match
+    /// those of the table. This does not include a simple `VALUE`. See comments in code for
+    /// details.
     pub cast_exprs: Vec<ExprImpl>,
 
     // used for the 'RETURNING" keyword to indicate the returning items and schema
@@ -68,7 +69,6 @@ impl Binder {
         returning_items: Vec<SelectItem>,
     ) -> Result<BoundInsert> {
         let (schema_name, table_name) = Self::resolve_schema_qualified_name(&self.db_name, name)?;
-        // let table_source = self.bind_table_source(schema_name.as_deref(), &table_name)?;
         self.bind_table(schema_name.as_deref(), &table_name, None)?;
 
         let table_catalog = self.resolve_dml_table(schema_name.as_deref(), &table_name, true)?;

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -36,7 +36,7 @@ use crate::utils::{ColIndexMapping, Condition};
 #[derive(Debug, Clone)]
 pub struct LogicalInsert {
     pub base: PlanBase,
-    table_source_name: String, // explain-only
+    table_name: String, // explain-only
     table_id: TableId,
     input: PlanRef,
     column_indices: Vec<usize>, // columns in which to insert
@@ -48,7 +48,7 @@ impl LogicalInsert {
     /// Create a [`LogicalInsert`] node. Used internally by optimizer.
     pub fn new(
         input: PlanRef,
-        table_source_name: String,
+        table_name: String,
         table_id: TableId,
         column_indices: Vec<usize>,
         row_id_index: Option<usize>,
@@ -64,7 +64,7 @@ impl LogicalInsert {
         let base = PlanBase::new_logical(ctx, schema, vec![], functional_dependency);
         Self {
             base,
-            table_source_name,
+            table_name,
             table_id,
             input,
             column_indices,
@@ -76,7 +76,7 @@ impl LogicalInsert {
     /// Create a [`LogicalInsert`] node. Used by planner.
     pub fn create(
         input: PlanRef,
-        table_source_name: String,
+        table_name: String,
         table_id: TableId,
         column_indices: Vec<usize>,
         row_id_index: Option<usize>,
@@ -84,7 +84,7 @@ impl LogicalInsert {
     ) -> Result<Self> {
         Ok(Self::new(
             input,
-            table_source_name,
+            table_name,
             table_id,
             column_indices,
             row_id_index,
@@ -97,7 +97,7 @@ impl LogicalInsert {
             f,
             "{} {{ table: {}{} }}",
             name,
-            self.table_source_name,
+            self.table_name,
             if self.returning {
                 ", returning: true"
             } else {
@@ -135,7 +135,7 @@ impl PlanTreeNodeUnary for LogicalInsert {
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::new(
             input,
-            self.table_source_name.clone(),
+            self.table_name.clone(),
             self.table_id,
             self.column_indices.clone(),
             self.row_id_index,

--- a/src/frontend/src/optimizer/plan_node/logical_update.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_update.rs
@@ -48,7 +48,7 @@ impl LogicalUpdate {
     /// Create a [`LogicalUpdate`] node. Used internally by optimizer.
     pub fn new(
         input: PlanRef,
-        table_source_name: String,
+        table_name: String,
         table_id: TableId,
         exprs: Vec<ExprImpl>,
         returning: bool,
@@ -63,7 +63,7 @@ impl LogicalUpdate {
         let base = PlanBase::new_logical(ctx, schema, vec![], fd_set);
         Self {
             base,
-            table_name: table_source_name,
+            table_name,
             table_id,
             input,
             exprs,
@@ -74,18 +74,12 @@ impl LogicalUpdate {
     /// Create a [`LogicalUpdate`] node. Used by planner.
     pub fn create(
         input: PlanRef,
-        table_source_name: String,
+        table_name: String,
         table_id: TableId,
         exprs: Vec<ExprImpl>,
         returning: bool,
     ) -> Result<Self> {
-        Ok(Self::new(
-            input,
-            table_source_name,
-            table_id,
-            exprs,
-            returning,
-        ))
+        Ok(Self::new(input, table_name, table_id, exprs, returning))
     }
 
     pub(super) fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {

--- a/src/source/src/table.rs
+++ b/src/source/src/table.rs
@@ -25,10 +25,10 @@ use risingwave_connector::source::StreamChunkWithState;
 use tokio::sync::mpsc::error::SendError;
 use tokio::sync::{mpsc, oneshot};
 
-pub type TableSourceRef = Arc<TableSource>;
+pub type TableDmlHandleRef = Arc<TableDmlHandle>;
 
 #[derive(Debug)]
-struct TableSourceCore {
+struct TableDmlHandleCore {
     /// The senders of the changes channel.
     ///
     /// When a `StreamReader` is created, a channel will be created and the sender will be
@@ -36,24 +36,24 @@ struct TableSourceCore {
     changes_txs: Vec<mpsc::UnboundedSender<(StreamChunk, oneshot::Sender<usize>)>>,
 }
 
-/// [`TableSource`] is a special internal source to handle table updates from user,
+/// [`TableDmlHandle`] is a special internal source to handle table updates from user,
 /// including insert/delete/update statements via SQL interface.
 ///
 /// Changed rows will be send to the associated "materialize" streaming task, then be written to the
-/// state store. Therefore, [`TableSource`] can be simply be treated as a channel without side
+/// state store. Therefore, [`TableDmlHandle`] can be simply be treated as a channel without side
 /// effects.
 #[derive(Debug)]
-pub struct TableSource {
-    core: RwLock<TableSourceCore>,
+pub struct TableDmlHandle {
+    core: RwLock<TableDmlHandleCore>,
 
     /// All columns in this table.
     #[allow(dead_code)]
     column_descs: Vec<ColumnDesc>,
 }
 
-impl TableSource {
+impl TableDmlHandle {
     pub fn new(column_descs: Vec<ColumnDesc>) -> Self {
-        let core = TableSourceCore {
+        let core = TableDmlHandleCore {
             changes_txs: vec![],
         };
 
@@ -81,7 +81,7 @@ impl TableSource {
             let core = self.core.upgradable_read();
 
             // The `changes_txs` should not be empty normally, since we ensured that the channels
-            // between the `TableSource` and the `SourceExecutor`s are ready before we making the
+            // between the `TableDmlHandle` and the `SourceExecutor`s are ready before we making the
             // table catalog visible to the users. However, when we're recovering, it's possible
             // that the streaming executors are not ready when the frontend is able to schedule DML
             // tasks to the compute nodes, so this'll be temporarily unavailable, so we throw an
@@ -156,15 +156,15 @@ mod tests {
 
     use super::*;
 
-    fn new_source() -> TableSource {
-        TableSource::new(vec![ColumnDesc::unnamed(
+    fn new_source() -> TableDmlHandle {
+        TableDmlHandle::new(vec![ColumnDesc::unnamed(
             ColumnId::from(0),
             DataType::Int64,
         )])
     }
 
     #[tokio::test]
-    async fn test_table_source() -> Result<()> {
+    async fn test_table_dml_handle() -> Result<()> {
         let source = Arc::new(new_source());
         let mut reader = source.stream_reader().into_stream();
 

--- a/src/stream/src/executor/dml.rs
+++ b/src/stream/src/executor/dml.rs
@@ -73,7 +73,7 @@ impl DmlExecutor {
         let mut upstream = self.upstream.execute();
 
         // Construct the reader of batch data (DML from users). We must create a variable to hold
-        // this `Arc<TableSource>` here, or it will be dropped due to the `Weak` reference in
+        // this `Arc<TableDmlHandle>` here, or it will be dropped due to the `Weak` reference in
         // `DmlManager`.
         let batch_reader = self
             .dml_manager

--- a/src/stream/src/executor/source/reader.rs
+++ b/src/stream/src/executor/source/reader.rs
@@ -145,7 +145,7 @@ mod tests {
     use assert_matches::assert_matches;
     use futures::{pin_mut, FutureExt};
     use risingwave_common::array::StreamChunk;
-    use risingwave_source::TableSource;
+    use risingwave_source::TableDmlHandle;
     use tokio::sync::mpsc;
 
     use super::*;
@@ -154,8 +154,8 @@ mod tests {
     async fn test_pause_and_resume() {
         let (barrier_tx, barrier_rx) = mpsc::unbounded_channel();
 
-        let table_source = TableSource::new(vec![]);
-        let source_stream = table_source.stream_reader().into_stream();
+        let table_dml_handle = TableDmlHandle::new(vec![]);
+        let source_stream = table_dml_handle.stream_reader().into_stream();
 
         let stream = SourceReaderStream::new(barrier_rx, source_stream);
         pin_mut!(stream);
@@ -171,7 +171,9 @@ mod tests {
         }
 
         // Write a chunk, and we should receive it.
-        table_source.write_chunk(StreamChunk::default()).unwrap();
+        table_dml_handle
+            .write_chunk(StreamChunk::default())
+            .unwrap();
         assert_matches!(next!().unwrap(), Either::Right(_));
         // Write a barrier, and we should receive it.
         barrier_tx.send(Barrier::new_test_barrier(1)).unwrap();
@@ -183,7 +185,9 @@ mod tests {
         // Write a barrier.
         barrier_tx.send(Barrier::new_test_barrier(2)).unwrap();
         // Then write a chunk.
-        table_source.write_chunk(StreamChunk::default()).unwrap();
+        table_dml_handle
+            .write_chunk(StreamChunk::default())
+            .unwrap();
 
         // We should receive the barrier.
         assert_matches!(next!().unwrap(), Either::Left(_));


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

As title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
