### PR TITLE
fix(frontend): `now` fragment should be singleton

### DIFF
--- a/e2e_test/streaming/dynamic_filter.slt
+++ b/e2e_test/streaming/dynamic_filter.slt
@@ -99,7 +99,7 @@ drop table t1;
 statement ok
 drop table t2;
 
-#  ~ Simple Agg with timestamp/timestamptz ~
+#  Simple Agg with timestamp/timestamptz
 statement ok
 create table t1 (v1 timestamp);
 

--- a/e2e_test/streaming/temporal_filter.slt
+++ b/e2e_test/streaming/temporal_filter.slt
@@ -1,0 +1,25 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t1 (v1 timestamp);
+
+# This statement should be correct for the next ~1000 years
+statement ok
+create materialized view mv1 as select v1 from t1 where v1 > now();
+
+statement ok
+insert into t1 values ('3031-01-01 19:00:00'), ('3031-01-01 20:00:00'), ('3031-01-01 21:00:00'), ('0001-01-01 21:00:00');
+
+query I
+select * from mv1 order by v1;
+----
+3031-01-01 19:00:00
+3031-01-01 20:00:00
+3031-01-01 21:00:00
+
+statement ok
+drop materialized view mv1;
+
+statement ok
+drop table t1;

--- a/src/frontend/src/stream_fragmenter/mod.rs
+++ b/src/frontend/src/stream_fragmenter/mod.rs
@@ -253,7 +253,10 @@ fn build_fragment(
             current_fragment.is_singleton = node.is_singleton;
         }
 
-        NodeBody::Now(_) => current_fragment.fragment_type_mask |= FragmentTypeFlag::Now as u32,
+        NodeBody::Now(_) => {
+            current_fragment.fragment_type_mask |= FragmentTypeFlag::Now as u32;
+            current_fragment.is_singleton = true;
+        }
 
         _ => {}
     };


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?
`now` fragment was not singleton

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
Fixes: https://github.com/risingwavelabs/risingwave/issues/7543

Fixes adding e2e test for now/temporal filter: https://github.com/risingwavelabs/risingwave/issues/6790