### PR TITLE
refactor(source): migrate all parsers and readers to the new stream based trait

### DIFF
--- a/src/batch/src/executor/source.rs
+++ b/src/batch/src/executor/source.rs
@@ -23,7 +23,7 @@ use risingwave_common::catalog::{ColumnDesc, ColumnId, Field, Schema, TableId};
 use risingwave_common::error::ErrorCode::{ConnectorError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
-use risingwave_connector::parser::SourceParserImpl;
+use risingwave_connector::parser::SpecificParserConfig;
 use risingwave_connector::source::monitor::SourceMetrics;
 use risingwave_connector::source::{
     ConnectorProperties, SourceColumnDesc, SourceFormat, SourceInfo, SplitImpl, SplitMetaData,
@@ -68,7 +68,7 @@ impl BoxedExecutorBuilder for SourceExecutor {
         let config = ConnectorProperties::extract(source_props)
             .map_err(|e| RwError::from(ConnectorError(e.into())))?;
 
-        let info = &source_node.get_info().unwrap();
+        let info = source_node.get_info().unwrap();
         let format = match info.get_row_format()? {
             RowFormatType::Json => SourceFormat::Json,
             RowFormatType::Protobuf => SourceFormat::Protobuf,
@@ -83,19 +83,9 @@ impl BoxedExecutorBuilder for SourceExecutor {
                 "protobuf file location not provided".to_string(),
             )));
         }
-        let source_parser_rs = SourceParserImpl::create(
-            &format,
-            &source_node.properties,
-            info.row_schema_location.as_str(),
-            info.use_schema_registry,
-            info.proto_message_name.clone(),
-        )
-        .await;
-        let parser = if let Ok(source_parser) = source_parser_rs {
-            source_parser
-        } else {
-            return Err(source_parser_rs.err().unwrap());
-        };
+
+        let parser_config =
+            SpecificParserConfig::new(format, info, &source_node.properties).await?;
 
         let columns: Vec<_> = source_node
             .columns
@@ -106,7 +96,7 @@ impl BoxedExecutorBuilder for SourceExecutor {
         let connector_source = ConnectorSource {
             config,
             columns,
-            parser,
+            parser_config,
             connector_message_buffer_size: source
                 .context()
                 .get_config()
@@ -163,7 +153,7 @@ impl Executor for SourceExecutor {
 impl SourceExecutor {
     #[try_stream(ok = DataChunk, error = RwError)]
     async fn do_execute(self: Box<Self>) {
-        let reader = self
+        let stream = self
             .connector_source
             .stream_reader(
                 Some(vec![self.split]),
@@ -172,8 +162,6 @@ impl SourceExecutor {
                 SourceInfo::new(u32::MAX, self.source_id),
             )
             .await?;
-
-        let stream = reader.into_stream();
 
         #[for_await]
         for chunk in stream {

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -105,25 +105,26 @@ macro_rules! impl_split {
 #[macro_export]
 macro_rules! impl_split_reader {
     ($({ $variant_name:ident, $split_reader_name:ident} ),*) => {
-        impl SplitReaderImpl {
-            pub fn into_stream(self) -> BoxSourceStream {
+        impl SplitReaderV2Impl {
+            pub fn into_stream(self) -> BoxSourceWithStateStream {
                 match self {
-                    $( Self::$variant_name(inner) => $crate::source::SplitReader::into_stream(*inner), )*
-                }
+                    $( Self::$variant_name(inner) => inner.into_stream(), )*                 }
             }
 
             pub async fn create(
                 config: ConnectorProperties,
                 state: ConnectorState,
+                parser_config: ParserConfig,
+                metrics: Arc<SourceMetrics>,
+                source_info: SourceInfo,
                 columns: Option<Vec<Column>>,
             ) -> Result<Self> {
                 if state.is_none() {
                     return Ok(Self::Dummy(Box::new(DummySplitReader {})));
                 }
-
+                let splits = state.unwrap();
                 let connector = match config {
-                     $( ConnectorProperties::$variant_name(props) => Self::$variant_name(Box::new(<$split_reader_name as $crate::source::SplitReader>::new(*props, state, columns).await?)), )*
-                    _ => todo!()
+                     $( ConnectorProperties::$variant_name(props) => Self::$variant_name(Box::new($split_reader_name::new(*props, splits, parser_config, metrics, source_info, columns).await?)), )*
                 };
 
                 Ok(connector)
@@ -157,4 +158,147 @@ macro_rules! impl_connector_properties {
             }
         }
     }
+}
+
+#[macro_export]
+macro_rules! impl_common_parser_logic {
+    ($parser_name:ty) => {
+        impl $parser_name {
+            #[try_stream(boxed, ok = $crate::source::StreamChunkWithState, error = RwError)]
+            async fn into_chunk_stream(self, data_stream: $crate::source::BoxSourceStream) {
+                #[for_await]
+                for batch in data_stream {
+                    let batch = batch?;
+                    let mut builder =
+                    $crate::parser::SourceStreamChunkBuilder::with_capacity(self.rw_columns.clone(), batch.len());
+                    let mut split_offset_mapping: std::collections::HashMap<$crate::source::SplitId, String> = std::collections::HashMap::new();
+
+                    for msg in batch {
+                        if let Some(content) = msg.payload {
+                            split_offset_mapping.insert(msg.split_id, msg.offset);
+
+                            let old_op_num = builder.op_num();
+
+                            if let Err(e) = self.parse_inner(content.as_ref(), builder.row_writer())
+                                .await
+                            {
+                                tracing::warn!("message parsing failed {}, skipping", e.to_string());
+                                continue;
+                            }
+
+                            let new_op_num = builder.op_num();
+
+                            // new_op_num - old_op_num is the number of rows added to the builder
+                            for _ in old_op_num..new_op_num {
+                                // TODO: support more kinds of SourceMeta
+                                if let $crate::source::SourceMeta::Kafka(kafka_meta) = msg.meta.clone() {
+                                    let f = |desc: &SourceColumnDesc| -> Option<risingwave_common::types::Datum> {
+                                        if !desc.is_meta {
+                                            return None;
+                                        }
+                                        match desc.name.as_str() {
+                                            "_rw_kafka_timestamp" => Some(
+                                                kafka_meta
+                                                    .timestamp
+                                                    .map(|ts| risingwave_expr::vector_op::cast::i64_to_timestamptz(ts).unwrap().into()),
+                                            ),
+                                            _ => unreachable!(
+                                                "kafka will not have this meta column: {}",
+                                                desc.name
+                                            ),
+                                        }
+                                    };
+                                    builder.row_writer().fulfill_meta_column(f)?;
+                                }
+                            }
+                        }
+                    }
+                    yield $crate::source::StreamChunkWithState {
+                        chunk: builder.finish(),
+                        split_offset_mapping: Some(split_offset_mapping),
+                    };
+                }
+            }
+        }
+
+        impl $crate::parser::ByteStreamSourceParser for $parser_name {
+            fn into_stream(self, data_stream: $crate::source::BoxSourceStream) -> $crate::source::BoxSourceWithStateStream {
+                self.into_chunk_stream(data_stream)
+            }
+        }
+
+    }
+}
+
+#[macro_export]
+macro_rules! impl_common_split_reader_logic {
+    ($reader:ty, $props:ty) => {
+        impl $reader {
+            #[try_stream(boxed, ok = $crate::source::StreamChunkWithState, error = risingwave_common::error::RwError)]
+            pub(crate) async fn into_msg_stream(self) {
+                let parser_config = self.parser_config.clone();
+                let actor_id = self.source_info.actor_id.to_string();
+                let source_id = self.source_info.source_id.to_string();
+                let split_id = self.split_id.clone();
+                let metrics = self.metrics.clone();
+
+                let data_stream = self.into_data_stream();
+
+                let data_stream = data_stream
+                    .map_ok(move |data_batch| {
+                        metrics
+                            .partition_input_count
+                            .with_label_values(&[&actor_id, &source_id, &split_id])
+                            .inc_by(data_batch.len() as u64);
+                        let sum_bytes = data_batch
+                            .iter()
+                            .map(|msg| match &msg.payload {
+                                None => 0,
+                                Some(payload) => payload.len() as u64,
+                            })
+                            .sum();
+                        metrics
+                            .partition_input_bytes
+                            .with_label_values(&[&actor_id, &source_id, &split_id])
+                            .inc_by(sum_bytes);
+                        data_batch
+                    })
+                    .boxed();
+                let parser =
+                    $crate::parser::ByteStreamSourceParserImpl::create(parser_config)?;
+                #[for_await]
+                for msg_batch in parser.into_stream(data_stream) {
+                    yield msg_batch?;
+                }
+            }
+        }
+
+        #[async_trait]
+        impl $crate::source::SplitReaderV2 for $reader {
+            type Properties = $props;
+
+            async fn new(
+                properties: $props,
+                state: Vec<SplitImpl>,
+                parser_config: ParserConfig,
+                metrics: Arc<SourceMetrics>,
+                source_info: SourceInfo,
+                columns: Option<Vec<Column>>,
+            ) -> Result<Self> {
+                Self::new(
+                    properties,
+                    state,
+                    parser_config,
+                    metrics,
+                    source_info,
+                    columns,
+                )
+                .await
+            }
+
+            fn into_stream(self) -> $crate::source::BoxSourceWithStateStream {
+                self.into_msg_stream()
+            }
+        }
+    };
 }

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -14,10 +14,12 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use apache_avro::types::Value;
 use apache_avro::{from_avro_datum, Reader, Schema};
 use chrono::Datelike;
+use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::array::{ListValue, StructValue};
 use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
@@ -30,9 +32,11 @@ use risingwave_pb::plan_common::ColumnDesc;
 use url::Url;
 
 use super::schema_resolver::*;
+use crate::impl_common_parser_logic;
 use crate::parser::schema_registry::{extract_schema_id, Client};
 use crate::parser::util::get_kafka_topic;
-use crate::parser::{ParseFuture, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
+use crate::parser::{SourceStreamChunkRowWriter, WriteGuard};
+use crate::source::SourceColumnDesc;
 
 fn unix_epoch_days() -> i32 {
     NaiveDateWrapper::from_ymd_uncheck(1970, 1, 1)
@@ -40,28 +44,37 @@ fn unix_epoch_days() -> i32 {
         .num_days_from_ce()
 }
 
+impl_common_parser_logic!(AvroParser);
+
 #[derive(Debug)]
 pub struct AvroParser {
-    schema: Schema,
-    schema_resolver: Option<ConfluentSchemaResolver>,
+    schema: Arc<Schema>,
+    schema_resolver: Option<Arc<ConfluentSchemaResolver>>,
+    rw_columns: Vec<SourceColumnDesc>,
 }
-// confluent_wire_format, kafka only, subject-name: "${topic-name}-value"
-impl AvroParser {
+
+#[derive(Debug, Clone)]
+pub struct AvroParserConfig {
+    schema: Arc<Schema>,
+    schema_resolver: Option<Arc<ConfluentSchemaResolver>>,
+}
+
+impl AvroParserConfig {
     pub async fn new(
+        props: &HashMap<String, String>,
         schema_location: &str,
         use_schema_registry: bool,
-        props: HashMap<String, String>,
     ) -> Result<Self> {
         let url = Url::parse(schema_location).map_err(|e| {
             InternalError(format!("failed to parse url ({}): {}", schema_location, e))
         })?;
         let (schema, schema_resolver) = if use_schema_registry {
-            let kafka_topic = get_kafka_topic(&props)?;
-            let client = Client::new(url, &props)?;
+            let kafka_topic = get_kafka_topic(props)?;
+            let client = Client::new(url, props)?;
             let (schema, resolver) =
                 ConfluentSchemaResolver::new(format!("{}-value", kafka_topic).as_str(), client)
                     .await?;
-            (schema, Some(resolver))
+            (Arc::new(schema), Some(Arc::new(resolver)))
         } else {
             let schema_content = match url.scheme() {
                 "file" => read_schema_from_local(url.path()),
@@ -75,7 +88,7 @@ impl AvroParser {
             let schema = Schema::parse_str(&schema_content).map_err(|e| {
                 RwError::from(InternalError(format!("Avro schema parse error {}", e)))
             })?;
-            (schema, None)
+            (Arc::new(schema), None)
         };
         Ok(Self {
             schema,
@@ -85,7 +98,7 @@ impl AvroParser {
 
     pub fn map_to_columns(&self) -> Result<Vec<ColumnDesc>> {
         // there must be a record at top level
-        if let Schema::Record { fields, .. } = &self.schema {
+        if let Schema::Record { fields, .. } = self.schema.as_ref() {
             let mut index = 0;
             let fields = fields
                 .iter()
@@ -176,8 +189,23 @@ impl AvroParser {
 
         Ok(data_type)
     }
+}
 
-    async fn parse_inner(
+// confluent_wire_format, kafka only, subject-name: "${topic-name}-value"
+impl AvroParser {
+    pub fn new(rw_columns: Vec<SourceColumnDesc>, config: AvroParserConfig) -> Result<Self> {
+        let AvroParserConfig {
+            schema,
+            schema_resolver,
+        } = config;
+        Ok(Self {
+            schema,
+            schema_resolver,
+            rw_columns,
+        })
+    }
+
+    pub(crate) async fn parse_inner(
         &self,
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
@@ -303,22 +331,6 @@ fn from_avro_value(value: Value) -> Result<Datum> {
     Ok(Some(v))
 }
 
-impl SourceParser for AvroParser {
-    type ParseResult<'a> = impl ParseFuture<'a, Result<WriteGuard>>;
-
-    fn parse<'a, 'b, 'c>(
-        &'a self,
-        payload: &'b [u8],
-        writer: SourceStreamChunkRowWriter<'c>,
-    ) -> Self::ParseResult<'a>
-    where
-        'b: 'a,
-        'c: 'a,
-    {
-        self.parse_inner(payload, writer)
-    }
-}
-
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;
@@ -338,9 +350,9 @@ mod test {
 
     use super::{
         read_schema_from_http, read_schema_from_local, read_schema_from_s3, unix_epoch_days,
-        AvroParser,
+        AvroParser, AvroParserConfig,
     };
-    use crate::parser::{SourceParser, SourceStreamChunkBuilder};
+    use crate::parser::SourceStreamChunkBuilder;
     use crate::source::SourceColumnDesc;
 
     fn test_data_path(file_name: &str) -> String {
@@ -362,7 +374,7 @@ mod test {
         let mut s3_config_props = HashMap::new();
         s3_config_props.insert("region".to_string(), "ap-southeast-1".to_string());
         let url = Url::parse(&schema_location).unwrap();
-        let schema_content = read_schema_from_s3(&url, s3_config_props).await;
+        let schema_content = read_schema_from_s3(&url, &s3_config_props).await;
         assert!(schema_content.is_ok());
         let schema = Schema::parse_str(&schema_content.unwrap());
         assert!(schema.is_ok());
@@ -392,9 +404,14 @@ mod test {
         println!("schema = {:?}", schema.unwrap());
     }
 
-    async fn new_avro_parser_from_local(file_name: &str) -> error::Result<AvroParser> {
+    async fn new_avro_conf_from_local(file_name: &str) -> error::Result<AvroParserConfig> {
         let schema_path = "file://".to_owned() + &test_data_path(file_name);
-        AvroParser::new(schema_path.as_str(), false, HashMap::new()).await
+        AvroParserConfig::new(&HashMap::new(), schema_path.as_str(), false).await
+    }
+
+    async fn new_avro_parser_from_local(file_name: &str) -> error::Result<AvroParser> {
+        let conf = new_avro_conf_from_local(file_name).await?;
+        AvroParser::new(Vec::default(), conf)
     }
 
     #[tokio::test]
@@ -415,7 +432,10 @@ mod test {
         let mut builder = SourceStreamChunkBuilder::with_capacity(columns, 1);
         {
             let writer = builder.row_writer();
-            avro_parser.parse(&input_data[..], writer).await.unwrap();
+            avro_parser
+                .parse_inner(&input_data[..], writer)
+                .await
+                .unwrap();
         }
         let chunk = builder.finish();
         let (op, row) = chunk.rows().next().unwrap();
@@ -637,10 +657,10 @@ mod test {
 
     #[tokio::test]
     async fn test_map_to_columns() {
-        let avro_parser_rs = new_avro_parser_from_local("simple-schema.avsc")
+        let conf = new_avro_conf_from_local("simple-schema.avsc")
             .await
             .unwrap();
-        println!("{:?}", avro_parser_rs.map_to_columns().unwrap());
+        println!("{:?}", conf.map_to_columns().unwrap());
     }
 
     #[tokio::test]

--- a/src/connector/src/parser/avro/schema_resolver.rs
+++ b/src/connector/src/parser/avro/schema_resolver.rs
@@ -32,7 +32,7 @@ const AVRO_SCHEMA_LOCATION_S3_REGION: &str = "region";
 /// S3 file location format: <s3://bucket_name/file_name>
 pub(super) async fn read_schema_from_s3(
     url: &Url,
-    properties: HashMap<String, String>,
+    properties: &HashMap<String, String>,
 ) -> Result<String> {
     let bucket = url
         .domain()

--- a/src/connector/src/parser/canal/mod.rs
+++ b/src/connector/src/parser/canal/mod.rs
@@ -30,13 +30,13 @@ mod tests {
     use risingwave_expr::vector_op::cast::str_to_timestamp;
 
     use super::*;
-    use crate::parser::{SourceParser, SourceStreamChunkBuilder};
+    use crate::parser::SourceStreamChunkBuilder;
     use crate::source::SourceColumnDesc;
 
     #[tokio::test]
     async fn test_json_parser() {
         let payload = br#"{"data":[{"id":"1","name":"mike","is_adult":"0","balance":"1500.62","reg_time":"2018-01-01 00:00:01","win_rate":"0.65"}],"database":"demo","es":1668673476000,"id":7,"isDdl":false,"mysqlType":{"id":"int","name":"varchar(40)","is_adult":"boolean","balance":"decimal(10,2)","reg_time":"timestamp","win_rate":"double"},"old":[{"balance":"1000.62"}],"pkNames":null,"sql":"","sqlType":{"id":4,"name":12,"is_adult":-6,"balance":3,"reg_time":93,"win_rate":8},"table":"demo","ts":1668673476732,"type":"UPDATE"}"#;
-        let parser = CanalJsonParser;
+
         let descs = vec![
             SourceColumnDesc::simple("ID", DataType::Int64, 0.into()),
             SourceColumnDesc::simple("NAME", DataType::Varchar, 1.into()),
@@ -46,10 +46,12 @@ mod tests {
             SourceColumnDesc::simple("win_rate", DataType::Float64, 5.into()),
         ];
 
+        let parser = CanalJsonParser::new(descs.clone()).unwrap();
+
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 2);
 
         let writer = builder.row_writer();
-        parser.parse(payload, writer).await.unwrap();
+        parser.parse_inner(payload, writer).await.unwrap();
 
         let chunk = builder.finish();
 
@@ -116,16 +118,17 @@ mod tests {
     async fn test_parse_multi_rows() {
         let payload = br#"{"data": [{"v1": "1", "v2": "2"}, {"v1": "3", "v2": "4"}], "old": null, "mysqlType":{"v1": "int", "v2": "int"}, "sqlType":{"v1": 4, "v2": 4}, "database":"demo","es":1668673394000,"id":5,"isDdl":false, "table":"demo","ts":1668673394788,"type":"INSERT"}"#;
 
-        let parser = CanalJsonParser;
         let descs = vec![
             SourceColumnDesc::simple("v1", DataType::Int32, 0.into()),
             SourceColumnDesc::simple("v2", DataType::Int32, 1.into()),
         ];
 
+        let parser = CanalJsonParser::new(descs.clone()).unwrap();
+
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 2);
 
         let writer = builder.row_writer();
-        parser.parse(payload, writer).await.unwrap();
+        parser.parse_inner(payload, writer).await.unwrap();
 
         let chunk = builder.finish();
 

--- a/src/connector/src/parser/canal/simd_json_parser.rs
+++ b/src/connector/src/parser/canal/simd_json_parser.rs
@@ -15,7 +15,7 @@
 use std::str::FromStr;
 
 use anyhow::anyhow;
-use futures::future::ready;
+use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
@@ -27,19 +27,28 @@ use simd_json::{BorrowedValue, StaticNode, ValueAccess};
 
 use super::util::at_least_one_ok;
 use crate::parser::canal::operators::*;
-use crate::parser::{ParseFuture, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
-use crate::{ensure_rust_type, ensure_str};
+use crate::parser::{SourceStreamChunkRowWriter, WriteGuard};
+use crate::source::SourceColumnDesc;
+use crate::{ensure_rust_type, ensure_str, impl_common_parser_logic};
 
 const AFTER: &str = "data";
 const BEFORE: &str = "old";
 const OP: &str = "type";
 const IS_DDL: &str = "isddl";
 
+impl_common_parser_logic!(CanalJsonParser);
 #[derive(Debug)]
-pub struct CanalJsonParser;
+pub struct CanalJsonParser {
+    pub(crate) rw_columns: Vec<SourceColumnDesc>,
+}
 
 impl CanalJsonParser {
-    fn parse_inner(
+    pub fn new(rw_columns: Vec<SourceColumnDesc>) -> Result<Self> {
+        Ok(Self { rw_columns })
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn parse_inner(
         &self,
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
@@ -169,22 +178,6 @@ impl CanalJsonParser {
                 other
             )))),
         }
-    }
-}
-
-impl SourceParser for CanalJsonParser {
-    type ParseResult<'a> = impl ParseFuture<'a, Result<WriteGuard>>;
-
-    fn parse<'a, 'b, 'c>(
-        &'a self,
-        payload: &'b [u8],
-        writer: SourceStreamChunkRowWriter<'c>,
-    ) -> Self::ParseResult<'a>
-    where
-        'b: 'a,
-        'c: 'a,
-    {
-        ready(self.parse_inner(payload, writer))
     }
 }
 

--- a/src/connector/src/parser/csv_parser.rs
+++ b/src/connector/src/parser/csv_parser.rs
@@ -161,7 +161,7 @@ impl CsvParser {
     }
 
     #[try_stream(boxed, ok = StreamChunkWithState, error = RwError)]
-    pub async fn into_stream(mut self, data_stream: BoxSourceStream) {
+    async fn into_stream(mut self, data_stream: BoxSourceStream) {
         // the remain length of the last seen message
         let mut remain_len = 0;
         // current offset

--- a/src/connector/src/parser/maxwell/mod.rs
+++ b/src/connector/src/parser/maxwell/mod.rs
@@ -25,16 +25,17 @@ mod test {
     use risingwave_expr::vector_op::cast::str_to_timestamp;
 
     use super::*;
-    use crate::parser::{SourceColumnDesc, SourceParser, SourceStreamChunkBuilder};
+    use crate::parser::{SourceColumnDesc, SourceStreamChunkBuilder};
     #[tokio::test]
     async fn test_json_parser() {
-        let parser = MaxwellParser;
         let descs = vec![
             SourceColumnDesc::simple("ID", DataType::Int32, 0.into()),
             SourceColumnDesc::simple("NAME", DataType::Varchar, 1.into()),
             SourceColumnDesc::simple("is_adult", DataType::Int16, 2.into()),
             SourceColumnDesc::simple("birthday", DataType::Timestamp, 3.into()),
         ];
+
+        let parser = MaxwellParser::new(descs.clone()).unwrap();
 
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 4);
         let payloads = vec![
@@ -45,7 +46,7 @@ mod test {
 
         for payload in payloads {
             let writer = builder.row_writer();
-            parser.parse(payload, writer).await.unwrap();
+            parser.parse_inner(payload, writer).await.unwrap();
         }
 
         let chunk = builder.finish();

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -14,14 +14,11 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::sync::Arc;
 
 pub use avro::*;
 pub use canal::*;
 use csv_parser::CsvParser;
 pub use debezium::*;
-use enum_as_inner::EnumAsInner;
-use futures::Future;
 use itertools::Itertools;
 pub use json_parser::*;
 pub use protobuf::*;
@@ -292,98 +289,6 @@ impl SourceStreamChunkRowWriter<'_> {
     }
 }
 
-pub trait ParseFuture<'a, Out> = Future<Output = Out> + Send + 'a;
-
-// TODO: use `async_fn_in_traits` to implement it
-/// `SourceParser` is the message parser, `ChunkReader` will parse the messages in `SourceReader`
-/// one by one through `SourceParser` and assemble them into `DataChunk`
-/// Note that the `skip_parse` parameter in `SourceColumnDesc`, when it is true, should skip the
-/// parse and return `Datum` of `None`
-pub trait SourceParser: Send + Debug + 'static {
-    type ParseResult<'a>: ParseFuture<'a, Result<WriteGuard>>;
-    /// Parse the payload and append the result to the [`StreamChunk`] directly.
-    ///
-    /// # Arguments
-    ///
-    /// - `self`: A needs to be a member method because some format like Protobuf needs to be
-    ///   pre-compiled.
-    /// - writer: Write exactly one record during a `parse` call.
-    ///
-    /// # Returns
-    ///
-    /// A [`WriteGuard`] to ensure that at least one record was appended or error occurred.
-    fn parse<'a, 'b, 'c>(
-        &'a self,
-        payload: &'b [u8],
-        writer: SourceStreamChunkRowWriter<'c>,
-    ) -> Self::ParseResult<'a>
-    where
-        'b: 'a,
-        'c: 'a;
-}
-
-#[derive(Debug)]
-pub enum SourceParserImpl {
-    Json(JsonParser),
-    Protobuf(ProtobufParser),
-    DebeziumJson(DebeziumJsonParser),
-    Avro(AvroParser),
-    Maxwell(MaxwellParser),
-    CanalJson(CanalJsonParser),
-}
-
-impl SourceParserImpl {
-    pub async fn parse(
-        &self,
-        payload: &[u8],
-        writer: SourceStreamChunkRowWriter<'_>,
-    ) -> Result<WriteGuard> {
-        match self {
-            Self::Json(parser) => parser.parse(payload, writer).await,
-            Self::Protobuf(parser) => parser.parse(payload, writer).await,
-            Self::DebeziumJson(parser) => parser.parse(payload, writer).await,
-            Self::Avro(avro_parser) => avro_parser.parse(payload, writer).await,
-            Self::Maxwell(maxwell_parser) => maxwell_parser.parse(payload, writer).await,
-            Self::CanalJson(parser) => parser.parse(payload, writer).await,
-        }
-    }
-
-    pub async fn create(
-        format: &SourceFormat,
-        properties: &HashMap<String, String>,
-        schema_location: &str,
-        use_schema_registry: bool,
-        proto_message_name: String,
-    ) -> Result<Arc<Self>> {
-        const PROTOBUF_MESSAGE_KEY: &str = "proto.message";
-        const USE_SCHEMA_REGISTRY: &str = "use_schema_registry";
-        let parser = match format {
-            SourceFormat::Json => SourceParserImpl::Json(JsonParser),
-            SourceFormat::Protobuf => SourceParserImpl::Protobuf(
-                ProtobufParser::new(
-                    schema_location,
-                    &proto_message_name,
-                    use_schema_registry,
-                    properties.clone(),
-                )
-                .await?,
-            ),
-            SourceFormat::DebeziumJson => SourceParserImpl::DebeziumJson(DebeziumJsonParser),
-            SourceFormat::Avro => SourceParserImpl::Avro(
-                AvroParser::new(schema_location, use_schema_registry, properties.clone()).await?,
-            ),
-            SourceFormat::Maxwell => SourceParserImpl::Maxwell(MaxwellParser),
-            SourceFormat::CanalJson => SourceParserImpl::CanalJson(CanalJsonParser),
-            _ => {
-                return Err(RwError::from(ProtocolError(
-                    "format not support".to_string(),
-                )));
-            }
-        };
-        Ok(Arc::new(parser))
-    }
-}
-
 /// `ByteStreamSourceParser` is a new message parser, the parser should consume
 /// the input data stream and return a stream of parsed msgs.
 pub trait ByteStreamSourceParser: Send + Debug + 'static {
@@ -402,69 +307,122 @@ pub trait ByteStreamSourceParser: Send + Debug + 'static {
 #[derive(Debug)]
 pub enum ByteStreamSourceParserImpl {
     Csv(CsvParser),
-}
-
-#[derive(Debug, Clone)]
-pub struct ParserConfig {
-    pub common: CommonParserConfig,
-    pub specific: SpecificParserConfig,
-}
-
-#[derive(Debug, Clone)]
-pub struct CommonParserConfig {
-    pub props: HashMap<String, String>,
-    pub rw_columns: Vec<SourceColumnDesc>,
-}
-
-#[derive(Debug, Clone, EnumAsInner)]
-pub enum SpecificParserConfig {
-    Csv(CsvParserConfig),
-}
-
-impl SpecificParserConfig {
-    pub fn new(format: &SourceFormat, info: &StreamSourceInfo) -> Self {
-        match format {
-            SourceFormat::Csv => SpecificParserConfig::Csv(CsvParserConfig {
-                delimiter: info.csv_delimiter as u8,
-                has_header: info.csv_has_header,
-            }),
-            _ => unreachable!(),
-        }
-    }
-}
-
-impl ParserConfig {
-    pub fn new(
-        format: &SourceFormat,
-        info: &StreamSourceInfo,
-        props: &HashMap<String, String>,
-        rw_columns: &Vec<SourceColumnDesc>,
-    ) -> Self {
-        let common = CommonParserConfig {
-            props: props.clone(),
-            rw_columns: rw_columns.to_owned(),
-        };
-        let specific = SpecificParserConfig::new(format, info);
-
-        Self { common, specific }
-    }
+    Json(JsonParser),
+    Protobuf(ProtobufParser),
+    DebeziumJson(DebeziumJsonParser),
+    Avro(AvroParser),
+    Maxwell(MaxwellParser),
+    CanalJson(CanalJsonParser),
 }
 
 impl ByteStreamSourceParserImpl {
     pub fn into_stream(self, msg_stream: BoxSourceStream) -> BoxSourceWithStateStream {
         match self {
             Self::Csv(parser) => parser.into_stream(msg_stream),
+            Self::Json(parser) => parser.into_stream(msg_stream),
+            Self::Protobuf(parser) => parser.into_stream(msg_stream),
+            Self::DebeziumJson(parser) => parser.into_stream(msg_stream),
+            Self::Avro(parser) => parser.into_stream(msg_stream),
+            Self::Maxwell(parser) => parser.into_stream(msg_stream),
+            Self::CanalJson(parser) => parser.into_stream(msg_stream),
         }
     }
 
-    // Keep this `async` in consideration of other parsers in the future.
-    #[allow(clippy::unused_async)]
-    pub async fn create(parser_config: ParserConfig) -> Result<Self> {
-        let CommonParserConfig { rw_columns, .. } = parser_config.common;
+    pub fn create(parser_config: ParserConfig) -> Result<Self> {
+        let CommonParserConfig { rw_columns } = parser_config.common;
         match parser_config.specific {
-            SpecificParserConfig::Csv(csv_parser_config) => {
-                CsvParser::new(rw_columns, csv_parser_config).map(Self::Csv)
+            SpecificParserConfig::Csv(config) => CsvParser::new(rw_columns, config).map(Self::Csv),
+            SpecificParserConfig::Avro(config) => {
+                AvroParser::new(rw_columns, config).map(Self::Avro)
             }
+            SpecificParserConfig::Protobuf(config) => {
+                ProtobufParser::new(rw_columns, config).map(Self::Protobuf)
+            }
+            SpecificParserConfig::Json => JsonParser::new(rw_columns).map(Self::Json),
+            SpecificParserConfig::CanalJson => {
+                CanalJsonParser::new(rw_columns).map(Self::CanalJson)
+            }
+            SpecificParserConfig::DebeziumJson => {
+                DebeziumJsonParser::new(rw_columns).map(Self::DebeziumJson)
+            }
+            SpecificParserConfig::Maxwell => MaxwellParser::new(rw_columns).map(Self::Maxwell),
         }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ParserConfig {
+    pub common: CommonParserConfig,
+    pub specific: SpecificParserConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CommonParserConfig {
+    pub rw_columns: Vec<SourceColumnDesc>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum SpecificParserConfig {
+    Csv(CsvParserConfig),
+    Avro(AvroParserConfig),
+    Protobuf(ProtobufParserConfig),
+    #[default]
+    Json,
+    DebeziumJson,
+    Maxwell,
+    CanalJson,
+}
+
+impl SpecificParserConfig {
+    pub async fn new(
+        format: SourceFormat,
+        info: &StreamSourceInfo,
+        props: &HashMap<String, String>,
+    ) -> Result<Self> {
+        let conf = match format {
+            SourceFormat::Csv => SpecificParserConfig::Csv(CsvParserConfig {
+                delimiter: info.csv_delimiter as u8,
+                has_header: info.csv_has_header,
+            }),
+            SourceFormat::Avro => SpecificParserConfig::Avro(
+                AvroParserConfig::new(props, &info.row_schema_location, info.use_schema_registry)
+                    .await?,
+            ),
+            SourceFormat::Protobuf => SpecificParserConfig::Protobuf(
+                ProtobufParserConfig::new(
+                    props,
+                    &info.row_schema_location,
+                    &info.proto_message_name,
+                    info.use_schema_registry,
+                )
+                .await?,
+            ),
+            SourceFormat::Json => SpecificParserConfig::Json,
+            SourceFormat::DebeziumJson => SpecificParserConfig::DebeziumJson,
+            SourceFormat::Maxwell => SpecificParserConfig::Maxwell,
+            SourceFormat::CanalJson => SpecificParserConfig::CanalJson,
+            _ => {
+                return Err(RwError::from(ProtocolError(
+                    "invalid source format".to_string(),
+                )));
+            }
+        };
+        Ok(conf)
+    }
+}
+
+impl ParserConfig {
+    pub async fn new(
+        format: SourceFormat,
+        info: &StreamSourceInfo,
+        props: &HashMap<String, String>,
+        rw_columns: &Vec<SourceColumnDesc>,
+    ) -> Result<Self> {
+        let common = CommonParserConfig {
+            rw_columns: rw_columns.to_owned(),
+        };
+        let specific = SpecificParserConfig::new(format, info, props).await?;
+
+        Ok(Self { common, specific })
     }
 }

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-use futures::future::ready;
+use futures_async_stream::try_stream;
 use itertools::Itertools;
 use prost_reflect::{
     Cardinality, DescriptorPool, DynamicMessage, FieldDescriptor, Kind, MessageDescriptor,
@@ -29,29 +29,40 @@ use risingwave_pb::plan_common::ColumnDesc;
 use url::Url;
 
 use super::schema_resolver::*;
+use crate::impl_common_parser_logic;
 use crate::parser::schema_registry::{extract_schema_id, Client};
 use crate::parser::util::get_kafka_topic;
-use crate::parser::{ParseFuture, SourceParser, SourceStreamChunkRowWriter, WriteGuard};
+use crate::parser::{SourceStreamChunkRowWriter, WriteGuard};
+use crate::source::SourceColumnDesc;
+
+impl_common_parser_logic!(ProtobufParser);
 
 #[derive(Debug, Clone)]
 pub struct ProtobufParser {
     message_descriptor: MessageDescriptor,
     confluent_wire_type: bool,
+    rw_columns: Vec<SourceColumnDesc>,
 }
 
-impl ProtobufParser {
+#[derive(Debug, Clone)]
+pub struct ProtobufParserConfig {
+    confluent_wire_type: bool,
+    message_descriptor: MessageDescriptor,
+}
+
+impl ProtobufParserConfig {
     pub async fn new(
+        props: &HashMap<String, String>,
         location: &str,
         message_name: &str,
         use_schema_registry: bool,
-        props: HashMap<String, String>,
     ) -> Result<Self> {
         let url = Url::parse(location)
             .map_err(|e| InternalError(format!("failed to parse url ({}): {}", location, e)))?;
 
         let schema_bytes = if use_schema_registry {
-            let kafka_topic = get_kafka_topic(&props)?;
-            let client = Client::new(url, &props)?;
+            let kafka_topic = get_kafka_topic(props)?;
+            let client = Client::new(url, props)?;
             compile_file_descriptor_from_schema_registry(
                 format!("{}-value", kafka_topic).as_str(),
                 &client,
@@ -153,8 +164,23 @@ impl ProtobufParser {
             })
         }
     }
+}
 
-    fn parse_inner(
+impl ProtobufParser {
+    pub fn new(rw_columns: Vec<SourceColumnDesc>, config: ProtobufParserConfig) -> Result<Self> {
+        let ProtobufParserConfig {
+            confluent_wire_type,
+            message_descriptor,
+        } = config;
+        Ok(Self {
+            message_descriptor,
+            confluent_wire_type,
+            rw_columns,
+        })
+    }
+
+    #[allow(clippy::unused_async)]
+    pub async fn parse_inner(
         &self,
         mut payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
@@ -304,22 +330,6 @@ pub(crate) fn resolve_pb_header(payload: &[u8]) -> Result<&[u8]> {
     }
 }
 
-impl SourceParser for ProtobufParser {
-    type ParseResult<'a> = impl ParseFuture<'a, Result<WriteGuard>>;
-
-    fn parse<'a, 'b, 'c>(
-        &'a self,
-        payload: &'b [u8],
-        writer: SourceStreamChunkRowWriter<'c>,
-    ) -> Self::ParseResult<'a>
-    where
-        'b: 'a,
-        'c: 'a,
-    {
-        ready(self.parse_inner(payload, writer))
-    }
-}
-
 #[cfg(test)]
 mod test {
 
@@ -350,7 +360,9 @@ mod test {
         let location = schema_dir() + "/simple-schema";
         let message_name = "test.TestRecord";
         println!("location: {}", location);
-        let parser = ProtobufParser::new(&location, message_name, false, HashMap::new()).await?;
+        let conf =
+            ProtobufParserConfig::new(&HashMap::new(), &location, message_name, false).await?;
+        let parser = ProtobufParser::new(Vec::default(), conf)?;
         let value = DynamicMessage::decode(parser.message_descriptor, PRE_GEN_PROTO_DATA).unwrap();
 
         assert_eq!(
@@ -386,8 +398,9 @@ mod test {
         let location = schema_dir() + "/complex-schema";
         let message_name = "test.User";
 
-        let parser = ProtobufParser::new(&location, message_name, false, HashMap::new()).await?;
-        let columns = parser.map_to_columns().unwrap();
+        let conf =
+            ProtobufParserConfig::new(&HashMap::new(), &location, message_name, false).await?;
+        let columns = conf.map_to_columns().unwrap();
 
         assert_eq!(columns[0].name, "id".to_string());
         assert_eq!(columns[1].name, "code".to_string());

--- a/src/connector/src/parser/protobuf/schema_resolver.rs
+++ b/src/connector/src/parser/protobuf/schema_resolver.rs
@@ -31,7 +31,7 @@ const PB_SCHEMA_LOCATION_S3_REGION: &str = "region";
 // TODO(Tao): Probably we should never allow to use S3 URI.
 pub(super) async fn load_file_descriptor_from_s3(
     location: &Url,
-    properties: HashMap<String, String>,
+    properties: &HashMap<String, String>,
 ) -> Result<Vec<u8>> {
     let bucket = location.domain().ok_or_else(|| {
         RwError::from(InternalError(format!(

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -13,22 +13,21 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::sync::{Arc, LazyLock};
+use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use bytes::Bytes;
 use enum_as_inner::EnumAsInner;
 use futures::stream::BoxStream;
-use futures::{pin_mut, Stream, StreamExt};
 use itertools::Itertools;
 use prost::Message;
-use risingwave_common::error::ErrorCode;
+use risingwave_common::array::StreamChunk;
+use risingwave_common::catalog::TableId;
+use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_pb::connector_service::TableSchema;
 use risingwave_pb::source::ConnectorSplit;
 use serde::{Deserialize, Serialize};
-use tokio::runtime::Runtime;
-use tokio::sync::mpsc;
 
 use super::datagen::DatagenMeta;
 use super::filesystem::{FsSplit, S3FileReader, S3Properties, S3SplitEnumerator, S3_CONNECTOR};
@@ -36,7 +35,6 @@ use super::google_pubsub::GooglePubsubMeta;
 use super::kafka::KafkaMeta;
 use super::monitor::SourceMetrics;
 use super::nexmark::source::message::NexmarkMeta;
-use super::SourceInfo;
 use crate::parser::ParserConfig;
 use crate::source::cdc::{
     CdcProperties, CdcSplit, CdcSplitReader, DebeziumSplitEnumerator, MYSQL_CDC_CONNECTOR,
@@ -65,7 +63,6 @@ use crate::source::pulsar::source::reader::PulsarSplitReader;
 use crate::source::pulsar::{
     PulsarProperties, PulsarSplit, PulsarSplitEnumerator, PULSAR_CONNECTOR,
 };
-use crate::source::BoxSourceWithStateStream;
 use crate::{impl_connector_properties, impl_split, impl_split_enumerator, impl_split_reader};
 
 /// [`SplitEnumerator`] fetches the split metadata from the external source service.
@@ -79,21 +76,53 @@ pub trait SplitEnumerator: Sized {
     async fn list_splits(&mut self) -> Result<Vec<Self::Split>>;
 }
 
-/// [`SplitReader`] is an abstraction of the external connector read interface,
-/// used to read messages from the outside and transform them into source-oriented
-/// [`SourceMessage`], in order to improve throughput, it is recommended to return a batch of
-/// messages at a time.
-#[async_trait]
-pub trait SplitReader: Sized {
-    type Properties;
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SourceInfo {
+    pub actor_id: u32,
+    pub source_id: TableId,
+}
 
-    async fn new(
-        properties: Self::Properties,
-        state: ConnectorState,
-        columns: Option<Vec<Column>>,
-    ) -> Result<Self>;
+impl SourceInfo {
+    pub fn new(actor_id: u32, source_id: TableId) -> Self {
+        SourceInfo {
+            actor_id,
+            source_id,
+        }
+    }
+}
 
-    fn into_stream(self) -> BoxSourceStream;
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SourceFormat {
+    Invalid,
+    Json,
+    Protobuf,
+    DebeziumJson,
+    Avro,
+    Maxwell,
+    CanalJson,
+    Csv,
+}
+
+pub type BoxSourceStream = BoxStream<'static, Result<Vec<SourceMessage>>>;
+pub type BoxSourceWithStateStream = BoxStream<'static, Result<StreamChunkWithState, RwError>>;
+
+/// [`StreamChunkWithState`] returns stream chunk together with offset for each split. In the
+/// current design, one connector source can have multiple split reader. The keys are unique
+/// `split_id` and values are the latest offset for each split.
+#[derive(Clone, Debug)]
+pub struct StreamChunkWithState {
+    pub chunk: StreamChunk,
+    pub split_offset_mapping: Option<HashMap<SplitId, String>>,
+}
+
+/// The `split_offset_mapping` field is unused for the table source, so we implement `From` for it.
+impl From<StreamChunk> for StreamChunkWithState {
+    fn from(chunk: StreamChunk) -> Self {
+        Self {
+            chunk,
+            split_offset_mapping: None,
+        }
+    }
 }
 
 /// [`SplitReaderV2`] is a new abstraction of the external connector read interface which is
@@ -109,12 +138,11 @@ pub trait SplitReaderV2: Sized {
         parser_config: ParserConfig,
         metrics: Arc<SourceMetrics>,
         source_info: SourceInfo,
+        columns: Option<Vec<Column>>,
     ) -> Result<Self>;
 
     fn into_stream(self) -> BoxSourceWithStateStream;
 }
-
-pub type BoxSourceStream = BoxStream<'static, Result<Vec<SourceMessage>>>;
 
 /// The max size of a chunk yielded by source stream.
 pub const MAX_CHUNK_SIZE: usize = 1024;
@@ -201,51 +229,17 @@ impl SplitImpl {
     }
 }
 
-pub enum SplitReaderImpl {
+pub enum SplitReaderV2Impl {
+    S3(Box<S3FileReader>),
+    Dummy(Box<DummySplitReader>),
     Kinesis(Box<KinesisSplitReader>),
     Kafka(Box<KafkaSplitReader>),
-    Dummy(Box<DummySplitReader>),
     Nexmark(Box<NexmarkSplitReader>),
     Pulsar(Box<PulsarSplitReader>),
     Datagen(Box<DatagenSplitReader>),
     MySqlCdc(Box<CdcSplitReader>),
     PostgresCdc(Box<CdcSplitReader>),
     GooglePubsub(Box<PubsubSplitReader>),
-}
-
-pub enum SplitReaderV2Impl {
-    S3(Box<S3FileReader>),
-    Dummy(Box<DummySplitReader>),
-}
-
-impl SplitReaderV2Impl {
-    pub fn into_stream(self) -> BoxSourceWithStateStream {
-        match self {
-            Self::S3(s3_reader) => SplitReaderV2::into_stream(*s3_reader),
-            Self::Dummy(dummy_reader) => SplitReaderV2::into_stream(*dummy_reader),
-        }
-    }
-
-    pub async fn create(
-        config: ConnectorProperties,
-        state: ConnectorState,
-        parser_config: ParserConfig,
-        metrics: Arc<SourceMetrics>,
-        source_info: SourceInfo,
-        _columns: Option<Vec<Column>>,
-    ) -> Result<Self> {
-        if state.is_none() {
-            return Ok(Self::Dummy(Box::new(DummySplitReader {})));
-        }
-        let state = state.unwrap();
-        let reader = match config {
-            ConnectorProperties::S3(s3_props) => Self::S3(Box::new(
-                S3FileReader::new(*s3_props, state, parser_config, metrics, source_info).await?,
-            )),
-            _ => todo!(),
-        };
-        Ok(reader)
-    }
 }
 
 pub enum SplitEnumeratorImpl {
@@ -297,6 +291,7 @@ impl_split! {
 }
 
 impl_split_reader! {
+    { S3, S3FileReader },
     { Kafka, KafkaSplitReader },
     { Pulsar, PulsarSplitReader },
     { Kinesis, KinesisSplitReader },
@@ -362,35 +357,6 @@ pub trait SplitMetaData: Sized {
 /// to source executor, `ConnectorState` is [`None`] and [`DummySplitReader`] is up instead of other
 /// split readers.
 pub type ConnectorState = Option<Vec<SplitImpl>>;
-
-/// Spawn the data generator to a dedicated runtime, returns a channel receiver
-/// for acquiring the generated data. This is used for the [`DatagenSplitReader`] and
-/// [`NexmarkSplitReader`] in case that they are CPU intensive and may block the streaming actors.
-pub fn spawn_data_generation_stream<T: Send + 'static>(
-    stream: impl Stream<Item = T> + Send + 'static,
-    buffer_size: usize,
-) -> impl Stream<Item = T> + Send + 'static {
-    static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .thread_name("risingwave-data-generation")
-            .enable_all()
-            .build()
-            .expect("failed to build data-generation runtime")
-    });
-
-    let (generation_tx, generation_rx) = mpsc::channel(buffer_size);
-    RUNTIME.spawn(async move {
-        pin_mut!(stream);
-        while let Some(result) = stream.next().await {
-            if generation_tx.send(result).await.is_err() {
-                tracing::warn!("failed to send next event to reader, exit");
-                break;
-            }
-        }
-    });
-
-    tokio_stream::wrappers::ReceiverStream::new(generation_rx)
-}
 
 #[cfg(test)]
 mod tests {

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -353,9 +353,9 @@ pub trait SplitMetaData: Sized {
 }
 
 /// [`ConnectorState`] maintains the consuming splits' info. In specific split readers,
-/// `ConnectorState` cannot be [`None`] and only contains one [`SplitImpl`]. If no split is assigned
-/// to source executor, `ConnectorState` is [`None`] and [`DummySplitReader`] is up instead of other
-/// split readers.
+/// `ConnectorState` cannot be [`None`] and contains one(for mq split readers) or many(for fs
+/// split readers) [`SplitImpl`]. If no split is assigned to source executor, `ConnectorState` is
+/// [`None`] and [`DummySplitReader`] is up instead of other split readers.
 pub type ConnectorState = Option<Vec<SplitImpl>>;
 
 #[cfg(test)]

--- a/src/connector/src/source/data_gen_util.rs
+++ b/src/connector/src/source/data_gen_util.rs
@@ -1,0 +1,48 @@
+// Copyright 2023 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::LazyLock;
+
+use futures::{pin_mut, Stream, StreamExt};
+use tokio::runtime::Runtime;
+use tokio::sync::mpsc;
+
+/// Spawn the data generator to a dedicated runtime, returns a channel receiver
+/// for acquiring the generated data. This is used for the [`DatagenSplitReader`] and
+/// [`NexmarkSplitReader`] in case that they are CPU intensive and may block the streaming actors.
+pub fn spawn_data_generation_stream<T: Send + 'static>(
+    stream: impl Stream<Item = T> + Send + 'static,
+    buffer_size: usize,
+) -> impl Stream<Item = T> + Send + 'static {
+    static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .thread_name("risingwave-data-generation")
+            .enable_all()
+            .build()
+            .expect("failed to build data-generation runtime")
+    });
+
+    let (generation_tx, generation_rx) = mpsc::channel(buffer_size);
+    RUNTIME.spawn(async move {
+        pin_mut!(stream);
+        while let Some(result) = stream.next().await {
+            if generation_tx.send(result).await.is_err() {
+                tracing::warn!("failed to send next event to reader, exit");
+                break;
+            }
+        }
+    });
+
+    tokio_stream::wrappers::ReceiverStream::new(generation_rx)
+}

--- a/src/connector/src/source/data_gen_util.rs
+++ b/src/connector/src/source/data_gen_util.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Singularity Data
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -13,53 +13,63 @@
 // limitations under the License.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
+use futures_async_stream::try_stream;
 use itertools::zip_eq;
 use risingwave_common::field_generator::FieldGeneratorImpl;
 
 use super::generator::DatagenEventGenerator;
+use crate::impl_common_split_reader_logic;
+use crate::parser::ParserConfig;
+use crate::source::data_gen_util::spawn_data_generation_stream;
 use crate::source::datagen::source::SEQUENCE_FIELD_KIND;
 use crate::source::datagen::{DatagenProperties, DatagenSplit};
+use crate::source::monitor::SourceMetrics;
 use crate::source::{
-    spawn_data_generation_stream, BoxSourceStream, Column, ConnectorState, DataType, SplitId,
-    SplitImpl, SplitMetaData, SplitReader,
+    BoxSourceStream, Column, DataType, SourceInfo, SplitId, SplitImpl, SplitMetaData,
 };
+
+impl_common_split_reader_logic!(DatagenSplitReader, DatagenProperties);
 
 pub struct DatagenSplitReader {
     generator: DatagenEventGenerator,
     assigned_split: DatagenSplit,
+
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    metrics: Arc<SourceMetrics>,
+    source_info: SourceInfo,
 }
 
-#[async_trait]
-impl SplitReader for DatagenSplitReader {
-    type Properties = DatagenProperties;
-
+impl DatagenSplitReader {
+    #[allow(clippy::unused_async)]
     async fn new(
         properties: DatagenProperties,
-        state: ConnectorState,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        metrics: Arc<SourceMetrics>,
+        source_info: SourceInfo,
         columns: Option<Vec<Column>>,
     ) -> Result<Self> {
         let mut assigned_split = DatagenSplit::default();
-        let mut split_id: SplitId = "".into();
         let mut events_so_far = u64::default();
-        if let Some(splits) = state {
-            tracing::debug!("Splits for datagen found! {:?}", splits);
-            for split in splits {
-                // TODO: currently, assume there's only on split in one reader
-                split_id = split.id();
-                if let SplitImpl::Datagen(n) = split {
-                    if let Some(s) = n.start_offset {
-                        // start_offset in `SplitImpl` indicates the latest successfully generated
-                        // index, so here we use start_offset+1
-                        events_so_far = s + 1;
-                    };
-                    assigned_split = n;
-                    break;
-                }
-            }
+        tracing::debug!("Splits for datagen found! {:?}", splits);
+
+        assert!(splits.len() == 1);
+        let split = splits.into_iter().next().unwrap();
+        // TODO: currently, assume there's only on split in one reader
+        let split_id = split.id();
+        if let SplitImpl::Datagen(n) = split {
+            if let Some(s) = n.start_offset {
+                // start_offset in `SplitImpl` indicates the latest successfully generated
+                // index, so here we use start_offset+1
+                events_so_far = s + 1;
+            };
+            assigned_split = n;
         }
 
         let split_index = assigned_split.split_index as u64;
@@ -107,7 +117,7 @@ impl SplitReader for DatagenSplitReader {
             fields_map,
             rows_per_second,
             events_so_far,
-            split_id,
+            split_id.clone(),
             split_num,
             split_index,
         )?;
@@ -115,10 +125,14 @@ impl SplitReader for DatagenSplitReader {
         Ok(DatagenSplitReader {
             generator,
             assigned_split,
+            split_id,
+            parser_config,
+            metrics,
+            source_info,
         })
     }
 
-    fn into_stream(self) -> BoxSourceStream {
+    pub(crate) fn into_data_stream(self) -> BoxSourceStream {
         // Will buffer at most 4 event chunks.
         const BUFFER_SIZE: usize = 4;
         spawn_data_generation_stream(self.generator.into_stream(), BUFFER_SIZE).boxed()
@@ -261,11 +275,11 @@ mod tests {
                 })),
             },
         ];
-        let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
+        let state = vec![SplitImpl::Datagen(DatagenSplit {
             split_index: 0,
             split_num: 1,
             start_offset: None,
-        })]);
+        })];
         let properties = DatagenProperties {
             split_num: None,
             rows_per_second: 10,
@@ -288,9 +302,16 @@ mod tests {
             )),
         };
 
-        let mut reader = DatagenSplitReader::new(properties, state, Some(mock_datum))
-            .await?
-            .into_stream();
+        let mut reader = DatagenSplitReader::new(
+            properties,
+            state,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Some(mock_datum),
+        )
+        .await?
+        .into_data_stream();
 
         let msg = reader.next().await.unwrap().unwrap();
         assert_eq!(
@@ -313,29 +334,44 @@ mod tests {
                 data_type: DataType::Int32,
             },
         ];
-        let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
+        let state = vec![SplitImpl::Datagen(DatagenSplit {
             split_index: 0,
             split_num: 1,
             start_offset: None,
-        })]);
+        })];
         let properties = DatagenProperties {
             split_num: None,
             rows_per_second: 10,
             fields: HashMap::new(),
         };
-        let stream = DatagenSplitReader::new(properties.clone(), state, Some(mock_datum.clone()))
-            .await?
-            .into_stream();
+        let stream = DatagenSplitReader::new(
+            properties.clone(),
+            state,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Some(mock_datum.clone()),
+        )
+        .await?
+        .into_data_stream();
+
         let v1 = stream.skip(1).next().await.unwrap()?;
 
-        let state = Some(vec![SplitImpl::Datagen(DatagenSplit {
+        let state = vec![SplitImpl::Datagen(DatagenSplit {
             split_index: 0,
             split_num: 1,
             start_offset: Some(9),
-        })]);
-        let mut stream = DatagenSplitReader::new(properties, state, Some(mock_datum))
-            .await?
-            .into_stream();
+        })];
+        let mut stream = DatagenSplitReader::new(
+            properties,
+            state,
+            Default::default(),
+            Default::default(),
+            Default::default(),
+            Some(mock_datum),
+        )
+        .await?
+        .into_data_stream();
         let v2 = stream.next().await.unwrap()?;
 
         assert_eq!(v1, v2);

--- a/src/connector/src/source/dummy_connector.rs
+++ b/src/connector/src/source/dummy_connector.rs
@@ -21,31 +21,12 @@ use futures::StreamExt;
 use super::monitor::SourceMetrics;
 use super::{SourceInfo, SplitImpl, SplitReaderV2};
 use crate::parser::ParserConfig;
-use crate::source::{
-    BoxSourceStream, BoxSourceWithStateStream, Column, ConnectorState, SplitReader,
-};
+use crate::source::{BoxSourceWithStateStream, Column};
 
 /// [`DummySplitReader`] is a placeholder for source executor that is assigned no split. It will
 /// wait forever when calling `next`.
 #[derive(Clone, Debug)]
 pub struct DummySplitReader;
-
-#[async_trait]
-impl SplitReader for DummySplitReader {
-    type Properties = ();
-
-    async fn new(
-        _properties: Self::Properties,
-        _state: ConnectorState,
-        _columns: Option<Vec<Column>>,
-    ) -> Result<Self> {
-        Ok(Self {})
-    }
-
-    fn into_stream(self) -> BoxSourceStream {
-        futures::stream::pending().boxed()
-    }
-}
 
 #[async_trait]
 impl SplitReaderV2 for DummySplitReader {
@@ -57,6 +38,7 @@ impl SplitReaderV2 for DummySplitReader {
         _parser_config: ParserConfig,
         _metrics: Arc<SourceMetrics>,
         _source_info: SourceInfo,
+        _columns: Option<Vec<Column>>,
     ) -> Result<Self> {
         Ok(Self {})
     }

--- a/src/connector/src/source/google_pubsub/source/reader.rs
+++ b/src/connector/src/source/google_pubsub/source/reader.rs
@@ -12,33 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use anyhow::{anyhow, ensure, Context, Result};
 use async_trait::async_trait;
 use chrono::{NaiveDateTime, TimeZone, Utc};
+use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use google_cloud_pubsub::client::Client;
 use google_cloud_pubsub::subscription::{SeekTo, Subscription};
-use risingwave_common::{bail, try_match_expand};
+use risingwave_common::bail;
 use tonic::Code;
 
 use super::TaggedReceivedMessage;
+use crate::impl_common_split_reader_logic;
+use crate::parser::ParserConfig;
 use crate::source::google_pubsub::PubsubProperties;
-use crate::source::{
-    BoxSourceStream, Column, ConnectorState, SourceMessage, SplitId, SplitImpl, SplitMetaData,
-    SplitReader,
-};
+use crate::source::monitor::SourceMetrics;
+use crate::source::{Column, SourceInfo, SourceMessage, SplitId, SplitImpl, SplitMetaData};
 
 const PUBSUB_MAX_FETCH_MESSAGES: usize = 1024;
 
+impl_common_split_reader_logic!(PubsubSplitReader, PubsubProperties);
+
 pub struct PubsubSplitReader {
     subscription: Subscription,
-    split_id: SplitId,
     stop_offset: Option<NaiveDateTime>,
+
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    metrics: Arc<SourceMetrics>,
+    source_info: SourceInfo,
 }
 
 impl PubsubSplitReader {
     #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
-    pub async fn into_stream(self) {
+    async fn into_data_stream(self) {
         loop {
             let pull_result = self
                 .subscription
@@ -100,22 +109,25 @@ impl PubsubSplitReader {
     }
 }
 
-#[async_trait]
-impl SplitReader for PubsubSplitReader {
-    type Properties = PubsubProperties;
-
+impl PubsubSplitReader {
     async fn new(
         properties: PubsubProperties,
-        state: ConnectorState,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        metrics: Arc<SourceMetrics>,
+        source_info: SourceInfo,
         _columns: Option<Vec<Column>>,
     ) -> Result<Self> {
-        let splits = state.ok_or_else(|| anyhow!("no default state for reader"))?;
         ensure!(
             splits.len() == 1,
             "the pubsub reader only supports a single split"
         );
-        let split = try_match_expand!(splits.into_iter().next().unwrap(), SplitImpl::GooglePubsub)
-            .map_err(|e| anyhow!(e))?;
+        let split = splits
+            .into_iter()
+            .next()
+            .unwrap()
+            .into_google_pubsub()
+            .unwrap();
 
         // Set environment variables consumed by `google_cloud_pubsub`
         properties.initialize_env();
@@ -152,10 +164,9 @@ impl SplitReader for PubsubSplitReader {
             subscription,
             split_id: split.id(),
             stop_offset,
+            parser_config,
+            metrics,
+            source_info,
         })
-    }
-
-    fn into_stream(self) -> BoxSourceStream {
-        self.into_stream()
     }
 }

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, Result};
@@ -21,15 +22,19 @@ use aws_sdk_kinesis::model::ShardIteratorType;
 use aws_sdk_kinesis::output::GetRecordsOutput;
 use aws_sdk_kinesis::types::SdkError;
 use aws_sdk_kinesis::Client as KinesisClient;
+use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use tokio_retry;
 
+use crate::impl_common_split_reader_logic;
+use crate::parser::ParserConfig;
 use crate::source::kinesis::source::message::KinesisMessage;
 use crate::source::kinesis::split::KinesisOffset;
 use crate::source::kinesis::KinesisProperties;
-use crate::source::{
-    BoxSourceStream, Column, ConnectorState, SourceMessage, SplitId, SplitImpl, SplitReader,
-};
+use crate::source::monitor::SourceMetrics;
+use crate::source::{Column, SourceInfo, SourceMessage, SplitId, SplitImpl, SplitMetaData};
+
+impl_common_split_reader_logic!(KinesisSplitReader, KinesisProperties);
 
 #[derive(Debug, Clone)]
 pub struct KinesisSplitReader {
@@ -40,21 +45,25 @@ pub struct KinesisSplitReader {
     shard_iter: Option<String>,
     start_position: KinesisOffset,
     end_position: KinesisOffset,
+
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    metrics: Arc<SourceMetrics>,
+    source_info: SourceInfo,
 }
 
-#[async_trait]
-impl SplitReader for KinesisSplitReader {
-    type Properties = KinesisProperties;
-
+impl KinesisSplitReader {
     async fn new(
         properties: KinesisProperties,
-        state: ConnectorState,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        metrics: Arc<SourceMetrics>,
+        source_info: SourceInfo,
         _columns: Option<Vec<Column>>,
     ) -> Result<Self> {
-        let split = match state.unwrap().into_iter().next().unwrap() {
-            SplitImpl::Kinesis(ks) => ks,
-            split => return Err(anyhow!("expect KinesisSplit, got {:?}", split)),
-        };
+        assert!(splits.len() == 1);
+
+        let split = splits.into_iter().next().unwrap().into_kinesis().unwrap();
 
         let start_position = match &split.start_position {
             KinesisOffset::None => match &properties.scan_startup_mode {
@@ -82,6 +91,7 @@ impl SplitReader for KinesisSplitReader {
         let stream_name = properties.common.stream_name.clone();
         let client = properties.common.build_client().await?;
 
+        let split_id = split.id();
         Ok(Self {
             client,
             stream_name,
@@ -90,17 +100,17 @@ impl SplitReader for KinesisSplitReader {
             latest_offset: None,
             start_position,
             end_position: split.end_position,
+            split_id,
+            parser_config,
+            metrics,
+            source_info,
         })
-    }
-
-    fn into_stream(self) -> BoxSourceStream {
-        self.into_stream()
     }
 }
 
 impl KinesisSplitReader {
     #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
-    pub async fn into_stream(mut self) {
+    pub(crate) async fn into_data_stream(mut self) {
         self.new_shard_iter().await?;
         loop {
             if self.shard_iter.is_none() {
@@ -272,30 +282,36 @@ mod tests {
 
         let mut trim_horizen_reader = KinesisSplitReader::new(
             properties.clone(),
-            Some(vec![SplitImpl::Kinesis(KinesisSplit {
+            vec![SplitImpl::Kinesis(KinesisSplit {
                 shard_id: "shardId-000000000001".to_string().into(),
                 start_position: KinesisOffset::Earliest,
                 end_position: KinesisOffset::None,
-            })]),
+            })],
+            Default::default(),
+            Default::default(),
+            Default::default(),
             None,
         )
         .await?
-        .into_stream();
+        .into_data_stream();
         println!("{:?}", trim_horizen_reader.next().await.unwrap()?);
 
         let mut offset_reader = KinesisSplitReader::new(
             properties.clone(),
-            Some(vec![SplitImpl::Kinesis(KinesisSplit {
+            vec![SplitImpl::Kinesis(KinesisSplit {
                 shard_id: "shardId-000000000001".to_string().into(),
                 start_position: KinesisOffset::SequenceNumber(
                     "49629139817504901062972448413535783695568426186596941842".to_string(),
                 ),
                 end_position: KinesisOffset::None,
-            })]),
+            })],
+            Default::default(),
+            Default::default(),
+            Default::default(),
             None,
         )
         .await?
-        .into_stream();
+        .into_data_stream();
         println!("{:?}", offset_reader.next().await.unwrap()?);
 
         Ok(())

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Singularity Data
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/connector/src/source/mod.rs
+++ b/src/connector/src/source/mod.rs
@@ -1,6 +1,4 @@
-use std::collections::HashMap;
-
-// Copyright 2023 RisingWave Labs
+// Copyright 2023 Singularity Data
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,10 +11,10 @@ use std::collections::HashMap;
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use futures::stream::BoxStream;
 
 pub mod base;
 pub mod cdc;
+pub mod data_gen_util;
 pub mod datagen;
 pub mod dummy_connector;
 pub mod filesystem;
@@ -30,59 +28,8 @@ pub use base::*;
 pub use google_pubsub::GOOGLE_PUBSUB_CONNECTOR;
 pub use kafka::KAFKA_CONNECTOR;
 pub use kinesis::KINESIS_CONNECTOR;
-use risingwave_common::array::StreamChunk;
-use risingwave_common::catalog::TableId;
 mod manager;
 pub use manager::SourceColumnDesc;
-use risingwave_common::error::RwError;
 
 pub use crate::source::nexmark::NEXMARK_CONNECTOR;
 pub use crate::source::pulsar::PULSAR_CONNECTOR;
-
-#[derive(Clone, Copy, Debug, Default)]
-pub struct SourceInfo {
-    pub actor_id: u32,
-    pub source_id: TableId,
-}
-
-impl SourceInfo {
-    pub fn new(actor_id: u32, source_id: TableId) -> Self {
-        SourceInfo {
-            actor_id,
-            source_id,
-        }
-    }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum SourceFormat {
-    Invalid,
-    Json,
-    Protobuf,
-    DebeziumJson,
-    Avro,
-    Maxwell,
-    CanalJson,
-    Csv,
-}
-
-pub type BoxSourceWithStateStream = BoxStream<'static, Result<StreamChunkWithState, RwError>>;
-
-/// [`StreamChunkWithState`] returns stream chunk together with offset for each split. In the
-/// current design, one connector source can have multiple split reader. The keys are unique
-/// `split_id` and values are the latest offset for each split.
-#[derive(Clone, Debug)]
-pub struct StreamChunkWithState {
-    pub chunk: StreamChunk,
-    pub split_offset_mapping: Option<HashMap<SplitId, String>>,
-}
-
-/// The `split_offset_mapping` field is unused for the table source, so we implement `From` for it.
-impl From<StreamChunk> for StreamChunkWithState {
-    fn from(chunk: StreamChunk) -> Self {
-        Self {
-            chunk,
-            split_offset_mapping: None,
-        }
-    }
-}

--- a/src/connector/src/source/nexmark/source/reader.rs
+++ b/src/connector/src/source/nexmark/source/reader.rs
@@ -12,63 +12,66 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
-use itertools::Itertools;
 use nexmark::config::NexmarkConfig;
 use nexmark::event::EventType;
 use nexmark::EventGenerator;
 use tokio::time::Instant;
 
+use crate::impl_common_split_reader_logic;
+use crate::parser::ParserConfig;
+use crate::source::data_gen_util::spawn_data_generation_stream;
+use crate::source::monitor::SourceMetrics;
 use crate::source::nexmark::source::message::NexmarkMessage;
 use crate::source::nexmark::{NexmarkProperties, NexmarkSplit};
 use crate::source::{
-    spawn_data_generation_stream, BoxSourceStream, Column, ConnectorState, SourceMessage, SplitId,
-    SplitMetaData, SplitReader,
+    BoxSourceStream, Column, SourceInfo, SourceMessage, SplitId, SplitImpl, SplitMetaData,
 };
+
+impl_common_split_reader_logic!(NexmarkSplitReader, NexmarkProperties);
 
 #[derive(Debug)]
 pub struct NexmarkSplitReader {
     generator: EventGenerator,
     assigned_split: NexmarkSplit,
-    split_id: SplitId,
     event_num: u64,
     event_type: Option<EventType>,
     use_real_time: bool,
     min_event_gap_in_ns: u64,
     max_chunk_size: u64,
+
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    metrics: Arc<SourceMetrics>,
+    source_info: SourceInfo,
 }
 
-#[async_trait]
-impl SplitReader for NexmarkSplitReader {
-    type Properties = NexmarkProperties;
-
+impl NexmarkSplitReader {
+    #[allow(clippy::unused_async)]
     async fn new(
         properties: NexmarkProperties,
-        state: ConnectorState,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        metrics: Arc<SourceMetrics>,
+        source_info: SourceInfo,
         _columns: Option<Vec<Column>>,
     ) -> Result<Self> {
-        let mut assigned_split = NexmarkSplit::default();
-        let mut split_id = "".into();
-        let mut split_num = 1;
-        let mut offset = 0;
+        tracing::debug!("Splits for nexmark found! {:?}", splits);
+        assert!(splits.len() == 1);
+        // TODO: currently, assume there's only one split in one reader
+        let split = splits.into_iter().next().unwrap().into_nexmark().unwrap();
+        let split_id = split.id();
 
-        if let Some(splits) = state {
-            tracing::debug!("Splits for nexmark found! {:?}", splits);
-            // TODO: currently, assume there's only one split in one reader
-            let split = splits.into_iter().exactly_one().unwrap();
-            split_id = split.id();
-            let split = split.into_nexmark().unwrap();
-
-            let split_index = split.split_index as u64;
-            split_num = split.split_num as u64;
-            offset = split.start_offset.unwrap_or(split_index);
-            assigned_split = split;
-        }
+        let split_index = split.split_index as u64;
+        let split_num = split.split_num as u64;
+        let offset = split.start_offset.unwrap_or(split_index);
+        let assigned_split = split;
 
         let mut generator = EventGenerator::new(NexmarkConfig::from(&*properties))
             .with_offset(offset)
@@ -88,19 +91,22 @@ impl SplitReader for NexmarkSplitReader {
             event_type: properties.table_type,
             use_real_time: properties.use_real_time,
             min_event_gap_in_ns: properties.min_event_gap_in_ns,
+            parser_config,
+            metrics,
+            source_info,
         })
-    }
-
-    fn into_stream(self) -> BoxSourceStream {
-        // Will buffer at most 4 event chunks.
-        const BUFFER_SIZE: usize = 4;
-        spawn_data_generation_stream(self.into_stream(), BUFFER_SIZE).boxed()
     }
 }
 
 impl NexmarkSplitReader {
+    fn into_data_stream(self) -> BoxSourceStream {
+        // Will buffer at most 4 event chunks.
+        const BUFFER_SIZE: usize = 4;
+        spawn_data_generation_stream(self.into_data_stream_inner(), BUFFER_SIZE).boxed()
+    }
+
     #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
-    async fn into_stream(mut self) {
+    async fn into_data_stream_inner(mut self) {
         let start_time = Instant::now();
         let start_offset = self.generator.global_offset();
         let start_ts = self.generator.timestamp();
@@ -179,10 +185,17 @@ mod tests {
         assert_eq!(list_splits_resp.len(), 2);
 
         for split in list_splits_resp {
-            let state = Some(vec![split]);
-            let mut reader = NexmarkSplitReader::new(props.clone(), state, None)
-                .await?
-                .into_stream();
+            let state = vec![split];
+            let mut reader = NexmarkSplitReader::new(
+                props.clone(),
+                state,
+                Default::default(),
+                Default::default(),
+                Default::default(),
+                None,
+            )
+            .await?
+            .into_data_stream();
             let _chunk = reader.next().await.unwrap()?;
         }
 

--- a/src/connector/src/source/pulsar/source/reader.rs
+++ b/src/connector/src/source/pulsar/source/reader.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, ensure, Result};
 use async_trait::async_trait;
-use futures::StreamExt;
+use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use pulsar::consumer::InitialPosition;
@@ -24,16 +25,26 @@ use pulsar::message::proto::MessageIdData;
 use pulsar::{Consumer, ConsumerBuilder, ConsumerOptions, Pulsar, SubType, TokioExecutor};
 use risingwave_common::try_match_expand;
 
+use crate::impl_common_split_reader_logic;
+use crate::parser::ParserConfig;
+use crate::source::monitor::SourceMetrics;
 use crate::source::pulsar::split::PulsarSplit;
 use crate::source::pulsar::{PulsarEnumeratorOffset, PulsarProperties};
 use crate::source::{
-    BoxSourceStream, Column, ConnectorState, SourceMessage, SplitImpl, SplitReader, MAX_CHUNK_SIZE,
+    Column, SourceInfo, SourceMessage, SplitId, SplitImpl, SplitMetaData, MAX_CHUNK_SIZE,
 };
+
+impl_common_split_reader_logic!(PulsarSplitReader, PulsarProperties);
 
 pub struct PulsarSplitReader {
     pulsar: Pulsar<TokioExecutor>,
     consumer: Consumer<Vec<u8>, TokioExecutor>,
     split: PulsarSplit,
+
+    split_id: SplitId,
+    parser_config: ParserConfig,
+    metrics: Arc<SourceMetrics>,
+    source_info: SourceInfo,
 }
 
 // {ledger_id}:{entry_id}:{partition}:{batch_index}
@@ -78,16 +89,15 @@ fn parse_message_id(id: &str) -> Result<MessageIdData> {
     Ok(message_id)
 }
 
-#[async_trait]
-impl SplitReader for PulsarSplitReader {
-    type Properties = PulsarProperties;
-
+impl PulsarSplitReader {
     async fn new(
         props: PulsarProperties,
-        state: ConnectorState,
+        splits: Vec<SplitImpl>,
+        parser_config: ParserConfig,
+        metrics: Arc<SourceMetrics>,
+        source_info: SourceInfo,
         _columns: Option<Vec<Column>>,
     ) -> Result<Self> {
-        let splits = state.ok_or_else(|| anyhow!("no default state for reader"))?;
         ensure!(splits.len() == 1, "only support single split");
         let split = try_match_expand!(splits.into_iter().next().unwrap(), SplitImpl::Pulsar)?;
 
@@ -140,18 +150,18 @@ impl SplitReader for PulsarSplitReader {
         Ok(Self {
             pulsar,
             consumer,
+            split_id: split.id(),
             split,
+            parser_config,
+            metrics,
+            source_info,
         })
-    }
-
-    fn into_stream(self) -> BoxSourceStream {
-        self.into_stream()
     }
 }
 
 impl PulsarSplitReader {
     #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
-    pub async fn into_stream(self) {
+    pub(crate) async fn into_data_stream(self) {
         #[for_await]
         for msgs in self.consumer.ready_chunks(MAX_CHUNK_SIZE) {
             let mut res = Vec::with_capacity(msgs.len());

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -20,7 +20,7 @@ use risingwave_common::catalog::ColumnDesc;
 use risingwave_common::error::ErrorCode::{self, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
-use risingwave_connector::parser::{AvroParser, ProtobufParser};
+use risingwave_connector::parser::{AvroParserConfig, ProtobufParserConfig};
 use risingwave_connector::source::KAFKA_CONNECTOR;
 use risingwave_pb::catalog::{
     ColumnIndex as ProstColumnIndex, Source as ProstSource, StreamSourceInfo,
@@ -44,10 +44,10 @@ async fn extract_avro_table_schema(
     schema: &AvroSchema,
     with_properties: HashMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let parser = AvroParser::new(
+    let parser = AvroParserConfig::new(
+        &with_properties,
         schema.row_schema_location.0.as_str(),
         schema.use_schema_registry,
-        with_properties,
     )
     .await?;
     let vec_column_desc = parser.map_to_columns()?;
@@ -65,11 +65,11 @@ async fn extract_protobuf_table_schema(
     schema: &ProtobufSchema,
     with_properties: HashMap<String, String>,
 ) -> Result<Vec<ColumnCatalog>> {
-    let parser = ProtobufParser::new(
+    let parser = ProtobufParserConfig::new(
+        &with_properties,
         &schema.row_schema_location.0,
         &schema.message_name.0,
         schema.use_schema_registry,
-        with_properties,
     )
     .await?;
     let column_descs = parser.map_to_columns()?;

--- a/src/source/benches/json_parser.rs
+++ b/src/source/benches/json_parser.rs
@@ -17,7 +17,7 @@ use rand::distributions::Alphanumeric;
 use rand::prelude::*;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::types::{DataType, NaiveDateTimeWrapper, NaiveDateWrapper};
-use risingwave_connector::parser::{JsonParser, SourceParser, SourceStreamChunkBuilder};
+use risingwave_connector::parser::{JsonParser, SourceStreamChunkBuilder};
 use risingwave_connector::source::SourceColumnDesc;
 
 const NUM_RECORDS: usize = 1 << 18; // ~ 250,000
@@ -130,7 +130,7 @@ fn get_descs() -> Vec<SourceColumnDesc> {
 
 fn bench_json_parser(c: &mut Criterion) {
     let descs = get_descs();
-    let parser = JsonParser {};
+    let parser = JsonParser::new(descs.clone()).unwrap();
     let records = generate_all_json();
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -141,7 +141,7 @@ fn bench_json_parser(c: &mut Criterion) {
             let mut builder = SourceStreamChunkBuilder::with_capacity(descs.clone(), NUM_RECORDS);
             for record in &records {
                 let writer = builder.row_writer();
-                parser.parse(record, writer).await.unwrap();
+                parser.parse_inner(record, writer).await.unwrap();
             }
         })
     });

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -16,219 +16,47 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use futures::future::try_join_all;
-use futures::stream::BoxStream;
 use futures::StreamExt;
-use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::error::ErrorCode::ConnectorError;
-use risingwave_common::error::{internal_error, Result, RwError, ToRwResult};
-use risingwave_common::types::Datum;
+use risingwave_common::error::{internal_error, Result};
 use risingwave_common::util::select_all;
-use risingwave_connector::parser::{SourceParserImpl, SourceStreamChunkBuilder};
+use risingwave_connector::parser::{CommonParserConfig, ParserConfig, SpecificParserConfig};
 use risingwave_connector::source::monitor::SourceMetrics;
 use risingwave_connector::source::{
-    Column, ConnectorProperties, ConnectorState, SourceColumnDesc, SourceFormat, SourceInfo,
-    SourceMessage, SourceMeta, SplitId, SplitMetaData, SplitReaderImpl, StreamChunkWithState,
+    BoxSourceWithStateStream, Column, ConnectorProperties, ConnectorState, SourceColumnDesc,
+    SourceInfo, SplitReaderV2Impl,
 };
-use risingwave_expr::vector_op::cast::i64_to_timestamptz;
-
-fn default_split_id() -> SplitId {
-    "None".into()
-}
-
-struct InnerConnectorSourceReader {
-    reader: SplitReaderImpl,
-    // split should be None or only contains one value
-    split: ConnectorState,
-
-    metrics: Arc<SourceMetrics>,
-    source_info: SourceInfo,
-}
-
-/// [`ConnectorSource`] serves as a bridge between external components and streaming or
-/// batch processing. [`ConnectorSource`] introduces schema at this level while
-/// [`SplitReaderImpl`] simply loads raw content from message queue or file system.
-/// Parallel means that multiple [`InnerConnectorSourceReader`] will run in parallel during the
-/// `next`, so that 0 or more Splits reads can be handled at the Source level.
-pub struct ConnectorSourceReader {
-    parser: Arc<SourceParserImpl>,
-    columns: Vec<SourceColumnDesc>,
-
-    // merge all streams of inner reader into one
-    // TODO: make this static dispatch instead of box
-    stream: BoxStream<'static, Result<Vec<SourceMessage>>>,
-}
-
-impl InnerConnectorSourceReader {
-    async fn new(
-        prop: ConnectorProperties,
-        split: ConnectorState,
-        columns: Vec<SourceColumnDesc>,
-        metrics: Arc<SourceMetrics>,
-        source_info: SourceInfo,
-    ) -> Result<Self> {
-        tracing::debug!(
-            "Spawning new connector source inner reader with config {:?}, split {:?}",
-            prop,
-            split
-        );
-
-        // Here is a workaround, we now provide the vec with only one element
-        let reader = SplitReaderImpl::create(
-            prop,
-            split.clone(),
-            Some(
-                columns
-                    .iter()
-                    .cloned()
-                    .map(|col| Column {
-                        name: col.name,
-                        data_type: col.data_type,
-                    })
-                    .collect_vec(),
-            ),
-        )
-        .await
-        .to_rw_result()?;
-
-        Ok(InnerConnectorSourceReader {
-            reader,
-            split,
-            metrics,
-            source_info,
-        })
-    }
-
-    #[try_stream(boxed, ok = Vec<SourceMessage>, error = RwError)]
-    async fn into_stream(self) {
-        let actor_id = self.source_info.actor_id.to_string();
-        let source_id = self.source_info.source_id.to_string();
-        let id = match &self.split {
-            Some(splits) => splits[0].id(),
-            None => default_split_id(),
-        };
-        #[for_await]
-        for msgs in self.reader.into_stream() {
-            let msgs = msgs?;
-            self.metrics
-                .partition_input_count
-                .with_label_values(&[&actor_id, &source_id, &id])
-                .inc_by(msgs.len() as u64);
-            let sum_bytes = msgs
-                .iter()
-                .map(|msg| match &msg.payload {
-                    None => 0,
-                    Some(payload) => payload.len() as u64,
-                })
-                .sum();
-            self.metrics
-                .partition_input_bytes
-                .with_label_values(&[&actor_id, &source_id, &id])
-                .inc_by(sum_bytes);
-            yield msgs;
-        }
-    }
-}
-
-impl ConnectorSourceReader {
-    #[try_stream(boxed, ok = StreamChunkWithState, error = RwError)]
-    pub async fn into_stream(self) {
-        #[for_await]
-        for batch in self.stream {
-            let batch = batch?;
-            let mut builder =
-                SourceStreamChunkBuilder::with_capacity(self.columns.clone(), batch.len());
-            let mut split_offset_mapping: HashMap<SplitId, String> = HashMap::new();
-
-            for msg in batch {
-                if let Some(content) = msg.payload {
-                    split_offset_mapping.insert(msg.split_id, msg.offset);
-
-                    let old_op_num = builder.op_num();
-
-                    if let Err(e) = self
-                        .parser
-                        .parse(content.as_ref(), builder.row_writer())
-                        .await
-                    {
-                        tracing::warn!("message parsing failed {}, skipping", e.to_string());
-                        continue;
-                    }
-
-                    let new_op_num = builder.op_num();
-
-                    // new_op_num - old_op_num is the number of rows added to the builder
-                    for _ in old_op_num..new_op_num {
-                        // TODO: support more kinds of SourceMeta
-                        if let SourceMeta::Kafka(kafka_meta) = msg.meta.clone() {
-                            let f = |desc: &SourceColumnDesc| -> Option<Datum> {
-                                if !desc.is_meta {
-                                    return None;
-                                }
-                                match desc.name.as_str() {
-                                    "_rw_kafka_timestamp" => Some(
-                                        kafka_meta
-                                            .timestamp
-                                            .map(|ts| i64_to_timestamptz(ts).unwrap().into()),
-                                    ),
-                                    _ => unreachable!(
-                                        "kafka will not have this meta column: {}",
-                                        desc.name
-                                    ),
-                                }
-                            };
-                            builder.row_writer().fulfill_meta_column(f)?;
-                        }
-                    }
-                }
-            }
-            yield StreamChunkWithState {
-                chunk: builder.finish(),
-                split_offset_mapping: Some(split_offset_mapping),
-            };
-        }
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct ConnectorSource {
     pub config: ConnectorProperties,
     pub columns: Vec<SourceColumnDesc>,
-    pub parser: Arc<SourceParserImpl>,
+    // pub parser: Arc<SourceParserImpl>,
+    pub parser_config: SpecificParserConfig,
     pub connector_message_buffer_size: usize,
 }
 
 impl ConnectorSource {
-    #[allow(clippy::too_many_arguments)]
-    pub async fn new(
-        format: SourceFormat,
-        row_schema_location: &str,
-        use_schema_registry: bool,
-        proto_message_name: String,
+    pub fn new(
         properties: HashMap<String, String>,
         columns: Vec<SourceColumnDesc>,
         connector_node_addr: Option<String>,
         connector_message_buffer_size: usize,
+        parser_config: SpecificParserConfig,
     ) -> Result<Self> {
-        let mut config = ConnectorProperties::extract(properties.clone())
-            .map_err(|e| ConnectorError(e.into()))?;
+        let mut config =
+            ConnectorProperties::extract(properties).map_err(|e| ConnectorError(e.into()))?;
         if let Some(addr) = connector_node_addr {
             // fixme: require source_id
             config.init_properties_for_cdc(0, addr, None)
         }
-        let parser = SourceParserImpl::create(
-            &format,
-            &properties,
-            row_schema_location,
-            use_schema_registry,
-            proto_message_name,
-        )
-        .await?;
+
         Ok(Self {
             config,
             columns,
-            parser,
+            parser_config,
             connector_message_buffer_size,
         })
     }
@@ -257,7 +85,7 @@ impl ConnectorSource {
         column_ids: Vec<ColumnId>,
         metrics: Arc<SourceMetrics>,
         source_info: SourceInfo,
-    ) -> Result<ConnectorSourceReader> {
+    ) -> Result<BoxSourceWithStateStream> {
         let config = self.config.clone();
         let columns = self.get_target_columns(column_ids)?;
         let source_metrics = metrics.clone();
@@ -269,23 +97,44 @@ impl ConnectorSource {
                 .collect::<Vec<ConnectorState>>(),
             None => vec![None],
         };
-        let readers = try_join_all(to_reader_splits.into_iter().map(|split| {
-            tracing::debug!("spawning connector split reader for split {:?}", split);
+        let readers = try_join_all(to_reader_splits.into_iter().map(|state| {
+            tracing::debug!("spawning connector split reader for split {:?}", state);
             let props = config.clone();
             let columns = columns.clone();
+            let data_gen_columns = Some(
+                columns
+                    .iter()
+                    .cloned()
+                    .map(|col| Column {
+                        name: col.name,
+                        data_type: col.data_type,
+                    })
+                    .collect_vec(),
+            );
             let metrics = source_metrics.clone();
+
             async move {
-                InnerConnectorSourceReader::new(props, split, columns, metrics, source_info).await
+                // InnerConnectorSourceReader::new(props, split, columns, metrics,
+                // source_info).await
+                let parser_config = ParserConfig {
+                    specific: self.parser_config.clone(),
+                    common: CommonParserConfig {
+                        rw_columns: columns,
+                    },
+                };
+                SplitReaderV2Impl::create(
+                    props,
+                    state,
+                    parser_config,
+                    metrics,
+                    source_info,
+                    data_gen_columns,
+                )
+                .await
             }
         }))
         .await?;
 
-        let stream = select_all(readers.into_iter().map(|r| r.into_stream())).boxed();
-
-        Ok(ConnectorSourceReader {
-            parser: self.parser.clone(),
-            columns,
-            stream,
-        })
+        Ok(select_all(readers.into_iter().map(|r| r.into_stream())).boxed())
     }
 }

--- a/src/source/src/fs_connector_source.rs
+++ b/src/source/src/fs_connector_source.rs
@@ -21,8 +21,7 @@ use risingwave_common::error::{internal_error, Result, RwError};
 use risingwave_connector::parser::{CommonParserConfig, ParserConfig, SpecificParserConfig};
 use risingwave_connector::source::monitor::SourceMetrics;
 use risingwave_connector::source::{
-    ConnectorProperties, ConnectorState, SourceColumnDesc, SourceFormat, SourceInfo,
-    SplitReaderV2Impl,
+    ConnectorProperties, ConnectorState, SourceColumnDesc, SourceInfo, SplitReaderV2Impl,
 };
 
 #[derive(Clone, Debug)]
@@ -30,14 +29,12 @@ pub struct FsConnectorSource {
     pub config: ConnectorProperties,
     pub columns: Vec<SourceColumnDesc>,
     pub properties: HashMap<String, String>,
-    pub format: SourceFormat,
     pub parser_config: SpecificParserConfig,
 }
 
 impl FsConnectorSource {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        format: SourceFormat,
         properties: HashMap<String, String>,
         columns: Vec<SourceColumnDesc>,
         connector_node_addr: Option<String>,
@@ -55,7 +52,6 @@ impl FsConnectorSource {
             config,
             columns,
             properties,
-            format,
             parser_config,
         })
     }
@@ -91,7 +87,6 @@ impl FsConnectorSource {
         let parser_config = ParserConfig {
             specific: self.parser_config.clone(),
             common: CommonParserConfig {
-                props: self.properties.clone(),
                 rw_columns: columns,
             },
         };

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -98,8 +98,7 @@ impl SourceDescBuilder {
             ProstRowFormatType::Avro => SourceFormat::Avro,
             ProstRowFormatType::Maxwell => SourceFormat::Maxwell,
             ProstRowFormatType::CanalJson => SourceFormat::CanalJson,
-            ProstRowFormatType::Csv => SourceFormat::Csv,
-            ProstRowFormatType::RowUnspecified => unreachable!(),
+            _ => unreachable!(),
         };
 
         if format == SourceFormat::Protobuf && self.source_info.row_schema_location.is_empty() {
@@ -119,17 +118,16 @@ impl SourceDescBuilder {
             "source should have at least one pk column"
         );
 
+        let psrser_config =
+            SpecificParserConfig::new(format, &self.source_info, &self.properties).await?;
+
         let source = ConnectorSource::new(
-            format.clone(),
-            &self.source_info.row_schema_location,
-            self.source_info.use_schema_registry,
-            self.source_info.proto_message_name,
             self.properties,
             columns.clone(),
             self.connector_params.connector_rpc_endpoint,
             self.connector_message_buffer_size,
-        )
-        .await?;
+            psrser_config,
+        )?;
 
         Ok(SourceDesc {
             source,
@@ -144,7 +142,7 @@ impl SourceDescBuilder {
         self.metrics.clone()
     }
 
-    pub fn build_fs_source_desc(&self) -> Result<FsSourceDesc> {
+    pub async fn build_fs_source_desc(&self) -> Result<FsSourceDesc> {
         let format = match self.source_info.get_row_format()? {
             ProstRowFormatType::Csv => SourceFormat::Csv,
             _ => unreachable!(),
@@ -165,10 +163,10 @@ impl SourceDescBuilder {
             "source should have at least one pk column"
         );
 
-        let parser_config = SpecificParserConfig::new(&format, &self.source_info);
+        let parser_config =
+            SpecificParserConfig::new(format, &self.source_info, &self.properties).await?;
 
         let source = FsConnectorSource::new(
-            format.clone(),
             self.properties.clone(),
             columns.clone(),
             self.connector_params.connector_rpc_endpoint.clone(),

--- a/src/stream/src/executor/source/fs_source_executor.rs
+++ b/src/stream/src/executor/source/fs_source_executor.rs
@@ -24,7 +24,7 @@ use risingwave_connector::source::{
     BoxSourceWithStateStream, ConnectorState, SourceInfo, SplitId, SplitImpl, SplitMetaData,
     StreamChunkWithState,
 };
-use risingwave_source::source_desc::FsSourceDesc;
+use risingwave_source::source_desc::{FsSourceDesc, SourceDescBuilder};
 use risingwave_storage::StateStore;
 use tokio::sync::mpsc::UnboundedReceiver;
 use tokio::time::Instant;
@@ -258,12 +258,12 @@ impl<S: StateStore> FsSourceExecutor<S> {
                 ))
             })?;
 
-        let source_desc = self
-            .stream_source_core
-            .source_desc_builder
-            .take()
-            .unwrap()
+        let source_desc_builder: SourceDescBuilder =
+            self.stream_source_core.source_desc_builder.take().unwrap();
+
+        let source_desc = source_desc_builder
             .build_fs_source_desc()
+            .await
             .map_err(StreamExecutorError::connector_error)?;
 
         // If the first barrier is configuration change, then the source executor must be newly


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->

- migrate all parsers/readers to the new stream based trait

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
#7032