### PR TITLE
feat(service-params): add comments for `--state-store` params for `compute-node`, `compactor-node`

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -54,8 +54,8 @@ pub struct ComputeNodeOpts {
     pub client_address: Option<String>,
 
     /// One of:
-    /// 1. `hummock+{object_store}` where `object_store` 
-    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`, 
+    /// 1. `hummock+{object_store}` where `object_store`
+    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`,
     /// `memory` or `memory-shared`.
     /// 2. `in-memory`
     /// 3. `sled://{path}`

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -53,6 +53,12 @@ pub struct ComputeNodeOpts {
     #[clap(long)]
     pub client_address: Option<String>,
 
+    /// One of:
+    /// 1. `hummock+{object_store}` where `object_store` 
+    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`, 
+    /// `memory` or `memory-shared`.
+    /// 2. `in-memory`
+    /// 3. `sled://{path}`
     #[clap(long, default_value = "hummock+memory")]
     pub state_store: String,
 

--- a/src/storage/compactor/src/lib.rs
+++ b/src/storage/compactor/src/lib.rs
@@ -35,6 +35,9 @@ pub struct CompactorOpts {
     #[clap(long)]
     pub port: Option<u16>,
 
+    /// Of the form `hummock+{object_store}` where `object_store` 
+    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`, 
+    /// `memory` or `memory-shared`.
     #[clap(long, default_value = "")]
     pub state_store: String,
 
@@ -63,6 +66,7 @@ pub struct CompactorOpts {
     #[clap(long, default_value = "")]
     pub config_path: String,
 }
+
 
 use std::future::Future;
 use std::pin::Pin;

--- a/src/storage/compactor/src/lib.rs
+++ b/src/storage/compactor/src/lib.rs
@@ -35,8 +35,8 @@ pub struct CompactorOpts {
     #[clap(long)]
     pub port: Option<u16>,
 
-    /// Of the form `hummock+{object_store}` where `object_store` 
-    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`, 
+    /// Of the form `hummock+{object_store}` where `object_store`
+    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`,
     /// `memory` or `memory-shared`.
     #[clap(long, default_value = "")]
     pub state_store: String,
@@ -66,7 +66,6 @@ pub struct CompactorOpts {
     #[clap(long, default_value = "")]
     pub config_path: String,
 }
-
 
 use std::future::Future;
 use std::pin::Pin;


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
Make it known to the users what are valid params

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
fixes https://github.com/risingwavelabs/risingwave/issues/7531