### PR TITLE
feat(compaction):  support split compaction group

### DIFF
--- a/dashboard/proto/gen/hummock.ts
+++ b/dashboard/proto/gen/hummock.ts
@@ -774,6 +774,7 @@ export interface SplitCompactionGroupRequest {
 }
 
 export interface SplitCompactionGroupResponse {
+  newGroupId: number;
 }
 
 export interface CompactionConfig {
@@ -4273,21 +4274,23 @@ export const SplitCompactionGroupRequest = {
 };
 
 function createBaseSplitCompactionGroupResponse(): SplitCompactionGroupResponse {
-  return {};
+  return { newGroupId: 0 };
 }
 
 export const SplitCompactionGroupResponse = {
-  fromJSON(_: any): SplitCompactionGroupResponse {
-    return {};
+  fromJSON(object: any): SplitCompactionGroupResponse {
+    return { newGroupId: isSet(object.newGroupId) ? Number(object.newGroupId) : 0 };
   },
 
-  toJSON(_: SplitCompactionGroupResponse): unknown {
+  toJSON(message: SplitCompactionGroupResponse): unknown {
     const obj: any = {};
+    message.newGroupId !== undefined && (obj.newGroupId = Math.round(message.newGroupId));
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<SplitCompactionGroupResponse>, I>>(_: I): SplitCompactionGroupResponse {
+  fromPartial<I extends Exact<DeepPartial<SplitCompactionGroupResponse>, I>>(object: I): SplitCompactionGroupResponse {
     const message = createBaseSplitCompactionGroupResponse();
+    message.newGroupId = object.newGroupId ?? 0;
     return message;
   },
 };

--- a/dashboard/proto/gen/hummock.ts
+++ b/dashboard/proto/gen/hummock.ts
@@ -768,6 +768,14 @@ export interface PinVersionResponse {
   pinnedVersion: HummockVersion | undefined;
 }
 
+export interface SplitCompactionGroupRequest {
+  groupId: number;
+  tableIds: number[];
+}
+
+export interface SplitCompactionGroupResponse {
+}
+
 export interface CompactionConfig {
   maxBytesForLevelBase: number;
   maxLevel: number;
@@ -4229,6 +4237,57 @@ export const PinVersionResponse = {
     message.pinnedVersion = (object.pinnedVersion !== undefined && object.pinnedVersion !== null)
       ? HummockVersion.fromPartial(object.pinnedVersion)
       : undefined;
+    return message;
+  },
+};
+
+function createBaseSplitCompactionGroupRequest(): SplitCompactionGroupRequest {
+  return { groupId: 0, tableIds: [] };
+}
+
+export const SplitCompactionGroupRequest = {
+  fromJSON(object: any): SplitCompactionGroupRequest {
+    return {
+      groupId: isSet(object.groupId) ? Number(object.groupId) : 0,
+      tableIds: Array.isArray(object?.tableIds) ? object.tableIds.map((e: any) => Number(e)) : [],
+    };
+  },
+
+  toJSON(message: SplitCompactionGroupRequest): unknown {
+    const obj: any = {};
+    message.groupId !== undefined && (obj.groupId = Math.round(message.groupId));
+    if (message.tableIds) {
+      obj.tableIds = message.tableIds.map((e) => Math.round(e));
+    } else {
+      obj.tableIds = [];
+    }
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SplitCompactionGroupRequest>, I>>(object: I): SplitCompactionGroupRequest {
+    const message = createBaseSplitCompactionGroupRequest();
+    message.groupId = object.groupId ?? 0;
+    message.tableIds = object.tableIds?.map((e) => e) || [];
+    return message;
+  },
+};
+
+function createBaseSplitCompactionGroupResponse(): SplitCompactionGroupResponse {
+  return {};
+}
+
+export const SplitCompactionGroupResponse = {
+  fromJSON(_: any): SplitCompactionGroupResponse {
+    return {};
+  },
+
+  toJSON(_: SplitCompactionGroupResponse): unknown {
+    const obj: any = {};
+    return obj;
+  },
+
+  fromPartial<I extends Exact<DeepPartial<SplitCompactionGroupResponse>, I>>(_: I): SplitCompactionGroupResponse {
+    const message = createBaseSplitCompactionGroupResponse();
     return message;
   },
 };

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -543,6 +543,13 @@ message PinVersionResponse {
   HummockVersion pinned_version = 1;
 }
 
+message SplitCompactionGroupRequest {
+  uint64 group_id = 1;
+  repeated uint32 table_ids = 2;
+}
+
+message SplitCompactionGroupResponse {}
+
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);
   rpc GetCurrentVersion(GetCurrentVersionRequest) returns (GetCurrentVersionResponse);
@@ -571,6 +578,7 @@ service HummockManagerService {
   rpc InitMetadataForReplay(InitMetadataForReplayRequest) returns (InitMetadataForReplayResponse);
   rpc SetCompactorRuntimeConfig(SetCompactorRuntimeConfigRequest) returns (SetCompactorRuntimeConfigResponse);
   rpc PinVersion(PinVersionRequest) returns (PinVersionResponse);
+  rpc SplitCompactionGroup(SplitCompactionGroupRequest) returns (SplitCompactionGroupResponse);
 }
 
 message CompactionConfig {

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -548,7 +548,9 @@ message SplitCompactionGroupRequest {
   repeated uint32 table_ids = 2;
 }
 
-message SplitCompactionGroupResponse {}
+message SplitCompactionGroupResponse {
+  uint64 new_group_id = 1;
+}
 
 service HummockManagerService {
   rpc UnpinVersionBefore(UnpinVersionBeforeRequest) returns (UnpinVersionBeforeResponse);

--- a/src/ctl/src/cmd_impl/hummock/compaction_group.rs
+++ b/src/ctl/src/cmd_impl/hummock/compaction_group.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_hummock_sdk::compaction_group::StateTableId;
 use risingwave_hummock_sdk::CompactionGroupId;
 use risingwave_pb::hummock::rise_ctl_update_compaction_config_request::mutable_config::MutableConfig;
 
@@ -34,7 +35,7 @@ pub async fn update_compaction_config(
         .risectl_update_compaction_config(ids.as_slice(), configs.as_slice())
         .await?;
     println!(
-        "Succeed: update compaction groups {:#?}\n with configs {:#?}",
+        "Succeed: update compaction groups {:#?} with configs {:#?}.",
         ids, configs
     );
     Ok(())
@@ -77,4 +78,20 @@ pub fn build_compaction_config_vec(
         configs.push(MutableConfig::MaxSubCompaction(c));
     }
     configs
+}
+
+pub async fn split_compaction_group(
+    context: &CtlContext,
+    group_id: CompactionGroupId,
+    table_ids_to_new_group: &[StateTableId],
+) -> anyhow::Result<()> {
+    let meta_client = context.meta_client().await?;
+    let new_group_id = meta_client
+        .split_compaction_group(group_id, table_ids_to_new_group)
+        .await?;
+    println!(
+        "Succeed: split compaction group {}. tables {:#?} are moved to new group {}.",
+        group_id, table_ids_to_new_group, new_group_id
+    );
+    Ok(())
 }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -140,6 +140,13 @@ enum HummockCommands {
         #[clap(long)]
         max_sub_compaction: Option<u32>,
     },
+    /// Split given compaction group into two. Moves the given tables to the new group.
+    SplitCompactionGroup {
+        #[clap(long)]
+        compaction_group_id: u64,
+        #[clap(long)]
+        table_ids: Vec<u32>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -276,6 +283,13 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                 ),
             )
             .await?
+        }
+        Commands::Hummock(HummockCommands::SplitCompactionGroup {
+            compaction_group_id,
+            table_ids,
+        }) => {
+            cmd_impl::hummock::split_compaction_group(context, compaction_group_id, &table_ids)
+                .await?;
         }
         Commands::Table(TableCommands::Scan { mv_name }) => {
             cmd_impl::table::scan(context, mv_name).await?

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -416,14 +416,15 @@ impl<S: MetaStore> HummockManager<S> {
     }
 
     /// Splits a compaction group into two. The new one will contain `table_ids`.
+    /// Returns the newly created compaction group id.
     #[named]
     pub async fn split_compaction_group(
         &self,
         parent_group_id: CompactionGroupId,
         table_ids: &[StateTableId],
-    ) -> Result<()> {
+    ) -> Result<CompactionGroupId> {
         if table_ids.is_empty() {
-            return Ok(());
+            return Ok(parent_group_id);
         }
         let table_ids = table_ids.iter().cloned().unique().collect_vec();
         let mut versioning_guard = write_lock!(self, versioning).await;
@@ -532,7 +533,7 @@ impl<S: MetaStore> HummockManager<S> {
         branched_ssts.commit_memory();
         self.notify_last_version_delta(versioning);
 
-        Ok(())
+        Ok(new_group_id)
     }
 }
 

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -1334,6 +1334,34 @@ async fn test_split_compaction_group_on_commit() {
             .member_table_ids,
         vec![101]
     );
+    let branched_ssts = hummock_manager
+        .versioning
+        .read(&["", "", ""])
+        .await
+        .branched_ssts
+        .clone();
+    assert_eq!(branched_ssts.len(), 1);
+    assert_eq!(branched_ssts.values().next().unwrap().len(), 2);
+    assert_eq!(
+        branched_ssts
+            .values()
+            .next()
+            .unwrap()
+            .get(&2)
+            .cloned()
+            .unwrap(),
+        1
+    );
+    assert_eq!(
+        branched_ssts
+            .values()
+            .next()
+            .unwrap()
+            .get(&3)
+            .cloned()
+            .unwrap(),
+        1
+    );
 }
 
 #[tokio::test]
@@ -1460,6 +1488,34 @@ async fn test_split_compaction_group_on_demand() {
             .member_table_ids,
         vec![100, 101]
     );
+    let branched_ssts = hummock_manager
+        .versioning
+        .read(&["", "", ""])
+        .await
+        .branched_ssts
+        .clone();
+    assert_eq!(branched_ssts.len(), 2);
+    for sst_id in [10, 11] {
+        assert_eq!(branched_ssts.get(&sst_id).unwrap().len(), 2);
+        assert_eq!(
+            branched_ssts
+                .get(&sst_id)
+                .unwrap()
+                .get(&2)
+                .cloned()
+                .unwrap(),
+            1
+        );
+        assert_eq!(
+            branched_ssts
+                .get(&sst_id)
+                .unwrap()
+                .get(&new_group_id)
+                .cloned()
+                .unwrap(),
+            1
+        );
+    }
 }
 
 #[tokio::test]

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -498,4 +498,15 @@ where
             }
         }
     }
+
+    async fn split_compaction_group(
+        &self,
+        request: Request<SplitCompactionGroupRequest>,
+    ) -> Result<Response<SplitCompactionGroupResponse>, Status> {
+        let req = request.into_inner();
+        self.hummock_manager
+            .split_compaction_group(req.group_id, &req.table_ids)
+            .await?;
+        Ok(Response::new(SplitCompactionGroupResponse {}))
+    }
 }

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -504,9 +504,10 @@ where
         request: Request<SplitCompactionGroupRequest>,
     ) -> Result<Response<SplitCompactionGroupResponse>, Status> {
         let req = request.into_inner();
-        self.hummock_manager
+        let new_group_id = self
+            .hummock_manager
             .split_compaction_group(req.group_id, &req.table_ids)
             .await?;
-        Ok(Response::new(SplitCompactionGroupResponse {}))
+        Ok(Response::new(SplitCompactionGroupResponse { new_group_id }))
     }
 }

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -242,6 +242,8 @@ impl HummockVersionUpdateExt for HummockVersion {
                         insert_table_infos.push(branch_table_info);
                     }
                 }
