### PR TITLE
feat(cli): fallback to env if CLI arg is absent

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -38,37 +38,37 @@ use risingwave_common_proc_macro::OverrideConfig;
 #[derive(Parser, Clone, Debug)]
 pub struct ComputeNodeOpts {
     // TODO: rename to listen_address and separate out the port.
-    #[clap(long, default_value = "127.0.0.1:5688")]
+    #[clap(long, env, default_value = "127.0.0.1:5688")]
     pub host: String,
 
     /// The address of the compute node's meta client.
     ///
     /// Optional, we will use listen_address if not specified.
-    #[clap(long)]
+    #[clap(long, env)]
     pub client_address: Option<String>,
 
-    #[clap(long, default_value = "127.0.0.1:1222")]
+    #[clap(long, env, default_value = "127.0.0.1:1222")]
     pub prometheus_listener_addr: String,
 
-    #[clap(long, default_value = "http://127.0.0.1:5690")]
+    #[clap(long, env, default_value = "http://127.0.0.1:5690")]
     pub meta_address: String,
 
     /// Endpoint of the connector node
-    #[clap(long, env = "CONNECTOR_RPC_ENDPOINT")]
+    #[clap(long, env)]
     pub connector_rpc_endpoint: Option<String>,
 
     /// The path of `risingwave.toml` configuration file.
     ///
     /// If empty, default configuration values will be used.
-    #[clap(long, default_value = "")]
+    #[clap(long, env, default_value = "")]
     pub config_path: String,
 
     /// Total available memory in bytes, used by LRU Manager
-    #[clap(long, default_value_t = default_total_memory_bytes())]
+    #[clap(long, env, default_value_t = default_total_memory_bytes())]
     pub total_memory_bytes: usize,
 
     /// The parallelism that the compute node will register to the scheduler of the meta service.
-    #[clap(long, default_value_t = default_parallelism())]
+    #[clap(long, env, default_value_t = default_parallelism())]
     pub parallelism: usize,
 
     #[clap(flatten)]
@@ -84,30 +84,30 @@ struct OverrideConfigOpts {
     /// `memory` or `memory-shared`.
     /// 2. `in-memory`
     /// 3. `sled://{path}`
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = storage.state_store)]
     pub state_store: Option<String>,
 
     /// Used for control the metrics level, similar to log level.
     /// 0 = close metrics
     /// >0 = open metrics
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = server.metrics_level)]
     pub metrics_level: Option<u32>,
 
     /// Path to file cache data directory.
     /// Left empty to disable file cache.
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = storage.file_cache.dir)]
     pub file_cache_dir: Option<String>,
 
     /// Enable reporting tracing information to jaeger.
-    #[clap(parse(from_flag = true_if_present), long)]
+    #[clap(parse(from_flag = true_if_present), long, env)]
     #[override_opts(path = streaming.enable_jaeger_tracing)]
     pub enable_jaeger_tracing: Flag,
 
     /// Enable async stack tracing for risectl.
-    #[clap(long, arg_enum)]
+    #[clap(long, env, arg_enum)]
     #[override_opts(path = streaming.async_stack_trace)]
     pub async_stack_trace: Option<AsyncStackTraceOption>,
 }

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -70,24 +70,24 @@ use session::SessionManagerImpl;
 #[derive(Parser, Clone, Debug)]
 pub struct FrontendOpts {
     // TODO: rename to listen_address and separate out the port.
-    #[clap(long, default_value = "127.0.0.1:4566")]
+    #[clap(long, env, default_value = "127.0.0.1:4566")]
     pub host: String,
 
     // Optional, we will use listen_address if not specified.
-    #[clap(long)]
+    #[clap(long, env)]
     pub client_address: Option<String>,
 
     // TODO: This is currently unused.
-    #[clap(long)]
+    #[clap(long, env)]
     pub port: Option<u16>,
 
-    #[clap(long, default_value = "http://127.0.0.1:5690")]
+    #[clap(long, env, default_value = "http://127.0.0.1:5690")]
     pub meta_addr: String,
 
-    #[clap(long, default_value = "127.0.0.1:2222")]
+    #[clap(long, env, default_value = "127.0.0.1:2222")]
     pub prometheus_listener_addr: String,
 
-    #[clap(long, default_value = "127.0.0.1:6786")]
+    #[clap(long, env, default_value = "127.0.0.1:6786")]
     pub health_check_listener_addr: String,
 
     /// The path of `risingwave.toml` configuration file.
@@ -96,7 +96,7 @@ pub struct FrontendOpts {
     ///
     /// Note that internal system parameters should be defined in the configuration file at
     /// [`risingwave_common::config`] instead of command line arguments.
-    #[clap(long, default_value = "")]
+    #[clap(long, env, default_value = "")]
     pub config_path: String,
 
     #[clap(flatten)]
@@ -109,7 +109,7 @@ struct OverrideConfigOpts {
     /// Used for control the metrics level, similar to log level.
     /// 0 = close metrics
     /// >0 = open metrics
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = server.metrics_level)]
     pub metrics_level: Option<u32>,
 }

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -58,57 +58,57 @@ use crate::rpc::server::{rpc_serve, AddressInfo, MetaStoreBackend};
 #[derive(Debug, Clone, Parser)]
 pub struct MetaNodeOpts {
     // TODO: rename to listen_address and separate out the port.
-    #[clap(long, default_value = "127.0.0.1:5690")]
+    #[clap(long, env, default_value = "127.0.0.1:5690")]
     listen_addr: String,
 
     /// Deprecated. But we keep it for backward compatibility.
-    #[clap(long)]
+    #[clap(long, env)]
     host: Option<String>,
 
     /// The endpoint for this meta node, which also serves as its unique identifier in cluster
     /// membership and leader election.
-    #[clap(long)]
+    #[clap(long, env)]
     meta_endpoint: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, env)]
     dashboard_host: Option<String>,
 
