### PR TITLE
ci: add github_token for buf-setup-action

### DIFF
--- a/.github/workflows/protobuf-breaking.yml
+++ b/.github/workflows/protobuf-breaking.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: bufbuild/buf-setup-action@v1
+        with:
+          github_token: ${{ github.token }}
       # Run breaking change detection against the `main` branch
       - uses: bufbuild/buf-breaking-action@v1
         with:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

