### PR TITLE
test(scale): cover more operators in nexmark chaos tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6291,6 +6291,7 @@ dependencies = [
  "madsim-rdkafka",
  "madsim-tokio",
  "paste",
+ "pretty_assertions",
  "rand 0.8.5",
  "risingwave_common",
  "risingwave_compactor",

--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -1460,65 +1460,72 @@
                 auction.id
         )
   batch_plan: |
-    BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    BatchSimpleAgg { aggs: [min(min(max(bid.price)))] }
     └─BatchExchange { order: [], dist: Single }
-      └─BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
-        └─BatchHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction)] }
-          └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+      └─BatchSimpleAgg { aggs: [min(max(bid.price))] }
+        └─BatchHashAgg { group_key: [auction.id], aggs: [max(bid.price)] }
+          └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction AND (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires), output: [auction.id, bid.price] }
             ├─BatchExchange { order: [], dist: HashShard(auction.id) }
-            | └─BatchScan { table: auction, columns: [auction.id, auction.item_name], distribution: UpstreamHashShard(auction.id) }
+            | └─BatchScan { table: auction, columns: [auction.id, auction.date_time, auction.expires], distribution: UpstreamHashShard(auction.id) }
             └─BatchExchange { order: [], dist: HashShard(bid.auction) }
-              └─BatchScan { table: bid, columns: [bid.auction], distribution: SomeShard }
+              └─BatchScan { table: bid, columns: [bid.auction, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
-    StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
-    └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-      └─StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
+    └─StreamProject { exprs: [min(min(max(bid.price)))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, min(min(max(bid.price)))] }
         └─StreamExchange { dist: Single }
-          └─StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
-            └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr1] }
-              └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
-                  └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                    ├─StreamExchange { dist: HashShard(auction.id) }
-                    | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
-                    └─StreamExchange { dist: HashShard(bid.auction) }
-                      └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(max(bid.price))] }
+            └─StreamProject { exprs: [auction.id, max(bid.price), Vnode(auction.id) as $expr1] }
+              └─StreamProject { exprs: [auction.id, max(bid.price)] }
+                └─StreamHashAgg { group_key: [auction.id], aggs: [count, max(bid.price)] }
+                  └─StreamProject { exprs: [auction.id, bid.price, bid._row_id, bid.auction] }
+                    └─StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+                      └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                        ├─StreamExchange { dist: HashShard(auction.id) }
+                        | └─StreamTableScan { table: auction, columns: [auction.id, auction.date_time, auction.expires], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+                        └─StreamExchange { dist: HashShard(bid.auction) }
+                          └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
-      StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+      StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-          StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
-              state table: 0
+        StreamProject { exprs: [min(min(max(bid.price)))] }
+          StreamGlobalSimpleAgg { aggs: [count, min(min(max(bid.price)))] }
+              result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
-          state table: 1
-        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr3] }
-          StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
-                result table: 2, state tables: []
-              StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                  left table: 3, right table 5, left degree table: 4, right degree table: 6,
-                StreamExchange Hash([0]) from 2
-                StreamExchange Hash([0]) from 3
+      StreamHashAgg { group_key: [$expr3], aggs: [count, min(max(bid.price))] }
+          result table: 3, state tables: [2]
+        StreamProject { exprs: [auction.id, max(bid.price), Vnode(auction.id) as $expr3] }
+          StreamProject { exprs: [auction.id, max(bid.price)] }
+            StreamHashAgg { group_key: [auction.id], aggs: [count, max(bid.price)] }
+                result table: 5, state tables: [4]
+              StreamProject { exprs: [auction.id, bid.price, bid._row_id, bid.auction] }
+                StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
+                  StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                      left table: 6, right table 8, left degree table: 7, right degree table: 9,
+                    StreamExchange Hash([0]) from 2
+                    StreamExchange Hash([0]) from 3
 
     Fragment 2
