### PR TITLE
fix(streaming): two phase agg group key

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1036,7 +1036,7 @@
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum(t.v1), count(t.v1), sum($expr1), sum(t.v1), count(t.v1)] }
             └─StreamProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: force two phase aggregation should succeed with UpstreamHashShard, but not SomeShard.
+- name: force two phase aggregation should succeed with UpstreamHashShard and SomeShard (batch only).
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
@@ -1137,5 +1137,27 @@
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
                   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: two phase agg with hop window
-  sql: select 1
+- name: two phase agg on hop window input
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_FORCE_TWO_PHASE_AGG=true;
+    create table bid(date_time TIMESTAMP, auction int);
+    SELECT
+      count(*) AS num,
+      window_start AS starttime_c
+    FROM HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+    GROUP BY
+      bid.auction,
+      window_start
+    ) AS CountBids
+  batch_plan: |
+  stream_plan: |
+- name: two phase agg with stream SomeShard (via index)
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_FORCE_TWO_PHASE_AGG=true;
+    create table t (id int primary key, col int);
+    create index idx on t(col);
+    select count(id), min(col) from idx group by int;
+  batch_plan: |
+  stream_plan: |

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1075,13 +1075,11 @@
     └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
       └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
-            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
-                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
-                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
 - name: force two phase aggregation should succeed with hashshard, but not SomeShard.
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
@@ -1177,10 +1175,8 @@
     └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
       └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
-            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
-                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
-                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1183,7 +1183,7 @@
                         └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                           └─StreamFilter { predicate: IsNotNull(bid.date_time) }
                             └─StreamTableScan { table: bid, columns: [bid.date_time, bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
-- name: two phase agg with stream SomeShard (via index)
+- name: two phase agg with stream SomeShard (via index) should fail
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -708,8 +708,7 @@
       └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1))] }
         └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3, t.v2) }
           └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-            └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
-              └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -696,7 +696,7 @@
         └─StreamExchange { dist: Single }
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
             └─StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: force two phase aggregation
+- name: force two phase aggregation on satisfied dist should fail
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
@@ -704,19 +704,16 @@
     select min(v3), sum(v1) from t group by v1, v3, v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [min(min(t.v3)), sum(sum(t.v1))] }
-      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1))] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3, t.v2) }
-          └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
+      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
-    └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }
-      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(min(t.v3)), sum(sum(t.v1))] }
-        └─StreamExchange { dist: HashShard(t.v1, t.v3, t.v2) }
-          └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [count, min(t.v3), sum(t.v1)] }
-            └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
-              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2] }
+    └─StreamProject { exprs: [min(t.v3), sum(t.v1), t.v1, t.v3, t.v2] }
+      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(t.v3), sum(t.v1)] }
+        └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
+          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: enable two phase aggregation
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
@@ -1092,7 +1089,7 @@
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum(t.v1), count(t.v1), sum($expr1), sum(t.v1), count(t.v1)] }
             └─StreamProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: correlated two phase agg https://github.com/risingwavelabs/risingwave/issues/7928
+- name: two phase agg with same dist https://github.com/risingwavelabs/risingwave/issues/7928
   sql: |
     set QUERY_MODE to DISTRIBUTED;
     set RW_FORCE_TWO_PHASE_AGG to TRUE;
@@ -1131,10 +1128,48 @@
     └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
       └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
-            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
-              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
-                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
-                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
-                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+          └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+            └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+- name: two phase agg with different dist
+  sql: |
+    set QUERY_MODE to DISTRIBUTED;
+    set RW_FORCE_TWO_PHASE_AGG to TRUE;
+    CREATE TABLE lineitem (
+        l_orderkey BIGINT,
+        l_tax NUMERIC,
+        l_commitdate DATE,
+        l_shipinstruct VARCHAR,
+        PRIMARY KEY (l_orderkey)
+    );
+    SELECT
+        1 as col_0
+    FROM
+        (
+            SELECT
+                t_0.l_commitdate AS col_2
+            FROM
+                lineitem AS t_0
+            GROUP BY
+                t_0.l_tax,
+                t_0.l_shipinstruct,
+                t_0.l_orderkey,
+                t_0.l_commitdate
+        ) AS sq_1
+    GROUP BY
+        sq_1.col_2;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
+          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
+            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
+  stream_plan: |
+    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
+    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
+      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
+        └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
+          └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+            └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1044,10 +1044,11 @@
     select min(v3), sum(v1) from t group by v1, v3, v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
-      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
-          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [min(min(t.v3)), sum(sum(t.v1))] }
+      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1))] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3, t.v2) }
+          └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }
@@ -1136,3 +1137,5 @@
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
                   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+- name: two phase agg with hop window
+  sql: select 1

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1080,7 +1080,7 @@
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
                   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: force two phase aggregation should succeed with hashshard, but not SomeShard.
+- name: force two phase aggregation should succeed with UpstreamHashShard, but not SomeShard.
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
@@ -1101,7 +1101,7 @@
           └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [count, min(t.v3), sum(t.v1)] }
             └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: enable two phase aggregation
+- name: enable two phase aggregation with simple agg
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_ENABLE_TWO_PHASE_AGG=true;
@@ -1120,7 +1120,7 @@
           └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), sum(t.v2)] }
             └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: disable two phase aggregation
+- name: disable two phase aggregation with simple agg
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_ENABLE_TWO_PHASE_AGG=false;
@@ -1136,7 +1136,51 @@
       └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
         └─StreamExchange { dist: Single }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: two phase agg with same dist should fail
