### PR TITLE
fix: move install mysql-client to ci image

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -6,7 +6,7 @@ ARG RUST_TOOLCHAIN
 
 RUN apt-get update -yy && \
     DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl parallel \
-    openssl libssl-dev libsasl2-dev libcurl4-openssl-dev pkg-config bash openjdk-11-jdk wget unzip git tmux lld postgresql-client kafkacat netcat \
+    openssl libssl-dev libsasl2-dev libcurl4-openssl-dev pkg-config bash openjdk-11-jdk wget unzip git tmux lld postgresql-client kafkacat netcat mysql-client \
     maven -yy \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 

--- a/ci/build-ci-image.sh
+++ b/ci/build-ci-image.sh
@@ -14,7 +14,7 @@ export RUST_TOOLCHAIN=$(cat ../rust-toolchain)
 # !!! CHANGE THIS WHEN YOU WANT TO BUMP CI IMAGE !!! #
 #          AND ALSO docker-compose.yml               #
 ######################################################
-export BUILD_ENV_VERSION=v20230119-1
+export BUILD_ENV_VERSION=v20230126
 
 export BUILD_TAG="public.ecr.aws/x5u3w5h6/rw-build-env:${BUILD_ENV_VERSION}"
 

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       retries: 5
 
   source-test-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230119-1
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230126
     depends_on:
       - mysql
       - db
@@ -38,7 +38,7 @@ services:
       - ..:/risingwave
 
   sink-test-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230119-1
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230126
     depends_on:
       - mysql
       - db
@@ -46,12 +46,12 @@ services:
       - ..:/risingwave
 
   rw-build-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230119-1
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230126
     volumes:
       - ..:/risingwave
 
   regress-test-env:
-    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230119-1
+    image: public.ecr.aws/x5u3w5h6/rw-build-env:v20230126
     depends_on:
       db:
         condition: service_healthy

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -43,7 +43,6 @@ cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 # prepare environment mysql sink
-apt-get -y install mysql-client
 mysql --host=mysql --port=3306 -u root -p123456 -e "CREATE DATABASE IF NOT EXISTS test;"
 # grant access to `test` for ci test user
 mysql --host=mysql --port=3306 -u root -p123456 -e "GRANT ALL PRIVILEGES ON test.* TO 'mysqluser'@'%';"

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -51,8 +51,7 @@ cargo make pre-start-dev
 cargo make link-all-in-one-binaries
 
 echo "--- e2e, ci-1cn-1fe, mysql & postgres cdc"
-# install mysql client
-apt-get -y install mysql-client
+
 # import data to mysql
 mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc.sql
 


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

fix main

aca70301a066b29f133a0ca205bb85e89a237a1c

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Refer to a related PR or issue link (optional)

the issue is introduced because of the upstream change