### PR TITLE
feat: kafka-upsert with json,avro format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5867,6 +5867,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http",
  "aws-types",
+ "bincode",
  "byteorder",
  "bytes",
  "chrono",

--- a/dashboard/proto/gen/catalog.ts
+++ b/dashboard/proto/gen/catalog.ts
@@ -82,6 +82,7 @@ export interface StreamSourceInfo {
   protoMessageName: string;
   csvDelimiter: number;
   csvHasHeader: boolean;
+  upsertAvroPrimaryKey: string;
 }
 
 export interface Source {
@@ -379,6 +380,7 @@ function createBaseStreamSourceInfo(): StreamSourceInfo {
     protoMessageName: "",
     csvDelimiter: 0,
     csvHasHeader: false,
+    upsertAvroPrimaryKey: "",
   };
 }
 
@@ -391,6 +393,7 @@ export const StreamSourceInfo = {
       protoMessageName: isSet(object.protoMessageName) ? String(object.protoMessageName) : "",
       csvDelimiter: isSet(object.csvDelimiter) ? Number(object.csvDelimiter) : 0,
       csvHasHeader: isSet(object.csvHasHeader) ? Boolean(object.csvHasHeader) : false,
+      upsertAvroPrimaryKey: isSet(object.upsertAvroPrimaryKey) ? String(object.upsertAvroPrimaryKey) : "",
     };
   },
 
@@ -402,6 +405,7 @@ export const StreamSourceInfo = {
     message.protoMessageName !== undefined && (obj.protoMessageName = message.protoMessageName);
     message.csvDelimiter !== undefined && (obj.csvDelimiter = Math.round(message.csvDelimiter));
     message.csvHasHeader !== undefined && (obj.csvHasHeader = message.csvHasHeader);
+    message.upsertAvroPrimaryKey !== undefined && (obj.upsertAvroPrimaryKey = message.upsertAvroPrimaryKey);
     return obj;
   },
 
@@ -413,6 +417,7 @@ export const StreamSourceInfo = {
     message.protoMessageName = object.protoMessageName ?? "";
     message.csvDelimiter = object.csvDelimiter ?? 0;
     message.csvHasHeader = object.csvHasHeader ?? false;
+    message.upsertAvroPrimaryKey = object.upsertAvroPrimaryKey ?? "";
     return message;
   },
 };

--- a/dashboard/proto/gen/plan_common.ts
+++ b/dashboard/proto/gen/plan_common.ts
@@ -136,6 +136,8 @@ export const RowFormatType = {
   CSV: "CSV",
   NATIVE: "NATIVE",
   DEBEZIUM_AVRO: "DEBEZIUM_AVRO",
+  UPSERT_JSON: "UPSERT_JSON",
+  UPSERT_AVRO: "UPSERT_AVRO",
   UNRECOGNIZED: "UNRECOGNIZED",
 } as const;
 
