### PR TITLE
fix(compaction): fix corner case

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -741,7 +741,6 @@ where
             .compaction_group(compaction_group_id)
             .await
             .ok_or(Error::InvalidCompactionGroup(compaction_group_id))?;
-        let all_table_ids = self.all_table_ids().await;
         if !compaction
             .compaction_statuses
             .contains_key(&compaction_group_id)
@@ -776,7 +775,7 @@ where
             (versioning_guard.current_version.clone(), watermark)
         };
         if current_version.levels.get(&compaction_group_id).is_none() {
-            // sync_group has not been called for this group, which means no data even written.
+            // compaction group has been deleted.
             return Ok(None);
         }
         let can_trivial_move = manual_compaction_option.is_none();
@@ -813,6 +812,7 @@ where
                 start_time.elapsed()
             );
         } else {
+            let all_table_ids = self.all_table_ids().await;
             // to get all relational table_id from sst_info
             let table_ids = compact_task
                 .input_ssts


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As we don't hold versioning lock throughout `get_compact_task_impl`, this bug can happen:
1. `get_compact_task_impl`: [get all_table_ids](https://github.com/risingwavelabs/risingwave/blob/9068a4ed612482ff3d101a5d6a97a5010113349c/src/meta/src/hummock/manager/mod.rs#L744).
2. New table is created and its SSTs are added to version by checkpoint. So `all_table_ids` got in step 1 is stale.
3. `get_compact_task_impl`: [new compaction task](https://github.com/risingwavelabs/risingwave/blob/9068a4ed612482ff3d101a5d6a97a5010113349c/src/meta/src/hummock/manager/mod.rs#L784) includes these new table's SSTs as input.
4. Compaction task's [existing_table_ids](https://github.com/risingwavelabs/risingwave/blob/main/src/meta/src/hummock/manager/mod.rs#L831) doesn't contain these new SSTs. **Thus compaction filter will remove their KVs unexpectedly.**

This PR fixes it by calling `all_table_ids` after new compaction task's input is selected.
Also fix an outdated comment.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
