### PR TITLE
fix(meta): Temporarily fix breakage of playground due to missing --host arg

### DIFF
--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -97,8 +97,8 @@ fn get_services(profile: &str) -> (Vec<RisingWaveService>, bool) {
                 RisingWaveService::Meta(osstrs([
                     "--listen-addr",
                     "0.0.0.0:5690",
-                    "--host",
-                    "127.0.0.1",
+                    "--meta-endpoint",
+                    "127.0.0.1:5690",
                     "--dashboard-host",
                     "0.0.0.0:5691",
                 ])),

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -66,6 +66,10 @@ pub struct MetaNodeOpts {
     #[clap(long, default_value = "127.0.0.1:5690")]
     listen_addr: String,
 
+    // Currently does nothing
+    #[clap(long)]
+    host: Option<String>,
+
     /// The endpoint for this meta node, which also serves as its unique identifier in cluster
     /// membership and leader election.
     #[clap(long)]

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -66,10 +66,6 @@ pub struct MetaNodeOpts {
     #[clap(long, default_value = "127.0.0.1:5690")]
     listen_addr: String,
 
-    // Currently does nothing
-    #[clap(long)]
-    host: Option<String>,
-
     /// The endpoint for this meta node, which also serves as its unique identifier in cluster
     /// membership and leader election.
     #[clap(long)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
We may rename the args again, but let's stop the breakage due to missing playground arg changes due to https://github.com/risingwavelabs/risingwave/pull/7527...

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
