### PR TITLE
fix(chore): Echo correct setup during sim tests

### DIFF
--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -20,16 +20,16 @@ export LOGDIR=.risingwave/log
 
 mkdir -p $LOGDIR
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, ddl"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, ddl"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation ./e2e_test/ddl/\*\*/\*.slt > $LOGDIR/ddl-{}.log && rm $LOGDIR/ddl-{}.log'
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, streaming"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, streaming"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation ./e2e_test/streaming/\*\*/\*.slt > $LOGDIR/streaming-{}.log && rm $LOGDIR/streaming-{}.log'
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, batch"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation ./e2e_test/batch/\*\*/\*.slt > $LOGDIR/batch-{}.log && rm $LOGDIR/batch-{}.log'
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, kafka source"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, kafka source"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kafka-datadir=./scripts/source/test_data ./e2e_test/source/kafka.slt > $LOGDIR/source-{}.log && rm $LOGDIR/source-{}.log'
 
 echo "--- deterministic simulation e2e, ci-3cn-2fe, parallel, streaming"
@@ -38,5 +38,5 @@ seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation -j 16 ./e2
 echo "--- deterministic simulation e2e, ci-3cn-2fe, parallel, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation -j 16 ./e2e_test/batch/\*\*/\*.slt > $LOGDIR/parallel-batch-{}.log && rm $LOGDIR/parallel-batch-{}.log'
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, fuzzing"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, fuzzing"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --sqlsmith 100 ./src/tests/sqlsmith/tests/testdata > $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'

--- a/ci/scripts/deterministic-recovery-test.sh
+++ b/ci/scripts/deterministic-recovery-test.sh
@@ -14,8 +14,8 @@ export LOGDIR=.risingwave/log
 
 mkdir -p $LOGDIR
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, recovery, streaming"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, recovery, streaming"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill --kill-rate=${KILL_RATE} ./e2e_test/streaming/\*\*/\*.slt > $LOGDIR/recovery-streaming-{}.log && rm $LOGDIR/recovery-streaming-{}.log'
 
-echo "--- deterministic simulation e2e, ci-3cn-1fe, recovery, batch"
+echo "--- deterministic simulation e2e, ci-3cn-2fe, recovery, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kill --kill-rate=${KILL_RATE} ./e2e_test/batch/\*\*/\*.slt > $LOGDIR/recovery-batch-{}.log && rm $LOGDIR/recovery-batch-{}.log'


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

We are using 2 frontend notes by default and not 1 (see [simulation tests args](https://github.com/risingwavelabs/risingwave/blob/8d99f7aedf86d7a3a43eed075c163afee6d1298e/src/tests/simulation/src/main.rs#L43)). Updating echo to reflect that. 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