-    #[clap(long)]
+    #[clap(long, env)]
     prometheus_host: Option<String>,
 
-    #[clap(long, default_value_t = String::from(""))]
+    #[clap(long, env, default_value_t = String::from(""))]
     etcd_endpoints: String,
 
     /// Enable authentication with etcd. By default disabled.
-    #[clap(long)]
+    #[clap(long, env)]
     etcd_auth: bool,
 
     /// Username of etcd, required when --etcd-auth is enabled.
     /// Default value is read from the 'ETCD_USERNAME' environment variable.
-    #[clap(long, env = "ETCD_USERNAME", default_value = "")]
+    #[clap(long, env, default_value = "")]
     etcd_username: String,
 
     /// Password of etcd, required when --etcd-auth is enabled.
     /// Default value is read from the 'ETCD_PASSWORD' environment variable.
-    #[clap(long, env = "ETCD_PASSWORD", default_value = "")]
+    #[clap(long, env, default_value = "")]
     etcd_password: String,
 
-    #[clap(long)]
+    #[clap(long, env)]
     dashboard_ui_path: Option<String>,
 
     /// For dashboard service to fetch cluster info.
-    #[clap(long)]
+    #[clap(long, env)]
     prometheus_endpoint: Option<String>,
 
     /// Endpoint of the connector node, there will be a sidecar connector node
     /// colocated with Meta node in the cloud environment
-    #[clap(long, env = "META_CONNECTOR_RPC_ENDPOINT")]
+    #[clap(long, env)]
     pub connector_rpc_endpoint: Option<String>,
 
     /// The path of `risingwave.toml` configuration file.
     ///
     /// If empty, default configuration values will be used.
-    #[clap(long, default_value = "")]
+    #[clap(long, env, default_value = "")]
     pub config_path: String,
 
     #[clap(flatten)]
@@ -118,7 +118,7 @@ pub struct MetaNodeOpts {
 /// Command-line arguments for compute-node that overrides the config file.
 #[derive(Parser, Clone, Debug, OverrideConfig)]
 pub struct OverrideConfigOpts {
-    #[clap(long, arg_enum)]
+    #[clap(long, env, arg_enum)]
     #[override_opts(path = meta.backend)]
     backend: Option<MetaBackend>,
 }

--- a/src/storage/compactor/src/lib.rs
+++ b/src/storage/compactor/src/lib.rs
@@ -25,30 +25,30 @@ use crate::server::compactor_serve;
 #[derive(Parser, Clone, Debug)]
 pub struct CompactorOpts {
     // TODO: rename to listen_address and separate out the port.
-    #[clap(long, default_value = "127.0.0.1:6660")]
+    #[clap(long, env, default_value = "127.0.0.1:6660")]
     pub host: String,
 
     // Optional, we will use listen_address if not specified.
-    #[clap(long)]
+    #[clap(long, env)]
     pub client_address: Option<String>,
 
     // TODO: This is currently unused.
-    #[clap(long)]
+    #[clap(long, env)]
     pub port: Option<u16>,
 
-    #[clap(long, default_value = "127.0.0.1:1260")]
+    #[clap(long, env, default_value = "127.0.0.1:1260")]
     pub prometheus_listener_addr: String,
 
-    #[clap(long, default_value = "http://127.0.0.1:5690")]
+    #[clap(long, env, default_value = "http://127.0.0.1:5690")]
     pub meta_address: String,
 
-    #[clap(long)]
+    #[clap(long, env)]
     pub compaction_worker_threads_number: Option<usize>,
 
     /// The path of `risingwave.toml` configuration file.
     ///
     /// If empty, default configuration values will be used.
-    #[clap(long, default_value = "")]
+    #[clap(long, env, default_value = "")]
     pub config_path: String,
 
     #[clap(flatten)]
@@ -61,19 +61,19 @@ struct OverrideConfigOpts {
     /// Of the form `hummock+{object_store}` where `object_store`
     /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`,
     /// `memory` or `memory-shared`.
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = storage.state_store)]
     pub state_store: Option<String>,
 
     /// Used for control the metrics level, similar to log level.
     /// 0 = close metrics
     /// >0 = open metrics
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = server.metrics_level)]
     pub metrics_level: Option<u32>,
 
     /// It's a hint used by meta node.
-    #[clap(long)]
+    #[clap(long, env)]
     #[override_opts(path = storage.max_concurrent_compaction_task_number)]
     pub max_concurrent_task_number: Option<u64>,
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title

## Checklist

- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment

### Release note

All components accept environment variable as fallback for absent CLI args. Note that flags will be `true` as long as the environment variable is present, the value does not matter.

## Refer to a related PR or issue link (optional)
