### PR TITLE
chore: use short connection in etcd election client

### DIFF
--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -289,18 +289,14 @@ impl ElectionClient for EtcdElectionClient {
 }
 
 impl EtcdElectionClient {
-    pub(crate) async fn new(
-        endpoints: Vec<String>,
-        options: Option<ConnectOptions>,
-        id: String,
-    ) -> MetaResult<Self> {
+    pub(crate) fn new(endpoints: Vec<String>, options: Option<ConnectOptions>, id: String) -> Self {
         let (sender, _) = watch::channel(false);
-        Ok(Self {
+        Self {
             endpoints,
             options,
             id,
             is_leader_sender: sender,
-        })
+        }
     }
 
     async fn client(&self) -> MetaResult<Client> {
@@ -336,15 +332,11 @@ mod tests {
             let (stop_sender, stop_receiver) = watch::channel(());
             clients.push((
                 stop_sender,
-                Arc::new(
-                    EtcdElectionClient::new(
-                        vec!["localhost:2388".to_string()],
-                        None,
-                        format!("client_{}", i).to_string(),
-                    )
-                    .await
-                    .unwrap(),
-                ),
+                Arc::new(EtcdElectionClient::new(
+                    vec!["localhost:2388".to_string()],
+                    None,
+                    format!("client_{}", i).to_string(),
+                )),
             ));
         }
 

--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -34,17 +34,18 @@ pub struct ElectionMember {
 #[async_trait::async_trait]
 pub trait ElectionClient: Send + Sync + 'static {
     fn id(&self) -> MetaResult<String>;
-    async fn run_once(&self, ttl: i64, stop: watch::Receiver<()>) -> MetaResult<()>;
-    fn subscribe(&self) -> watch::Receiver<bool>;
+    async fn run_once(&self, ttl: i64, stop: Receiver<()>) -> MetaResult<()>;
+    fn subscribe(&self) -> Receiver<bool>;
     async fn leader(&self) -> MetaResult<Option<ElectionMember>>;
     async fn get_members(&self) -> MetaResult<Vec<ElectionMember>>;
     async fn is_leader(&self) -> bool;
 }
 
 pub struct EtcdElectionClient {
-    client: Client,
     id: String,
     is_leader_sender: watch::Sender<bool>,
+    endpoints: Vec<String>,
+    options: Option<ConnectOptions>,
 }
 
 #[async_trait::async_trait]
@@ -54,7 +55,7 @@ impl ElectionClient for EtcdElectionClient {
     }
 
     async fn leader(&self) -> MetaResult<Option<ElectionMember>> {
-        let mut election_client = self.client.election_client();
+        let mut election_client = self.client().await?.election_client();
         let leader = election_client.leader(META_ELECTION_KEY).await;
 
         let leader = match leader {
@@ -72,8 +73,9 @@ impl ElectionClient for EtcdElectionClient {
     }
 
     async fn run_once(&self, ttl: i64, stop: watch::Receiver<()>) -> MetaResult<()> {
-        let mut lease_client = self.client.lease_client();
-        let mut election_client = self.client.election_client();
+        let client = self.client().await?;
+        let mut lease_client = client.lease_client();
+        let mut election_client = client.election_client();
         let mut stop = stop;
 
         tracing::info!("client {} start election", self.id);
@@ -124,7 +126,7 @@ impl ElectionClient for EtcdElectionClient {
 
         let (keep_alive_fail_tx, mut keep_alive_fail_rx) = oneshot::channel();
 
-        let mut lease_client = self.client.lease_client();
+        let mut lease_client = client.lease_client();
 
         let mut stop_ = stop.clone();
 
@@ -246,7 +248,7 @@ impl ElectionClient for EtcdElectionClient {
     }
 
     async fn get_members(&self) -> MetaResult<Vec<ElectionMember>> {
-        let mut client = self.client.kv_client();
+        let mut client = self.client().await?.kv_client();
         let keys = client
             .get(META_ELECTION_KEY, Some(GetOptions::new().with_prefix()))
             .await?;
@@ -292,14 +294,18 @@ impl EtcdElectionClient {
         options: Option<ConnectOptions>,
         id: String,
     ) -> MetaResult<Self> {
-        let client = Client::connect(&endpoints, options.clone()).await?;
-
         let (sender, _) = watch::channel(false);
         Ok(Self {
-            client,
+            endpoints,
+            options,
             id,
             is_leader_sender: sender,
         })
+    }
+
+    async fn client(&self) -> MetaResult<Client> {
+        let client = Client::connect(self.endpoints.clone(), self.options.clone()).await?;
+        Ok(client)
     }
 }
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -121,14 +121,11 @@ pub async fn rpc_serve(
             .map_err(|e| anyhow::anyhow!("failed to connect etcd {}", e))?;
             let meta_store = Arc::new(EtcdMetaStore::new(client));
 
-            let election_client = Arc::new(
-                EtcdElectionClient::new(
-                    endpoints,
-                    Some(options),
-                    address_info.advertise_addr.clone(),
-                )
-                .await?,
-            );
+            let election_client = Arc::new(EtcdElectionClient::new(
+                endpoints,
+                Some(options),
+                address_info.advertise_addr.clone(),
+            ));
 
             rpc_serve_with_store(
                 meta_store,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR changes the connection in the ETCD election client to a short connection to resolve a stuck etcd master migration in case of auth enable.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