-      Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+      Chain { table: auction, columns: [auction.id, auction.date_time, auction.expires], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
         Upstream
         BatchPlanNode
 
     Fragment 3
-      Chain { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+      Chain { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 1 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
-     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
-     Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
-     Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
-     Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [min(max(bid_price)), $expr3], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [count, min(min(max(bid_price)))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 2 { columns: [$expr3, max(bid_price), auction_id], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
+     Table 3 { columns: [$expr3, count, min(max(bid_price))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 4 { columns: [auction_id, bid_price, bid__row_id, bid_auction], primary key: [$0 ASC, $1 DESC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
+     Table 5 { columns: [auction_id, count, max(bid_price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [auction_id, auction_date_time, auction_expires], primary key: [$0 ASC], value indices: [0, 1, 2], distribution key: [0] }
+     Table 7 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
+     Table 8 { columns: [bid_auction, bid_price, bid_date_time, bid__row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
+     Table 9 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 4294967294 { columns: [min_final], primary key: [], value indices: [0], distribution key: [] }

--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -1436,3 +1436,89 @@
      Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
+- id: nexmark_q106
+  before:
+  - create_tables
+  sql: |
+    -- A self-made query that covers two-phase stateful simple aggregation.
+    --
+    -- Show the minimum final price of all auctions.
+    SELECT
+        MIN(final) AS min_final
+    FROM
+        (
+            SELECT
+                auction.id,
+                MAX(price) AS final
+            FROM
+                auction,
+                bid
+            WHERE
+                bid.auction = auction.id
+                AND bid.date_time BETWEEN auction.date_time AND auction.expires
+            GROUP BY
+                auction.id
+        )
+  batch_plan: |
+    BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+        └─BatchHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction)] }
+          └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+            ├─BatchExchange { order: [], dist: HashShard(auction.id) }
+            | └─BatchScan { table: auction, columns: [auction.id, auction.item_name], distribution: UpstreamHashShard(auction.id) }
+            └─BatchExchange { order: [], dist: HashShard(bid.auction) }
+              └─BatchScan { table: bid, columns: [bid.auction], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+    └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+      └─StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
+            └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr1] }
+              └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+                  └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                    ├─StreamExchange { dist: HashShard(auction.id) }
+                    | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+                    └─StreamExchange { dist: HashShard(bid.auction) }
+                      └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+  stream_dist_plan: |
+    Fragment 0
+      StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+          materialized table: 4294967294
+        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+          StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+              state table: 0
+            StreamExchange Single from 1
+
+    Fragment 1
+      StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
+          state table: 1
+        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr3] }
+          StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+                result table: 2, state tables: []
+              StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                  left table: 3, right table 5, left degree table: 4, right degree table: 6,
+                StreamExchange Hash([0]) from 2
+                StreamExchange Hash([0]) from 3
+
+    Fragment 2
+      Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+        Upstream
+        BatchPlanNode
+
+    Fragment 3
+      Chain { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+        Upstream
+        BatchPlanNode
+
+     Table 0 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
+     Table 1 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
+     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
+     Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
+     Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
+     Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -10,8 +10,7 @@
       date_time TIMESTAMP,
       expires TIMESTAMP,
       seller INTEGER,
-      category INTEGER,
-      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
+      category INTEGER)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Auction'
@@ -24,8 +23,7 @@
       channel VARCHAR,
       url VARCHAR,
       date_time TIMESTAMP,
-      extra VARCHAR,
-      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
+      extra VARCHAR)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Bid'
@@ -38,8 +36,7 @@
       credit_card VARCHAR,
       city VARCHAR,
       state VARCHAR,
-      date_time TIMESTAMP,
-      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
+      date_time TIMESTAMP)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Person'
@@ -56,10 +53,9 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -67,13 +63,12 @@
         StreamExchange Hash([4]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 1
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [4] }
 - id: nexmark_q1
   before:
@@ -92,10 +87,9 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, date_time, _row_id], watermark_columns: [date_time] }
+      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, date_time, _row_id] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -103,13 +97,12 @@
         StreamExchange Hash([4]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr55, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr55, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 1
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [4] }
 - id: nexmark_q2
   before:
@@ -126,8 +119,7 @@
       └─StreamProject { exprs: [auction, price, _row_id] }
         └─StreamFilter { predicate: (((((auction = 1007:Int32) OR (auction = 1020:Int32)) OR (auction = 2001:Int32)) OR (auction = 2019:Int32)) OR (auction = 2087:Int32)) }
           └─StreamRowIdGen { row_id_index: 7 }
-            └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -138,11 +130,10 @@
       StreamProject { exprs: [auction, price, _row_id] }
         StreamFilter { predicate: (((((auction = 1007:Int32) OR (auction = 1020:Int32)) OR (auction = 2001:Int32)) OR (auction = 2019:Int32)) OR (auction = 2087:Int32)) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                  source state table: 1
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, price, _row_id], primary key: [$2 ASC], value indices: [0, 1, 2], distribution key: [2] }
 - id: nexmark_q3
   before:
@@ -172,14 +163,12 @@
       | └─StreamProject { exprs: [id, seller, _row_id] }
       |   └─StreamFilter { predicate: (category = 10:Int32) }
       |     └─StreamRowIdGen { row_id_index: 9 }
-      |       └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-      |         └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamExchange { dist: HashShard(id) }
         └─StreamProject { exprs: [id, name, city, state, _row_id] }
           └─StreamFilter { predicate: (((state = 'or':Varchar) OR (state = 'id':Varchar)) OR (state = 'ca':Varchar)) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+              └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden), id#1(hidden)], pk_columns: [_row_id, _row_id#1, seller, id#1], pk_conflict: "no check" }
@@ -193,24 +182,22 @@
       StreamProject { exprs: [id, seller, _row_id] }
         StreamFilter { predicate: (category = 10:Int32) }
           StreamRowIdGen { row_id_index: 9 }
-            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                  source state table: 5
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 4
 
     Fragment 2
       StreamProject { exprs: [id, name, city, state, _row_id] }
         StreamFilter { predicate: (((state = 'or':Varchar) OR (state = 'id':Varchar)) OR (state = 'ca':Varchar)) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
-              StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-                  source state table: 7
+            StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+                source state table: 5
 
      Table 0 { columns: [id, seller, _row_id], primary key: [$1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [1] }
      Table 1 { columns: [seller, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [id, name, city, state, _row_id], primary key: [$0 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [name, city, state, id, _row_id, seller, _row_id#1, id#1], primary key: [$4 ASC, $6 ASC, $5 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [5] }
 - id: nexmark_q4
   before:
@@ -250,15 +237,13 @@
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
                     ├─StreamExchange { dist: HashShard(id) }
-                    | └─StreamProject { exprs: [id, date_time, expires, category, _row_id], watermark_columns: [date_time] }
+                    | └─StreamProject { exprs: [id, date_time, expires, category, _row_id] }
                     |   └─StreamRowIdGen { row_id_index: 9 }
-                    |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                    |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                    |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
                     └─StreamExchange { dist: HashShard(auction) }
-                      └─StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+                      └─StreamProject { exprs: [auction, price, date_time, _row_id] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
@@ -280,18 +265,16 @@
                 StreamExchange Hash([0]) from 3
 
     Fragment 2
-      StreamProject { exprs: [id, date_time, expires, category, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [id, date_time, expires, category, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 7
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 6
 
     Fragment 3
-      StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, price, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 9
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 7
 
      Table 0 { columns: [category, count, sum(max(price)), count(max(price))], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 1 { columns: [id, category, count, max(price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
@@ -299,8 +282,8 @@
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 4 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
      Table 5 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 9 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [category, avg], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
 - id: nexmark_q5
   before:
@@ -361,30 +344,28 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamShare { id = 1097 }
+          |   └─StreamShare { id = 1091 }
           |     └─StreamProject { exprs: [auction, window_start, count] }
           |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
           |         └─StreamExchange { dist: HashShard(auction, window_start) }
           |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-          |             └─StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
+          |             └─StreamProject { exprs: [auction, date_time, _row_id] }
           |               └─StreamFilter { predicate: IsNotNull(date_time) }
           |                 └─StreamRowIdGen { row_id_index: 7 }
-          |                   └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          |                     └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |                   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamProject { exprs: [max(count), window_start] }
             └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamShare { id = 1097 }
+                  └─StreamShare { id = 1091 }
                     └─StreamProject { exprs: [auction, window_start, count] }
                       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
                         └─StreamExchange { dist: HashShard(auction, window_start) }
                           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-                            └─StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
+                            └─StreamProject { exprs: [auction, date_time, _row_id] }
                               └─StreamFilter { predicate: IsNotNull(date_time) }
                                 └─StreamRowIdGen { row_id_index: 7 }
-                                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
@@ -396,7 +377,7 @@
               StreamExchange Hash([2]) from 1
               StreamProject { exprs: [max(count), window_start] }
                 StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
-                    result table: 8, state tables: [7]
+                    result table: 7, state tables: [6]
                   StreamExchange Hash([1]) from 4
 
     Fragment 1
@@ -411,12 +392,11 @@
 
     Fragment 3
       StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-        StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
+        StreamProject { exprs: [auction, date_time, _row_id] }
           StreamFilter { predicate: IsNotNull(date_time) }
             StreamRowIdGen { row_id_index: 7 }
-              StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                    source state table: 6
+              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  source state table: 5
 
     Fragment 4
       StreamProject { exprs: [auction, window_start, count] }
@@ -427,9 +407,9 @@
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 7 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 8 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
+     Table 7 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
@@ -490,22 +470,20 @@
       └─StreamFilter { predicate: (date_time >= $expr2) AND (date_time <= $expr1) }
         └─StreamHashJoin { type: Inner, predicate: price = max(price), output: all }
           ├─StreamExchange { dist: HashShard(price) }
-          | └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
-          |   └─StreamShare { id = 582 }
-          |     └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+          | └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+          |   └─StreamShare { id = 576 }
+          |     └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
           |       └─StreamRowIdGen { row_id_index: 7 }
-          |         └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          |           └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |         └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
-            └─StreamProject { exprs: [max(price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2], watermark_columns: [$expr1, ($expr1 - '00:00:10':Interval)] }
+            └─StreamProject { exprs: [max(price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2] }
               └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, max(price)] }
                 └─StreamExchange { dist: HashShard($expr1) }
-                  └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id], watermark_columns: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
-                    └─StreamShare { id = 582 }
-                      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+                  └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
+                    └─StreamShare { id = 576 }
+                      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, bidder, date_time, _row_id(hidden), $expr119(hidden), max(price)(hidden)], pk_columns: [_row_id, $expr119, price, max(price)], pk_conflict: "no check" }
@@ -518,32 +496,31 @@
               StreamExchange Hash([0]) from 3
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
         StreamExchange Hash([4]) from 2
 
     Fragment 2
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 5
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 4
 
     Fragment 3
-      StreamProject { exprs: [max(price), $expr119, ($expr119 - '00:00:10':Interval) as $expr120], watermark_columns: [$expr119, ($expr119 - '00:00:10':Interval)] }
+      StreamProject { exprs: [max(price), $expr119, ($expr119 - '00:00:10':Interval) as $expr120] }
         StreamAppendOnlyHashAgg { group_key: [$expr119], aggs: [count, max(price)] }
-            result table: 6, state tables: []
+            result table: 5, state tables: []
           StreamExchange Hash([0]) from 4
 
     Fragment 4
-      StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr119, price, _row_id], watermark_columns: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr119, price, _row_id] }
         StreamExchange Hash([4]) from 2
 
      Table 0 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$2 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [2] }
      Table 1 { columns: [price, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(price), $expr119, $expr120], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 3 { columns: [max(price), $expr119, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [$expr119, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [$expr119, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, price, bidder, date_time, _row_id, $expr119, max(price)], primary key: [$4 ASC, $5 ASC, $1 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [1] }
 - id: nexmark_q8
   before:
@@ -597,20 +574,18 @@
     StreamMaterialize { columns: [id, name, starttime, $expr226(hidden), seller(hidden), $expr227(hidden), $expr228(hidden)], pk_columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
-      | └─StreamProject { exprs: [id, name, $expr1, $expr2], watermark_columns: [$expr1, $expr2] }
+      | └─StreamProject { exprs: [id, name, $expr1, $expr2] }
       |   └─StreamAppendOnlyHashAgg { group_key: [id, name, $expr1, $expr2], aggs: [count] }
       |     └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
-      |       └─StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr1, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr2, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      |       └─StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr1, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr2, _row_id] }
       |         └─StreamRowIdGen { row_id_index: 7 }
-      |           └─StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
-      |             └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-      └─StreamProject { exprs: [seller, $expr3, $expr4], watermark_columns: [$expr3, $expr4] }
+      |           └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+      └─StreamProject { exprs: [seller, $expr3, $expr4] }
         └─StreamAppendOnlyHashAgg { group_key: [seller, $expr3, $expr4], aggs: [count] }
           └─StreamExchange { dist: HashShard(seller, $expr3, $expr4) }
-            └─StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr3, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr4, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+            └─StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr3, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr4, _row_id] }
               └─StreamRowIdGen { row_id_index: 9 }
-                └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                  └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, name, starttime, $expr226(hidden), seller(hidden), $expr227(hidden), $expr228(hidden)], pk_columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], pk_conflict: "no check" }
@@ -618,39 +593,37 @@
         StreamHashJoin { type: Inner, predicate: id = seller AND $expr225 = $expr227 AND $expr226 = $expr228, output: all }
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamExchange Hash([0, 2, 3]) from 1
-          StreamProject { exprs: [seller, $expr227, $expr228], watermark_columns: [$expr227, $expr228] }
+          StreamProject { exprs: [seller, $expr227, $expr228] }
             StreamAppendOnlyHashAgg { group_key: [seller, $expr227, $expr228], aggs: [count] }
-                result table: 7, state tables: []
+                result table: 6, state tables: []
               StreamExchange Hash([0, 1, 2]) from 3
 
     Fragment 1
-      StreamProject { exprs: [id, name, $expr225, $expr226], watermark_columns: [$expr225, $expr226] }
+      StreamProject { exprs: [id, name, $expr225, $expr226] }
         StreamAppendOnlyHashAgg { group_key: [id, name, $expr225, $expr226], aggs: [count] }
             result table: 4, state tables: []
           StreamExchange Hash([0, 1, 2, 3]) from 2
 
     Fragment 2
-      StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr225, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr226, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr225, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr226, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-                source state table: 6
+          StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+              source state table: 5
 
     Fragment 3
-      StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr227, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr228, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+      StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr227, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr228, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 9
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 7
 
      Table 0 { columns: [id, name, $expr225, $expr226], primary key: [$0 ASC, $2 ASC, $3 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0, 2, 3] }
      Table 1 { columns: [id, $expr225, $expr226, name, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0, 1, 2] }
      Table 2 { columns: [seller, $expr227, $expr228], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0, 1, 2] }
      Table 3 { columns: [seller, $expr227, $expr228, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
      Table 4 { columns: [id, name, $expr225, $expr226, count], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0, 1, 2, 3] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 7 { columns: [seller, $expr227, $expr228, count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
-     Table 9 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [seller, $expr227, $expr228, count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
+     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [0, 2, 3] }
 - id: nexmark_q9
   before:
@@ -698,12 +671,10 @@
           └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
             ├─StreamExchange { dist: HashShard(id) }
             | └─StreamRowIdGen { row_id_index: 9 }
-            |   └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+            |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
-                └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1, id, auction], pk_conflict: "no check" }
@@ -719,23 +690,21 @@
 
     Fragment 1
       StreamRowIdGen { row_id_index: 9 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 6
+        StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+            source state table: 5
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            source state table: 6
 
      Table 0 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, auction, bidder, price, channel, url, date_time_0, extra, _row_id_0], primary key: [$0 ASC, $12 DESC, $15 ASC, $9 ASC, $17 ASC, $10 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17], distribution key: [0] }
      Table 1 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], primary key: [$0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0] }
      Table 2 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 3 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$0 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [0] }
      Table 4 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id, _row_id#1], primary key: [$13 ASC, $14 ASC, $0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0] }
 - id: nexmark_q10
   before:
@@ -749,10 +718,9 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(date_time, 'HH:MI':Varchar) as $expr2, _row_id], watermark_columns: [date_time] }
+      └─StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(date_time, 'HH:MI':Varchar) as $expr2, _row_id] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -760,13 +728,12 @@
         StreamExchange Hash([6]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr109, ToChar(date_time, 'HH:MI':Varchar) as $expr110, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr109, ToChar(date_time, 'HH:MI':Varchar) as $expr110, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 1
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, date, time, _row_id], primary key: [$6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [6] }
 - id: nexmark_q11
   before:
@@ -845,11 +812,10 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, date_time, extra, _row_id], watermark_columns: [date_time] }
+      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, date_time, extra, _row_id] }
         └─StreamFilter { predicate: ((0.908:Decimal * price) > 1000000:Int32) AND ((0.908:Decimal * price) < 50000000:Int32) }
           └─StreamRowIdGen { row_id_index: 7 }
-            └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -857,14 +823,13 @@
         StreamExchange Hash([6]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr109, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr110, date_time, extra, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr109, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr110, date_time, extra, _row_id] }
         StreamFilter { predicate: ((0.908:Decimal * price) > 1000000:Int32) AND ((0.908:Decimal * price) < 50000000:Int32) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                  source state table: 1
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id], primary key: [$6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [6] }
 - id: nexmark_q15
   before:
@@ -903,8 +868,7 @@
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
@@ -917,12 +881,11 @@
     Fragment 1
       StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr55, price, bidder, auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 4
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 3
 
      Table 0 { columns: [$expr55, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
 - id: nexmark_q16
   before:
@@ -963,8 +926,7 @@
         └─StreamExchange { dist: HashShard(channel, $expr1) }
           └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
@@ -977,12 +939,11 @@
     Fragment 1
       StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr109, ToChar(date_time, 'HH:mm':Varchar) as $expr110, price, bidder, auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 4
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 3
 
      Table 0 { columns: [channel, $expr109, count, max($expr110), count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], distribution key: [0, 1] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
 - id: nexmark_q17
   before:
@@ -1015,8 +976,7 @@
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
@@ -1029,12 +989,11 @@
     Fragment 1
       StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr108, price, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 2
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 1
 
      Table 0 { columns: [auction, $expr108, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price), sum(price)_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11], distribution key: [0, 1] }
-     Table 2 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
 - id: nexmark_q18
   before:
@@ -1059,12 +1018,11 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id], watermark_columns: [date_time] }
+      └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
         └─StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
           └─StreamExchange { dist: HashShard(bidder, auction) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -1072,19 +1030,18 @@
         StreamExchange Hash([7]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
         StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
             state table: 0
           StreamExchange Hash([1, 0]) from 2
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 2
+        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            source state table: 1
 
      Table 0 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$1 ASC, $0 ASC, $5 DESC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [1, 0] }
-     Table 2 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [7] }
 - id: nexmark_q19
   before:
@@ -1129,16 +1086,14 @@
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden), id(hidden)], pk_columns: [_row_id, _row_id#1, auction, id], pk_conflict: "no check" }
     └─StreamAppendOnlyHashJoin { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id, id] }
       ├─StreamExchange { dist: HashShard(auction) }
-      | └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id], watermark_columns: [date_time] }
+      | └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 7 }
-      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-      |       └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+      |     └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
       └─StreamExchange { dist: HashShard(id) }
-        └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], watermark_columns: [date_time] }
+        └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id] }
           └─StreamFilter { predicate: (category = 10:Int32) }
             └─StreamRowIdGen { row_id_index: 9 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden), id(hidden)], pk_columns: [_row_id, _row_id#1, auction, id], pk_conflict: "no check" }
@@ -1149,26 +1104,24 @@
           StreamExchange Hash([0]) from 2
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 5
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 4
 
     Fragment 2
-      StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id] }
         StreamFilter { predicate: (category = 10:Int32) }
           StreamRowIdGen { row_id_index: 9 }
-            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-              StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                  source state table: 7
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 5
 
      Table 0 { columns: [auction, bidder, price, channel, url, date_time, _row_id], primary key: [$0 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [0] }
      Table 1 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], primary key: [$0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0] }
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id, _row_id#1, id], primary key: [$14 ASC, $15 ASC, $0 ASC, $16 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], distribution key: [0] }
 - id: nexmark_q21
   before:
@@ -1207,8 +1160,7 @@
     └─StreamExchange { dist: HashShard(_row_id) }
       └─StreamProject { exprs: [auction, bidder, price, channel, SplitPart(url, '/':Varchar, 4:Int32) as $expr1, SplitPart(url, '/':Varchar, 5:Int32) as $expr2, SplitPart(url, '/':Varchar, 6:Int32) as $expr3, _row_id] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -1218,11 +1170,10 @@
     Fragment 1
       StreamProject { exprs: [auction, bidder, price, channel, SplitPart(url, '/':Varchar, 4:Int32) as $expr163, SplitPart(url, '/':Varchar, 5:Int32) as $expr164, SplitPart(url, '/':Varchar, 6:Int32) as $expr165, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 1
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 0
 
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, dir1, dir2, dir3, _row_id], primary key: [$7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [7] }
 - id: nexmark_q101
   before:
@@ -1259,14 +1210,12 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
         └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, current_highest_bid, _row_id(hidden), auction(hidden)], pk_columns: [_row_id, auction, auction_id], pk_conflict: "no check" }
@@ -1276,29 +1225,27 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [auction, max(price)] }
             StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
