### PR TITLE
chore(log): suppress unnecessary warning

### DIFF
--- a/src/storage/src/hummock/iterator/merge_inner.rs
+++ b/src/storage/src/hummock/iterator/merge_inner.rs
@@ -18,7 +18,6 @@ use std::future::Future;
 use std::ops::{Deref, DerefMut};
 
 use risingwave_hummock_sdk::key::{FullKey, TableKey, UserKey};
-use tracing::warn;
 
 use crate::hummock::iterator::{DirectionEnum, HummockIterator, HummockIteratorDirection};
 use crate::hummock::value::HummockValue;
@@ -261,7 +260,9 @@ impl<'a, T: Ord> Drop for PeekMutGuard<'a, T> {
     /// call `PeekMut::pop` on the `PeekMut` and recycle the node to the unused list.
     fn drop(&mut self) {
         if let Some(peek) = self.peek.take() {
-            warn!("PeekMut are dropped without used. May be caused by future cancellation");
+            tracing::debug!(
+                "PeekMut are dropped without used. May be caused by future cancellation"
+            );
             let top = PeekMut::pop(peek);
             self.unused.push_back(top);
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Change this warning message into a debug message, because it's the expected behavior during backfill. Otherwise it can overwhelm the log stream during a large MV creation.

## Checklist

- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
