### PR TITLE
refactor(meta): use short prefix name for hummock meta store model

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -15,7 +15,6 @@
 pub mod compaction_config;
 mod level_selector;
 mod overlap_strategy;
-mod prost_type;
 use risingwave_hummock_sdk::prost_key_range::KeyRangeExt;
 use risingwave_pb::hummock::compact_task::{self, TaskStatus};
 
@@ -42,7 +41,7 @@ use crate::hummock::model::CompactionGroup;
 use crate::rpc::metrics::MetaMetrics;
 
 pub struct CompactStatus {
-    compaction_group_id: CompactionGroupId,
+    pub(crate) compaction_group_id: CompactionGroupId,
     pub(crate) level_handlers: Vec<LevelHandler>,
 }
 

--- a/src/meta/src/hummock/model/compact_task_assignment.rs
+++ b/src/meta/src/hummock/model/compact_task_assignment.rs
@@ -16,10 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockCompactionTaskId;
 use risingwave_pb::hummock::CompactTaskAssignment;
 
+use crate::hummock::model::HUMMOCK_COMPACT_TASK_ASSIGNMENT;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// `cf(compact_task_assignment)`: `CompactTaskId` -> `CompactTaskAssignment`
-const HUMMOCK_COMPACT_TASK_ASSIGNMENT: &str = "cf/compact_task_assignment";
 
 /// `AssignedCompactTasks` tracks compact tasks assigned to context id.
 impl MetadataModel for CompactTaskAssignment {

--- a/src/meta/src/hummock/model/compaction_group_config.rs
+++ b/src/meta/src/hummock/model/compaction_group_config.rs
@@ -19,6 +19,7 @@ pub use risingwave_common::catalog::TableOption;
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::CompactionConfig;
 
+use crate::hummock::model::HUMMOCK_COMPACTION_GROUP_CONFIG_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
 
 #[derive(Debug, Clone, PartialEq)]
@@ -67,8 +68,6 @@ impl From<&CompactionGroup> for risingwave_pb::hummock::CompactionGroup {
         }
     }
 }