+- name: force two phase agg with different distributions on inner and outer agg.
+  sql: |
+    set QUERY_MODE to DISTRIBUTED;
+    set RW_FORCE_TWO_PHASE_AGG to TRUE;
+    CREATE TABLE lineitem (
+        l_orderkey BIGINT,
+        l_tax NUMERIC,
+        l_commitdate DATE,
+        l_shipinstruct VARCHAR,
+        PRIMARY KEY (l_orderkey)
+    );
+    SELECT
+        1 as col_0
+    FROM
+        (
+            SELECT
+                t_0.l_commitdate AS col_2
+            FROM
+                lineitem AS t_0
+            GROUP BY
+                t_0.l_tax,
+                t_0.l_shipinstruct,
+                t_0.l_orderkey,
+                t_0.l_commitdate
+        ) AS sq_1
+    GROUP BY
+        sq_1.col_2;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
+          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
+            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
+  stream_plan: |
+    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
+    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
+      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
+        └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
+              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+- name: force two phase agg with same distribution.
   sql: |
     set QUERY_MODE to DISTRIBUTED;
     set RW_FORCE_TWO_PHASE_AGG to TRUE;

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1044,11 +1044,10 @@
     select min(v3), sum(v1) from t group by v1, v3, v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [min(min(t.v3)), sum(sum(t.v1))] }
-      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1))] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3, t.v2) }
-          └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
+      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1143,21 +1143,63 @@
     SET RW_FORCE_TWO_PHASE_AGG=true;
     create table bid(date_time TIMESTAMP, auction int);
     SELECT
-      count(*) AS num,
-      window_start AS starttime_c
-    FROM HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+      max(CountBids.num) AS maxn,
+      CountBids.starttime_c
+    FROM (
+      SELECT
+        count(*) AS num,
+        window_start AS starttime_c
+      FROM HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
+      GROUP BY
+        bid.auction,
+        window_start
+    ) as CountBids
     GROUP BY
-      bid.auction,
-      window_start
-    ) AS CountBids
+    CountBids.starttime_c;
   batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [max(max(sum0(count))), window_start] }
+      └─BatchHashAgg { group_key: [window_start], aggs: [max(max(sum0(count)))] }
+        └─BatchExchange { order: [], dist: HashShard(window_start) }
+          └─BatchHashAgg { group_key: [window_start], aggs: [max(sum0(count))] }
+            └─BatchHashAgg { group_key: [bid.auction, window_start], aggs: [sum0(count)] }
+              └─BatchExchange { order: [], dist: HashShard(bid.auction, window_start) }
+                └─BatchHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+                  └─BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
+                    └─BatchFilter { predicate: IsNotNull(bid.date_time) }
+                      └─BatchScan { table: bid, columns: [bid.date_time, bid.auction], distribution: SomeShard }
   stream_plan: |
