### PR TITLE
fix(test): fix the deterministic kafka source test

### DIFF
--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -30,7 +30,7 @@ echo "--- deterministic simulation e2e, ci-3cn-2fe, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation ./e2e_test/batch/\*\*/\*.slt 2> $LOGDIR/batch-{}.log && rm $LOGDIR/batch-{}.log'
 
 echo "--- deterministic simulation e2e, ci-3cn-2fe, kafka source"
-seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kafka-datadir=./scripts/source/test_data ./e2e_test/source/kafka.slt 2> $LOGDIR/source-{}.log && rm $LOGDIR/source-{}.log'
+seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --kafka-datadir=./scripts/source/test_data ./e2e_test/source/basic/kafka.slt 2> $LOGDIR/source-{}.log && rm $LOGDIR/source-{}.log'
 
 echo "--- deterministic simulation e2e, ci-3cn-2fe, parallel, streaming"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation -j 16 ./e2e_test/streaming/\*\*/\*.slt 2> $LOGDIR/parallel-streaming-{}.log && rm $LOGDIR/parallel-streaming-{}.log'

--- a/src/tests/simulation/src/kafka.rs
+++ b/src/tests/simulation/src/kafka.rs
@@ -61,7 +61,9 @@ pub async fn producer(broker_addr: &str, datadir: String) {
     for file in std::fs::read_dir(datadir).unwrap() {
         let file = file.unwrap();
         let name = file.file_name().into_string().unwrap();
-        let (topic, partitions) = name.split_once('.').unwrap();
+        let Some((topic, partitions)) = name.split_once('.') else {
+            panic!("invalid file name: {name:?}. expected format \"topic.partitions\"");
+        };
         admin
             .create_topics(
                 &[NewTopic::new(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Correct the path of `kafka.slt`.
- Improve error message for the panic #7633.

## Checklist

- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
close #7633