### PR TITLE
feat(planner-test): backtrace on panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6374,6 +6374,7 @@ name = "risingwave_planner_test"
 version = "0.2.0-alpha"
 dependencies = [
  "anyhow",
+ "backtrace",
  "console",
  "futures",
  "itertools",

--- a/src/frontend/planner_test/Cargo.toml
+++ b/src/frontend/planner_test/Cargo.toml
@@ -10,6 +10,7 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = "1"
+backtrace = "0.3.67"
 console = "0.15"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"

--- a/src/frontend/planner_test/src/bin/apply.rs
+++ b/src/frontend/planner_test/src/bin/apply.rs
@@ -17,6 +17,7 @@ use std::path::Path;
 use std::thread::available_parallelism;
 
 use anyhow::{anyhow, Context, Result};
+use backtrace::Backtrace;
 use console::style;
 use futures::StreamExt;
 use risingwave_planner_test::{resolve_testcase_id, TestCase};
@@ -24,13 +25,15 @@ use risingwave_planner_test::{resolve_testcase_id, TestCase};
 #[tokio::main]
 async fn main() -> Result<()> {
     std::panic::set_hook(Box::new(move |e| {
+        let backtrace = Backtrace::new();
         println!(
-            "{}{}{}{}{}\n{e}",
+            "{}{}{}{}{}\nBACKTRACE{:?}\n{e}",
             style("ERROR: ").red().bold(),
             style("apply-planner-test").yellow(),
             style(" panicked! Try ").red().bold(),
             style("run-planner-test --no-fail-fast").yellow(),
-            style(" to find which test case panicked.").red().bold()
+            style(" to find which test case panicked.").red().bold(),
+            backtrace,
         );
         std::process::abort();
     }));

--- a/src/frontend/planner_test/src/bin/apply.rs
+++ b/src/frontend/planner_test/src/bin/apply.rs
@@ -27,7 +27,7 @@ async fn main() -> Result<()> {
     std::panic::set_hook(Box::new(move |e| {
         let backtrace = Backtrace::new();
         println!(
-            "{}{}{}{}{}\nBACKTRACE{:?}\n{e}",
+            "{}{}{}{}{}\n{:?}\n{e}",
             style("ERROR: ").red().bold(),
             style("apply-planner-test").yellow(),
             style(" panicked! Try ").red().bold(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Comments: the backtrace is verbose but now contains sufficient information to debug

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/7754