### PR TITLE
fix(expr): handle time operation out of range

### DIFF
--- a/e2e_test/batch/types/date.slt
+++ b/e2e_test/batch/types/date.slt
@@ -58,3 +58,20 @@ INSERT INTO dates VALUES ('1000000000-01-01');
 
 statement ok
 DROP TABLE dates;
+
+# Issue #7566
+# date_int_sub
+statement err out of range
+select DATE '2022-08-09' - (INT '-2147483648');
+
+# date_int_add
+statement err out of range
+select DATE '2022-08-09' + (INT '-2147483648');
+
+# date_interval_sub
+statement err out of range
+select DATE '2022-08-09' - (INTERVAL '-2147483648 days');
+
+# date_interval_add
+statement err out of range
+select DATE '2022-08-09' + (INTERVAL '-2147483648 days');

--- a/e2e_test/batch/types/date.slt
+++ b/e2e_test/batch/types/date.slt
@@ -61,17 +61,17 @@ DROP TABLE dates;
 
 # Issue #7566
 # date_int_sub
-statement err out of range
+statement error out of range
 select DATE '2022-08-09' - (INT '-2147483648');
 
 # date_int_add
-statement err out of range
+statement error out of range
 select DATE '2022-08-09' + (INT '-2147483648');
 
 # date_interval_sub
-statement err out of range
+statement error out of range
 select DATE '2022-08-09' - (INTERVAL '-2147483648 days');
 
 # date_interval_add
-statement err out of range
+statement error out of range
 select DATE '2022-08-09' + (INTERVAL '-2147483648 days');

--- a/e2e_test/batch/types/time.slt.part
+++ b/e2e_test/batch/types/time.slt.part
@@ -55,3 +55,12 @@ select v3 from t where v3 > '2022-01-01'::DATE;
 
 statement ok
 drop table t;
+
+# Issue #7566
+# timestamp_interval_sub
+statement err out of range
+select TIMESTAMP '2022-08-09 00:00:00' - (INTERVAL '-2147483648 days');
+
+# timestamp_interval_add
+statement err out of range
+select TIMESTAMP '2022-08-09 00:00:00' + (INTERVAL '-2147483648 days');

--- a/e2e_test/batch/types/time.slt.part
+++ b/e2e_test/batch/types/time.slt.part
@@ -58,9 +58,9 @@ drop table t;
 
 # Issue #7566
 # timestamp_interval_sub
-statement err out of range
+statement error out of range
 select TIMESTAMP '2022-08-09 00:00:00' - (INTERVAL '-2147483648 days');
 
 # timestamp_interval_add
-statement err out of range
+statement error out of range
 select TIMESTAMP '2022-08-09 00:00:00' + (INTERVAL '-2147483648 days');

--- a/e2e_test/batch/types/timestamptz_utc.slt.part
+++ b/e2e_test/batch/types/timestamptz_utc.slt.part
@@ -119,3 +119,12 @@ query T
 select '2022-03-13 09:00:00Z'::timestamptz + interval '1' day - interval '24' hour;
 ----
 2022-03-13 09:00:00+00:00
+
+# Issue #7566
+# timestamptz_interval_sub
+statement err out of range
+select TIMESTAMP WITH TIME ZONE '2022-08-09 00:00:00' - (INTERVAL '-2147483648 days');
+
+# timestamptz_interval_add
+statement err out of range
+select TIMESTAMP WITH TIME ZONE '2022-08-09 00:00:00' + (INTERVAL '-2147483648 days');

--- a/e2e_test/batch/types/timestamptz_utc.slt.part
+++ b/e2e_test/batch/types/timestamptz_utc.slt.part
@@ -122,9 +122,9 @@ select '2022-03-13 09:00:00Z'::timestamptz + interval '1' day - interval '24' ho
 
 # Issue #7566
 # timestamptz_interval_sub
-statement err out of range
+statement error out of range
 select TIMESTAMP WITH TIME ZONE '2022-08-09 00:00:00' - (INTERVAL '-2147483648 days');
 
 # timestamptz_interval_add
-statement err out of range
+statement error out of range
 select TIMESTAMP WITH TIME ZONE '2022-08-09 00:00:00' + (INTERVAL '-2147483648 days');

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -22,7 +22,7 @@ use std::ops::{Add, Neg, Sub};
 use anyhow::anyhow;
 use byteorder::{BigEndian, NetworkEndian, ReadBytesExt, WriteBytesExt};
 use bytes::BytesMut;
-use num_traits::{CheckedAdd, CheckedSub, Zero};
+use num_traits::{CheckedAdd, CheckedNeg, CheckedSub, Zero};
 use postgres_types::{to_sql_checked, FromSql};
 use risingwave_pb::data::IntervalUnit as IntervalUnitProto;
 
@@ -126,15 +126,6 @@ impl IntervalUnit {
         let mut interval = *self;
         interval.justify_interval();
         interval
-    }
-
-    #[must_use]
-    pub fn negative(&self) -> Self {
-        IntervalUnit {
-            months: -self.months,
-            days: -self.days,
-            ms: -self.ms,
-        }
     }
 
     #[must_use]
@@ -582,6 +573,15 @@ impl Eq for IntervalUnit {}
 impl Ord for IntervalUnit {
     fn cmp(&self, other: &Self) -> Ordering {
         self.partial_cmp(other).unwrap()
+    }
+}
+
+impl CheckedNeg for IntervalUnit {
+    fn checked_neg(&self) -> Option<Self> {
+        let months = self.months.checked_neg()?;
+        let days = self.days.checked_neg()?;
+        let ms = self.ms.checked_neg()?;
+        Some(IntervalUnit { months, days, ms })
     }
 }
 

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -26,6 +26,7 @@
 #![feature(iterator_try_collect)]
 #![feature(exclusive_range_pattern)]
 #![feature(once_cell)]
+#![feature(try_blocks)]
 
 pub mod error;
 pub mod expr;


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [Singularity Data, Inc. Contributor License Agreement](https://gist.github.com/skyzh/0663682a70b0edde7ae991492f2314cb#file-s9y_cla).

## What's changed and what's your intention?

Handle the potential "out of range" panics in time operations as careful as possible.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
- Fix #7566