### PR TITLE
refactor(optimizer): refine logical optimizer

### DIFF
--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -276,7 +276,7 @@ impl LogicalOptimizer {
         }
         // Predicate push down before translate apply, because we need to calculate the domain
         // and predicate push down can reduce the size of domain.
-        plan = Self::predicate_pushdown(plan, explain_trace, &ctx);
+        plan = Self::predicate_pushdown(plan, explain_trace, ctx);
         // General Unnesting.
         // Translate Apply, push Apply down the plan and finally replace Apply with regular inner
         // join.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR does not change the optimizer's behavior except bring forward the `UNION_MERGE` rule. I think it is mixed into unnesting logic by mistake.

extract some common logic into functions.
- predicate pushdown
- unnesting
- col prune

The PR do not change them:
- join reorder, because we will have a different strategy for streaming soon. https://github.com/risingwavelabs/rfcs/pull/23
- optimization about OverWindow, because we might implement the execution with separate progress.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

