### PR TITLE
fix: fix dashboard proto-gen shell script

### DIFF
--- a/dashboard/scripts/generate_proto.sh
+++ b/dashboard/scripts/generate_proto.sh
@@ -14,6 +14,7 @@ else
 fi
 
 protoc --plugin=./node_modules/.bin/protoc-gen-ts_proto \
+    --experimental_allow_proto3_optional \
     --ts_proto_out=proto/gen/ \
     --proto_path=tmp_gen \
     --ts_proto_opt=outputServices=false \


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix the error below when running `npm run gen-proto` for dashboard:

```
meta.proto: This file contains proto3 optional fields, but --experimental_allow_proto3_optional was not set.
```

## Related PR

#7668