### PR TITLE
chore(streaming): rewrite nexmark q5 to benefit from common sub-plan sharing

### DIFF
--- a/e2e_test/streaming/nexmark/views/q5.slt.part
+++ b/e2e_test/streaming/nexmark/views/q5.slt.part
@@ -11,8 +11,8 @@ FROM (
     FROM 
         HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
     GROUP BY
-    	window_start, 
-		bid.auction
+        bid.auction,
+    	window_start
 ) AS AuctionBids
 JOIN (
 	SELECT

--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -249,8 +249,8 @@
       FROM
         HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
       GROUP BY
-        window_start,
-        bid.auction
+        bid.auction,
+        window_start
     ) AS AuctionBids
     JOIN (
       SELECT
@@ -276,7 +276,7 @@
         └─BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─BatchExchange { order: [], dist: HashShard(window_start) }
           | └─BatchProject { exprs: [bid.auction, count, window_start] }
-          |   └─BatchHashAgg { group_key: [window_start, bid.auction], aggs: [count] }
+          |   └─BatchHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
           |     └─BatchHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start] }
           |       └─BatchExchange { order: [], dist: HashShard(bid.auction) }
           |         └─BatchFilter { predicate: IsNotNull(bid.date_time) }
@@ -290,16 +290,16 @@
                       └─BatchFilter { predicate: IsNotNull(bid.date_time) }
                         └─BatchScan { table: bid, columns: [bid.auction, bid.date_time], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1], pk_conflict: "no check" }
+    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
     └─StreamProject { exprs: [bid.auction, count, window_start, window_start] }
       └─StreamFilter { predicate: (count >= max(count)) }
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [bid.auction, count, window_start] }
-          |   └─StreamAppendOnlyHashAgg { group_key: [window_start, bid.auction], aggs: [count, count] }
-          |     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
-          |       └─StreamProject { exprs: [bid.auction, window_start, bid._row_id] }
-          |         └─StreamShare { id = 1043 }
+          |   └─StreamShare { id = 1009 }
+          |     └─StreamProject { exprs: [bid.auction, window_start, count] }
+          |       └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
+          |         └─StreamExchange { dist: HashShard(bid.auction, window_start) }
           |           └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
           |             └─StreamFilter { predicate: IsNotNull(bid.date_time) }
           |               └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -307,16 +307,16 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [bid.auction, window_start, count] }
-                  └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-                    └─StreamExchange { dist: HashShard(bid.auction, window_start) }
-                      └─StreamProject { exprs: [bid.auction, window_start, bid._row_id] }
-                        └─StreamShare { id = 1043 }
+                  └─StreamShare { id = 1009 }
+                    └─StreamProject { exprs: [bid.auction, window_start, count] }
+                      └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
+                        └─StreamExchange { dist: HashShard(bid.auction, window_start) }
                           └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                             └─StreamFilter { predicate: IsNotNull(bid.date_time) }
                               └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
-      StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1], pk_conflict: "no check" }
+      StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [bid.auction, count, window_start, window_start] }
           StreamFilter { predicate: (count >= max(count)) }
@@ -330,13 +330,13 @@
 
     Fragment 1
       StreamProject { exprs: [bid.auction, count, window_start] }
-        StreamAppendOnlyHashAgg { group_key: [window_start, bid.auction], aggs: [count, count] }
-            result table: 4, state tables: []
-          StreamExchange Hash([0, 1]) from 2
+        StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
-      StreamProject { exprs: [bid.auction, window_start, bid._row_id] }
-        StreamExchange Hash([2]) from 3
+      StreamProject { exprs: [bid.auction, window_start, count] }
+        StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
+            result table: 4, state tables: []
+          StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
       StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
@@ -347,23 +347,16 @@
 
     Fragment 4
       StreamProject { exprs: [bid.auction, window_start, count] }
