### PR TITLE
perf(shared buffer): add bloom filter for immutable memtables

### DIFF
--- a/src/storage/hummock_test/src/hummock_read_version_tests.rs
+++ b/src/storage/hummock_test/src/hummock_read_version_tests.rs
@@ -58,6 +58,7 @@ async fn test_read_version_basic() {
             size,
             vec![],
             TableId::from(table_id),
+            vec![],
             None,
         );
 
@@ -95,6 +96,7 @@ async fn test_read_version_basic() {
                 size,
                 vec![],
                 TableId::from(table_id),
+                vec![],
                 None,
             );
 
@@ -273,6 +275,7 @@ async fn test_read_filter_basic() {
             size,
             vec![],
             TableId::from(table_id),
+            vec![],
             None,
         );
 

--- a/src/storage/src/hummock/event_handler/uploader.rs
+++ b/src/storage/src/hummock/event_handler/uploader.rs
@@ -773,6 +773,7 @@ mod tests {
             size,
             vec![],
             TEST_TABLE_ID,
+            vec![],
             tracker,
         )
     }

--- a/src/storage/src/hummock/local_version/local_version_manager.rs
+++ b/src/storage/src/hummock/local_version/local_version_manager.rs
@@ -145,6 +145,7 @@ impl LocalVersionManager {
             size,
             delete_ranges,
             table_id,
+            vec![],
             Some(
                 self.buffer_tracker
                     .get_memory_limiter()

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -23,7 +23,7 @@ pub use block::*;
 mod block_iterator;
 pub use block_iterator::*;
 mod bloom;
-use bloom::Bloom;
+pub use bloom::Bloom;
 pub mod builder;
 pub use builder::*;
 pub mod writer;

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use async_stack_trace::StackTrace;
 use bytes::{BufMut, Bytes, BytesMut};
-use futures::{pin_mut, Stream, StreamExt};
+use futures::{pin_mut, Stream};
 use futures_async_stream::try_stream;
 use itertools::{izip, Itertools};
 use risingwave_common::array::{Op, StreamChunk, Vis};
@@ -958,6 +958,7 @@ impl<S: StateStore> StateTable<S> {
         &self,
         pk_prefix: impl Row,
     ) -> StreamExecutorResult<RowStream<'_, S>> {
+        use futures::StreamExt;
         let (mem_table_iter, storage_iter_stream) = self
             .iter_with_pk_prefix_inner(pk_prefix, self.epoch())
             .await?;
@@ -1001,6 +1002,7 @@ impl<S: StateStore> StateTable<S> {
         // iterate over each vnode that the `StateTable` owns.
         vnode: VirtualNode,
     ) -> StreamExecutorResult<RowStream<'_, S>> {
+        use futures::StreamExt;
         let (mem_table_iter, storage_iter_stream) =
             self.iter_with_pk_range_inner(pk_range, vnode).await?;
         let storage_iter = storage_iter_stream.into_stream();
@@ -1156,6 +1158,7 @@ where
     /// `mem_table`, result `mem_table` is returned according to the operation(RowOp) on it.
     #[try_stream(ok = (Cow<'a, Bytes>, OwnedRow), error = StreamExecutorError)]
     async fn into_stream(self) {
+        use futures::StreamExt;
         let storage_iter = self.storage_iter.peekable();
         pin_mut!(storage_iter);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->

add bloom filter for immutable memtables, add track memory usage of them

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
#7608 