### PR TITLE
perf(stream,agg): reuse existing `count(*)` as internal row count agg call

### DIFF
--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -511,6 +511,7 @@ export interface SimpleAggNode {
    */
   isAppendOnly: boolean;
   distinctDedupTables: { [key: number]: Table };
+  rowCountIndex: number;
 }
 
 export interface SimpleAggNode_DistinctDedupTablesEntry {
@@ -531,6 +532,7 @@ export interface HashAggNode {
    */
   isAppendOnly: boolean;
   distinctDedupTables: { [key: number]: Table };
+  rowCountIndex: number;
 }
 
 export interface HashAggNode_DistinctDedupTablesEntry {
@@ -2336,6 +2338,7 @@ function createBaseSimpleAggNode(): SimpleAggNode {
     resultTable: undefined,
     isAppendOnly: false,
     distinctDedupTables: {},
+    rowCountIndex: 0,
   };
 }
 
@@ -2355,6 +2358,7 @@ export const SimpleAggNode = {
           return acc;
         }, {})
         : {},
+      rowCountIndex: isSet(object.rowCountIndex) ? Number(object.rowCountIndex) : 0,
     };
   },
 
@@ -2384,6 +2388,7 @@ export const SimpleAggNode = {
         obj.distinctDedupTables[k] = Table.toJSON(v);
       });
     }
+    message.rowCountIndex !== undefined && (obj.rowCountIndex = Math.round(message.rowCountIndex));
     return obj;
   },
 
@@ -2405,6 +2410,7 @@ export const SimpleAggNode = {
       },
       {},
     );
+    message.rowCountIndex = object.rowCountIndex ?? 0;
     return message;
   },
 };
@@ -2446,6 +2452,7 @@ function createBaseHashAggNode(): HashAggNode {
     resultTable: undefined,
     isAppendOnly: false,
     distinctDedupTables: {},
+    rowCountIndex: 0,
   };
 }
 
@@ -2465,6 +2472,7 @@ export const HashAggNode = {
           return acc;
         }, {})
         : {},
+      rowCountIndex: isSet(object.rowCountIndex) ? Number(object.rowCountIndex) : 0,
     };
   },
 
@@ -2494,6 +2502,7 @@ export const HashAggNode = {
         obj.distinctDedupTables[k] = Table.toJSON(v);
       });
     }
+    message.rowCountIndex !== undefined && (obj.rowCountIndex = Math.round(message.rowCountIndex));
     return obj;
   },
 
@@ -2515,6 +2524,7 @@ export const HashAggNode = {
       },
       {},
     );
+    message.rowCountIndex = object.rowCountIndex ?? 0;
     return message;
   },
 };

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -225,6 +225,7 @@ message SimpleAggNode {
   // It is true when the input is append-only
   bool is_append_only = 5;
   map<uint32, catalog.Table> distinct_dedup_tables = 6;
+  uint32 row_count_index = 7;
 }
 
 message HashAggNode {
@@ -236,6 +237,7 @@ message HashAggNode {
   // It is true when the input is append-only
   bool is_append_only = 5;
   map<uint32, catalog.Table> distinct_dedup_tables = 6;
+  uint32 row_count_index = 7;
 }
 
 message TopNNode {

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -32,7 +32,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.v1, (min(t.v2) + (max(t.v3) * count(t.v1))) as $expr1] }
-      └─StreamHashAgg { group_key: [t.v1], aggs: [count, min(t.v2), max(t.v3), count(t.v1)] }
+      └─StreamHashAgg { group_key: [t.v1], aggs: [min(t.v2), max(t.v3), count(t.v1), count] }
         └─StreamExchange { dist: HashShard(t.v1) }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
@@ -52,9 +52,9 @@
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v2)) * sum0(count(t.v3)))) as $expr2] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), max(max(t.v2)), sum0(count(t.v3))] }
+      └─StreamGlobalSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v2)), sum0(count(t.v3)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), max(t.v2), count(t.v3)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [min(t.v1), max(t.v2), count(t.v3), count] }
             └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
@@ -84,7 +84,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v3, agg], pk_columns: [v3], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.v3, (min(t.v1) * (sum($expr1)::Decimal / count($expr1))) as $expr2] }
-      └─StreamHashAgg { group_key: [t.v3], aggs: [count, min(t.v1), sum($expr1), count($expr1)] }
+      └─StreamHashAgg { group_key: [t.v3], aggs: [min(t.v1), sum($expr1), count($expr1), count] }
         └─StreamExchange { dist: HashShard(t.v3) }
           └─StreamProject { exprs: [t.v3, t.v1, (t.v1 + t.v2) as $expr1, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -152,9 +152,9 @@
   stream_plan: |
     StreamMaterialize { columns: [cnt, sum], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count($expr1)), sum(sum($expr1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum0(count($expr1)), sum(sum($expr1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum0(count($expr1)), sum(sum($expr1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count($expr1), sum($expr1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count($expr1), sum($expr1)] }
             └─StreamProject { exprs: [(t.v1 + t.v2) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
@@ -170,7 +170,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, agg], pk_columns: [v1], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.v1, ((sum($expr1) / count($expr1)) + max(t.v1)) as $expr2] }
-      └─StreamHashAgg { group_key: [t.v1], aggs: [count, sum($expr1), count($expr1), max(t.v1)] }
+      └─StreamHashAgg { group_key: [t.v1], aggs: [sum($expr1), count($expr1), max(t.v1), count] }
         └─StreamExchange { dist: HashShard(t.v1) }
           └─StreamProject { exprs: [t.v1, (t.v2 + t.v3) as $expr1, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -422,9 +422,9 @@
   stream_plan: |
     StreamMaterialize { columns: [agg], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [(min(min(t.v1)) + (max(max(t.v3)) * sum0(count(t.v2)))) as $expr2] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), max(max(t.v3)), sum0(count(t.v2))] }
+      └─StreamGlobalSimpleAgg { aggs: [min(min(t.v1)), max(max(t.v3)), sum0(count(t.v2)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), max(t.v3), count(t.v2)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [min(t.v1), max(t.v3), count(t.v2), count] }
             └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: dup group key
@@ -464,7 +464,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v2, min_v1, v3, max_v1, t.v2(hidden)], pk_columns: [v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.v2, min(t.v1), t.v3, max(t.v1), t.v2] }
-      └─StreamHashAgg { group_key: [t.v3, t.v2], aggs: [count, min(t.v1), max(t.v1)] }
+      └─StreamHashAgg { group_key: [t.v3, t.v2], aggs: [min(t.v1), max(t.v1), count] }
         └─StreamExchange { dist: HashShard(t.v2, t.v3) }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: order by agg input
@@ -482,9 +482,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1)] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: order by other columns
   sql: |
@@ -501,9 +501,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1)] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: order by ASC/DESC and default
   sql: |
@@ -520,9 +520,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1)] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: order by NULLS FIRST/LAST and default
   sql: |
@@ -539,9 +539,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1)] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: order by complex expressions
   sql: |
@@ -558,9 +558,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1)] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: filter clause
   sql: |
@@ -577,9 +577,9 @@
   stream_plan: |
     StreamMaterialize { columns: [sa], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v1) filter((t.v1 > 0:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v1) filter((t.v1 > 0:Int32))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v1) filter((t.v1 > 0:Int32))] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v1) filter((t.v1 > 0:Int32))] }
             └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: |
     filter clause
@@ -612,9 +612,9 @@
   stream_plan: |
     StreamMaterialize { columns: [sab], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max($expr1) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, max(max($expr1) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))))] }
+      └─StreamGlobalSimpleAgg { aggs: [max(max($expr1) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr2], aggs: [count, max($expr1) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32)))] }
+          └─StreamHashAgg { group_key: [$expr2], aggs: [max($expr1) filter((t.a < t.b) AND ((t.a + t.b) < 100:Int32) AND ((t.a * t.b) <> ((t.a + t.b) - 1:Int32))), count] }
             └─StreamProject { exprs: [t.a, t.b, $expr1, t._row_id, Vnode(t._row_id) as $expr2] }
               └─StreamProject { exprs: [t.a, t.b, (t.a * t.b) as $expr1, t._row_id] }
                 └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -634,7 +634,7 @@
   stream_plan: |
     StreamMaterialize { columns: [avga, t.b(hidden)], pk_columns: [t.b], pk_conflict: "no check" }
     └─StreamProject { exprs: [(sum(t.a) filter((t.a > t.b))::Decimal / count(t.a) filter((t.a > t.b))) as $expr1, t.b] }
-      └─StreamHashAgg { group_key: [t.b], aggs: [count, sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b))] }
+      └─StreamHashAgg { group_key: [t.b], aggs: [sum(t.a) filter((t.a > t.b)), count(t.a) filter((t.a > t.b)), count] }
         └─StreamExchange { dist: HashShard(t.b) }
           └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: count filter clause
@@ -652,9 +652,9 @@
   stream_plan: |
     StreamMaterialize { columns: [cnt_agb], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count filter((t.a > t.b)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum0(count filter((t.a > t.b)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum0(count filter((t.a > t.b))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count filter((t.a > t.b))] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count filter((t.a > t.b))] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: filter clause + non-boolean function
   sql: |
@@ -692,9 +692,9 @@
   stream_plan: |
     StreamMaterialize { columns: [b], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v2) filter((t.v2 < 5:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v2) filter((t.v2 < 5:Int32))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v2) filter((t.v2 < 5:Int32))] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v2) filter((t.v2 < 5:Int32))] }
             └─StreamTableScan { table: t, columns: [t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: only distinct agg
   sql: |
@@ -723,7 +723,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a, distinct_b_num, sum_c], pk_columns: [a], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.a, count(distinct t.b), sum(t.c)] }
-      └─StreamHashAgg { group_key: [t.a], aggs: [count, count(distinct t.b), sum(t.c)] }
+      └─StreamHashAgg { group_key: [t.a], aggs: [count(distinct t.b), sum(t.c), count] }
         └─StreamExchange { dist: HashShard(t.a) }
           └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: distinct agg and non-disintct agg with intersected argument
@@ -746,7 +746,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a, distinct_b_num, distinct_c_sum, sum_c], pk_columns: [a], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.a, count(distinct t.b), count(distinct t.c), sum(t.c)] }
-      └─StreamHashAgg { group_key: [t.a], aggs: [count, count(distinct t.b), count(distinct t.c), sum(t.c)] }
+      └─StreamHashAgg { group_key: [t.a], aggs: [count(distinct t.b), count(distinct t.c), sum(t.c), count] }
         └─StreamExchange { dist: HashShard(t.a) }
           └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: distinct agg with filter
@@ -767,7 +767,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a, count, sum], pk_columns: [a], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.a, count(distinct t.b) filter((t.b < 100:Int32)), sum(t.c)] }
-      └─StreamHashAgg { group_key: [t.a], aggs: [count, count(distinct t.b) filter((t.b < 100:Int32)), sum(t.c)] }
+      └─StreamHashAgg { group_key: [t.a], aggs: [count(distinct t.b) filter((t.b < 100:Int32)), sum(t.c), count] }
         └─StreamExchange { dist: HashShard(t.a) }
           └─StreamTableScan { table: t, columns: [t.a, t.b, t.c, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: non-distinct agg with filter
@@ -794,9 +794,9 @@
   stream_plan: |
     StreamMaterialize { columns: [s1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum($expr1) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr1) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32)))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1) filter((t.b < 100:Int32) AND ((t.b * 2:Int32) > 10:Int32))] }
             └─StreamProject { exprs: [t.b, (Length(t.a) * t.b) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
@@ -823,7 +823,7 @@
   stream_plan: |
     StreamMaterialize { columns: [cnt, i.x(hidden)], pk_columns: [i.x], pk_conflict: "no check" }
     └─StreamProject { exprs: [count, i.x] }
-      └─StreamHashAgg { group_key: [i.x], aggs: [count, count] }
+      └─StreamHashAgg { group_key: [i.x], aggs: [count] }
         └─StreamTableScan { table: i, columns: [i.x, i.t._row_id], pk: [i.t._row_id], dist: UpstreamHashShard(i.x) }
 - name: distinct aggregates only have one distinct argument doesn't need expand
   sql: |
@@ -1031,9 +1031,9 @@
   stream_plan: |
     StreamMaterialize { columns: [stddev_samp, stddev_pop], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [Case((sum0(count(t.v1)) <= 1:Int64), null:Float64, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / (sum0(count(t.v1)) - 1:Int64))::Float64, 0.5:Float64)) as $expr2, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / sum0(count(t.v1)))::Float64, 0.5:Float64) as $expr3] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr1)), sum(sum(t.v1)), sum0(count(t.v1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1)), sum(sum(t.v1)), sum0(count(t.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum(t.v1), count(t.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1), sum(t.v1), count(t.v1)] }
             └─StreamProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1, t._row_id] }
               └─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: force two phase aggregation should succeed with UpstreamHashShard and SomeShard (batch only).
@@ -1052,9 +1052,9 @@
   stream_plan: |
     StreamMaterialize { columns: [min, sum, t.v1(hidden), t.v3(hidden), t.v2(hidden)], pk_columns: [t.v1, t.v3, t.v2], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v3)), sum(sum(t.v1)), t.v1, t.v3, t.v2] }
-      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [count, min(min(t.v3)), sum(sum(t.v1))] }
+      └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2], aggs: [min(min(t.v3)), sum(sum(t.v1)), count] }
         └─StreamExchange { dist: HashShard(t.v1, t.v3, t.v2) }
-          └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [count, min(t.v3), sum(t.v1)] }
+          └─StreamHashAgg { group_key: [t.v1, t.v3, t.v2, $expr1], aggs: [min(t.v3), sum(t.v1), count] }
             └─StreamProject { exprs: [t.v1, t.v2, t.v3, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t.v3, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: enable two phase aggregation with simple agg should have two phase agg
@@ -1071,9 +1071,9 @@
   stream_plan: |
     StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(t.v1)), sum(sum(t.v2))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(t.v1)), sum(sum(t.v2))] }
+      └─StreamGlobalSimpleAgg { aggs: [min(min(t.v1)), sum(sum(t.v2)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(t.v1), sum(t.v2)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [min(t.v1), sum(t.v2), count] }
             └─StreamProject { exprs: [t.v1, t.v2, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: disable two phase aggregation with simple agg
@@ -1089,7 +1089,7 @@
   stream_plan: |
     StreamMaterialize { columns: [min, sum], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(t.v1), sum(t.v2)] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(t.v1), sum(t.v2)] }
+      └─StreamGlobalSimpleAgg { aggs: [min(t.v1), sum(t.v2), count] }
         └─StreamExchange { dist: Single }
           └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: force two phase agg with different distributions on inner and outer agg should have exchange
@@ -1130,9 +1130,9 @@
   stream_plan: |
     StreamMaterialize { columns: [col_0, lineitem.l_commitdate(hidden)], pk_columns: [lineitem.l_commitdate], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(lineitem.l_commitdate)), lineitem.l_commitdate] }
-      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [count, max(max(lineitem.l_commitdate))] }
+      └─StreamHashAgg { group_key: [lineitem.l_commitdate], aggs: [max(max(lineitem.l_commitdate)), count] }
         └─StreamExchange { dist: HashShard(lineitem.l_commitdate) }
-          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [count, max(lineitem.l_commitdate)] }
+          └─StreamHashAgg { group_key: [lineitem.l_commitdate, $expr1], aggs: [max(lineitem.l_commitdate), count] }
             └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate, Vnode(lineitem.l_orderkey) as $expr1] }
               └─StreamProject { exprs: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate] }
                 └─StreamHashAgg { group_key: [lineitem.l_tax, lineitem.l_shipinstruct, lineitem.l_orderkey, lineitem.l_commitdate], aggs: [count] }
@@ -1171,14 +1171,14 @@
   stream_plan: |
     StreamMaterialize { columns: [maxn, starttime_c], pk_columns: [starttime_c], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(sum0(count))), window_start] }
-      └─StreamHashAgg { group_key: [window_start], aggs: [count, max(max(sum0(count)))] }
+      └─StreamHashAgg { group_key: [window_start], aggs: [max(max(sum0(count))), count] }
         └─StreamExchange { dist: HashShard(window_start) }
-          └─StreamHashAgg { group_key: [window_start, $expr2], aggs: [count, max(sum0(count))] }
+          └─StreamHashAgg { group_key: [window_start, $expr2], aggs: [max(sum0(count)), count] }
             └─StreamProject { exprs: [bid.auction, window_start, sum0(count), Vnode(bid.auction, window_start) as $expr2] }
               └─StreamProject { exprs: [bid.auction, window_start, sum0(count)] }
-                └─StreamHashAgg { group_key: [bid.auction, window_start], aggs: [count, sum0(count)] }
+                └─StreamHashAgg { group_key: [bid.auction, window_start], aggs: [sum0(count), count] }
                   └─StreamExchange { dist: HashShard(bid.auction, window_start) }
-                    └─StreamHashAgg { group_key: [bid.auction, window_start, $expr1], aggs: [count, count] }
+                    └─StreamHashAgg { group_key: [bid.auction, window_start, $expr1], aggs: [count] }
                       └─StreamProject { exprs: [bid.auction, window_start, bid._row_id, Vnode(bid._row_id) as $expr1] }
                         └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                           └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -1200,7 +1200,7 @@
   stream_plan: |
     StreamMaterialize { columns: [count, idx.id(hidden)], pk_columns: [idx.id], pk_conflict: "no check" }
     └─StreamProject { exprs: [count, idx.id] }
-      └─StreamHashAgg { group_key: [idx.id], aggs: [count, count] }
+      └─StreamHashAgg { group_key: [idx.id], aggs: [count] }
         └─StreamExchange { dist: HashShard(idx.id) }
           └─StreamTableScan { table: idx, columns: [idx.id], pk: [idx.id], dist: SomeShard }
 - name: two phase agg with stream SomeShard (via index) but pk does not satisfy output dist should use two phase agg
@@ -1220,8 +1220,8 @@
   stream_plan: |
     StreamMaterialize { columns: [count, idx.col1(hidden)], pk_columns: [idx.col1], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count), idx.col1] }
-      └─StreamHashAgg { group_key: [idx.col1], aggs: [count, sum0(count)] }
+      └─StreamHashAgg { group_key: [idx.col1], aggs: [sum0(count), count] }
         └─StreamExchange { dist: HashShard(idx.col1) }
-          └─StreamHashAgg { group_key: [idx.col1, $expr1], aggs: [count, count] }
+          └─StreamHashAgg { group_key: [idx.col1, $expr1], aggs: [count] }
             └─StreamProject { exprs: [idx.col1, idx.id, Vnode(idx.id) as $expr1] }
               └─StreamTableScan { table: idx, columns: [idx.col1, idx.id], pk: [idx.id], dist: UpstreamHashShard(idx.id) }

--- a/src/frontend/planner_test/tests/testdata/append_only.yaml
+++ b/src/frontend/planner_test/tests/testdata/append_only.yaml
@@ -5,7 +5,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, mx2], pk_columns: [v1], pk_conflict: "no check" }
     └─StreamProject { exprs: [t1.v1, max(t1.v2)] }
-      └─StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [count, max(t1.v2)] }
+      └─StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [max(t1.v2), count] }
         └─StreamExchange { dist: HashShard(t1.v1) }
           └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
 - sql: |
