### PR TITLE
ci: print time summary for cargo make

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -37,3 +37,4 @@ RUN cargo install cargo-llvm-cov cargo-nextest cargo-udeps cargo-hakari cargo-so
 ENV RUSTC_WRAPPER=sccache
 ENV SCCACHE_BUCKET=ci-sccache-bucket
 ENV CARGO_INCREMENTAL=0
+ENV CARGO_MAKE_PRINT_TIME_SUMMARY=true


### PR DESCRIPTION
also bumps cargo make to 0.36.5 to make cmd in log less verbose

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
