### PR TITLE
chore(sqlsmith): disable `FILTER` with correlated input reference

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -387,7 +387,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         let distinct = self.flip_coin() && self.is_distinct_allowed;
         let filter = if self.flip_coin() {
             let context = SqlGeneratorContext::new_with_can_agg(false);
-            Some(Box::new(self.gen_expr(&DataType::Boolean, context)))
+            // ENABLE: https://github.com/risingwavelabs/risingwave/issues/4762
+            // Prevent correlated query with `FILTER`
+            let old_ctxt = self.new_local_context();
+            let expr = Some(Box::new(self.gen_expr(&DataType::Boolean, context)));
+            self.restore_context(old_ctxt);
+            expr
         } else {
             None
         };
@@ -661,7 +666,7 @@ pub fn print_function_table() -> String {
         .map(|sig| {
             format!(
                 "{:?} CAST {:?} -> {:?}",
-                sig.context, sig.to_type, sig.from_type,
+                sig.context, sig.from_type, sig.to_type,
             )
         })
         .sorted()

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -52,7 +52,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             };
         }
 
-        if *typ == DataType::Boolean && self.rng.gen_bool(0.1) {
+        if *typ == DataType::Boolean && self.rng.gen_bool(0.05) {
             return match self.rng.gen_bool(0.5) {
                 true => {
                     let (ty, expr) = self.gen_arbitrary_expr(context);
@@ -346,7 +346,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         };
         // Generating correlated subquery tends to create queries which cannot be unnested.
         // we still want to test it, but reduce the chance it occurs.
-        let (subquery, _) = match self.rng.gen_bool(0.1) {
+        let (subquery, _) = match self.rng.gen_bool(0.05) {
             true => self.gen_correlated_query(),
             false => self.gen_local_query(),
         };


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Workaround: https://github.com/risingwavelabs/risingwave/issues/4762

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
