### PR TITLE
fix(optimizer): handle non-injective changes of `logical_rewrite_for_stream`

### DIFF
--- a/src/common/src/util/column_index_mapping.rs
+++ b/src/common/src/util/column_index_mapping.rs
@@ -268,6 +268,17 @@ impl ColIndexMapping {
     pub fn is_empty(&self) -> bool {
         self.target_size() == 0
     }
+
+    pub fn is_injective(&self) -> bool {
+        let mut tar_exists = vec![false; self.target_size()];
+        for i in self.map.iter().flatten() {
+            if tar_exists[*i] {
+                return false;
+            }
+            tar_exists[*i] = true;
+        }
+        true
+    }
 }
 
 impl ColIndexMapping {

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -35,6 +35,7 @@ use plan_expr_rewriter::ConstEvalRewriter;
 use property::Order;
 use risingwave_common::catalog::{ColumnCatalog, ConflictBehavior, Field, Schema};
 use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_pb::catalog::WatermarkDesc;
 
@@ -294,8 +295,35 @@ impl PlanRoot {
             Convention::Logical => {
                 let plan = self.gen_optimized_logical_plan_for_stream()?;
 
-                let (plan, out_col_change) =
-                    plan.logical_rewrite_for_stream(&mut Default::default())?;
+                let (plan, out_col_change) = {
+                    let (plan, out_col_change) =
+                        plan.logical_rewrite_for_stream(&mut Default::default())?;
+                    if out_col_change.is_injective() {
+                        (plan, out_col_change)
+                    } else {
+                        let mut output_indices = (0..plan.schema().len()).collect_vec();
+                        #[allow(unused_assignments)]
+                        let (mut map, mut target_size) = out_col_change.into_parts();
+
+                        // TODO(st1page): https://github.com/risingwavelabs/risingwave/issues/7234
+                        // assert_eq!(target_size, output_indices.len());
+                        target_size = plan.schema().len();
+                        let mut tar_exists = vec![false; target_size];
+                        for i in map.iter_mut().flatten() {
+                            if tar_exists[*i] {
+                                output_indices.push(*i);
+                                *i = target_size;
+                                target_size += 1;
+                            } else {
+                                tar_exists[*i] = true;
+                            }
+                        }
+                        let plan =
+                            LogicalProject::with_out_col_idx(plan, output_indices.into_iter());
+                        let out_col_change = ColIndexMapping::with_target_size(map, target_size);
+                        (plan.into(), out_col_change)
+                    }
+                };
 
                 if explain_trace {
                     ctx.trace("Logical Rewrite For Stream:");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix #8216 

```
dev=>     create table t(x int);
CREATE_TABLE
dev=> explain create materialized view mv as     SELECT t.x x1, t.x x2 FROM t join t tt ON t.x=tt.x;
                                                                                      QUERY PLAN                                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 StreamMaterialize { columns: [t.x(hidden), x1, t._row_id(hidden), t._row_id#1(hidden), t.x#1(hidden), x2], pk_columns: [t._row_id, t._row_id#1, x2, t.x#1], pk_conflict: "no check" }
 └─StreamProject { exprs: [t.x, t.x, t._row_id, t._row_id, t.x, t.x] }
   └─StreamHashJoin { type: Inner, predicate: t.x = t.x }
     ├─StreamExchange { dist: HashShard(t.x) }
     | └─StreamTableScan { table: t, columns: [x, _row_id] }
     └─StreamExchange { dist: HashShard(t.x) }
       └─StreamTableScan { table: t, columns: [x, _row_id] }
(7 rows)


```
## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

