### PR TITLE
feat: package dashboard artifact in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,6 +23,9 @@ ENV IN_CONTAINER=1
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
 
+RUN curl -LO https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
+RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact /risingwave/ui && rm dashboard-artifact.zip
+
 # We need to add the `rustfmt` dependency, otherwise `risingwave_pb` will not compile
 RUN rustup self update \
   && rustup set profile minimal \
@@ -50,11 +53,10 @@ LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwa
 RUN mkdir -p /risingwave/bin/connector-node
 COPY --from=builder /risingwave/bin/risingwave /risingwave/bin/risingwave
 COPY --from=builder /risingwave/bin/connector-node /risingwave/bin/connector-node
+COPY --from=builder /risingwave/ui /risingwave/ui
 # Set default playground mode to docker-playground profile
 ENV PLAYGROUND_PROFILE docker-playground
 # Set default dashboard UI to local path instead of github proxy
-RUN curl -LO https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
-RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact /risingwave/ui && rm dashboard-artifact.zip
 ENV RW_DASHBOARD_UI_PATH /risingwave/ui
 ENTRYPOINT [ "/risingwave/bin/risingwave" ]
 CMD [ "playground" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 as base
 
 ENV LANG en_US.utf8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven git
 
 FROM base as builder
 
@@ -42,6 +42,8 @@ RUN for component in "risingwave" "compute-node" "meta-node" "frontend" "compact
 RUN cd risingwave-connector-node && mvn -B package -Dmaven.test.skip=true
 RUN tar -zxvf /risingwave/risingwave-connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
 
+RUN git worktree add /risingwave/ui origin/dashboard-artifact
+
 FROM ubuntu:22.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-11-jdk && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
@@ -52,5 +54,7 @@ COPY --from=builder /risingwave/bin/risingwave /risingwave/bin/risingwave
 COPY --from=builder /risingwave/bin/connector-node /risingwave/bin/connector-node
 # Set default playground mode to docker-playground profile
 ENV PLAYGROUND_PROFILE docker-playground
+# Set default dashboard UI to local path instead of github proxy
+ENV RW_DASHBOARD_UI_PATH /risingwave/ui
 ENTRYPOINT [ "/risingwave/bin/risingwave" ]
 CMD [ "playground" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,9 +23,6 @@ ENV IN_CONTAINER=1
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
 
-RUN curl -O https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
-RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact ui && rm dashboard-artifact.zip
-
 # We need to add the `rustfmt` dependency, otherwise `risingwave_pb` will not compile
 RUN rustup self update \
   && rustup set profile minimal \
@@ -56,6 +53,8 @@ COPY --from=builder /risingwave/bin/connector-node /risingwave/bin/connector-nod
 # Set default playground mode to docker-playground profile
 ENV PLAYGROUND_PROFILE docker-playground
 # Set default dashboard UI to local path instead of github proxy
+RUN curl -LO https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
+RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact /risingwave/ui && rm dashboard-artifact.zip
 ENV RW_DASHBOARD_UI_PATH /risingwave/ui
 ENTRYPOINT [ "/risingwave/bin/risingwave" ]
 CMD [ "playground" ]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 as base
 
 ENV LANG en_US.utf8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven unzip
 
 FROM base as builder
 
@@ -24,7 +24,7 @@ ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
 
 RUN curl -LO https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
-RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact /risingwave/ui && rm dashboard-artifact.zip
+RUN unzip dashboard-artifact.zip && mv risingwave-dashboard-artifact /risingwave/ui && rm dashboard-artifact.zip
 
 # We need to add the `rustfmt` dependency, otherwise `risingwave_pb` will not compile
 RUN rustup self update \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04 as base
 
 ENV LANG en_US.utf8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven git
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl pkg-config bash lld maven
 
 FROM base as builder
 
@@ -23,6 +23,9 @@ ENV IN_CONTAINER=1
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
 
+RUN wget https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
+RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact ui && rm dashboard-artifact.zip
+
 # We need to add the `rustfmt` dependency, otherwise `risingwave_pb` will not compile
 RUN rustup self update \
   && rustup set profile minimal \
@@ -41,8 +44,6 @@ RUN for component in "risingwave" "compute-node" "meta-node" "frontend" "compact
 
 RUN cd risingwave-connector-node && mvn -B package -Dmaven.test.skip=true
 RUN tar -zxvf /risingwave/risingwave-connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
-
-RUN git worktree add /risingwave/ui origin/dashboard-artifact
 
 FROM ubuntu:22.04 as image-base
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-11-jdk && rm -rf /var/lib/{apt,dpkg,cache,log}/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -23,7 +23,7 @@ ENV IN_CONTAINER=1
 ARG GIT_SHA
 ENV GIT_SHA=$GIT_SHA
 
-RUN wget https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
+RUN curl -O https://github.com/risingwavelabs/risingwave/archive/refs/heads/dashboard-artifact.zip
 RUN tar -zxvf dashboard-artifact.zip && mv risingwave-dashboard-artifact ui && rm dashboard-artifact.zip
 
 # We need to add the `rustfmt` dependency, otherwise `risingwave_pb` will not compile


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously when using RisingWave via docker, dashboard artifact is proxied to GitHub, so it's not accessible without internet connection. This PR adds dashboard artifact to the docker image and use the local one.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Documentation


<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->


### Types of user-facing changes


- Installation and deployment
- Other (please specify in the release note below)

### Release note



</details>
