### PR TITLE
fix(expr): use checked operations for substr

### DIFF
--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -3,7 +3,7 @@ statement error out of range
 select substr('W7Jc3Vyufj', (INT '-2147483648'));
 
 -- issue: https://github.com/risingwavelabs/risingwave/issues/7601
-statement error out of range
+QUERY T
 select substr('a', 2147483646, 1);
-
-select substr('a', 2147483640, 1);
+----
+(empty)

--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -1,8 +1,8 @@
--- issue: https://github.com/risingwavelabs/risingwave/issues/7632
+# issue: https://github.com/risingwavelabs/risingwave/issues/7632
 statement error out of range
 select substr('W7Jc3Vyufj', (INT '-2147483648'));
 
--- issue: https://github.com/risingwavelabs/risingwave/issues/7601
+# issue: https://github.com/risingwavelabs/risingwave/issues/7601
 QUERY T
 select substr('a', 2147483646, 1);
 ----

--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -1,6 +1,26 @@
 # issue: https://github.com/risingwavelabs/risingwave/issues/7632
-statement error out of range
+query T
 select substr('W7Jc3Vyufj', (INT '-2147483648'));
+----
+W7Jc3Vyufj
+
+statement error length in substr should be non-negative
+select substr('W7Jc3Vyufj', INT '-2147483648', INT '-2147483648');
+
+query T
+select substr('W7Jc3Vyufj', INT '2147483647', INT '2147483647');
+----
+(empty)
+
+query T
+select substr('W7Jc3Vyufj', INT '-2147483645', INT '2147483647');
+----
+W
+
+query T
+select substr('W7Jc3Vyufj', INT '-2147483648', INT '2147483647');
+----
+(empty)
 
 # issue: https://github.com/risingwavelabs/risingwave/issues/7601
 query T

--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -1,0 +1,9 @@
+-- issue: https://github.com/risingwavelabs/risingwave/issues/7632
+statement error out of range
+select substr('W7Jc3Vyufj', (INT '-2147483648'));
+
+-- issue: https://github.com/risingwavelabs/risingwave/issues/7601
+statement error out of range
+select substr('a', 2147483646, 1);
+
+select substr('a', 2147483640, 1);

--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -3,7 +3,7 @@ statement error out of range
 select substr('W7Jc3Vyufj', (INT '-2147483648'));
 
 # issue: https://github.com/risingwavelabs/risingwave/issues/7601
-QUERY T
+query T
 select substr('a', 2147483646, 1);
 ----
 (empty)

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -42,10 +42,7 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     // the length of `s`.
     // 0 <= begin <= s.len()
     let begin = min(max(start, 0) as usize, s.len());
-    let end = (start
-        .saturating_add(count)
-        .max(0) as usize)
-        .min(s.len());
+    let end = (start.saturating_add(count).max(0) as usize).min(s.len());
     writer.write_str(&s[begin..end]).unwrap();
     Ok(())
 }

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -41,6 +41,9 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
         bail!("length in substr should be non-negative: {}", count);
     }
     let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
+    // NOTE: we use `s.len()` here as an upper bound.
+    // This is so it will return an empty slice if it exceeds
+    // the length of `s`.
     let begin = min(max(start, 0) as usize, s.len());
     let end = (start
         .checked_add(count)

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -42,9 +42,10 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     }
     let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
     let begin = min(max(start, 0) as usize, s.len());
-    let end = begin
-        .checked_add(count as usize)
+    let end = (start
+        .checked_add(count)
         .ok_or(ExprError::NumericOutOfRange)?
+        .max(0) as usize)
         .min(s.len());
     writer.write_str(&s[begin..end]).unwrap();
     Ok(())

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -19,11 +19,7 @@ use crate::{bail, ExprError, Result};
 
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
-    let start = (start
-        .checked_sub(1)
-        .ok_or(ExprError::NumericOutOfRange)?
-        .max(0) as usize)
-        .min(s.len());
+    let start = (start.saturating_sub(1).max(0) as usize).min(s.len());
     writer.write_str(&s[start..]).unwrap();
     Ok(())
 }
@@ -40,14 +36,14 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     if count < 0 {
         bail!("length in substr should be non-negative: {}", count);
     }
