### PR TITLE
feat(expr): support pow function

### DIFF
--- a/dashboard/proto/gen/expr.ts
+++ b/dashboard/proto/gen/expr.ts
@@ -105,6 +105,7 @@ export const ExprNode_Type = {
   BIT_LENGTH: "BIT_LENGTH",
   OVERLAY: "OVERLAY",
   REGEXP_MATCH: "REGEXP_MATCH",
+  POW: "POW",
   /** IS_TRUE - Boolean comparison */
   IS_TRUE: "IS_TRUE",
   IS_NOT_TRUE: "IS_NOT_TRUE",
@@ -338,6 +339,9 @@ export function exprNode_TypeFromJSON(object: any): ExprNode_Type {
     case 232:
     case "REGEXP_MATCH":
       return ExprNode_Type.REGEXP_MATCH;
+    case 233:
+    case "POW":
+      return ExprNode_Type.POW;
     case 301:
     case "IS_TRUE":
       return ExprNode_Type.IS_TRUE;
@@ -534,6 +538,8 @@ export function exprNode_TypeToJSON(object: ExprNode_Type): string {
       return "OVERLAY";
     case ExprNode_Type.REGEXP_MATCH:
       return "REGEXP_MATCH";
+    case ExprNode_Type.POW:
+      return "POW";
     case ExprNode_Type.IS_TRUE:
       return "IS_TRUE";
     case ExprNode_Type.IS_NOT_TRUE:

--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -1,0 +1,49 @@
+query R
+select pow(2.0, 3.0)
+----
+8
+
+query R
+select pow(2.0::decimal, 3.0::decimal)
+----
+8
+
+query R
+select pow(2.0::double, 3.0::double)
+----
+8
+
+query R
+select pow(2.0::smallint, 3.0::smallint)
+----
+8
+
+query R
+select pow(2.0::bigint, 3.0::bigint)
+----
+8
+
+query R
+select pow(2.0, -2);
+----
+0.25
+
+query R
+select pow(2.23, -2.33);
+----
+0.15432975583772085
+
+query R
+select pow(100000, 0);
+----
+1
+
+query R
+select pow(100000, -200000000000000);
+----
+0
+
+query T
+select pow(100000, 200000000000000);
+----
+Infinity

--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -43,7 +43,9 @@ select pow(100000, -200000000000000);
 ----
 0
 
-query T
+statement error QueryError: Expr error: Numeric out of range
 select pow(100000, 200000000000000);
-----
-Infinity
+
+
+statement error QueryError: Expr error: Numeric out of range
+select pow(-100000, 200000000000001);

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -93,6 +93,7 @@ message ExprNode {
     BIT_LENGTH = 230;
     OVERLAY = 231;
     REGEXP_MATCH = 232;
+    POW = 233;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -54,7 +54,7 @@ use core::str::FromStr;
 pub use num_traits::Float;
 use num_traits::{
     AsPrimitive, Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub,
-    FromPrimitive, Num, NumCast, One, Signed, ToPrimitive, Zero,
+    FromPrimitive, Num, NumCast, One, Pow, Signed, ToPrimitive, Zero,
 };
 
 // masks for the parts of the IEEE 754 float
@@ -388,6 +388,17 @@ impl_ordered_float_binop! {Sub, sub, SubAssign, sub_assign}
 impl_ordered_float_binop! {Mul, mul, MulAssign, mul_assign}
 impl_ordered_float_binop! {Div, div, DivAssign, div_assign}
 impl_ordered_float_binop! {Rem, rem, RemAssign, rem_assign}
+
+impl<T> Pow<OrderedFloat<T>> for OrderedFloat<T>
+where
+    T: Float,
+{
+    type Output = OrderedFloat<T>;
+
+    fn pow(self, rhs: Self) -> Self::Output {
+        OrderedFloat(self.0.powf(rhs.0))
+    }
+}
 
 impl<T> CheckedAdd for OrderedFloat<T>
 where

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -288,6 +288,56 @@ macro_rules! gen_binary_expr_atm {
     };
 }
 
+/// `gen_binary_expr_atm` is similar to `gen_binary_expr_cmp`.
+///  `atm` means arithmetic here.
+/// They are differentiate cuz one type may not support atm and cmp at the same time. For example,
+/// Varchar can support compare but not arithmetic.
+/// * `$general_f`: generic atm function (require a common ``TryInto`` type for two input)
+/// * `$i1`, `$i2`, `$rt`, `$func`: extra list passed to `$macro` directly
+macro_rules! gen_binary_expr_pow {
+    ($macro:ident, $l:expr, $r:expr, $ret:expr, $general_f:ident,) => {
+        $macro! {
+            [$l, $r, $ret],
+            { int16, int16, float64, $general_f },
+            { int16, int32, float64, $general_f },
+            { int16, int64, float64, $general_f },
+            { int16, float32, float64, $general_f },
+            { int16, float64, float64, $general_f },
+            { int32, int16, float64, $general_f },
+            { int32, int32, float64, $general_f },
+            { int32, int64, float64, $general_f },
+            { int32, float32, float64, $general_f },
+            { int32, float64, float64, $general_f },
+            { int64, int16, float64, $general_f },
+            { int64, int32, float64, $general_f },
+            { int64, int64, float64, $general_f },
+            { int64, float32, float64 , $general_f},
+            { int64, float64, float64, $general_f },
+            { float32, int16, float64, $general_f },
+            { float32, int32, float64, $general_f },
+            { float32, int64, float64 , $general_f},
+            { float32, float32, float64, $general_f },
+            { float32, float64, float64, $general_f },
+            { float64, int16, float64, $general_f },
+            { float64, int32, float64, $general_f },
+            { float64, int64, float64, $general_f },
+            { float64, float32, float64, $general_f },
+            { float64, float64, float64, $general_f },
+            { decimal, int16, float64, $general_f },
+            { decimal, int32, float64, $general_f },
+            { decimal, int64, float64, $general_f },
+            { decimal, float32, float64, $general_f },
+            { decimal, float64, float64, $general_f },
+            { int16, decimal, float64, $general_f },
+            { int32, decimal, float64, $general_f },
+            { int64, decimal, float64, $general_f },
+            { decimal, decimal, float64, $general_f },
+            { float32, decimal, float64, $general_f },
+            { float64, decimal, float64, $general_f },
+        }
+    };
+}
+
 /// `gen_binary_expr_bitwise` is similar to `gen_binary_expr_atm`.
 /// They are differentiate because bitwise operation only supports integral datatype.
 /// * `$general_f`: generic atm function (require a common ``TryInto`` type for two input)
@@ -660,6 +710,13 @@ pub fn new_binary_expr(
                 general_bitxor,
                 {
                 },
+            }
+        }
+        Type::Pow => {
+            gen_binary_expr_pow! {
+                gen_atm_impl,
+                l, r, ret,
+                general_pow,
             }
         }
         Type::Extract => build_extract_expr(ret, l, r)?,

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -110,7 +110,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         | IsNotNull | Neg | Ascii | Abs | Ceil | Floor | Round | BitwiseNot | CharLength
         | BoolOut | OctetLength | BitLength | ToTimestamp => build_unary_expr_prost(prost),
         Equal | NotEqual | LessThan | LessThanOrEqual | GreaterThan | GreaterThanOrEqual | Add
-        | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | TumbleStart
+        | Subtract | Multiply | Divide | Modulus | Extract | RoundDigit | Pow | TumbleStart
         | Position | BitwiseShiftLeft | BitwiseShiftRight | BitwiseAnd | BitwiseOr | BitwiseXor
         | ConcatOp | AtTimeZone | CastWithTimeZone => build_binary_expr_prost(prost),
         And | Or | IsDistinctFrom | IsNotDistinctFrom | ArrayAccess => {

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -172,6 +172,7 @@ fn build_type_derive_map() -> FuncSigMap {
         &[T::Int16, T::Int32, T::Int64, T::Decimal],
     );
     map.insert(E::RoundDigit, vec![T::Decimal, T::Int32], T::Decimal);
+    map.insert(E::Pow, vec![T::Float64, T::Float64], T::Float64);
 
     // build bitwise operator
     // bitwise operator

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -115,7 +115,12 @@ where
     T2: Into<T3> + Debug,
     T3: Pow<T3> + num_traits::Float,
 {
-    Ok(l.into().powf(r.into()))
+    let res = l.into().powf(r.into());
+    if res.is_infinite() {
+        Err(ExprError::NumericOutOfRange)
+    } else {
+        Ok(res)
+    }
 }
 
 #[inline(always)]

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -16,7 +16,7 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 
 use chrono::{Duration, NaiveDateTime};
-use num_traits::{CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Signed, Zero};
+use num_traits::{CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Pow, Signed, Zero};
 use risingwave_common::types::{
     CheckedAdd, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
     OrderedF64,
@@ -106,6 +106,16 @@ pub fn general_abs<T1: Signed + CheckedNeg>(expr: T1) -> Result<T1> {
 
 pub fn decimal_abs(decimal: Decimal) -> Result<Decimal> {
     Ok(Decimal::abs(&decimal))
+}
+
+#[inline(always)]
+pub fn general_pow<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
+where
+    T1: Into<T3> + Debug,
+    T2: Into<T3> + Debug,
+    T3: Pow<T3> + num_traits::Float,
+{
+    Ok(l.into().powf(r.into()))
 }
 
 #[inline(always)]

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -327,6 +327,7 @@ impl Binder {
                         (1, raw_call(ExprType::Round)),
                     ]),
                 ),
+                ("pow", raw_call(ExprType::Pow)),
                 ("ceil", raw_call(ExprType::Ceil)),
                 ("floor", raw_call(ExprType::Floor)),
                 ("abs", raw_call(ExprType::Abs)),

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -521,6 +521,7 @@ fn make_general_expr(func: ExprType, exprs: Vec<Expr>) -> Option<Expr> {
         E::IsNotFalse => Some(Expr::IsNotFalse(Box::new(exprs[0].clone()))),
         E::Position => Some(Expr::Function(make_simple_func("position", &exprs))),
         E::RoundDigit => Some(Expr::Function(make_simple_func("round", &exprs))),
+        E::Pow => Some(Expr::Function(make_simple_func("pow", &exprs))),
         E::Repeat => Some(Expr::Function(make_simple_func("repeat", &exprs))),
         E::CharLength => Some(Expr::Function(make_simple_func("char_length", &exprs))),
         E::Substr => Some(Expr::Function(make_simple_func("substr", &exprs))),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)

-->
As per the title.

Right now, both x and y are casted into Float64 when pow(x, y).
By PG's standard, we also need to support Decimal but Decimal has no built-in pow and we may also change the underlying crate for Decimal. So we leave it aside for now.

Urgently requested by user.

#7725 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features). https://github.com/risingwavelabs/risingwave/issues/7329
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

If your pull request contains user-facing changes, please specify the types of the changes, and create a release note. Otherwise, please feel free to remove this section.

### Types of user-facing changes

Please keep the types that apply to your changes, and remove those that do not apply.

- SQL functions

### Release note

Please create a release note for your changes. In the release note, focus on the impact on users, and mention the environment or conditions where the impact may occur.

`pow` is a mathematical function, see https://www.postgresql.org/docs/7.4/functions-math.html
But this PR only implements for dp(double precision) as function parameters. Decimal has not been implemented yet.

## Refer to a related PR or issue link (optional)
#7725 