+                // Remove SST from sub level may result in empty sub level. It will be purged
+                // whenever another compaction task is finished.
                 let removed = sub_level
                     .table_infos
                     .drain_filter(|sst_info| sst_info.table_ids.is_empty())

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -31,7 +31,6 @@ use risingwave_meta::hummock::test_utils::{
 use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::LocalNotification;
 use risingwave_meta::storage::MemStore;
-use risingwave_pb::common::{WorkerNode, WorkerType};
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::compactor::{Compactor, CompactorContext};

--- a/src/storage/hummock_test/src/sync_point_tests.rs
+++ b/src/storage/hummock_test/src/sync_point_tests.rs
@@ -31,7 +31,7 @@ use risingwave_meta::hummock::test_utils::{
 use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
 use risingwave_meta::manager::LocalNotification;
 use risingwave_meta::storage::MemStore;
-use risingwave_pb::common::WorkerNode;
+use risingwave_pb::common::{WorkerNode, WorkerType};
 use risingwave_pb::hummock::compact_task::TaskStatus;
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::compactor::{Compactor, CompactorContext};
@@ -181,10 +181,7 @@ async fn test_syncpoints_test_local_notification_receiver() {
 
     // Test release hummock contexts
     env.notification_manager()
-        .notify_local_subscribers(LocalNotification::WorkerNodeIsDeleted(WorkerNode {
-            id: context_id,
-            ..Default::default()
-        }))
+        .notify_local_subscribers(LocalNotification::WorkerNodeIsDeleted(worker_node))
         .await;
     sync_point::wait_timeout(
         "AFTER_RELEASE_HUMMOCK_CONTEXTS_ASYNC",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR exposes RPC to split a compaction group into two.
Also add corresponding risectl cmd.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
