### PR TITLE
feat(stream): lazy emit for HashAggExecutor

### DIFF
--- a/src/stream/src/executor/aggregation/agg_group.rs
+++ b/src/stream/src/executor/aggregation/agg_group.rs
@@ -46,7 +46,7 @@ impl<S: StateStore> Debug for AggGroup<S> {
         f.debug_struct("AggGroup")
             .field("group_key", &self.group_key)
             .field("prev_outputs", &self.prev_outputs)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/src/stream/src/executor/aggregation/mod.rs
+++ b/src/stream/src/executor/aggregation/mod.rs
@@ -39,9 +39,11 @@ mod state_cache;
 mod table;
 mod value;
 
-/// Generate [`crate::executor::HashAggExecutor`]'s schema from `input`, `agg_calls` and
-/// `group_key_indices`. For [`crate::executor::HashAggExecutor`], the group key indices should
-/// be provided.
+/// Generate [`HashAggExecutor`][HashAggExecutor]'s schema from `input`, `agg_calls` and
+/// `group_key_indices`. For [`HashAggExecutor`][HashAggExecutor], the group key indices should be
+/// provided.
+///
+/// [HashAggExecutor]:crate::executor::HashAggExecutor
 pub fn generate_agg_schema(
     input: &dyn Executor,
     agg_calls: &[AggCall],

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -510,7 +510,7 @@ impl<K: HashKey, S: StateStore, E: imp::EmitPolicy> HashAggExecutor<K, S, E> {
                 };
 
                 // Calculate current outputs, concurrently.
-                let futs = keys_in_batch
+                let futs: Vec<_> = keys_in_batch
                     .iter()
                     .zip(agg_groups.into_iter())
                     .into_iter()
@@ -524,7 +524,8 @@ impl<K: HashKey, S: StateStore, E: imp::EmitPolicy> HashAggExecutor<K, S, E> {
                             Ok::<_, StreamExecutorError>((key.clone(), agg_group, curr_outputs))
                         });
                         f
-                    });
+                    })
+                    .collect();
                 let outputs_in_batch: Vec<_> = stream::iter(futs)
                     .buffer_unordered(10)
                     .fuse()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Support append-only output from HashAgg if the first group key has a watermark defined on it.

The PR is the backend implementation.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)

#6042 