### PR TITLE
fix: sleep after election failed when etcd cluster is gone 

### DIFF
--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -23,7 +23,6 @@ use tokio::sync::watch;
 use tokio::sync::watch::Sender as WatchSender;
 use tokio::task::JoinHandle;
 use tokio::time;
-use tokio::time::sleep_until;
 
 use super::follower_svc::start_follower_srv;
 use crate::manager::MetaOpts;

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -22,6 +22,8 @@ use tokio::sync::oneshot::channel as OneChannel;
 use tokio::sync::watch;
 use tokio::sync::watch::Sender as WatchSender;
 use tokio::task::JoinHandle;
+use tokio::time;
+use tokio::time::sleep_until;
 
 use super::follower_svc::start_follower_srv;
 use crate::manager::MetaOpts;
@@ -141,6 +143,7 @@ pub async fn rpc_serve_with_store<S: MetaStore>(
                 .await
             {
                 tracing::error!("election error happened, {}", e.to_string());
+                time::sleep(Duration::from_secs(1)).await;
             }
         });
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Prevent infinite follower logs caused by etcd server downtime

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
