### PR TITLE
feat(connector): nd-stream wrapper

### DIFF
--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -236,6 +236,7 @@ macro_rules! impl_common_split_reader_logic {
         impl $reader {
             #[try_stream(boxed, ok = $crate::source::StreamChunkWithState, error = risingwave_common::error::RwError)]
             pub(crate) async fn into_chunk_stream(self) {
+                use crate::parser::ByteStreamSourceParser;
                 let parser_config = self.parser_config.clone();
                 let actor_id = self.source_ctx.source_info.actor_id.to_string();
                 let source_id = self.source_ctx.source_info.source_id.to_string();

--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -236,7 +236,7 @@ macro_rules! impl_common_split_reader_logic {
         impl $reader {
             #[try_stream(boxed, ok = $crate::source::StreamChunkWithState, error = risingwave_common::error::RwError)]
             pub(crate) async fn into_chunk_stream(self) {
-                use crate::parser::ByteStreamSourceParser;
+                use $crate::parser::ByteStreamSourceParser;
                 let parser_config = self.parser_config.clone();
                 let actor_id = self.source_ctx.source_info.actor_id.to_string();
                 let source_id = self.source_ctx.source_info.source_id.to_string();

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -319,9 +319,11 @@ pub enum ByteStreamSourceParserImpl {
     CanalJson(CanalJsonParser),
     DebeziumAvro(DebeziumAvroParser),
 }
-
-impl ByteStreamSourceParserImpl {
-    pub fn into_stream(self, msg_stream: BoxSourceStream) -> BoxSourceWithStateStream {
+impl ByteStreamSourceParser for ByteStreamSourceParserImpl {
+    fn into_stream(
+        self,
+        msg_stream: crate::source::BoxSourceStream,
+    ) -> crate::source::BoxSourceWithStateStream {
         match self {
             Self::Csv(parser) => parser.into_stream(msg_stream),
             Self::Json(parser) => parser.into_stream(msg_stream),
@@ -333,7 +335,9 @@ impl ByteStreamSourceParserImpl {
             Self::DebeziumAvro(parser) => parser.into_stream(msg_stream),
         }
     }
+}
 
+impl ByteStreamSourceParserImpl {
     pub fn create(parser_config: ParserConfig, source_ctx: SourceContextRef) -> Result<Self> {
         let CommonParserConfig { rw_columns } = parser_config.common;
         match parser_config.specific {

--- a/src/connector/src/source/filesystem/mod.rs
+++ b/src/connector/src/source/filesystem/mod.rs
@@ -15,5 +15,6 @@
 pub use s3::{S3FileReader, S3Properties, S3SplitEnumerator, S3_CONNECTOR};
 
 mod file_common;
+pub mod nd_streaming;
 pub use file_common::FsSplit;
 mod s3;

--- a/src/connector/src/source/filesystem/nd_streaming.rs
+++ b/src/connector/src/source/filesystem/nd_streaming.rs
@@ -14,14 +14,11 @@
 
 use std::io::BufRead;
 
-use anyhow::anyhow;
 use bytes::BytesMut;
-use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::{for_await, try_stream};
-use risingwave_common::error::RwError;
 
 use crate::parser::ByteStreamSourceParser;
-use crate::source::{BoxSourceStream, SourceMessage, StreamChunkWithState};
+use crate::source::{BoxSourceStream, SourceMessage};
 #[derive(Debug)]
 
 /// A newline-delimited bytes stream wrapper that can any converts arbitrary file(bytes) streams
@@ -122,6 +119,8 @@ impl<T: ByteStreamSourceParser> ByteStreamSourceParser for NdByteStreamWrapper<T
 mod tests {
     use std::sync::Arc;
 
+    use futures::{StreamExt, TryStreamExt};
+
     use super::*;
 
     #[tokio::test]
@@ -130,7 +129,7 @@ mod tests {
         const N2: usize = 500;
         const N3: usize = 50;
         let lines = (0..N1)
-            .map(|x| (0..x % N2).map(|y| 'A').collect::<String>())
+            .map(|x| (0..x % N2).map(|_| 'A').collect::<String>())
             .collect::<Vec<_>>();
         let total_chars = lines.iter().map(|e| e.len()).sum::<usize>();
         let text = lines.join("\n").into_bytes();

--- a/src/connector/src/source/filesystem/nd_streaming.rs
+++ b/src/connector/src/source/filesystem/nd_streaming.rs
@@ -1,0 +1,153 @@
+use std::io::BufRead;
+
+use anyhow::anyhow;
+use bytes::BytesMut;
+use futures::{StreamExt, TryStreamExt};
+use futures_async_stream::{for_await, try_stream};
+use risingwave_common::error::RwError;
+
+use crate::parser::ByteStreamSourceParser;
+use crate::source::{BoxSourceStream, SourceMessage, StreamChunkWithState};
+#[derive(Debug)]
+
+/// A newline-delimited bytes stream wrapper that can any converts arbitrary file(bytes) streams
+/// into message streams segmented by the newline character '\n'.
+pub struct NdByteStreamWrapper<T> {
+    inner: T,
+}
+impl<T> NdByteStreamWrapper<T> {
+    pub fn new(inner: T) -> Self
+    where
+        T: ByteStreamSourceParser,
+    {
+        Self { inner }
+    }
+
+    #[try_stream(boxed, ok = Vec<SourceMessage>, error = anyhow::Error)]
+    /// This function splits a byte stream by the newline character '\n' into a message stream.
+    /// It can be difficult to split and compute offsets correctly when the bytes are received in
+    /// chunks.  There are two cases to consider:
+    /// - When a bytes chunk does not end with '\n', we should not treat the last segment as a new
+    ///   line message, but keep it for the next chunk, and insert it before next chunk's first line
+    ///   beginning.
+    /// - When a bytes chunk ends with '\n', there is no additional action required.
+    async fn split_stream(data_stream: BoxSourceStream) {
+        let mut buf = BytesMut::new();
+
+        let mut last_message = None;
+        #[for_await]
+        for batch in data_stream {
+            let batch = batch?;
+
+            if batch.is_empty() {
+                continue;
+            }
+            let (offset, split_id, meta) = batch
+                .first()
+                .map(|msg| (msg.offset.clone(), msg.split_id.clone(), msg.meta.clone()))
+                .unwrap(); // Never panic because we check batch is not empty
+
+            let mut offset: usize = offset.parse()?;
+
+            // Never panic because we check batch is not empty
+            let last_offset: usize = batch.last().map(|m| m.offset.clone()).unwrap().parse()?;
+            for (i, msg) in batch.into_iter().enumerate() {
+                let payload = msg.payload.unwrap_or_default();
+                if i == 0 {
+                    // The 'offset' field in 'SourceMessage' indicates the end position of a chunk.
+                    // But indicates the beginning here.
+                    offset -= payload.len();
+                }
+                buf.extend(payload);
+            }
+            let mut msgs = Vec::new();
+            for (i, line) in buf.lines().enumerate() {
+                let mut line = line?;
+                offset += line.len();
+                // Insert the trailing of the last chunk in front of the first line, do not count
+                // the length here.
+                if i == 0 && last_message.is_some() {
+                    let msg: SourceMessage = std::mem::take(&mut last_message).unwrap();
+                    line = String::from_utf8(msg.payload.unwrap().into()).unwrap() + &line;
+                }
+
+                msgs.push(SourceMessage {
+                    payload: Some(line.into()),
+                    offset: offset.to_string(),
+                    split_id: split_id.clone(),
+                    meta: meta.clone(),
+                });
+                offset += 1;
+            }
+
+            if offset > last_offset {
+                last_message = msgs.pop();
+            }
+
+            if !msgs.is_empty() {
+                yield msgs;
+            }
+
+            buf.clear();
+        }
+        if let Some(msg) = last_message {
+            yield vec![msg];
+        }
+    }
+}
+impl<T: ByteStreamSourceParser> ByteStreamSourceParser for NdByteStreamWrapper<T> {
+    fn into_stream(
+        self,
+        data_stream: crate::source::BoxSourceStream,
+    ) -> crate::source::BoxSourceWithStateStream {
+        self.inner.into_stream(Self::split_stream(data_stream))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_split_stream() {
+        const N1: usize = 10000;
+        const N2: usize = 500;
+        const N3: usize = 50;
+        let lines = (0..N1)
+            .map(|x| (0..x % N2).map(|y| 'A').collect::<String>())
+            .collect::<Vec<_>>();
+        let total_chars = lines.iter().map(|e| e.len()).sum::<usize>();
+        let text = lines.join("\n").into_bytes();
+        let split_id: Arc<str> = "1".to_string().into_boxed_str().into();
+        let s = text
+            .chunks(N2)
+            .enumerate()
+            .map(move |(i, e)| {
+                Ok(e.chunks(N3)
+                    .enumerate()
+                    .map(|(j, buf)| SourceMessage {
+                        payload: Some(buf.to_owned().into()),
+                        offset: (i * N2 + (j + 1) * N3).to_string(),
+                        split_id: split_id.clone(),
+                        meta: crate::source::SourceMeta::Empty,
+                    })
+                    .collect::<Vec<_>>())
+            })
+            .collect::<Vec<_>>();
+        let stream = futures::stream::iter(s).boxed();
+        let msg_stream = NdByteStreamWrapper::<()>::split_stream(stream)
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        let items = msg_stream
+            .into_iter()
+            .flatten()
+            .map(|e| String::from_utf8(e.payload.unwrap().into()).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(items.len(), N1);
+        let text = items.join("");
+        assert_eq!(text.len(), total_chars);
+    }
+}

--- a/src/connector/src/source/filesystem/nd_streaming.rs
+++ b/src/connector/src/source/filesystem/nd_streaming.rs
@@ -15,7 +15,7 @@
 use std::io::BufRead;
 
 use bytes::BytesMut;
-use futures_async_stream::{for_await, try_stream};
+use futures_async_stream::try_stream;
 
 use crate::parser::ByteStreamSourceParser;
 use crate::source::{BoxSourceStream, SourceMessage};

--- a/src/connector/src/source/filesystem/nd_streaming.rs
+++ b/src/connector/src/source/filesystem/nd_streaming.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::io::BufRead;
 
 use anyhow::anyhow;

--- a/src/connector/src/source/filesystem/s3/source/reader.rs
+++ b/src/connector/src/source/filesystem/s3/source/reader.rs
@@ -27,9 +27,10 @@ use tokio_util::io;
 use tokio_util::io::ReaderStream;
 
 use crate::aws_utils::{default_conn_config, s3_client, AwsConfigV2};
-use crate::parser::{ByteStreamSourceParserImpl, ParserConfig};
+use crate::parser::{ByteStreamSourceParser, ByteStreamSourceParserImpl, ParserConfig};
 use crate::source::base::{SplitMetaData, SplitReader, MAX_CHUNK_SIZE};
 use crate::source::filesystem::file_common::FsSplit;
+use crate::source::filesystem::nd_streaming::NdByteStreamWrapper;
 use crate::source::filesystem::s3::S3Properties;
 use crate::source::{
     BoxSourceWithStateStream, Column, SourceContextRef, SourceMessage, SourceMeta, SplitImpl,
@@ -197,7 +198,11 @@ impl S3FileReader {
 
             let parser =
                 ByteStreamSourceParserImpl::create(self.parser_config.clone(), source_ctx)?;
-            let msg_stream = parser.into_stream(Box::pin(data_stream));
+            let msg_stream = if matches!(parser, ByteStreamSourceParserImpl::Json(_)) {
+                NdByteStreamWrapper::new(parser).into_stream(Box::pin(data_stream))
+            } else {
+                parser.into_stream(Box::pin(data_stream))
+            };
             #[for_await]
             for msg in msg_stream {
                 let msg = msg?;

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -149,6 +149,7 @@ impl SourceDescBuilder {
     pub async fn build_fs_source_desc(&self) -> Result<FsSourceDesc> {
         let format = match self.source_info.get_row_format()? {
             ProstRowFormatType::Csv => SourceFormat::Csv,
+            ProstRowFormatType::Json => SourceFormat::Json,
             _ => unreachable!(),
         };
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

`NdByteStreamWrapper` has been introduced to bridge any parser made for a message-based stream to a file-based (byte) stream by segmenting the stream using the newline character '\n' as the delimiter. Thus, we can unify the parsing process for row formats such as CSV and ndjson, and reuse the parsers.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

----

I will create a new PR to refactor the current CSV parser to adopt this.