+    StreamMaterialize { columns: [maxn, starttime_c], pk_columns: [starttime_c], pk_conflict: "no check" }
+    └─StreamProject { exprs: [max(max(sum0(count))), window_start] }
+      └─StreamHashAgg { group_key: [window_start], aggs: [count, max(max(sum0(count)))] }
+        └─StreamExchange { dist: HashShard(window_start) }
+          └─StreamHashAgg { group_key: [window_start, $expr2], aggs: [count, max(sum0(count))] }
+            └─StreamProject { exprs: [bid.auction, window_start, sum0(count), Vnode(bid.auction, window_start) as $expr2] }
+              └─StreamProject { exprs: [bid.auction, window_start, sum0(count)] }
+                └─StreamHashAgg { group_key: [bid.auction, window_start], aggs: [count, sum0(count)] }
+                  └─StreamExchange { dist: HashShard(bid.auction, window_start) }
+                    └─StreamHashAgg { group_key: [bid.auction, window_start, $expr1], aggs: [count, count] }
+                      └─StreamProject { exprs: [bid.auction, window_start, bid._row_id, Vnode(bid._row_id) as $expr1] }
+                        └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
+                          └─StreamFilter { predicate: IsNotNull(bid.date_time) }
+                            └─StreamTableScan { table: bid, columns: [bid.date_time, bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
 - name: two phase agg with stream SomeShard (via index)
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
     create table t (id int primary key, col int);
     create index idx on t(col);
-    select count(id), min(col) from idx group by int;
+    with sq as (select id from idx) select count(*) from sq group by sq.id;
   batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [sum0(count)] }
+      └─BatchHashAgg { group_key: [idx.id], aggs: [sum0(count)] }
+        └─BatchExchange { order: [], dist: HashShard(idx.id) }
+          └─BatchHashAgg { group_key: [idx.id], aggs: [count] }
+            └─BatchScan { table: idx, columns: [idx.id], distribution: SomeShard }
   stream_plan: |
+    StreamMaterialize { columns: [count, idx.id(hidden)], pk_columns: [idx.id], pk_conflict: "no check" }
+    └─StreamProject { exprs: [count, idx.id] }
+      └─StreamHashAgg { group_key: [idx.id], aggs: [count, count] }
+        └─StreamExchange { dist: HashShard(idx.id) }
+          └─StreamTableScan { table: idx, columns: [idx.id], pk: [idx.id], dist: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1057,7 +1057,7 @@
           └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [count, min(t.v3), sum(t.v1)] }
             └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: enable two phase aggregation with simple agg
+- name: enable two phase aggregation with simple agg should have two phase agg
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_ENABLE_TWO_PHASE_AGG=true;
@@ -1092,7 +1092,7 @@
       └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
         └─StreamExchange { dist: Single }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: force two phase agg with different distributions on inner and outer agg.
+- name: force two phase agg with different distributions on inner and outer agg should have exchange
   sql: |
     set QUERY_MODE to DISTRIBUTED;
     set RW_FORCE_TWO_PHASE_AGG to TRUE;
@@ -1137,7 +1137,7 @@
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
                   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: two phase agg on hop window input
+- name: two phase agg on hop window input should use two phase agg
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
@@ -1183,7 +1183,7 @@
                         └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                           └─StreamFilter { predicate: IsNotNull(bid.date_time) }
                             └─StreamTableScan { table: bid, columns: [bid.date_time, bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
-- name: two phase agg with stream SomeShard (via index) should fail
+- name: two phase agg with stream SomeShard (via index) but pk satisfies output dist should use shuffle agg
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;
@@ -1203,3 +1203,25 @@
       └─StreamHashAgg { group_key: [idx.id], aggs: [count, count] }
         └─StreamExchange { dist: HashShard(idx.id) }
           └─StreamTableScan { table: idx, columns: [idx.id], pk: [idx.id], dist: SomeShard }
+- name: two phase agg with stream SomeShard (via index) but pk does not satisfy output dist should use two phase agg
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_FORCE_TWO_PHASE_AGG=true;
+    create table t (id int primary key, col1 int, col2 int);
+    create index idx on t(id);
+    with sq as (select col1, col2 from idx) select count(*) from sq group by sq.col1;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [sum0(count)] }
+      └─BatchHashAgg { group_key: [idx.col1], aggs: [sum0(count)] }
+        └─BatchExchange { order: [], dist: HashShard(idx.col1) }
+          └─BatchHashAgg { group_key: [idx.col1], aggs: [count] }
+            └─BatchScan { table: idx, columns: [idx.col1], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [count, idx.col1(hidden)], pk_columns: [idx.col1], pk_conflict: "no check" }
+    └─StreamProject { exprs: [sum0(count), idx.col1] }
+      └─StreamHashAgg { group_key: [idx.col1], aggs: [count, sum0(count)] }
+        └─StreamExchange { dist: HashShard(idx.col1) }
+          └─StreamHashAgg { group_key: [idx.col1, $expr1], aggs: [count, count] }
+            └─StreamProject { exprs: [idx.col1, idx.id, Vnode(idx.id) as $expr1] }
+              └─StreamTableScan { table: idx, columns: [idx.col1, idx.id], pk: [idx.id], dist: UpstreamHashShard(idx.id) }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1131,7 +1131,60 @@
           └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
             └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
               └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: two phase agg with different dist
+- name: force two phase aggregation should succeed with hashshard
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_FORCE_TWO_PHASE_AGG=true;
+    create table t(v1 int, v2 smallint, v3 varchar);
+    select min(v3), sum(v1) from t group by v1, v3, v2;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
+      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
+          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2] }
+    └─StreamProject { exprs: [min(t.v3), sum(t.v1), t.v1, t.v3, t.v2] }
+      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(t.v3), sum(t.v1)] }
+        └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
+          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+- name: enable two phase aggregation
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_ENABLE_TWO_PHASE_AGG=true;
+    create table t(v1 int, v2 int);
+    select min(v1), sum(v2) from t;
+  batch_plan: |
+    BatchSimpleAgg { aggs: [min(min(t.v1)), sum(sum(t.v2))] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchSimpleAgg { aggs: [min(t.v1), sum(t.v2)] }
+        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [min, sum], pk_columns: [] }
+    └─StreamProject { exprs: [min(min(t.v1)), sum(sum(t.v2))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), sum(sum(t.v2))] }
+        └─StreamExchange { dist: Single }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), sum(t.v2)] }
+            └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id) as $expr1] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+- name: disable two phase aggregation
+  sql: |
+    SET QUERY_MODE TO DISTRIBUTED;
+    SET RW_ENABLE_TWO_PHASE_AGG=false;
+    create table t(v1 int, v2 int);
+    select min(v1), sum(v2) from t;
+  batch_plan: |
+    BatchSimpleAgg { aggs: [min(t.v1), sum(t.v2)] }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [min, sum], pk_columns: [] }
+    └─StreamProject { exprs: [min(t.v1), sum(t.v2)] }
+      └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
+        └─StreamExchange { dist: Single }
+          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+- name: two phase agg with same dist should fail
   sql: |
     set QUERY_MODE to DISTRIBUTED;
     set RW_FORCE_TWO_PHASE_AGG to TRUE;

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1093,3 +1093,49 @@
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum(t.v1), count(t.v1), sum($expr1), sum(t.v1), count(t.v1)] }
             └─StreamProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+- name: correlated two phase agg https://github.com/risingwavelabs/risingwave/issues/7928
