### PR TITLE
feat(cmd_all): sort component strings in err msg

### DIFF
--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -162,7 +162,9 @@ fn main() -> Result<()> {
             func(args)?;
         }
         None => {
-            bail!("unknown target: {}\nPlease either:\n* set `RW_NODE` env variable (`RW_NODE=<component>`)\n* create a symbol link to `risingwave` binary (ln -s risingwave <component>)\n* start with subcommand `risingwave <component>``\nwith one of the following: {:?}", target, fns.keys().collect::<Vec<_>>());
+            let mut components = fns.keys().collect::<Vec<_>>();
+            components.sort();
+            bail!("unknown target: {}\nPlease either:\n* set `RW_NODE` env variable (`RW_NODE=<component>`)\n* create a symbol link to `risingwave` binary (ln -s risingwave <component>)\n* start with subcommand `risingwave <component>``\nwith one of the following: {:?}", target, components);
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
clearer err msg

```
> ./target/debug/risingwave 
Error: unknown target: risingwave
Please either:
* set `RW_NODE` env variable (`RW_NODE=<component>`)
* create a symbol link to `risingwave` binary (ln -s risingwave <component>)
* start with subcommand `risingwave <component>``
with one of the following: ["compactor", "compactor-node", "compactor_node", "compute", "compute-node", "compute_node", "ctl", "frontend", "frontend-node", "frontend_node", "meta", "meta-node", "meta_node", "play", "playground", "risectl"]
```

@JuchangGit hope this is clearer for you.

## Checklist For Contributors

- [X] I have written necessary rustdoc comments
- [X] I have added necessary unit tests and integration tests
- [X] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [X] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [X] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [X] My PR **DOES NOT** contain user-facing changes.

## Related

Should fix: https://github.com/risingwavelabs/risingwave/issues/8211
