### PR TITLE
perf(stream): refactor `zip_eq` to `zip`

### DIFF
--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -276,7 +276,7 @@ where
     ) -> StreamExecutorResult<()> {
         match visibility {
             None => {
-                for (op, data) in ops.iter().zip_eq(data.iter()) {
+                for (op, data) in ops.iter().zip(data.iter()) {
                     match op {
                         Op::Insert | Op::UpdateInsert => {
                             self.result = S::accumulate(self.result.as_ref(), data)?

--- a/src/stream/src/executor/aggregation/agg_impl/row_count.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/row_count.rs
@@ -79,7 +79,7 @@ impl StreamingAggImpl for StreamingRowCountAgg {
                 }
             }
             Some(visibility) => {
-                for (op, visible) in ops.iter().zip_eq(visibility.iter()) {
+                for (op, visible) in ops.iter().zip(visibility.iter()) {
                     if visible {
                         match op {
                             Op::Insert | Op::UpdateInsert => self.row_cnt += 1,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

WIP for #7351 . Benchmark first.
- Should replace the `zip_eq` with an assert which can be optimized away.

q17 flamegraph shows that much time is used by `zip_eq`:
<img width="1482" alt="Screenshot 2023-02-08 at 2 34 09 AM" src="https://user-images.githubusercontent.com/47273164/217334808-9286a552-4281-4eb9-a176-591a0aafdb92.png">

Additionally can optimize `SerializedKey`?
<img width="1482" alt="Screenshot 2023-02-08 at 2 52 34 AM" src="https://user-images.githubusercontent.com/47273164/217338894-d86d6f2f-3e33-47de-b26c-9760c2370e9b.png">



## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

## Refer to a related PR or issue link (optional)