-    let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
+    let start = start.saturating_sub(1);
     // NOTE: we use `s.len()` here as an upper bound.
     // This is so it will return an empty slice if it exceeds
     // the length of `s`.
+    // 0 <= begin <= s.len()
     let begin = min(max(start, 0) as usize, s.len());
     let end = (start
-        .checked_add(count)
-        .ok_or(ExprError::NumericOutOfRange)?
+        .saturating_add(count)
         .max(0) as usize)
         .min(s.len());
     writer.write_str(&s[begin..end]).unwrap();

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -15,7 +15,7 @@
 use std::cmp::{max, min};
 use std::fmt::Write;
 
-use crate::{bail, ExprError, Result};
+use crate::{bail, Result};
 
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: &mut dyn Write) -> Result<()> {

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -14,9 +14,8 @@
 
 use std::cmp::{max, min};
 use std::fmt::Write;
-use crate::ExprError;
 
-use crate::{bail, Result};
+use crate::{bail, ExprError, Result};
 
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
@@ -41,9 +40,7 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     if count < 0 {
         bail!("length in substr should be non-negative: {}", count);
     }
-    let start = start
-        .checked_sub(1)
-        .ok_or(ExprError::NumericOutOfRange)?;
+    let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
     let begin = max(start, 0) as usize;
     let end = (start
         .checked_add(count)

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -14,12 +14,17 @@
 
 use std::cmp::{max, min};
 use std::fmt::Write;
+use crate::ExprError;
 
 use crate::{bail, Result};
 
 #[inline(always)]
 pub fn substr_start(s: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
-    let start = min(max(start - 1, 0) as usize, s.len());
+    let start = (start
+        .checked_sub(1)
+        .ok_or(ExprError::NumericOutOfRange)?
+        .max(0) as usize)
+        .min(s.len());
     writer.write_str(&s[start..]).unwrap();
     Ok(())
 }
@@ -36,8 +41,14 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     if count < 0 {
         bail!("length in substr should be non-negative: {}", count);
     }
-    let begin = max(start - 1, 0) as usize;
-    let end = min(max(start - 1 + count, 0) as usize, s.len());
+    let start = start
+        .checked_sub(1)
+        .ok_or(ExprError::NumericOutOfRange)?;
+    let begin = max(start, 0) as usize;
+    let end = (start
+        .checked_add(count)
+        .ok_or(ExprError::NumericOutOfRange)? as usize)
+        .min(s.len());
     writer.write_str(&s[begin..end]).unwrap();
     Ok(())
 }

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -41,7 +41,7 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
         bail!("length in substr should be non-negative: {}", count);
     }
     let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
-    let begin = max(start, 0) as usize;
+    let begin = min(max(start, 0) as usize, s.len());
     let end = (start
         .checked_add(count)
         .ok_or(ExprError::NumericOutOfRange)? as usize)

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -42,9 +42,9 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     }
     let start = start.checked_sub(1).ok_or(ExprError::NumericOutOfRange)?;
     let begin = min(max(start, 0) as usize, s.len());
-    let end = (start
-        .checked_add(count)
-        .ok_or(ExprError::NumericOutOfRange)? as usize)
+    let end = begin
+        .checked_add(count as usize)
+        .ok_or(ExprError::NumericOutOfRange)?
         .min(s.len());
     writer.write_str(&s[begin..end]).unwrap();
     Ok(())

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -67,6 +67,11 @@ fn is_numeric_overflow_error(db_error: &str) -> bool {
     db_error.contains("Number") && db_error.contains("overflows")
 }
 
+/// Negative substr error
+fn is_neg_substr_error(db_error: &str) -> bool {
+    db_error.contains("length in substr should be non-negative")
+}
+
 /// Certain errors are permitted to occur. This is because:
 /// 1. It is more complex to generate queries without these errors.
 /// 2. These errors seldom occur, skipping them won't affect overall effectiveness of sqlsmith.
@@ -80,4 +85,5 @@ pub fn is_permissible_error(db_error: &str) -> bool {
         || is_nested_loop_join_error(db_error)
         || is_subquery_unnesting_error(db_error)
         || is_numeric_overflow_error(db_error)
+        || is_neg_substr_error(db_error)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As per title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

Closes #7601 
Closes https://github.com/risingwavelabs/risingwave/issues/7632