### PR TITLE
refactor(common): cleanup DataType const

### DIFF
--- a/src/common/benches/bench_row.rs
+++ b/src/common/benches/bench_row.rs
@@ -180,7 +180,7 @@ fn bench_row(c: &mut Criterion) {
     let cases = vec![
         Case::new(
             "Int16",
-            vec![DataType::INT16],
+            vec![DataType::Int16],
             vec![ColumnId::new(0)],
             vec![OwnedRow::new(vec![Some(ScalarImpl::Int16(5))]); 100000],
             None,

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -643,7 +643,7 @@ mod tests {
                 array! { BoolArray, [Some(false), Some(false), Some(true), None]}.into(),
                 array! { I32Array, [Some(42), Some(28), Some(19), None] }.into(),
             ],
-            vec![DataType::Boolean, DataType::INT32],
+            vec![DataType::Boolean, DataType::Int32],
             vec![String::from("a"), String::from("b")],
         );
         assert_eq!(

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -235,20 +235,6 @@ impl From<&ProstDataType> for DataType {
 }
 
 impl DataType {
-    pub const BOOLEAN: DataType = DataType::Boolean;
-    pub const DATE: DataType = DataType::Date;
-    pub const DECIMAL: DataType = DataType::Decimal;
-    pub const FLOAT32: DataType = DataType::Float32;
-    pub const FLOAT64: DataType = DataType::Float64;
-    pub const INT16: DataType = DataType::Int16;
-    pub const INT32: DataType = DataType::Int32;
-    pub const INT64: DataType = DataType::Int64;
-    pub const INTERVAL: DataType = DataType::Interval;
-    pub const TIME: DataType = DataType::Time;
-    pub const TIMESTAMP: DataType = DataType::Timestamp;
-    pub const TIMESTAMPTZ: DataType = DataType::Timestamptz;
-    pub const VARCHAR: DataType = DataType::Varchar;
-
     pub fn create_array_builder(&self, capacity: usize) -> ArrayBuilderImpl {
         use crate::array::*;
         match self {

--- a/src/connector/src/source/nexmark/source/combined_event.rs
+++ b/src/connector/src/source/nexmark/source/combined_event.rs
@@ -165,7 +165,7 @@ pub(crate) fn get_bid_struct_type() -> StructType {
         DataType::Varchar,
         DataType::Varchar,
         DataType::Timestamp,
-        DataType::VARCHAR,
+        DataType::Varchar,
     ];
     let field_names = vec![
         "auction",

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_meta_snapshot.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_meta_snapshot.rs
@@ -24,9 +24,9 @@ pub const RW_META_SNAPSHOT_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     // the smallest epoch this meta snapshot includes
     (DataType::Int64, "safe_epoch"),
     // human-readable timestamp of safe_epoch
-    (DataType::TIMESTAMP, "safe_epoch_ts"),
+    (DataType::Timestamp, "safe_epoch_ts"),
     // the largest epoch this meta snapshot includes
     (DataType::Int64, "max_committed_epoch"),
     // human-readable timestamp of max_committed_epoch
-    (DataType::TIMESTAMP, "max_committed_epoch_ts"),
+    (DataType::Timestamp, "max_committed_epoch_ts"),
 ];

--- a/src/frontend/src/handler/describe.rs
+++ b/src/frontend/src/handler/describe.rs
@@ -182,13 +182,13 @@ pub fn handle_describe(handler_args: HandlerArgs, table_name: ObjectName) -> Res
         vec![
             PgFieldDescriptor::new(
                 "Name".to_owned(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
             PgFieldDescriptor::new(
                 "Type".to_owned(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
         ],
     ))

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -202,8 +202,8 @@ pub async fn handle_explain(
         rows.into(),
         vec![PgFieldDescriptor::new(
             "QUERY PLAN".to_owned(),
-            DataType::VARCHAR.to_oid(),
-            DataType::VARCHAR.type_len(),
+            DataType::Varchar.to_oid(),
+            DataType::Varchar.type_len(),
         )],
     ))
 }

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -105,13 +105,13 @@ pub fn handle_show_object(handler_args: HandlerArgs, command: ShowObject) -> Res
                 vec![
                     PgFieldDescriptor::new(
                         "Name".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                     PgFieldDescriptor::new(
                         "Type".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                 ],
             ));
@@ -129,8 +129,8 @@ pub fn handle_show_object(handler_args: HandlerArgs, command: ShowObject) -> Res
         rows.into(),
         vec![PgFieldDescriptor::new(
             "Name".to_owned(),
-            DataType::VARCHAR.to_oid(),
-            DataType::VARCHAR.type_len(),
+            DataType::Varchar.to_oid(),
+            DataType::Varchar.type_len(),
         )],
     ))
 }
@@ -184,13 +184,13 @@ pub fn handle_show_create_object(
         vec![
             PgFieldDescriptor::new(
                 "Name".to_owned(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
             PgFieldDescriptor::new(
                 "Create Sql".to_owned(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
         ],
     ))

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -208,7 +208,7 @@ mod tests {
         let field = Field::with_name(DataType::Int32, "v1");
         let pg_field = to_pg_field(&field);
         assert_eq!(pg_field.get_name(), "v1");
-        assert_eq!(pg_field.get_type_oid(), DataType::INT32.to_oid());
+        assert_eq!(pg_field.get_type_oid(), DataType::Int32.to_oid());
     }
 
     #[test]

--- a/src/frontend/src/handler/variable.rs
+++ b/src/frontend/src/handler/variable.rs
@@ -70,8 +70,8 @@ pub(super) async fn handle_show(
         vec![row].into(),
         vec![PgFieldDescriptor::new(
             name.to_ascii_lowercase(),
-            DataType::VARCHAR.to_oid(),
-            DataType::VARCHAR.type_len(),
+            DataType::Varchar.to_oid(),
+            DataType::Varchar.type_len(),
         )],
     ))
 }
@@ -99,18 +99,18 @@ fn handle_show_all(handler_args: HandlerArgs) -> Result<RwPgResponse> {
         vec![
             PgFieldDescriptor::new(
                 "Name".to_string(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
             PgFieldDescriptor::new(
                 "Setting".to_string(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
             PgFieldDescriptor::new(
                 "Description".to_string(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
         ],
     ))
@@ -136,13 +136,13 @@ async fn handle_show_system_params(handler_args: HandlerArgs) -> Result<RwPgResp
         vec![
             PgFieldDescriptor::new(
                 "Name".to_string(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
             PgFieldDescriptor::new(
                 "Value".to_string(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.type_len(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.type_len(),
             ),
         ],
     ))

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -790,21 +790,21 @@ impl Session<PgResponseStream> for SessionImpl {
                     vec![
                         PgFieldDescriptor::new(
                             "Name".to_owned(),
-                            DataType::VARCHAR.to_oid(),
-                            DataType::VARCHAR.type_len(),
+                            DataType::Varchar.to_oid(),
+                            DataType::Varchar.type_len(),
                         ),
                         PgFieldDescriptor::new(
                             "Type".to_owned(),
-                            DataType::VARCHAR.to_oid(),
-                            DataType::VARCHAR.type_len(),
+                            DataType::Varchar.to_oid(),
+                            DataType::Varchar.type_len(),
                         ),
                     ]
                 }
                 _ => {
                     vec![PgFieldDescriptor::new(
                         "Name".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     )]
                 }
             },
@@ -812,13 +812,13 @@ impl Session<PgResponseStream> for SessionImpl {
                 vec![
                     PgFieldDescriptor::new(
                         "Name".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                     PgFieldDescriptor::new(
                         "Create Sql".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                 ]
             }
@@ -828,25 +828,25 @@ impl Session<PgResponseStream> for SessionImpl {
                     vec![
                         PgFieldDescriptor::new(
                             "Name".to_string(),
-                            DataType::VARCHAR.to_oid(),
-                            DataType::VARCHAR.type_len(),
+                            DataType::Varchar.to_oid(),
+                            DataType::Varchar.type_len(),
                         ),
                         PgFieldDescriptor::new(
                             "Setting".to_string(),
-                            DataType::VARCHAR.to_oid(),
-                            DataType::VARCHAR.type_len(),
+                            DataType::Varchar.to_oid(),
+                            DataType::Varchar.type_len(),
                         ),
                         PgFieldDescriptor::new(
                             "Description".to_string(),
-                            DataType::VARCHAR.to_oid(),
-                            DataType::VARCHAR.type_len(),
+                            DataType::Varchar.to_oid(),
+                            DataType::Varchar.type_len(),
                         ),
                     ]
                 } else {
                     vec![PgFieldDescriptor::new(
                         name.to_ascii_lowercase(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     )]
                 }
             }
@@ -854,21 +854,21 @@ impl Session<PgResponseStream> for SessionImpl {
                 vec![
                     PgFieldDescriptor::new(
                         "Name".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                     PgFieldDescriptor::new(
                         "Type".to_owned(),
-                        DataType::VARCHAR.to_oid(),
-                        DataType::VARCHAR.type_len(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
                     ),
                 ]
             }
             Statement::Explain { .. } => {
                 vec![PgFieldDescriptor::new(
                     "QUERY PLAN".to_owned(),
-                    DataType::VARCHAR.to_oid(),
-                    DataType::VARCHAR.type_len(),
+                    DataType::Varchar.to_oid(),
+                    DataType::Varchar.type_len(),
                 )]
             }
             _ => {

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -647,7 +647,7 @@ mod tests {
     fn test_prepared_statement_with_explicit_param() {
         let raw_statement = "SELECT * FROM test_table WHERE id = $1".to_string();
         let prepared_statement =
-            PreparedStatement::parse_statement(raw_statement, vec![DataType::INT32.to_oid()])
+            PreparedStatement::parse_statement(raw_statement, vec![DataType::Int32.to_oid()])
                 .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
         assert!("SELECT * FROM test_table WHERE id = 0::INT" == default_sql);
@@ -657,7 +657,7 @@ mod tests {
         let raw_statement = "INSERT INTO test (index,data) VALUES ($1,$2)".to_string();
         let prepared_statement = PreparedStatement::parse_statement(
             raw_statement,
-            vec![DataType::INT32.to_oid(), DataType::VARCHAR.to_oid()],
+            vec![DataType::Int32.to_oid(), DataType::Varchar.to_oid()],
         )
         .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
@@ -670,7 +670,7 @@ mod tests {
         let raw_statement = "UPDATE COFFEES SET SALES = $1 WHERE COF_NAME LIKE $2".to_string();
         let prepared_statement = PreparedStatement::parse_statement(
             raw_statement,
-            vec![DataType::INT32.to_oid(), DataType::VARCHAR.to_oid()],
+            vec![DataType::Int32.to_oid(), DataType::Varchar.to_oid()],
         )
         .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
@@ -684,9 +684,9 @@ mod tests {
         let prepared_statement = PreparedStatement::parse_statement(
             raw_statement,
             vec![
-                DataType::INT32.to_oid(),
-                DataType::VARCHAR.to_oid(),
-                DataType::VARCHAR.to_oid(),
+                DataType::Int32.to_oid(),
+                DataType::Varchar.to_oid(),
+                DataType::Varchar.to_oid(),
             ],
         )
         .unwrap();
@@ -733,7 +733,7 @@ mod tests {
         let raw_statement =
             "SELECT * FROM test_table WHERE id = $1 AND name = $2::VARCHAR".to_string();
         let prepared_statement =
-            PreparedStatement::parse_statement(raw_statement, vec![DataType::INT32.to_oid()])
+            PreparedStatement::parse_statement(raw_statement, vec![DataType::Int32.to_oid()])
                 .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
         assert!("SELECT * FROM test_table WHERE id = 0::INT AND name = '0'" == default_sql);
@@ -744,7 +744,7 @@ mod tests {
 
         let raw_statement = "INSERT INTO test (index,data) VALUES ($1,$2)".to_string();
         let prepared_statement =
-            PreparedStatement::parse_statement(raw_statement, vec![DataType::INT32.to_oid()])
+            PreparedStatement::parse_statement(raw_statement, vec![DataType::Int32.to_oid()])
                 .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
         assert!("INSERT INTO test (index,data) VALUES (0::INT,'0')" == default_sql);
@@ -756,7 +756,7 @@ mod tests {
         let raw_statement =
             "UPDATE COFFEES SET SALES = $1 WHERE COF_NAME LIKE $2::VARCHAR".to_string();
         let prepared_statement =
-            PreparedStatement::parse_statement(raw_statement, vec![DataType::INT32.to_oid()])
+            PreparedStatement::parse_statement(raw_statement, vec![DataType::Int32.to_oid()])
                 .unwrap();
         let default_sql = prepared_statement.instance_default().unwrap();
         assert!("UPDATE COFFEES SET SALES = 0::INT WHERE COF_NAME LIKE '0'" == default_sql);
@@ -774,7 +774,7 @@ mod tests {
 
         let raw_statement = "SELECT $1,$1::INT,$2::VARCHAR,$2;".to_string();
         let prepared_statement =
-            PreparedStatement::parse_statement(raw_statement, vec![DataType::INT32.to_oid()])
+            PreparedStatement::parse_statement(raw_statement, vec![DataType::Int32.to_oid()])
                 .unwrap();
         let sql = prepared_statement
             .instance(&["1".into(), "DATA".into()], &[])
@@ -1028,7 +1028,7 @@ mod tests {
             .map(|b| b.freeze())
             .collect::<Vec<_>>();
         raw_params.push("TEST".into());
-        let type_description = vec![DataType::Float32, DataType::Float64, DataType::VARCHAR];
+        let type_description = vec![DataType::Float32, DataType::Float64, DataType::Varchar];
         let params = PreparedStatement::parse_params(
             &type_description,
             &raw_params,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

These const were introduced to mimic `postgres_types::Type` (https://github.com/risingwavelabs/risingwave/pull/6335#discussion_r1041961956). However their `Type` is an opaque wrapper and `Inner` enum is not exposed. These consts were the only way to access them. In our case we use the enum directly.

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
