### PR TITLE
fix(sqlsmith): generate typed null

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -638,6 +638,13 @@ fn make_bin_op(func: ExprType, exprs: &[Expr]) -> Option<Expr> {
     })
 }
 
+pub(crate) fn typed_null(ty: &DataType) -> Expr {
+    Expr::Cast {
+        expr: Box::new(sql_null()),
+        data_type: data_type_to_ast_data_type(ty),
+    }
+}
+
 /// Generates a `NULL` value.
 pub(crate) fn sql_null() -> Expr {
     Expr::Value(Value::Null)

--- a/src/tests/sqlsmith/src/sql_gen/scalar.rs
+++ b/src/tests/sqlsmith/src/sql_gen/scalar.rs
@@ -22,7 +22,6 @@ use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{DataType as AstDataType, Expr, Value};
 
 use crate::sql_gen::expr::typed_null;
-use crate::sql_gen::types::data_type_to_ast_data_type;
 use crate::sql_gen::SqlGenerator;
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {

--- a/src/tests/sqlsmith/src/sql_gen/scalar.rs
+++ b/src/tests/sqlsmith/src/sql_gen/scalar.rs
@@ -21,7 +21,7 @@ use rand::Rng;
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{DataType as AstDataType, Expr, Value};
 
-use crate::sql_gen::expr::{sql_null, typed_null};
+use crate::sql_gen::expr::typed_null;
 use crate::sql_gen::types::data_type_to_ast_data_type;
 use crate::sql_gen::SqlGenerator;
 

--- a/src/tests/sqlsmith/src/sql_gen/scalar.rs
+++ b/src/tests/sqlsmith/src/sql_gen/scalar.rs
@@ -21,7 +21,7 @@ use rand::Rng;
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::{DataType as AstDataType, Expr, Value};
 
-use crate::sql_gen::expr::sql_null;
+use crate::sql_gen::expr::{sql_null, typed_null};
 use crate::sql_gen::types::data_type_to_ast_data_type;
 use crate::sql_gen::SqlGenerator;
 
@@ -35,10 +35,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             // NOTE(kwannoel): We generate Cast with NULL to avoid generating lots of ambiguous
             // expressions. For instance agg calls such as `max(NULL)` may be generated,
             // and coerced to VARCHAR, where we require a `NULL::int` instead.
-            return Expr::Cast {
-                expr: Box::new(sql_null()),
-                data_type: data_type_to_ast_data_type(typ),
-            };
+            return typed_null(typ);
         }
         // Scalars which may generate negative numbers are wrapped in
         // `Nested` to ambiguity while parsing.
@@ -103,7 +100,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             //         .map(|typ| self.gen_simple_scalar(typ))
             //         .collect(),
             // ),
-            _ => sql_null(),
+            _ => typed_null(typ),
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)

closes https://github.com/risingwavelabs/risingwave/issues/7677