### PR TITLE
refactor(sink): distinguish upsert connectors and append-only connectors

### DIFF
--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -105,8 +105,10 @@ impl SinkConfig {
 #[derive(Debug)]
 pub enum SinkImpl {
     Redis(Box<RedisSink>),
-    Kafka(Box<KafkaSink>),
-    Remote(Box<RemoteSink>),
+    Kafka(Box<KafkaSink<true>>),
+    UpsertKafka(Box<KafkaSink<false>>),
+    Remote(Box<RemoteSink<true>>),
+    UpsertRemote(Box<RemoteSink<false>>),
     Console(Box<ConsoleSink>),
     Blackhole,
 }
@@ -132,47 +134,48 @@ impl SinkImpl {
     }
 }
 
-#[async_trait]
-impl Sink for SinkImpl {
-    async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
-        match self {
-            SinkImpl::Redis(sink) => sink.write_batch(chunk).await,
-            SinkImpl::Kafka(sink) => sink.write_batch(chunk).await,
-            SinkImpl::Remote(sink) => sink.write_batch(chunk).await,
-            SinkImpl::Console(sink) => sink.write_batch(chunk).await,
-            SinkImpl::Blackhole => Ok(()),
-        }
-    }
+macro_rules! impl_sink {
+    ($($variant_name:ident),*) => {
+        #[async_trait]
+        impl Sink for SinkImpl {
+            async fn write_batch(&mut self, chunk: StreamChunk) -> Result<()> {
+                match self {
+                    $( SinkImpl::$variant_name(inner) => inner.write_batch(chunk).await, )*
+                    SinkImpl::Blackhole => Ok(()),
+                }
+            }
 
-    async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
-        match self {
-            SinkImpl::Redis(sink) => sink.begin_epoch(epoch).await,
-            SinkImpl::Kafka(sink) => sink.begin_epoch(epoch).await,
-            SinkImpl::Remote(sink) => sink.begin_epoch(epoch).await,
-            SinkImpl::Console(sink) => sink.begin_epoch(epoch).await,
-            SinkImpl::Blackhole => Ok(()),
-        }
-    }
+            async fn begin_epoch(&mut self, epoch: u64) -> Result<()> {
+                match self {
+                    $( SinkImpl::$variant_name(inner) => inner.begin_epoch(epoch).await, )*
+                    SinkImpl::Blackhole => Ok(()),
+                }
+            }
 
-    async fn commit(&mut self) -> Result<()> {
-        match self {
-            SinkImpl::Redis(sink) => sink.commit().await,
-            SinkImpl::Kafka(sink) => sink.commit().await,
-            SinkImpl::Remote(sink) => sink.commit().await,
-            SinkImpl::Console(sink) => sink.commit().await,
-            SinkImpl::Blackhole => Ok(()),
-        }
-    }
+            async fn commit(&mut self) -> Result<()> {
+                match self {
+                    $( SinkImpl::$variant_name(inner) => inner.commit().await, )*
+                    SinkImpl::Blackhole => Ok(()),
+                }
+            }
 
-    async fn abort(&mut self) -> Result<()> {
-        match self {
-            SinkImpl::Redis(sink) => sink.abort().await,
-            SinkImpl::Kafka(sink) => sink.abort().await,
-            SinkImpl::Remote(sink) => sink.abort().await,
-            SinkImpl::Console(sink) => sink.abort().await,
-            SinkImpl::Blackhole => Ok(()),
+            async fn abort(&mut self) -> Result<()> {
+                match self {
+                    $( SinkImpl::$variant_name(inner) => inner.abort().await, )*
+                    SinkImpl::Blackhole => Ok(()),
+                }
+            }
         }
     }
+}
+
+impl_sink! {
+    Redis,
+    Kafka,
+    UpsertKafka,
+    Remote,
+    UpsertRemote,
+    Console
 }
 
 pub type Result<T> = std::result::Result<T, SinkError>;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Add `APPEND_ONLY` generic for sinks that support both upsert mode and append-only mode.
- Refactor `impl Sink for SinkImpl` via macro.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Refer to a related PR or issue link

#7414