### PR TITLE
fix(test): fix occasional timeout of recovery test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3497,9 +3497,9 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff08a176759ae5e6cf2c5153028d258cdbb318cfee2e89f986cbd33dc40e1671"
+checksum = "7e3c98b41d46214f4ae435a95e246710ad7fb1100754f809dd7c18606a7607c4"
 dependencies = [
  "ahash 0.7.6",
  "async-channel",
@@ -3525,9 +3525,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-aws-sdk-s3"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0798f5f47c2c9265e22bb0b9b16c73c8eabbceb79b7fec0610569fdcd293be"
+checksum = "4eeb7fb1e7d0d15c979ee36d9c44074298ff5662b317a1e122807e350d9b92b6"
 dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",
@@ -3542,9 +3542,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-etcd-client"
-version = "0.2.15"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b25dd57e0c5b84c838451374177f34be28df7b7885d950f736d46937afc42e96"
+checksum = "bb918383c4f5966f29760ec48820e1c2846739e4ae411c2a8aaa4466ce1421b7"
 dependencies = [
  "etcd-client",
  "futures-util",

--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -116,7 +116,7 @@ impl S3StreamingUploader {
                 .key(&self.key)
                 .send()
                 .await?;
-            self.upload_id = Some(resp.upload_id().unwrap().into());
+            self.upload_id = Some(resp.upload_id.unwrap());
         }
 
         // Get the data to upload for the next part.
@@ -187,7 +187,7 @@ impl S3StreamingUploader {
                 .iter()
                 .map(|(part_id, output)| {
                     CompletedPart::builder()
-                        .set_e_tag(output.e_tag().map(|s| s.into()))
+                        .set_e_tag(output.e_tag.clone())
                         .set_part_number(Some(*part_id))
                         .build()
                 })
@@ -389,7 +389,7 @@ impl ObjectStore for S3ObjectStore {
                 .last_modified()
                 .expect("last_modified required")
                 .as_secs_f64(),
-            total_size: resp.content_length() as usize,
+            total_size: resp.content_length as usize,
         })
     }
 
@@ -484,7 +484,7 @@ impl ObjectStore for S3ObjectStore {
                 request = request.continuation_token(continuation_token);
             }
             let result = request.send().await?;
-            let is_truncated = result.is_truncated();
+            let is_truncated = result.is_truncated;
             ret.append(
                 &mut result
                     .contents()
@@ -500,7 +500,7 @@ impl ObjectStore for S3ObjectStore {
                     })
                     .collect_vec(),
             );
-            next_continuation_token = result.next_continuation_token().map(|s| s.to_string());
+            next_continuation_token = result.next_continuation_token;
             if !is_truncated {
                 break;
             }
@@ -731,10 +731,10 @@ impl S3ObjectStore {
                 .is_ok()
             {
                 tracing::info!(
-                        "S3 bucket {:?} is configured to automatically purge abandoned MultipartUploads after {} days",
-                        bucket,
-                        S3_INCOMPLETE_MULTIPART_UPLOAD_RETENTION_DAYS,
-                    );
+                    "S3 bucket {:?} is configured to automatically purge abandoned MultipartUploads after {} days",
+                    bucket,
+                    S3_INCOMPLETE_MULTIPART_UPLOAD_RETENTION_DAYS,
+                );
             } else {
                 tracing::warn!("Failed to configure life cycle rule for S3 bucket: {:?}. It is recommended to configure it manually to avoid unnecessary storage cost.", bucket);
             }

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -13,14 +13,14 @@ normal = ["serde"]
 [dependencies]
 anyhow = "1.0"
 async-trait = "0.1"
-aws-sdk-s3 = { version = "0.2.16", package = "madsim-aws-sdk-s3" }
+aws-sdk-s3 = { version = "0.2.17", package = "madsim-aws-sdk-s3" }
 clap = "3"
 console = "0.15"
-etcd-client = { version = "0.2.15", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2.17", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"
-madsim = "0.2.16"
+madsim = "0.2.17"
 paste = "1"
 rand = "0.8"
 rdkafka = { package = "madsim-rdkafka", version = "=0.2.14-alpha", features = ["cmake-build"] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR tries to fix the occasional timeout of recovery test. fix #7979.

The timeout was caused by a deadlock in the cascade drop when killing a node. It is a bug in madsim.
I have fixed it in https://github.com/madsim-rs/madsim/pull/125 so this PR is simply a version bump.

This PR also contains an improvement to the etcd simulator inspired by today's PoC meeting.
It will raise an `etcdserver: request is too large` error when the request is larger than 1.5MB. https://github.com/madsim-rs/madsim/pull/124


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