@@ -33,7 +33,7 @@
   stream_plan: |
     StreamMaterialize { columns: [max_v1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(t1.v1))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(max(t1.v1))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [max(max(t1.v1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(t1.v1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [max(t1.v1)] }
             └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/distribution_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/distribution_derive.yaml
@@ -211,7 +211,7 @@
   stream_plan: |
     StreamMaterialize { columns: [max_v, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(a.v), a.k1] }
-      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(a.v)] }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [max(a.v), count] }
         └─StreamExchange { dist: HashShard(a.k1) }
           └─StreamTableScan { table: a, columns: [a.k1, a.v, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
@@ -219,7 +219,7 @@
       StreamMaterialize { columns: [max_v, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(a.v), a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, max(a.v)] }
+          StreamHashAgg { group_key: [a.k1], aggs: [max(a.v), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -229,7 +229,7 @@
         BatchPlanNode
 
      Table 0 { columns: [a_k1, a_v, a__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [a_k1, count, max(a_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [a_k1, max(a_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [max_v, a.k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk1_from_Ak1
   before:
@@ -246,21 +246,21 @@
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1.k1(hidden)], pk_columns: [ak1.k1], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(ak1.v), ak1.k1] }
-      └─StreamHashAgg { group_key: [ak1.k1], aggs: [count, max(ak1.v)] }
+      └─StreamHashAgg { group_key: [ak1.k1], aggs: [max(ak1.v), count] }
         └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], dist: UpstreamHashShard(ak1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_v, ak1.k1(hidden)], pk_columns: [ak1.k1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(ak1.v), ak1.k1] }
-          StreamHashAgg { group_key: [ak1.k1], aggs: [count, max(ak1.v)] }
+          StreamHashAgg { group_key: [ak1.k1], aggs: [max(ak1.v), count] }
               result table: 1, state tables: [0]
             Chain { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], dist: UpstreamHashShard(ak1.k1) }
               Upstream
               BatchPlanNode
 
      Table 0 { columns: [ak1_k1, ak1_v, ak1_a__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [ak1_k1, count, max(ak1_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [ak1_k1, max(ak1_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [max_v, ak1.k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk1_from_Ak1k2
   before:
@@ -278,7 +278,7 @@
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1k2.k1(hidden)], pk_columns: [ak1k2.k1], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(ak1k2.v), ak1k2.k1] }
-      └─StreamHashAgg { group_key: [ak1k2.k1], aggs: [count, max(ak1k2.v)] }
+      └─StreamHashAgg { group_key: [ak1k2.k1], aggs: [max(ak1k2.v), count] }
         └─StreamExchange { dist: HashShard(ak1k2.k1) }
           └─StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.v, ak1k2.k2, ak1k2.a._row_id], pk: [ak1k2.a._row_id], dist: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
@@ -286,7 +286,7 @@
       StreamMaterialize { columns: [max_v, ak1k2.k1(hidden)], pk_columns: [ak1k2.k1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(ak1k2.v), ak1k2.k1] }
-          StreamHashAgg { group_key: [ak1k2.k1], aggs: [count, max(ak1k2.v)] }
+          StreamHashAgg { group_key: [ak1k2.k1], aggs: [max(ak1k2.v), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -296,7 +296,7 @@
         BatchPlanNode
 
      Table 0 { columns: [ak1k2_k1, ak1k2_v, ak1k2_a__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [ak1k2_k1, count, max(ak1k2_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [ak1k2_k1, max(ak1k2_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [max_v, ak1k2.k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk2_from_Ak1k2
   before:
@@ -314,7 +314,7 @@
   stream_plan: |
     StreamMaterialize { columns: [max_v, ak1k2.k2(hidden)], pk_columns: [ak1k2.k2], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(ak1k2.v), ak1k2.k2] }
-      └─StreamHashAgg { group_key: [ak1k2.k2], aggs: [count, max(ak1k2.v)] }
+      └─StreamHashAgg { group_key: [ak1k2.k2], aggs: [max(ak1k2.v), count] }
         └─StreamExchange { dist: HashShard(ak1k2.k2) }
           └─StreamTableScan { table: ak1k2, columns: [ak1k2.k2, ak1k2.v, ak1k2.k1, ak1k2.a._row_id], pk: [ak1k2.a._row_id], dist: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
@@ -322,7 +322,7 @@
       StreamMaterialize { columns: [max_v, ak1k2.k2(hidden)], pk_columns: [ak1k2.k2], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(ak1k2.v), ak1k2.k2] }
-          StreamHashAgg { group_key: [ak1k2.k2], aggs: [count, max(ak1k2.v)] }
+          StreamHashAgg { group_key: [ak1k2.k2], aggs: [max(ak1k2.v), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -332,7 +332,7 @@
         BatchPlanNode
 
      Table 0 { columns: [ak1k2_k2, ak1k2_v, ak1k2_a__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [ak1k2_k2, count, max(ak1k2_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [ak1k2_k2, max(ak1k2_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [max_v, ak1k2.k2], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk1k2_from_Ak1k2
   before:
@@ -349,20 +349,20 @@
   stream_plan: |
     StreamMaterialize { columns: [sum_v, ak1k2.k1(hidden), ak1k2.k2(hidden)], pk_columns: [ak1k2.k1, ak1k2.k2], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(ak1k2.v), ak1k2.k1, ak1k2.k2] }
-      └─StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [count, sum(ak1k2.v)] }
+      └─StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [sum(ak1k2.v), count] }
         └─StreamTableScan { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v, ak1k2.a._row_id], pk: [ak1k2.a._row_id], dist: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [sum_v, ak1k2.k1(hidden), ak1k2.k2(hidden)], pk_columns: [ak1k2.k1, ak1k2.k2], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(ak1k2.v), ak1k2.k1, ak1k2.k2] }
-          StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [count, sum(ak1k2.v)] }
+          StreamHashAgg { group_key: [ak1k2.k1, ak1k2.k2], aggs: [sum(ak1k2.v), count] }
               result table: 0, state tables: []
             Chain { table: ak1k2, columns: [ak1k2.k1, ak1k2.k2, ak1k2.v, ak1k2.a._row_id], pk: [ak1k2.a._row_id], dist: UpstreamHashShard(ak1k2.k1, ak1k2.k2) }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [ak1k2_k1, ak1k2_k2, count, sum(ak1k2_v)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 0 { columns: [ak1k2_k1, ak1k2_k2, sum(ak1k2_v), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
      Table 4294967294 { columns: [sum_v, ak1k2.k1, ak1k2.k2], primary key: [$1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [1, 2] }
 - id: aggk1k2_from_Ak1
   before:
@@ -379,20 +379,20 @@
   stream_plan: |
     StreamMaterialize { columns: [sum_v, ak1.k1(hidden), ak1.k2(hidden)], pk_columns: [ak1.k1, ak1.k2], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(ak1.v), ak1.k1, ak1.k2] }
-      └─StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [count, sum(ak1.v)] }
+      └─StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [sum(ak1.v), count] }
         └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], dist: UpstreamHashShard(ak1.k1) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [sum_v, ak1.k1(hidden), ak1.k2(hidden)], pk_columns: [ak1.k1, ak1.k2], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(ak1.v), ak1.k1, ak1.k2] }
-          StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [count, sum(ak1.v)] }
+          StreamHashAgg { group_key: [ak1.k1, ak1.k2], aggs: [sum(ak1.v), count] }
               result table: 0, state tables: []
             Chain { table: ak1, columns: [ak1.k1, ak1.k2, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], dist: UpstreamHashShard(ak1.k1) }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [ak1_k1, ak1_k2, count, sum(ak1_v)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 0 { columns: [ak1_k1, ak1_k2, sum(ak1_v), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 4294967294 { columns: [sum_v, ak1.k1, ak1.k2], primary key: [$1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [1] }
 - id: aggk1_from_aggk1
   before:
@@ -417,22 +417,20 @@
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(count), a.k1] }
-      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
-        └─StreamProject { exprs: [a.k1, count] }
-          └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-            └─StreamExchange { dist: HashShard(a.k1) }
-              └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [max(count), count] }
+        └─StreamHashAgg { group_key: [a.k1], aggs: [count] }
+          └─StreamExchange { dist: HashShard(a.k1) }
+            └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(count), a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
+          StreamHashAgg { group_key: [a.k1], aggs: [max(count), count] }
               result table: 1, state tables: [0]
-            StreamProject { exprs: [a.k1, count] }
-              StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
-                  result table: 2, state tables: []
-                StreamExchange Hash([0]) from 1
+            StreamHashAgg { group_key: [a.k1], aggs: [count] }
+                result table: 2, state tables: []
+              StreamExchange Hash([0]) from 1
 
     Fragment 1
       Chain { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
@@ -440,8 +438,8 @@
         BatchPlanNode
 
      Table 0 { columns: [a_k1, count], primary key: [$0 ASC, $1 DESC], value indices: [0, 1], distribution key: [0] }
-     Table 1 { columns: [a_k1, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 2 { columns: [a_k1, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [a_k1, max(count), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 2 { columns: [a_k1, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [max_num, a.k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk1_from_aggk1k2
   before:
@@ -480,26 +478,24 @@
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(count), a.k1] }
-      └─StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
+      └─StreamHashAgg { group_key: [a.k1], aggs: [max(count), count] }
         └─StreamExchange { dist: HashShard(a.k1) }
-          └─StreamProject { exprs: [a.k1, a.k2, count] }
-            └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(a.k1, a.k2) }
-                └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
+          └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+            └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+              └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden)], pk_columns: [a.k1], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(count), a.k1] }
-          StreamHashAgg { group_key: [a.k1], aggs: [count, max(count)] }
+          StreamHashAgg { group_key: [a.k1], aggs: [max(count), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
     Fragment 1
-      StreamProject { exprs: [a.k1, a.k2, count] }
-        StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-            result table: 2, state tables: []
-          StreamExchange Hash([0, 1]) from 2
+      StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+          result table: 2, state tables: []
+        StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
       Chain { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
@@ -507,8 +503,8 @@
         BatchPlanNode
 
      Table 0 { columns: [a_k1, count, a_k2], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 1 { columns: [a_k1, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 2 { columns: [a_k1, a_k2, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 1 { columns: [a_k1, max(count), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 2 { columns: [a_k1, a_k2, count], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 4294967294 { columns: [max_num, a.k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk2_from_aggk1k2
   before:
@@ -547,26 +543,24 @@
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k2(hidden)], pk_columns: [a.k2], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(count), a.k2] }
-      └─StreamHashAgg { group_key: [a.k2], aggs: [count, max(count)] }
+      └─StreamHashAgg { group_key: [a.k2], aggs: [max(count), count] }
         └─StreamExchange { dist: HashShard(a.k2) }
-          └─StreamProject { exprs: [a.k1, a.k2, count] }
-            └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(a.k1, a.k2) }
-                └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
+          └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+            └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+              └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k2(hidden)], pk_columns: [a.k2], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(count), a.k2] }
-          StreamHashAgg { group_key: [a.k2], aggs: [count, max(count)] }
+          StreamHashAgg { group_key: [a.k2], aggs: [max(count), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([1]) from 1
 
     Fragment 1
-      StreamProject { exprs: [a.k1, a.k2, count] }
-        StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-            result table: 2, state tables: []
-          StreamExchange Hash([0, 1]) from 2
+      StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+          result table: 2, state tables: []
+        StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
       Chain { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
@@ -574,8 +568,8 @@
         BatchPlanNode
 
      Table 0 { columns: [a_k2, count, a_k1], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 1 { columns: [a_k2, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 2 { columns: [a_k1, a_k2, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 1 { columns: [a_k2, max(count), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 2 { columns: [a_k1, a_k2, count], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 4294967294 { columns: [max_num, a.k2], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: aggk1k2_from_aggk1k2
   before:
@@ -600,22 +594,20 @@
   stream_plan: |
     StreamMaterialize { columns: [max_num, a.k1(hidden), a.k2(hidden)], pk_columns: [a.k1, a.k2], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(count), a.k1, a.k2] }
-      └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, max(count)] }
-        └─StreamProject { exprs: [a.k1, a.k2, count] }
-          └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-            └─StreamExchange { dist: HashShard(a.k1, a.k2) }
-              └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
+      └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [max(count), count] }
+        └─StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+          └─StreamExchange { dist: HashShard(a.k1, a.k2) }
+            └─StreamTableScan { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [max_num, a.k1(hidden), a.k2(hidden)], pk_columns: [a.k1, a.k2], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(count), a.k1, a.k2] }
-          StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, max(count)] }
+          StreamHashAgg { group_key: [a.k1, a.k2], aggs: [max(count), count] }
               result table: 1, state tables: [0]
-            StreamProject { exprs: [a.k1, a.k2, count] }
-              StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count, count] }
-                  result table: 2, state tables: []
-                StreamExchange Hash([0, 1]) from 1
+            StreamHashAgg { group_key: [a.k1, a.k2], aggs: [count] }
+                result table: 2, state tables: []
+              StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
       Chain { table: a, columns: [a.k1, a.k2, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
@@ -623,8 +615,8 @@
         BatchPlanNode
 
      Table 0 { columns: [a_k1, a_k2, count], primary key: [$0 ASC, $1 ASC, $2 DESC], value indices: [0, 1, 2], distribution key: [0, 1] }
-     Table 1 { columns: [a_k1, a_k2, count, max(count)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
-     Table 2 { columns: [a_k1, a_k2, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 1 { columns: [a_k1, a_k2, max(count), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 2 { columns: [a_k1, a_k2, count], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 4294967294 { columns: [max_num, a.k1, a.k2], primary key: [$1 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [1, 2] }
 - id: Ak1_join_aggk1_onk1
   before:
@@ -652,7 +644,7 @@
       ├─StreamExchange { dist: HashShard(ak1.k1) }
       | └─StreamTableScan { table: ak1, columns: [ak1.k1, ak1.v, ak1.a._row_id], pk: [ak1.a._row_id], dist: UpstreamHashShard(ak1.k1) }
       └─StreamProject { exprs: [count, a.k1] }
-        └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+        └─StreamHashAgg { group_key: [a.k1], aggs: [count] }
           └─StreamExchange { dist: HashShard(a.k1) }
             └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
   stream_dist_plan: |
@@ -663,7 +655,7 @@
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [count, a.k1] }
-            StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+            StreamHashAgg { group_key: [a.k1], aggs: [count] }
                 result table: 4, state tables: []
               StreamExchange Hash([0]) from 2
 
@@ -681,7 +673,7 @@
      Table 1 { columns: [ak1_k1, ak1_a__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [count, a_k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [a_k1, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [a_k1, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [a_k1, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [v, bv, ak1.a._row_id, ak1.k1, a.k1], primary key: [$2 ASC, $4 ASC, $3 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [3] }
 - id: aggk1_join_Ak1_onk1
   before:
@@ -706,7 +698,7 @@
     StreamMaterialize { columns: [v, bv, a.k1(hidden), ak1.a._row_id(hidden), ak1.k1(hidden)], pk_columns: [a.k1, ak1.a._row_id, ak1.k1], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count, a.k1, ak1.a._row_id, ak1.k1] }
       ├─StreamProject { exprs: [count, a.k1] }
-      | └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+      | └─StreamHashAgg { group_key: [a.k1], aggs: [count] }
       |   └─StreamExchange { dist: HashShard(a.k1) }
       |     └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
       └─StreamExchange { dist: HashShard(ak1.k1) }
@@ -718,7 +710,7 @@
         StreamHashJoin { type: Inner, predicate: a.k1 = ak1.k1, output: [ak1.v, count, a.k1, ak1.a._row_id, ak1.k1] }
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamProject { exprs: [count, a.k1] }
-            StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+            StreamHashAgg { group_key: [a.k1], aggs: [count] }
                 result table: 4, state tables: []
               StreamExchange Hash([0]) from 1
           StreamExchange Hash([0]) from 2
@@ -737,7 +729,7 @@
      Table 1 { columns: [a_k1, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 2 { columns: [ak1_k1, ak1_v, ak1_a__row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 3 { columns: [ak1_k1, ak1_a__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4 { columns: [a_k1, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [a_k1, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [v, bv, a.k1, ak1.a._row_id, ak1.k1], primary key: [$2 ASC, $3 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [2] }
 - id: aggk1_join_aggk1_onk1
   before:
@@ -770,11 +762,11 @@
     StreamMaterialize { columns: [num, bv, a.k1(hidden), b.k1(hidden)], pk_columns: [a.k1, b.k1], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count, a.k1, b.k1] }
       ├─StreamProject { exprs: [count, a.k1] }
-      | └─StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+      | └─StreamHashAgg { group_key: [a.k1], aggs: [count] }
       |   └─StreamExchange { dist: HashShard(a.k1) }
       |     └─StreamTableScan { table: a, columns: [a.k1, a._row_id], pk: [a._row_id], dist: UpstreamHashShard(a._row_id) }
       └─StreamProject { exprs: [count, b.k1] }
-        └─StreamHashAgg { group_key: [b.k1], aggs: [count, count] }
+        └─StreamHashAgg { group_key: [b.k1], aggs: [count] }
           └─StreamExchange { dist: HashShard(b.k1) }
             └─StreamTableScan { table: b, columns: [b.k1, b._row_id], pk: [b._row_id], dist: UpstreamHashShard(b._row_id) }
   stream_dist_plan: |
@@ -784,11 +776,11 @@
         StreamHashJoin { type: Inner, predicate: a.k1 = b.k1, output: [count, count, a.k1, b.k1] }
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamProject { exprs: [count, a.k1] }
-            StreamHashAgg { group_key: [a.k1], aggs: [count, count] }
+            StreamHashAgg { group_key: [a.k1], aggs: [count] }
                 result table: 4, state tables: []
               StreamExchange Hash([0]) from 1
           StreamProject { exprs: [count, b.k1] }
-            StreamHashAgg { group_key: [b.k1], aggs: [count, count] }
+            StreamHashAgg { group_key: [b.k1], aggs: [count] }
                 result table: 5, state tables: []
               StreamExchange Hash([0]) from 2
 
@@ -806,8 +798,8 @@
      Table 1 { columns: [a_k1, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 2 { columns: [count, b_k1], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [b_k1, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [a_k1, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 5 { columns: [b_k1, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [a_k1, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
+     Table 5 { columns: [b_k1, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [num, bv, a.k1, b.k1], primary key: [$2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - sql: |
     create table t1 (row_id int, uid int, v int, created_at timestamp);

--- a/src/frontend/planner_test/tests/testdata/dynamic_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/dynamic_filter.yaml
@@ -19,9 +19,9 @@
       ├─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [max(max(t2.v2))] }
-          └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+          └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t2.v2)] }
+              └─StreamHashAgg { group_key: [$expr1], aggs: [max(t2.v2), count] }
                 └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr1] }
                   └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: |
@@ -63,9 +63,9 @@
         | └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamProject { exprs: [max(max(t2.v2))] }
-            └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+            └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
               └─StreamExchange { dist: Single }
-                └─StreamHashAgg { group_key: [$expr2], aggs: [count, max(t2.v2)] }
+                └─StreamHashAgg { group_key: [$expr2], aggs: [max(t2.v2), count] }
                   └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr2] }
                     └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: Ensure error on multiple rows on inner side
@@ -115,9 +115,9 @@
       | └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(max(max(t2.v2))) }
         └─StreamProject { exprs: [max(max(t2.v2))] }
-          └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+          └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t2.v2)] }
+              └─StreamHashAgg { group_key: [$expr1], aggs: [max(t2.v2), count] }
                 └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr1] }
                   └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: Dynamic filter join on unequal types
@@ -139,9 +139,9 @@
         | └─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamProject { exprs: [max(max(t2.v2))] }
-            └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+            └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
               └─StreamExchange { dist: Single }
-                └─StreamHashAgg { group_key: [$expr2], aggs: [count, max(t2.v2)] }
+                └─StreamHashAgg { group_key: [$expr2], aggs: [max(t2.v2), count] }
                   └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr2] }
                     └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: Dynamic filter on semi join
@@ -155,9 +155,9 @@
       ├─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [max(max(t2.v2))] }
-          └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+          └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t2.v2)] }
+              └─StreamHashAgg { group_key: [$expr1], aggs: [max(t2.v2), count] }
                 └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr1] }
                   └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: Complex expression on RHS of condition will still result in dynamic filter
@@ -177,8 +177,8 @@
       ├─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [(2:Int32 * max(max(t2.v2))) as $expr2] }
-          └─StreamGlobalSimpleAgg { aggs: [count, max(max(t2.v2))] }
+          └─StreamGlobalSimpleAgg { aggs: [max(max(t2.v2)), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t2.v2)] }
+              └─StreamHashAgg { group_key: [$expr1], aggs: [max(t2.v2), count] }
                 └─StreamProject { exprs: [t2.v2, t2._row_id, Vnode(t2._row_id) as $expr1] }
                   └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -488,7 +488,7 @@
     StreamMaterialize { columns: [max_time, t.v2(hidden)], pk_columns: [t.v2], pk_conflict: "no check" }
     └─StreamDynamicFilter { predicate: (max(t.v1) >= now), output: [max(t.v1), t.v2] }
       ├─StreamProject { exprs: [max(t.v1), t.v2] }
-      | └─StreamHashAgg { group_key: [t.v2], aggs: [count, max(t.v1)] }
+      | └─StreamHashAgg { group_key: [t.v2], aggs: [max(t.v1), count] }
       |   └─StreamExchange { dist: HashShard(t.v2) }
       |     └─StreamTableScan { table: t, columns: [t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange { dist: Broadcast }

--- a/src/frontend/planner_test/tests/testdata/mv_column_name.yaml
+++ b/src/frontend/planner_test/tests/testdata/mv_column_name.yaml
@@ -55,8 +55,8 @@
   stream_plan: |
     StreamMaterialize { columns: [count, max], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count), max(max(t.a))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum0(count), max(max(t.a))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum0(count), max(max(t.a)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, count, max(t.a)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t.a)] }
             └─StreamProject { exprs: [t.a, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.a, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }

--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -186,10 +186,10 @@
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
     └─StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price))) as $expr1] }
-      └─StreamHashAgg { group_key: [auction.category], aggs: [count, sum(max(bid.price)), count(max(bid.price))] }
+      └─StreamHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price)), count] }
         └─StreamExchange { dist: HashShard(auction.category) }
           └─StreamProject { exprs: [auction.id, auction.category, max(bid.price)] }
-            └─StreamHashAgg { group_key: [auction.id, auction.category], aggs: [count, max(bid.price)] }
+            └─StreamHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price), count] }
               └─StreamProject { exprs: [auction.id, auction.category, bid.price, bid._row_id, bid.auction] }
                 └─StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
                   └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
@@ -202,13 +202,13 @@
       StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [auction.category, (sum(max(bid.price)) / count(max(bid.price))) as $expr52] }
-          StreamHashAgg { group_key: [auction.category], aggs: [count, sum(max(bid.price)), count(max(bid.price))] }
+          StreamHashAgg { group_key: [auction.category], aggs: [sum(max(bid.price)), count(max(bid.price)), count] }
               result table: 0, state tables: []
             StreamExchange Hash([1]) from 1
 
     Fragment 1
       StreamProject { exprs: [auction.id, auction.category, max(bid.price)] }
-        StreamHashAgg { group_key: [auction.id, auction.category], aggs: [count, max(bid.price)] }
+        StreamHashAgg { group_key: [auction.id, auction.category], aggs: [max(bid.price), count] }
             result table: 2, state tables: [1]
           StreamProject { exprs: [auction.id, auction.category, bid.price, bid._row_id, bid.auction] }
             StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
@@ -227,9 +227,9 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [auction_category, count, sum(max(bid_price)), count(max(bid_price))], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
+     Table 0 { columns: [auction_category, sum(max(bid_price)), count(max(bid_price)), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 1 { columns: [auction_id, auction_category, bid_price, bid__row_id, bid_auction], primary key: [$0 ASC, $1 ASC, $2 DESC, $3 ASC, $4 ASC], value indices: [0, 2, 3, 4], distribution key: [0] }
-     Table 2 { columns: [auction_id, auction_category, count, max(bid_price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 2 { columns: [auction_id, auction_category, max(bid_price), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 3 { columns: [auction_id, auction_date_time, auction_expires, auction_category], primary key: [$0 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
      Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 5 { columns: [bid_auction, bid_price, bid_date_time, bid__row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -292,24 +292,22 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [bid.auction, count, window_start] }
-          |   └─StreamShare { id = 956 }
-          |     └─StreamProject { exprs: [bid.auction, window_start, count] }
-          |       └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-          |         └─StreamExchange { dist: HashShard(bid.auction, window_start) }
-          |           └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-          |             └─StreamFilter { predicate: IsNotNull(bid.date_time) }
-          |               └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+          |   └─StreamShare { id = 935 }
+          |     └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+          |       └─StreamExchange { dist: HashShard(bid.auction, window_start) }
+          |         └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
+          |           └─StreamFilter { predicate: IsNotNull(bid.date_time) }
+          |             └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           └─StreamProject { exprs: [max(count), window_start] }
-            └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+            └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [bid.auction, window_start, count] }
-                  └─StreamShare { id = 956 }
-                    └─StreamProject { exprs: [bid.auction, window_start, count] }
-                      └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-                        └─StreamExchange { dist: HashShard(bid.auction, window_start) }
-                          └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
-                            └─StreamFilter { predicate: IsNotNull(bid.date_time) }
-                              └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+                  └─StreamShare { id = 935 }
+                    └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+                      └─StreamExchange { dist: HashShard(bid.auction, window_start) }
+                        └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
+                          └─StreamFilter { predicate: IsNotNull(bid.date_time) }
+                            └─StreamTableScan { table: bid, columns: [bid.auction, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
@@ -320,7 +318,7 @@
                 left table: 0, right table 2, left degree table: 1, right degree table: 3,
               StreamExchange Hash([2]) from 1
               StreamProject { exprs: [max(count), window_start] }
-                StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+                StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
                     result table: 6, state tables: [5]
                   StreamExchange Hash([1]) from 4
 
@@ -329,10 +327,9 @@
         StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
-      StreamProject { exprs: [bid.auction, window_start, count] }
-        StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count, count] }
-            result table: 4, state tables: []
-          StreamExchange Hash([0, 1]) from 3
+      StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+          result table: 4, state tables: []
+        StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
       StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
@@ -349,9 +346,9 @@
      Table 1 { columns: [window_start, bid_auction, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [bid_auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 4 { columns: [bid_auction, window_start, count], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 5 { columns: [window_start, count, bid_auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 6 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 6 { columns: [window_start, max(count), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
@@ -414,7 +411,7 @@
           | └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           └─StreamExchange { dist: HashShard(max(bid.price)) }
             └─StreamProject { exprs: [max(bid.price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, max(bid.price)] }
+              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(bid.price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, bid.price, bid._row_id] }
                     └─StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -436,7 +433,7 @@
 
     Fragment 2
       StreamProject { exprs: [max(bid.price), $expr110, ($expr110 - '00:00:10':Interval) as $expr111] }
-        StreamAppendOnlyHashAgg { group_key: [$expr110], aggs: [count, max(bid.price)] }
+        StreamAppendOnlyHashAgg { group_key: [$expr110], aggs: [max(bid.price), count] }
             result table: 4, state tables: []
           StreamExchange Hash([0]) from 3
 
@@ -450,7 +447,7 @@
      Table 1 { columns: [bid_price, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(bid_price), $expr110, $expr111], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 3 { columns: [max(bid_price), $expr110, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 4 { columns: [$expr110, count, max(bid_price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [$expr110, max(bid_price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, price, bidder, date_time, bid._row_id, $expr110, max(bid.price)], primary key: [$4 ASC, $5 ASC, $1 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [1] }
 - id: nexmark_q8
   before:
@@ -768,19 +765,17 @@
                   └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
-    └─StreamProject { exprs: [$expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-        └─StreamExchange { dist: HashShard($expr1) }
-          └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, bid.price, bid.bidder, bid.auction, bid._row_id] }
-            └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+      └─StreamExchange { dist: HashShard($expr1) }
+        └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, bid.price, bid.bidder, bid.auction, bid._row_id] }
+          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [$expr51, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-          StreamAppendOnlyHashAgg { group_key: [$expr51], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-              result table: 0, state tables: []
-            StreamExchange Hash([0]) from 1
+        StreamAppendOnlyHashAgg { group_key: [$expr51], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+            result table: 0, state tables: []
+          StreamExchange Hash([0]) from 1
 
     Fragment 1
       StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr51, bid.price, bid.bidder, bid.auction, bid._row_id] }
@@ -788,7 +783,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [$expr51, count, count_0, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), count(distinct bid_bidder), count(distinct bid_bidder) filter((bid_price < 10000:Int32)), count(distinct bid_bidder) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_bidder) filter((bid_price >= 1000000:Int32)), count(distinct bid_auction), count(distinct bid_auction) filter((bid_price < 10000:Int32)), count(distinct bid_auction) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_auction) filter((bid_price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [0] }
+     Table 0 { columns: [$expr51, count, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), count(distinct bid_bidder), count(distinct bid_bidder) filter((bid_price < 10000:Int32)), count(distinct bid_bidder) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_bidder) filter((bid_price >= 1000000:Int32)), count(distinct bid_auction), count(distinct bid_auction) filter((bid_price < 10000:Int32)), count(distinct bid_auction) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_auction) filter((bid_price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
      Table 4294967294 { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
 - id: nexmark_q16
   before:
@@ -824,19 +819,17 @@
                   └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
-    └─StreamProject { exprs: [bid.channel, $expr1, max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-      └─StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr1], aggs: [count, max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-        └─StreamExchange { dist: HashShard(bid.channel, $expr1) }
-          └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr2, bid.price, bid.bidder, bid.auction, bid._row_id] }
-            └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    └─StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+      └─StreamExchange { dist: HashShard(bid.channel, $expr1) }
+        └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr2, bid.price, bid.bidder, bid.auction, bid._row_id] }
+          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [bid.channel, $expr101, max($expr102), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-          StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr101], aggs: [count, max($expr102), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
-              result table: 0, state tables: []
-            StreamExchange Hash([0, 1]) from 1
+        StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr101], aggs: [max($expr102), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+            result table: 0, state tables: []
+          StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
       StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr101, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr102, bid.price, bid.bidder, bid.auction, bid._row_id] }
@@ -844,7 +837,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [bid_channel, $expr101, count, max($expr102), count_0, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), count(distinct bid_bidder), count(distinct bid_bidder) filter((bid_price < 10000:Int32)), count(distinct bid_bidder) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_bidder) filter((bid_price >= 1000000:Int32)), count(distinct bid_auction), count(distinct bid_auction) filter((bid_price < 10000:Int32)), count(distinct bid_auction) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_auction) filter((bid_price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], distribution key: [0, 1] }
+     Table 0 { columns: [bid_channel, $expr101, max($expr102), count, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), count(distinct bid_bidder), count(distinct bid_bidder) filter((bid_price < 10000:Int32)), count(distinct bid_bidder) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_bidder) filter((bid_price >= 1000000:Int32)), count(distinct bid_auction), count(distinct bid_auction) filter((bid_price < 10000:Int32)), count(distinct bid_auction) filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count(distinct bid_auction) filter((bid_price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
      Table 4294967294 { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
 - id: nexmark_q17
   before:
@@ -873,7 +866,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
     └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)) as $expr2, sum(bid.price)] }
-      └─StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr1], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+      └─StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─StreamExchange { dist: HashShard(bid.auction, $expr1) }
           └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price, bid._row_id] }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -881,18 +874,18 @@
     Fragment 0
       StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [bid.auction, $expr102, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)) as $expr103, sum(bid.price)] }
-          StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr102], aggs: [count, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+        StreamProject { exprs: [bid.auction, $expr101, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)) as $expr102, sum(bid.price)] }
+          StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr101], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
-      StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr102, bid.price, bid._row_id] }
+      StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr101, bid.price, bid._row_id] }
         Chain { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [bid_auction, $expr102, count, count_0, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), min(bid_price), max(bid_price), sum(bid_price), count(bid_price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10], distribution key: [0, 1] }
+     Table 0 { columns: [bid_auction, $expr101, count, count filter((bid_price < 10000:Int32)), count filter((bid_price >= 10000:Int32) AND (bid_price < 1000000:Int32)), count filter((bid_price >= 1000000:Int32)), min(bid_price), max(bid_price), sum(bid_price), count(bid_price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
      Table 4294967294 { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
 - id: nexmark_q18
   before:
@@ -1087,7 +1080,7 @@
       ├─StreamExchange { dist: HashShard(auction.id) }
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction, max(bid.price)] }
-        └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, max(bid.price)] }
+        └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [max(bid.price), count] }
           └─StreamExchange { dist: HashShard(bid.auction) }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
@@ -1098,7 +1091,7 @@
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [bid.auction, max(bid.price)] }
-            StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, max(bid.price)] }
+            StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [max(bid.price), count] }
                 result table: 4, state tables: []
               StreamExchange Hash([0]) from 2
 
@@ -1116,7 +1109,7 @@
      Table 1 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 2 { columns: [bid_auction, max(bid_price)], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 3 { columns: [bid_auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [bid_auction, count, max(bid_price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [bid_auction, max(bid_price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, current_highest_bid, bid.auction], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
 - id: nexmark_q102
   before:
@@ -1155,7 +1148,7 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
     └─StreamDynamicFilter { predicate: (count(bid.auction) >= $expr1), output: [auction.id, auction.item_name, count(bid.auction)] }
       ├─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-      | └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+      | └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction), count] }
       |   └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
       |     ├─StreamExchange { dist: HashShard(auction.id) }
       |     | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
@@ -1163,12 +1156,11 @@
       |       └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [(sum0(count) / count(bid.auction)) as $expr1] }
-          └─StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(bid.auction)] }
+          └─StreamGlobalSimpleAgg { aggs: [sum0(count), count(bid.auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamProject { exprs: [bid.auction, count] }
-                └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-                  └─StreamExchange { dist: HashShard(bid.auction) }
-                    └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+              └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+                └─StreamExchange { dist: HashShard(bid.auction) }
+                  └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1176,7 +1168,7 @@
         StreamDynamicFilter { predicate: (count(bid.auction) >= $expr52), output: [auction.id, auction.item_name, count(bid.auction)] }
             left table: 0, right table 1
           StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction), count] }
                 result table: 2, state tables: []
               StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
                   left table: 3, right table 5, left degree table: 4, right degree table: 6,
@@ -1196,15 +1188,14 @@
 
     Fragment 3
       StreamProject { exprs: [(sum0(count) / count(bid.auction)) as $expr52] }
-        StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(bid.auction)] }
+        StreamGlobalSimpleAgg { aggs: [sum0(count), count(bid.auction), count] }
             result table: 7, state tables: []
           StreamExchange Single from 4
 
     Fragment 4
-      StreamProject { exprs: [bid.auction, count] }
-        StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-            result table: 8, state tables: []
-          StreamExchange Hash([0]) from 5
+      StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+          result table: 8, state tables: []
+        StreamExchange Hash([0]) from 5
 
     Fragment 5
       Chain { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -1213,13 +1204,13 @@
 
      Table 0 { columns: [auction_id, auction_item_name, count(bid_auction)], primary key: [$2 ASC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [$expr52], primary key: [], value indices: [0], distribution key: [] }
-     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 2 { columns: [auction_id, auction_item_name, count(bid_auction), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [bid_auction, bid__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 7 { columns: [count, sum0(count), count(bid_auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
-     Table 8 { columns: [bid_auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 7 { columns: [sum0(count), count(bid_auction), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 8 { columns: [bid_auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q103
   before:
@@ -1254,10 +1245,9 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamProject { exprs: [bid.auction, count] }
-            └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(bid.auction) }
-                └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+          └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+            └─StreamExchange { dist: HashShard(bid.auction) }
+              └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name], pk_columns: [auction_id], pk_conflict: "no check" }
@@ -1267,10 +1257,9 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [bid.auction] }
             StreamFilter { predicate: (count >= 20:Int32) }
-              StreamProject { exprs: [bid.auction, count] }
-                StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-                    result table: 4, state tables: []
-                  StreamExchange Hash([0]) from 2
+              StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+                  result table: 4, state tables: []
+                StreamExchange Hash([0]) from 2
 
     Fragment 1
       Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
@@ -1286,7 +1275,7 @@
      Table 1 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 2 { columns: [bid_auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [bid_auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [bid_auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [bid_auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
 - id: nexmark_q104
   before:
@@ -1321,10 +1310,9 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamProject { exprs: [bid.auction, count] }
-            └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(bid.auction) }
-                └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+          └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+            └─StreamExchange { dist: HashShard(bid.auction) }
+              └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name], pk_columns: [auction_id], pk_conflict: "no check" }
@@ -1334,10 +1322,9 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [bid.auction] }
             StreamFilter { predicate: (count < 20:Int32) }
-              StreamProject { exprs: [bid.auction, count] }
-                StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count, count] }
-                    result table: 4, state tables: []
-                  StreamExchange Hash([0]) from 2
+              StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+                  result table: 4, state tables: []
+                StreamExchange Hash([0]) from 2
 
     Fragment 1
       Chain { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
@@ -1353,7 +1340,7 @@
      Table 1 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 2 { columns: [bid_auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [bid_auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [bid_auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 4 { columns: [bid_auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
 - id: nexmark_q105
   before:
@@ -1389,7 +1376,7 @@
           └─StreamGroupTopN { order: "[count(bid.auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr1] }
               └─StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+                └─StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction), count] }
                   └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
                     ├─StreamExchange { dist: HashShard(auction.id) }
                     | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
@@ -1409,7 +1396,7 @@
           state table: 1
         StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction), Vnode(auction.id) as $expr3] }
           StreamProject { exprs: [auction.id, auction.item_name, count(bid.auction)] }
-            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count, count(bid.auction)] }
+            StreamHashAgg { group_key: [auction.id, auction.item_name], aggs: [count(bid.auction), count] }
                 result table: 2, state tables: []
               StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
                   left table: 3, right table 5, left degree table: 4, right degree table: 6,
@@ -1428,7 +1415,7 @@
 
      Table 0 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
      Table 1 { columns: [auction_id, auction_item_name, count(bid_auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
-     Table 2 { columns: [auction_id, auction_item_name, count, count(bid_auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 2 { columns: [auction_id, auction_item_name, count(bid_auction), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 3 { columns: [auction_id, auction_item_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 4 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 5 { columns: [bid_auction, bid__row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
@@ -1470,12 +1457,12 @@
   stream_plan: |
     StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(max(bid.price)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(max(bid.price)))] }
+      └─StreamGlobalSimpleAgg { aggs: [min(min(max(bid.price))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(max(bid.price))] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [min(max(bid.price)), count] }
             └─StreamProject { exprs: [auction.id, max(bid.price), Vnode(auction.id) as $expr1] }
               └─StreamProject { exprs: [auction.id, max(bid.price)] }
-                └─StreamHashAgg { group_key: [auction.id], aggs: [count, max(bid.price)] }
+                └─StreamHashAgg { group_key: [auction.id], aggs: [max(bid.price), count] }
                   └─StreamProject { exprs: [auction.id, bid.price, bid._row_id, bid.auction] }
                     └─StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
                       └─StreamHashJoin { type: Inner, predicate: auction.id = bid.auction, output: all }
@@ -1488,16 +1475,16 @@
       StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [min(min(max(bid.price)))] }
-          StreamGlobalSimpleAgg { aggs: [count, min(min(max(bid.price)))] }
+          StreamGlobalSimpleAgg { aggs: [min(min(max(bid.price))), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamHashAgg { group_key: [$expr3], aggs: [count, min(max(bid.price))] }
+      StreamHashAgg { group_key: [$expr3], aggs: [min(max(bid.price)), count] }
           result table: 3, state tables: [2]
         StreamProject { exprs: [auction.id, max(bid.price), Vnode(auction.id) as $expr3] }
           StreamProject { exprs: [auction.id, max(bid.price)] }
-            StreamHashAgg { group_key: [auction.id], aggs: [count, max(bid.price)] }
+            StreamHashAgg { group_key: [auction.id], aggs: [max(bid.price), count] }
                 result table: 5, state tables: [4]
               StreamProject { exprs: [auction.id, bid.price, bid._row_id, bid.auction] }
                 StreamFilter { predicate: (bid.date_time >= auction.date_time) AND (bid.date_time <= auction.expires) }
@@ -1517,11 +1504,11 @@
         BatchPlanNode
 
      Table 0 { columns: [min(max(bid_price)), $expr3], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 1 { columns: [count, min(min(max(bid_price)))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [min(min(max(bid_price))), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 2 { columns: [$expr3, max(bid_price), auction_id], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
-     Table 3 { columns: [$expr3, count, min(max(bid_price))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 3 { columns: [$expr3, min(max(bid_price)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
      Table 4 { columns: [auction_id, bid_price, bid__row_id, bid_auction], primary key: [$0 ASC, $1 DESC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
-     Table 5 { columns: [auction_id, count, max(bid_price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [auction_id, max(bid_price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 6 { columns: [auction_id, auction_date_time, auction_expires], primary key: [$0 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 7 { columns: [auction_id, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 8 { columns: [bid_auction, bid_price, bid_date_time, bid__row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -229,10 +229,10 @@
   stream_plan: |
     StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
     └─StreamProject { exprs: [category, (sum(max(price))::Decimal / count(max(price))) as $expr1] }
-      └─StreamHashAgg { group_key: [category], aggs: [count, sum(max(price)), count(max(price))] }
+      └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
-            └─StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [count, max(price)] }
+            └─StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [max(price), count] }
               └─StreamProject { exprs: [id, category, price, _row_id, _row_id, auction] }
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
@@ -249,13 +249,13 @@
       StreamMaterialize { columns: [category, avg], pk_columns: [category], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [category, (sum(max(price))::Decimal / count(max(price))) as $expr52] }
-          StreamHashAgg { group_key: [category], aggs: [count, sum(max(price)), count(max(price))] }
+          StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
               result table: 0, state tables: []
             StreamExchange Hash([1]) from 1
 
     Fragment 1
       StreamProject { exprs: [id, category, max(price)] }
-        StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [count, max(price)] }
+        StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [max(price), count] }
             result table: 1, state tables: []
           StreamProject { exprs: [id, category, price, _row_id, _row_id, auction] }
             StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
@@ -276,8 +276,8 @@
           StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
               source state table: 7
 
-     Table 0 { columns: [category, count, sum(max(price)), count(max(price))], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
-     Table 1 { columns: [id, category, count, max(price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 0 { columns: [category, sum(max(price)), count(max(price)), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
+     Table 1 { columns: [id, category, max(price), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 2 { columns: [id, date_time, expires, category, _row_id], primary key: [$0 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
      Table 3 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 4 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -344,28 +344,26 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamShare { id = 1064 }
-          |     └─StreamProject { exprs: [auction, window_start, count] }
-          |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-          |         └─StreamExchange { dist: HashShard(auction, window_start) }
-          |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-          |             └─StreamProject { exprs: [auction, date_time, _row_id] }
-          |               └─StreamFilter { predicate: IsNotNull(date_time) }
-          |                 └─StreamRowIdGen { row_id_index: 7 }
-          |                   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |   └─StreamShare { id = 1043 }
+          |     └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+          |       └─StreamExchange { dist: HashShard(auction, window_start) }
+          |         └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
+          |           └─StreamProject { exprs: [auction, date_time, _row_id] }
+          |             └─StreamFilter { predicate: IsNotNull(date_time) }
+          |               └─StreamRowIdGen { row_id_index: 7 }
+          |                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamProject { exprs: [max(count), window_start] }
-            └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+            └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamShare { id = 1064 }
-                    └─StreamProject { exprs: [auction, window_start, count] }
-                      └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-                        └─StreamExchange { dist: HashShard(auction, window_start) }
-                          └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-                            └─StreamProject { exprs: [auction, date_time, _row_id] }
-                              └─StreamFilter { predicate: IsNotNull(date_time) }
-                                └─StreamRowIdGen { row_id_index: 7 }
-                                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamShare { id = 1043 }
+                    └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+                      └─StreamExchange { dist: HashShard(auction, window_start) }
+                        └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
+                          └─StreamProject { exprs: [auction, date_time, _row_id] }
+                            └─StreamFilter { predicate: IsNotNull(date_time) }
+                              └─StreamRowIdGen { row_id_index: 7 }
+                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], pk_columns: [auction, window_start, window_start#1], pk_conflict: "no check" }
@@ -376,7 +374,7 @@
                 left table: 0, right table 2, left degree table: 1, right degree table: 3,
               StreamExchange Hash([2]) from 1
               StreamProject { exprs: [max(count), window_start] }
-                StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+                StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
                     result table: 7, state tables: [6]
                   StreamExchange Hash([1]) from 4
 
@@ -385,10 +383,9 @@
         StreamExchange Hash([0, 1]) from 2
 
     Fragment 2
-      StreamProject { exprs: [auction, window_start, count] }
-        StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-            result table: 4, state tables: []
-          StreamExchange Hash([0, 1]) from 3
+      StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+          result table: 4, state tables: []
+        StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
       StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
@@ -406,10 +403,10 @@
      Table 1 { columns: [window_start, auction, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 2 { columns: [max(count), window_start], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
      Table 3 { columns: [window_start, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 4 { columns: [auction, window_start, count, count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 4 { columns: [auction, window_start, count], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 5 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 6 { columns: [window_start, count, auction], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
-     Table 7 { columns: [window_start, count, max(count)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 7 { columns: [window_start, max(count), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, num, window_start, window_start#1], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [2] }
 - id: nexmark_q6
   before:
@@ -477,7 +474,7 @@
           |         └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
             └─StreamProject { exprs: [max(price), $expr1, ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, max(price)] }
+              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
                     └─StreamShare { id = 564 }
@@ -507,7 +504,7 @@
 
     Fragment 3
       StreamProject { exprs: [max(price), $expr115, ($expr115 - '00:00:10':Interval) as $expr116] }
-        StreamAppendOnlyHashAgg { group_key: [$expr115], aggs: [count, max(price)] }
+        StreamAppendOnlyHashAgg { group_key: [$expr115], aggs: [max(price), count] }
             result table: 5, state tables: []
           StreamExchange Hash([0]) from 4
 
@@ -520,7 +517,7 @@
      Table 2 { columns: [max(price), $expr115, $expr116], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 3 { columns: [max(price), $expr115, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [$expr115, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [$expr115, max(price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [auction, price, bidder, date_time, _row_id, $expr115, max(price)], primary key: [$4 ASC, $5 ASC, $1 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [1] }
 - id: nexmark_q8
   before:
@@ -863,20 +860,18 @@
                   └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
-    └─StreamProject { exprs: [$expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-        └─StreamExchange { dist: HashShard($expr1) }
-          └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
-            └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+    └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+      └─StreamExchange { dist: HashShard($expr1) }
+        └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
+          └─StreamRowIdGen { row_id_index: 7 }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [$expr53, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-          StreamAppendOnlyHashAgg { group_key: [$expr53], aggs: [count, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-              result table: 0, state tables: []
-            StreamExchange Hash([0]) from 1
+        StreamAppendOnlyHashAgg { group_key: [$expr53], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+            result table: 0, state tables: []
+          StreamExchange Hash([0]) from 1
 
     Fragment 1
       StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr53, price, bidder, auction, _row_id] }
@@ -884,7 +879,7 @@
           StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
               source state table: 3
 
-     Table 0 { columns: [$expr53, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [0] }
+     Table 0 { columns: [$expr53, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC], value indices: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
      Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], distribution key: [0] }
 - id: nexmark_q16
@@ -921,20 +916,18 @@
                   └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
-    └─StreamProject { exprs: [channel, $expr1, max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-      └─StreamAppendOnlyHashAgg { group_key: [channel, $expr1], aggs: [count, max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-        └─StreamExchange { dist: HashShard(channel, $expr1) }
-          └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
-            └─StreamRowIdGen { row_id_index: 7 }
-              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+    └─StreamAppendOnlyHashAgg { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+      └─StreamExchange { dist: HashShard(channel, $expr1) }
+        └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
+          └─StreamRowIdGen { row_id_index: 7 }
+            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], pk_columns: [channel, day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [channel, $expr105, max($expr106), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-          StreamAppendOnlyHashAgg { group_key: [channel, $expr105], aggs: [count, max($expr106), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
-              result table: 0, state tables: []
-            StreamExchange Hash([0, 1]) from 1
+        StreamAppendOnlyHashAgg { group_key: [channel, $expr105], aggs: [max($expr106), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+            result table: 0, state tables: []
+          StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
       StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr105, ToChar(date_time, 'HH:mm':Varchar) as $expr106, price, bidder, auction, _row_id] }
@@ -942,7 +935,7 @@
           StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
               source state table: 3
 
-     Table 0 { columns: [channel, $expr105, count, max($expr106), count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15], distribution key: [0, 1] }
+     Table 0 { columns: [channel, $expr105, max($expr106), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
      Table 3 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0, 1] }
 - id: nexmark_q17
@@ -972,7 +965,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
     └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price)::Decimal / count(price)) as $expr2, sum(price)] }
-      └─StreamAppendOnlyHashAgg { group_key: [auction, $expr1], aggs: [count, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+      └─StreamAppendOnlyHashAgg { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
@@ -981,18 +974,18 @@
     Fragment 0
       StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], pk_columns: [auction, day], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [auction, $expr104, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price)::Decimal / count(price)) as $expr105, sum(price)] }
-          StreamAppendOnlyHashAgg { group_key: [auction, $expr104], aggs: [count, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+        StreamProject { exprs: [auction, $expr103, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price)::Decimal / count(price)) as $expr104, sum(price)] }
+          StreamAppendOnlyHashAgg { group_key: [auction, $expr103], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
-      StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr104, price, _row_id] }
+      StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr103, price, _row_id] }
         StreamRowIdGen { row_id_index: 7 }
           StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
               source state table: 1
 
-     Table 0 { columns: [auction, $expr104, count, count_0, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10], distribution key: [0, 1] }
+     Table 0 { columns: [auction, $expr103, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
      Table 1 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
 - id: nexmark_q18
@@ -1212,7 +1205,7 @@
       |   └─StreamRowIdGen { row_id_index: 9 }
       |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
-        └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
+        └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [max(price), count] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1224,7 +1217,7 @@
             left table: 0, right table 2, left degree table: 1, right degree table: 3,
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [auction, max(price)] }
-            StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, max(price)] }
+            StreamAppendOnlyHashAgg { group_key: [auction], aggs: [max(price), count] }
                 result table: 5, state tables: []
               StreamExchange Hash([0]) from 2
 
@@ -1244,7 +1237,7 @@
      Table 2 { columns: [auction, max(price)], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [auction, max(price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, current_highest_bid, _row_id, auction], primary key: [$3 ASC, $4 ASC, $0 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
 - id: nexmark_q102
@@ -1286,7 +1279,7 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
     └─StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] }
       ├─StreamProject { exprs: [id, item_name, count(auction)] }
-      | └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count, count(auction)] }
+      | └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
       |   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard(id) }
       |     | └─StreamProject { exprs: [id, item_name, _row_id] }
@@ -1294,22 +1287,21 @@
       |     |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       |     └─StreamExchange { dist: HashShard(auction) }
       |       └─StreamProject { exprs: [auction, _row_id] }
-      |         └─StreamShare { id = 767 }
+      |         └─StreamShare { id = 756 }
       |           └─StreamProject { exprs: [auction, _row_id] }
       |             └─StreamRowIdGen { row_id_index: 7 }
       |               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
-          └─StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
+          └─StreamGlobalSimpleAgg { aggs: [sum0(count), count(auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamProject { exprs: [auction, count] }
-                └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                  └─StreamExchange { dist: HashShard(auction) }
-                    └─StreamProject { exprs: [auction, _row_id] }
-                      └─StreamShare { id = 767 }
-                        └─StreamProject { exprs: [auction, _row_id] }
-                          └─StreamRowIdGen { row_id_index: 7 }
-                            └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+              └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+                └─StreamExchange { dist: HashShard(auction) }
+                  └─StreamProject { exprs: [auction, _row_id] }
+                    └─StreamShare { id = 756 }
+                      └─StreamProject { exprs: [auction, _row_id] }
+                        └─StreamRowIdGen { row_id_index: 7 }
+                          └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], pk_columns: [auction_id, auction_item_name], pk_conflict: "no check" }
@@ -1317,7 +1309,7 @@
         StreamDynamicFilter { predicate: (count(auction) >= $expr53), output: [id, item_name, count(auction)] }
             left table: 0, right table 1
           StreamProject { exprs: [id, item_name, count(auction)] }
-            StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count, count(auction)] }
+            StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
                 result table: 2, state tables: []
               StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                   left table: 3, right table 5, left degree table: 4, right degree table: 6,
@@ -1343,15 +1335,14 @@
 
     Fragment 4
       StreamProject { exprs: [(sum0(count) / count(auction)) as $expr53] }
-        StreamGlobalSimpleAgg { aggs: [count, sum0(count), count(auction)] }
+        StreamGlobalSimpleAgg { aggs: [sum0(count), count(auction), count] }
             result table: 9, state tables: []
           StreamExchange Single from 5
 
     Fragment 5
-      StreamProject { exprs: [auction, count] }
-        StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-            result table: 10, state tables: []
-          StreamExchange Hash([0]) from 6
+      StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+          result table: 10, state tables: []
+        StreamExchange Hash([0]) from 6
 
     Fragment 6
       StreamProject { exprs: [auction, _row_id] }
@@ -1359,15 +1350,15 @@
 
      Table 0 { columns: [id, item_name, count(auction)], primary key: [$2 ASC, $0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 1 { columns: [$expr53], primary key: [], value indices: [0], distribution key: [] }
-     Table 2 { columns: [id, item_name, count, count(auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 2 { columns: [id, item_name, count(auction), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 3 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
      Table 6 { columns: [auction, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 7 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 8 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 9 { columns: [count, sum0(count), count(auction)], primary key: [], value indices: [0, 1, 2], distribution key: [] }
-     Table 10 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 9 { columns: [sum0(count), count(auction), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 10 { columns: [auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4294967294 { columns: [auction_id, auction_item_name, bid_count], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q103
   before:
@@ -1405,11 +1396,10 @@
       |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamProject { exprs: [auction, count] }
-            └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(auction) }
-                └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+            └─StreamExchange { dist: HashShard(auction) }
+              └─StreamRowIdGen { row_id_index: 7 }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1419,10 +1409,9 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [auction] }
             StreamFilter { predicate: (count >= 20:Int32) }
-              StreamProject { exprs: [auction, count] }
-                StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 5, state tables: []
-                  StreamExchange Hash([0]) from 2
+              StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+                  result table: 5, state tables: []
+                StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
@@ -1440,7 +1429,7 @@
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q104
@@ -1479,11 +1468,10 @@
       |     └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamProject { exprs: [auction, count] }
-            └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-              └─StreamExchange { dist: HashShard(auction) }
-                └─StreamRowIdGen { row_id_index: 7 }
-                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+            └─StreamExchange { dist: HashShard(auction) }
+              └─StreamRowIdGen { row_id_index: 7 }
+                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [auction_id, auction_item_name, _row_id(hidden)], pk_columns: [_row_id, auction_id], pk_conflict: "no check" }
@@ -1493,10 +1481,9 @@
           StreamExchange Hash([0]) from 1
           StreamProject { exprs: [auction] }
             StreamFilter { predicate: (count < 20:Int32) }
-              StreamProject { exprs: [auction, count] }
-                StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count, count] }
-                    result table: 5, state tables: []
-                  StreamExchange Hash([0]) from 2
+              StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+                  result table: 5, state tables: []
+                StreamExchange Hash([0]) from 2
 
     Fragment 1
       StreamProject { exprs: [id, item_name, _row_id] }
@@ -1514,7 +1501,7 @@
      Table 2 { columns: [auction], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [auction, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
-     Table 5 { columns: [auction, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 5 { columns: [auction, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 6 { columns: [partition_id, offset], primary key: [$0 ASC], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [auction_id, auction_item_name, _row_id], primary key: [$2 ASC, $0 ASC], value indices: [0, 1, 2], distribution key: [0] }
 - id: nexmark_q105
@@ -1553,7 +1540,7 @@
           └─StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
               └─StreamProject { exprs: [id, item_name, count(auction)] }
-                └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count, count(auction)] }
+                └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
                   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamProject { exprs: [id, item_name, _row_id] }
@@ -1577,7 +1564,7 @@
           state table: 1
         StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr3] }
           StreamProject { exprs: [id, item_name, count(auction)] }
-            StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count, count(auction)] }
+            StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
                 result table: 2, state tables: []
               StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                   left table: 3, right table 5, left degree table: 4, right degree table: 6,
@@ -1598,7 +1585,7 @@
 
      Table 0 { columns: [id, item_name, count(auction), $expr3], primary key: [$2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
      Table 1 { columns: [id, item_name, count(auction), $expr3], primary key: [$3 ASC, $2 DESC, $0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [0], vnode column idx: 3 }
-     Table 2 { columns: [id, item_name, count, count(auction)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
+     Table 2 { columns: [id, item_name, count(auction), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0] }
      Table 3 { columns: [id, item_name, _row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 4 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 5 { columns: [auction, _row_id], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
@@ -1644,12 +1631,12 @@
   stream_plan: |
     StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [min(min(max(price)))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, min(min(max(price)))] }
+      └─StreamGlobalSimpleAgg { aggs: [min(min(max(price))), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, min(max(price))] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [min(max(price)), count] }
             └─StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
               └─StreamProject { exprs: [id, max(price)] }
-                └─StreamAppendOnlyHashAgg { group_key: [id], aggs: [count, max(price)] }
+                └─StreamAppendOnlyHashAgg { group_key: [id], aggs: [max(price), count] }
                   └─StreamProject { exprs: [id, price, _row_id, _row_id, auction] }
                     └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
                       └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
@@ -1666,16 +1653,16 @@
       StreamMaterialize { columns: [min_final], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [min(min(max(price)))] }
-          StreamGlobalSimpleAgg { aggs: [count, min(min(max(price)))] }
+          StreamGlobalSimpleAgg { aggs: [min(min(max(price))), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamHashAgg { group_key: [$expr3], aggs: [count, min(max(price))] }
+      StreamHashAgg { group_key: [$expr3], aggs: [min(max(price)), count] }
           result table: 3, state tables: [2]
         StreamProject { exprs: [id, max(price), Vnode(id) as $expr3] }
           StreamProject { exprs: [id, max(price)] }
-            StreamAppendOnlyHashAgg { group_key: [id], aggs: [count, max(price)] }
+            StreamAppendOnlyHashAgg { group_key: [id], aggs: [max(price), count] }
                 result table: 4, state tables: []
               StreamProject { exprs: [id, price, _row_id, _row_id, auction] }
                 StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
@@ -1697,10 +1684,10 @@
               source state table: 10
 
      Table 0 { columns: [min(max(price)), $expr3], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 1 { columns: [count, min(min(max(price)))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [min(min(max(price))), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 2 { columns: [$expr3, max(price), id], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
-     Table 3 { columns: [$expr3, count, min(max(price))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
-     Table 4 { columns: [id, count, max(price)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 3 { columns: [$expr3, min(max(price)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 4 { columns: [id, max(price), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 5 { columns: [id, date_time, expires, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
      Table 6 { columns: [id, _row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 7 { columns: [auction, price, date_time, _row_id], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }

--- a/src/frontend/planner_test/tests/testdata/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/over_window_function.yaml
@@ -291,11 +291,10 @@
     StreamMaterialize { columns: [window_start, window_end, supplier_id, price, cnt], pk_columns: [window_start, window_end, supplier_id], pk_conflict: "no check" }
     └─StreamGroupTopN { order: "[sum(bid.price) DESC]", limit: 3, offset: 0, group_key: [0, 1] }
       └─StreamExchange { dist: HashShard($expr1, $expr2) }
-        └─StreamProject { exprs: [$expr1, $expr2, bid.supplier_id, sum(bid.price), count] }
-          └─StreamHashAgg { group_key: [$expr1, $expr2, bid.supplier_id], aggs: [count, sum(bid.price), count] }
-            └─StreamExchange { dist: HashShard($expr1, $expr2, bid.supplier_id) }
-              └─StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval) as $expr1, (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval) as $expr2, bid.supplier_id, bid.price, bid._row_id] }
-                └─StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+        └─StreamHashAgg { group_key: [$expr1, $expr2, bid.supplier_id], aggs: [sum(bid.price), count] }
+          └─StreamExchange { dist: HashShard($expr1, $expr2, bid.supplier_id) }
+            └─StreamProject { exprs: [TumbleStart(bid.bidtime, '00:10:00':Interval) as $expr1, (TumbleStart(bid.bidtime, '00:10:00':Interval) + '00:10:00':Interval) as $expr2, bid.supplier_id, bid.price, bid._row_id] }
+              └─StreamTableScan { table: bid, columns: [bid.bidtime, bid.price, bid.item, bid.supplier_id, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
 - before:
   - create_bid
   sql: |

--- a/src/frontend/planner_test/tests/testdata/pk_derive.yaml
+++ b/src/frontend/planner_test/tests/testdata/pk_derive.yaml
@@ -23,11 +23,11 @@
     StreamMaterialize { columns: [max_v1, max_v2, t1.id(hidden), t2.id(hidden)], pk_columns: [t1.id, t2.id], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: t1.id = t2.id, output: [max(t1.v1), max(t2.v2), t1.id, t2.id] }
       ├─StreamProject { exprs: [max(t1.v1), t1.id] }
-      | └─StreamHashAgg { group_key: [t1.id], aggs: [count, max(t1.v1)] }
+      | └─StreamHashAgg { group_key: [t1.id], aggs: [max(t1.v1), count] }
       |   └─StreamExchange { dist: HashShard(t1.id) }
       |     └─StreamTableScan { table: t1, columns: [t1.id, t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamProject { exprs: [max(t2.v2), t2.id] }
-        └─StreamHashAgg { group_key: [t2.id], aggs: [count, max(t2.v2)] }
+        └─StreamHashAgg { group_key: [t2.id], aggs: [max(t2.v2), count] }
           └─StreamExchange { dist: HashShard(t2.id) }
             └─StreamTableScan { table: t2, columns: [t2.id, t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - sql: |
@@ -53,13 +53,13 @@
     StreamMaterialize { columns: [max_v, min_v, t.id(hidden), t.id#1(hidden)], pk_columns: [t.id, t.id#1], pk_conflict: "no check" }
     └─StreamHashJoin { type: Inner, predicate: t.id = t.id, output: [max(t.v), min(t.v), t.id, t.id] }
       ├─StreamProject { exprs: [max(t.v), t.id] }
-      | └─StreamHashAgg { group_key: [t.id], aggs: [count, max(t.v)] }
+      | └─StreamHashAgg { group_key: [t.id], aggs: [max(t.v), count] }
       |   └─StreamExchange { dist: HashShard(t.id) }
       |     └─StreamProject { exprs: [t.id, t.v, t._row_id] }
       |       └─StreamShare { id = 325 }
       |         └─StreamTableScan { table: t, columns: [t.id, t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamProject { exprs: [min(t.v), t.id] }
-        └─StreamHashAgg { group_key: [t.id], aggs: [count, min(t.v)] }
+        └─StreamHashAgg { group_key: [t.id], aggs: [min(t.v), count] }
           └─StreamExchange { dist: HashShard(t.id) }
             └─StreamProject { exprs: [t.id, t.v, t._row_id] }
               └─StreamShare { id = 325 }

--- a/src/frontend/planner_test/tests/testdata/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/share.yaml
@@ -36,9 +36,9 @@
   stream_plan: |
     StreamMaterialize { columns: [cnt], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count)] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum0(count)] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count] }
             └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = id, output: [_row_id, id, _row_id, id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamProject { exprs: [id, _row_id] }
@@ -117,28 +117,26 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamProject { exprs: [auction, count, window_start] }
-          |   └─StreamShare { id = 1064 }
-          |     └─StreamProject { exprs: [auction, window_start, count] }
-          |       └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-          |         └─StreamExchange { dist: HashShard(auction, window_start) }
-          |           └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-          |             └─StreamProject { exprs: [auction, date_time, _row_id] }
-          |               └─StreamFilter { predicate: IsNotNull(date_time) }
-          |                 └─StreamRowIdGen { row_id_index: 7 }
-          |                   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+          |   └─StreamShare { id = 1043 }
+          |     └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+          |       └─StreamExchange { dist: HashShard(auction, window_start) }
+          |         └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
+          |           └─StreamProject { exprs: [auction, date_time, _row_id] }
+          |             └─StreamFilter { predicate: IsNotNull(date_time) }
+          |               └─StreamRowIdGen { row_id_index: 7 }
+          |                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamProject { exprs: [max(count), window_start] }
-            └─StreamHashAgg { group_key: [window_start], aggs: [count, max(count)] }
+            └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamProject { exprs: [auction, window_start, count] }
-                  └─StreamShare { id = 1064 }
-                    └─StreamProject { exprs: [auction, window_start, count] }
-                      └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count, count] }
-                        └─StreamExchange { dist: HashShard(auction, window_start) }
-                          └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
-                            └─StreamProject { exprs: [auction, date_time, _row_id] }
-                              └─StreamFilter { predicate: IsNotNull(date_time) }
-                                └─StreamRowIdGen { row_id_index: 7 }
-                                  └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+                  └─StreamShare { id = 1043 }
+                    └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+                      └─StreamExchange { dist: HashShard(auction, window_start) }
+                        └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
+                          └─StreamProject { exprs: [auction, date_time, _row_id] }
+                            └─StreamFilter { predicate: IsNotNull(date_time) }
+                              └─StreamRowIdGen { row_id_index: 7 }
+                                └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
 - sql: |
     set rw_enable_share_plan=true;
     create table t(a int, b int);
@@ -150,17 +148,17 @@
       | └─StreamProject { exprs: [sum0(count), 0:Int32] }
       |   └─StreamShare { id = 325 }
       |     └─StreamProject { exprs: [sum0(count)] }
-      |       └─StreamGlobalSimpleAgg { aggs: [count, sum0(count)] }
+      |       └─StreamGlobalSimpleAgg { aggs: [sum0(count), count] }
       |         └─StreamExchange { dist: Single }
-      |           └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+      |           └─StreamStatelessLocalSimpleAgg { aggs: [count] }
       |             └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange { dist: HashShard(1:Int32) }
         └─StreamProject { exprs: [sum0(count), 1:Int32] }
           └─StreamShare { id = 325 }
             └─StreamProject { exprs: [sum0(count)] }
-              └─StreamGlobalSimpleAgg { aggs: [count, sum0(count)] }
+              └─StreamGlobalSimpleAgg { aggs: [sum0(count), count] }
                 └─StreamExchange { dist: Single }
-                  └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+                  └─StreamStatelessLocalSimpleAgg { aggs: [count] }
                     └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     set rw_enable_share_plan=false;
@@ -171,15 +169,15 @@
     └─StreamUnion { all: true }
       ├─StreamExchange { dist: HashShard(0:Int32) }
       | └─StreamProject { exprs: [sum0(count), 0:Int32] }
-      |   └─StreamGlobalSimpleAgg { aggs: [count, sum0(count)] }
+      |   └─StreamGlobalSimpleAgg { aggs: [sum0(count), count] }
       |     └─StreamExchange { dist: Single }
-      |       └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+      |       └─StreamStatelessLocalSimpleAgg { aggs: [count] }
       |         └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange { dist: HashShard(1:Int32) }
         └─StreamProject { exprs: [sum0(count), 1:Int32] }
-          └─StreamGlobalSimpleAgg { aggs: [count, sum0(count)] }
+          └─StreamGlobalSimpleAgg { aggs: [sum0(count), count] }
             └─StreamExchange { dist: Single }
-              └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+              └─StreamStatelessLocalSimpleAgg { aggs: [count] }
                 └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - id: force_share_source_for_self_join
   before:
@@ -190,9 +188,9 @@
   stream_plan: |
     StreamMaterialize { columns: [cnt], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count)] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum0(count)] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count] }
             └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = id, output: [_row_id, id, _row_id, id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamProject { exprs: [id, _row_id] }

--- a/src/frontend/planner_test/tests/testdata/stream_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/stream_dist_agg.yaml
@@ -18,21 +18,21 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(s.v)] }
-      └─StreamGlobalSimpleAgg { aggs: [count, max(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [max(s.v), count] }
         └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(s.v)] }
-          StreamGlobalSimpleAgg { aggs: [count, max(s.v)] }
+          StreamGlobalSimpleAgg { aggs: [max(s.v), count] }
               result table: 1, state tables: [0]
             Chain { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
               Upstream
               BatchPlanNode
 
      Table 0 { columns: [s_v, s_t__row_id], primary key: [$0 DESC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 1 { columns: [count, max(s_v)], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [max(s_v), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: sum_on_single
   before:
@@ -46,20 +46,20 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(s.v)] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(s.v), count] }
         └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(s.v)] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(s.v)] }
+          StreamGlobalSimpleAgg { aggs: [sum(s.v), count] }
               result table: 0, state tables: []
             Chain { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [count, sum(s_v)], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(s_v), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: cnt_on_single
   before:
@@ -73,20 +73,20 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(s.v)] }
-      └─StreamGlobalSimpleAgg { aggs: [count, count(s.v)] }
+      └─StreamGlobalSimpleAgg { aggs: [count(s.v), count] }
         └─StreamTableScan { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(s.v)] }
-          StreamGlobalSimpleAgg { aggs: [count, count(s.v)] }
+          StreamGlobalSimpleAgg { aggs: [count(s.v), count] }
               result table: 0, state tables: []
             Chain { table: s, columns: [s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [count, count(s_v)], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [count(s_v), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: string_agg_on_single
   before:
@@ -101,7 +101,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST)), count] }
         └─StreamProject { exprs: [s.s, ',':Varchar, s.v, s.t._row_id] }
           └─StreamTableScan { table: s, columns: [s.v, s.s, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
@@ -109,7 +109,7 @@
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
-          StreamGlobalSimpleAgg { aggs: [count, string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST))] }
+          StreamGlobalSimpleAgg { aggs: [string_agg(s.s, ',':Varchar order_by(s.v ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamProject { exprs: [s.s, ',':Varchar, s.v, s.t._row_id] }
               Chain { table: s, columns: [s.v, s.s, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
@@ -117,7 +117,7 @@
                 BatchPlanNode
 
      Table 0 { columns: [s_v, s_t__row_id, s_s, ',':Varchar], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 1 { columns: [count, string_agg(s_s, ',':Varchar order_by(s_v ASC NULLS LAST))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [string_agg(s_s, ',':Varchar order_by(s_v ASC NULLS LAST)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: extreme_on_T
   before:
@@ -132,9 +132,9 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(t.v))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, max(max(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [max(max(t.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t.v)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [max(t.v), count] }
             └─StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
@@ -142,12 +142,12 @@
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(max(t.v))] }
-          StreamGlobalSimpleAgg { aggs: [count, max(max(t.v))] }
+          StreamGlobalSimpleAgg { aggs: [max(max(t.v)), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamHashAgg { group_key: [$expr3], aggs: [count, max(t.v)] }
+      StreamHashAgg { group_key: [$expr3], aggs: [max(t.v), count] }
           result table: 3, state tables: [2]
         StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id) as $expr3] }
           Chain { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -155,9 +155,9 @@
             BatchPlanNode
 
      Table 0 { columns: [max(t_v), $expr3], primary key: [$0 DESC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 1 { columns: [count, max(max(t_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [max(max(t_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 2 { columns: [$expr3, t_v, t__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
-     Table 3 { columns: [$expr3, count, max(t_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 3 { columns: [$expr3, max(t_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: extreme_on_AO
   before:
@@ -167,26 +167,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(ao.v))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(max(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [max(max(ao.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [max(ao.v)] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(max(ao.v))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(max(ao.v))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [max(max(ao.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [max(ao.v)] }
         Chain { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, max(max(ao_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [max(max(ao_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: sum_on_T
   before:
@@ -201,26 +201,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(t.v))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(t.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(t.v)] }
             └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(sum(t.v))] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(sum(t.v))] }
+          StreamGlobalSimpleAgg { aggs: [sum(sum(t.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum(t.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum(t.v)] }
         Chain { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum(t_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(sum(t_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: sum_on_AO
   before:
@@ -230,26 +230,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum(ao.v))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum(sum(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(sum(ao.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(ao.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(ao.v)] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(sum(ao.v))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum(sum(ao.v))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [sum(sum(ao.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum(ao.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum(ao.v)] }
         Chain { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum(ao_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(sum(ao_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: cnt_on_T
   before:
@@ -264,26 +264,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count(t.v))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum0(count(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum0(count(t.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count(t.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count(t.v)] }
             └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum0(count(t.v))] }
-          StreamGlobalSimpleAgg { aggs: [count, sum0(count(t.v))] }
+          StreamGlobalSimpleAgg { aggs: [sum0(count(t.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, count(t.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [count(t.v)] }
         Chain { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum0(count(t_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum0(count(t_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: cnt_on_AO
   before:
@@ -293,26 +293,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum0(count(ao.v))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum0(count(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [sum0(count(ao.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, count(ao.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [count(ao.v)] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum0(count(ao.v))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, sum0(count(ao.v))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [sum0(count(ao.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, count(ao.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [count(ao.v)] }
         Chain { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum0(count(ao_v))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum0(count(ao_v)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: string_agg_on_T
   before:
@@ -327,7 +327,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [t.s, ',':Varchar, t.o, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.o, t.s, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -336,7 +336,7 @@
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamGlobalSimpleAgg { aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+          StreamGlobalSimpleAgg { aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
@@ -347,7 +347,7 @@
           BatchPlanNode
 
      Table 0 { columns: [t_o, t__row_id, t_s, ',':Varchar], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 1 { columns: [count, string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 1 { columns: [string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: string_agg_on_AO
   before:
@@ -357,7 +357,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -366,7 +366,7 @@
       StreamMaterialize { columns: [a1], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
@@ -376,7 +376,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [a1], primary key: [], value indices: [0], distribution key: [] }
 - id: extreme_count_on_T
   before:
@@ -391,9 +391,9 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(t.v)), sum0(count(t.v))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, max(max(t.v)), sum0(count(t.v))] }
+      └─StreamGlobalSimpleAgg { aggs: [max(max(t.v)), sum0(count(t.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamHashAgg { group_key: [$expr1], aggs: [count, max(t.v), count(t.v)] }
+          └─StreamHashAgg { group_key: [$expr1], aggs: [max(t.v), count(t.v), count] }
             └─StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id) as $expr1] }
               └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
@@ -401,12 +401,12 @@
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(max(t.v)), sum0(count(t.v))] }
-          StreamGlobalSimpleAgg { aggs: [count, max(max(t.v)), sum0(count(t.v))] }
+          StreamGlobalSimpleAgg { aggs: [max(max(t.v)), sum0(count(t.v)), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
     Fragment 1
-      StreamHashAgg { group_key: [$expr3], aggs: [count, max(t.v), count(t.v)] }
+      StreamHashAgg { group_key: [$expr3], aggs: [max(t.v), count(t.v), count] }
           result table: 3, state tables: [2]
         StreamProject { exprs: [t.v, t._row_id, Vnode(t._row_id) as $expr3] }
           Chain { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -414,9 +414,9 @@
             BatchPlanNode
 
      Table 0 { columns: [max(t_v), $expr3], primary key: [$0 DESC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 1 { columns: [count, max(max(t_v)), sum0(count(t_v))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 1 { columns: [max(max(t_v)), sum0(count(t_v)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 2 { columns: [$expr3, t_v, t__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
-     Table 3 { columns: [$expr3, count, max(t_v), count(t_v)], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [], vnode column idx: 0 }
+     Table 3 { columns: [$expr3, max(t_v), count(t_v), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [], vnode column idx: 0 }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: extreme_count_on_AO
   before:
@@ -426,26 +426,26 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(max(ao.v)), sum0(count(ao.v))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(max(ao.v)), sum0(count(ao.v))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [max(max(ao.v)), sum0(count(ao.v)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v), count(ao.v)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [max(ao.v), count(ao.v)] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(max(ao.v)), sum0(count(ao.v))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(max(ao.v)), sum0(count(ao.v))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [max(max(ao.v)), sum0(count(ao.v)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, max(ao.v), count(ao.v)] }
+      StreamStatelessLocalSimpleAgg { aggs: [max(ao.v), count(ao.v)] }
         Chain { table: ao, columns: [ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, max(max(ao_v)), sum0(count(ao_v))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [max(max(ao_v)), sum0(count(ao_v)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: count_string_agg_on_T
   before:
@@ -460,7 +460,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -469,7 +469,7 @@
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamGlobalSimpleAgg { aggs: [count, count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+          StreamGlobalSimpleAgg { aggs: [count(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamExchange Single from 1
 
@@ -480,7 +480,7 @@
           BatchPlanNode
 
      Table 0 { columns: [t_o, t__row_id, t_s, ',':Varchar], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 1 { columns: [count, count(t_v), string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 1 { columns: [count(t_v), string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: count_string_agg_on_AO
   before:
@@ -490,7 +490,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -499,7 +499,7 @@
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [count(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
@@ -509,7 +509,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, count(ao_v), string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [count(ao_v), string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: extreme_string_agg_on_T
   before:
@@ -524,7 +524,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamGlobalSimpleAgg { aggs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [t.v, t.s, ',':Varchar, t.o, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.v, t.o, t.s, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -533,7 +533,7 @@
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
-          StreamGlobalSimpleAgg { aggs: [count, max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+          StreamGlobalSimpleAgg { aggs: [max(t.v), string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
               result table: 2, state tables: [0, 1]
             StreamExchange Single from 1
 
@@ -545,7 +545,7 @@
 
      Table 0 { columns: [t_v, t__row_id], primary key: [$0 DESC, $1 ASC], value indices: [0, 1], distribution key: [] }
      Table 1 { columns: [t_o, t__row_id, t_s, ',':Varchar], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3], distribution key: [] }
-     Table 2 { columns: [count, max(t_v), string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 2 { columns: [max(t_v), string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: extreme_string_agg_on_AO
   before:
@@ -555,7 +555,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyGlobalSimpleAgg { aggs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: Single }
           └─StreamProject { exprs: [ao.v, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.v, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -564,7 +564,7 @@
       StreamMaterialize { columns: [a1, a2], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
-          StreamAppendOnlyGlobalSimpleAgg { aggs: [count, max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+          StreamAppendOnlyGlobalSimpleAgg { aggs: [max(ao.v), string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
@@ -574,7 +574,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, max(ao_v), string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [max(ao_v), string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 4294967294 { columns: [a1, a2], primary key: [], value indices: [0, 1], distribution key: [] }
 - id: extreme_on_T_by_k
   before:
@@ -590,7 +590,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(t.v), t.k] }
-      └─StreamHashAgg { group_key: [t.k], aggs: [count, max(t.v)] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [max(t.v), count] }
         └─StreamExchange { dist: HashShard(t.k) }
           └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
@@ -598,7 +598,7 @@
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(t.v), t.k] }
-          StreamHashAgg { group_key: [t.k], aggs: [count, max(t.v)] }
+          StreamHashAgg { group_key: [t.k], aggs: [max(t.v), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -608,7 +608,7 @@
         BatchPlanNode
 
      Table 0 { columns: [t_k, t_v, t__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [t_k, count, max(t_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [t_k, max(t_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, t.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: extreme_on_Tk_by_k
   before:
@@ -623,21 +623,21 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(tk.v), tk.k] }
-      └─StreamHashAgg { group_key: [tk.k], aggs: [count, max(tk.v)] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [max(tk.v), count] }
         └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(tk.v), tk.k] }
-          StreamHashAgg { group_key: [tk.k], aggs: [count, max(tk.v)] }
+          StreamHashAgg { group_key: [tk.k], aggs: [max(tk.v), count] }
               result table: 1, state tables: [0]
             Chain { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
               Upstream
               BatchPlanNode
 
      Table 0 { columns: [tk_k, tk_v, tk_t__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [tk_k, count, max(tk_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [tk_k, max(tk_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, tk.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: extreme_on_S_by_k
   before:
@@ -653,7 +653,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(s.v), s.k] }
-      └─StreamHashAgg { group_key: [s.k], aggs: [count, max(s.v)] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [max(s.v), count] }
         └─StreamExchange { dist: HashShard(s.k) }
           └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
@@ -661,7 +661,7 @@
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(s.v), s.k] }
-          StreamHashAgg { group_key: [s.k], aggs: [count, max(s.v)] }
+          StreamHashAgg { group_key: [s.k], aggs: [max(s.v), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -671,7 +671,7 @@
         BatchPlanNode
 
      Table 0 { columns: [s_k, s_v, s_t__row_id], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [s_k, count, max(s_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [s_k, max(s_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, s.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: extreme_on_AO_by_k
   before:
@@ -681,7 +681,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [max(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, max(ao.v)] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [max(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
@@ -689,7 +689,7 @@
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [max(ao.v), ao.k] }
-          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, max(ao.v)] }
+          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [max(ao.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -698,7 +698,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [ao_k, count, max(ao_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [ao_k, max(ao_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, ao.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: sum_on_T_by_k
   before:
@@ -714,7 +714,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(t.v), t.k] }
-      └─StreamHashAgg { group_key: [t.k], aggs: [count, sum(t.v)] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [sum(t.v), count] }
         └─StreamExchange { dist: HashShard(t.k) }
           └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
@@ -722,7 +722,7 @@
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(t.v), t.k] }
-          StreamHashAgg { group_key: [t.k], aggs: [count, sum(t.v)] }
+          StreamHashAgg { group_key: [t.k], aggs: [sum(t.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -731,7 +731,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [t_k, count, sum(t_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [t_k, sum(t_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, t.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: sum_on_Tk_by_k
   before:
@@ -746,20 +746,20 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(tk.v), tk.k] }
-      └─StreamHashAgg { group_key: [tk.k], aggs: [count, sum(tk.v)] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [sum(tk.v), count] }
         └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(tk.v), tk.k] }
-          StreamHashAgg { group_key: [tk.k], aggs: [count, sum(tk.v)] }
+          StreamHashAgg { group_key: [tk.k], aggs: [sum(tk.v), count] }
               result table: 0, state tables: []
             Chain { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [tk_k, count, sum(tk_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [tk_k, sum(tk_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, tk.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: sum_on_S_by_k
   before:
@@ -775,7 +775,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(s.v), s.k] }
-      └─StreamHashAgg { group_key: [s.k], aggs: [count, sum(s.v)] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [sum(s.v), count] }
         └─StreamExchange { dist: HashShard(s.k) }
           └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
@@ -783,7 +783,7 @@
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(s.v), s.k] }
-          StreamHashAgg { group_key: [s.k], aggs: [count, sum(s.v)] }
+          StreamHashAgg { group_key: [s.k], aggs: [sum(s.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -792,7 +792,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [s_k, count, sum(s_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [s_k, sum(s_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, s.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: sum_on_AO_by_k
   before:
@@ -802,7 +802,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, sum(ao.v)] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [sum(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
@@ -810,7 +810,7 @@
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(ao.v), ao.k] }
-          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, sum(ao.v)] }
+          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [sum(ao.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -819,7 +819,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [ao_k, count, sum(ao_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [ao_k, sum(ao_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, ao.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: cnt_on_T_by_k
   before:
@@ -835,7 +835,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(t.v), t.k] }
-      └─StreamHashAgg { group_key: [t.k], aggs: [count, count(t.v)] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [count(t.v), count] }
         └─StreamExchange { dist: HashShard(t.k) }
           └─StreamTableScan { table: t, columns: [t.k, t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   stream_dist_plan: |
@@ -843,7 +843,7 @@
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(t.v), t.k] }
-          StreamHashAgg { group_key: [t.k], aggs: [count, count(t.v)] }
+          StreamHashAgg { group_key: [t.k], aggs: [count(t.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -852,7 +852,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [t_k, count, count(t_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [t_k, count(t_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, t.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: cnt_on_Tk_by_k
   before:
@@ -867,20 +867,20 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(tk.v), tk.k] }
-      └─StreamHashAgg { group_key: [tk.k], aggs: [count, count(tk.v)] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [count(tk.v), count] }
         └─StreamTableScan { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(tk.v), tk.k] }
-          StreamHashAgg { group_key: [tk.k], aggs: [count, count(tk.v)] }
+          StreamHashAgg { group_key: [tk.k], aggs: [count(tk.v), count] }
               result table: 0, state tables: []
             Chain { table: tk, columns: [tk.k, tk.v, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [tk_k, count, count(tk_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [tk_k, count(tk_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, tk.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: cnt_on_S_by_k
   before:
@@ -896,7 +896,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(s.v), s.k] }
-      └─StreamHashAgg { group_key: [s.k], aggs: [count, count(s.v)] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [count(s.v), count] }
         └─StreamExchange { dist: HashShard(s.k) }
           └─StreamTableScan { table: s, columns: [s.k, s.v, s.o, s.t._row_id], pk: [s.t._row_id], dist: Single }
   stream_dist_plan: |
@@ -904,7 +904,7 @@
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(s.v), s.k] }
-          StreamHashAgg { group_key: [s.k], aggs: [count, count(s.v)] }
+          StreamHashAgg { group_key: [s.k], aggs: [count(s.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -913,7 +913,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [s_k, count, count(s_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [s_k, count(s_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, s.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: cnt_on_AO_by_k
   before:
@@ -923,7 +923,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [count(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, count(ao.v)] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |
@@ -931,7 +931,7 @@
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [count(ao.v), ao.k] }
-          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, count(ao.v)] }
+          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count(ao.v), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -940,7 +940,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [ao_k, count, count(ao_v)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [ao_k, count(ao_v), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, ao.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: string_agg_on_T_by_k
   before:
@@ -957,7 +957,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), t.k] }
-      └─StreamHashAgg { group_key: [t.k], aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+      └─StreamHashAgg { group_key: [t.k], aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: HashShard(t.k) }
           └─StreamProject { exprs: [t.k, t.s, ',':Varchar, t.o, t._row_id] }
             └─StreamTableScan { table: t, columns: [t.k, t.o, t.s, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -966,7 +966,7 @@
       StreamMaterialize { columns: [a1, t.k(hidden)], pk_columns: [t.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), t.k] }
-          StreamHashAgg { group_key: [t.k], aggs: [count, string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST))] }
+          StreamHashAgg { group_key: [t.k], aggs: [string_agg(t.s, ',':Varchar order_by(t.o ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -977,7 +977,7 @@
           BatchPlanNode
 
      Table 0 { columns: [t_k, t_o, t__row_id, t_s, ',':Varchar], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2, 3, 4], distribution key: [0] }
-     Table 1 { columns: [t_k, count, string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [t_k, string_agg(t_s, ',':Varchar order_by(t_o ASC NULLS LAST)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, t.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: string_agg_on_Tk_by_k
   before:
@@ -993,7 +993,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), tk.k] }
-      └─StreamHashAgg { group_key: [tk.k], aggs: [count, string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
+      └─StreamHashAgg { group_key: [tk.k], aggs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), count] }
         └─StreamProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o, tk.t._row_id] }
           └─StreamTableScan { table: tk, columns: [tk.k, tk.o, tk.s, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
   stream_dist_plan: |
@@ -1001,7 +1001,7 @@
       StreamMaterialize { columns: [a1, tk.k(hidden)], pk_columns: [tk.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), tk.k] }
-          StreamHashAgg { group_key: [tk.k], aggs: [count, string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST))] }
+          StreamHashAgg { group_key: [tk.k], aggs: [string_agg(tk.s, ',':Varchar order_by(tk.o ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamProject { exprs: [tk.k, tk.s, ',':Varchar, tk.o, tk.t._row_id] }
               Chain { table: tk, columns: [tk.k, tk.o, tk.s, tk.t._row_id], pk: [tk.t._row_id], dist: UpstreamHashShard(tk.k) }
@@ -1009,7 +1009,7 @@
                 BatchPlanNode
 
      Table 0 { columns: [tk_k, tk_o, tk_t__row_id, tk_s, ',':Varchar], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2, 3, 4], distribution key: [0] }
-     Table 1 { columns: [tk_k, count, string_agg(tk_s, ',':Varchar order_by(tk_o ASC NULLS LAST))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [tk_k, string_agg(tk_s, ',':Varchar order_by(tk_o ASC NULLS LAST)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, tk.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: string_agg_on_S_by_k
   before:
@@ -1026,7 +1026,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), s.k] }
-      └─StreamHashAgg { group_key: [s.k], aggs: [count, string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
+      └─StreamHashAgg { group_key: [s.k], aggs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: HashShard(s.k) }
           └─StreamProject { exprs: [s.k, s.s, ',':Varchar, s.o, s.t._row_id] }
             └─StreamTableScan { table: s, columns: [s.k, s.o, s.s, s.t._row_id], pk: [s.t._row_id], dist: Single }
@@ -1035,7 +1035,7 @@
       StreamMaterialize { columns: [a1, s.k(hidden)], pk_columns: [s.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), s.k] }
-          StreamHashAgg { group_key: [s.k], aggs: [count, string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST))] }
+          StreamHashAgg { group_key: [s.k], aggs: [string_agg(s.s, ',':Varchar order_by(s.o ASC NULLS LAST)), count] }
               result table: 1, state tables: [0]
             StreamExchange Hash([0]) from 1
 
@@ -1046,7 +1046,7 @@
           BatchPlanNode
 
      Table 0 { columns: [s_k, s_o, s_t__row_id, s_s, ',':Varchar], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [1, 2, 3, 4], distribution key: [0] }
-     Table 1 { columns: [s_k, count, string_agg(s_s, ',':Varchar order_by(s_o ASC NULLS LAST))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 1 { columns: [s_k, string_agg(s_s, ',':Varchar order_by(s_o ASC NULLS LAST)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, s.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }
 - id: string_agg_on_AO_by_k
   before:
@@ -1056,7 +1056,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
     └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -1065,7 +1065,7 @@
       StreamMaterialize { columns: [a1, ao.k(hidden)], pk_columns: [ao.k], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), ao.k] }
-          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count, string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST))] }
+          StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC NULLS LAST)), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -1075,5 +1075,5 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [ao_k, count, string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [ao_k, string_agg(ao_s, ',':Varchar order_by(ao_o ASC NULLS LAST)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [a1, ao.k], primary key: [$1 ASC], value indices: [0, 1], distribution key: [1] }

--- a/src/frontend/planner_test/tests/testdata/time_window.yaml
+++ b/src/frontend/planner_test/tests/testdata/time_window.yaml
@@ -152,7 +152,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, window_end, avg], pk_columns: [v1, window_end], pk_conflict: "no check" }
     └─StreamProject { exprs: [t.v1, window_end, (sum(t.v3) / count(t.v3)::Float64) as $expr1] }
-      └─StreamHashAgg { group_key: [t.v1, window_end], aggs: [count, sum(t.v3), count(t.v3)] }
+      └─StreamHashAgg { group_key: [t.v1, window_end], aggs: [sum(t.v3), count(t.v3), count] }
         └─StreamExchange { dist: HashShard(t.v1, window_end) }
           └─StreamHopWindow { time_col: t.v2, slide: 00:01:00, size: 00:10:00, output: [t.v1, t.v3, window_end, t._row_id] }
             └─StreamFilter { predicate: IsNotNull(t.v2) }

--- a/src/frontend/planner_test/tests/testdata/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch.yaml
@@ -141,7 +141,7 @@
   stream_plan: |
     StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus], pk_conflict: "no check" }
     └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32) as $expr3, RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32) as $expr4, RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32) as $expr5, count] }
-      └─StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [count, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+      └─StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr1), sum($expr2), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
         └─StreamExchange { dist: HashShard(lineitem.l_returnflag, lineitem.l_linestatus) }
           └─StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)) as $expr2, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
             └─StreamFilter { predicate: (lineitem.l_shipdate <= '1998-09-21 00:00:00':Timestamp) }
@@ -150,19 +150,19 @@
     Fragment 0
       StreamMaterialize { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], pk_columns: [l_returnflag, l_linestatus], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr358), sum($expr359), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32) as $expr360, RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32) as $expr361, RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32) as $expr362, count] }
-          StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [count, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr358), sum($expr359), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
+        StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr355), sum($expr356), RoundDigit((sum(lineitem.l_quantity) / count(lineitem.l_quantity)), 4:Int32) as $expr357, RoundDigit((sum(lineitem.l_extendedprice) / count(lineitem.l_extendedprice)), 4:Int32) as $expr358, RoundDigit((sum(lineitem.l_discount) / count(lineitem.l_discount)), 4:Int32) as $expr359, count] }
+          StreamHashAgg { group_key: [lineitem.l_returnflag, lineitem.l_linestatus], aggs: [sum(lineitem.l_quantity), sum(lineitem.l_extendedprice), sum($expr355), sum($expr356), count(lineitem.l_quantity), count(lineitem.l_extendedprice), sum(lineitem.l_discount), count(lineitem.l_discount), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1]) from 1
 
     Fragment 1
-      StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr358, ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)) as $expr359, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
+      StreamProject { exprs: [lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_quantity, lineitem.l_extendedprice, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr355, ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) * (1:Int32 + lineitem.l_tax)) as $expr356, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber] }
         StreamFilter { predicate: (lineitem.l_shipdate <= '1998-09-21 00:00:00':Timestamp) }
           Chain { table: lineitem, columns: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_tax, lineitem.l_returnflag, lineitem.l_linestatus, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [lineitem_l_returnflag, lineitem_l_linestatus, count, sum(lineitem_l_quantity), sum(lineitem_l_extendedprice), sum($expr358), sum($expr359), count(lineitem_l_quantity), count(lineitem_l_extendedprice), sum(lineitem_l_discount), count(lineitem_l_discount), count_0], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10, 11], distribution key: [0, 1] }
+     Table 0 { columns: [lineitem_l_returnflag, lineitem_l_linestatus, sum(lineitem_l_quantity), sum(lineitem_l_extendedprice), sum($expr355), sum($expr356), count(lineitem_l_quantity), count(lineitem_l_extendedprice), sum(lineitem_l_discount), count(lineitem_l_discount), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3, 4, 5, 6, 7, 8, 9, 10], distribution key: [0, 1] }
      Table 4294967294 { columns: [l_returnflag, l_linestatus, sum_qty, sum_base_price, sum_disc_price, sum_charge, avg_qty, avg_price, avg_disc, count_order], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9], distribution key: [0, 1] }
 - id: tpch_q2
   before:
@@ -322,7 +322,7 @@
                 |   |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
                 |   |     └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name, nation.n_regionkey], pk: [nation.n_nationkey], dist: UpstreamHashShard(nation.n_nationkey) }
                 |   └─StreamProject { exprs: [part.p_partkey, min(partsupp.ps_supplycost)] }
-                |     └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
+                |     └─StreamHashAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost), count] }
                 |       └─StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
                 |         ├─StreamExchange { dist: HashShard(part.p_partkey) }
                 |         | └─StreamProject { exprs: [part.p_partkey] }
@@ -374,7 +374,7 @@
           left table: 6, right table 8, left degree table: 7, right degree table: 9,
         StreamExchange Hash([0]) from 3
         StreamProject { exprs: [part.p_partkey, min(partsupp.ps_supplycost)] }
-          StreamHashAgg { group_key: [part.p_partkey], aggs: [count, min(partsupp.ps_supplycost)] }
+          StreamHashAgg { group_key: [part.p_partkey], aggs: [min(partsupp.ps_supplycost), count] }
               result table: 23, state tables: [22]
             StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM partsupp.ps_partkey, output: [part.p_partkey, partsupp.ps_supplycost, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey, region.r_regionkey, nation.n_regionkey] }
                 left table: 24, right table 26, left degree table: 25, right degree table: 27,
@@ -502,7 +502,7 @@
      Table 20 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, partsupp_ps_supplycost], primary key: [$0 ASC, $1 ASC], value indices: [0, 1, 2], distribution key: [0] }
      Table 21 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 22 { columns: [part_p_partkey, partsupp_ps_supplycost, partsupp_ps_partkey, partsupp_ps_suppkey, supplier_s_suppkey, nation_n_nationkey, supplier_s_nationkey, region_r_regionkey, nation_n_regionkey], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8], distribution key: [0] }
-     Table 23 { columns: [part_p_partkey, count, min(partsupp_ps_supplycost)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 23 { columns: [part_p_partkey, min(partsupp_ps_supplycost), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 24 { columns: [part_p_partkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 25 { columns: [part_p_partkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 26 { columns: [partsupp_ps_partkey, partsupp_ps_supplycost, partsupp_ps_suppkey, supplier_s_suppkey, nation_n_nationkey, supplier_s_nationkey, nation_n_regionkey, region_r_regionkey], primary key: [$0 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $7 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [0] }
@@ -599,7 +599,7 @@
           └─StreamGroupTopN { order: "[sum($expr1) DESC, orders.o_orderdate ASC]", limit: 10, offset: 0, group_key: [4] }
             └─StreamProject { exprs: [lineitem.l_orderkey, sum($expr1), orders.o_orderdate, orders.o_shippriority, Vnode(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) as $expr2] }
               └─StreamProject { exprs: [lineitem.l_orderkey, sum($expr1), orders.o_orderdate, orders.o_shippriority] }
-                └─StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [count, sum($expr1)] }
+                └─StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum($expr1), count] }
                   └─StreamExchange { dist: HashShard(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) }
                     └─StreamProject { exprs: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
                       └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderdate, orders.o_shippriority, lineitem.l_orderkey, lineitem.l_extendedprice, lineitem.l_discount, customer.c_custkey, orders.o_orderkey, orders.o_custkey, lineitem.l_linenumber] }
@@ -630,7 +630,7 @@
           state table: 1
         StreamProject { exprs: [lineitem.l_orderkey, sum($expr73), orders.o_orderdate, orders.o_shippriority, Vnode(lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority) as $expr74] }
           StreamProject { exprs: [lineitem.l_orderkey, sum($expr73), orders.o_orderdate, orders.o_shippriority] }
-            StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [count, sum($expr73)] }
+            StreamHashAgg { group_key: [lineitem.l_orderkey, orders.o_orderdate, orders.o_shippriority], aggs: [sum($expr73), count] }
                 result table: 2, state tables: []
               StreamExchange Hash([0, 1, 2]) from 2
 
@@ -669,7 +669,7 @@
 
      Table 0 { columns: [lineitem_l_orderkey, sum($expr73), orders_o_orderdate, orders_o_shippriority, $expr74], primary key: [$1 DESC, $2 ASC, $0 ASC, $3 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [] }
      Table 1 { columns: [lineitem_l_orderkey, sum($expr73), orders_o_orderdate, orders_o_shippriority, $expr74], primary key: [$4 ASC, $1 DESC, $2 ASC, $0 ASC, $3 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0, 2, 3], vnode column idx: 4 }
-     Table 2 { columns: [lineitem_l_orderkey, orders_o_orderdate, orders_o_shippriority, count, sum($expr73)], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
+     Table 2 { columns: [lineitem_l_orderkey, orders_o_orderdate, orders_o_shippriority, sum($expr73), count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
      Table 3 { columns: [orders_o_orderkey, orders_o_orderdate, orders_o_shippriority, customer_c_custkey, orders_o_custkey], primary key: [$0 ASC, $3 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
      Table 4 { columns: [orders_o_orderkey, customer_c_custkey, orders_o_custkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0] }
      Table 5 { columns: [lineitem_l_orderkey, lineitem_l_extendedprice, lineitem_l_discount, lineitem_l_linenumber], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -735,26 +735,24 @@
                   └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_commitdate, lineitem.l_receiptdate], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority], pk_conflict: "no check" }
-    └─StreamProject { exprs: [orders.o_orderpriority, count] }
-      └─StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count, count] }
-        └─StreamExchange { dist: HashShard(orders.o_orderpriority) }
-          └─StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders.o_orderkey] }
-            ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
-            | └─StreamProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
-            |   └─StreamFilter { predicate: (orders.o_orderdate >= '1997-07-01':Date) AND (orders.o_orderdate < '1997-10-01 00:00:00':Timestamp) }
-            |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
-            └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-              └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_linenumber] }
-                └─StreamFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
-                  └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+    └─StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
+      └─StreamExchange { dist: HashShard(orders.o_orderpriority) }
+        └─StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders.o_orderkey] }
+          ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
+          | └─StreamProject { exprs: [orders.o_orderkey, orders.o_orderpriority] }
+          |   └─StreamFilter { predicate: (orders.o_orderdate >= '1997-07-01':Date) AND (orders.o_orderdate < '1997-10-01 00:00:00':Timestamp) }
+          |     └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderpriority, orders.o_orderdate], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
+          └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+            └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_linenumber] }
+              └─StreamFilter { predicate: (lineitem.l_commitdate < lineitem.l_receiptdate) }
+                └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [o_orderpriority, order_count], pk_columns: [o_orderpriority], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [orders.o_orderpriority, count] }
-          StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count, count] }
-              result table: 0, state tables: []
-            StreamExchange Hash([0]) from 1
+        StreamHashAgg { group_key: [orders.o_orderpriority], aggs: [count] }
+            result table: 0, state tables: []
+          StreamExchange Hash([0]) from 1
 
     Fragment 1
       StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, orders.o_orderkey] }
@@ -776,7 +774,7 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [orders_o_orderpriority, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [orders_o_orderpriority, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 1 { columns: [orders_o_orderkey, orders_o_orderpriority], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 2 { columns: [orders_o_orderkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 3 { columns: [lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0] }
@@ -868,7 +866,7 @@
   stream_plan: |
     StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name], pk_conflict: "no check" }
     └─StreamProject { exprs: [nation.n_name, sum($expr1)] }
-      └─StreamHashAgg { group_key: [nation.n_name], aggs: [count, sum($expr1)] }
+      └─StreamHashAgg { group_key: [nation.n_name], aggs: [sum($expr1), count] }
         └─StreamExchange { dist: HashShard(nation.n_name) }
           └─StreamProject { exprs: [nation.n_name, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, region.r_regionkey, nation.n_regionkey] }
             └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, customer.c_custkey, orders.o_orderkey, orders.o_custkey, supplier.s_suppkey, customer.c_nationkey, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, nation.n_regionkey, region.r_regionkey] }
@@ -901,7 +899,7 @@
       StreamMaterialize { columns: [n_name, revenue], pk_columns: [n_name], order_descs: [revenue, n_name], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [nation.n_name, sum($expr71)] }
-          StreamHashAgg { group_key: [nation.n_name], aggs: [count, sum($expr71)] }
+          StreamHashAgg { group_key: [nation.n_name], aggs: [sum($expr71), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -970,7 +968,7 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [nation_n_name, count, sum($expr71)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [nation_n_name, sum($expr71), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 1 { columns: [lineitem_l_extendedprice, lineitem_l_discount, nation_n_name, nation_n_regionkey, customer_c_custkey, orders_o_orderkey, orders_o_custkey, supplier_s_suppkey, customer_c_nationkey, supplier_s_nationkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_suppkey, nation_n_nationkey], primary key: [$3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC, $11 ASC, $12 ASC, $13 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [3] }
      Table 2 { columns: [nation_n_regionkey, customer_c_custkey, orders_o_orderkey, orders_o_custkey, supplier_s_suppkey, customer_c_nationkey, supplier_s_nationkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_suppkey, nation_n_nationkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC], value indices: [11], distribution key: [0] }
      Table 3 { columns: [region_r_regionkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
@@ -1025,9 +1023,9 @@
   stream_plan: |
     StreamMaterialize { columns: [revenue], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum($expr1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1)] }
             └─StreamProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount) as $expr1, lineitem.l_orderkey, lineitem.l_linenumber] }
               └─StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Date) AND (lineitem.l_shipdate < '1995-01-01 00:00:00':Timestamp) AND (lineitem.l_discount >= 0.07:Decimal) AND (lineitem.l_discount <= 0.09:Decimal) AND (lineitem.l_quantity < 24:Int32) }
                 └─StreamTableScan { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
@@ -1036,19 +1034,19 @@
       StreamMaterialize { columns: [revenue], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(sum($expr73))] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr73))] }
+          StreamGlobalSimpleAgg { aggs: [sum(sum($expr73)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr73)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum($expr73)] }
         StreamProject { exprs: [(lineitem.l_extendedprice * lineitem.l_discount) as $expr73, lineitem.l_orderkey, lineitem.l_linenumber] }
           StreamFilter { predicate: (lineitem.l_shipdate >= '1994-01-01':Date) AND (lineitem.l_shipdate < '1995-01-01 00:00:00':Timestamp) AND (lineitem.l_discount >= 0.07:Decimal) AND (lineitem.l_discount <= 0.09:Decimal) AND (lineitem.l_quantity < 24:Int32) }
             Chain { table: lineitem, columns: [lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_quantity, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
               Upstream
               BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum($expr73))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(sum($expr73)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [revenue], primary key: [], value indices: [0], distribution key: [] }
 - id: tpch_q7
   before:
@@ -1147,7 +1145,7 @@
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "no check" }
     └─StreamProject { exprs: [nation.n_name, nation.n_name, $expr1, sum($expr2)] }
-      └─StreamHashAgg { group_key: [nation.n_name, nation.n_name, $expr1], aggs: [count, sum($expr2)] }
+      └─StreamHashAgg { group_key: [nation.n_name, nation.n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(nation.n_name, nation.n_name, $expr1) }
           └─StreamProject { exprs: [nation.n_name, nation.n_name, Extract('YEAR':Varchar, lineitem.l_shipdate) as $expr1, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr2, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey] }
             └─StreamFilter { predicate: (((nation.n_name = 'ROMANIA':Varchar) AND (nation.n_name = 'IRAN':Varchar)) OR ((nation.n_name = 'IRAN':Varchar) AND (nation.n_name = 'ROMANIA':Varchar))) }
@@ -1178,7 +1176,7 @@
       StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [nation.n_name, nation.n_name, $expr149, sum($expr150)] }
-          StreamHashAgg { group_key: [nation.n_name, nation.n_name, $expr149], aggs: [count, sum($expr150)] }
+          StreamHashAgg { group_key: [nation.n_name, nation.n_name, $expr149], aggs: [sum($expr150), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1, 2]) from 1
 
@@ -1245,7 +1243,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [nation_n_name, nation_n_name_0, $expr149, count, sum($expr150)], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
+     Table 0 { columns: [nation_n_name, nation_n_name_0, $expr149, sum($expr150), count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
      Table 1 { columns: [lineitem_l_extendedprice, lineitem_l_discount, lineitem_l_shipdate, nation_n_name, customer_c_nationkey, supplier_s_suppkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey, orders_o_custkey, customer_c_custkey], primary key: [$4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC, $11 ASC, $13 ASC, $12 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13], distribution key: [4] }
      Table 2 { columns: [customer_c_nationkey, supplier_s_suppkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey, customer_c_custkey, orders_o_custkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC], value indices: [10], distribution key: [0] }
      Table 3 { columns: [nation_n_nationkey, nation_n_name], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
@@ -1377,7 +1375,7 @@
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year], pk_conflict: "no check" }
     └─StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-      └─StreamHashAgg { group_key: [$expr1], aggs: [count, sum($expr2), sum($expr3)] }
+      └─StreamHashAgg { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [Extract('YEAR':Varchar, orders.o_orderdate) as $expr1, Case((nation.n_name = 'IRAN':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Decimal) as $expr2, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr3, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, region.r_regionkey, nation.n_regionkey] }
             └─StreamHashJoin { type: Inner, predicate: nation.n_regionkey = region.r_regionkey, output: [lineitem.l_extendedprice, lineitem.l_discount, orders.o_orderdate, nation.n_name, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey, customer.c_custkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, nation.n_regionkey, region.r_regionkey] }
@@ -1419,7 +1417,7 @@
       StreamMaterialize { columns: [o_year, mkt_share], pk_columns: [o_year], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [$expr291, RoundDigit((sum($expr292) / sum($expr293)), 6:Int32) as $expr294] }
-          StreamHashAgg { group_key: [$expr291], aggs: [count, sum($expr292), sum($expr293)] }
+          StreamHashAgg { group_key: [$expr291], aggs: [sum($expr292), sum($expr293), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -1511,7 +1509,7 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [$expr291, count, sum($expr292), sum($expr293)], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
+     Table 0 { columns: [$expr291, sum($expr292), sum($expr293), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 1 { columns: [lineitem_l_extendedprice, lineitem_l_discount, nation_n_name, orders_o_orderdate, nation_n_regionkey, part_p_partkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_partkey, supplier_s_suppkey, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey, customer_c_custkey, orders_o_custkey, customer_c_nationkey, nation_n_nationkey_0], primary key: [$4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC, $11 ASC, $12 ASC, $13 ASC, $14 ASC, $15 ASC, $17 ASC, $16 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17], distribution key: [4] }
      Table 2 { columns: [nation_n_regionkey, part_p_partkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_partkey, supplier_s_suppkey, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey, customer_c_custkey, orders_o_custkey, nation_n_nationkey_0, customer_c_nationkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC, $11 ASC, $12 ASC, $13 ASC], value indices: [14], distribution key: [0] }
      Table 3 { columns: [region_r_regionkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
@@ -1634,7 +1632,7 @@
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year], pk_conflict: "no check" }
     └─StreamProject { exprs: [nation.n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-      └─StreamHashAgg { group_key: [nation.n_name, $expr1], aggs: [count, sum($expr2)] }
+      └─StreamHashAgg { group_key: [nation.n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(nation.n_name, $expr1) }
           └─StreamProject { exprs: [nation.n_name, Extract('YEAR':Varchar, orders.o_orderdate) as $expr1, ((lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) - (partsupp.ps_supplycost * lineitem.l_quantity)) as $expr2, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey] }
             └─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [lineitem.l_quantity, lineitem.l_extendedprice, lineitem.l_discount, partsupp.ps_supplycost, orders.o_orderdate, nation.n_name, part.p_partkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, supplier.s_suppkey, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, partsupp.ps_partkey, partsupp.ps_suppkey, orders.o_orderkey] }
@@ -1665,7 +1663,7 @@
       StreamMaterialize { columns: [nation, o_year, sum_profit], pk_columns: [nation, o_year], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [nation.n_name, $expr218, RoundDigit(sum($expr219), 2:Int32) as $expr220] }
-          StreamHashAgg { group_key: [nation.n_name, $expr218], aggs: [count, sum($expr219)] }
+          StreamHashAgg { group_key: [nation.n_name, $expr218], aggs: [sum($expr219), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1]) from 1
 
@@ -1732,7 +1730,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [nation_n_name, $expr218, count, sum($expr219)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 0 { columns: [nation_n_name, $expr218, sum($expr219), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
      Table 1 { columns: [lineitem_l_orderkey, lineitem_l_quantity, lineitem_l_extendedprice, lineitem_l_discount, nation_n_name, partsupp_ps_supplycost, part_p_partkey, lineitem_l_linenumber, lineitem_l_partkey, supplier_s_suppkey, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, partsupp_ps_partkey, partsupp_ps_suppkey], primary key: [$0 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC, $10 ASC, $11 ASC, $12 ASC, $13 ASC, $14 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14], distribution key: [0] }
      Table 2 { columns: [lineitem_l_orderkey, part_p_partkey, lineitem_l_linenumber, lineitem_l_partkey, supplier_s_suppkey, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, partsupp_ps_partkey, partsupp_ps_suppkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC, $7 ASC, $8 ASC, $9 ASC], value indices: [10], distribution key: [0] }
      Table 3 { columns: [orders_o_orderkey, orders_o_orderdate], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
@@ -1846,7 +1844,7 @@
           └─StreamGroupTopN { order: "[sum($expr1) DESC]", limit: 20, offset: 0, group_key: [8] }
             └─StreamProject { exprs: [customer.c_custkey, customer.c_name, sum($expr1), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, Vnode(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) as $expr2] }
               └─StreamProject { exprs: [customer.c_custkey, customer.c_name, sum($expr1), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-                └─StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [count, sum($expr1)] }
+                └─StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum($expr1), count] }
                   └─StreamExchange { dist: HashShard(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) }
                     └─StreamProject { exprs: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment, (lineitem.l_extendedprice * (1.00:Decimal - lineitem.l_discount)) as $expr1, orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
                       └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, customer.c_address, customer.c_phone, customer.c_acctbal, customer.c_comment, lineitem.l_extendedprice, lineitem.l_discount, nation.n_name, orders.o_orderkey, orders.o_custkey, nation.n_nationkey, customer.c_nationkey, lineitem.l_orderkey, lineitem.l_linenumber] }
@@ -1880,7 +1878,7 @@
           state table: 1
         StreamProject { exprs: [customer.c_custkey, customer.c_name, sum($expr73), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment, Vnode(customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment) as $expr74] }
           StreamProject { exprs: [customer.c_custkey, customer.c_name, sum($expr73), customer.c_acctbal, nation.n_name, customer.c_address, customer.c_phone, customer.c_comment] }
-            StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [count, sum($expr73)] }
+            StreamHashAgg { group_key: [customer.c_custkey, customer.c_name, customer.c_acctbal, customer.c_phone, nation.n_name, customer.c_address, customer.c_comment], aggs: [sum($expr73), count] }
                 result table: 2, state tables: []
               StreamExchange Hash([0, 1, 2, 3, 4, 5, 6]) from 2
 
@@ -1929,7 +1927,7 @@
 
      Table 0 { columns: [customer_c_custkey, customer_c_name, sum($expr73), customer_c_acctbal, nation_n_name, customer_c_address, customer_c_phone, customer_c_comment, $expr74], primary key: [$2 DESC, $0 ASC, $1 ASC, $3 ASC, $6 ASC, $4 ASC, $5 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8], distribution key: [] }
      Table 1 { columns: [customer_c_custkey, customer_c_name, sum($expr73), customer_c_acctbal, nation_n_name, customer_c_address, customer_c_phone, customer_c_comment, $expr74], primary key: [$8 ASC, $2 DESC, $0 ASC, $1 ASC, $3 ASC, $6 ASC, $4 ASC, $5 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8], distribution key: [0, 1, 3, 6, 4, 5, 7], vnode column idx: 8 }
-     Table 2 { columns: [customer_c_custkey, customer_c_name, customer_c_acctbal, customer_c_phone, nation_n_name, customer_c_address, customer_c_comment, count, sum($expr73)], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC], value indices: [7, 8], distribution key: [0, 1, 2, 3, 4, 5, 6] }
+     Table 2 { columns: [customer_c_custkey, customer_c_name, customer_c_acctbal, customer_c_phone, nation_n_name, customer_c_address, customer_c_comment, sum($expr73), count], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC], value indices: [7, 8], distribution key: [0, 1, 2, 3, 4, 5, 6] }
      Table 3 { columns: [customer_c_custkey, customer_c_name, customer_c_address, customer_c_phone, customer_c_acctbal, customer_c_comment, orders_o_orderkey, nation_n_name, orders_o_custkey, customer_c_nationkey, nation_n_nationkey], primary key: [$6 ASC, $0 ASC, $8 ASC, $10 ASC, $9 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10], distribution key: [6] }
      Table 4 { columns: [orders_o_orderkey, customer_c_custkey, orders_o_custkey, nation_n_nationkey, customer_c_nationkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC], value indices: [5], distribution key: [0] }
      Table 5 { columns: [lineitem_l_orderkey, lineitem_l_extendedprice, lineitem_l_discount, lineitem_l_linenumber], primary key: [$0 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -2039,7 +2037,7 @@
     StreamMaterialize { columns: [ps_partkey, value], pk_columns: [ps_partkey], order_descs: [value, ps_partkey], pk_conflict: "no check" }
     └─StreamDynamicFilter { predicate: (sum($expr1) > $expr3), output: [partsupp.ps_partkey, sum($expr1)] }
       ├─StreamProject { exprs: [partsupp.ps_partkey, sum($expr1)] }
-      | └─StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum($expr1)] }
+      | └─StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [sum($expr1), count] }
       |   └─StreamExchange { dist: HashShard(partsupp.ps_partkey) }
       |     └─StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty) as $expr1, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
       |       └─StreamShare { id = 1471 }
@@ -2056,9 +2054,9 @@
       |                 └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], dist: UpstreamHashShard(nation.n_nationkey) }
       └─StreamExchange { dist: Broadcast }
         └─StreamProject { exprs: [(sum(sum($expr2)) * 0.0001000000:Decimal) as $expr3] }
-          └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr2))] }
+          └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr2)), count] }
             └─StreamExchange { dist: Single }
-              └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr2)] }
+              └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr2)] }
                 └─StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty) as $expr2, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
                   └─StreamShare { id = 1471 }
                     └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
@@ -2079,7 +2077,7 @@
         StreamDynamicFilter { predicate: (sum($expr218) > $expr220), output: [partsupp.ps_partkey, sum($expr218)] }
             left table: 0, right table 1
           StreamProject { exprs: [partsupp.ps_partkey, sum($expr218)] }
-            StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [count, sum($expr218)] }
+            StreamHashAgg { group_key: [partsupp.ps_partkey], aggs: [sum($expr218), count] }
                 result table: 2, state tables: []
               StreamExchange Hash([0]) from 1
           StreamExchange Broadcast from 7
@@ -2119,18 +2117,18 @@
 
     Fragment 7
       StreamProject { exprs: [(sum(sum($expr219)) * 0.0001000000:Decimal) as $expr220] }
-        StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr219))] }
+        StreamGlobalSimpleAgg { aggs: [sum(sum($expr219)), count] }
             result table: 11, state tables: []
           StreamExchange Single from 8
 
     Fragment 8
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr219)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum($expr219)] }
         StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty) as $expr219, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
           StreamExchange Hash([5]) from 2
 
      Table 0 { columns: [partsupp_ps_partkey, sum($expr218)], primary key: [$1 ASC, $0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 1 { columns: [$expr220], primary key: [], value indices: [0], distribution key: [] }
-     Table 2 { columns: [partsupp_ps_partkey, count, sum($expr218)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 2 { columns: [partsupp_ps_partkey, sum($expr218), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 3 { columns: [partsupp_ps_partkey, partsupp_ps_availqty, partsupp_ps_supplycost, supplier_s_nationkey, partsupp_ps_suppkey, supplier_s_suppkey], primary key: [$3 ASC, $0 ASC, $4 ASC, $5 ASC], value indices: [0, 1, 2, 3, 4, 5], distribution key: [3] }
      Table 4 { columns: [supplier_s_nationkey, partsupp_ps_partkey, partsupp_ps_suppkey, supplier_s_suppkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0] }
      Table 5 { columns: [nation_n_nationkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
@@ -2139,7 +2137,7 @@
      Table 8 { columns: [partsupp_ps_suppkey, partsupp_ps_partkey, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 9 { columns: [supplier_s_suppkey, supplier_s_nationkey], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 10 { columns: [supplier_s_suppkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 11 { columns: [count, sum(sum($expr219))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 11 { columns: [sum(sum($expr219)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 4294967294 { columns: [ps_partkey, value], primary key: [$1 DESC, $0 ASC], value indices: [0, 1], distribution key: [0] }
 - id: tpch_q12
   before:
@@ -2203,7 +2201,7 @@
   stream_plan: |
     StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode], pk_conflict: "no check" }
     └─StreamProject { exprs: [lineitem.l_shipmode, sum($expr1), sum($expr2)] }
-      └─StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [count, sum($expr1), sum($expr2)] }
+      └─StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum($expr1), sum($expr2), count] }
         └─StreamExchange { dist: HashShard(lineitem.l_shipmode) }
           └─StreamProject { exprs: [lineitem.l_shipmode, Case(((orders.o_orderpriority = '1-URGENT':Varchar) OR (orders.o_orderpriority = '2-HIGH':Varchar)), 1:Int32, 0:Int32) as $expr1, Case(((orders.o_orderpriority <> '1-URGENT':Varchar) AND (orders.o_orderpriority <> '2-HIGH':Varchar)), 1:Int32, 0:Int32) as $expr2, orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
             └─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [orders.o_orderpriority, lineitem.l_shipmode, orders.o_orderkey, lineitem.l_orderkey, lineitem.l_linenumber] }
@@ -2218,7 +2216,7 @@
       StreamMaterialize { columns: [l_shipmode, high_line_count, low_line_count], pk_columns: [l_shipmode], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [lineitem.l_shipmode, sum($expr141), sum($expr142)] }
-          StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [count, sum($expr141), sum($expr142)] }
+          StreamHashAgg { group_key: [lineitem.l_shipmode], aggs: [sum($expr141), sum($expr142), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0]) from 1
 
@@ -2241,7 +2239,7 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [lineitem_l_shipmode, count, sum($expr141), sum($expr142)], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
+     Table 0 { columns: [lineitem_l_shipmode, sum($expr141), sum($expr142), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 1 { columns: [orders_o_orderkey, orders_o_orderpriority], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 2 { columns: [orders_o_orderkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 3 { columns: [lineitem_l_orderkey, lineitem_l_shipmode, lineitem_l_linenumber], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
@@ -2302,30 +2300,28 @@
                     └─BatchScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], distribution: UpstreamHashShard(orders.o_orderkey) }
   stream_plan: |
     StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count], pk_conflict: "no check" }
-    └─StreamProject { exprs: [count(orders.o_orderkey), count] }
-      └─StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count, count] }
-        └─StreamExchange { dist: HashShard(count(orders.o_orderkey)) }
-          └─StreamProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
-            └─StreamHashAgg { group_key: [customer.c_custkey], aggs: [count, count(orders.o_orderkey)] }
-              └─StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: all }
-                ├─StreamExchange { dist: HashShard(customer.c_custkey) }
-                | └─StreamTableScan { table: customer, columns: [customer.c_custkey], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }
-                └─StreamExchange { dist: HashShard(orders.o_custkey) }
-                  └─StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
-                    └─StreamFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
-                      └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
+    └─StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
+      └─StreamExchange { dist: HashShard(count(orders.o_orderkey)) }
+        └─StreamProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
+          └─StreamHashAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey), count] }
+            └─StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: all }
+              ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+              | └─StreamTableScan { table: customer, columns: [customer.c_custkey], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }
+              └─StreamExchange { dist: HashShard(orders.o_custkey) }
+                └─StreamProject { exprs: [orders.o_orderkey, orders.o_custkey] }
+                  └─StreamFilter { predicate: Not(Like(orders.o_comment, '%:1%:2%':Varchar)) }
+                    └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_custkey, orders.o_comment], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [c_count, custdist], pk_columns: [c_count], order_descs: [custdist, c_count], pk_conflict: "no check" }
           materialized table: 4294967294
-        StreamProject { exprs: [count(orders.o_orderkey), count] }
-          StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count, count] }
-              result table: 0, state tables: []
-            StreamExchange Hash([1]) from 1
+        StreamHashAgg { group_key: [count(orders.o_orderkey)], aggs: [count] }
+            result table: 0, state tables: []
+          StreamExchange Hash([1]) from 1
 
     Fragment 1
       StreamProject { exprs: [customer.c_custkey, count(orders.o_orderkey)] }
-        StreamHashAgg { group_key: [customer.c_custkey], aggs: [count, count(orders.o_orderkey)] }
+        StreamHashAgg { group_key: [customer.c_custkey], aggs: [count(orders.o_orderkey), count] }
             result table: 1, state tables: []
           StreamHashJoin { type: LeftOuter, predicate: customer.c_custkey = orders.o_custkey, output: all }
               left table: 2, right table 4, left degree table: 3, right degree table: 5,
@@ -2344,8 +2340,8 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [count(orders_o_orderkey), count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
-     Table 1 { columns: [customer_c_custkey, count, count(orders_o_orderkey)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 0 { columns: [count(orders_o_orderkey), count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
+     Table 1 { columns: [customer_c_custkey, count(orders_o_orderkey), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 2 { columns: [customer_c_custkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 3 { columns: [customer_c_custkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 4 { columns: [orders_o_orderkey, orders_o_custkey], primary key: [$1 ASC, $0 ASC], value indices: [0, 1], distribution key: [1] }
@@ -2397,9 +2393,9 @@
   stream_plan: |
     StreamMaterialize { columns: [promo_revenue], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [((100.00:Decimal * sum(sum($expr1))) / sum(sum($expr2))) as $expr3] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr1)), sum(sum($expr2))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1)), sum(sum($expr2)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1), sum($expr2)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1), sum($expr2)] }
             └─StreamProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Decimal) as $expr1, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr2, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
               └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
                 ├─StreamExchange { dist: HashShard(lineitem.l_partkey) }
@@ -2413,12 +2409,12 @@
       StreamMaterialize { columns: [promo_revenue], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [((100.00:Decimal * sum(sum($expr212))) / sum(sum($expr213))) as $expr214] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr212)), sum(sum($expr213))] }
+          StreamGlobalSimpleAgg { aggs: [sum(sum($expr212)), sum(sum($expr213)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr212), sum($expr213)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum($expr212), sum($expr213)] }
         StreamProject { exprs: [Case(Like(part.p_type, 'PROMO%':Varchar), (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)), 0:Decimal) as $expr212, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr213, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
           StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: [lineitem.l_extendedprice, lineitem.l_discount, part.p_type, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, part.p_partkey] }
               left table: 1, right table 3, left degree table: 2, right degree table: 4,
@@ -2437,7 +2433,7 @@
         Upstream
         BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum($expr212)), sum(sum($expr213))], primary key: [], value indices: [0, 1, 2], distribution key: [] }
+     Table 0 { columns: [sum(sum($expr212)), sum(sum($expr213)), count], primary key: [], value indices: [0, 1, 2], distribution key: [] }
      Table 1 { columns: [lineitem_l_partkey, lineitem_l_extendedprice, lineitem_l_discount, lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$0 ASC, $3 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0] }
      Table 2 { columns: [lineitem_l_partkey, lineitem_l_orderkey, lineitem_l_linenumber, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0] }
      Table 3 { columns: [part_p_partkey, part_p_type], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
@@ -2518,23 +2514,23 @@
       |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
       |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], pk: [supplier.s_suppkey], dist: UpstreamHashShard(supplier.s_suppkey) }
       |   └─StreamProject { exprs: [lineitem.l_suppkey, sum($expr1)] }
-      |     └─StreamShare { id = 820 }
+      |     └─StreamShare { id = 821 }
       |       └─StreamProject { exprs: [lineitem.l_suppkey, sum($expr1)] }
-      |         └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum($expr1)] }
+      |         └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum($expr1), count] }
       |           └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
       |             └─StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, lineitem.l_orderkey, lineitem.l_linenumber] }
       |               └─StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Date) AND (lineitem.l_shipdate < '1993-04-01 00:00:00':Timestamp) }
       |                 └─StreamTableScan { table: lineitem, columns: [lineitem.l_suppkey, lineitem.l_extendedprice, lineitem.l_discount, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_shipdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
       └─StreamExchange { dist: HashShard(max(max(sum($expr1)))) }
         └─StreamProject { exprs: [max(max(sum($expr1)))] }
-          └─StreamGlobalSimpleAgg { aggs: [count, max(max(sum($expr1)))] }
+          └─StreamGlobalSimpleAgg { aggs: [max(max(sum($expr1))), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg { group_key: [$expr2], aggs: [count, max(sum($expr1))] }
+              └─StreamHashAgg { group_key: [$expr2], aggs: [max(sum($expr1)), count] }
                 └─StreamProject { exprs: [lineitem.l_suppkey, sum($expr1), Vnode(lineitem.l_suppkey) as $expr2] }
                   └─StreamProject { exprs: [lineitem.l_suppkey, sum($expr1)] }
-                    └─StreamShare { id = 820 }
+                    └─StreamShare { id = 821 }
                       └─StreamProject { exprs: [lineitem.l_suppkey, sum($expr1)] }
-                        └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum($expr1)] }
+                        └─StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum($expr1), count] }
                           └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
                             └─StreamProject { exprs: [lineitem.l_suppkey, (lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, lineitem.l_orderkey, lineitem.l_linenumber] }
                               └─StreamFilter { predicate: (lineitem.l_shipdate >= '1993-01-01':Date) AND (lineitem.l_shipdate < '1993-04-01 00:00:00':Timestamp) }
@@ -2562,7 +2558,7 @@
 
     Fragment 3
       StreamProject { exprs: [lineitem.l_suppkey, sum($expr86)] }
-        StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [count, sum($expr86)] }
+        StreamHashAgg { group_key: [lineitem.l_suppkey], aggs: [sum($expr86), count] }
             result table: 8, state tables: []
           StreamExchange Hash([0]) from 4
 
@@ -2575,12 +2571,12 @@
 
     Fragment 5
       StreamProject { exprs: [max(max(sum($expr80)))] }
-        StreamGlobalSimpleAgg { aggs: [count, max(max(sum($expr80)))] }
+        StreamGlobalSimpleAgg { aggs: [max(max(sum($expr80))), count] }
             result table: 10, state tables: [9]
           StreamExchange Single from 6
 
     Fragment 6
-      StreamHashAgg { group_key: [$expr87], aggs: [count, max(sum($expr80))] }
+      StreamHashAgg { group_key: [$expr87], aggs: [max(sum($expr80)), count] }
           result table: 12, state tables: [11]
         StreamProject { exprs: [lineitem.l_suppkey, sum($expr80), Vnode(lineitem.l_suppkey) as $expr87] }
           StreamProject { exprs: [lineitem.l_suppkey, sum($expr80)] }
@@ -2594,11 +2590,11 @@
      Table 5 { columns: [supplier_s_suppkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 6 { columns: [lineitem_l_suppkey, sum($expr80)], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
      Table 7 { columns: [lineitem_l_suppkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 8 { columns: [lineitem_l_suppkey, count, sum($expr86)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 8 { columns: [lineitem_l_suppkey, sum($expr86), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 9 { columns: [max(sum($expr80)), $expr87], primary key: [$0 DESC, $1 ASC], value indices: [0, 1], distribution key: [] }
-     Table 10 { columns: [count, max(max(sum($expr80)))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 10 { columns: [max(max(sum($expr80))), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 11 { columns: [$expr87, sum($expr80), lineitem_l_suppkey], primary key: [$0 ASC, $1 DESC, $2 ASC], value indices: [1, 2], distribution key: [2], vnode column idx: 0 }
-     Table 12 { columns: [$expr87, count, max(sum($expr80))], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
+     Table 12 { columns: [$expr87, max(sum($expr80)), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [], vnode column idx: 0 }
      Table 4294967294 { columns: [s_suppkey, s_name, s_address, s_phone, total_revenue, lineitem.l_suppkey, max(max(sum($expr80)))], primary key: [$0 ASC, $5 ASC, $4 ASC, $6 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [4] }
 - id: tpch_q16
   before:
@@ -2668,7 +2664,7 @@
   stream_plan: |
     StreamMaterialize { columns: [p_brand, p_type, p_size, supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size], pk_conflict: "no check" }
     └─StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, count(distinct partsupp.ps_suppkey)] }
-      └─StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count, count(distinct partsupp.ps_suppkey)] }
+      └─StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(distinct partsupp.ps_suppkey), count] }
         └─StreamExchange { dist: HashShard(part.p_brand, part.p_type, part.p_size) }
           └─StreamHashJoin { type: LeftAnti, predicate: partsupp.ps_suppkey = supplier.s_suppkey, output: [part.p_brand, part.p_type, part.p_size, partsupp.ps_suppkey, partsupp.ps_partkey, part.p_partkey] }
             ├─StreamExchange { dist: HashShard(partsupp.ps_suppkey) }
@@ -2687,7 +2683,7 @@
       StreamMaterialize { columns: [p_brand, p_type, p_size, supplier_cnt], pk_columns: [p_brand, p_type, p_size], order_descs: [supplier_cnt, p_brand, p_type, p_size], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [part.p_brand, part.p_type, part.p_size, count(distinct partsupp.ps_suppkey)] }
-          StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count, count(distinct partsupp.ps_suppkey)] }
+          StreamHashAgg { group_key: [part.p_brand, part.p_type, part.p_size], aggs: [count(distinct partsupp.ps_suppkey), count] }
               result table: 0, state tables: []
             StreamExchange Hash([0, 1, 2]) from 1
 
@@ -2721,7 +2717,7 @@
             Upstream
             BatchPlanNode
 
-     Table 0 { columns: [part_p_brand, part_p_type, part_p_size, count, count(distinct partsupp_ps_suppkey)], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
+     Table 0 { columns: [part_p_brand, part_p_type, part_p_size, count(distinct partsupp_ps_suppkey), count], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3, 4], distribution key: [0, 1, 2] }
      Table 2 { columns: [partsupp_ps_suppkey, part_p_brand, part_p_type, part_p_size, partsupp_ps_partkey, part_p_partkey], primary key: [$0 ASC, $4 ASC, $5 ASC], value indices: [0, 1, 2, 3, 4, 5], distribution key: [0] }
      Table 3 { columns: [partsupp_ps_suppkey, partsupp_ps_partkey, part_p_partkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0] }
      Table 4 { columns: [supplier_s_suppkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
@@ -2803,9 +2799,9 @@
   stream_plan: |
     StreamMaterialize { columns: [avg_yearly], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32) as $expr2] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(lineitem.l_extendedprice))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
             └─StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, part.p_partkey] }
               └─StreamFilter { predicate: (lineitem.l_quantity < $expr1) }
                 └─StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
@@ -2818,7 +2814,7 @@
                   |       └─StreamFilter { predicate: (part.p_brand = 'Brand#13':Varchar) AND (part.p_container = 'JUMBO PKG':Varchar) }
                   |         └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_brand, part.p_container], pk: [part.p_partkey], dist: UpstreamHashShard(part.p_partkey) }
                   └─StreamProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity))) as $expr1] }
-                    └─StreamHashAgg { group_key: [part.p_partkey], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                    └─StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] }
                       └─StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
                         ├─StreamExchange { dist: HashShard(part.p_partkey) }
                         | └─StreamProject { exprs: [part.p_partkey] }
@@ -2834,19 +2830,19 @@
       StreamMaterialize { columns: [avg_yearly], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [RoundDigit((sum(sum(lineitem.l_extendedprice)) / 7.0:Decimal), 16:Int32) as $expr153] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(sum(lineitem.l_extendedprice))] }
+          StreamGlobalSimpleAgg { aggs: [sum(sum(lineitem.l_extendedprice)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum(lineitem.l_extendedprice)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum(lineitem.l_extendedprice)] }
         StreamProject { exprs: [lineitem.l_extendedprice, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey, part.p_partkey] }
           StreamFilter { predicate: (lineitem.l_quantity < $expr152) }
             StreamHashJoin { type: Inner, predicate: part.p_partkey IS NOT DISTINCT FROM part.p_partkey, output: all }
                 left table: 1, right table 3, left degree table: 2, right degree table: 4,
               StreamExchange Hash([2]) from 2
               StreamProject { exprs: [part.p_partkey, (0.2:Decimal * (sum(lineitem.l_quantity) / count(lineitem.l_quantity))) as $expr152] }
-                StreamHashAgg { group_key: [part.p_partkey], aggs: [count, sum(lineitem.l_quantity), count(lineitem.l_quantity)] }
+                StreamHashAgg { group_key: [part.p_partkey], aggs: [sum(lineitem.l_quantity), count(lineitem.l_quantity), count] }
                     result table: 9, state tables: []
                   StreamHashJoin { type: LeftOuter, predicate: part.p_partkey IS NOT DISTINCT FROM lineitem.l_partkey, output: [part.p_partkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey] }
                       left table: 10, right table 12, left degree table: 11, right degree table: 13,
@@ -2887,7 +2883,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum(lineitem_l_extendedprice))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(sum(lineitem_l_extendedprice)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 1 { columns: [lineitem_l_quantity, lineitem_l_extendedprice, part_p_partkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_partkey], primary key: [$2 ASC, $3 ASC, $4 ASC, $5 ASC], value indices: [0, 1, 2, 3, 4, 5], distribution key: [2] }
      Table 2 { columns: [part_p_partkey, lineitem_l_orderkey, lineitem_l_linenumber, lineitem_l_partkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC], value indices: [4], distribution key: [0] }
      Table 3 { columns: [part_p_partkey, $expr152], primary key: [$0 ASC], value indices: [0, 1], distribution key: [0] }
@@ -2896,7 +2892,7 @@
      Table 6 { columns: [lineitem_l_partkey, lineitem_l_orderkey, lineitem_l_linenumber, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0] }
      Table 7 { columns: [part_p_partkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 8 { columns: [part_p_partkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 9 { columns: [part_p_partkey, count, sum(lineitem_l_quantity), count(lineitem_l_quantity)], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
+     Table 9 { columns: [part_p_partkey, sum(lineitem_l_quantity), count(lineitem_l_quantity), count], primary key: [$0 ASC], value indices: [1, 2, 3], distribution key: [0] }
      Table 10 { columns: [part_p_partkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 11 { columns: [part_p_partkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 12 { columns: [lineitem_l_partkey, lineitem_l_quantity, lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$0 ASC, $2 ASC, $3 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -2999,7 +2995,7 @@
           └─StreamGroupTopN { order: "[orders.o_totalprice DESC, orders.o_orderdate ASC]", limit: 100, offset: 0, group_key: [6] }
             └─StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity), Vnode(orders.o_orderkey) as $expr1] }
               └─StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
-                └─StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [count, sum(lineitem.l_quantity)] }
+                └─StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity), count] }
                   └─StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
                     ├─StreamHashJoin { type: Inner, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_custkey, customer.c_name, orders.o_orderkey, orders.o_totalprice, orders.o_orderdate, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
                     | ├─StreamExchange { dist: HashShard(orders.o_orderkey) }
@@ -3013,7 +3009,7 @@
                     └─StreamProject { exprs: [lineitem.l_orderkey] }
                       └─StreamFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                         └─StreamProject { exprs: [lineitem.l_orderkey, sum(lineitem.l_quantity)] }
-                          └─StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [count, sum(lineitem.l_quantity)] }
+                          └─StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity), count] }
                             └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
                               └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
@@ -3030,7 +3026,7 @@
           state table: 1
         StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity), Vnode(orders.o_orderkey) as $expr3] }
           StreamProject { exprs: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, sum(lineitem.l_quantity)] }
-            StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [count, sum(lineitem.l_quantity)] }
+            StreamHashAgg { group_key: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice], aggs: [sum(lineitem.l_quantity), count] }
                 result table: 2, state tables: []
               StreamHashJoin { type: LeftSemi, predicate: orders.o_orderkey = lineitem.l_orderkey, output: [customer.c_name, customer.c_custkey, orders.o_orderkey, orders.o_orderdate, orders.o_totalprice, lineitem.l_quantity, orders.o_custkey, lineitem.l_orderkey, lineitem.l_linenumber] }
                   left table: 3, right table 5, left degree table: 4, right degree table: 6,
@@ -3041,7 +3037,7 @@
                 StreamProject { exprs: [lineitem.l_orderkey] }
                   StreamFilter { predicate: (sum(lineitem.l_quantity) > 1:Int32) }
                     StreamProject { exprs: [lineitem.l_orderkey, sum(lineitem.l_quantity)] }
-                      StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [count, sum(lineitem.l_quantity)] }
+                      StreamHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity), count] }
                           result table: 15, state tables: []
                         StreamExchange Hash([0]) from 6
 
@@ -3073,7 +3069,7 @@
 
      Table 0 { columns: [customer_c_name, customer_c_custkey, orders_o_orderkey, orders_o_orderdate, orders_o_totalprice, sum(lineitem_l_quantity), $expr3], primary key: [$4 DESC, $3 ASC, $0 ASC, $1 ASC, $2 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [] }
      Table 1 { columns: [customer_c_name, customer_c_custkey, orders_o_orderkey, orders_o_orderdate, orders_o_totalprice, sum(lineitem_l_quantity), $expr3], primary key: [$6 ASC, $4 DESC, $3 ASC, $0 ASC, $1 ASC, $2 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [2], vnode column idx: 6 }
-     Table 2 { columns: [customer_c_name, customer_c_custkey, orders_o_orderkey, orders_o_orderdate, orders_o_totalprice, count, sum(lineitem_l_quantity)], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC], value indices: [5, 6], distribution key: [2] }
+     Table 2 { columns: [customer_c_name, customer_c_custkey, orders_o_orderkey, orders_o_orderdate, orders_o_totalprice, sum(lineitem_l_quantity), count], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC], value indices: [5, 6], distribution key: [2] }
      Table 3 { columns: [customer_c_custkey, customer_c_name, orders_o_orderkey, orders_o_totalprice, orders_o_orderdate, lineitem_l_quantity, orders_o_custkey, lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$2 ASC, $0 ASC, $6 ASC, $7 ASC, $8 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7, 8], distribution key: [2] }
      Table 4 { columns: [orders_o_orderkey, customer_c_custkey, orders_o_custkey, lineitem_l_orderkey, lineitem_l_linenumber, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC], value indices: [5], distribution key: [0] }
      Table 5 { columns: [lineitem_l_orderkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
@@ -3086,7 +3082,7 @@
      Table 12 { columns: [customer_c_custkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 13 { columns: [orders_o_orderkey, orders_o_custkey, orders_o_totalprice, orders_o_orderdate], primary key: [$1 ASC, $0 ASC], value indices: [0, 1, 2, 3], distribution key: [1] }
      Table 14 { columns: [orders_o_custkey, orders_o_orderkey, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
-     Table 15 { columns: [lineitem_l_orderkey, count, sum(lineitem_l_quantity)], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 15 { columns: [lineitem_l_orderkey, sum(lineitem_l_quantity), count], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
      Table 4294967294 { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], primary key: [$4 DESC, $3 ASC, $0 ASC, $1 ASC, $2 ASC], value indices: [0, 1, 2, 3, 4, 5], distribution key: [] }
 - id: tpch_q19
   before:
@@ -3154,9 +3150,9 @@
   stream_plan: |
     StreamMaterialize { columns: [revenue], pk_columns: [], pk_conflict: "no check" }
     └─StreamProject { exprs: [sum(sum($expr1))] }
-      └─StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr1))] }
+      └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1)), count] }
         └─StreamExchange { dist: Single }
-          └─StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr1)] }
+          └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1)] }
             └─StreamProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr1, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
               └─StreamFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
                 └─StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
@@ -3172,12 +3168,12 @@
       StreamMaterialize { columns: [revenue], pk_columns: [], pk_conflict: "no check" }
           materialized table: 4294967294
         StreamProject { exprs: [sum(sum($expr72))] }
-          StreamGlobalSimpleAgg { aggs: [count, sum(sum($expr72))] }
+          StreamGlobalSimpleAgg { aggs: [sum(sum($expr72)), count] }
               result table: 0, state tables: []
             StreamExchange Single from 1
 
     Fragment 1
-      StreamStatelessLocalSimpleAgg { aggs: [count, sum($expr72)] }
+      StreamStatelessLocalSimpleAgg { aggs: [sum($expr72)] }
         StreamProject { exprs: [(lineitem.l_extendedprice * (1:Int32 - lineitem.l_discount)) as $expr72, lineitem.l_orderkey, lineitem.l_linenumber, part.p_partkey, lineitem.l_partkey] }
           StreamFilter { predicate: (((((((part.p_brand = 'Brand#52':Varchar) AND In(part.p_container, 'SM CASE':Varchar, 'SM BOX':Varchar, 'SM PACK':Varchar, 'SM PKG':Varchar)) AND (lineitem.l_quantity >= 1:Int32)) AND (lineitem.l_quantity <= 11:Int32)) AND (part.p_size <= 5:Int32)) OR (((((part.p_brand = 'Brand#24':Varchar) AND In(part.p_container, 'MED BAG':Varchar, 'MED BOX':Varchar, 'MED PKG':Varchar, 'MED PACK':Varchar)) AND (lineitem.l_quantity >= 30:Int32)) AND (lineitem.l_quantity <= 40:Int32)) AND (part.p_size <= 10:Int32))) OR (((((part.p_brand = 'Brand#32':Varchar) AND In(part.p_container, 'LG CASE':Varchar, 'LG BOX':Varchar, 'LG PACK':Varchar, 'LG PKG':Varchar)) AND (lineitem.l_quantity >= 10:Int32)) AND (lineitem.l_quantity <= 20:Int32)) AND (part.p_size <= 15:Int32))) }
             StreamHashJoin { type: Inner, predicate: lineitem.l_partkey = part.p_partkey, output: all }
@@ -3198,7 +3194,7 @@
           Upstream
           BatchPlanNode
 
-     Table 0 { columns: [count, sum(sum($expr72))], primary key: [], value indices: [0, 1], distribution key: [] }
+     Table 0 { columns: [sum(sum($expr72)), count], primary key: [], value indices: [0, 1], distribution key: [] }
      Table 1 { columns: [lineitem_l_partkey, lineitem_l_quantity, lineitem_l_extendedprice, lineitem_l_discount, lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$0 ASC, $4 ASC, $5 ASC], value indices: [0, 1, 2, 3, 4, 5], distribution key: [0] }
      Table 2 { columns: [lineitem_l_partkey, lineitem_l_orderkey, lineitem_l_linenumber, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC], value indices: [3], distribution key: [0] }
      Table 3 { columns: [part_p_partkey, part_p_brand, part_p_size, part_p_container], primary key: [$0 ASC], value indices: [0, 1, 2, 3], distribution key: [0] }
@@ -3331,7 +3327,7 @@
               |         └─StreamFilter { predicate: Like(part.p_name, 'forest%':Varchar) }
               |           └─StreamTableScan { table: part, columns: [part.p_partkey, part.p_name], pk: [part.p_partkey], dist: UpstreamHashShard(part.p_partkey) }
               └─StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity)) as $expr2] }
-                └─StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count, sum(lineitem.l_quantity)] }
+                └─StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity), count] }
                   └─StreamHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, lineitem.l_suppkey] }
                     ├─StreamExchange { dist: HashShard(partsupp.ps_partkey, partsupp.ps_suppkey) }
                     | └─StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey] }
@@ -3375,7 +3371,7 @@
               left table: 8, right table 10, left degree table: 9, right degree table: 11,
             StreamExchange Hash([0, 1]) from 5
             StreamProject { exprs: [partsupp.ps_partkey, partsupp.ps_suppkey, (0.5:Decimal * sum(lineitem.l_quantity)) as $expr116] }
-              StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [count, sum(lineitem.l_quantity)] }
+              StreamHashAgg { group_key: [partsupp.ps_partkey, partsupp.ps_suppkey], aggs: [sum(lineitem.l_quantity), count] }
                   result table: 16, state tables: []
                 StreamHashJoin { type: LeftOuter, predicate: partsupp.ps_partkey IS NOT DISTINCT FROM lineitem.l_partkey AND partsupp.ps_suppkey IS NOT DISTINCT FROM lineitem.l_suppkey, output: [partsupp.ps_partkey, partsupp.ps_suppkey, lineitem.l_quantity, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_partkey, lineitem.l_suppkey] }
                     left table: 17, right table 19, left degree table: 18, right degree table: 20,
@@ -3432,7 +3428,7 @@
      Table 13 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0] }
      Table 14 { columns: [part_p_partkey], primary key: [$0 ASC], value indices: [0], distribution key: [0] }
      Table 15 { columns: [part_p_partkey, _degree], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
-     Table 16 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, count, sum(lineitem_l_quantity)], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
+     Table 16 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, sum(lineitem_l_quantity), count], primary key: [$0 ASC, $1 ASC], value indices: [2, 3], distribution key: [0, 1] }
      Table 17 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey], primary key: [$0 ASC, $1 ASC], value indices: [0, 1], distribution key: [0, 1] }
      Table 18 { columns: [partsupp_ps_partkey, partsupp_ps_suppkey, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0, 1] }
      Table 19 { columns: [lineitem_l_partkey, lineitem_l_suppkey, lineitem_l_quantity, lineitem_l_orderkey, lineitem_l_linenumber], primary key: [$0 ASC, $1 ASC, $3 ASC, $4 ASC], value indices: [0, 1, 2, 3, 4], distribution key: [0, 1] }
@@ -3551,36 +3547,35 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
             └─StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name) as $expr1] }
-              └─StreamProject { exprs: [supplier.s_name, count] }
-                └─StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
-                  └─StreamExchange { dist: HashShard(supplier.s_name) }
-                    └─StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
-                      ├─StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
-                      | ├─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
-                      | | ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                      | | | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
-                      | | |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
-                      | | |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
-                      | | |   |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
-                      | | |   |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], dist: UpstreamHashShard(supplier.s_suppkey) }
-                      | | |   |   └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
-                      | | |   |     └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
-                      | | |   |       └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                      | | |   |         └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                      | | |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
-                      | | |     └─StreamProject { exprs: [nation.n_nationkey] }
-                      | | |       └─StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
-                      | | |         └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], dist: UpstreamHashShard(nation.n_nationkey) }
-                      | | └─StreamExchange { dist: HashShard(orders.o_orderkey) }
-                      | |   └─StreamProject { exprs: [orders.o_orderkey] }
-                      | |     └─StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
-                      | |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
-                      | └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                      |   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
-                      └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
-                        └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
-                          └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
-                            └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+              └─StreamHashAgg { group_key: [supplier.s_name], aggs: [count] }
+                └─StreamExchange { dist: HashShard(supplier.s_name) }
+                  └─StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
+                    ├─StreamHashJoin { type: LeftSemi, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: all }
+                    | ├─StreamHashJoin { type: Inner, predicate: lineitem.l_orderkey = orders.o_orderkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
+                    | | ├─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                    | | | └─StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [supplier.s_name, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber, supplier.s_nationkey, nation.n_nationkey] }
+                    | | |   ├─StreamExchange { dist: HashShard(supplier.s_nationkey) }
+                    | | |   | └─StreamHashJoin { type: Inner, predicate: supplier.s_suppkey = lineitem.l_suppkey, output: [supplier.s_name, supplier.s_nationkey, lineitem.l_orderkey, lineitem.l_suppkey, supplier.s_suppkey, lineitem.l_linenumber] }
+                    | | |   |   ├─StreamExchange { dist: HashShard(supplier.s_suppkey) }
+                    | | |   |   | └─StreamTableScan { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_nationkey], pk: [supplier.s_suppkey], dist: UpstreamHashShard(supplier.s_suppkey) }
+                    | | |   |   └─StreamExchange { dist: HashShard(lineitem.l_suppkey) }
+                    | | |   |     └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
+                    | | |   |       └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                    | | |   |         └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                    | | |   └─StreamExchange { dist: HashShard(nation.n_nationkey) }
+                    | | |     └─StreamProject { exprs: [nation.n_nationkey] }
+                    | | |       └─StreamFilter { predicate: (nation.n_name = 'GERMANY':Varchar) }
+                    | | |         └─StreamTableScan { table: nation, columns: [nation.n_nationkey, nation.n_name], pk: [nation.n_nationkey], dist: UpstreamHashShard(nation.n_nationkey) }
+                    | | └─StreamExchange { dist: HashShard(orders.o_orderkey) }
+                    | |   └─StreamProject { exprs: [orders.o_orderkey] }
+                    | |     └─StreamFilter { predicate: (orders.o_orderstatus = 'F':Varchar) }
+                    | |       └─StreamTableScan { table: orders, columns: [orders.o_orderkey, orders.o_orderstatus], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
+                    | └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                    |   └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
+                    └─StreamExchange { dist: HashShard(lineitem.l_orderkey) }
+                      └─StreamProject { exprs: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber] }
+                        └─StreamFilter { predicate: (lineitem.l_receiptdate > lineitem.l_commitdate) }
+                          └─StreamTableScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_suppkey, lineitem.l_linenumber, lineitem.l_commitdate, lineitem.l_receiptdate], pk: [lineitem.l_orderkey, lineitem.l_linenumber], dist: UpstreamHashShard(lineitem.l_orderkey, lineitem.l_linenumber) }
   stream_dist_plan: |
     Fragment 0
       StreamMaterialize { columns: [s_name, numwait], pk_columns: [s_name], order_descs: [numwait, s_name], pk_conflict: "no check" }
@@ -3594,10 +3589,9 @@
       StreamGroupTopN { order: "[count DESC, supplier.s_name ASC]", limit: 100, offset: 0, group_key: [2] }
           state table: 1
         StreamProject { exprs: [supplier.s_name, count, Vnode(supplier.s_name) as $expr3] }
-          StreamProject { exprs: [supplier.s_name, count] }
-            StreamHashAgg { group_key: [supplier.s_name], aggs: [count, count] }
-                result table: 2, state tables: []
-              StreamExchange Hash([0]) from 2
+          StreamHashAgg { group_key: [supplier.s_name], aggs: [count] }
+              result table: 2, state tables: []
+            StreamExchange Hash([0]) from 2
 
     Fragment 2
       StreamHashJoin { type: LeftAnti, predicate: lineitem.l_orderkey = lineitem.l_orderkey AND (lineitem.l_suppkey <> lineitem.l_suppkey), output: [supplier.s_name, supplier.s_suppkey, lineitem.l_orderkey, lineitem.l_linenumber, lineitem.l_suppkey, nation.n_nationkey, supplier.s_nationkey, orders.o_orderkey] }
@@ -3663,7 +3657,7 @@
 
      Table 0 { columns: [supplier_s_name, count, $expr3], primary key: [$1 DESC, $0 ASC], value indices: [0, 1, 2], distribution key: [] }
      Table 1 { columns: [supplier_s_name, count, $expr3], primary key: [$2 ASC, $1 DESC, $0 ASC], value indices: [0, 1, 2], distribution key: [0], vnode column idx: 2 }
-     Table 2 { columns: [supplier_s_name, count, count_0], primary key: [$0 ASC], value indices: [1, 2], distribution key: [0] }
+     Table 2 { columns: [supplier_s_name, count], primary key: [$0 ASC], value indices: [1], distribution key: [0] }
      Table 3 { columns: [supplier_s_name, lineitem_l_orderkey, lineitem_l_suppkey, supplier_s_suppkey, lineitem_l_linenumber, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey], primary key: [$1 ASC, $3 ASC, $4 ASC, $2 ASC, $5 ASC, $6 ASC, $7 ASC], value indices: [0, 1, 2, 3, 4, 5, 6, 7], distribution key: [1] }
      Table 4 { columns: [lineitem_l_orderkey, supplier_s_suppkey, lineitem_l_linenumber, lineitem_l_suppkey, nation_n_nationkey, supplier_s_nationkey, orders_o_orderkey, _degree], primary key: [$0 ASC, $1 ASC, $2 ASC, $3 ASC, $4 ASC, $5 ASC, $6 ASC], value indices: [7], distribution key: [0] }
      Table 5 { columns: [lineitem_l_orderkey, lineitem_l_suppkey, lineitem_l_linenumber], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0] }
@@ -3776,22 +3770,21 @@
                           └─BatchScan { table: customer, columns: [customer.c_acctbal, customer.c_phone], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [cntrycode, numcust, totacctbal], pk_columns: [cntrycode], pk_conflict: "no check" }
-    └─StreamProject { exprs: [$expr2, count, sum(customer.c_acctbal)] }
-      └─StreamHashAgg { group_key: [$expr2], aggs: [count, count, sum(customer.c_acctbal)] }
-        └─StreamExchange { dist: HashShard($expr2) }
-          └─StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32) as $expr2, customer.c_acctbal, customer.c_custkey] }
-            └─StreamDynamicFilter { predicate: (customer.c_acctbal > $expr1), output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
-              ├─StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
-              | ├─StreamExchange { dist: HashShard(customer.c_custkey) }
-              | | └─StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-              | |   └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }
-              | └─StreamExchange { dist: HashShard(orders.o_custkey) }
-              |   └─StreamTableScan { table: orders, columns: [orders.o_custkey, orders.o_orderkey], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
-              └─StreamExchange { dist: Broadcast }
-                └─StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))) as $expr1] }
-                  └─StreamGlobalSimpleAgg { aggs: [count, sum(sum(customer.c_acctbal)), sum0(count(customer.c_acctbal))] }
-                    └─StreamExchange { dist: Single }
-                      └─StreamStatelessLocalSimpleAgg { aggs: [count, sum(customer.c_acctbal), count(customer.c_acctbal)] }
-                        └─StreamProject { exprs: [customer.c_acctbal, customer.c_custkey] }
-                          └─StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
-                            └─StreamTableScan { table: customer, columns: [customer.c_acctbal, customer.c_custkey, customer.c_phone], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }
+    └─StreamHashAgg { group_key: [$expr2], aggs: [count, sum(customer.c_acctbal)] }
+      └─StreamExchange { dist: HashShard($expr2) }
+        └─StreamProject { exprs: [Substr(customer.c_phone, 1:Int32, 2:Int32) as $expr2, customer.c_acctbal, customer.c_custkey] }
+          └─StreamDynamicFilter { predicate: (customer.c_acctbal > $expr1), output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
+            ├─StreamHashJoin { type: LeftAnti, predicate: customer.c_custkey = orders.o_custkey, output: [customer.c_phone, customer.c_acctbal, customer.c_custkey] }
+            | ├─StreamExchange { dist: HashShard(customer.c_custkey) }
+            | | └─StreamFilter { predicate: In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+            | |   └─StreamTableScan { table: customer, columns: [customer.c_custkey, customer.c_phone, customer.c_acctbal], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }
+            | └─StreamExchange { dist: HashShard(orders.o_custkey) }
+            |   └─StreamTableScan { table: orders, columns: [orders.o_custkey, orders.o_orderkey], pk: [orders.o_orderkey], dist: UpstreamHashShard(orders.o_orderkey) }
+            └─StreamExchange { dist: Broadcast }
+              └─StreamProject { exprs: [(sum(sum(customer.c_acctbal)) / sum0(count(customer.c_acctbal))) as $expr1] }
+                └─StreamGlobalSimpleAgg { aggs: [sum(sum(customer.c_acctbal)), sum0(count(customer.c_acctbal)), count] }
+                  └─StreamExchange { dist: Single }
+                    └─StreamStatelessLocalSimpleAgg { aggs: [sum(customer.c_acctbal), count(customer.c_acctbal)] }
+                      └─StreamProject { exprs: [customer.c_acctbal, customer.c_custkey] }
+                        └─StreamFilter { predicate: (customer.c_acctbal > 0.00:Decimal) AND In(Substr(customer.c_phone, 1:Int32, 2:Int32), '30':Varchar, '24':Varchar, '31':Varchar, '38':Varchar, '25':Varchar, '34':Varchar, '37':Varchar) }
+                          └─StreamTableScan { table: customer, columns: [customer.c_acctbal, customer.c_custkey, customer.c_phone], pk: [customer.c_custkey], dist: UpstreamHashShard(customer.c_custkey) }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_agg.rs
@@ -77,8 +77,7 @@ impl BatchHashAgg {
             .iter()
             .enumerate()
             .map(|(partial_output_idx, agg_call)| {
-                agg_call
-                    .partial_to_total_agg_call(partial_output_idx + self.group_key().len(), false)
+                agg_call.partial_to_total_agg_call(partial_output_idx + self.group_key().len())
             })
             .collect();
         let total_agg_logical = LogicalAgg::new(

--- a/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_simple_agg.rs
@@ -93,7 +93,7 @@ impl ToDistributedBatch for BatchSimpleAgg {
                 .iter()
                 .enumerate()
                 .map(|(partial_output_idx, agg_call)| {
-                    agg_call.partial_to_total_agg_call(partial_output_idx, false)
+                    agg_call.partial_to_total_agg_call(partial_output_idx)
                 })
                 .collect();
             let total_agg_logical =

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -623,17 +623,7 @@ impl PlanAggCall {
         }
     }
 
-    pub fn partial_to_total_agg_call(
-        &self,
-        partial_output_idx: usize,
-        is_stream_row_count: bool,
-    ) -> PlanAggCall {
-        if self.agg_kind == AggKind::Count && is_stream_row_count {
-            // For stream row count agg, should only count output rows of partial phase,
-            // but not all inputs of partial phase. Here we just generate exact the same
-            // agg call for global phase as partial phase, which should be `count(*)`.
-            return self.clone();
-        }
+    pub fn partial_to_total_agg_call(&self, partial_output_idx: usize) -> PlanAggCall {
         let total_agg_kind = match &self.agg_kind {
             AggKind::Min | AggKind::Max | AggKind::StringAgg | AggKind::FirstValue => self.agg_kind,
             AggKind::Count | AggKind::ApproxCountDistinct | AggKind::Sum0 => AggKind::Sum0,

--- a/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_global_simple_agg.rs
@@ -34,7 +34,7 @@ pub struct StreamGlobalSimpleAgg {
 
 impl StreamGlobalSimpleAgg {
     pub fn new(logical: LogicalAgg, row_count_idx: usize) -> Self {
-        debug_assert_eq!(
+        assert_eq!(
             logical.agg_calls()[row_count_idx],
             PlanAggCall::count_star()
         );

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -39,7 +39,7 @@ pub struct StreamHashAgg {
 
 impl StreamHashAgg {
     pub fn new(logical: LogicalAgg, vnode_col_idx: Option<usize>, row_count_idx: usize) -> Self {
-        debug_assert_eq!(
+        assert_eq!(
             logical.agg_calls()[row_count_idx],
             PlanAggCall::count_star()
         );

--- a/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_local_simple_agg.rs
@@ -97,6 +97,7 @@ impl StreamNode for StreamLocalSimpleAgg {
                 .iter()
                 .map(PlanAggCall::to_protobuf)
                 .collect(),
+            row_count_index: u32::MAX, // this is not used
             distribution_key: self
                 .distribution()
                 .dist_column_indices()

--- a/src/stream/src/executor/agg_common.rs
+++ b/src/stream/src/executor/agg_common.rs
@@ -24,6 +24,9 @@ use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, PkIndices};
 use crate::task::AtomicU64Ref;
 
+/// We assume the first state of aggregation is always `StreamingRowCountAgg`.
+pub const ROW_COUNT_COLUMN: usize = 0;
+
 /// Arguments needed to construct an `XxxAggExecutor`.
 pub struct AggExecutorArgs<S: StateStore> {
     // basic

--- a/src/stream/src/executor/agg_common.rs
+++ b/src/stream/src/executor/agg_common.rs
@@ -24,9 +24,6 @@ use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, PkIndices};
 use crate::task::AtomicU64Ref;
 
-/// We assume the first state of aggregation is always `StreamingRowCountAgg`.
-pub const ROW_COUNT_COLUMN: usize = 0;
-
 /// Arguments needed to construct an `XxxAggExecutor`.
 pub struct AggExecutorArgs<S: StateStore> {
     // basic
@@ -40,6 +37,7 @@ pub struct AggExecutorArgs<S: StateStore> {
 
     // agg common things
     pub agg_calls: Vec<AggCall>,
+    pub row_count_index: usize,
     pub storages: Vec<AggStateStorage<S>>,
     pub result_table: StateTable<S>,
     pub distinct_dedup_tables: HashMap<usize, StateTable<S>>,

--- a/src/stream/src/executor/aggregation/agg_group.rs
+++ b/src/stream/src/executor/aggregation/agg_group.rs
@@ -31,9 +31,6 @@ use crate::common::table::state_table::StateTable;
 use crate::executor::error::StreamExecutorResult;
 use crate::executor::PkIndices;
 
-/// We assume the first state of aggregation is always `StreamingRowCountAgg`.
-const ROW_COUNT_COLUMN: usize = 0;
-
 mod changes_builder {
     use super::*;
 
@@ -189,6 +186,9 @@ pub struct AggGroup<S: StateStore, Strtg: Strategy> {
     /// Previous outputs of managed states. Initializing with `None`.
     prev_outputs: Option<OwnedRow>,
 
+    /// Index of row count agg call (`count(*)`) in the call list.
+    row_count_index: usize,
+
     _phantom: PhantomData<Strtg>,
 }
 
@@ -220,6 +220,7 @@ impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
         storages: &[AggStateStorage<S>],
         result_table: &StateTable<S>,
         pk_indices: &PkIndices,
+        row_count_index: usize,
         extreme_cache_size: usize,
         input_schema: &Schema,
     ) -> StreamExecutorResult<AggGroup<S, Strtg>> {
@@ -246,6 +247,7 @@ impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
             group_key,
             states,
             prev_outputs,
+            row_count_index,
             _phantom: PhantomData,
         })
     }
@@ -256,7 +258,7 @@ impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
 
     fn prev_row_count(&self) -> usize {
         match &self.prev_outputs {
-            Some(states) => states[ROW_COUNT_COLUMN]
+            Some(states) => states[self.row_count_index]
                 .as_ref()
                 .map(|x| *x.as_int64() as usize)
                 .unwrap_or(0),
@@ -322,8 +324,8 @@ impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
         storages: &[AggStateStorage<S>],
     ) -> StreamExecutorResult<OwnedRow> {
         // Row count doesn't need I/O, so the following statement is supposed to be fast.
-        let row_count = self.states[ROW_COUNT_COLUMN]
-            .get_output(&storages[ROW_COUNT_COLUMN], self.group_key.as_ref())
+        let row_count = self.states[self.row_count_index]
+            .get_output(&storages[self.row_count_index], self.group_key.as_ref())
             .await?
             .as_ref()
             .map(|x| *x.as_int64() as usize)
@@ -356,7 +358,7 @@ impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
         new_ops: &mut Vec<Op>,
     ) -> AggChangesInfo {
         let prev_row_count = self.prev_row_count();
-        let curr_row_count = curr_outputs[ROW_COUNT_COLUMN]
+        let curr_row_count = curr_outputs[self.row_count_index]
             .as_ref()
             .map(|x| *x.as_int64() as usize)
             .expect("row count should not be None");

--- a/src/stream/src/executor/aggregation/agg_group.rs
+++ b/src/stream/src/executor/aggregation/agg_group.rs
@@ -214,6 +214,7 @@ pub struct AggChangesInfo {
 impl<S: StateStore, Strtg: Strategy> AggGroup<S, Strtg> {
     /// Create [`AggGroup`] for the given [`AggCall`]s and `group_key`.
     /// For [`crate::executor::GlobalSimpleAggExecutor`], the `group_key` should be `None`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create(
         group_key: Option<OwnedRow>,
         agg_calls: &[AggCall],

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -20,7 +20,7 @@ use risingwave_common::row::RowExt;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_storage::StateStore;
 
-use super::agg_common::AggExecutorArgs;
+use super::agg_common::{AggExecutorArgs, ROW_COUNT_COLUMN};
 use super::aggregation::{
     agg_call_filter_res, iter_table_storage, AggChangesInfo, AggStateStorage, AlwaysOutput,
     DistinctDeduplicater,
@@ -311,6 +311,7 @@ impl<S: StateStore> GlobalSimpleAggExecutor<S> {
                 &this.storages,
                 &this.result_table,
                 &this.input_pk_indices,
+                ROW_COUNT_COLUMN,
                 this.extreme_cache_size,
                 &this.input_schema,
             )

--- a/src/stream/src/executor/global_simple_agg.rs
+++ b/src/stream/src/executor/global_simple_agg.rs
@@ -406,7 +406,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::Count,
+                kind: AggKind::Count, // as row count, index: 0
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 order_pairs: vec![],
@@ -448,6 +448,7 @@ mod tests {
             store,
             Box::new(source),
             agg_calls,
+            0,
             vec![2],
             1,
         )

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -29,7 +29,7 @@ use risingwave_common::util::epoch::EpochPair;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_storage::StateStore;
 
-use super::agg_common::AggExecutorArgs;
+use super::agg_common::{AggExecutorArgs, ROW_COUNT_COLUMN};
 use super::aggregation::{
     agg_call_filter_res, iter_table_storage, AggStateStorage, DistinctDeduplicater,
     OnlyOutputIfHasInput,
@@ -258,6 +258,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                                 &this.storages,
                                 &this.result_table,
                                 &this.input_pk_indices,
+                                ROW_COUNT_COLUMN,
                                 this.extreme_cache_size,
                                 &this.input_schema,
                             )

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -650,6 +650,7 @@ mod tests {
         store: S,
         input: Box<dyn Executor>,
         agg_calls: Vec<AggCall>,
+        row_count_index: usize,
         group_key_indices: Vec<usize>,
         pk_indices: PkIndices,
         extreme_cache_size: usize,
@@ -688,6 +689,7 @@ mod tests {
             extreme_cache_size,
 
             agg_calls,
+            row_count_index,
             storages,
             result_table,
             distinct_dedup_tables: Default::default(),
@@ -752,7 +754,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::Count,
+                kind: AggKind::Count, // as row count, index: 0
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 order_pairs: vec![],
@@ -784,6 +786,7 @@ mod tests {
             store,
             Box::new(source),
             agg_calls,
+            0,
             keys,
             vec![],
             1 << 10,
@@ -856,7 +859,7 @@ mod tests {
         let append_only = false;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::Count,
+                kind: AggKind::Count, // as row count, index: 0
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 order_pairs: vec![],
@@ -889,6 +892,7 @@ mod tests {
             store,
             Box::new(source),
             agg_calls,
+            0,
             key_indices,
             vec![],
             1 << 10,
@@ -962,7 +966,7 @@ mod tests {
         let keys = vec![0];
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::Count,
+                kind: AggKind::Count, // as row count, index: 0
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 order_pairs: vec![],
@@ -985,6 +989,7 @@ mod tests {
             store,
             Box::new(source),
             agg_calls,
+            0,
             keys,
             vec![2],
             1 << 10,
@@ -1063,7 +1068,7 @@ mod tests {
         let append_only = true;
         let agg_calls = vec![
             AggCall {
-                kind: AggKind::Count,
+                kind: AggKind::Count, // as row count, index: 0
                 args: AggArgs::None,
                 return_type: DataType::Int64,
                 order_pairs: vec![],
@@ -1086,6 +1091,7 @@ mod tests {
             store,
             Box::new(source),
             agg_calls,
+            0,
             keys,
             vec![2],
             1 << 10,

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -168,7 +168,17 @@ async fn test_merger_sum_aggr() {
                 filter: None,
                 distinct: false,
             },
+            AggCall {
+                kind: AggKind::Count, // as row count, index: 2
+                args: AggArgs::None,
+                return_type: DataType::Int64,
+                order_pairs: vec![],
+                append_only,
+                filter: None,
+                distinct: false,
+            },
         ],
+        2, // row_count_index
         vec![],
         2,
     )

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -338,6 +338,7 @@ pub mod agg_executor {
         store: S,
         input: BoxedExecutor,
         agg_calls: Vec<AggCall>,
+        row_count_index: usize,
         pk_indices: PkIndices,
         executor_id: u64,
     ) -> Box<dyn Executor> {
@@ -374,6 +375,7 @@ pub mod agg_executor {
             extreme_cache_size: 1024,
 
             agg_calls,
+            row_count_index,
             storages,
             result_table,
             distinct_dedup_tables: Default::default(),

--- a/src/stream/src/from_proto/global_simple_agg.rs
+++ b/src/stream/src/from_proto/global_simple_agg.rs
@@ -63,6 +63,7 @@ impl ExecutorBuilder for GlobalSimpleAggExecutorBuilder {
             extreme_cache_size: stream.config.developer.unsafe_stream_extreme_cache_size,
 
             agg_calls,
+            row_count_index: node.get_row_count_index() as usize,
             storages,
             result_table,
             distinct_dedup_tables,

--- a/src/stream/src/from_proto/hash_agg.rs
+++ b/src/stream/src/from_proto/hash_agg.rs
@@ -105,6 +105,7 @@ impl ExecutorBuilder for HashAggExecutorBuilder {
                 extreme_cache_size: stream.config.developer.unsafe_stream_extreme_cache_size,
 
                 agg_calls,
+                row_count_index: node.get_row_count_index() as usize,
                 storages,
                 result_table,
                 distinct_dedup_tables,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR makes `HashAggExecutor` and `GlobalSimpleExecutor` reuse existing `count(*)` written by user as their internal row count agg call. This will close #8197.

Incidentally, it also removes unneeded `count(*)` inserted into `LocalSimpleAgg`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
