### PR TITLE
fix(expr): incorrect decimal rounding due to `rust_decimal` bug

### DIFF
--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -20,7 +20,8 @@ pub fn round_digits<D: Into<i32>>(input: Decimal, digits: D) -> Decimal {
     if digits < 0 {
         Decimal::zero()
     } else {
-        input.round_dp(digits as u32)
+        // rust_decimal can only handle up to 28 digits of scale
+        input.round_dp(std::cmp::min(digits as u32, 28))
     }
 }
 
@@ -77,6 +78,8 @@ mod tests {
         do_test("84818.33333333333333333333333", 4, "84818.3333");
         do_test("84818.15", 1, "84818.2");
         do_test("21.372736", -1, "0");
+        // Maximum of 28 digits
+        do_test("0", 340, &format!("0.{}", "0".repeat(28)));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Rust decimal bug allows rounding past 28 significant digits which is its maximum.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link (optional)
https://github.com/risingwavelabs/risingwave/pull/7815#issuecomment-1424223070