### PR TITLE
chore(risedev): bump etcd to stable v3.5.7

### DIFF
--- a/src/risedevtool/etcd.toml
+++ b/src/risedevtool/etcd.toml
@@ -2,7 +2,7 @@ extend = "common.toml"
 
 [env]
 ETCD_SYSTEM = "${SYSTEM}"
-ETCD_VER = "v3.6.0-alpha.0" # Only v.3.6.0-alpha.0 supported darwin-arm64.
+ETCD_VER = "v3.5.7"
 ETCD_DOWNLOAD_URL_LINUX = "https://github.com/etcd-io/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-${ETCD_SYSTEM}.tar.gz"
 ETCD_DOWNLOAD_URL_OTHER = "https://github.com/etcd-io/etcd/releases/download/${ETCD_VER}/etcd-${ETCD_VER}-${ETCD_SYSTEM}.zip"
 ETCD_DOWNLOAD_PATH_LINUX = "${PREFIX_TMP}/etcd.tar.gz"


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The original `v3.6.0-alpha.0` now gives a "Not Found" error.

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