-        StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-            result table: 7, state tables: []
-          StreamExchange Hash([0, 1]) from 5
-
-    Fragment 5
-      StreamProject { exprs: [bid.auction, window_start, bid._row_id] }
-        StreamExchange Hash([2]) from 3
+        StreamExchange Hash([0, 1]) from 2
 
      Table 0 { columns: [bid_auction, count, window_start], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [2] }
      Table 1 { columns: [window_start, bid_auction, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [window_start, bid_auction, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [1, 0] }
+     Table 4 { columns: [bid_auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
      Table 5 { columns: [window_start, count, bid_auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 6 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 7 { columns: [bid_auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
-     Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$2 ASC, $0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
+     Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
   - create_tables

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -299,8 +299,8 @@
       FROM
         HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
       GROUP BY
-        window_start,
-        bid.auction
+        bid.auction,
+        window_start
     ) AS AuctionBids
     JOIN (
       SELECT
@@ -326,7 +326,7 @@
         └─BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─BatchExchange { order: [], dist: HashShard(window_start) }
           | └─BatchProject { exprs: [auction, count, window_start] }
-          |   └─BatchHashAgg { group_key: [window_start, auction], aggs: [count] }
+          |   └─BatchHashAgg { group_key: [auction, window_start], aggs: [count] }
           |     └─BatchHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start] }
           |       └─BatchExchange { order: [], dist: HashShard(auction) }
           |         └─BatchProject { exprs: [auction, date_time] }
@@ -342,16 +342,16 @@
                         └─BatchFilter { predicate: IsNotNull(date_time) }
                           └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
-    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1], pk_conflict: "no check" }
+    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
     └─StreamProject { exprs: [auction, count, window_start, window_start] }
       └─StreamFilter { predicate: (count >= max(count)) }
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamAppendOnlyHashAgg { group_key: [window_start, auction], aggs: [count, count] }
-          |     └─StreamExchange { dist: HashShard(auction, window_start) }
-          |       └─StreamProject { exprs: [auction, window_start, _row_id] }
-          |         └─StreamShare { id = 1155 }
+          |   └─StreamShare { id = 1121 }
+          |     └─StreamProject { exprs: [auction, window_start, count] }
+          |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
+          |         └─StreamExchange { dist: HashShard(auction, window_start) }
           |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |             └─StreamProject { exprs: [auction, date_time, _row_id] }
           |               └─StreamFilter { predicate: IsNotNull(date_time) }
@@ -361,10 +361,10 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-                    └─StreamExchange { dist: HashShard(auction, window_start) }
-                      └─StreamProject { exprs: [auction, window_start, _row_id] }
-                        └─StreamShare { id = 1155 }
+                  └─StreamShare { id = 1121 }
+                    └─StreamProject { exprs: [auction, window_start, count] }
+                      └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
+                        └─StreamExchange { dist: HashShard(auction, window_start) }
                           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                             └─StreamProject { exprs: [auction, date_time, _row_id] }
                               └─StreamFilter { predicate: IsNotNull(date_time) }
@@ -372,7 +372,7 @@
                                   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
-      StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1], pk_conflict: "no check" }
+      StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [auction, count, window_start, window_start] }
           StreamFilter { predicate: (count >= max(count)) }
@@ -386,13 +386,13 @@
 
     Fragment 1
       StreamProject { exprs: [auction, count, window_start] }
-        StreamAppendOnlyHashAgg { group_key: [window_start, auction], aggs: [count, count] }
-            result table: 4, state tables: []
-          StreamExchange Hash([0, 1]) from 2
+        StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
-      StreamProject { exprs: [auction, window_start, _row_id] }
-        StreamExchange Hash([2, 1]) from 3
+      StreamProject { exprs: [auction, window_start, count] }
+        StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
+            result table: 4, state tables: []
+          StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
       StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
@@ -404,24 +404,17 @@
 
     Fragment 4
       StreamProject { exprs: [auction, window_start, count] }
-        StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-            result table: 8, state tables: []
-          StreamExchange Hash([0, 1]) from 5
-
-    Fragment 5
-      StreamProject { exprs: [auction, window_start, _row_id] }
-        StreamExchange Hash([2, 1]) from 3
+        StreamExchange Hash([0, 1]) from 2
 
      Table 0 { columns: [auction, count, window_start], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [2] }
      Table 1 { columns: [window_start, auction, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [window_start, auction, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [1, 0] }
+     Table 4 { columns: [auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 6 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 7 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 8 { columns: [auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
-     Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$2 ASC, $0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
+     Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
   - create_sources

--- a/src/frontend/planner_test/tests/testdata/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/share.yaml
@@ -70,8 +70,8 @@
       FROM
         HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
       GROUP BY
-        window_start,
-        bid.auction
+        bid.auction,
+        window_start
     ) AS AuctionBids
     JOIN (
       SELECT
@@ -97,7 +97,7 @@
         └─BatchHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─BatchExchange { order: [], dist: HashShard(window_start) }
           | └─BatchProject { exprs: [auction, count, window_start] }
-          |   └─BatchHashAgg { group_key: [window_start, auction], aggs: [count] }
+          |   └─BatchHashAgg { group_key: [auction, window_start], aggs: [count] }
           |     └─BatchHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start] }
           |       └─BatchExchange { order: [], dist: HashShard(auction) }
           |         └─BatchProject { exprs: [auction, date_time] }
@@ -113,16 +113,16 @@
                         └─BatchFilter { predicate: IsNotNull(date_time) }
                           └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
-    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [window_start, auction, window_start#1], pk_conflict: "no check" }
+    StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
     └─StreamProject { exprs: [auction, count, window_start, window_start] }
       └─StreamFilter { predicate: (count >= max(count)) }
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamAppendOnlyHashAgg { group_key: [window_start, auction], aggs: [count, count] }
-          |     └─StreamExchange { dist: HashShard(auction, window_start) }
-          |       └─StreamProject { exprs: [auction, window_start, _row_id] }
-          |         └─StreamShare { id = 1155 }
+          |   └─StreamShare { id = 1121 }
+          |     └─StreamProject { exprs: [auction, window_start, count] }
+          |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
+          |         └─StreamExchange { dist: HashShard(auction, window_start) }
           |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |             └─StreamProject { exprs: [auction, date_time, _row_id] }
           |               └─StreamFilter { predicate: IsNotNull(date_time) }
@@ -132,10 +132,10 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-                    └─StreamExchange { dist: HashShard(auction, window_start) }
-                      └─StreamProject { exprs: [auction, window_start, _row_id] }
-                        └─StreamShare { id = 1155 }
+                  └─StreamShare { id = 1121 }
+                    └─StreamProject { exprs: [auction, window_start, count] }
+                      └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
+                        └─StreamExchange { dist: HashShard(auction, window_start) }
                           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                             └─StreamProject { exprs: [auction, date_time, _row_id] }
                               └─StreamFilter { predicate: IsNotNull(date_time) }

--- a/src/tests/simulation/src/nexmark/q5.sql
+++ b/src/tests/simulation/src/nexmark/q5.sql
@@ -10,8 +10,8 @@ SELECT AuctionBids.auction, AuctionBids.num FROM (
     FROM
         HOP(bid, date_time, INTERVAL '2' SECOND, INTERVAL '10' SECOND)
     GROUP BY
-        window_start,
-        bid.auction
+        bid.auction,
+        window_start
 ) AS AuctionBids
 JOIN (
     SELECT


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Reorder `GROUP BY window_start, bid.auction` into `GROUP BY bid.auction, window_start`, so that we can share a large sub-plan.
- Theoretically, the ordering in group-by clause doesn't matter, however, in our LogicalAgg implementation, we store them in a `vec` so the ordering matter in terms of common sub-plan detection.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

#7343