+  sql: |
+    set QUERY_MODE to DISTRIBUTED;
+    set RW_FORCE_TWO_PHASE_AGG to TRUE;
+    CREATE TABLE lineitem (
+        l_orderkey BIGINT,
+        l_tax NUMERIC,
+        l_commitdate DATE,
+        l_shipinstruct VARCHAR,
+        PRIMARY KEY (l_orderkey)
+    );
+    SELECT
+        1 as col_0
+    FROM
+        (
+            SELECT
+                t_0.l_commitdate AS col_2
+            FROM
+                lineitem AS t_0
+            GROUP BY
+                t_0.l_tax,
+                t_0.l_shipinstruct,
+                t_0.l_orderkey,
+                t_0.l_commitdate
+        ) AS sq_1
+    GROUP BY
+        sq_1.col_2;
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [1:Int32] }
+      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
+        └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
+          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
+            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
+  stream_plan: |
+    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
+    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
+      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
+        └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
+              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
+                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
+                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1036,50 +1036,6 @@
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum(t.v1), count(t.v1), sum($expr1), sum(t.v1), count(t.v1)] }
             └─StreamProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: two phase agg with same dist https://github.com/risingwavelabs/risingwave/issues/7928
-  sql: |
-    set QUERY_MODE to DISTRIBUTED;
-    set RW_FORCE_TWO_PHASE_AGG to TRUE;
-    CREATE TABLE lineitem (
-        l_orderkey BIGINT,
-        l_tax NUMERIC,
-        l_commitdate DATE,
-        l_shipinstruct VARCHAR,
-        PRIMARY KEY (l_orderkey)
-    );
-    SELECT
-        1 as col_0
-    FROM
-        (
-            SELECT
-                t_0.l_commitdate AS col_2
-            FROM
-                lineitem AS t_0
-            GROUP BY
-                t_0.l_tax,
-                t_0.l_shipinstruct,
-                t_0.l_orderkey,
-                t_0.l_commitdate
-        ) AS sq_1
-    GROUP BY
-        sq_1.col_2;
-  batch_plan: |
-    BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [1:Int32] }
-      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
-        └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
-          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
-            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
-  stream_plan: |
-    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
-    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
-      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
-        └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
-            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
-              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
-                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
 - name: force two phase aggregation should succeed with UpstreamHashShard, but not SomeShard.
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
@@ -1094,7 +1050,7 @@
           └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
             └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2] }
+    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }
       └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(min(t.v3)), sum(sum(t.v1))] }
         └─StreamExchange { dist: HashShard(t.v1, t.v3, t.v2) }
@@ -1113,7 +1069,7 @@
       └─BatchSimpleAgg { aggs: [min(t.v1), sum(t.v2)] }
         └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [min, sum], pk_columns: [] }
+    StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v1)), sum(sum(t.v2))] }
       └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), sum(sum(t.v2))] }
         └─StreamExchange { dist: Single }
@@ -1131,7 +1087,7 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [min, sum], pk_columns: [] }
+    StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(t.v1), sum(t.v2)] }
       └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
         └─StreamExchange { dist: Single }
@@ -1148,7 +1104,7 @@
         PRIMARY KEY (l_orderkey)
     );
     SELECT
-        1 as col_0
+        max(sq_1.col_2) as col_0
     FROM
         (
             SELECT
@@ -1165,61 +1121,18 @@
         sq_1.col_2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [1:Int32] }
-      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
+    └─BatchProject { exprs: [max(max(lineitem.l_commitdate))] }
+      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [max(max(lineitem.l_commitdate))] }
         └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
-          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
-            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
+          └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [max(lineitem.l_commitdate)] }
+            └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
+              └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
   stream_plan: |
-    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
-    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
-      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
+    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate], pk_conflict: "no check" }
+    └─StreamProject { exprs: [max(max(lineitem.l_commitdate)), lineitem.l_commitdate] }
+      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count, max(max(lineitem.l_commitdate))] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
-            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
-              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
-                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: force two phase agg with same distribution.
-  sql: |
-    set QUERY_MODE to DISTRIBUTED;
-    set RW_FORCE_TWO_PHASE_AGG to TRUE;
-    CREATE TABLE lineitem (
-        l_orderkey BIGINT,
-        l_tax NUMERIC,
-        l_commitdate DATE,
-        l_shipinstruct VARCHAR,
-        PRIMARY KEY (l_orderkey)
-    );
-    SELECT
-        1 as col_0
-    FROM
-        (
-            SELECT
-                t_0.l_commitdate AS col_2
-            FROM
-                lineitem AS t_0
-            GROUP BY
-                t_0.l_tax,
-                t_0.l_shipinstruct,
-                t_0.l_orderkey,
-                t_0.l_commitdate
-        ) AS sq_1
-    GROUP BY
-        sq_1.col_2;
-  batch_plan: |
-    BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [1:Int32] }
-      └─BatchHashAgg { group_key: [lineitem.l_commitdate], aggs: [] }
-        └─BatchExchange { order: [], dist: HashShard(lineitem.l_commitdate) }
-          └─BatchHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [] }
-            └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], distribution: UpstreamHashShard(lineitem.l_orderkey) }
-  stream_plan: |
-    StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate] }
-    └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
-      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
-        └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count] }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count, max(lineitem.l_commitdate)] }
             └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -696,59 +696,6 @@
         └─StreamExchange { dist: Single }
           └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
             └─StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: force two phase aggregation on satisfied dist should fail