@@ -173,6 +175,12 @@ export function rowFormatTypeFromJSON(object: any): RowFormatType {
     case 9:
     case "DEBEZIUM_AVRO":
       return RowFormatType.DEBEZIUM_AVRO;
+    case 10:
+    case "UPSERT_JSON":
+      return RowFormatType.UPSERT_JSON;
+    case 11:
+    case "UPSERT_AVRO":
+      return RowFormatType.UPSERT_AVRO;
     case -1:
     case "UNRECOGNIZED":
     default:
@@ -202,6 +210,10 @@ export function rowFormatTypeToJSON(object: RowFormatType): string {
       return "NATIVE";
     case RowFormatType.DEBEZIUM_AVRO:
       return "DEBEZIUM_AVRO";
+    case RowFormatType.UPSERT_JSON:
+      return "UPSERT_JSON";
+    case RowFormatType.UPSERT_AVRO:
+      return "UPSERT_AVRO";
     case RowFormatType.UNRECOGNIZED:
     default:
       return "UNRECOGNIZED";

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -30,6 +30,7 @@ message StreamSourceInfo {
   string proto_message_name = 4;
   int32 csv_delimiter = 5;
   bool csv_has_header = 6;
+  string upsert_avro_primary_key = 7;
 }
 
 message Source {

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -81,4 +81,6 @@ enum RowFormatType {
   CSV = 7;
   NATIVE = 8;
   DEBEZIUM_AVRO = 9;
+  UPSERT_JSON = 10;
+  UPSERT_AVRO = 11;
 }

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -22,6 +22,7 @@ aws-sdk-kinesis = { workspace = true }
 aws-sdk-s3 = { workspace = true } 
 aws-smithy-http = { workspace = true }
 aws-types = { workspace = true }
+bincode = "1"
 byteorder = "1"
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
@@ -66,7 +67,6 @@ tonic = { version = "0.2", package = "madsim-tonic" }
 tracing = "0.1"
 url = "2"
 urlencoding = "2"
-
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }
 

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
+
 use aws_sdk_kinesis::Client as KinesisClient;
 use http::Uri;
 use rdkafka::ClientConfig;
@@ -198,4 +200,12 @@ impl KinesisCommon {
         }
         Ok(KinesisClient::from_conf(builder.build()))
     }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct UpsertMessage<'a> {
+    #[serde(borrow)]
+    pub primary_key: Cow<'a, [u8]>,
+    #[serde(borrow)]
+    pub record: Cow<'a, [u8]>,
 }

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -26,6 +26,7 @@ use url::Url;
 
 use super::schema_resolver::*;
 use super::util::{extract_inner_field_schema, from_avro_value};
+use crate::common::UpsertMessage;
 use crate::impl_common_parser_logic;
 use crate::parser::avro::util::avro_field_to_column_desc;
 use crate::parser::schema_registry::{extract_schema_id, Client};
