### PR TITLE
feat(risedev): add `check-fix` task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -748,7 +748,15 @@ script = """
 #!/usr/bin/env bash
 
 echo "Running $(tput setaf 4)cargo clippy$(tput sgr0) checks and attempting to fix"
-cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+if [ $# -gt 0 ]; then
+  ARGS=("$@")
+
+  echo "Applying clippy --fix for $@ (including dirty and staged files)"
+  cargo clippy ${ARGS[@]/#/--package risingwave_} --all-features --fix --allow-dirty --allow-staged
+else
+  echo "Applying clippy --fix for all targets to all files (including dirty and staged files)"
+  cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+fi
 """
 
 [tasks.check-typos]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -741,6 +741,16 @@ cargo clippy --all-targets --all-features
 echo "If cargo clippy check failed or generates warning, you may run $(tput setaf 4)cargo clippy --workspace --all-targets --fix$(tput sgr0) to fix it. Note that clippy fix requires manual review, as not all auto fixes are guaranteed to be reasonable."
 """
 
+[tasks.check-clippy-fix]
+category = "RiseDev - Check"
+description = "Run cargo clippy check and fixes all files (including dirty and staged)"
+script = """
+#!/usr/bin/env bash
+
+echo "Running $(tput setaf 4)cargo clippy$(tput sgr0) checks and attempting to fix"
+cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
+"""
+
 [tasks.check-typos]
 category = "RiseDev - Check"
 description = "Run cargo typos-cli check"
@@ -775,6 +785,27 @@ description = "Perform pre-CI checks and automatically fix cargo sort, cargo hak
 
 [tasks.c]
 alias = "check"
+
+[tasks.check-fix]
+category = "RiseDev - Check"
+dependencies = [
+  "warn-on-missing-tools",
+  "check-hakari",
+  "check-dep-sort",
+  "check-fmt",
+  "check-clippy-fix",
+  "check-typos",
+]
+script = """
+#!/usr/bin/env bash
+
+echo "Good work! You may run $(tput setaf 4)./risedev test$(tput sgr0) or $(tput setaf 4)./risedev test-cov$(tput sgr0) to run unit tests."
+"""
+description = "Perform pre-CI checks and automatically fix cargo sort, cargo hakari, fixes cargo fmt warnings"
+
+[tasks.cf]
+alias = "check-fix"
+
 
 [tasks.install]
 category = "RiseDev - Prepare"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Applies clippy fixes to all files, including staged and dirty

Usage: 
`./risedev cf frontend meta`
```
...
Applying clippy --fix for frontend meta (including dirty and staged files)
```

`./risedev cf`
```
...
Applying clippy --fix for all targets (including dirty and staged files)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/issues/7756