### PR TITLE
fix(meta): Meta node should be identified by its `meta_endpoint` parameter for cluster membership

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -181,8 +181,8 @@ services:
       - meta-node
       - "--listen-addr"
       - "0.0.0.0:5690"
-      - "--host"
-      - meta-node-0
+      - "--meta-endpoint"
+      - "meta-node-0:5690"
       - "--dashboard-host"
       - "0.0.0.0:5691"
       - "--prometheus-host"

--- a/src/meta/src/rpc/follower_svc.rs
+++ b/src/meta/src/rpc/follower_svc.rs
@@ -37,7 +37,7 @@ pub async fn start_follower_srv(
     let leader_srv = LeaderServiceImpl::new(
         election_client,
         MetaLeaderInfo {
-            node_address: address_info.listen_addr.to_string(),
+            node_address: address_info.meta_endpoint.to_string(),
             lease_id: 0,
         },
     );

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -190,7 +190,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             election_client.leader().await.unwrap().unwrap().into()
         } else {
             MetaLeaderInfo {
-                node_address: address_info.meta_endpoint.clone().to_string(),
+                node_address: address_info.meta_endpoint.clone(),
                 lease_id: 0,
             }
         };

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -41,8 +41,7 @@ pub enum MetaStoreBackend {
 
 #[derive(Clone)]
 pub struct AddressInfo {
-    pub endpoint: String,
-    pub addr: String,
+    pub meta_endpoint: String,
     pub listen_addr: SocketAddr,
     pub prometheus_addr: Option<SocketAddr>,
     pub dashboard_addr: Option<SocketAddr>,
@@ -52,8 +51,7 @@ pub struct AddressInfo {
 impl Default for AddressInfo {
     fn default() -> Self {
         Self {
-            endpoint: "".to_string(),
-            addr: "127.0.0.1:0000".to_string(),
+            meta_endpoint: "".to_string(),
             listen_addr: SocketAddr::V4("127.0.0.1:0000".parse().unwrap()),
             prometheus_addr: None,
             dashboard_addr: None,
@@ -91,8 +89,12 @@ pub async fn rpc_serve(
             let meta_store = Arc::new(EtcdMetaStore::new(client));
 
             let election_client = Arc::new(
-                EtcdElectionClient::new(endpoints, Some(options), address_info.endpoint.clone())
-                    .await?,
+                EtcdElectionClient::new(
+                    endpoints,
+                    Some(options),
+                    address_info.meta_endpoint.clone(),
+                )
+                .await?,
             );
 
             rpc_serve_with_store(
@@ -149,10 +151,12 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
 
     let join_handle = tokio::spawn(async move {
         if let Some(election_client) = election_client.clone() {
-            let mut state_watcher = election_client.subscribe();
+            let mut is_leader_watcher = election_client.subscribe();
             let svc_shutdown_rx_clone = svc_shutdown_rx.clone();
             let (follower_shutdown_tx, follower_shutdown_rx) = OneChannel::<()>();
-            let follower_handle: Option<JoinHandle<()>> = if !*state_watcher.borrow() {
+
+            // If not the leader, spawn a follower.
+            let follower_handle: Option<JoinHandle<()>> = if !*is_leader_watcher.borrow() {
                 let address_info_clone = address_info.clone();
 
                 let election_client_ = election_client.clone();
@@ -170,9 +174,9 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
                 None
             };
 
-            while !*state_watcher.borrow_and_update() {
-                if let Err(e) = state_watcher.changed().await {
-                    tracing::error!("state watcher recv failed {}", e.to_string());
+            while !*is_leader_watcher.borrow_and_update() {
+                if let Err(e) = is_leader_watcher.changed().await {
+                    tracing::error!("leader watcher recv failed {}", e.to_string());
                 }
             }
 
@@ -186,7 +190,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             election_client.leader().await.unwrap().unwrap().into()
         } else {
             MetaLeaderInfo {
-                node_address: address_info.listen_addr.clone().to_string(),
+                node_address: address_info.meta_endpoint.clone().to_string(),
                 lease_id: 0,
             }
         };

--- a/src/risedevtool/src/task/meta_node_service.rs
+++ b/src/risedevtool/src/task/meta_node_service.rs
@@ -44,8 +44,8 @@ impl MetaNodeService {
     pub fn apply_command_args(cmd: &mut Command, config: &MetaNodeConfig) -> Result<()> {
         cmd.arg("--listen-addr")
             .arg(format!("{}:{}", config.listen_address, config.port))
-            .arg("--host")
-            .arg(config.address.clone())
+            .arg("--meta-endpoint")
+            .arg(format!("{}:{}", config.address, config.port))
             .arg("--dashboard-host")
             .arg(format!(
                 "{}:{}",

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -152,7 +152,7 @@ impl Cluster {
             &conf.config_path,
             "--listen-addr",
             "0.0.0.0:5690",
-            "--meta_endpoint",
+            "--meta-endpoint",
             "192.168.1.1:5690",
             "--backend",
             "etcd",

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -152,6 +152,8 @@ impl Cluster {
             &conf.config_path,
             "--listen-addr",
             "0.0.0.0:5690",
+            "--meta_endpoint",
+            "192.168.1.1:5690",
             "--backend",
             "etcd",
             "--etcd-endpoints",


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Meta node should be identified by its `meta_endpoint` parameter. Previously, this defaults to the `listen_addr`. The purpose of `meta_endpoint` is to serve as a unique identifier for cluster membership and for leadership election and connecting to leader.  


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

### Types of user-facing changes

Possibly breaks any usage of risingwave that does not pass `meta_endpoint` when running with etcd.
### Release note
Meta node run with etcd must now specify `--meta-endpoint`

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/7526