-                result table: 6, state tables: []
+                result table: 5, state tables: []
               StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 5
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 4
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            source state table: 6
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction, max(price)], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [auction, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [auction, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, current_highest_bid, _row_id, auction], primary key: [$3 ASC, $4 ASC, $0 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
 - id: nexmark_q102
   before:
@@ -1345,15 +1292,13 @@
         |     ├─StreamExchange { dist: HashShard(id) }
         |     | └─StreamProject { exprs: [id, item_name, _row_id] }
         |     |   └─StreamRowIdGen { row_id_index: 9 }
-        |     |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-        |     |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+        |     |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
         |     └─StreamExchange { dist: HashShard(auction) }
         |       └─StreamProject { exprs: [auction, _row_id] }
-        |         └─StreamShare { id = 804 }
+        |         └─StreamShare { id = 794 }
         |           └─StreamProject { exprs: [auction, _row_id] }
         |             └─StreamRowIdGen { row_id_index: 7 }
-        |               └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-        |                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+        |               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
         └─StreamExchange { dist: Broadcast }
           └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
             └─StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
@@ -1362,11 +1307,10 @@
                   └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
                     └─StreamExchange { dist: HashShard(auction) }
                       └─StreamProject { exprs: [auction, _row_id] }
-                        └─StreamShare { id = 804 }
+                        └─StreamShare { id = 794 }
                           └─StreamProject { exprs: [auction, _row_id] }
                             └─StreamRowIdGen { row_id_index: 7 }
-                              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1386,9 +1330,8 @@
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 8
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 7
 
     Fragment 2
       StreamProject { exprs: [auction, _row_id] }
@@ -1397,20 +1340,19 @@
     Fragment 3
       StreamProject { exprs: [auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 10
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
     Fragment 4
       StreamProject { exprs: [(sum0(count) / count(auction)) as $expr55] }
         StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
-            result table: 11, state tables: []
+            result table: 9, state tables: []
           StreamExchange Single from 5
 
     Fragment 5
       StreamProject { exprs: [auction, count] }
         StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-            result table: 12, state tables: []
+            result table: 10, state tables: []
           StreamExchange Hash([0]) from 6
 
     Fragment 6
@@ -1424,10 +1366,10 @@
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 11 { columns: [count, sum0(count), count(auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
-     Table 12 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 9 { columns: [count, sum0(count), count(auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 10 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q103
   before:
@@ -1462,16 +1404,14 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
           └─StreamProject { exprs: [auction, count] }
             └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
               └─StreamExchange { dist: HashShard(auction) }
                 └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1483,29 +1423,27 @@
             StreamFilter { predicate: (count >= 20:Int32) }
               StreamProject { exprs: [auction, count] }
                 StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 6, state tables: []
+                    result table: 5, state tables: []
                   StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 5
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 4
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            source state table: 6
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q104
   before:
@@ -1540,16 +1478,14 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
           └─StreamProject { exprs: [auction, count] }
             └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
               └─StreamExchange { dist: HashShard(auction) }
                 └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1561,29 +1497,27 @@
             StreamFilter { predicate: (count < 20:Int32) }
               StreamProject { exprs: [auction, count] }
                 StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 6, state tables: []
+                    result table: 5, state tables: []
                   StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 5
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 4
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            source state table: 6
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q105
   before:
@@ -1626,13 +1560,11 @@
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamProject { exprs: [id, item_name, _row_id] }
                     |   └─StreamRowIdGen { row_id_index: 9 }
-                    |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                    |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                    |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
                     └─StreamExchange { dist: HashShard(auction) }
                       └─StreamProject { exprs: [auction, _row_id] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1657,16 +1589,14 @@
     Fragment 2
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 8
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 7
 
     Fragment 3
       StreamProject { exprs: [auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 10
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
      Table 0 { columns: [id, item_name, count(auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
      Table 1 { columns: [id, item_name, count(auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
@@ -1675,8 +1605,8 @@
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
 - id: nexmark_q106
   before:
@@ -1726,15 +1656,13 @@
                     └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                       └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
                         ├─StreamExchange { dist: HashShard(id) }
-                        | └─StreamProject { exprs: [id, date_time, expires, _row_id], watermark_columns: [date_time] }
+                        | └─StreamProject { exprs: [id, date_time, expires, _row_id] }
                         |   └─StreamRowIdGen { row_id_index: 9 }
-                        |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                        |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                        |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
                         └─StreamExchange { dist: HashShard(auction) }
-                          └─StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+                          └─StreamProject { exprs: [auction, price, date_time, _row_id] }
                             └─StreamRowIdGen { row_id_index: 7 }
-                              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
@@ -1759,18 +1687,16 @@
                     StreamExchange Hash([0]) from 3
 
     Fragment 2
-      StreamProject { exprs: [id, date_time, expires, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [id, date_time, expires, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 10
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 9
 
     Fragment 3
-      StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+      StreamProject { exprs: [auction, price, date_time, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 12
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 10
 
      Table 0 { columns: [min(max(price)), $expr3], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [] }
      Table 1 { columns: [count, min(min(max(price)))], primary key: [], value indices: [0, 1], distribution key: [] }
@@ -1781,6 +1707,6 @@
      Table 6 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 7 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
      Table 8 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 9 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 12 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [min_final], primary key: [], value indices: [0], distribution key: [] }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -1678,3 +1678,89 @@
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
+- id: nexmark_q106
+  before:
+  - create_tables
+  sql: |
+    -- A self-made query that covers two-phase stateful simple aggregation.
+    --
+    -- Show the minimum final price of all auctions.
+    SELECT
+        MIN(final) AS min_final
+    FROM
+        (
+            SELECT
+                auction.id,
+                MAX(price) AS final
+            FROM
+                auction,
+                bid
+            WHERE
+                bid.auction = auction.id
+                AND bid.date_time BETWEEN auction.date_time AND auction.expires
+            GROUP BY
+                auction.id
+        )
+  batch_plan: |
+    BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+        └─BatchHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction)] }
+          └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+            ├─BatchExchange { order: [], dist: HashShard(auction.id) }
+            | └─BatchScan { table: auction, columns: [auction.id, auction.item_name], distribution: UpstreamHashShard(auction.id) }
+            └─BatchExchange { order: [], dist: HashShard(bid.auction) }
+              └─BatchScan { table: bid, columns: [bid.auction], distribution: SomeShard }
+  stream_plan: |
+    StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+    └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+      └─StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
+            └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr1] }
+              └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+                  └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                    ├─StreamExchange { dist: HashShard(auction.id) }
+                    | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+                    └─StreamExchange { dist: HashShard(bid.auction) }
+                      └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+  stream_dist_plan: |
+    Fragment 0
+      StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+          materialized table: 4294967294
+        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+          StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+              state table: 0
+            StreamExchange Single from 1
+
+    Fragment 1
+      StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
+          state table: 1
+        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr3] }
+          StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
+            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+                result table: 2, state tables: []
+              StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
+                  left table: 3, right table 5, left degree table: 4, right degree table: 6,
+                StreamExchange Hash([0]) from 2
+                StreamExchange Hash([0]) from 3
+
+    Fragment 2
+      Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
+        Upstream
+        BatchPlanNode
+
+    Fragment 3
+      Chain { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+        Upstream
+        BatchPlanNode
+
+     Table 0 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
+     Table 1 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
+     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
+     Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
+     Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
+     Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -1680,7 +1680,7 @@
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
 - id: nexmark_q106
   before:
-  - create_tables
+  - create_sources
   sql: |
     -- A self-made query that covers two-phase stateful simple aggregation.
     --
@@ -1702,65 +1702,85 @@
                 auction.id
         )
   batch_plan: |
-    BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    BatchSimpleAgg { aggs: [min(min(max(price)))] }
     └─BatchExchange { order: [], dist: Single }
-      └─BatchTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
-        └─BatchHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction)] }
-          └─BatchHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-            ├─BatchExchange { order: [], dist: HashShard(auction.id) }
-            | └─BatchScan { table: auction, columns: [auction.id, auction.item_name], distribution: UpstreamHashShard(auction.id) }
-            └─BatchExchange { order: [], dist: HashShard(bid.auction) }
-              └─BatchScan { table: bid, columns: [bid.auction], distribution: SomeShard }
+      └─BatchSimpleAgg { aggs: [min(max(price))] }
+        └─BatchHashAgg { group_key: [id], aggs: [max(price)] }
+          └─BatchHashJoin { type: Inner, predicate: id = auction AND (date_time >= date_time) AND (date_time <= expires), output: [id, price] }
+            ├─BatchExchange { order: [], dist: HashShard(id) }
+            | └─BatchProject { exprs: [id, date_time, expires] }
+            |   └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"], filter: (None, None) }
+            └─BatchExchange { order: [], dist: HashShard(auction) }
+              └─BatchProject { exprs: [auction, price, date_time] }
+                └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
-    StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
-    └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-      └─StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
+    StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
+    └─StreamProject { exprs: [min(min(max(price)))] }
+      └─StreamGlobalSimpleAgg { aggs: [count, min(min(max(price)))] }
         └─StreamExchange { dist: Single }
-          └─StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
-            └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr1] }
-              └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
-                  └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                    ├─StreamExchange { dist: HashShard(auction.id) }
-                    | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
-                    └─StreamExchange { dist: HashShard(bid.auction) }
-                      └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(max(price))] }
+            └─StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
+              └─StreamProject { exprs: [id, max(price)] }
+                └─StreamAppendOnlyHashAgg { group_key: [id], aggs: [count, max(price)] }
+                  └─StreamProject { exprs: [id, price, _row_id, _row_id, auction] }
+                    └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
+                      └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                        ├─StreamExchange { dist: HashShard(id) }
+                        | └─StreamProject { exprs: [id, date_time, expires, _row_id], watermark_columns: [date_time] }
+                        |   └─StreamRowIdGen { row_id_index: 9 }
+                        |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                        |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                        └─StreamExchange { dist: HashShard(auction) }
+                          └─StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+                            └─StreamRowIdGen { row_id_index: 7 }
+                              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
-      StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
+      StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-          StreamTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0 }
-              state table: 0
+        StreamProject { exprs: [min(min(max(price)))] }
+          StreamGlobalSimpleAgg { aggs: [count, min(min(max(price)))] }
+              result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
-          state table: 1
-        StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr3] }
-          StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
-                result table: 2, state tables: []
-              StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
-                  left table: 3, right table 5, left degree table: 4, right degree table: 6,
-                StreamExchange Hash([0]) from 2
-                StreamExchange Hash([0]) from 3
+      StreamHashAgg { group_key: [$expr3], aggs: [count, min(max(price))] }
+          result table: 3, state tables: [2]
+        StreamProject { exprs: [id, max(price), Vnode(id) as $expr3] }
+          StreamProject { exprs: [id, max(price)] }
+            StreamAppendOnlyHashAgg { group_key: [id], aggs: [count, max(price)] }
+                result table: 4, state tables: []
+              StreamProject { exprs: [id, price, _row_id, _row_id, auction] }
+                StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
+                  StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                      left table: 5, right table 7, left degree table: 6, right degree table: 8,
+                    StreamExchange Hash([0]) from 2
+                    StreamExchange Hash([0]) from 3
 
     Fragment 2
-      Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
-        Upstream
-        BatchPlanNode
+      StreamProject { exprs: [id, date_time, expires, _row_id], watermark_columns: [date_time] }
+        StreamRowIdGen { row_id_index: 9 }
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 10
 
     Fragment 3
-      Chain { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
-        Upstream
-        BatchPlanNode
+      StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
+        StreamRowIdGen { row_id_index: 7 }
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 12
 
-     Table 0 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 1 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
-     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
-     Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
-     Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
-     Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [min(max(price)), $expr3], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [count, min(min(max(price)))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 2 { columns: [$expr3, max(price), id], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
+     Table 3 { columns: [$expr3, count, min(max(price))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 4 { columns: [id, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [id, date_time, expires, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
+     Table 6 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 7 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
+     Table 8 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
+     Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 12 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4294967294 { columns: [min_final], primary key: [], value indices: [0], distribution key: [] }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -10,7 +10,8 @@
       date_time TIMESTAMP,
       expires TIMESTAMP,
       seller INTEGER,
-      category INTEGER)
+      category INTEGER,
+      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Auction'
@@ -23,7 +24,8 @@
       channel VARCHAR,
       url VARCHAR,
       date_time TIMESTAMP,
-      extra VARCHAR)
+      extra VARCHAR,
+      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Bid'
@@ -36,7 +38,8 @@
       credit_card VARCHAR,
       city VARCHAR,
       state VARCHAR,
-      date_time TIMESTAMP)
+      date_time TIMESTAMP,
+      WATERMARK FOR date_time AS date_time - INTERVAL '4' SECOND)
     with (
       connector = 'nexmark',
       nexmark.table.type = 'Person'
@@ -53,9 +56,10 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -63,12 +67,13 @@
         StreamExchange Hash([4]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 0
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [4] }
 - id: nexmark_q1
   before:
@@ -87,9 +92,10 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, date_time, _row_id] }
+      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, date_time, _row_id], watermark_columns: [date_time] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -97,12 +103,13 @@
         StreamExchange Hash([4]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr55, date_time, _row_id] }
+      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr55, date_time, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 0
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [4] }
 - id: nexmark_q2
   before:
@@ -119,7 +126,8 @@
       └─StreamProject { exprs: [auction, price, _row_id] }
         └─StreamFilter { predicate: (((((auction = 1007:Int32) OR (auction = 1020:Int32)) OR (auction = 2001:Int32)) OR (auction = 2019:Int32)) OR (auction = 2087:Int32)) }
           └─StreamRowIdGen { row_id_index: 7 }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -130,10 +138,11 @@
       StreamProject { exprs: [auction, price, _row_id] }
         StreamFilter { predicate: (((((auction = 1007:Int32) OR (auction = 1020:Int32)) OR (auction = 2001:Int32)) OR (auction = 2019:Int32)) OR (auction = 2087:Int32)) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 0
+            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, price, _row_id], primary key: [$2 ASC], value indices: [0, 1, 2], distribution key: [2] }
 - id: nexmark_q3
   before:
@@ -163,12 +172,14 @@
       | └─StreamProject { exprs: [id, seller, _row_id] }
       |   └─StreamFilter { predicate: (category = 10:Int32) }
       |     └─StreamRowIdGen { row_id_index: 9 }
-      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |       └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+      |         └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamExchange { dist: HashShard(id) }
         └─StreamProject { exprs: [id, name, city, state, _row_id] }
           └─StreamFilter { predicate: (((state = 'or':Varchar) OR (state = 'id':Varchar)) OR (state = 'ca':Varchar)) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden), id#1(hidden)], pk_columns: [_row_id, _row_id#1, seller, id#1], pk_conflict: "no check" }
@@ -182,22 +193,24 @@
       StreamProject { exprs: [id, seller, _row_id] }
         StreamFilter { predicate: (category = 10:Int32) }
           StreamRowIdGen { row_id_index: 9 }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 4
+            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                  source state table: 5
 
     Fragment 2
       StreamProject { exprs: [id, name, city, state, _row_id] }
         StreamFilter { predicate: (((state = 'or':Varchar) OR (state = 'id':Varchar)) OR (state = 'ca':Varchar)) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-                source state table: 5
+            StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
+              StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+                  source state table: 7
 
      Table 0 { columns: [id, seller, _row_id], primary key: [$1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [1] }
      Table 1 { columns: [seller, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [id, name, city, state, _row_id], primary key: [$0 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [name, city, state, id, _row_id, seller, _row_id#1, id#1], primary key: [$4 ASC, $6 ASC, $5 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [5] }
 - id: nexmark_q4
   before:
@@ -237,13 +250,15 @@
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
                     ├─StreamExchange { dist: HashShard(id) }
-                    | └─StreamProject { exprs: [id, date_time, expires, category, _row_id] }
+                    | └─StreamProject { exprs: [id, date_time, expires, category, _row_id], watermark_columns: [date_time] }
                     |   └─StreamRowIdGen { row_id_index: 9 }
-                    |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                    |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                    |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
                     └─StreamExchange { dist: HashShard(auction) }
-                      └─StreamProject { exprs: [auction, price, date_time, _row_id] }
+                      └─StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
@@ -265,16 +280,18 @@
                 StreamExchange Hash([0]) from 3
 
     Fragment 2
-      StreamProject { exprs: [id, date_time, expires, category, _row_id] }
+      StreamProject { exprs: [id, date_time, expires, category, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 6
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 7
 
     Fragment 3
-      StreamProject { exprs: [auction, price, date_time, _row_id] }
+      StreamProject { exprs: [auction, price, date_time, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 7
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 9
 
      Table 0 { columns: [category, count, sum(max(price)), count(max(price))], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 1 { columns: [id, category, count, max(price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
@@ -282,8 +299,8 @@
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 4 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
      Table 5 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 9 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [category, avg], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
 - id: nexmark_q5
   before:
@@ -344,28 +361,30 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamShare { id = 1091 }
+          |   └─StreamShare { id = 1097 }
           |     └─StreamProject { exprs: [auction, window_start, count] }
           |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
           |         └─StreamExchange { dist: HashShard(auction, window_start) }
           |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-          |             └─StreamProject { exprs: [auction, date_time, _row_id] }
+          |             └─StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
           |               └─StreamFilter { predicate: IsNotNull(date_time) }
           |                 └─StreamRowIdGen { row_id_index: 7 }
-          |                   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |                   └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          |                     └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamProject { exprs: [max(count), window_start] }
             └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamShare { id = 1091 }
+                  └─StreamShare { id = 1097 }
                     └─StreamProject { exprs: [auction, window_start, count] }
                       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
                         └─StreamExchange { dist: HashShard(auction, window_start) }
                           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-                            └─StreamProject { exprs: [auction, date_time, _row_id] }
+                            └─StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
                               └─StreamFilter { predicate: IsNotNull(date_time) }
                                 └─StreamRowIdGen { row_id_index: 7 }
-                                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
@@ -377,7 +396,7 @@
               StreamExchange Hash([2]) from 1
               StreamProject { exprs: [max(count), window_start] }
                 StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
-                    result table: 7, state tables: [6]
+                    result table: 8, state tables: [7]
                   StreamExchange Hash([1]) from 4
 
     Fragment 1
@@ -392,11 +411,12 @@
 
     Fragment 3
       StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-        StreamProject { exprs: [auction, date_time, _row_id] }
+        StreamProject { exprs: [auction, date_time, _row_id], watermark_columns: [date_time] }
           StreamFilter { predicate: IsNotNull(date_time) }
             StreamRowIdGen { row_id_index: 7 }
-              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                  source state table: 5
+              StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                    source state table: 6
 
     Fragment 4
       StreamProject { exprs: [auction, window_start, count] }
@@ -407,9 +427,9 @@
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 7 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 7 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
+     Table 8 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
@@ -470,20 +490,22 @@
       └─StreamFilter { predicate: (date_time >= $expr2) AND (date_time <= $expr1) }
         └─StreamHashJoin { type: Inner, predicate: price = max(price), output: all }
           ├─StreamExchange { dist: HashShard(price) }
-          | └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
-          |   └─StreamShare { id = 576 }
-          |     └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+          | └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
+          |   └─StreamShare { id = 582 }
+          |     └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
           |       └─StreamRowIdGen { row_id_index: 7 }
-          |         └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |         └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          |           └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
-            └─StreamProject { exprs: [max(price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2] }
+            └─StreamProject { exprs: [max(price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2], watermark_columns: [$expr1, ($expr1 - '00:00:10':Interval)] }
               └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, max(price)] }
                 └─StreamExchange { dist: HashShard($expr1) }
-                  └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
-                    └─StreamShare { id = 576 }
-                      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+                  └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id], watermark_columns: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
+                    └─StreamShare { id = 582 }
+                      └─StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, price, bidder, date_time, _row_id(hidden), $expr119(hidden), max(price)(hidden)], pk_columns: [_row_id, $expr119, price, max(price)], pk_conflict: "no check" }
@@ -496,31 +518,32 @@
               StreamExchange Hash([0]) from 3
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
         StreamExchange Hash([4]) from 2
 
     Fragment 2
-      StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, date_time, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 4
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 5
 
     Fragment 3
-      StreamProject { exprs: [max(price), $expr119, ($expr119 - '00:00:10':Interval) as $expr120] }
+      StreamProject { exprs: [max(price), $expr119, ($expr119 - '00:00:10':Interval) as $expr120], watermark_columns: [$expr119, ($expr119 - '00:00:10':Interval)] }
         StreamAppendOnlyHashAgg { group_key: [$expr119], aggs: [count, max(price)] }
-            result table: 5, state tables: []
+            result table: 6, state tables: []
           StreamExchange Hash([0]) from 4
 
     Fragment 4
-      StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr119, price, _row_id] }
+      StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr119, price, _row_id], watermark_columns: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
         StreamExchange Hash([4]) from 2
 
      Table 0 { columns: [auction, bidder, price, date_time, _row_id], primary key: [$2 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [2] }
      Table 1 { columns: [price, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(price), $expr119, $expr120], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 3 { columns: [max(price), $expr119, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [$expr119, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [$expr119, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, price, bidder, date_time, _row_id, $expr119, max(price)], primary key: [$4 ASC, $5 ASC, $1 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [1] }
 - id: nexmark_q8
   before:
@@ -574,18 +597,20 @@
     StreamMaterialize { columns: [id, name, starttime, $expr226(hidden), seller(hidden), $expr227(hidden), $expr228(hidden)], pk_columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
-      | └─StreamProject { exprs: [id, name, $expr1, $expr2] }
+      | └─StreamProject { exprs: [id, name, $expr1, $expr2], watermark_columns: [$expr1, $expr2] }
       |   └─StreamAppendOnlyHashAgg { group_key: [id, name, $expr1, $expr2], aggs: [count] }
       |     └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
-      |       └─StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr1, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr2, _row_id] }
+      |       └─StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr1, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr2, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
       |         └─StreamRowIdGen { row_id_index: 7 }
-      |           └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-      └─StreamProject { exprs: [seller, $expr3, $expr4] }
+      |           └─StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
+      |             └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+      └─StreamProject { exprs: [seller, $expr3, $expr4], watermark_columns: [$expr3, $expr4] }
         └─StreamAppendOnlyHashAgg { group_key: [seller, $expr3, $expr4], aggs: [count] }
           └─StreamExchange { dist: HashShard(seller, $expr3, $expr4) }
-            └─StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr3, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr4, _row_id] }
+            └─StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr3, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr4, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
               └─StreamRowIdGen { row_id_index: 9 }
-                └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                  └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, name, starttime, $expr226(hidden), seller(hidden), $expr227(hidden), $expr228(hidden)], pk_columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], pk_conflict: "no check" }
@@ -593,37 +618,39 @@
         StreamHashJoin { type: Inner, predicate: id = seller AND $expr225 = $expr227 AND $expr226 = $expr228, output: all }
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamExchange Hash([0, 2, 3]) from 1
-          StreamProject { exprs: [seller, $expr227, $expr228] }
+          StreamProject { exprs: [seller, $expr227, $expr228], watermark_columns: [$expr227, $expr228] }
             StreamAppendOnlyHashAgg { group_key: [seller, $expr227, $expr228], aggs: [count] }
-                result table: 6, state tables: []
+                result table: 7, state tables: []
               StreamExchange Hash([0, 1, 2]) from 3
 
     Fragment 1
-      StreamProject { exprs: [id, name, $expr225, $expr226] }
+      StreamProject { exprs: [id, name, $expr225, $expr226], watermark_columns: [$expr225, $expr226] }
         StreamAppendOnlyHashAgg { group_key: [id, name, $expr225, $expr226], aggs: [count] }
             result table: 4, state tables: []
           StreamExchange Hash([0, 1, 2, 3]) from 2
 
     Fragment 2
-      StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr225, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr226, _row_id] }
+      StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr225, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr226, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
-              source state table: 5
+          StreamWatermarkFilter { watermark_descs: [idx: 6, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "_row_id"] }
+                source state table: 6
 
     Fragment 3
-      StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr227, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr228, _row_id] }
+      StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr227, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr228, _row_id], watermark_columns: [TumbleStart(date_time, '00:00:10':Interval), (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval)] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 7
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 9
 
      Table 0 { columns: [id, name, $expr225, $expr226], primary key: [$0 ASC, $2 ASC, $3 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0, 2, 3] }
      Table 1 { columns: [id, $expr225, $expr226, name, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0, 1, 2] }
      Table 2 { columns: [seller, $expr227, $expr228], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0, 1, 2] }
      Table 3 { columns: [seller, $expr227, $expr228, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
      Table 4 { columns: [id, name, $expr225, $expr226, count], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0, 1, 2, 3] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 6 { columns: [seller, $expr227, $expr228, count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
-     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 7 { columns: [seller, $expr227, $expr228, count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0, 1, 2] }
+     Table 9 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [id, name, starttime, $expr226, seller, $expr227, $expr228], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [0, 2, 3] }
 - id: nexmark_q9
   before:
@@ -671,10 +698,12 @@
           └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
             ├─StreamExchange { dist: HashShard(id) }
             | └─StreamRowIdGen { row_id_index: 9 }
-            |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+            |   └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
-                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], pk_columns: [_row_id, _row_id#1, id, auction], pk_conflict: "no check" }
@@ -690,21 +719,23 @@
 
     Fragment 1
       StreamRowIdGen { row_id_index: 9 }
-        StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-            source state table: 5
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              source state table: 6
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-            source state table: 6
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
      Table 0 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, auction, bidder, price, channel, url, date_time_0, extra, _row_id_0], primary key: [$0 ASC, $12 DESC, $15 ASC, $9 ASC, $17 ASC, $10 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17], distribution key: [0] }
      Table 1 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], primary key: [$0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0] }
      Table 2 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 3 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$0 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [0] }
      Table 4 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id, _row_id#1], primary key: [$13 ASC, $14 ASC, $0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0] }
 - id: nexmark_q10
   before:
@@ -718,9 +749,10 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(date_time, 'HH:MI':Varchar) as $expr2, _row_id] }
+      └─StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(date_time, 'HH:MI':Varchar) as $expr2, _row_id], watermark_columns: [date_time] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -728,12 +760,13 @@
         StreamExchange Hash([6]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr109, ToChar(date_time, 'HH:MI':Varchar) as $expr110, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, date_time, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr109, ToChar(date_time, 'HH:MI':Varchar) as $expr110, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 0
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, date_time, date, time, _row_id], primary key: [$6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [6] }
 - id: nexmark_q11
   before:
@@ -812,10 +845,11 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, date_time, extra, _row_id] }
+      └─StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr1, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, date_time, extra, _row_id], watermark_columns: [date_time] }
         └─StreamFilter { predicate: ((0.908:Decimal * price) > 1000000:Int32) AND ((0.908:Decimal * price) < 50000000:Int32) }
           └─StreamRowIdGen { row_id_index: 7 }
