### PR TITLE
fix(meta): start leader service directly in meta election scenario

### DIFF
--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -197,9 +197,7 @@ impl ElectionClient for EtcdElectionClient {
 
         let _guard = scopeguard::guard(handle, |handle| handle.abort());
 
-        if restored_leader {
-            self.is_leader_sender.send_replace(true);
-        } else {
+        if !restored_leader {
             self.is_leader_sender.send_replace(false);
             tracing::info!("no restored leader, campaigning");
             tokio::select! {
@@ -216,6 +214,8 @@ impl ElectionClient for EtcdElectionClient {
                 }
             };
         }
+
+        self.is_leader_sender.send_replace(true);
 
         let mut observe_stream = election_client.observe(META_ELECTION_KEY).await?;
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -155,6 +155,8 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
             let svc_shutdown_rx_clone = svc_shutdown_rx.clone();
             let (follower_shutdown_tx, follower_shutdown_rx) = OneChannel::<()>();
 
+            let _resp = is_leader_watcher.changed().await;
+
             // If not the leader, spawn a follower.
             let follower_handle: Option<JoinHandle<()>> = if !*is_leader_watcher.borrow() {
                 let address_info_clone = address_info.clone();


### PR DESCRIPTION
Signed-off-by: Peng Chen <peng@singularity-data.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

If the election client resumes from the leader state, it will start directly from the leader service

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
