### PR TITLE
fix(meta): add back host, a deprecated cmd line argument

### DIFF
--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -66,6 +66,10 @@ pub struct MetaNodeOpts {
     #[clap(long, default_value = "127.0.0.1:5690")]
     listen_addr: String,
 
+    /// Deprecated. But we keep it for backward compatibility.
+    #[clap(long)]
+    host: Option<String>,
+
     /// The endpoint for this meta node, which also serves as its unique identifier in cluster
     /// membership and leader election.
     #[clap(long)]
@@ -120,6 +124,7 @@ pub struct MetaNodeOpts {
 }
 
 use std::future::Future;
+use std::net::SocketAddr;
 use std::pin::Pin;
 
 use risingwave_common::config::load_config;
@@ -132,13 +137,14 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         let config = load_config(&opts.config_path);
         tracing::info!("Starting meta node with config {:?}", config);
         tracing::info!("Starting meta node with options {:?}", opts);
-        let listen_addr = opts.listen_addr.parse().unwrap();
+        let listen_addr: SocketAddr = opts.listen_addr.parse().unwrap();
+        let meta_addr = opts.host.unwrap_or_else(|| opts.listen_addr.clone());
         let dashboard_addr = opts.dashboard_host.map(|x| x.parse().unwrap());
         let prometheus_addr = opts.prometheus_host.map(|x| x.parse().unwrap());
         let (meta_endpoint, backend) = match opts.backend {
             Backend::Etcd => (
                 opts.meta_endpoint
-                    .expect("meta_endpoint must be specified when using etcd"),
+                    .unwrap_or_else(|| format!("{}:{}", meta_addr, listen_addr.port())),
                 MetaStoreBackend::Etcd {
                     endpoints: opts
                         .etcd_endpoints


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->

risingwave-operator made a [temporary fix](https://github.com/risingwavelabs/risingwave-operator/commit/f011c368e0ffc72e615d4717fefbef4650851d2e) with regards to the breaking change that uses `meta-endpoint` instead of `host`, please refer to #7527.
But the cloud is unable to adopt this change right now, so we add `host` back.


By looking at the temporary fix, it used to use `IP` as `host` and now uses `IP:PORT` as `meta-endpoint`.
So this hot fix uses `IP` from `host` and  `PORT` from `listening-addr` to compose `meta-endpoint`, please correct me if I am wrong.

## Checklist

- [x] I have written necessary rustdoc comments
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