-            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+            └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -823,13 +857,14 @@
         StreamExchange Hash([6]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr109, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr110, date_time, extra, _row_id] }
+      StreamProject { exprs: [auction, bidder, (0.908:Decimal * price) as $expr109, Case(((Extract('HOUR':Varchar, date_time) >= 8:Int32) AND (Extract('HOUR':Varchar, date_time) <= 18:Int32)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, date_time) <= 6:Int32) OR (Extract('HOUR':Varchar, date_time) >= 20:Int32)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr110, date_time, extra, _row_id], watermark_columns: [date_time] }
         StreamFilter { predicate: ((0.908:Decimal * price) > 1000000:Int32) AND ((0.908:Decimal * price) < 50000000:Int32) }
           StreamRowIdGen { row_id_index: 7 }
-            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-                source state table: 0
+            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, bidtimetype, date_time, extra, _row_id], primary key: [$6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [6] }
 - id: nexmark_q15
   before:
@@ -868,7 +903,8 @@
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
@@ -881,11 +917,12 @@
     Fragment 1
       StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr55, price, bidder, auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 3
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 4
 
      Table 0 { columns: [$expr55, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [0] }
-     Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
 - id: nexmark_q16
   before:
@@ -926,7 +963,8 @@
         └─StreamExchange { dist: HashShard(channel, $expr1) }
           └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
@@ -939,11 +977,12 @@
     Fragment 1
       StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr109, ToChar(date_time, 'HH:mm':Varchar) as $expr110, price, bidder, auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 3
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 4
 
      Table 0 { columns: [channel, $expr109, count, max($expr110), count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], distribution key: [0, 1] }
-     Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
 - id: nexmark_q17
   before:
@@ -976,7 +1015,8 @@
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
@@ -989,11 +1029,12 @@
     Fragment 1
       StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr108, price, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 1
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 2
 
      Table 0 { columns: [auction, $expr108, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price), sum(price)_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11], distribution key: [0, 1] }
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 2 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
 - id: nexmark_q18
   before:
