### PR TITLE
ci: upgrade actions/checkout to v3

### DIFF
--- a/.github/workflows/dashboard_main.yml
+++ b/.github/workflows/dashboard_main.yml
@@ -7,7 +7,7 @@ jobs:
   dashboard-ui-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
           node-version: '18'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y make build-essential cmake protobuf-compiler curl openssl libssl-dev libsasl2-dev libcurl4-openssl-dev pkg-config postgresql-client tmux lld

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -12,6 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     name: license-header-check
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Check License Header
       uses: apache/skywalking-eyes/header@main

--- a/.github/workflows/typo.yml
+++ b/.github/workflows/typo.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Actions Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Check spelling of the entire repository
       uses: crate-ci/typos@v1.11.1


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

upgrade actions/checkout to v3

> ANNOTATIONS
> ! Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.