### PR TITLE
refactor(meta): refactor CREATE_COMPACTION_GROUP_FOR_MV

### DIFF
--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -22,7 +22,7 @@ use risingwave_hummock_sdk::compaction_group::{StateTableId, StaticCompactionGro
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
 use risingwave_pb::hummock::CompactionConfig;
-use tokio::sync::RwLock;
+use tokio::sync::{OnceCell, RwLock};
 
 use super::versioning::Versioning;
 use super::write_lock;
@@ -359,24 +359,32 @@ impl<S: MetaStore> CompactionGroupManagerInner<S> {
                 }
             }
         }
+        // All NewCompactionGroup pairs are mapped to one new compaction group.
+        let new_compaction_group_id: OnceCell<CompactionGroupId> = OnceCell::new();
         let mut compaction_group_id_set = self.compaction_groups.keys().cloned().collect_vec();
         let old_id_cnt = compaction_group_id_set.len();
         let mut compaction_groups = BTreeMapTransaction::new(&mut self.compaction_groups);
         for (table_id, compaction_group_id, table_option) in pairs.iter_mut() {
             let mut compaction_group =
                 if *compaction_group_id == StaticCompactionGroupId::NewCompactionGroup as u64 {
-                    *compaction_group_id = self
-                        .id_generator_ref
-                        .generate::<{ IdCategory::CompactionGroup }>()
+                    *compaction_group_id = *new_compaction_group_id
+                        .get_or_try_init(|| async {
+                            self.id_generator_ref
+                                .generate::<{ IdCategory::CompactionGroup }>()
+                                .await
+                                .map(|new_id| {
+                                    compaction_group_id_set.push(new_id);
+                                    compaction_groups.insert(
+                                        new_id,
+                                        CompactionGroup::new(
+                                            new_id,
+                                            CompactionConfigBuilder::new().build(),
+                                        ),
+                                    );
+                                    new_id
+                                })
+                        })
                         .await?;
-                    compaction_group_id_set.push(*compaction_group_id);
-                    compaction_groups.insert(
-                        *compaction_group_id,
-                        CompactionGroup::new(
-                            *compaction_group_id,
-                            CompactionConfigBuilder::new().build(),
-                        ),
-                    );
                     compaction_groups.get_mut(*compaction_group_id).unwrap()
                 } else {
                     compaction_groups
@@ -934,7 +942,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(registered_number().await, 4);
-        assert_eq!(group_number().await, 6);
+        assert_eq!(group_number().await, 3);
 
         // Test `StaticCompactionGroupId::NewCompactionGroup` in `unregister_table_fragments`
         compaction_group_manager


### PR DESCRIPTION
I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

When CREATE_COMPACTION_GROUP_FOR_MV is true:

- Before this PR, all tables of a stream job will be assigned their own new compaction groups. This is unnecessary, especially for small tables.
- With this PR, all tables of a stream job will be assigned one same new compaction group.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
