### PR TITLE
doc: Let logo always visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <picture>
-<img src='./docs/images/logo-title.svg' alt='RisingWave Logo'>
+<img src='./docs/images/logo-title.svg' alt='RisingWave Logo' style='visibility:visible'>
 </picture>
 
 [![Slack](https://badgen.net/badge/Slack/Join%20RisingWave/0abd59?icon=slack)](https://join.slack.com/t/risingwave-community/shared_invite/zt-120rft0mr-d8uGk3d~NZiZAQWPnElOfw)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Sometimes GitHub sets it to visible, but sometimes not. 😅 It seems this happens when single theme is used.

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/37948597/221319643-eb54c132-73fd-4138-bf07-9506b7dde9a2.png">


## Documentation
- [x] My PR **DOES NOT** contain user-facing changes