### PR TITLE
fix(expr): overlay panic on overflow

### DIFF
--- a/e2e_test/batch/functions/overlay.slt.part
+++ b/e2e_test/batch/functions/overlay.slt.part
@@ -29,3 +29,6 @@ SELECT OVERLAY('abc' PLACING 'xyz' FOR 2)
 
 statement error
 SELECT OVERLAY('abc' PLACING 'xyz' FOR 2 FROM 1)
+
+statement error
+SELECT OVERLAY('l2bWQBOIj9' PLACING 'DIHgr7AB4z' FROM (INT '-2147483648') FOR (INT '1'));

--- a/src/expr/src/vector_op/overlay.rs
+++ b/src/expr/src/vector_op/overlay.rs
@@ -14,7 +14,7 @@
 
 use std::fmt::Write;
 
-use crate::Result;
+use crate::{ExprError, Result};
 
 #[inline(always)]
 pub fn overlay(s: &str, new_sub_str: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
@@ -34,7 +34,11 @@ pub fn overlay_for(
 
     // If start is out of range, attach it to the end.
     // Note that indices are 1-based.
-    let start = ((start - 1).max(0) as usize).min(s.len());
+    let start = (start
+        .checked_sub(1)
+        .ok_or(ExprError::NumericOutOfRange)?
+        .max(0) as usize)
+        .min(s.len());
 
     let remaining = start + count;
 


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Use `checked_sub`.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

Fixes #7573