### PR TITLE
fix(meta): allow `create table` have multiple state tables

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -108,7 +108,7 @@ psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.s
 # start cluster w/o clean-data
 cargo make dev ci-1cn-1fe-with-recovery
 echo "wait for recovery finish"
-sleep 10
+sleep 20
 echo "check mviews after cluster recovery"
 # check results
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'

--- a/e2e_test/source/cdc/cdc.check_new_rows.slt
+++ b/e2e_test/source/cdc/cdc.check_new_rows.slt
@@ -4,17 +4,17 @@ select cnt from products_cnt;
 ----
 11
 
-query II
+query I
 select cnt from orders_cnt;
 ----
 4
 
-query III
+query I
 select cnt from shipments_cnt;
 ----
 4
 
-query IIII
+query III
 select order_id, product_id, shipment_id from enriched_orders order by order_id;
 ----
 10001  102   1001
@@ -22,7 +22,7 @@ select order_id, product_id, shipment_id from enriched_orders order by order_id;
 10003  106   1003
 10004  110   1004
 
-query VI
+query IIT
 select v1, v2, v3 from mytable order by v1;
 ----
 2 2 yes

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -984,7 +984,7 @@ where
         &self,
         source: &Source,
         mview: &Table,
-        internal_table: &Table,
+        internal_tables: Vec<Table>,
     ) -> MetaResult<NotificationVersion> {
         let core = &mut *self.core.lock().await;
         let database_core = &mut core.database;
@@ -1016,11 +1016,16 @@ where
 
         sources.insert(source.id, source.clone());
         tables.insert(mview.id, mview.clone());
-        tables.insert(internal_table.id, internal_table.clone());
-
+        for table in &internal_tables {
+            tables.insert(table.id, table.clone());
+        }
         commit_meta!(self, sources, tables)?;
-        self.notify_frontend(Operation::Add, Info::Table(internal_table.to_owned()))
-            .await;
+
+        for internal_table in internal_tables {
+            self.notify_frontend(Operation::Add, Info::Table(internal_table))
+                .await;
+        }
+
         self.notify_frontend(Operation::Add, Info::Table(mview.to_owned()))
             .await;
 

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -460,18 +460,10 @@ where
             StreamingJob::Table(source, table) => {
                 creating_internal_table_ids.push(table.id);
                 if let Some(source) = source {
-                    let internal_tables: [_; 1] = internal_tables.try_into().unwrap();
                     self.catalog_manager
-                        .finish_create_table_procedure_with_source(
-                            source,
-                            table,
-                            &internal_tables[0],
-                        )
+                        .finish_create_table_procedure_with_source(source, table, internal_tables)
                         .await?
                 } else {
-                    assert!(internal_tables.is_empty());
-                    // Though `internal_tables` is empty here, we pass it as a parameter to reuse
-                    // the method.
                     self.catalog_manager
                         .finish_create_table_procedure(internal_tables, table)
                         .await?


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).
fix #8290 
as title
## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
