### PR TITLE
fix(meta): backward compatible with host when running in mem meta backend

### DIFF
--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -141,27 +141,22 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         let meta_addr = opts.host.unwrap_or_else(|| opts.listen_addr.clone());
         let dashboard_addr = opts.dashboard_host.map(|x| x.parse().unwrap());
         let prometheus_addr = opts.prometheus_host.map(|x| x.parse().unwrap());
-        let (meta_endpoint, backend) = match opts.backend {
-            Backend::Etcd => (
-                opts.meta_endpoint
-                    .unwrap_or_else(|| format!("{}:{}", meta_addr, listen_addr.port())),
-                MetaStoreBackend::Etcd {
-                    endpoints: opts
-                        .etcd_endpoints
-                        .split(',')
-                        .map(|x| x.to_string())
-                        .collect(),
-                    credentials: match opts.etcd_auth {
-                        true => Some((opts.etcd_username, opts.etcd_password)),
-                        false => None,
-                    },
+        let meta_endpoint = opts
+            .meta_endpoint
+            .unwrap_or_else(|| format!("{}:{}", meta_addr, listen_addr.port()));
+        let backend = match opts.backend {
+            Backend::Etcd => MetaStoreBackend::Etcd {
+                endpoints: opts
+                    .etcd_endpoints
+                    .split(',')
+                    .map(|x| x.to_string())
+                    .collect(),
+                credentials: match opts.etcd_auth {
+                    true => Some((opts.etcd_username, opts.etcd_password)),
+                    false => None,
                 },
-            ),
-            Backend::Mem => (
-                opts.meta_endpoint
-                    .unwrap_or_else(|| opts.listen_addr.clone()),
-                MetaStoreBackend::Mem,
-            ),
+            },
+            Backend::Mem => MetaStoreBackend::Mem,
         };
 
         let max_heartbeat_interval =


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->

See #7616, the previous pr only changes the etcd backend. It fails when running mem backend.

Now both etcd backend and mem backend run with the same `meta-endpoint` when `meta-endpoint` is not provided, 
i.e. `format!("{}:{}", meta_addr, listen_addr.port())`

## Checklist

- [x] I have written necessary rustdoc comments
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)