### PR TITLE
refactor(common): DRY `Scalar::to_scalar_value`

### DIFF
--- a/src/common/src/array/jsonb_array.rs
+++ b/src/common/src/array/jsonb_array.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 
 use super::{Array, ArrayBuilder};
 use crate::buffer::{Bitmap, BitmapBuilder};
-use crate::types::{Scalar, ScalarImpl, ScalarRef};
+use crate::types::{Scalar, ScalarRef};
 use crate::util::iter_util::ZipEqFast;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -31,10 +31,6 @@ impl Scalar for JsonbVal {
 
     fn as_scalar_ref(&self) -> Self::ScalarRefType<'_> {
         JsonbRef(self.0.as_ref())
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Jsonb(self)
     }
 }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -423,7 +423,9 @@ pub trait Scalar:
     /// Get a reference to current scalar.
     fn as_scalar_ref(&self) -> Self::ScalarRefType<'_>;
 
-    fn to_scalar_value(self) -> ScalarImpl;
+    fn to_scalar_value(self) -> ScalarImpl {
+        self.into()
+    }
 }
 
 /// Convert an `Option<Scalar>` to corresponding `Option<ScalarRef>`.

--- a/src/common/src/types/scalar_impl.rs
+++ b/src/common/src/types/scalar_impl.rs
@@ -37,10 +37,6 @@ macro_rules! impl_all_native_scalar {
                 fn as_scalar_ref(&self) -> Self {
                     *self
                 }
-
-                fn to_scalar_value(self) -> ScalarImpl {
-                    ScalarImpl::$variant_name(self)
-                }
             }
 
             impl<'scalar> ScalarRef<'scalar> for $scalar_type {
@@ -68,10 +64,6 @@ impl Scalar for Box<str> {
     fn as_scalar_ref(&self) -> &str {
         self.as_ref()
     }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Utf8(self)
-    }
 }
 
 /// Implement `Scalar` for `Bytes`.
@@ -80,10 +72,6 @@ impl Scalar for Box<[u8]> {
 
     fn as_scalar_ref(&self) -> &[u8] {
         self
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Bytea(self)
     }
 }
 
@@ -94,10 +82,6 @@ impl Scalar for StructValue {
     fn as_scalar_ref(&self) -> StructRef<'_> {
         StructRef::ValueRef { val: self }
     }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Struct(self)
-    }
 }
 
 /// Implement `Scalar` for `ListValue`.
@@ -106,10 +90,6 @@ impl Scalar for ListValue {
 
     fn as_scalar_ref(&self) -> ListRef<'_> {
         ListRef::ValueRef { val: self }
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::List(self)
     }
 }
 
@@ -164,10 +144,6 @@ impl Scalar for bool {
     fn as_scalar_ref(&self) -> bool {
         *self
     }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Bool(self)
-    }
 }
 
 /// Implement `ScalarRef` for `bool`.
@@ -189,10 +165,6 @@ impl Scalar for Decimal {
 
     fn as_scalar_ref(&self) -> Decimal {
         *self
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Decimal(self)
     }
 }
 
@@ -216,10 +188,6 @@ impl Scalar for IntervalUnit {
     fn as_scalar_ref(&self) -> IntervalUnit {
         *self
     }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::Interval(self)
-    }
 }
 
 /// Implement `ScalarRef` for `IntervalUnit`.
@@ -241,10 +209,6 @@ impl Scalar for NaiveDateWrapper {
 
     fn as_scalar_ref(&self) -> NaiveDateWrapper {
         *self
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::NaiveDate(self)
     }
 }
 
@@ -268,10 +232,6 @@ impl Scalar for NaiveDateTimeWrapper {
     fn as_scalar_ref(&self) -> NaiveDateTimeWrapper {
         *self
     }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::NaiveDateTime(self)
-    }
 }
 
 /// Implement `ScalarRef` for `NaiveDateTimeWrapper`.
@@ -293,10 +253,6 @@ impl Scalar for NaiveTimeWrapper {
 
     fn as_scalar_ref(&self) -> NaiveTimeWrapper {
         *self
-    }
-
-    fn to_scalar_value(self) -> ScalarImpl {
-        ScalarImpl::NaiveTime(self)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We already have macro `for_all_scalar_variants! { impl_convert }` that generates `From<Foo> for ScalarImpl`. No need to repeat it.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