-
-const HUMMOCK_COMPACTION_GROUP_CONFIG_CF_NAME: &str = "cf/hummock_compaction_group_config";
 
 impl MetadataModel for CompactionGroup {
     type KeyType = CompactionGroupId;

--- a/src/meta/src/hummock/model/compaction_status.rs
+++ b/src/meta/src/hummock/model/compaction_status.rs
@@ -18,9 +18,8 @@ use itertools::Itertools;
 use risingwave_hummock_sdk::CompactionGroupId;
 
 use crate::hummock::compaction::CompactStatus;
+use crate::hummock::model::HUMMOCK_COMPACTION_STATUS_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-const HUMMOCK_COMPACTION_STATUS_CF_NAME: &str = "cf/hummock_compaction_status";
 
 impl MetadataModel for CompactStatus {
     type KeyType = CompactionGroupId;

--- a/src/meta/src/hummock/model/mod.rs
+++ b/src/meta/src/hummock/model/mod.rs
@@ -29,7 +29,7 @@ pub use version::*;
 pub use version_delta::*;
 
 /// Column family names for hummock.
-/// Deprecated cf_name should be reserved for backward compatibility.
+/// Deprecated `cf_name` should be reserved for backward compatibility.
 const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_0";
 const HUMMOCK_VERSION_DELTA_CF_NAME: &str = "cf/hummock_1";
 const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_2";

--- a/src/meta/src/hummock/model/mod.rs
+++ b/src/meta/src/hummock/model/mod.rs
@@ -29,7 +29,7 @@ pub use version::*;
 pub use version_delta::*;
 
 /// Column family names for hummock.
-/// Deprecated CF_NAME should be reserved for backward compatibility.
+/// Deprecated cf_name should be reserved for backward compatibility.
 const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_0";
 const HUMMOCK_VERSION_DELTA_CF_NAME: &str = "cf/hummock_1";
 const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_2";

--- a/src/meta/src/hummock/model/mod.rs
+++ b/src/meta/src/hummock/model/mod.rs
@@ -14,6 +14,7 @@
 
 mod compact_task_assignment;
 mod compaction_group_config;
+mod compaction_status;
 mod pinned_snapshot;
 mod pinned_version;
 mod version;
@@ -21,7 +22,19 @@ mod version_delta;
 mod version_stats;
 
 pub use compaction_group_config::CompactionGroup;
+pub use compaction_status::*;
 pub use pinned_snapshot::*;
 pub use pinned_version::*;
 pub use version::*;
 pub use version_delta::*;
+
+/// Column family names for hummock.
+/// Deprecated CF_NAME should be reserved for backward compatibility.
+const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_0";
+const HUMMOCK_VERSION_DELTA_CF_NAME: &str = "cf/hummock_1";
+const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_2";
+const HUMMOCK_PINNED_SNAPSHOT_CF_NAME: &str = "cf/hummock_3";
+const HUMMOCK_COMPACTION_STATUS_CF_NAME: &str = "cf/hummock_4";
+const HUMMOCK_COMPACT_TASK_ASSIGNMENT: &str = "cf/hummock_5";
+const HUMMOCK_COMPACTION_GROUP_CONFIG_CF_NAME: &str = "cf/hummock_6";
+const HUMMOCK_VERSION_STATS_CF_NAME: &str = "cf/hummock_7";

--- a/src/meta/src/hummock/model/pinned_snapshot.rs
+++ b/src/meta/src/hummock/model/pinned_snapshot.rs
@@ -16,11 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockContextId;
 use risingwave_pb::hummock::HummockPinnedSnapshot;
 
+use crate::hummock::model::HUMMOCK_PINNED_SNAPSHOT_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// Column family name for hummock pinned snapshot
-/// `cf(hummock_pinned_snapshot)`: `HummockContextId` -> `HummockPinnedSnapshot`
-const HUMMOCK_PINNED_SNAPSHOT_CF_NAME: &str = "cf/hummock_pinned_snapshot";
 
 /// `HummockPinnedSnapshot` tracks pinned snapshots by given context id.
 impl MetadataModel for HummockPinnedSnapshot {

--- a/src/meta/src/hummock/model/pinned_version.rs
+++ b/src/meta/src/hummock/model/pinned_version.rs
@@ -16,11 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockContextId;
 use risingwave_pb::hummock::HummockPinnedVersion;
 
+use crate::hummock::model::HUMMOCK_PINNED_VERSION_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// Column family name for hummock pinned version
-/// `cf(hummock_pinned_version)`: `HummockContextId` -> `HummockPinnedVersion`
-const HUMMOCK_PINNED_VERSION_CF_NAME: &str = "cf/hummock_pinned_version";
 
 /// `HummockPinnedVersion` tracks pinned versions by given context id.
 impl MetadataModel for HummockPinnedVersion {

--- a/src/meta/src/hummock/model/version.rs
+++ b/src/meta/src/hummock/model/version.rs
@@ -16,11 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::hummock::HummockVersion;
 
+use crate::hummock::model::HUMMOCK_VERSION_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// Column family name for hummock version.
-/// `cf(hummock_version)`: `HummockVersionId` -> `HummockVersion`
-const HUMMOCK_VERSION_CF_NAME: &str = "cf/hummock_version";
 
 /// `HummockVersion` tracks `Sstables` in given version.
 impl MetadataModel for HummockVersion {

--- a/src/meta/src/hummock/model/version_delta.rs
+++ b/src/meta/src/hummock/model/version_delta.rs
@@ -16,11 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::hummock::HummockVersionDelta;
 
+use crate::hummock::model::HUMMOCK_VERSION_DELTA_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// Column family name for hummock version delta.
-/// `cf(hummock_version_delta)`: `HummockVersionId` -> `HummockVersionDelta`
-const HUMMOCK_VERSION_DELTA_CF_NAME: &str = "cf/hummock_version_delta";
 
 /// `HummockVersionDelta` tracks delta of `Sstables` in given version based on previous version.
 impl MetadataModel for HummockVersionDelta {

--- a/src/meta/src/hummock/model/version_stats.rs
+++ b/src/meta/src/hummock/model/version_stats.rs
@@ -16,10 +16,8 @@ use prost::Message;
 use risingwave_hummock_sdk::HummockVersionId;
 use risingwave_pb::hummock::HummockVersionStats;
 
+use crate::hummock::model::HUMMOCK_VERSION_STATS_CF_NAME;
 use crate::model::{MetadataModel, MetadataModelResult};
-
-/// `cf(hummock_table_stats)`: `HummockVersionId` -> `TableStatsMap`
-const HUMMOCK_VERSION_STATS_CF_NAME: &str = "cf/hummock_version_stats";
 
 /// `HummockVersionStats` stores stats for hummock version.
 /// Currently it only persists one row for latest version.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Before this PR we prefix hummock meta store model's key with descriptive name like "cf/hummock_version_delta".
This PR changes these prefix to shorter "cf/hummock_#" for better write performance and storage efficiency.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