-  sql: |
-    SET QUERY_MODE TO DISTRIBUTED;
-    SET RW_FORCE_TWO_PHASE_AGG=true;
-    create table t(v1 int, v2 smallint, v3 varchar);
-    select min(v3), sum(v1) from t group by v1, v3, v2;
-  batch_plan: |
-    BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
-      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
-          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
-  stream_plan: |
-    StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2] }
-    └─StreamProject { exprs: [min(t.v3), sum(t.v1), t.v1, t.v3, t.v2] }
-      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(t.v3), sum(t.v1)] }
-        └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
-          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: enable two phase aggregation
-  sql: |
-    SET QUERY_MODE TO DISTRIBUTED;
-    SET RW_ENABLE_TWO_PHASE_AGG=true;
-    create table t(v1 int, v2 int);
-    select min(v1), sum(v2) from t;
-  batch_plan: |
-    BatchSimpleAgg { aggs: [min(min(t.v1)), sum(sum(t.v2))] }
-    └─BatchExchange { order: [], dist: Single }
-      └─BatchSimpleAgg { aggs: [min(t.v1), sum(t.v2)] }
-        └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
-  stream_plan: |
-    StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
-    └─StreamProject { exprs: [min(min(t.v1)), sum(sum(t.v2))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), sum(sum(t.v2))] }
-        └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), sum(t.v2)] }
-            └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id) as $expr1] }
-              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
-- name: disable two phase aggregation
-  sql: |
-    SET QUERY_MODE TO DISTRIBUTED;
-    SET RW_ENABLE_TWO_PHASE_AGG=false;
-    create table t(v1 int, v2 int);
-    select min(v1), sum(v2) from t;
-  batch_plan: |
-    BatchSimpleAgg { aggs: [min(t.v1), sum(t.v2)] }
-    └─BatchExchange { order: [], dist: Single }
-      └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
-  stream_plan: |
-    StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
-    └─StreamProject { exprs: [min(t.v1), sum(t.v2)] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
-        └─StreamExchange { dist: Single }
-          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: only distinct agg
   sql: |
     create table t(a int, b int, c int);
@@ -1128,9 +1075,13 @@
     └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
       └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
-            └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
+              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
+                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
+                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
 - name: force two phase aggregation should succeed with hashshard, but not SomeShard.
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
@@ -1139,16 +1090,19 @@
     select min(v3), sum(v1) from t group by v1, v3, v2;
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchProject { exprs: [min(t.v3), sum(t.v1)] }
-      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
-        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v2, t.v3) }
-          └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
+    └─BatchProject { exprs: [min(min(t.v3)), sum(sum(t.v1))] }
+      └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1))] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1, t.v3, t.v2) }
+          └─BatchHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(t.v3), sum(t.v1)] }
+            └─BatchScan { table: t, columns: [t.v1, t.v2, t.v3], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2] }
-    └─StreamProject { exprs: [min(t.v3), sum(t.v1), t.v1, t.v3, t.v2] }
-      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(t.v3), sum(t.v1)] }
-        └─StreamExchange { dist: HashShard(t.v1, t.v2, t.v3) }
-          └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+    └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }
+      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(min(t.v3)), sum(sum(t.v1))] }
+        └─StreamExchange { dist: HashShard(t.v1, t.v3, t.v2) }
+          └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [count, min(t.v3), sum(t.v1)] }
+            └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
+              └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: enable two phase aggregation
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
@@ -1223,6 +1177,10 @@
     └─StreamProject { exprs: [1:Int32, lineitem.l_commitdate] }
       └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
-            └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
-              └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr2], aggs: [count] }
+            └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr2] }
+              └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
+                └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
+                  └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, $expr1], aggs: [count] }
+                    └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct, Vnode(lineitem.l_orderkey) as $expr1] }
+                      └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1131,7 +1131,7 @@
           └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
             └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
               └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_tax, lineitem.l_commitdate, lineitem.l_shipinstruct], pk: [lineitem.l_orderkey], dist: UpstreamHashShard(lineitem.l_orderkey) }
-- name: force two phase aggregation should succeed with hashshard
+- name: force two phase aggregation should succeed with hashshard, but not SomeShard.
   sql: |
     SET QUERY_MODE TO DISTRIBUTED;
     SET RW_FORCE_TWO_PHASE_AGG=true;

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -25,7 +25,7 @@ use super::{
     ToDistributedBatch,
 };
 use crate::expr::ExprRewriter;
-use crate::optimizer::plan_node::{ToLocalBatch};
+use crate::optimizer::plan_node::ToLocalBatch;
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
 use crate::utils::ColIndexMappingRewriteExt;
 

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -25,7 +25,7 @@ use super::{
     ToDistributedBatch,
 };
 use crate::expr::ExprRewriter;
