### PR TITLE
chore(deps): Bump OpenDAL to 0.26

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,6 +918,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f34fac4d7cdaefa2deded0eda2d5d59dbfd43370ff3f856209e72340ae84c294"
+dependencies = [
+ "futures",
+ "pin-project",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,12 +962,6 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -4123,14 +4129,14 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opendal"
-version = "0.24.6"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a657010a255640ce4b5e06b3bf275e3debe013208998cb22fa315eb40395919"
+checksum = "c40ed33cc9fed187ce8293587416e0afd6ac9fcde17f2a20ad0dca14dd685ebe"
 dependencies = [
  "anyhow",
  "async-compat",
  "async-trait",
- "backon",
+ "backon 0.2.0",
  "base64 0.21.0",
  "bincode 2.0.0-rc.2",
  "bytes",
@@ -4138,6 +4144,7 @@ dependencies = [
  "futures",
  "hdrs",
  "http",
+ "hyper",
  "log",
  "md-5",
  "once_cell",
@@ -5367,13 +5374,13 @@ dependencies = [
 
 [[package]]
 name = "reqsign"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642e28b7bf97b5112610ee78c7128f67d8e73fb17c88ce6f5f67dc9816957d52"
+checksum = "7e0154ced5e44389686689a3c96c49ca5a70ad9c708e0989982adae2e0378bbf"
 dependencies = [
  "anyhow",
- "backon",
- "base64 0.20.0",
+ "backon 0.4.0",
+ "base64 0.21.0",
  "bytes",
  "dirs",
  "form_urlencoded",

--- a/src/object_store/Cargo.toml
+++ b/src/object_store/Cargo.toml
@@ -24,7 +24,7 @@ fail = "0.5"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 hyper = "0.14"
 itertools = "0.10"
-opendal = "0.24.6"
+opendal = "0.26.2"
 prometheus = { version = "0.13", features = ["process"] }
 random-string = "1.0"
 risingwave_common = { path = "../common" }

--- a/src/object_store/src/object/opendal_engine/hdfs.rs
+++ b/src/object_store/src/object/opendal_engine/hdfs.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use opendal::services::hdfs;
+use opendal::services::Hdfs;
 use opendal::Operator;
 
 use super::{EngineType, OpendalObjectStore};
@@ -21,14 +21,14 @@ impl OpendalObjectStore {
     /// create opendal hdfs engine.
     pub fn new_hdfs_engine(namenode: String, root: String) -> ObjectResult<Self> {
         // Create hdfs backend builder.
-        let mut builder = hdfs::Builder::default();
+        let mut builder = Hdfs::default();
         // Set the name node for hdfs.
         builder.name_node(&namenode);
         // Set the root for hdfs, all operations will happen under this root.
         // NOTE: the root must be absolute path.
         builder.root(&root);
 
-        let op: Operator = Operator::new(builder.build()?);
+        let op: Operator = Operator::create(builder)?.finish();
         Ok(Self {
             op,
             engine_type: EngineType::Hdfs,

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -17,7 +17,7 @@ use fail::fail_point;
 use futures::future::try_join_all;
 use futures::StreamExt;
 use itertools::Itertools;
-use opendal::services::memory;
+use opendal::services::Memory;
 use opendal::Operator;
 use tokio::io::AsyncRead;
 
@@ -42,9 +42,9 @@ impl OpendalObjectStore {
     /// create opendal memory engine, used for unit tests.
     pub fn new_memory_engine() -> ObjectResult<Self> {
         // Create memory backend builder.
-        let mut builder = memory::Builder::default();
+        let builder = Memory::default();
 
-        let op: Operator = Operator::new(builder.build()?);
+        let op: Operator = Operator::create(builder)?.finish();
         Ok(Self {
             op,
             engine_type: EngineType::Memory,


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR will bump opendal to v0.26.

Changelogs could be found at https://docs.rs/opendal/0.26.2/opendal/docs/changelog/index.html

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

No user face changes

### Release note

chore(deps): Bump OpenDAL to 0.26 
