### PR TITLE
feat(source): support debezium avro format

### DIFF
--- a/dashboard/proto/gen/plan_common.ts
+++ b/dashboard/proto/gen/plan_common.ts
@@ -135,6 +135,7 @@ export const RowFormatType = {
   CANAL_JSON: "CANAL_JSON",
   CSV: "CSV",
   NATIVE: "NATIVE",
+  DEBEZIUM_AVRO: "DEBEZIUM_AVRO",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -169,6 +170,9 @@ export function rowFormatTypeFromJSON(object: any): RowFormatType {
     case 8:
     case "NATIVE":
       return RowFormatType.NATIVE;
+    case 9:
+    case "DEBEZIUM_AVRO":
+      return RowFormatType.DEBEZIUM_AVRO;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -196,6 +200,8 @@ export function rowFormatTypeToJSON(object: RowFormatType): string {
       return "CSV";
     case RowFormatType.NATIVE:
       return "NATIVE";
+    case RowFormatType.DEBEZIUM_AVRO:
+      return "DEBEZIUM_AVRO";
     case RowFormatType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -80,4 +80,5 @@ enum RowFormatType {
   CANAL_JSON = 6;
   CSV = 7;
   NATIVE = 8;
+  DEBEZIUM_AVRO = 9;
 }

--- a/src/batch/src/executor/source.rs
+++ b/src/batch/src/executor/source.rs
@@ -77,6 +77,7 @@ impl BoxedExecutorBuilder for SourceExecutor {
             RowFormatType::Maxwell => SourceFormat::Maxwell,
             RowFormatType::CanalJson => SourceFormat::CanalJson,
             RowFormatType::Native => SourceFormat::Native,
+            RowFormatType::DebeziumAvro => SourceFormat::DebeziumAvro,
             _ => unreachable!(),
         };
         if format == SourceFormat::Protobuf && info.row_schema_location.is_empty() {

--- a/src/connector/src/parser/avro/mod.rs
+++ b/src/connector/src/parser/avro/mod.rs
@@ -13,6 +13,6 @@
 // limitations under the License.
 
 mod parser;
-mod schema_resolver;
+pub mod schema_resolver;
 
 pub use parser::*;

--- a/src/connector/src/parser/avro/mod.rs
+++ b/src/connector/src/parser/avro/mod.rs
@@ -14,5 +14,6 @@
 
 mod parser;
 pub mod schema_resolver;
+pub mod util;
 
 pub use parser::*;

--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -1,0 +1,109 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use apache_avro::Schema;
+use itertools::Itertools;
+use risingwave_common::error::ErrorCode::InternalError;
+use risingwave_common::error::{Result, RwError};
+use risingwave_common::types::DataType;
+use risingwave_pb::plan_common::ColumnDesc;
+
+pub(crate) fn avro_field_to_column_desc(
+    name: &str,
+    schema: &Schema,
+    index: &mut i32,
+) -> Result<ColumnDesc> {
+    let data_type = avro_type_mapping(schema)?;
+    match schema {
+        Schema::Record {
+            name: schema_name,
+            fields,
+            ..
+        } => {
+            let vec_column = fields
+                .iter()
+                .map(|f| avro_field_to_column_desc(&f.name, &f.schema, index))
+                .collect::<Result<Vec<_>>>()?;
+            *index += 1;
+            Ok(ColumnDesc {
+                column_type: Some(data_type.to_protobuf()),
+                column_id: *index,
+                name: name.to_owned(),
+                field_descs: vec_column,
+                type_name: schema_name.to_string(),
+            })
+        }
+        _ => {
+            *index += 1;
+            Ok(ColumnDesc {
+                column_type: Some(data_type.to_protobuf()),
+                column_id: *index,
+                name: name.to_owned(),
+                ..Default::default()
+            })
+        }
+    }
+}
+
+pub(crate) fn avro_type_mapping(schema: &Schema) -> Result<DataType> {
+    let data_type = match schema {
+        Schema::String => DataType::Varchar,
+        Schema::Int => DataType::Int32,
+        Schema::Long => DataType::Int64,
+        Schema::Boolean => DataType::Boolean,
+        Schema::Float => DataType::Float32,
+        Schema::Double => DataType::Float64,
+        Schema::Date => DataType::Date,
+        Schema::TimestampMillis => DataType::Timestamp,
+        Schema::TimestampMicros => DataType::Timestamp,
+        Schema::Duration => DataType::Interval,
+        Schema::Enum { .. } => DataType::Varchar,
+        Schema::Record { fields, .. } => {
+            let struct_fields = fields
+                .iter()
+                .map(|f| avro_type_mapping(&f.schema))
+                .collect::<Result<Vec<_>>>()?;
+            let struct_names = fields.iter().map(|f| f.name.clone()).collect_vec();
+            DataType::new_struct(struct_fields, struct_names)
+        }
+        Schema::Array(item_schema) => {
+            let item_type = avro_type_mapping(item_schema.as_ref())?;
+            DataType::List {
+                datatype: Box::new(item_type),
+            }
+        }
+        // Schema::Union(union_schema) if union_schema.is_nullable() => {
+        //     let nested_schema = union_schema
+        //         .variants()
+        //         .iter()
+        //         .find_or_first(|s| **s != Schema::Null)
+        //         .ok_or_else(|| {
+        //             RwError::from(InternalError(format!(
+        //                 "unsupported type in Avro: {:?}",
+        //                 union_schema
+        //             )))
+        //         })?;
+
+        //     avro_type_mapping(nested_schema)?
+        // }
+        _ => {
+            return Err(RwError::from(InternalError(format!(
+                "unsupported type in Avro: {:?}",
+                schema
+            ))));
+        }
+    };
+
+    Ok(data_type)
+}

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -1,10 +1,10 @@
-// Copyright 2022 Singularity Data
+// Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,22 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
 
 use apache_avro::types::Value;
 use apache_avro::{from_avro_datum, Schema};
 use futures_async_stream::try_stream;
-use risingwave_common::error::ErrorCode::ProtocolError;
+use reqwest::Url;
+use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
+use risingwave_pb::plan_common::ColumnDesc;
 
 use super::operators::*;
 use crate::impl_common_parser_logic;
-use crate::parser::schema_registry::extract_schema_id;
+use crate::parser::avro::util::avro_field_to_column_desc;
+use crate::parser::schema_registry::{extract_schema_id, Client};
 use crate::parser::schema_resolver::ConfluentSchemaResolver;
-use crate::parser::{
-    from_avro_value, get_from_avro_record, AvroParserConfig, SourceStreamChunkRowWriter, WriteGuard,
-};
+use crate::parser::util::get_kafka_topic;
+use crate::parser::{from_avro_value, SourceStreamChunkRowWriter, WriteGuard};
 use crate::source::SourceColumnDesc;
 
 const BEFORE: &str = "before";
@@ -45,16 +48,118 @@ pub struct DebeziumAvroParser {
     rw_columns: Vec<SourceColumnDesc>,
 }
 
+#[derive(Debug, Clone)]
+pub struct DebeziumAvroParserConfig {
+    pub schema: Arc<Schema>,
+    pub schema_resolver: Arc<ConfluentSchemaResolver>,
+}
+
+impl DebeziumAvroParserConfig {
+    pub async fn new(props: &HashMap<String, String>, schema_location: &str) -> Result<Self> {
+        let url = Url::parse(schema_location).map_err(|e| {
+            InternalError(format!("failed to parse url ({}): {}", schema_location, e))
+        })?;
+        let kafka_topic = get_kafka_topic(props)?;
+        let client = Client::new(url, props)?;
+        let (schema, resolver) =
+            ConfluentSchemaResolver::new(format!("{}-value", kafka_topic).as_str(), client).await?;
+        Ok(Self {
+            schema: Arc::new(schema),
+            schema_resolver: Arc::new(resolver),
+        })
+    }
+
+    fn extract_inner_schema(outer_schema: &Schema) -> Result<Schema> {
+        match outer_schema {
+            Schema::Record { fields, lookup, .. } => {
+                let index = lookup.get(BEFORE).ok_or_else(|| {
+                    RwError::from(ProtocolError(
+                        "debezium avro msg schema invalid, before field required".to_owned(),
+                    ))
+                })?;
+                let before_schema = &fields
+                    .get(*index)
+                    .ok_or_else(|| {
+                        RwError::from(ProtocolError("debezium avro msg schema illegal".to_owned()))
+                    })?
+                    .schema;
+                match before_schema {
+                    Schema::Union(union_schema) => {
+                        let inner_schema = union_schema
+                            .variants()
+                            .iter()
+                            .find(|s| **s != Schema::Null)
+                            .ok_or_else(|| {
+                                RwError::from(InternalError(
+                                    "before field of debezium avro msg schema invalid".to_owned(),
+                                ))
+                            })?
+                            .clone();
+                        Ok(inner_schema)
+                    }
+                    _ => Err(RwError::from(ProtocolError(
+                        "before field of debezium avro msg schema invalid, union required"
+                            .to_owned(),
+                    ))),
+                }
+            }
+            _ => Err(RwError::from(ProtocolError(
+                "debezium avro msg schema invalid, record required".to_owned(),
+            ))),
+        }
+    }
+
+    pub fn map_to_columns(&self) -> Result<Vec<ColumnDesc>> {
+        let inner_schema = Self::extract_inner_schema(self.schema.as_ref())?;
+        // there must be a record at top level
+        if let Schema::Record { fields, .. } = inner_schema {
+            let mut index = 0;
+            let fields = fields
+                .iter()
+                .map(|field| avro_field_to_column_desc(&field.name, &field.schema, &mut index))
+                .collect::<Result<Vec<_>>>()?;
+            tracing::info!("fields is {:?}", fields);
+            Ok(fields)
+        } else {
+            Err(RwError::from(InternalError(
+                "inner avro schema invalid, record required".into(),
+            )))
+        }
+    }
+}
+
+fn get_from_avro_value<'a>(avro_value: &'a Value, field_name: &str) -> Result<&'a Value> {
+    match avro_value {
+        Value::Record(fields) => fields
+            .iter()
+            .find(|val| val.0.eq(field_name))
+            .map(|entry| &entry.1)
+            .ok_or_else(|| {
+                RwError::from(ProtocolError(format!(
+                    "field {} not found in debezium event",
+                    field_name
+                )))
+            }),
+        Value::Union(_, boxed_value) => get_from_avro_value(boxed_value.as_ref(), field_name),
+        _ => Err(RwError::from(ProtocolError(format!(
+            "avro parse unexpected field {}",
+            field_name
+        )))),
+    }
+}
+
 impl DebeziumAvroParser {
-    pub fn new(rw_columns: Vec<SourceColumnDesc>, config: AvroParserConfig) -> Result<Self> {
-        let AvroParserConfig {
+    pub fn new(
+        rw_columns: Vec<SourceColumnDesc>,
+        config: DebeziumAvroParserConfig,
+    ) -> Result<Self> {
+        let DebeziumAvroParserConfig {
             schema,
             schema_resolver,
         } = config;
-        debug_assert!(schema_resolver.is_some());
         Ok(Self {
             schema,
-            schema_resolver: schema_resolver.unwrap(),
+            schema_resolver,
             rw_columns,
         })
     }
@@ -66,42 +171,42 @@ impl DebeziumAvroParser {
     ) -> Result<WriteGuard> {
         let (schema_id, mut raw_payload) = extract_schema_id(payload)?;
         let writer_schema = self.schema_resolver.get(schema_id).await?;
-        let avro_value =
-            from_avro_datum(writer_schema.as_ref(), &mut raw_payload, Some(&self.schema))
-                .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
-        let payload = get_from_avro_record(&avro_value, PAYLOAD)?;
-        let op = get_from_avro_record(payload, OP)?;
+
+        let avro_value = from_avro_datum(writer_schema.as_ref(), &mut raw_payload, None)
+            .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
+
+        let op = get_from_avro_value(&avro_value, OP)?;
         if let Value::String(op_str) = op {
             match op_str.as_str() {
                 DEBEZIUM_UPDATE_OP => {
-                    let before = get_from_avro_record(&avro_value, BEFORE)
+                    let before = get_from_avro_value(&avro_value, BEFORE)
                         .map_err(|_| {
                             RwError::from(ProtocolError(
                                 "before is missing for updating event. If you are using postgres, you may want to try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
                             ))
                         })?;
-                    let after = get_from_avro_record(&avro_value, AFTER)?;
+                    let after = get_from_avro_value(&avro_value, AFTER)?;
 
                     writer.update(|column| {
                         let before = from_avro_value(
-                            get_from_avro_record(&before, column.name.as_str())?.clone(),
+                            get_from_avro_value(before, column.name.as_str())?.clone(),
                         )?;
                         let after = from_avro_value(
-                            get_from_avro_record(&after, column.name.as_str())?.clone(),
+                            get_from_avro_value(after, column.name.as_str())?.clone(),
                         )?;
 
                         Ok((before, after))
                     })
                 }
                 DEBEZIUM_CREATE_OP | DEBEZIUM_READ_OP => {
-                    let after = get_from_avro_record(&avro_value, AFTER)?;
+                    let after = get_from_avro_value(&avro_value, AFTER)?;
 
                     writer.insert(|column| {
-                        from_avro_value(get_from_avro_record(&after, column.name.as_str())?.clone())
+                        from_avro_value(get_from_avro_value(after, column.name.as_str())?.clone())
                     })
                 }
                 DEBEZIUM_DELETE_OP => {
-                    let before = get_from_avro_record(&avro_value, BEFORE)
+                    let before = get_from_avro_value(&avro_value, BEFORE)
                         .map_err(|_| {
                             RwError::from(ProtocolError(
                                 "before is missing for updating event. If you are using postgres, you may want to try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
@@ -109,9 +214,7 @@ impl DebeziumAvroParser {
                         })?;
 
                     writer.delete(|column| {
-                        from_avro_value(
-                            get_from_avro_record(&before, column.name.as_str())?.clone(),
-                        )
+                        from_avro_value(get_from_avro_value(before, column.name.as_str())?.clone())
                     })
                 }
                 _ => Err(RwError::from(ProtocolError(format!(

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -1,0 +1,128 @@
+// Copyright 2022 Singularity Data
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+
+use apache_avro::types::Value;
+use apache_avro::{from_avro_datum, Schema};
+use futures_async_stream::try_stream;
+use risingwave_common::error::ErrorCode::ProtocolError;
+use risingwave_common::error::{Result, RwError};
+
+use super::operators::*;
+use crate::impl_common_parser_logic;
+use crate::parser::schema_registry::extract_schema_id;
+use crate::parser::schema_resolver::ConfluentSchemaResolver;
+use crate::parser::{
+    from_avro_value, get_from_avro_record, AvroParserConfig, SourceStreamChunkRowWriter, WriteGuard,
+};
+use crate::source::SourceColumnDesc;
+
+const BEFORE: &str = "before";
+const AFTER: &str = "after";
+const OP: &str = "op";
+const PAYLOAD: &str = "payload";
+
+impl_common_parser_logic!(DebeziumAvroParser);
+
+// TODO: avoid duplicated codes with `AvroParser`
+#[derive(Debug)]
+pub struct DebeziumAvroParser {
+    schema: Arc<Schema>,
+    schema_resolver: Arc<ConfluentSchemaResolver>,
+    rw_columns: Vec<SourceColumnDesc>,
+}
+
+impl DebeziumAvroParser {
+    pub fn new(rw_columns: Vec<SourceColumnDesc>, config: AvroParserConfig) -> Result<Self> {
+        let AvroParserConfig {
+            schema,
+            schema_resolver,
+        } = config;
+        debug_assert!(schema_resolver.is_some());
+        Ok(Self {
+            schema,
+            schema_resolver: schema_resolver.unwrap(),
+            rw_columns,
+        })
+    }
+
+    pub(crate) async fn parse_inner(
+        &self,
+        payload: &[u8],
+        mut writer: SourceStreamChunkRowWriter<'_>,
+    ) -> Result<WriteGuard> {
+        let (schema_id, mut raw_payload) = extract_schema_id(payload)?;
+        let writer_schema = self.schema_resolver.get(schema_id).await?;
+        let avro_value =
+            from_avro_datum(writer_schema.as_ref(), &mut raw_payload, Some(&self.schema))
+                .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
+        let payload = get_from_avro_record(&avro_value, PAYLOAD)?;
+        let op = get_from_avro_record(payload, OP)?;
+        if let Value::String(op_str) = op {
+            match op_str.as_str() {
+                DEBEZIUM_UPDATE_OP => {
+                    let before = get_from_avro_record(&avro_value, BEFORE)
+                        .map_err(|_| {
+                            RwError::from(ProtocolError(
+                                "before is missing for updating event. If you are using postgres, you may want to try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
+                            ))
+                        })?;
+                    let after = get_from_avro_record(&avro_value, AFTER)?;
+
+                    writer.update(|column| {
+                        let before = from_avro_value(
+                            get_from_avro_record(&before, column.name.as_str())?.clone(),
+                        )?;
+                        let after = from_avro_value(
+                            get_from_avro_record(&after, column.name.as_str())?.clone(),
+                        )?;
+
+                        Ok((before, after))
+                    })
+                }
+                DEBEZIUM_CREATE_OP | DEBEZIUM_READ_OP => {
+                    let after = get_from_avro_record(&avro_value, AFTER)?;
+
+                    writer.insert(|column| {
+                        from_avro_value(get_from_avro_record(&after, column.name.as_str())?.clone())
+                    })
+                }
+                DEBEZIUM_DELETE_OP => {
+                    let before = get_from_avro_record(&avro_value, BEFORE)
+                        .map_err(|_| {
+                            RwError::from(ProtocolError(
+                                "before is missing for updating event. If you are using postgres, you may want to try ALTER TABLE $TABLE_NAME REPLICA IDENTITY FULL;".to_string(),
+                            ))
+                        })?;
+
+                    writer.delete(|column| {
+                        from_avro_value(
+                            get_from_avro_record(&before, column.name.as_str())?.clone(),
+                        )
+                    })
+                }
+                _ => Err(RwError::from(ProtocolError(format!(
+                    "unknown debezium op: {}",
+                    op_str
+                )))),
+            }
+        } else {
+            Err(RwError::from(ProtocolError(
+                "payload op is not a string ".to_owned(),
+            )))
+        }
+    }
+}

--- a/src/connector/src/parser/debezium/mod.rs
+++ b/src/connector/src/parser/debezium/mod.rs
@@ -14,8 +14,10 @@
 
 pub use simd_json_parser::*;
 
+mod avro_parser;
 mod operators;
 mod simd_json_parser;
+pub use avro_parser::*;
 
 #[cfg(test)]
 mod test {

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -384,7 +384,7 @@ pub enum SpecificParserConfig {
     CanalJson,
     #[default]
     Native,
-    DebeziumAvro(AvroParserConfig),
+    DebeziumAvro(DebeziumAvroParserConfig),
 }
 
 impl SpecificParserConfig {
@@ -430,17 +430,9 @@ impl SpecificParserConfig {
             SourceFormat::Maxwell => SpecificParserConfig::Maxwell,
             SourceFormat::CanalJson => SpecificParserConfig::CanalJson,
             SourceFormat::Native => SpecificParserConfig::Native,
-            SourceFormat::DebeziumAvro => {
-                debug_assert!(info.use_schema_registry);
-                SpecificParserConfig::DebeziumAvro(
-                    AvroParserConfig::new(
-                        props,
-                        &info.row_schema_location,
-                        info.use_schema_registry,
-                    )
-                    .await?,
-                )
-            }
+            SourceFormat::DebeziumAvro => SpecificParserConfig::DebeziumAvro(
+                DebeziumAvroParserConfig::new(props, &info.row_schema_location).await?,
+            ),
             _ => {
                 return Err(RwError::from(ProtocolError(
                     "invalid source format".to_string(),

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -317,6 +317,7 @@ pub enum ByteStreamSourceParserImpl {
     Avro(AvroParser),
     Maxwell(MaxwellParser),
     CanalJson(CanalJsonParser),
+    DebeziumAvro(DebeziumAvroParser),
 }
 
 impl ByteStreamSourceParserImpl {
@@ -329,6 +330,7 @@ impl ByteStreamSourceParserImpl {
             Self::Avro(parser) => parser.into_stream(msg_stream),
             Self::Maxwell(parser) => parser.into_stream(msg_stream),
             Self::CanalJson(parser) => parser.into_stream(msg_stream),
+            Self::DebeziumAvro(parser) => parser.into_stream(msg_stream),
         }
     }
 
@@ -350,6 +352,9 @@ impl ByteStreamSourceParserImpl {
                 DebeziumJsonParser::new(rw_columns).map(Self::DebeziumJson)
             }
             SpecificParserConfig::Maxwell => MaxwellParser::new(rw_columns).map(Self::Maxwell),
+            SpecificParserConfig::DebeziumAvro(config) => {
+                DebeziumAvroParser::new(rw_columns, config).map(Self::DebeziumAvro)
+            }
             SpecificParserConfig::Native => {
                 unreachable!("Native parser should not be created")
             }
@@ -379,6 +384,7 @@ pub enum SpecificParserConfig {
     CanalJson,
     #[default]
     Native,
+    DebeziumAvro(AvroParserConfig),
 }
 
 impl SpecificParserConfig {
@@ -392,6 +398,7 @@ impl SpecificParserConfig {
             SpecificParserConfig::Maxwell => SourceFormat::Maxwell,
             SpecificParserConfig::CanalJson => SourceFormat::CanalJson,
             SpecificParserConfig::Native => SourceFormat::Native,
+            SpecificParserConfig::DebeziumAvro(_) => SourceFormat::DebeziumAvro,
         }
     }
 
@@ -423,6 +430,17 @@ impl SpecificParserConfig {
             SourceFormat::Maxwell => SpecificParserConfig::Maxwell,
             SourceFormat::CanalJson => SpecificParserConfig::CanalJson,
             SourceFormat::Native => SpecificParserConfig::Native,
+            SourceFormat::DebeziumAvro => {
+                debug_assert!(info.use_schema_registry);
+                SpecificParserConfig::DebeziumAvro(
+                    AvroParserConfig::new(
+                        props,
+                        &info.row_schema_location,
+                        info.use_schema_registry,
+                    )
+                    .await?,
+                )
+            }
             _ => {
                 return Err(RwError::from(ProtocolError(
                     "invalid source format".to_string(),

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -102,6 +102,7 @@ pub enum SourceFormat {
     CanalJson,
     Csv,
     Native,
+    DebeziumAvro,
 }
 
 pub type BoxSourceStream = BoxStream<'static, Result<Vec<SourceMessage>>>;

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -20,14 +20,17 @@ use risingwave_common::catalog::{ColumnCatalog, ColumnDesc, ROW_ID_COLUMN_ID};
 use risingwave_common::error::ErrorCode::{self, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
-use risingwave_connector::parser::{AvroParserConfig, ProtobufParserConfig};
+use risingwave_connector::parser::{
+    AvroParserConfig, DebeziumAvroParserConfig, ProtobufParserConfig,
+};
 use risingwave_connector::source::KAFKA_CONNECTOR;
 use risingwave_pb::catalog::{
     ColumnIndex as ProstColumnIndex, Source as ProstSource, StreamSourceInfo, WatermarkDesc,
 };
 use risingwave_pb::plan_common::RowFormatType;
 use risingwave_sqlparser::ast::{
-    AvroSchema, CreateSourceStatement, ProtobufSchema, SourceSchema, SourceWatermark,
+    AvroSchema, CreateSourceStatement, DebeziumAvroSchema, ProtobufSchema, SourceSchema,
+    SourceWatermark,
 };
 
 use super::create_table::bind_sql_table_constraints;
@@ -53,6 +56,23 @@ async fn extract_avro_table_schema(
         schema.use_schema_registry,
     )
     .await?;
+    let vec_column_desc = parser.map_to_columns()?;
+    Ok(vec_column_desc
+        .into_iter()
+        .map(|col| ColumnCatalog {
+            column_desc: col.into(),
+            is_hidden: false,
+        })
+        .collect_vec())
+}
+
+async fn extract_debezium_avro_table_schema(
+    schema: &DebeziumAvroSchema,
+    with_properties: HashMap<String, String>,
+) -> Result<Vec<ColumnCatalog>> {
+    let parser =
+        DebeziumAvroParserConfig::new(&with_properties, schema.row_schema_location.0.as_str())
+            .await?;
     let vec_column_desc = parser.map_to_columns()?;
     Ok(vec_column_desc
         .into_iter()
@@ -242,29 +262,42 @@ pub(crate) async fn resolve_source_schema(
         },
 
         SourceSchema::DebeziumAvro(avro_schema) => {
-            // TODO: support schemaless create source
-            // let (expected_column_len, expected_row_id_index) = if is_kafka && !is_materialized {
-            //     // The first column is `_rw_kafka_timestamp`.
-            //     (2, 1)
-            // } else {
-            //     (1, 0)
-            // };
-            // if columns.len() != expected_column_len
-            //     || pk_column_ids != vec![ROW_ID_COLUMN_ID]
-            //     || row_id_index != Some(expected_row_id_index)
-            // {
-            //     return Err(RwError::from(ProtocolError(
-            //         "User-defined schema is not allowed with row format avro. Please refer to https://www.risingwave.dev/docs/current/sql-create-source/#avro for more information.".to_string(),
-            //     )));
-            // }
+            if row_id_index.is_some() {
+                return Err(RwError::from(ProtocolError(
+                    "Primary key must be specified when creating table with row format
+            debezium_avro."
+                        .to_string(),
+                )));
+            }
 
-            // columns.extend(extract_avro_table_schema(avro_schema, with_properties.clone()).await?);
+            if columns.len() != pk_column_ids.len() {
+                return Err(RwError::from(ProtocolError(
+                    "User can only specify primary key columns when creating table with row
+            format debezium_avro."
+                        .to_string(),
+                )));
+            }
 
+            let mut full_columns =
+                extract_debezium_avro_table_schema(avro_schema, with_properties.clone()).await?;
+
+            for pk_column in columns.iter() {
+                let index = full_columns
+                    .iter()
+                    .position(|c| c.column_desc.name == pk_column.column_desc.name)
+                    .ok_or_else(|| {
+                        RwError::from(ProtocolError(format!(
+                            "pk column {} not exists",
+                            pk_column.column_desc.name
+                        )))
+                    })?;
+                let _ = full_columns.remove(index);
+            }
+
+            columns.extend(full_columns);
             StreamSourceInfo {
                 row_format: RowFormatType::DebeziumAvro as i32,
                 row_schema_location: avro_schema.row_schema_location.0.clone(),
-                use_schema_registry: avro_schema.use_schema_registry,
-                proto_message_name: "".to_owned(),
                 ..Default::default()
             }
         }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -240,6 +240,34 @@ pub(crate) async fn resolve_source_schema(
             row_format: RowFormatType::Native as i32,
             ..Default::default()
         },
+
+        SourceSchema::DebeziumAvro(avro_schema) => {
+            // TODO: support schemaless create source
+            // let (expected_column_len, expected_row_id_index) = if is_kafka && !is_materialized {
+            //     // The first column is `_rw_kafka_timestamp`.
+            //     (2, 1)
+            // } else {
+            //     (1, 0)
+            // };
+            // if columns.len() != expected_column_len
+            //     || pk_column_ids != vec![ROW_ID_COLUMN_ID]
+            //     || row_id_index != Some(expected_row_id_index)
+            // {
+            //     return Err(RwError::from(ProtocolError(
+            //         "User-defined schema is not allowed with row format avro. Please refer to https://www.risingwave.dev/docs/current/sql-create-source/#avro for more information.".to_string(),
+            //     )));
+            // }
+
+            // columns.extend(extract_avro_table_schema(avro_schema, with_properties.clone()).await?);
+
+            StreamSourceInfo {
+                row_format: RowFormatType::DebeziumAvro as i32,
+                row_schema_location: avro_schema.row_schema_location.0.clone(),
+                use_schema_registry: avro_schema.use_schema_registry,
+                proto_message_name: "".to_owned(),
+                ..Default::default()
+            }
+        }
     };
 
     Ok(source_info)

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -61,8 +61,7 @@ use crate::hummock::metrics_utils::{
 };
 use crate::hummock::CompactorManagerRef;
 use crate::manager::{
-    CatalogManager, CatalogManagerRef, ClusterManagerRef, IdCategory, LocalNotification,
-    MetaSrvEnv, META_NODE_ID,
+    CatalogManagerRef, ClusterManagerRef, IdCategory, LocalNotification, MetaSrvEnv, META_NODE_ID,
 };
 use crate::model::{
     BTreeMapEntryTransaction, BTreeMapTransaction, MetadataModel, ValTransaction, VarTransaction,

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -250,6 +250,7 @@ where
         compactor_manager: CompactorManagerRef,
         config: CompactionConfig,
     ) -> HummockManagerRef<S> {
+        use crate::manager::CatalogManager;
         let compaction_group_manager =
             Self::build_compaction_group_manager_with_config(&env, config)
                 .await

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -99,6 +99,7 @@ impl SourceDescBuilder {
             ProstRowFormatType::Maxwell => SourceFormat::Maxwell,
             ProstRowFormatType::CanalJson => SourceFormat::CanalJson,
             ProstRowFormatType::Native => SourceFormat::Native,
+            ProstRowFormatType::DebeziumAvro => SourceFormat::DebeziumAvro,
             _ => unreachable!(),
         };
 

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -96,7 +96,7 @@ pub enum SourceSchema {
     CanalJson,        // Keyword::CANAL_JSON
     Csv(CsvInfo),     // Keyword::CSV
     Native,
-    DebeziumAvro(AvroSchema),     // Keyword::DEBEZIUM_AVRO
+    DebeziumAvro(DebeziumAvroSchema), // Keyword::DEBEZIUM_AVRO
 }
 
 impl ParseTo for SourceSchema {
@@ -119,7 +119,7 @@ impl ParseTo for SourceSchema {
             impl_parse_to!(csv_info: CsvInfo, p);
             SourceSchema::Csv(csv_info)
         } else if p.parse_keywords(&[Keyword::DEBEZIUM_AVRO]) {
-            impl_parse_to!(avro_schema: AvroSchema, p);
+            impl_parse_to!(avro_schema: DebeziumAvroSchema, p);
             SourceSchema::DebeziumAvro(avro_schema)
         } else {
             return Err(ParserError::ParserError(
@@ -223,6 +223,51 @@ impl fmt::Display for AvroSchema {
         impl_fmt_display!(message_name, v, self);
         impl_fmt_display!([Keyword::ROW, Keyword::SCHEMA, Keyword::LOCATION], v);
         impl_fmt_display!(use_schema_registry => [Keyword::CONFLUENT, Keyword::SCHEMA, Keyword::REGISTRY], v, self);
+        impl_fmt_display!(row_schema_location, v, self);
+        v.iter().join(" ").fmt(f)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct DebeziumAvroSchema {
+    pub row_schema_location: AstString,
+}
+
+impl ParseTo for DebeziumAvroSchema {
+    fn parse_to(p: &mut Parser) -> Result<Self, ParserError> {
+        impl_parse_to!(
+            [
+                Keyword::ROW,
+                Keyword::SCHEMA,
+                Keyword::LOCATION,
+                Keyword::CONFLUENT,
+                Keyword::SCHEMA,
+                Keyword::REGISTRY
+            ],
+            p
+        );
+        impl_parse_to!(row_schema_location: AstString, p);
+        Ok(Self {
+            row_schema_location,
+        })
+    }
+}
+
+impl fmt::Display for DebeziumAvroSchema {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut v: Vec<String> = vec![];
+        impl_fmt_display!(
+            [
+                Keyword::ROW,
+                Keyword::SCHEMA,
+                Keyword::LOCATION,
+                Keyword::CONFLUENT,
+                Keyword::SCHEMA,
+                Keyword::REGISTRY
+            ],
+            v
+        );
         impl_fmt_display!(row_schema_location, v, self);
         v.iter().join(" ").fmt(f)
     }

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -96,6 +96,7 @@ pub enum SourceSchema {
     CanalJson,        // Keyword::CANAL_JSON
     Csv(CsvInfo),     // Keyword::CSV
     Native,
+    DebeziumAvro(AvroSchema),     // Keyword::DEBEZIUM_AVRO
 }
 
 impl ParseTo for SourceSchema {
@@ -117,6 +118,9 @@ impl ParseTo for SourceSchema {
         } else if p.parse_keywords(&[Keyword::CSV]) {
             impl_parse_to!(csv_info: CsvInfo, p);
             SourceSchema::Csv(csv_info)
+        } else if p.parse_keywords(&[Keyword::DEBEZIUM_AVRO]) {
+            impl_parse_to!(avro_schema: AvroSchema, p);
+            SourceSchema::DebeziumAvro(avro_schema)
         } else {
             return Err(ParserError::ParserError(
                 "expected JSON | PROTOBUF | DEBEZIUM_JSON | AVRO | MAXWELL | CANAL_JSON after ROW FORMAT".to_string(),
@@ -137,6 +141,7 @@ impl fmt::Display for SourceSchema {
             SourceSchema::CanalJson => write!(f, "CANAL JSON"),
             SourceSchema::Csv(csv_info) => write!(f, "CSV {}", csv_info),
             SourceSchema::Native => write!(f, "NATIVE"),
+            SourceSchema::DebeziumAvro(avro_schema) => write!(f, "DEBEZIUM {}", avro_schema),
         }
     }
 }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -173,6 +173,7 @@ define_keywords!(
     DATE,
     DAY,
     DEALLOCATE,
+    DEBEZIUM_AVRO,
     DEBEZIUM_JSON,
     DEC,
     DECIMAL,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)


-->

Support debezium avro format with schema registery. Example:
```
CREATE table dbz (id integer primary key) with (
    connector = 'kafka',
    topic = 'dbserver1.inventory.customers',
    properties.bootstrap.server = '127.0.0.1:9092',
    scan.startup.mode = 'earliest'
) row format debezium_avro row schema location CONFLUENT SCHEMA REGISTRY 'http://localhost:8081';
```

Known limitations of this PR:

- We must use CREATE TABLE syntax with primary key specified to create dbz avro source
- Schema resolution fails when calling the from_avro_datum even when reader_schema == writer_schame. This is a limitation in apache-avro rust lib. We can ignore it for now since we haven't support source table schema evolution.

Close #7892 #7904 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Connector (sources & sinks)

### Release note
```
CREATE TABLE [ IF NOT EXISTS ] source_name (
   pk_column_name data_type PRIMARY KEY
) 
WITH (
   connector='kafka',
   field_name='value', ...
) 
ROW FORMAT DEBEZIUM_AVRO
ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY '<schema_registry_url>';
```