@@ -38,15 +39,19 @@ impl_common_parser_logic!(AvroParser);
 #[derive(Debug)]
 pub struct AvroParser {
     schema: Arc<Schema>,
+    key_schema: Option<Arc<Schema>>,
     schema_resolver: Option<Arc<ConfluentSchemaResolver>>,
     rw_columns: Vec<SourceColumnDesc>,
     error_ctx: SourceErrorContext,
+    upsert_primary_key_column_name: Option<String>,
 }
 
 #[derive(Debug, Clone)]
 pub struct AvroParserConfig {
     pub schema: Arc<Schema>,
+    pub key_schema: Option<Arc<Schema>>,
     pub schema_resolver: Option<Arc<ConfluentSchemaResolver>>,
+    pub upsert_primary_key_column_name: Option<String>,
 }
 
 impl AvroParserConfig {
@@ -54,18 +59,39 @@ impl AvroParserConfig {
         props: &HashMap<String, String>,
         schema_location: &str,
         use_schema_registry: bool,
+        enable_upsert: bool,
+        upsert_primary_key_column_name: Option<String>,
     ) -> Result<Self> {
         let url = Url::parse(schema_location).map_err(|e| {
             InternalError(format!("failed to parse url ({}): {}", schema_location, e))
         })?;
-        let (schema, schema_resolver) = if use_schema_registry {
+        if use_schema_registry {
             let kafka_topic = get_kafka_topic(props)?;
             let client = Client::new(url, props)?;
-            let (schema, resolver) =
-                ConfluentSchemaResolver::new(format!("{}-value", kafka_topic).as_str(), client)
-                    .await?;
-            (Arc::new(schema), Some(Arc::new(resolver)))
+            let resolver = ConfluentSchemaResolver::new(client);
+
+            Ok(Self {
+                schema: resolver
+                    .get_by_subject_name(&format!("{}-value", kafka_topic))
+                    .await?,
+                key_schema: if enable_upsert {
+                    Some(
+                        resolver
+                            .get_by_subject_name(&format!("{}-key", kafka_topic))
+                            .await?,
+                    )
+                } else {
+                    None
+                },
+                schema_resolver: Some(Arc::new(resolver)),
+                upsert_primary_key_column_name,
+            })
         } else {
+            if enable_upsert {
+                return Err(RwError::from(InternalError(
+                    "avro upsert without schema registry is not supported".to_string(),
+                )));
+            }
             let schema_content = match url.scheme() {
                 "file" => read_schema_from_local(url.path()),
                 "s3" => read_schema_from_s3(&url, props).await,
@@ -78,12 +104,28 @@ impl AvroParserConfig {
             let schema = Schema::parse_str(&schema_content).map_err(|e| {
                 RwError::from(InternalError(format!("Avro schema parse error {}", e)))
             })?;
-            (Arc::new(schema), None)
-        };
-        Ok(Self {
-            schema,
-            schema_resolver,
-        })
+            Ok(Self {
+                schema: Arc::new(schema),
+                key_schema: None,
+                schema_resolver: None,
+                upsert_primary_key_column_name: None,
+            })
+        }
+    }
+
+    pub fn extract_pks(&self) -> Result<Vec<ColumnDesc>> {
+        if let Some(Schema::Record { fields, .. }) = self.key_schema.as_deref() {
+            let mut index = 0;
+            let fields = fields
+                .iter()
+                .map(|field| avro_field_to_column_desc(&field.name, &field.schema, &mut index))
+                .collect::<Result<Vec<_>>>()?;
+            Ok(fields)
+        } else {
+            Err(RwError::from(InternalError(
+                "schema invalid, record required".into(),
+            )))
+        }
     }
 
     pub fn map_to_columns(&self) -> Result<Vec<ColumnDesc>> {
@@ -112,14 +154,23 @@ impl AvroParser {
     ) -> Result<Self> {
         let AvroParserConfig {
             schema,
+            key_schema,
             schema_resolver,
+            upsert_primary_key_column_name,
         } = config;
         Ok(Self {
             schema,
+            key_schema,
             schema_resolver,
             rw_columns,
             error_ctx,
+            upsert_primary_key_column_name,
         })
+    }
+
+    /// The presence of a `key_schema` implies that upsert is enabled.
+    fn is_enable_upsert(&self) -> bool {
+        self.key_schema.is_some()
     }
 
     pub(crate) async fn parse_inner(
@@ -127,15 +178,37 @@ impl AvroParser {
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
+        enum Op {
+            Insert,
+            Delete,
+        }
+
+        let (_payload, op) = if self.is_enable_upsert() {
+            let msg: UpsertMessage<'_> = bincode::deserialize(payload)
+                .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
+            if !msg.record.is_empty() {
+                (msg.record, Op::Insert)
+            } else {
+                (msg.primary_key, Op::Delete)
+            }
+        } else {
+            (payload.into(), Op::Insert)
+        };
+
         // parse payload to avro value
         // if use confluent schema, get writer schema from confluent schema registry
         let avro_value = if let Some(resolver) = &self.schema_resolver {
-            let (schema_id, mut raw_payload) = extract_schema_id(payload)?;
+            let (schema_id, mut raw_payload) = extract_schema_id(&_payload)?;
             let writer_schema = resolver.get(schema_id).await?;
-            from_avro_datum(writer_schema.as_ref(), &mut raw_payload, Some(&self.schema))
+            let reader_schema = if matches!(op, Op::Delete) {
+                self.key_schema.as_deref()
+            } else {
+                Some(&*self.schema)
+            };
+            from_avro_datum(writer_schema.as_ref(), &mut raw_payload, reader_schema)
                 .map_err(|e| RwError::from(ProtocolError(e.to_string())))?
         } else {
-            let mut reader = Reader::with_schema(&self.schema, payload)
+            let mut reader = Reader::with_schema(&self.schema, payload as &[u8])
                 .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
             match reader.next() {
                 Some(Ok(v)) => v,
@@ -150,7 +223,7 @@ impl AvroParser {
 
         // parse the value to rw value
         if let Value::Record(fields) = avro_value {
-            writer.insert(|column| {
+            let fill = |column: &SourceColumnDesc| {
                 let tuple = fields
                     .iter()
                     .find(|val| column.name.eq(&val.0))
@@ -169,6 +242,41 @@ impl AvroParser {
                     );
                     e
                 })
+            };
+            match op {
+                Op::Insert => writer.insert(fill),
+                Op::Delete => writer.delete(fill),
+            }
+        } else if self.upsert_primary_key_column_name.is_some()
+            && matches!(op, Op::Delete)
+            && matches!(
+                avro_value,
+                Value::Boolean(_)
+                    | Value::String(_)
+                    | Value::Int(_)
+                    | Value::Long(_)
+                    | Value::Float(_)
+                    | Value::Decimal(_)
+                    | Value::Date(_)
+                    | Value::TimestampMillis(_)
+                    | Value::TimestampMicros(_)
+                    | Value::Duration(_)
+            )
+        {
+            writer.delete(|desc| {
+                if &desc.name != self.upsert_primary_key_column_name.as_ref().unwrap() {
+                    Ok(None)
+                } else {
+                    from_avro_value(avro_value.clone(), self.key_schema.as_deref().unwrap())
+                        .map_err(|e| {
+                            tracing::error!(
+                                "failed to process value ({}): {}",
+                                String::from_utf8_lossy(payload),
+                                e
+                            );
+                            e
+                        })
+                }
             })
         } else {
             Err(RwError::from(ProtocolError(
@@ -255,7 +363,7 @@ mod test {
 
     async fn new_avro_conf_from_local(file_name: &str) -> error::Result<AvroParserConfig> {
         let schema_path = "file://".to_owned() + &test_data_path(file_name);
-        AvroParserConfig::new(&HashMap::new(), schema_path.as_str(), false).await
+        AvroParserConfig::new(&HashMap::new(), schema_path.as_str(), false, false, None).await
     }
 
     async fn new_avro_parser_from_local(file_name: &str) -> error::Result<AvroParser> {

--- a/src/connector/src/parser/avro/schema_resolver.rs
+++ b/src/connector/src/parser/avro/schema_resolver.rs
@@ -23,7 +23,7 @@ use risingwave_common::error::{Result, RwError};
 use url::Url;
 
 use crate::aws_utils::{default_conn_config, s3_client, AwsConfigV2};
-use crate::parser::schema_registry::Client;
+use crate::parser::schema_registry::{Client, ConfluentSchema};
 use crate::parser::util::download_from_http;
 
 const AVRO_SCHEMA_LOCATION_S3_REGION: &str = "region";
@@ -89,20 +89,30 @@ pub struct ConfluentSchemaResolver {
 }
 
 impl ConfluentSchemaResolver {
-    // return the reader schema and a new `SchemaResolver`
-    pub async fn new(subject_name: &str, client: Client) -> Result<(Schema, Self)> {
-        let raw_schema = client.get_schema_by_subject(subject_name).await?;
+    async fn parse_and_cache_schema(&self, raw_schema: ConfluentSchema) -> Result<Arc<Schema>> {
         let schema = Schema::parse_str(&raw_schema.content)
             .map_err(|e| RwError::from(ProtocolError(format!("Avro schema parse error {}", e))))?;
-        let resolver = ConfluentSchemaResolver {
+        let schema = Arc::new(schema);
+        self.writer_schemas
+            .insert(raw_schema.id, Arc::clone(&schema))
+            .await;
+        Ok(schema)
+    }
+
+    /// Create a new `ConfluentSchemaResolver`
+    pub fn new(client: Client) -> Self {
+        ConfluentSchemaResolver {
             writer_schemas: Cache::new(u64::MAX),
             confluent_client: client,
-        };
-        resolver
-            .writer_schemas
-            .insert(raw_schema.id, Arc::new(schema.clone()))
-            .await;
-        Ok((schema, resolver))
+        }
+    }
+
+    pub async fn get_by_subject_name(&self, subject_name: &str) -> Result<Arc<Schema>> {
+        let raw_schema = self
+            .confluent_client
+            .get_schema_by_subject(subject_name)
+            .await?;
+        self.parse_and_cache_schema(raw_schema).await
     }
 
     // get the writer schema by id
@@ -111,15 +121,7 @@ impl ConfluentSchemaResolver {
             Ok(schema)
         } else {
             let raw_schema = self.confluent_client.get_schema_by_id(schema_id).await?;
-
-            let schema = Schema::parse_str(&raw_schema.content).map_err(|e| {
-                RwError::from(ProtocolError(format!("Avro schema parse error {}", e)))
-            })?;
-            let schema = Arc::new(schema);
-            self.writer_schemas
-                .insert(schema_id, Arc::clone(&schema))
-                .await;
-            Ok(schema)
+            self.parse_and_cache_schema(raw_schema).await
         }
     }
 }

--- a/src/connector/src/parser/json_parser.rs
+++ b/src/connector/src/parser/json_parser.rs
@@ -18,6 +18,7 @@ use risingwave_common::error::ErrorCode::ProtocolError;
 use risingwave_common::error::{Result, RwError};
 use simd_json::{BorrowedValue, ValueAccess};
 
+use crate::common::UpsertMessage;
 use crate::impl_common_parser_logic;
 use crate::parser::common::simd_json_parse_value;
 use crate::parser::util::at_least_one_ok;
@@ -31,6 +32,7 @@ impl_common_parser_logic!(JsonParser);
 pub struct JsonParser {
     rw_columns: Vec<SourceColumnDesc>,
     error_ctx: SourceErrorContext,
+    enable_upsert: bool,
 }
 
 impl JsonParser {
@@ -38,6 +40,7 @@ impl JsonParser {
         Ok(Self {
             rw_columns,
             error_ctx,
+            enable_upsert: false,
         })
     }
 
@@ -45,12 +48,24 @@ impl JsonParser {
         Ok(Self {
             rw_columns,
             error_ctx: SourceErrorContext::for_test(),
+            enable_upsert: false,
+        })
+    }
+
+    pub fn new_with_upsert(
+        rw_columns: Vec<SourceColumnDesc>,
+        error_ctx: SourceErrorContext,
+    ) -> Result<Self> {
+        Ok(Self {
+            rw_columns,
+            error_ctx,
+            enable_upsert: true,
         })
     }
 
     #[inline(always)]
     fn parse_single_value(
-        value: BorrowedValue<'_>,
+        value: &BorrowedValue<'_>,
         writer: &mut SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
         writer.insert(|desc| {
@@ -71,27 +86,62 @@ impl JsonParser {
         payload: &[u8],
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let mut payload_mut = payload.to_vec();
+        enum Op {
+            Insert,
+            Delete,
+        }
+
+        let (_payload, op) = if self.enable_upsert {
+            let msg: UpsertMessage<'_> = bincode::deserialize(payload)
+                .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
+            if !msg.record.is_empty() {
+                (msg.record, Op::Insert)
+            } else {
+                (msg.primary_key, Op::Delete)
+            }
+        } else {
+            (payload.into(), Op::Insert)
+        };
+
+        let mut payload_mut = _payload.to_vec();
 
         let value: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
-        let results = match value {
-            BorrowedValue::Array(objects) => objects
-                .into_iter()
-                .map(|obj| Self::parse_single_value(obj, &mut writer))
-                .collect_vec(),
-            _ => {
-                return Self::parse_single_value(value, &mut writer);
+        if let BorrowedValue::Array(ref objects) = value  && matches!(op, Op::Insert) {
+             at_least_one_ok(
+                objects
+                    .iter()
+                    .map(|obj| Self::parse_single_value(obj, &mut writer))
+                    .collect_vec(),
+            )
+        } else {
+            let fill_fn = |desc: &SourceColumnDesc| {
+                simd_json_parse_value(
+                    &desc.data_type,
+                    value.get(desc.name.to_ascii_lowercase().as_str()),
+                )
+                .map_err(|e| {
+                    tracing::error!(
+                        "failed to process value ({}): {}",
+                        String::from_utf8_lossy(payload),
+                        e
+                    );
+                    e.into()
+                })
+            };
+            match op {
+                Op::Insert => writer.insert(fill_fn),
+                Op::Delete => writer.delete(fill_fn),
             }
-        };
-        at_least_one_ok(results)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
+    use std::vec;
 
     use itertools::Itertools;
     use risingwave_common::array::{Op, StructValue};
@@ -101,6 +151,7 @@ mod tests {
     use risingwave_common::types::{DataType, Decimal, ScalarImpl, ToOwnedDatum};
     use risingwave_expr::vector_op::cast::{str_to_date, str_to_timestamp};
 
+    use crate::common::UpsertMessage;
     use crate::parser::{JsonParser, SourceColumnDesc, SourceStreamChunkBuilder};
     use crate::source::SourceErrorContext;
 
@@ -337,5 +388,70 @@ mod tests {
             ]) ))
         ];
         assert_eq!(row, expected);
+    }
+    #[tokio::test]
+    async fn test_json_upsert_parser() {
+        let items = &[
+            (r#"{"a":1}"#, r#"{"a":1,"b":2}"#),
+            (r#"{"a":1}"#, r#"{"a":1,"b":3}"#),
+            (r#"{"a":2}"#, r#"{"a":2,"b":2}"#),
+            (r#"{"a":2}"#, r#""#),
+        ]
+        .map(|(k, v)| {
+            bincode::serialize(&UpsertMessage {
+                primary_key: k.as_bytes().into(),
+                record: v.as_bytes().into(),
+            })
+            .unwrap()
+        });
+        let descs = vec![
+            SourceColumnDesc::simple("a", DataType::Int32, 0.into()),
+            SourceColumnDesc::simple("b", DataType::Int32, 1.into()),
+        ];
+        let parser =
+            JsonParser::new_with_upsert(descs.clone(), SourceErrorContext::for_test()).unwrap();
+        let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 4);
+        for item in items {
+            parser
+                .parse_inner(item, builder.row_writer())
+                .await
+                .unwrap();
+        }
+        let chunk = builder.finish();
+        let mut rows = chunk.rows();
+
+        {
+            let (op, row) = rows.next().unwrap();
+            assert_eq!(op, Op::Insert);
+            assert_eq!(
+                row.datum_at(0).to_owned_datum(),
+                (Some(ScalarImpl::Int32(1)))
+            );
+        }
+
+        {
+            let (op, row) = rows.next().unwrap();
+            assert_eq!(op, Op::Insert);
+            assert_eq!(
+                row.datum_at(0).to_owned_datum(),
+                (Some(ScalarImpl::Int32(1)))
+            );
+        }
+        {
+            let (op, row) = rows.next().unwrap();
+            assert_eq!(op, Op::Insert);
+            assert_eq!(
+                row.datum_at(0).to_owned_datum(),
+                (Some(ScalarImpl::Int32(2)))
+            );
+        }
+        {
+            let (op, row) = rows.next().unwrap();
+            assert_eq!(op, Op::Delete);
+            assert_eq!(
+                row.datum_at(0).to_owned_datum(),
+                (Some(ScalarImpl::Int32(2)))
+            );
+        }
     }
 }

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -142,9 +142,11 @@ impl SourceErrorContext {
 pub enum SourceFormat {
     Invalid,
     Json,
+    UpsertJson,
     Protobuf,
     DebeziumJson,
     Avro,
+    UpsertAvro,
     Maxwell,
     CanalJson,
     Csv,

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -53,6 +53,12 @@ pub struct KafkaProperties {
     #[serde(rename = "properties.group.id", alias = "kafka.consumer.group")]
     pub consumer_group: Option<String>,
 
+    /// This parameter is used to tell KafkaSplitReader to produce `UpsertMessage`s, which
+    /// combine both key and value fields of the Kafka message.
+    /// TODO: Currently, `Option<bool>` can not be parsed here.
+    #[serde(rename = "upsert")]
+    pub upsert: Option<String>,
+
     #[serde(flatten)]
     pub common: KafkaCommon,
 }

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -56,6 +56,8 @@ async fn extract_avro_table_schema(
         with_properties,
         schema.row_schema_location.0.as_str(),
         schema.use_schema_registry,
+        false,
+        None,
     )
     .await?;
     let vec_column_desc = conf.map_to_columns()?;
@@ -68,6 +70,47 @@ async fn extract_avro_table_schema(
         .collect_vec())
 }
 
+/// Map an Avro schema to a relational schema. And extract primary key columns.
+async fn extract_upsert_avro_table_schema(
+    schema: &AvroSchema,
+    with_properties: &HashMap<String, String>,
+) -> Result<(Vec<ColumnCatalog>, Vec<ColumnId>)> {
+    let conf = AvroParserConfig::new(
+        with_properties,
+        schema.row_schema_location.0.as_str(),
+        schema.use_schema_registry,
+        true,
+        None,
+    )
+    .await?;
+    let vec_column_desc = conf.map_to_columns()?;
+    let vec_pk_desc = conf.extract_pks()?;
+    let pks = vec_pk_desc
+        .into_iter()
+        .map(|desc| {
+            vec_column_desc
+                .iter()
+                .find(|x| x.name == desc.name)
+                .ok_or_else(|| {
+                    RwError::from(ErrorCode::InternalError(format!(
+                        "Can not found primary key column {} in value schema",
+                        desc.name
+                    )))
+                })
+        })
+        .map_ok(|desc| ColumnId::new(desc.column_id))
+        .collect::<Result<Vec<_>>>()?;
+    Ok((
+        vec_column_desc
+            .into_iter()
+            .map(|col| ColumnCatalog {
+                column_desc: col.into(),
+                is_hidden: false,
+            })
+            .collect_vec(),
+        pks,
+    ))
+}
 async fn extract_debezium_avro_table_pk_columns(
     schema: &DebeziumAvroSchema,
     with_properties: &HashMap<String, String>,
@@ -209,6 +252,7 @@ pub(crate) async fn resolve_source_schema(
             );
             StreamSourceInfo {
                 row_format: RowFormatType::Avro as i32,
+
                 row_schema_location: avro_schema.row_schema_location.0.clone(),
                 use_schema_registry: avro_schema.use_schema_registry,
                 proto_message_name: "".to_owned(),
@@ -216,8 +260,58 @@ pub(crate) async fn resolve_source_schema(
             }
         }
 
+        SourceSchema::UpsertAvro(avro_schema) => {
+            let mut upsert_avro_primary_key = Default::default();
+            if row_id_index.is_none() {
+                // user specify pk(s)
+                if columns.len() != pk_column_ids.len() || pk_column_ids.len() != 1 {
+                    return Err(RwError::from(ProtocolError(
+                        "You can specify single primary key column or leave the columns and primary key fields empty.".to_string(),
+                    )));
+                }
+                let pk_name = columns[0].column_desc.name.clone();
+
+                *columns = extract_avro_table_schema(avro_schema, with_properties).await?;
+                let pk_col = columns
+                    .iter()
+                    .find(|col| col.column_desc.name == pk_name)
+                    .ok_or_else(|| {
+                        RwError::from(ProtocolError(format!(
+                            "Primary key {pk_name} is not found."
+                        )))
+                    })?;
+
+                *pk_column_ids = vec![pk_col.column_id()];
+                upsert_avro_primary_key = pk_name;
+            } else {
+                // contains row_id, user specify some columns without pk
+                if !(*pk_column_ids == vec![ROW_ID_COLUMN_ID] && columns.len() == 1) {
+                    return Err(RwError::from(ProtocolError(
+                        "UPSERT AVRO will automatically extract the schema from the Avro schema. You can specify single primary key column or leave the columns and primary key fields empty.".to_string(),
+                )));
+                }
+                let (columns_extracted, pks_extracted) =
+                    extract_upsert_avro_table_schema(avro_schema, with_properties).await?;
+
+                *columns = columns_extracted;
+                *pk_column_ids = pks_extracted;
+            }
+
+            StreamSourceInfo {
+                row_format: RowFormatType::UpsertAvro as i32,
+                row_schema_location: avro_schema.row_schema_location.0.clone(),
+                use_schema_registry: avro_schema.use_schema_registry,
+                upsert_avro_primary_key,
+                ..Default::default()
+            }
+        }
+
         SourceSchema::Json => StreamSourceInfo {
             row_format: RowFormatType::Json as i32,
+            ..Default::default()
+        },
+        SourceSchema::UpsertJson => StreamSourceInfo {
+            row_format: RowFormatType::UpsertJson as i32,
             ..Default::default()
         },
 

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -100,6 +100,8 @@ impl SourceDescBuilder {
             ProstRowFormatType::CanalJson => SourceFormat::CanalJson,
             ProstRowFormatType::Native => SourceFormat::Native,
             ProstRowFormatType::DebeziumAvro => SourceFormat::DebeziumAvro,
+            ProstRowFormatType::UpsertJson => SourceFormat::UpsertJson,
+            ProstRowFormatType::UpsertAvro => SourceFormat::UpsertAvro,
             _ => unreachable!(),
         };
 

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -511,6 +511,8 @@ define_keywords!(
     UNNEST,
     UPDATE,
     UPPER,
+    UPSERT_AVRO,
+    UPSERT_JSON,
     USAGE,
     USER,
     USING,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

To support `upsert-kafka` in a manner similar to [how Flink does](https://nightlies.apache.org/flink/flink-docs-release-1.16/docs/connectors/table/upsert-kafka/), the key field of a Kafka message is used to indicate the values of the primary key column. If the value field of the message is not empty, the row will be inserted or updated. If the value field is empty, the row will be deleted. This behavior is not tied to any specific row format.

A Kafka connector with the `upsert` property enabled will produce `UpsertMessage`s encoded in bytes, instead of raw Kafka message values, as `SourceMessage`s.

The row formats prefixed with `UPSERT_` are aware that `SourceMessage`s contain not only the Kafka message value field but also the key field as primary columns, and will behave as expected.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- `UPSERT_JSON` & `UPSERT_AVRO` row formats were added.
- Add the 'upsert' property with kafka connector.


<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

- Connector (sources & sinks)

The 'upsert' property was added to kafka connector. Here's an example with `UPSERT_JSON` row format.

```sql
CREATE TABLE t1
(
    k1 Text,
    k2 Text,
    v1 Text,
    v2 Text,
    PRIMARY KEY(k1,k2)
    )
WITH (
   connector='kafka',
   upsert='true',
   properties.bootstrap.server='localhost:9092',
   topic='t1'
) ROW FORMAT UPSERT_JSON;
```

If the kafka message key is a single value (not a kv pair with column name), you can specify primary key when creating table. ( Please note that only single primary key column is supported in this case).

```sql
CREATE TABLE tt
(
    name Text,
    PRIMARY KEY(name)
    )
WITH (
   connector='kafka',
   upsert='true',
   properties.bootstrap.server='localhost:9092',
   topic='test_topic'
) ROW FORMAT UPSERT_AVRO
row schema location confluent schema registry 'http://127.0.0.1:8081';
```



Close #8055.
