### PR TITLE
feat(expr): jsonb IS [NOT] NULL

### DIFF
--- a/e2e_test/batch/types/jsonb.slt.part
+++ b/e2e_test/batch/types/jsonb.slt.part
@@ -124,6 +124,19 @@ select jsonb_array_length('null');
 statement ok
 drop table t;
 
+query TIT
+with t(v1) as (
+	values (null::jsonb), ('null'), ('[true, 4, "foo"]')
+) select
+	v1 is null,
+	case when jsonb_typeof(v1) = 'array' then jsonb_array_length(v1) end,
+	coalesce(v1 -> 1, v1, '"?"')
+from t;
+----
+t NULL "?"
+f NULL null
+f 3 4
+
 # Tests moved from regress tests due to not matching exactly.
 
 # PostgreSQL sorts shorter key "two" before longer key "three"
@@ -136,14 +149,3 @@ SELECT '{
 		true}'::jsonb; -- OK
 ----
 {"one": 1, "three": true, "two": "two"}
-
-# We do not support jsonb IS NULL yet.
-query TTTT
-SELECT
-  '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'ff',
-  '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'qq',
-  -- ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'Y') IS NULL AS f,
-  ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb ->> 'Y') IS NULL AS t,
-   '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'x';
-----
-{"a": 12, "b": 16} 123 t [1, 2]

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -104,6 +104,7 @@ fn build_type_derive_map() -> FuncSigMap {
         T::Timestamptz,
         T::Time,
         T::Interval,
+        T::Jsonb,
     ];
     let num_types = [
         T::Int16,

--- a/src/tests/regress/data/sql/jsonb.sql
+++ b/src/tests/regress/data/sql/jsonb.sql
@@ -171,9 +171,9 @@ SELECT test_json ->> 2 FROM test_jsonb WHERE json_type = 'object';
 --@ SELECT jsonb_object_keys(test_json) FROM test_jsonb WHERE json_type = 'object';
 
 -- nulls
---@ SELECT (test_json->'field3') IS NULL AS expect_false FROM test_jsonb WHERE json_type = 'object';
+SELECT (test_json->'field3') IS NULL AS expect_false FROM test_jsonb WHERE json_type = 'object';
 SELECT (test_json->>'field3') IS NULL AS expect_true FROM test_jsonb WHERE json_type = 'object';
---@ SELECT (test_json->3) IS NULL AS expect_false FROM test_jsonb WHERE json_type = 'array';
+SELECT (test_json->3) IS NULL AS expect_false FROM test_jsonb WHERE json_type = 'array';
 SELECT (test_json->>3) IS NULL AS expect_true FROM test_jsonb WHERE json_type = 'array';
 
 DROP TABLE test_jsonb;
@@ -933,12 +933,12 @@ SELECT '{"aa":["a","aaa"],"qq":{"a":"12","b":"16","c":["c1","c2"],"d":{"d1":"d1"
 SELECT '{"aa":["a","aaa"],"qq":{"a":"12","b":"16","c":["c1","c2",["c3"],{"c4":4}],"d":{"d1":"d1","d2":"d2"}}}'::jsonb;
 SELECT '{"ff":["a","aaa"]}'::jsonb;
 
---@ SELECT
---@   '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'ff',
---@   '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'qq',
---@   ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'Y') IS NULL AS f,
---@   ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb ->> 'Y') IS NULL AS t,
---@    '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'x';
+SELECT
+  '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'ff',
+  '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'qq',
+  ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'Y') IS NULL AS f,
+  ('{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb ->> 'Y') IS NULL AS t,
+   '{"ff":{"a":12,"b":16},"qq":123,"x":[1,2],"Y":null}'::jsonb -> 'x';
 
 -- nested containment
 --@ SELECT '{"a":[1,2],"c":"b"}'::jsonb @> '{"a":[1,2]}';


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add the missing support to use `jsonb` as input to `IS [NOT] NULL`. Also add tests for similar functions that are supposed to work for all types: `CASE WHEN`, `COALESCE`.

Note that `bytea` will be handled separately. Functions based on comparison (e.g. `IS DISTINCT FROM`, `NULLIF`, `IN`) are left out purposely.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added an item to track fuzzing tests.
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support jsonb IS [NOT] NULL.