-use crate::optimizer::plan_node::{BatchExchange, ToLocalBatch};
+use crate::optimizer::plan_node::{ToLocalBatch};
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
 use crate::utils::ColIndexMappingRewriteExt;
 

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -118,9 +118,9 @@ impl ToDistributedBatch for BatchHashAgg {
         if self.logical.two_phase_agg_forced() && self.logical.can_two_phase_agg() {
             let input = self.input().to_distributed()?;
             let input_dist = input.distribution();
-            let required_dist =
-                RequiredDist::shard_by_key(self.input().schema().len(), self.group_key());
-            if !input_dist.satisfies(&required_dist)
+            if !self
+                .logical
+                .hash_agg_dist_satisfied_by_input_dist(input_dist)
                 && matches!(
                     input_dist,
                     Distribution::HashShard(_)

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -120,8 +120,16 @@ impl ToDistributedBatch for BatchHashAgg {
         if self.logical.two_phase_agg_forced() && self.logical.can_two_phase_agg() {
             let input = self.input().to_distributed()?;
             let input_dist = input.distribution();
-            let required_dist = RequiredDist::shard_by_key(self.input().schema().len(), self.group_key());
-            if !input_dist.satisfies(&required_dist) && matches!(input_dist, Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _) | Distribution::SomeShard) {
+            let required_dist =
+                RequiredDist::shard_by_key(self.input().schema().len(), self.group_key());
+            if !input_dist.satisfies(&required_dist)
+                && matches!(
+                    input_dist,
+                    Distribution::HashShard(_)
+                        | Distribution::UpstreamHashShard(_, _)
+                        | Distribution::SomeShard
+                )
+            {
                 return self.to_two_phase_agg(input);
             }
         }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -58,9 +58,7 @@ impl BatchHashAgg {
         self.logical.group_key()
     }
 
-    fn to_two_phase_agg(&self, input: PlanRef) -> Result<PlanRef> {
-        let dist_input = input.to_distributed()?;
-
+    fn to_two_phase_agg(&self, dist_input: PlanRef) -> Result<PlanRef> {
         // partial agg - follows input distribution
         let partial_agg: PlanRef = self.clone_with_input(dist_input).into();
 

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -21,7 +21,7 @@ use risingwave_pb::batch_plan::HashAggNode;
 
 use super::generic::{GenericPlanRef, PlanAggCall};
 use super::{
-    ExprRewritable, LogicalAgg, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchProst,
+    ExprRewritable, LogicalAgg, PlanBase, PlanNodeType, PlanRef, PlanTreeNodeUnary, ToBatchProst,
     ToDistributedBatch,
 };
 use crate::expr::ExprRewriter;
@@ -61,6 +61,7 @@ impl BatchHashAgg {
     fn to_two_phase_agg(&self, dist_input: PlanRef) -> Result<PlanRef> {
         // partial agg - follows input distribution
         let partial_agg: PlanRef = self.clone_with_input(dist_input).into();
+        debug_assert!(partial_agg.node_type() == PlanNodeType::BatchHashAgg);
 
         // insert exchange
         let exchange = RequiredDist::shard_by_key(

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -158,11 +158,12 @@ impl LogicalAgg {
             ));
             Ok(global_agg.into())
         } else {
-            let exchange = RequiredDist::shard_by_key(input_col_num, self.group_key())
+            let group_key = (0..self.group_key().len()).collect_vec();
+
+            let exchange = RequiredDist::shard_by_key(input_col_num, &group_key)
                 .enforce_if_not_satisfies(local_agg.into(), &Order::any())?;
             // Local phase should have reordered the group keys into their required order.
             // we can just follow it.
-            let group_key = (0..self.group_key().len()).collect();
             let global_agg = StreamHashAgg::new(
                 LogicalAgg::new(
                     self.agg_calls()

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -287,6 +287,7 @@ impl LogicalAgg {
         self.can_two_phase_agg()
             && self.two_phase_agg_forced()
             && !input_dist.satisfies(&required_dist)
+            && matches!(input_dist, Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _))
     }
 
     pub(crate) fn can_two_phase_agg(&self) -> bool {

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -149,7 +149,7 @@ impl LogicalAgg {
         let global_group_key = local_agg
             .i2o_col_mapping()
             .rewrite_dist_key(local_group_key_without_vnode)
-            .unwrap_or_else(|| panic!("some input group key could not be mapped"));
+            .expect("some input group key could not be mapped");
 
         // Generate global agg step
         if self.group_key().is_empty() {
@@ -265,7 +265,7 @@ impl LogicalAgg {
             return self.gen_stateless_two_phase_streaming_agg_plan(stream_input);
         }
 
-        // Vnode-based 2-phase simple agg
+        // Vnode-based 2-phase agg
         // can be applied on agg calls not affected by order,
         // with input distributed by dist_key.
         match input_dist {

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -257,7 +257,7 @@ impl LogicalAgg {
             .any(|call| matches!(call.agg_kind, AggKind::StringAgg | AggKind::ArrayAgg))
     }
 
-    fn two_phase_agg_forced(&self) -> bool {
+    pub(crate) fn two_phase_agg_forced(&self) -> bool {
         self.base
             .ctx()
             .session_ctx()

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -310,23 +310,9 @@ impl LogicalAgg {
             .get_enable_two_phase_agg()
     }
 
-    /// Must try two phase agg iff we are forced to,
-    /// and we can do so.
+    /// Must try two phase agg iff we are forced to, and we satisfy the constraints.
     fn must_try_two_phase_agg(&self) -> bool {
         self.two_phase_agg_forced() && self.can_two_phase_agg()
-    }
-
-    fn should_vnode_two_phase_streaming_agg(&self, input_dist: &Distribution) -> bool {
-        self.can_two_phase_agg()
-            && self.two_phase_agg_forced()
-            && !input_dist.satisfies(&RequiredDist::shard_by_key(
-                self.input().schema().len(),
-                self.group_key(),
-            ))
-            && matches!(
-                input_dist,
-                Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _)
-            )
     }
 
     pub(crate) fn can_two_phase_agg(&self) -> bool {

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -287,7 +287,10 @@ impl LogicalAgg {
         self.can_two_phase_agg()
             && self.two_phase_agg_forced()
             && !input_dist.satisfies(&required_dist)
-            && matches!(input_dist, Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _))
+            && matches!(
+                input_dist,
+                Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _)
+            )
     }
 
     pub(crate) fn can_two_phase_agg(&self) -> bool {

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -132,6 +132,7 @@ impl LogicalAgg {
             .into(),
         );
         let vnode_col_idx = exprs.len() - 1;
+        // TODO(kwannoel): We should apply Project optimization rules here.
         let project = StreamProject::new(LogicalProject::new(stream_input, exprs));
 
         // Generate local agg step

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -202,7 +202,10 @@ impl LogicalAgg {
     fn gen_dist_stream_agg_plan(&self, stream_input: PlanRef) -> Result<PlanRef> {
         // Shuffle agg if group key is present.
         let input_dist = stream_input.distribution().clone();
-        println!("should two phase agg: {}", self.should_stream_two_phase_agg(&stream_input));
+        println!(
+            "should two phase agg: {}",
+            self.should_stream_two_phase_agg(&stream_input)
+        );
         println!("group_key empty: {}", self.group_key().is_empty());
         if !self.group_key().is_empty() && !self.should_stream_two_phase_agg(&stream_input) {
             println!("Generating stream hash agg");
@@ -286,7 +289,10 @@ impl LogicalAgg {
         // we should not use two phase agg.
         let required_dist =
             RequiredDist::shard_by_key(self.input().schema().len(), self.group_key());
-        println!("satisfies? {}", stream_input.distribution().satisfies(&required_dist));
+        println!(
+            "satisfies? {}",
+            stream_input.distribution().satisfies(&required_dist)
+        );
         self.can_two_phase_agg()
             && self.two_phase_agg_forced()
             && !stream_input.distribution().satisfies(&required_dist)
@@ -297,14 +303,16 @@ impl LogicalAgg {
         // we should not use two phase agg.
         let required_dist =
             RequiredDist::shard_by_key(self.input().schema().len(), self.group_key());
-        println!("satisfies? {}", self.input().distribution().satisfies(&required_dist));
+        println!(
+            "satisfies? {}",
+            self.input().distribution().satisfies(&required_dist)
+        );
         self.can_two_phase_agg()
             && self.two_phase_agg_forced()
             && !self.input().distribution().satisfies(&required_dist)
     }
 
     pub(crate) fn can_two_phase_agg(&self) -> bool {
-
         !self.agg_calls().is_empty()
             && self.agg_calls().iter().all(|call| {
                 matches!(

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -79,6 +79,10 @@ impl StreamHashAgg {
     pub fn group_key(&self) -> &[usize] {
         self.logical.group_key()
     }
+
+    pub(crate) fn i2o_col_mapping(&self) -> ColIndexMapping {
+        self.logical.i2o_col_mapping()
+    }
 }
 
 impl fmt::Display for StreamHashAgg {

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -22,7 +22,7 @@ use super::{ExprRewritable, LogicalAgg, PlanBase, PlanRef, PlanTreeNodeUnary, St
 use crate::expr::ExprRewriter;
 use crate::optimizer::property::Distribution;
 use crate::stream_fragmenter::BuildFragmentGraphState;
-use crate::utils::ColIndexMappingRewriteExt;
+use crate::utils::{ColIndexMapping, ColIndexMappingRewriteExt};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamHashAgg {

--- a/src/frontend/src/optimizer/property/distribution.rs
+++ b/src/frontend/src/optimizer/property/distribution.rs
@@ -306,6 +306,11 @@ impl RequiredDist {
         plan: PlanRef,
         required_order: &Order,
     ) -> Result<PlanRef> {
+        println!("plan dist: {}", plan.distribution());
+        match self {
+            RequiredDist::ShardByKey(_) => println!("required dist: {}", self.to_dist()),
+            _ => println!("required dist: {:?}", self),
+        };
         if !plan.distribution().satisfies(self) {
             Ok(self.enforce(plan, required_order))
         } else {

--- a/src/frontend/src/optimizer/property/distribution.rs
+++ b/src/frontend/src/optimizer/property/distribution.rs
@@ -306,11 +306,6 @@ impl RequiredDist {
         plan: PlanRef,
         required_order: &Order,
     ) -> Result<PlanRef> {
-        println!("plan dist: {}", plan.distribution());
-        match self {
-            RequiredDist::ShardByKey(_) => println!("required dist: {}", self.to_dist()),
-            _ => println!("required dist: {:?}", self),
-        };
         if !plan.distribution().satisfies(self) {
             Ok(self.enforce(plan, required_order))
         } else {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -62,7 +62,6 @@ pub fn mview_sql_gen<R: Rng>(rng: &mut R, tables: Vec<Table>, name: &str) -> (St
 /// which can lead to stack overflow
 /// (a simple workaround is limit length of
 /// generated query when `QUERY_MODE=local`.
-#[allow(dead_code)]
 pub fn session_sql_gen<R: Rng>(rng: &mut R) -> String {
     [
         "SET RW_ENABLE_TWO_PHASE_AGG TO TRUE",

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -245,7 +245,6 @@ async fn set_variable(client: &tokio_postgres::Client, variable: &str, value: &s
     s
 }
 
-#[allow(dead_code)]
 async fn test_session_variable<R: Rng>(client: &tokio_postgres::Client, rng: &mut R) {
     let session_sql = session_sql_gen(rng);
     tracing::info!("[EXECUTING TEST SESSION_VAR]: {}", session_sql);
@@ -286,8 +285,7 @@ async fn test_batch_queries<R: Rng>(
 ) -> f64 {
     let mut skipped = 0;
     for _ in 0..sample_size {
-        // ENABLE: https://github.com/risingwavelabs/risingwave/issues/7928
-        // test_session_variable(client, rng).await;
+        test_session_variable(client, rng).await;
         let sql = sql_gen(rng, tables.clone());
         tracing::info!("[EXECUTING TEST_BATCH]: {}", sql);
         let response = client.simple_query(sql.as_str()).await;
@@ -306,8 +304,7 @@ async fn test_stream_queries<R: Rng>(
 ) -> f64 {
     let mut skipped = 0;
     for _ in 0..sample_size {
-        // ENABLE: https://github.com/risingwavelabs/risingwave/issues/7928
-        // test_session_variable(client, rng).await;
+        test_session_variable(client, rng).await;
         let (sql, table) = mview_sql_gen(rng, tables.clone(), "stream_query");
         tracing::info!("[EXECUTING TEST_STREAM]: {}", sql);
         let response = client.simple_query(&sql).await;

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -83,12 +83,11 @@ pub async fn generate(client: &tokio_postgres::Client, testdata: &str, count: us
     let mut queries = String::with_capacity(10000);
     let mut generated_queries = 0;
     for _ in 0..count {
-        // ENABLE: https://github.com/risingwavelabs/risingwave/issues/7928
-        // test_session_variable(client, rng).await;
+        let session_sql = test_session_variable(client, &mut rng).await;
         let sql = sql_gen(&mut rng, tables.clone());
         tracing::info!("Executing: {}", sql);
         let response = client.query(sql.as_str(), &[]).await;
-        let skipped = validate_response(&setup_sql, &format!("{};", sql), response);
+        let skipped = validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
         if skipped == 0 {
             generated_queries += 1;
             queries.push_str(&format!("{};\n", &sql));
@@ -98,12 +97,11 @@ pub async fn generate(client: &tokio_postgres::Client, testdata: &str, count: us
 
     let mut generated_queries = 0;
     for _ in 0..count {
-        // ENABLE: https://github.com/risingwavelabs/risingwave/issues/7928
-        // test_session_variable(client, rng).await;
+        let session_sql = test_session_variable(client, &mut rng).await;
         let (sql, table) = mview_sql_gen(&mut rng, tables.clone(), "stream_query");
         tracing::info!("Executing: {}", sql);
         let response = client.query(&sql, &[]).await;
-        let skipped = validate_response(&setup_sql, &format!("{};", sql), response);
+        let skipped = validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
         drop_mview_table(&table, client).await;
         if skipped == 0 {
             generated_queries += 1;
@@ -245,10 +243,11 @@ async fn set_variable(client: &tokio_postgres::Client, variable: &str, value: &s
     s
 }
 
-async fn test_session_variable<R: Rng>(client: &tokio_postgres::Client, rng: &mut R) {
+async fn test_session_variable<R: Rng>(client: &tokio_postgres::Client, rng: &mut R) -> String {
     let session_sql = session_sql_gen(rng);
     tracing::info!("[EXECUTING TEST SESSION_VAR]: {}", session_sql);
     client.simple_query(session_sql.as_str()).await.unwrap();
+    session_sql
 }
 
 /// Expects at least 50% of inserted rows included.
@@ -285,11 +284,11 @@ async fn test_batch_queries<R: Rng>(
 ) -> f64 {
     let mut skipped = 0;
     for _ in 0..sample_size {
-        test_session_variable(client, rng).await;
+        let session_sql = test_session_variable(client, rng).await;
         let sql = sql_gen(rng, tables.clone());
         tracing::info!("[EXECUTING TEST_BATCH]: {}", sql);
         let response = client.simple_query(sql.as_str()).await;
-        skipped += validate_response(setup_sql, &format!("{};", sql), response);
+        skipped += validate_response(setup_sql, &format!("{};\n{};", session_sql, sql), response);
     }
     skipped as f64 / sample_size as f64
 }
@@ -304,11 +303,11 @@ async fn test_stream_queries<R: Rng>(
 ) -> f64 {
     let mut skipped = 0;
     for _ in 0..sample_size {
-        test_session_variable(client, rng).await;
+        let session_sql = test_session_variable(client, rng).await;
         let (sql, table) = mview_sql_gen(rng, tables.clone(), "stream_query");
         tracing::info!("[EXECUTING TEST_STREAM]: {}", sql);
         let response = client.simple_query(&sql).await;
-        skipped += validate_response(setup_sql, &format!("{};", sql), response);
+        skipped += validate_response(setup_sql, &format!("{};\n{};", session_sql, sql), response);
         drop_mview_table(&table, client).await;
     }
     skipped as f64 / sample_size as f64

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -87,7 +87,8 @@ pub async fn generate(client: &tokio_postgres::Client, testdata: &str, count: us
         let sql = sql_gen(&mut rng, tables.clone());
         tracing::info!("Executing: {}", sql);
         let response = client.query(sql.as_str(), &[]).await;
-        let skipped = validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
+        let skipped =
+            validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
         if skipped == 0 {
             generated_queries += 1;
             queries.push_str(&format!("{};\n", &sql));
@@ -101,7 +102,8 @@ pub async fn generate(client: &tokio_postgres::Client, testdata: &str, count: us
         let (sql, table) = mview_sql_gen(&mut rng, tables.clone(), "stream_query");
         tracing::info!("Executing: {}", sql);
         let response = client.query(&sql, &[]).await;
-        let skipped = validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
+        let skipped =
+            validate_response(&setup_sql, &format!("{};\n{};", session_sql, sql), response);
         drop_mview_table(&table, client).await;
         if skipped == 0 {
             generated_queries += 1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Fixes #7928 
- Use the right group key.
- Do proper checks on distribution to see if 2 phase agg is needed.
- Clean up `gen_dist_stream_agg_plan` logic.
- Re-enable fuzzing for 2 phase agg.

## Checklist

- [x] Fix review comments.
- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