@@ -1018,11 +1059,12 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
     └─StreamExchange { dist: HashShard(_row_id) }
-      └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
+      └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id], watermark_columns: [date_time] }
         └─StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
           └─StreamExchange { dist: HashShard(bidder, auction) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -1030,18 +1072,19 @@
         StreamExchange Hash([7]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id], watermark_columns: [date_time] }
         StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0] }
             state table: 0
           StreamExchange Hash([1, 0]) from 2
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-            source state table: 1
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 2
 
      Table 0 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$1 ASC, $0 ASC, $5 DESC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [1, 0] }
-     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 2 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], primary key: [$7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [7] }
 - id: nexmark_q19
   before:
@@ -1086,14 +1129,16 @@
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden), id(hidden)], pk_columns: [_row_id, _row_id#1, auction, id], pk_conflict: "no check" }
     └─StreamAppendOnlyHashJoin { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id, id] }
       ├─StreamExchange { dist: HashShard(auction) }
-      | └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id] }
+      | └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id], watermark_columns: [date_time] }
       |   └─StreamRowIdGen { row_id_index: 7 }
-      |     └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+      |       └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
       └─StreamExchange { dist: HashShard(id) }
-        └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id] }
+        └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], watermark_columns: [date_time] }
           └─StreamFilter { predicate: (category = 10:Int32) }
             └─StreamRowIdGen { row_id_index: 9 }
-              └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden), id(hidden)], pk_columns: [_row_id, _row_id#1, auction, id], pk_conflict: "no check" }
@@ -1104,24 +1149,26 @@
           StreamExchange Hash([0]) from 2
 
     Fragment 1
-      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id] }
+      StreamProject { exprs: [auction, bidder, price, channel, url, date_time, _row_id], watermark_columns: [date_time] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 4
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 5
 
     Fragment 2
-      StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id] }
+      StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], watermark_columns: [date_time] }
         StreamFilter { predicate: (category = 10:Int32) }
           StreamRowIdGen { row_id_index: 9 }
-            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-                source state table: 5
+            StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+              StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                  source state table: 7
 
      Table 0 { columns: [auction, bidder, price, channel, url, date_time, _row_id], primary key: [$0 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [0] }
      Table 1 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id], primary key: [$0 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0] }
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id, _row_id#1, id], primary key: [$14 ASC, $15 ASC, $0 ASC, $16 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16], distribution key: [0] }
 - id: nexmark_q21
   before:
@@ -1160,7 +1207,8 @@
     └─StreamExchange { dist: HashShard(_row_id) }
       └─StreamProject { exprs: [auction, bidder, price, channel, SplitPart(url, '/':Varchar, 4:Int32) as $expr1, SplitPart(url, '/':Varchar, 5:Int32) as $expr2, SplitPart(url, '/':Varchar, 6:Int32) as $expr3, _row_id] }
         └─StreamRowIdGen { row_id_index: 7 }
