### PR TITLE
chore: refactor wrapped etcd client with macro

### DIFF
--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -116,19 +116,18 @@ pub async fn rpc_serve(
             if let Some((username, password)) = &credentials {
                 options = options.with_user(username, password)
             }
-            let client = EtcdClient::connect(
-                endpoints.clone(),
-                Some(options.clone()),
-                credentials.is_some(),
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("failed to connect etcd {}", e))?;
+            let auth_enabled = credentials.is_some();
+            let client =
+                EtcdClient::connect(endpoints.clone(), Some(options.clone()), auth_enabled)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to connect etcd {}", e))?;
             let meta_store = Arc::new(EtcdMetaStore::new(client));
 
             let election_client = Arc::new(
                 EtcdElectionClient::new(
                     endpoints,
                     Some(options),
+                    auth_enabled,
                     address_info.advertise_addr.clone(),
                 )
                 .await?,

--- a/src/meta/src/storage/wrapped_etcd_client.rs
+++ b/src/meta/src/storage/wrapped_etcd_client.rs
@@ -28,66 +28,6 @@ pub enum WrappedEtcdClient {
     EnableRefresh(EtcdRefreshClient),
 }
 
-impl WrappedEtcdClient {
-    pub async fn connect(
-        endpoints: Vec<String>,
-        options: Option<ConnectOptions>,
-        auth_enabled: bool,
-    ) -> Result<Self> {
-        let client = etcd_client::Client::connect(&endpoints, options.clone()).await?;
-        if auth_enabled {
-            Ok(Self::EnableRefresh(EtcdRefreshClient {
-                inner: Arc::new(RwLock::new(ClientWithVersion::new(client, 0))),
-                endpoints,
-                options,
-            }))
-        } else {
-            Ok(Self::Raw(client))
-        }
-    }
-
-    pub async fn get(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        opts: Option<GetOptions>,
-    ) -> Result<GetResponse> {
-        match self {
-            Self::Raw(client) => client.kv_client().get(key, opts).await,
-            Self::EnableRefresh(client) => client.get(key, opts).await,
-        }
-    }
-
-    pub async fn put(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        value: impl Into<Vec<u8>> + Clone,
-        opts: Option<PutOptions>,
-    ) -> Result<PutResponse> {
-        match self {
-            Self::Raw(client) => client.kv_client().put(key, value, opts).await,
-            Self::EnableRefresh(client) => client.put(key, value, opts).await,
-        }
-    }
-
-    pub async fn delete(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        opts: Option<DeleteOptions>,
-    ) -> Result<DeleteResponse> {
-        match self {
-            Self::Raw(client) => client.kv_client().delete(key, opts).await,
-            Self::EnableRefresh(client) => client.delete(key, opts).await,
-        }
-    }
-
-    pub async fn txn(&self, txn: Txn) -> Result<TxnResponse> {
-        match self {
-            Self::Raw(client) => client.kv_client().txn(txn).await,
-            Self::EnableRefresh(client) => client.txn(txn).await,
-        }
-    }
-}
-
 struct ClientWithVersion {
     client: etcd_client::Client,
     // to avoid duplicate update.
@@ -148,169 +88,98 @@ impl EtcdRefreshClient {
             _ => false,
         }
     }
+}
 
-    #[inline]
-    pub async fn get(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        options: Option<GetOptions>,
-    ) -> Result<GetResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.kv_client().get(key, options).await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn put(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        value: impl Into<Vec<u8>> + Clone,
-        options: Option<PutOptions>,
-    ) -> Result<PutResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.kv_client().put(key, value, options).await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn delete(
-        &self,
-        key: impl Into<Vec<u8>> + Clone,
-        options: Option<DeleteOptions>,
-    ) -> Result<DeleteResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.kv_client().delete(key, options).await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn txn(&self, txn: Txn) -> Result<TxnResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (inner.client.kv_client().txn(txn).await, inner.version)
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn leader(&self, name: impl Into<Vec<u8>> + Clone) -> Result<LeaderResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.election_client().leader(name).await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn grant(
-        &self,
-        ttl: i64,
-        options: Option<LeaseGrantOptions>,
-    ) -> Result<LeaseGrantResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.lease_client().grant(ttl, options).await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
-
-    #[inline]
-    pub async fn keep_alive(&self, id: i64) -> Result<(LeaseKeeper, LeaseKeepAliveStream)> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.lease_client().keep_alive(id).await,
-                inner.version,
-            )
-        };
-
-        match resp {
-            Err(err) if Self::should_refresh(&err) => {
-                self.try_refresh_conn(version).await?;
-                Err(err)
+macro_rules! impl_etcd_client_command_proxy {
+    ($func:ident, $client:ident, ($($arg:ident : $sig:ty),+), $result:ty) => {
+        impl WrappedEtcdClient {
+            pub async fn $func(
+                &self,
+                $($arg:$sig),+
+            ) -> Result<$result> {
+                match self {
+                    Self::Raw(client) => client.$client().$func($($arg),+).await,
+                    Self::EnableRefresh(client) => client.$func($($arg),+).await,
+                }
             }
-            _ => resp,
+        }
+
+
+        impl EtcdRefreshClient {
+            #[inline]
+            pub async fn $func(
+                &self,
+                $($arg:$sig),+
+            ) -> Result<$result> {
+                let (resp, version) = {
+                    let inner = self.inner.read().await;
+                    (
+                        inner.client.$client().$func($($arg),+).await,
+                        inner.version,
+                    )
+                };
+
+                match resp {
+                    Err(err) if Self::should_refresh(&err) => {
+                        self.try_refresh_conn(version).await?;
+                        Err(err)
+                    }
+                    _ => resp,
+                }
+            }
         }
     }
+}
 
-    #[inline]
-    pub async fn campaign(
-        &self,
+impl_etcd_client_command_proxy!(get, kv_client, (key: impl Into<Vec<u8>> + Clone, opts: Option<GetOptions>), GetResponse);
+impl_etcd_client_command_proxy!(put, kv_client, (key: impl Into<Vec<u8>> + Clone, value: impl Into<Vec<u8>> + Clone, opts: Option<PutOptions>), PutResponse);
+impl_etcd_client_command_proxy!(delete, kv_client, (key: impl Into<Vec<u8>> + Clone, opts: Option<DeleteOptions>), DeleteResponse);
+impl_etcd_client_command_proxy!(txn, kv_client, (txn: Txn), TxnResponse);
+impl_etcd_client_command_proxy!(
+    grant,
+    lease_client,
+    (ttl: i64, options: Option<LeaseGrantOptions>),
+    LeaseGrantResponse
+);
+impl_etcd_client_command_proxy!(
+    keep_alive,
+    lease_client,
+    (id: i64),
+    (LeaseKeeper, LeaseKeepAliveStream)
+);
+impl_etcd_client_command_proxy!(leader, election_client, (name: impl Into<Vec<u8>> + Clone), LeaderResponse);
+impl_etcd_client_command_proxy!(
+    campaign,
+    election_client,
+    (
         name: impl Into<Vec<u8>>,
         value: impl Into<Vec<u8>>,
-        lease: i64,
-    ) -> Result<CampaignResponse> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner
-                    .client
-                    .election_client()
-                    .campaign(name, value, lease)
-                    .await,
-                inner.version,
-            )
-        };
-        if let Err(err) = &resp && Self::should_refresh(err) {
-            self.try_refresh_conn(version).await?;
-        }
-        resp
-    }
+        lease: i64
+    ),
+    CampaignResponse
+);
+impl_etcd_client_command_proxy!(
+    observe,
+    election_client,
+    (name: impl Into<Vec<u8>>),
+    ObserveStream
+);
 
