### PR TITLE
fix: fix build on macos

### DIFF
--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -40,7 +40,6 @@ risingwave_storage = { path = "../storage" }
 risingwave_stream = { path = "../stream" }
 risingwave_tracing = { path = "../tracing" }
 serde_json = "1"
-tikv-jemalloc-ctl = "0.5"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
@@ -54,6 +53,9 @@ tokio-stream = "0.1"
 tonic = { version = "0.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = "0.1"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tikv-jemalloc-ctl = "0.5"
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -40,6 +40,7 @@ risingwave_storage = { path = "../storage" }
 risingwave_stream = { path = "../stream" }
 risingwave_tracing = { path = "../tracing" }
 serde_json = "1"
+tikv-jemalloc-ctl = "0.5"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
@@ -53,9 +54,6 @@ tokio-stream = "0.1"
 tonic = { version = "0.2", package = "madsim-tonic" }
 tower = { version = "0.4", features = ["util", "load-shed"] }
 tracing = "0.1"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemalloc-ctl = "0.5"
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/compute/src/memory_management/policy.rs
+++ b/src/compute/src/memory_management/policy.rs
@@ -216,6 +216,7 @@ impl MemoryControl for StreamingOnlyPolicy {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn advance_jemalloc_epoch(prev_jemalloc_allocated_mib: usize) -> usize {
     use tikv_jemalloc_ctl::{epoch as jemalloc_epoch, stats as jemalloc_stats};
 
@@ -229,6 +230,11 @@ fn advance_jemalloc_epoch(prev_jemalloc_allocated_mib: usize) -> usize {
         tracing::warn!("Jemalloc read allocated failed! {:?}", e);
         prev_jemalloc_allocated_mib
     })
+}
+
+#[cfg(not(target_os = "linux"))]
+fn advance_jemalloc_epoch(_prev_jemalloc_allocated_mib: usize) -> usize {
+    0
 }
 
 fn calculate_lru_watermark(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix the compile error on macos introduced by #8253.

```
error[E0432]: unresolved import `tikv_jemalloc_ctl`
   --> src/compute/src/memory_management/policy.rs:220:9
    |
220 |     use tikv_jemalloc_ctl::{epoch as jemalloc_epoch, stats as jemalloc_stats};
    |         ^^^^^^^^^^^^^^^^^ use of undeclared crate or module `tikv_jemalloc_ctl`
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