-          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, _row_id(hidden)], pk_columns: [_row_id], pk_conflict: "no check" }
@@ -1170,10 +1218,11 @@
     Fragment 1
       StreamProject { exprs: [auction, bidder, price, channel, SplitPart(url, '/':Varchar, 4:Int32) as $expr163, SplitPart(url, '/':Varchar, 5:Int32) as $expr164, SplitPart(url, '/':Varchar, 6:Int32) as $expr165, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 0
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 1
 
-     Table 0 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, bidder, price, channel, dir1, dir2, dir3, _row_id], primary key: [$7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [7] }
 - id: nexmark_q101
   before:
@@ -1210,12 +1259,14 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
         └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, current_highest_bid, _row_id(hidden), auction(hidden)], pk_columns: [_row_id, auction, auction_id], pk_conflict: "no check" }
@@ -1225,27 +1276,29 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [auction, max(price)] }
             StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
-                result table: 5, state tables: []
+                result table: 6, state tables: []
               StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 4
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 5
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-            source state table: 6
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction, max(price)], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [auction, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, current_highest_bid, _row_id, auction], primary key: [$3 ASC, $4 ASC, $0 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
 - id: nexmark_q102
   before:
@@ -1292,13 +1345,15 @@
         |     ├─StreamExchange { dist: HashShard(id) }
         |     | └─StreamProject { exprs: [id, item_name, _row_id] }
         |     |   └─StreamRowIdGen { row_id_index: 9 }
-        |     |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+        |     |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+        |     |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
         |     └─StreamExchange { dist: HashShard(auction) }
         |       └─StreamProject { exprs: [auction, _row_id] }
-        |         └─StreamShare { id = 794 }
+        |         └─StreamShare { id = 804 }
         |           └─StreamProject { exprs: [auction, _row_id] }
         |             └─StreamRowIdGen { row_id_index: 7 }
-        |               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+        |               └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+        |                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
         └─StreamExchange { dist: Broadcast }
           └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
             └─StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
@@ -1307,10 +1362,11 @@
                   └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
                     └─StreamExchange { dist: HashShard(auction) }
                       └─StreamProject { exprs: [auction, _row_id] }
-                        └─StreamShare { id = 794 }
+                        └─StreamShare { id = 804 }
                           └─StreamProject { exprs: [auction, _row_id] }
                             └─StreamRowIdGen { row_id_index: 7 }
-                              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                              └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1330,8 +1386,9 @@
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 7
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 8
 
     Fragment 2
       StreamProject { exprs: [auction, _row_id] }
@@ -1340,19 +1397,20 @@
     Fragment 3
       StreamProject { exprs: [auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 10
 
     Fragment 4
       StreamProject { exprs: [(sum0(count) / count(auction)) as $expr55] }
         StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
-            result table: 9, state tables: []
+            result table: 11, state tables: []
           StreamExchange Single from 5
 
     Fragment 5
       StreamProject { exprs: [auction, count] }
         StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-            result table: 10, state tables: []
+            result table: 12, state tables: []
           StreamExchange Hash([0]) from 6
 
     Fragment 6
@@ -1366,10 +1424,10 @@
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 9 { columns: [count, sum0(count), count(auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
-     Table 10 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 11 { columns: [count, sum0(count), count(auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 12 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q103
   before:
@@ -1404,14 +1462,16 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
           └─StreamProject { exprs: [auction, count] }
             └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
               └─StreamExchange { dist: HashShard(auction) }
                 └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1423,27 +1483,29 @@
             StreamFilter { predicate: (count >= 20:Int32) }
               StreamProject { exprs: [auction, count] }
                 StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 5, state tables: []
+                    result table: 6, state tables: []
                   StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 4
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 5
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-            source state table: 6
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q104
   before:
@@ -1478,14 +1540,16 @@
       ├─StreamExchange { dist: HashShard(id) }
       | └─StreamProject { exprs: [id, item_name, _row_id] }
       |   └─StreamRowIdGen { row_id_index: 9 }
-      |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+      |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+      |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
           └─StreamProject { exprs: [auction, count] }
             └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
               └─StreamExchange { dist: HashShard(auction) }
                 └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                    └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1497,27 +1561,29 @@
             StreamFilter { predicate: (count < 20:Int32) }
               StreamProject { exprs: [auction, count] }
                 StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 5, state tables: []
+                    result table: 6, state tables: []
                   StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 4
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 5
 
     Fragment 2
       StreamRowIdGen { row_id_index: 7 }
-        StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-            source state table: 6
+        StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              source state table: 8
 
      Table 0 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 6 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q105
   before:
@@ -1560,11 +1626,13 @@
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamProject { exprs: [id, item_name, _row_id] }
                     |   └─StreamRowIdGen { row_id_index: 9 }
-                    |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                    |     └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                    |       └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
                     └─StreamExchange { dist: HashShard(auction) }
                       └─StreamProject { exprs: [auction, _row_id] }
                         └─StreamRowIdGen { row_id_index: 7 }
-                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                          └─StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], order_descs: [bid_count, auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1589,14 +1657,16 @@
     Fragment 2
       StreamProject { exprs: [id, item_name, _row_id] }
         StreamRowIdGen { row_id_index: 9 }
-          StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
-              source state table: 7
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
+                source state table: 8
 
     Fragment 3
       StreamProject { exprs: [auction, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
-          StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
-              source state table: 8
+          StreamWatermarkFilter { watermark_descs: [idx: 5, expr: (date_time - '00:00:04':Interval)] }
+            StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                source state table: 10
 
      Table 0 { columns: [id, item_name, count(auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
      Table 1 { columns: [id, item_name, count(auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
@@ -1605,6 +1675,6 @@
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
+     Table 10 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [] }

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -472,24 +472,13 @@ impl<S: StateStore, W: WatermarkBufferStrategy> StateTable<S, W> {
     /// Get the vnode value with given (prefix of) primary key
     fn compute_prefix_vnode(&self, pk_prefix: impl Row) -> VirtualNode {
         let prefix_len = pk_prefix.len();
-        let compute_vnode = || {
-            // For streaming, the given prefix must be enough to calculate the vnode
-            assert!(self.dist_key_in_pk_indices.iter().all(|&d| d < prefix_len));
-            compute_vnode(&pk_prefix, &self.dist_key_in_pk_indices, &self.vnodes)
-        };
-
         if let Some(vnode_col_idx_in_pk) = self.vnode_col_idx_in_pk {
             let vnode = pk_prefix.datum_at(vnode_col_idx_in_pk).unwrap();
-            let vnode = VirtualNode::from_scalar(vnode.into_int16());
-            // If the dist key indices is not empty, we additionally compute the vnode from the
-            // distribution key and assert that the two values are equal.
-            if cfg!(debug_assertions) && !self.dist_key_indices.is_empty() {
-                let computed_vnode = compute_vnode();
-                assert_eq!(vnode, computed_vnode);
-            }
-            vnode
+            VirtualNode::from_scalar(vnode.into_int16())
         } else {
-            compute_vnode()
+            // For streaming, the given prefix must be enough to calculate the vnode
+            assert!(self.dist_key_in_pk_indices.iter().all(|&d| d < prefix_len));
+            compute_vnode(pk_prefix, &self.dist_key_in_pk_indices, &self.vnodes)
         }
     }
 

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -22,6 +22,7 @@ glob = "0.3"
 itertools = "0.10"
 madsim = "0.2.17"
 paste = "1"
+pretty_assertions = "1"
 rand = "0.8"
 rdkafka = { package = "madsim-rdkafka", version = "=0.2.14-alpha", features = ["cmake-build"] }
 risingwave_common = { path = "../../common" }

--- a/src/tests/simulation/src/nexmark.rs
+++ b/src/tests/simulation/src/nexmark.rs
@@ -174,7 +174,7 @@ pub mod queries {
     pub mod q18 {
         use super::*;
         pub const CREATE: &str = include_str!("nexmark/q18.sql");
-        pub const SELECT: &str = "SELECT * FROM nexmark_q18 ORDER BY auction, bidder;";
+        pub const SELECT: &str = "SELECT * FROM nexmark_q18 ORDER BY auction, bidder, price DESC;";
         pub const DROP: &str = "DROP MATERIALIZED VIEW nexmark_q18;";
         pub const INITIAL_INTERVAL: Duration = DEFAULT_INITIAL_INTERVAL;
         pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;

--- a/src/tests/simulation/src/nexmark.rs
+++ b/src/tests/simulation/src/nexmark.rs
@@ -151,6 +151,24 @@ pub mod queries {
         pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;
     }
 
+    pub mod q15 {
+        use super::*;
+        pub const CREATE: &str = include_str!("nexmark/q15.sql");
+        pub const SELECT: &str = "SELECT * FROM nexmark_q15 ORDER BY day ASC, total_bids DESC;";
+        pub const DROP: &str = "DROP MATERIALIZED VIEW nexmark_q15;";
+        pub const INITIAL_INTERVAL: Duration = DEFAULT_INITIAL_INTERVAL;
+        pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;
+    }
+
+    pub mod q18 {
+        use super::*;
+        pub const CREATE: &str = include_str!("nexmark/q18.sql");
+        pub const SELECT: &str = "SELECT * FROM nexmark_q18 ORDER BY auction, bidder;";
+        pub const DROP: &str = "DROP MATERIALIZED VIEW nexmark_q18;";
+        pub const INITIAL_INTERVAL: Duration = DEFAULT_INITIAL_INTERVAL;
+        pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;
+    }
+
     pub mod q101 {
         use super::*;
         pub const CREATE: &str = include_str!("nexmark/q101.sql");

--- a/src/tests/simulation/src/nexmark.rs
+++ b/src/tests/simulation/src/nexmark.rs
@@ -224,4 +224,13 @@ pub mod queries {
         pub const INITIAL_INTERVAL: Duration = DEFAULT_INITIAL_INTERVAL;
         pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;
     }
+
+    pub mod q106 {
+        use super::*;
+        pub const CREATE: &str = include_str!("nexmark/q106.sql");
+        pub const SELECT: &str = "SELECT * FROM nexmark_q106;";
+        pub const DROP: &str = "DROP MATERIALIZED VIEW nexmark_q106;";
+        pub const INITIAL_INTERVAL: Duration = DEFAULT_INITIAL_INTERVAL;
+        pub const INITIAL_TIMEOUT: Duration = DEFAULT_INITIAL_TIMEOUT;
+    }
 }

--- a/src/tests/simulation/src/nexmark/create_source.sql
+++ b/src/tests/simulation/src/nexmark/create_source.sql
@@ -8,7 +8,8 @@ create source auction (
     expires TIMESTAMP,
     seller BIGINT,
     category BIGINT,
-    "extra" VARCHAR)
+    "extra" VARCHAR
+    {watermark_column})
 with (
     connector = 'nexmark',
     nexmark.table.type = 'Auction'
@@ -22,7 +23,8 @@ create source bid (
     "channel" VARCHAR,
     "url" VARCHAR,
     "date_time" TIMESTAMP,
-    "extra" VARCHAR)
+    "extra" VARCHAR
+    {watermark_column})
 with (
     connector = 'nexmark',
     nexmark.table.type = 'Bid'
@@ -30,14 +32,15 @@ with (
 );
 
 create source person (
-    id BIGINT, 
+    id BIGINT,
     name VARCHAR,
     "email_address" VARCHAR,
-    "credit_card" VARCHAR, 
+    "credit_card" VARCHAR,
     city VARCHAR,
     state VARCHAR,
     "date_time" TIMESTAMP,
-    "extra" VARCHAR)
+    "extra" VARCHAR
+    {watermark_column})
 with (
     connector = 'nexmark',
     nexmark.table.type = 'Person'

--- a/src/tests/simulation/src/nexmark/q106.sql
+++ b/src/tests/simulation/src/nexmark/q106.sql
@@ -2,6 +2,8 @@
 --
 -- Show the minimum final price of all auctions.
 
+CREATE MATERIALIZED VIEW nexmark_q106
+AS
 SELECT
     MIN(final) AS min_final
 FROM

--- a/src/tests/simulation/src/nexmark/q106.sql
+++ b/src/tests/simulation/src/nexmark/q106.sql
@@ -1,0 +1,20 @@
+-- A self-made query that covers two-phase stateful simple aggregation.
+--
+-- Show the minimum final price of all auctions.
+
+SELECT
+    MIN(final) AS min_final
+FROM
+    (
+        SELECT
+            auction.id,
+            MAX(price) AS final
+        FROM
+            auction,
+            bid
+        WHERE
+            bid.auction = auction.id
+            AND bid.date_time BETWEEN auction.date_time AND auction.expires
+        GROUP BY
+            auction.id
+    )

--- a/src/tests/simulation/src/nexmark/q15.sql
+++ b/src/tests/simulation/src/nexmark/q15.sql
@@ -1,0 +1,20 @@
+-- Covers append-only hash aggregation with `distinct`.
+
+CREATE MATERIALIZED VIEW nexmark_q15
+AS
+SELECT
+    TO_CHAR(date_time, 'yyyy-MM-dd') as day,
+    count(*) AS total_bids,
+    count(*) filter (where price < 10000) AS rank1_bids,
+    count(*) filter (where price >= 10000 and price < 1000000) AS rank2_bids,
+    count(*) filter (where price >= 1000000) AS rank3_bids,
+    count(distinct bidder) AS total_bidders,
+    count(distinct bidder) filter (where price < 10000) AS rank1_bidders,
+    count(distinct bidder) filter (where price >= 10000 and price < 1000000) AS rank2_bidders,
+    count(distinct bidder) filter (where price >= 1000000) AS rank3_bidders,
+    count(distinct auction) AS total_auctions,
+    count(distinct auction) filter (where price < 10000) AS rank1_auctions,
+    count(distinct auction) filter (where price >= 10000 and price < 1000000) AS rank2_auctions,
+    count(distinct auction) filter (where price >= 1000000) AS rank3_auctions
+FROM bid
+GROUP BY to_char(date_time, 'yyyy-MM-dd');

--- a/src/tests/simulation/src/nexmark/q18.sql
+++ b/src/tests/simulation/src/nexmark/q18.sql
@@ -1,8 +1,10 @@
 -- Covers group top-n (deduplication).
+--
+-- Note: the `ROW_NUMBER` is replaced with `RANK` to make the query result deterministic.
 
 CREATE MATERIALIZED VIEW nexmark_q18
 AS
 SELECT auction, bidder, price, channel, url, date_time, extra
-FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
+FROM (SELECT *, RANK() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
       FROM bid)
 WHERE rank_number <= 1;

--- a/src/tests/simulation/src/nexmark/q18.sql
+++ b/src/tests/simulation/src/nexmark/q18.sql
@@ -1,0 +1,8 @@
+-- Covers group top-n (deduplication).
+
+CREATE MATERIALIZED VIEW nexmark_q18
+AS
+SELECT auction, bidder, price, channel, url, date_time, extra
+FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
+      FROM bid)
+WHERE rank_number <= 1;

--- a/src/tests/simulation/src/utils.rs
+++ b/src/tests/simulation/src/utils.rs
@@ -16,14 +16,14 @@ pub trait AssertResult: AsRef<str> + Sized {
     /// Asserts that the result is equal to the expected result after trimming whitespace.
     #[track_caller]
     fn assert_result_eq(self, other: impl AsRef<str>) -> Self {
-        assert_eq!(self.as_ref().trim(), other.as_ref().trim());
+        pretty_assertions::assert_str_eq!(self.as_ref().trim(), other.as_ref().trim());
         self
     }
 
     /// Asserts that the result is not equal to the expected result after trimming whitespace.
     #[track_caller]
     fn assert_result_ne(self, other: impl AsRef<str>) -> Self {
-        assert_ne!(self.as_ref().trim(), other.as_ref().trim());
+        pretty_assertions::assert_ne!(self.as_ref().trim(), other.as_ref().trim());
         self
     }
 }

--- a/src/tests/simulation/tests/it/nexmark_chaos.rs
+++ b/src/tests/simulation/tests/it/nexmark_chaos.rs
@@ -40,7 +40,7 @@ async fn nexmark_chaos_common_inner(
     multiple: bool,
 ) -> Result<()> {
     let mut cluster =
-        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT), true).await?;
+        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT), false).await?;
     cluster.run(create).await?;
     sleep(Duration::from_secs(30)).await;
     let final_result = cluster.run(select).await?;

--- a/src/tests/simulation/tests/it/nexmark_chaos.rs
+++ b/src/tests/simulation/tests/it/nexmark_chaos.rs
@@ -159,6 +159,8 @@ test!(q7);
 test!(q8);
 test!(q9);
 // q10+: duplicated or unsupported
+test!(q15);
+test!(q18);
 
 // Self made queries.
 test!(q101);

--- a/src/tests/simulation/tests/it/nexmark_chaos.rs
+++ b/src/tests/simulation/tests/it/nexmark_chaos.rs
@@ -168,3 +168,4 @@ test!(q102);
 test!(q103);
 test!(q104);
 test!(q105);
+test!(q106);

--- a/src/tests/simulation/tests/it/nexmark_chaos.rs
+++ b/src/tests/simulation/tests/it/nexmark_chaos.rs
@@ -40,7 +40,7 @@ async fn nexmark_chaos_common_inner(
     multiple: bool,
 ) -> Result<()> {
     let mut cluster =
-        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT)).await?;
+        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT), true).await?;
     cluster.run(create).await?;
     sleep(Duration::from_secs(30)).await;
     let final_result = cluster.run(select).await?;

--- a/src/tests/simulation/tests/it/nexmark_q4.rs
+++ b/src/tests/simulation/tests/it/nexmark_q4.rs
@@ -46,7 +46,7 @@ const RESULT: &str = r#"
 
 async fn init() -> Result<NexmarkCluster> {
     let mut cluster =
-        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT)).await?;
+        NexmarkCluster::new(Configuration::for_scale(), 6, Some(20 * THROUGHPUT), false).await?;
     cluster.run(CREATE).await?;
     Ok(cluster)
 }

--- a/src/tests/simulation/tests/it/nexmark_source.rs
+++ b/src/tests/simulation/tests/it/nexmark_source.rs
@@ -28,7 +28,8 @@ use risingwave_simulation::utils::AssertResult;
 async fn nexmark_source() -> Result<()> {
     let events = 20 * THROUGHPUT;
 
-    let mut cluster = NexmarkCluster::new(Configuration::for_scale(), 6, Some(events)).await?;
+    let mut cluster =
+        NexmarkCluster::new(Configuration::for_scale(), 6, Some(events), false).await?;
 
     // Materialize all sources so that we can also check whether the row id generator is working
     // correctly after scaling.


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds some tests to cover more operators in nexmark chaos tests.
- ~Add watermark column for nexmark-chaos and `nexmark_source.yaml`, to cover `WatermarkFilter`.~ Watermark does not survive scaling test, will investigate later.
- q15: Covers append-only hash aggregation with `distinct`.
- q18: Covers group top-n (possibly deduplication in the future).
- q106: self-made, covers two-phase stateful simple aggregation. (Close #7788)

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
