### PR TITLE
feat(connector): allow custom s3 endpoint

### DIFF
--- a/src/connector/src/source/filesystem/s3/enumerator.rs
+++ b/src/connector/src/source/filesystem/s3/enumerator.rs
@@ -149,6 +149,7 @@ mod tests {
             match_pattern: Some("happy[0-9].csv".to_owned()),
             access: None,
             secret: None,
+            endpoint_url: None,
         };
         let mut enumerator = S3SplitEnumerator::new(props.clone()).await.unwrap();
         let splits = enumerator.list_splits().await.unwrap();

--- a/src/connector/src/source/filesystem/s3/mod.rs
+++ b/src/connector/src/source/filesystem/s3/mod.rs
@@ -33,6 +33,8 @@ pub struct S3Properties {
     pub access: Option<String>,
     #[serde(rename = "s3.credentials.secret", default)]
     pub secret: Option<String>,
+    #[serde(rename = "s3.endpoint_url")]
+    endpoint_url: Option<String>,
 }
 
 impl From<S3Properties> for HashMap<String, String> {
@@ -46,6 +48,10 @@ impl From<S3Properties> for HashMap<String, String> {
         if props.secret.is_some() {
             m.insert("secret_access".to_owned(), props.secret.unwrap());
         }
+        if props.endpoint_url.is_some() {
+            m.insert("endpoint_url".to_owned(), props.endpoint_url.unwrap());
+        }
+
         m
     }
 }

--- a/src/connector/src/source/filesystem/s3/source/reader.rs
+++ b/src/connector/src/source/filesystem/s3/source/reader.rs
@@ -231,6 +231,7 @@ mod tests {
             match_pattern: None,
             access: None,
             secret: None,
+            endpoint_url: None,
         };
         let mut enumerator = S3SplitEnumerator::new(props.clone()).await.unwrap();
         let splits = enumerator.list_splits().await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We should allow user to use other S3-compatible server in our S3 connector.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes


- Connector (sources & sinks)

- `s3.endpoint_url` parameter was added into s3 connector.

### Release note

- Support  S3-compatible server in S3 connector.

</details>
