### PR TITLE
chore(log): modify read current epoch error message

### DIFF
--- a/src/storage/src/hummock/error.rs
+++ b/src/storage/src/hummock/error.rs
@@ -44,7 +44,7 @@ enum HummockErrorInner {
     SharedBufferError(String),
     #[error("Wait epoch error {0}.")]
     WaitEpoch(String),
-    #[error("Read current epoch error {0}.")]
+    #[error("ReadCurrentEpoch error {0}.")]
     ReadCurrentEpoch(String),
     #[error("Expired Epoch: watermark {safe_epoch}, epoch {epoch}.")]
     ExpiredEpoch { safe_epoch: u64, epoch: u64 },

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -297,7 +297,7 @@ impl StateStore for HummockStorage {
             let sealed_epoch = self.seal_epoch.load(MemOrdering::SeqCst);
             if read_current_epoch > sealed_epoch {
                 return Err(HummockError::read_current_epoch(format!(
-                    "cannot read current epoch because read epoch {} > sealed epoch {}",
+                    "Cannot read when cluster is under recovery. read {} > max seal epoch {}",
                     read_current_epoch, sealed_epoch
                 ))
                 .into());
@@ -306,7 +306,7 @@ impl StateStore for HummockStorage {
             let min_current_epoch = self.min_current_epoch.load(MemOrdering::SeqCst);
             if read_current_epoch < min_current_epoch {
                 return Err(HummockError::read_current_epoch(format!(
-                    "cannot read current epoch because read epoch {} < min current epoch {}",
+                    "Cannot read when cluster is under recovery. read {} < min current epoch {}",
                     read_current_epoch, min_current_epoch
                 ))
                 .into());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The `ReadCurrentEpoch error` only occurs when the cluster is under recovery. This PR emphasizes this fact in error message, because the error message will be read by frontend user.
When seeing `ReadCurrentEpoch error` constantly, root cause of unsuccessful recovery should be investigated, instead of `ReadCurrentEpoch error` itself.

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
