### PR TITLE
perf(compaction): adjust restart points in block builder

### DIFF
--- a/dashboard/proto/gen/catalog.ts
+++ b/dashboard/proto/gen/catalog.ts
@@ -151,6 +151,7 @@ export interface Table {
   definition: string;
   handlePkConflict: boolean;
   readPrefixLenHint: number;
+  visitedByVnodeFetch: boolean;
   /**
    * Per-table catalog version, used by schema change. `None` for internal tables and tests.
    * Not to be confused with the global catalog version for notification service.
@@ -741,6 +742,7 @@ function createBaseTable(): Table {
     definition: "",
     handlePkConflict: false,
     readPrefixLenHint: 0,
+    visitedByVnodeFetch: false,
     version: undefined,
   };
 }
@@ -782,6 +784,7 @@ export const Table = {
       definition: isSet(object.definition) ? String(object.definition) : "",
       handlePkConflict: isSet(object.handlePkConflict) ? Boolean(object.handlePkConflict) : false,
       readPrefixLenHint: isSet(object.readPrefixLenHint) ? Number(object.readPrefixLenHint) : 0,
+      visitedByVnodeFetch: isSet(object.visitedByVnodeFetch) ? Boolean(object.visitedByVnodeFetch) : false,
       version: isSet(object.version) ? Table_TableVersion.fromJSON(object.version) : undefined,
     };
   },
@@ -841,6 +844,7 @@ export const Table = {
     message.definition !== undefined && (obj.definition = message.definition);
     message.handlePkConflict !== undefined && (obj.handlePkConflict = message.handlePkConflict);
     message.readPrefixLenHint !== undefined && (obj.readPrefixLenHint = Math.round(message.readPrefixLenHint));
+    message.visitedByVnodeFetch !== undefined && (obj.visitedByVnodeFetch = message.visitedByVnodeFetch);
     message.version !== undefined &&
       (obj.version = message.version ? Table_TableVersion.toJSON(message.version) : undefined);
     return obj;
@@ -890,6 +894,7 @@ export const Table = {
     message.definition = object.definition ?? "";
     message.handlePkConflict = object.handlePkConflict ?? false;
     message.readPrefixLenHint = object.readPrefixLenHint ?? 0;
+    message.visitedByVnodeFetch = object.visitedByVnodeFetch ?? false;
     message.version = (object.version !== undefined && object.version !== null)
       ? Table_TableVersion.fromPartial(object.version)
       : undefined;

--- a/dashboard/proto/gen/meta.ts
+++ b/dashboard/proto/gen/meta.ts
@@ -207,6 +207,7 @@ export interface TableFragments_Fragment {
    */
   vnodeMapping: ParallelUnitMapping | undefined;
   stateTableIds: number[];
+  vnodeVisitedStateTableIds: number[];
   /**
    * Note that this can be derived backwards from the upstream actors of the Actor held by the Fragment,
    * but in some scenarios (e.g. Scaling) it will lead to a lot of duplicate code,
@@ -768,6 +769,7 @@ function createBaseTableFragments_Fragment(): TableFragments_Fragment {
     actors: [],
     vnodeMapping: undefined,
     stateTableIds: [],
+    vnodeVisitedStateTableIds: [],
     upstreamFragmentIds: [],
   };
 }
@@ -783,6 +785,9 @@ export const TableFragments_Fragment = {
       actors: Array.isArray(object?.actors) ? object.actors.map((e: any) => StreamActor.fromJSON(e)) : [],
       vnodeMapping: isSet(object.vnodeMapping) ? ParallelUnitMapping.fromJSON(object.vnodeMapping) : undefined,
       stateTableIds: Array.isArray(object?.stateTableIds) ? object.stateTableIds.map((e: any) => Number(e)) : [],
+      vnodeVisitedStateTableIds: Array.isArray(object?.vnodeVisitedStateTableIds)
+        ? object.vnodeVisitedStateTableIds.map((e: any) => Number(e))
+        : [],
       upstreamFragmentIds: Array.isArray(object?.upstreamFragmentIds)
         ? object.upstreamFragmentIds.map((e: any) => Number(e))
         : [],
@@ -807,6 +812,11 @@ export const TableFragments_Fragment = {
     } else {
       obj.stateTableIds = [];
     }
+    if (message.vnodeVisitedStateTableIds) {
+      obj.vnodeVisitedStateTableIds = message.vnodeVisitedStateTableIds.map((e) => Math.round(e));
+    } else {
+      obj.vnodeVisitedStateTableIds = [];
+    }
     if (message.upstreamFragmentIds) {
       obj.upstreamFragmentIds = message.upstreamFragmentIds.map((e) => Math.round(e));
     } else {
@@ -825,6 +835,7 @@ export const TableFragments_Fragment = {
       ? ParallelUnitMapping.fromPartial(object.vnodeMapping)
       : undefined;
     message.stateTableIds = object.stateTableIds?.map((e) => e) || [];
+    message.vnodeVisitedStateTableIds = object.vnodeVisitedStateTableIds?.map((e) => e) || [];
     message.upstreamFragmentIds = object.upstreamFragmentIds?.map((e) => e) || [];
     return message;
   },

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -138,6 +138,7 @@ message Table {
   string definition = 21;
   bool handle_pk_conflict = 22;
   uint32 read_prefix_len_hint = 23;
+  bool visited_by_vnode_fetch = 24;
 
   // Per-table catalog version, used by schema change. `None` for internal tables and tests.
   // Not to be confused with the global catalog version for notification service.

--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -74,11 +74,12 @@ message TableFragments {
     // This field is always set to `Some`. For singleton, the parallel unit for all vnodes will be the same.
     common.ParallelUnitMapping vnode_mapping = 5;
     repeated uint32 state_table_ids = 6;
+    repeated uint32 vnode_visited_state_table_ids = 7;
     // Note that this can be derived backwards from the upstream actors of the Actor held by the Fragment,
     // but in some scenarios (e.g. Scaling) it will lead to a lot of duplicate code,
     // so we pre-generate and store it here, this member will only be initialized when creating the Fragment
     // and modified when creating the mv-on-mv
-    repeated uint32 upstream_fragment_ids = 7;
+    repeated uint32 upstream_fragment_ids = 8;
   }
   uint32 table_id = 1;
   State state = 2;

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -355,6 +355,7 @@ impl TableCatalog {
             definition: self.definition.clone(),
             handle_pk_conflict: self.handle_pk_conflict,
             read_prefix_len_hint: self.read_prefix_len_hint as u32,
+            visited_by_vnode_fetch: false,
             version: self.version.as_ref().map(TableVersion::to_prost),
         }
     }
@@ -500,6 +501,7 @@ mod tests {
             read_prefix_len_hint: 0,
             vnode_col_index: None,
             row_id_index: None,
+            visited_by_vnode_fetch: false,
             version: Some(ProstTableVersion {
                 version: 0,
                 next_column_id: 2,

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -943,7 +943,7 @@ mod tests {
         assert_eq!(registered_number().await, 0);
 
         // Test `StaticCompactionGroupId::NewCompactionGroup` in `register_table_fragments`
-        assert_eq!(group_number().await, 2);
+        assert_eq!(group_number().await, 3);
         table_properties.insert(
             String::from("independent_compaction_group"),
             String::from("1"),
@@ -953,7 +953,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(registered_number().await, 4);
-        assert_eq!(group_number().await, 3);
+        assert_eq!(group_number().await, 4);
 
         // Test `StaticCompactionGroupId::NewCompactionGroup` in `unregister_table_fragments`
         compaction_group_manager
@@ -961,6 +961,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(registered_number().await, 0);
-        assert_eq!(group_number().await, 2);
+        assert_eq!(group_number().await, 3);
     }
 }

--- a/src/meta/src/model/stream.rs
+++ b/src/meta/src/model/stream.rs
@@ -570,6 +570,13 @@ impl TableFragments {
             .collect_vec()
     }
 
+    pub fn vnode_visited_internal_table_ids(&self) -> Vec<u32> {
+        self.fragments
+            .values()
+            .flat_map(|f| f.vnode_visited_state_table_ids.clone())
+            .collect_vec()
+    }
+
     /// Returns all internal table ids including the mview table.
     pub fn all_table_ids(&self) -> impl Iterator<Item = u32> + '_ {
         self.fragments

--- a/src/storage/benches/bench_block_iter.rs
+++ b/src/storage/benches/bench_block_iter.rs
@@ -108,7 +108,7 @@ fn build_block_data(t: u32, i: u64) -> Bytes {
     let mut builder = BlockBuilder::new(options);
     for tt in 1..=t {
         for ii in 1..=i {
-            builder.add(&key(tt, ii), &value(ii));
+            builder.add(&key(tt, ii), &value(ii), true);
         }
     }
     Bytes::from(builder.build().to_vec())

--- a/src/storage/benches/bench_block_iter.rs
+++ b/src/storage/benches/bench_block_iter.rs
@@ -104,11 +104,12 @@ fn build_block_data(t: u32, i: u64) -> Bytes {
         capacity: BLOCK_CAPACITY,
         compression_algorithm: CompressionAlgorithm::None,
         restart_interval: RESTART_INTERVAL,
+        not_only_visited_by_vnode_fetch: true,
     };
     let mut builder = BlockBuilder::new(options);
     for tt in 1..=t {
         for ii in 1..=i {
-            builder.add(&key(tt, ii), &value(ii), true);
+            builder.add(&key(tt, ii), &value(ii));
         }
     }
     Bytes::from(builder.build().to_vec())

--- a/src/storage/hummock_sdk/src/compaction_group/mod.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/mod.rs
@@ -32,10 +32,12 @@ pub enum StaticCompactionGroupId {
     SharedBuffer = 1,
     /// All states goes to here by default.
     StateDefault = 2,
+    /// States which we visit them by fetching all KVs of certain vnode(s) goes to here.
+    StateVnodeVisit = 3,
     /// All MVs goes to here.
-    MaterializedView = 3,
+    MaterializedView = 4,
     /// Larger than any `StaticCompactionGroupId`.
-    End = 4,
+    End = 5,
 }
 
 impl From<StaticCompactionGroupId> for CompactionGroupId {

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -461,6 +461,7 @@ mod tests {
             definition: "".into(),
             handle_pk_conflict: false,
             read_prefix_len_hint: 1,
+            visited_by_vnode_fetch: false,
             version: None,
         }
     }

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -46,6 +46,7 @@ pub struct RemoteBuilderFactory<F: SstableWriterFactory> {
     pub remote_rpc_cost: Arc<AtomicU64>,
     pub filter_key_extractor: Arc<FilterKeyExtractorImpl>,
     pub sstable_writer_factory: F,
+    pub is_visited_by_vnode_fetch: bool,
 }
 
 #[async_trait::async_trait]
@@ -75,6 +76,7 @@ impl<F: SstableWriterFactory> TableBuilderFactory for RemoteBuilderFactory<F> {
             writer,
             self.options.clone(),
             self.filter_key_extractor.clone(),
+            self.is_visited_by_vnode_fetch,
         );
         Ok(builder)
     }

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -101,6 +101,7 @@ impl CompactorRunner {
         filter_key_extractor: Arc<FilterKeyExtractorImpl>,
         del_agg: Arc<RangeTombstonesCollector>,
         task_progress: Arc<TaskProgress>,
+        is_visited_by_vnode_fetch: bool,
     ) -> HummockResult<CompactOutput> {
         let iter = self.build_sst_iter()?;
         let (ssts, table_stats_map) = self
@@ -111,6 +112,7 @@ impl CompactorRunner {
                 del_agg,
                 filter_key_extractor,
                 Some(task_progress),
+                is_visited_by_vnode_fetch,
             )
             .await?;
         Ok((self.split_index, ssts, table_stats_map))

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -328,6 +328,7 @@ impl SharedBufferCompactRunner {
                 del_agg,
                 filter_key_extractor,
                 None,
+                false,
             )
             .await?;
         Ok((self.split_index, ssts, table_stats_map))

--- a/src/storage/src/hummock/sstable/block_iterator.rs
+++ b/src/storage/src/hummock/sstable/block_iterator.rs
@@ -252,10 +252,10 @@ mod tests {
     fn build_iterator_for_test() -> BlockIterator {
         let options = BlockBuilderOptions::default();
         let mut builder = BlockBuilder::new(options);
-        builder.add(&full_key(b"k01", 1), b"v01");
-        builder.add(&full_key(b"k02", 2), b"v02");
-        builder.add(&full_key(b"k04", 4), b"v04");
-        builder.add(&full_key(b"k05", 5), b"v05");
+        builder.add(&full_key(b"k01", 1), b"v01", true);
+        builder.add(&full_key(b"k02", 2), b"v02", true);
+        builder.add(&full_key(b"k04", 4), b"v04", true);
+        builder.add(&full_key(b"k05", 5), b"v05", true);
         let capacity = builder.uncompressed_block_size();
         let buf = builder.build().to_vec();
         BlockIterator::new(BlockHolder::from_owned_block(Box::new(

--- a/src/storage/src/hummock/sstable/block_iterator.rs
+++ b/src/storage/src/hummock/sstable/block_iterator.rs
@@ -252,10 +252,10 @@ mod tests {
     fn build_iterator_for_test() -> BlockIterator {
         let options = BlockBuilderOptions::default();
         let mut builder = BlockBuilder::new(options);
-        builder.add(&full_key(b"k01", 1), b"v01", true);
-        builder.add(&full_key(b"k02", 2), b"v02", true);
-        builder.add(&full_key(b"k04", 4), b"v04", true);
-        builder.add(&full_key(b"k05", 5), b"v05", true);
+        builder.add(&full_key(b"k01", 1), b"v01");
+        builder.add(&full_key(b"k02", 2), b"v02");
+        builder.add(&full_key(b"k04", 4), b"v04");
+        builder.add(&full_key(b"k05", 5), b"v05");
         let capacity = builder.uncompressed_block_size();
         let buf = builder.build().to_vec();
         BlockIterator::new(BlockHolder::from_owned_block(Box::new(

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -133,6 +133,7 @@ async fn compaction_test(
         table_type: 0,
         append_only: false,
         row_id_index: None,
+        visited_by_vnode_fetch: false,
         version: None,
     };
     let mut delete_range_table = delete_key_table.clone();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->
State table of GlobalSimpleAgg will be only visited by iter_all, thus we can reduce restart points in block builder of them because we will never seek from middle part of these tables.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
