### PR TITLE
chore(ci): add log for flaky meta backup test

### DIFF
--- a/src/meta/src/backup_restore/restore.rs
+++ b/src/meta/src/backup_restore/restore.rs
@@ -198,8 +198,8 @@ async fn restore_impl(
         tracing::info!(
             "snapshot {} after rewrite by snapshot {}:\n{}",
             target_id,
+            newest_id,
             target_snapshot,
-            newest_id
         );
     }
     if opts.dry_run {

--- a/src/storage/backup/integration_tests/run_all.sh
+++ b/src/storage/backup/integration_tests/run_all.sh
@@ -11,3 +11,5 @@ for t in "${tests[@]}"
 do
   bash "${DIR}/${t}"
 done
+
+echo "all tests succeeded"

--- a/src/storage/backup/integration_tests/test_query_backup.sh
+++ b/src/storage/backup/integration_tests/test_query_backup.sh
@@ -69,48 +69,35 @@ done
 echo "safe epoch after compaction: ${safe_epoch}"
 
 echo "QUERY_EPOCH=safe_epoch. It should fail because it's not covered by any backup"
-result=$(
-execute_sql "
-SET QUERY_EPOCH TO ${safe_epoch};
-select * from t1;
-" | grep "Read backup error backup include epoch ${safe_epoch} not found"
-)
-[ -n "${result}" ]
+execute_sql_and_expect \
+"SET QUERY_EPOCH TO ${safe_epoch};
+select * from t1;" \
+"Read backup error backup include epoch ${safe_epoch} not found"
 
 echo "QUERY_EPOCH=0 aka disabling query backup"
-result=$(
-execute_sql "
-SET QUERY_EPOCH TO 0;
-select * from t1;
-" | grep "1 row"
-)
-[ -n "${result}" ]
+execute_sql_and_expect \
+"SET QUERY_EPOCH TO 0;
+select * from t1;" \
+"1 row"
 
 echo "QUERY_EPOCH=backup_safe_epoch + 1, it's < safe_epoch but covered by backup"
 [ $((backup_safe_epoch + 1)) -eq 1 ]
-result=$(
-execute_sql "
-SET QUERY_EPOCH TO $((backup_safe_epoch + 1));
-select * from t1;
-" | grep "0 row"
-)
-[ -n "${result}" ]
+execute_sql_and_expect \
+"SET QUERY_EPOCH TO $((backup_safe_epoch + 1));
+select * from t1;" \
+"0 row"
 
 echo "QUERY_EPOCH=backup_mce < safe_epoch, it's < safe_epoch but covered by backup"
-result=$(
-execute_sql "
-SET QUERY_EPOCH TO $((backup_mce));
-select * from t1;
-" | grep "3 row"
-)
-[ -n "${result}" ]
+execute_sql_and_expect \
+"SET QUERY_EPOCH TO ${backup_mce};
+select * from t1;" \
+"3 row"
 
 echo "QUERY_EPOCH=future epoch. It should fail because it's not covered by any backup"
 future_epoch=18446744073709551615
-result=$(
-execute_sql "
-SET QUERY_EPOCH TO ${future_epoch};
-select * from t1;
-" | grep "Read backup error backup include epoch ${future_epoch} not found"
-)
-[ -n "${result}" ]
+execute_sql_and_expect \
+"SET QUERY_EPOCH TO ${future_epoch};
+select * from t1;" \
+"Read backup error backup include epoch ${future_epoch} not found"
+
+echo "test succeeded"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add logs to troubleshoot flaky test in #7850

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
