### PR TITLE
fix: bump madsim version to fix bugs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad8ec77ebfe5067154eb35baeb03c402e3c57a3db4866e9a1a276d40435c7fb8"
+checksum = "ff08a176759ae5e6cf2c5153028d258cdbb318cfee2e89f986cbd33dc40e1671"
 dependencies = [
  "ahash 0.7.6",
  "async-channel",
@@ -3525,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-aws-sdk-s3"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa6b576864ca304aa1248d800e56a906f5daa6c8a6e6132374648aea7ea86f1"
+checksum = "7e0798f5f47c2c9265e22bb0b9b16c73c8eabbceb79b7fec0610569fdcd293be"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",

--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -116,7 +116,7 @@ impl S3StreamingUploader {
                 .key(&self.key)
                 .send()
                 .await?;
-            self.upload_id = Some(resp.upload_id.unwrap());
+            self.upload_id = Some(resp.upload_id().unwrap().into());
         }
 
         // Get the data to upload for the next part.
@@ -187,7 +187,7 @@ impl S3StreamingUploader {
                 .iter()
                 .map(|(part_id, output)| {
                     CompletedPart::builder()
-                        .set_e_tag(output.e_tag.clone())
+                        .set_e_tag(output.e_tag().map(|s| s.into()))
                         .set_part_number(Some(*part_id))
                         .build()
                 })
@@ -389,7 +389,7 @@ impl ObjectStore for S3ObjectStore {
                 .last_modified()
                 .expect("last_modified required")
                 .as_secs_f64(),
-            total_size: resp.content_length as usize,
+            total_size: resp.content_length() as usize,
         })
     }
 
@@ -484,7 +484,7 @@ impl ObjectStore for S3ObjectStore {
                 request = request.continuation_token(continuation_token);
             }
             let result = request.send().await?;
-            let is_truncated = result.is_truncated;
+            let is_truncated = result.is_truncated();
             ret.append(
                 &mut result
                     .contents()
@@ -500,7 +500,7 @@ impl ObjectStore for S3ObjectStore {
                     })
                     .collect_vec(),
             );
-            next_continuation_token = result.next_continuation_token;
+            next_continuation_token = result.next_continuation_token().map(|s| s.to_string());
             if !is_truncated {
                 break;
             }

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -13,14 +13,14 @@ normal = ["serde"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-aws-sdk-s3 = { version = "0.2.15", package = "madsim-aws-sdk-s3" }
+aws-sdk-s3 = { version = "0.2.16", package = "madsim-aws-sdk-s3" }
 clap = "3"
 console = "0.15"
 etcd-client = { version = "0.2.15", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"
-madsim = "0.2.15"
+madsim = "0.2.16"
 paste = "1"
 rand = "0.8"
 rdkafka = { package = "madsim-rdkafka", version = "=0.2.14-alpha", features = ["cmake-build"] }


### PR DESCRIPTION
Signed-off-by: Runji Wang <wangrunji0408@163.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR bumps madsim version to fix 2 bugs:
1. madsim `panicked at 'unsupported clockid: 7'`
2. S3: Deleted object not found should not result in errors.

Related changes: https://github.com/madsim-rs/madsim/pull/121

## Checklist

- ~~I have written necessary rustdoc comments~~
- ~~I have added necessary unit tests and integration tests~~
- ~~I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).~~
- ~~I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

