### PR TITLE
fix(sqlsmith): limit number of cross joins

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -239,8 +239,8 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         // Generate CROSS JOIN
         let mut lateral_contexts = vec![];
-        for _ in 0..usize::min(self.tables.len(), 7) {
-            if self.rng.gen_bool(0.3) {
+        for _ in 0..usize::min(self.tables.len(), 5) {
+            if self.flip_coin() {
                 let (table_with_join, mut table) = self.gen_from_relation();
                 from.push(table_with_join);
                 lateral_contexts.append(&mut table);

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -239,7 +239,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         // Generate CROSS JOIN
         let mut lateral_contexts = vec![];
-        for _ in 0..self.tables.len() {
+        for _ in 0..usize::min(self.tables.len(), 7) {
             if self.rng.gen_bool(0.3) {
                 let (table_with_join, mut table) = self.gen_from_relation();
                 from.push(table_with_join);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #7889 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
