### PR TITLE
fix: alias of argument `advertise_addr`

### DIFF
--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -52,7 +52,7 @@ pub struct ComputeNodeOpts {
     /// This would be synonymous with the service's "public address"
     /// or "identifying address".
     /// Optional, we will use listen_addr if not specified.
-    #[clap(long, alias = "client_address", env = "RW_ADVERTISE_ADDR", long)]
+    #[clap(long, alias = "client-address", env = "RW_ADVERTISE_ADDR", long)]
     pub advertise_addr: Option<String>,
 
     #[clap(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The alias of `--advertise-addr` should be `--client-address` to keep compatible with previous versions.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

None

## Refer to a related PR or issue link (optional)

Introduced in #7530