### PR TITLE
chore: check breaking change in protobuf

### DIFF
--- a/.github/workflows/dashboard_pr.yml
+++ b/.github/workflows/dashboard_pr.yml
@@ -5,7 +5,7 @@ on:
     paths: [dashboard/**, proto/**]
 
 concurrency:
-  group: dashbaord-build-${{ github.ref }}
+  group: dashboard-build-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -6,8 +6,9 @@ on:
     paths: [proto/**]
 
 jobs:
-  validate-protos:
+  buf-breaking-check:
     runs-on: ubuntu-latest
+    name: Check breaking changes in Protobuf files
     steps:
       - uses: actions/checkout@v2
       - uses: bufbuild/buf-setup-action@v1

--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -1,0 +1,18 @@
+name: Protobuf Breaking Check
+
+on:
+  pull_request:
+    branches: [main]
+    paths: [proto/**]
+
+jobs:
+  validate-protos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: bufbuild/buf-setup-action@v1
+      # Run breaking change detection against the `main` branch
+      - uses: bufbuild/buf-breaking-action@v1
+        with:
+          input: 'proto'
+          against: '.git#branch=main,subdir=proto'

--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: bufbuild/buf-breaking-action@v1
         with:
           input: 'proto'
-          against: '.git#branch=main,subdir=proto'
+          against: 'https://github.com/risingwavelabs/risingwave.git#branch=main,subdir=proto'

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,4 +1,7 @@
 version: v1
+breaking:
+  use:
+    - WIRE
 lint:
   use:
     - DEFAULT

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,7 +1,7 @@
 version: v1
 breaking:
   use:
-    - WIRE
+    - WIRE_JSON # https://docs.buf.build/breaking/rules
 lint:
   use:
     - DEFAULT

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -30,6 +30,7 @@ enum WorkerType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   COMPUTE_NODE = 2;
+  RISE_CTL = 3;
   COMPACTOR = 4;
 }
 
@@ -62,7 +63,7 @@ message Buffer {
 
 // Vnode mapping for stream fragments. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
-  repeated uint64 original_indices = 1;
+  repeated uint32 original_indices = 1;
   repeated uint32 data = 2;
 }
 

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -30,8 +30,7 @@ enum WorkerType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   COMPUTE_NODE = 2;
-  RISE_CTL = 3;
-  COMPACTOR = 4;
+  COMPACTOR = 5;
 }
 
 message ParallelUnit {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -22,7 +22,6 @@ message HostAddress {
 
 // Encode which host machine an actor resides.
 message ActorInfo {
-  uint32 actor_id = 1;
   HostAddress host = 2;
 }
 
@@ -30,8 +29,8 @@ enum WorkerType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   COMPUTE_NODE = 2;
-  RISE_CTL = 3;
-  COMPACTOR = 4;
+  RISE_CONTROL = 3;
+  COMPACTOR = 5;
 }
 
 message ParallelUnit {
@@ -64,12 +63,12 @@ message Buffer {
 // Vnode mapping for stream fragments. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   repeated uint32 original_indices = 1;
-  repeated uint32 data = 2;
+  repeated uint64 data = 2;
 }
 
 message BatchQueryEpoch {
   oneof epoch {
-    uint64 committed = 1;
+    string committed = 1;
     uint64 current = 2;
     uint64 backup = 3;
   }

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -30,7 +30,7 @@ enum WorkerType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   COMPUTE_NODE = 2;
-  COMPACTOR = 5;
+  COMPACTOR = 4;
 }
 
 message ParallelUnit {
@@ -62,7 +62,7 @@ message Buffer {
 
 // Vnode mapping for stream fragments. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
-  repeated uint32 original_indices = 1;
+  repeated uint64 original_indices = 1;
   repeated uint32 data = 2;
 }
 

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -22,6 +22,7 @@ message HostAddress {
 
 // Encode which host machine an actor resides.
 message ActorInfo {
+  uint32 actor_id = 1;
   HostAddress host = 2;
 }
 
@@ -29,8 +30,8 @@ enum WorkerType {
   UNSPECIFIED = 0;
   FRONTEND = 1;
   COMPUTE_NODE = 2;
-  RISE_CONTROL = 3;
-  COMPACTOR = 5;
+  RISE_CTL = 3;
+  COMPACTOR = 4;
 }
 
 message ParallelUnit {
@@ -63,12 +64,12 @@ message Buffer {
 // Vnode mapping for stream fragments. Stores mapping from virtual node to parallel unit id.
 message ParallelUnitMapping {
   repeated uint32 original_indices = 1;
-  repeated uint64 data = 2;
+  repeated uint32 data = 2;
 }
 
 message BatchQueryEpoch {
   oneof epoch {
-    string committed = 1;
+    uint64 committed = 1;
     uint64 current = 2;
     uint64 backup = 3;
   }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds the workflow of detecting breaking changes in protobuf to the CI workflow. Here is an example of error reporting:
- https://github.com/risingwavelabs/risingwave/pull/7609/commits/c1dd48e4f4291270ec515886d999dbf8b946b733

We've set the rule category to `WIRE_JSON` which is explained [here](https://docs.buf.build/breaking/rules). Actually `WIRE` is enough for our major usages, while `WIRE_JSON` ensures that the name of the fields is not modified, which brings less confusion to the codebase and also makes the JSON-based dashboard easier to maintain (e.g., avoid #7262 from happening).

We may not need to add this workflow to GitHub's branch protection rule until the next release.