-    #[inline]
-    pub async fn observe(&self, name: impl Into<Vec<u8>>) -> Result<ObserveStream> {
-        let (resp, version) = {
-            let inner = self.inner.read().await;
-            (
-                inner.client.election_client().observe(name).await,
-                inner.version,
-            )
-        };
-        match resp {
-            Err(err) if Self::should_refresh(&err) => {
-                self.try_refresh_conn(version).await?;
-                Err(err)
-            }
-            _ => resp,
+impl WrappedEtcdClient {
+    pub async fn connect(
+        endpoints: Vec<String>,
+        options: Option<ConnectOptions>,
+        auth_enabled: bool,
+    ) -> Result<Self> {
+        let client = etcd_client::Client::connect(&endpoints, options.clone()).await?;
+        if auth_enabled {
+            Ok(Self::EnableRefresh(EtcdRefreshClient {
+                inner: Arc::new(RwLock::new(ClientWithVersion::new(client, 0))),
+                endpoints,
+                options,
+            }))
+        } else {
+            Ok(Self::Raw(client))
         }
     }
 }


### PR DESCRIPTION
Signed-off-by: Shanicky Chen <peng@risingwave-labs.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

This patch refactors the wrapped etcd client with macro. The changes consist of 93 insertions and 222 deletions across 3 files: election_client.rs, server.rs, and wrapped_etcd_client.rs.

The main modification is replacing the usage of `EtcdRefreshClient` with `WrappedEtcdClient` in `election_client.rs`. The `WrappedEtcdClient` is a client struct that can either wrap the `EtcdClient` or the `EtcdRefreshClient`. This allows the client to refresh its connection when it encounters an error.

In server.rs, `WrappedEtcdClient` is created with an additional parameter to indicate whether authentication is enabled. And in `wrapped_etcd_client.rs`, several macros are defined to proxy the methods of the `etcd_client::Client` and `etcd_client::KvClient`.

Overall, this patch aims to improve the functionality of the wrapped etcd client and make it more flexible.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
