### PR TITLE
refactor(frontend): simplify condition by merging lower bound and upper bound 

### DIFF
--- a/e2e_test/batch/basic/range_scan.slt.part
+++ b/e2e_test/batch/basic/range_scan.slt.part
@@ -132,6 +132,15 @@ SELECT * FROM orders_count_by_user_3 WHERE user_id >= 43 AND user_id < 100;
 43 1111 1
 43 2222 1
 
+query III rowsort
+SELECT * FROM orders_count_by_user_3 WHERE user_id > 40 AND user_id < 100 AND user_id in (42,43);
+----
+42 1111 1
+42 2222 2
+42 3333 1
+43 1111 1
+43 2222 1
+
 query III
 SELECT * FROM orders_count_by_user WHERE user_id = 42 AND date = 2222;
 ----
@@ -179,6 +188,10 @@ query III rowsort
 SELECT * FROM orders_count_by_user WHERE user_id = 9999 and date is null;
 ----
 9999 NULL 1
+
+query III rowsort
+SELECT * FROM orders_count_by_user WHERE user_id = 9999 and date is null and date <= 3333;
+----
 
 
 query III rowsort

--- a/src/frontend/planner_test/tests/testdata/range_scan.yaml
+++ b/src/frontend/planner_test/tests/testdata/range_scan.yaml
@@ -233,51 +233,82 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
-- name: Cannot push down for Mutiple upper bound 1.
+- name: merge mutiple upper bound
   before:
   - create_table_and_mv_ordered
   sql: |
-    SELECT * FROM orders_count_by_user_ordered WHERE user_id < 10 and user_id < 30
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count < 10 and orders_count < 30
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id < 10:Int32) AND (orders_count_by_user_ordered.user_id < 30:Int32) }
-      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
-- name: Cannot push down for Mutiple upper bound 2.
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count < Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: merge include and exclude upper bound of same value
   before:
   - create_table_and_mv_ordered
   sql: |
-    SELECT * FROM orders_count_by_user_ordered WHERE user_id < 10 and user_id <= 10
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count < 10 and orders_count <= 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id < 10:Int32) AND (orders_count_by_user_ordered.user_id <= 10:Int32) }
-      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
-- name: Cannot push down for Mutiple lower bound 1.
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count < Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: merge mutiple lower bound
   before:
   - create_table_and_mv_ordered
   sql: |
-    SELECT * FROM orders_count_by_user_ordered WHERE user_id > 10 and user_id > 30
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count > 10 and orders_count > 30
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id > 10:Int32) AND (orders_count_by_user_ordered.user_id > 30:Int32) }
-      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
-- name: Cannot push down for Mutiple lower bound 2.
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count > Int64(30)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: merge include and exclude lower bound of same value
   before:
   - create_table_and_mv_ordered
   sql: |
-    SELECT * FROM orders_count_by_user_ordered WHERE user_id > 10 and user_id >= 10
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count > 10 and orders_count >= 10
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id > 10:Int32) AND (orders_count_by_user_ordered.user_id >= 10:Int32) }
-      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
-- name: Cannot push down for Mix cmp and eq.
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count > Int64(10)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: invalid range
   before:
   - create_table_and_mv_ordered
   sql: |
-    SELECT * FROM orders_count_by_user_ordered WHERE user_id = 10 and user_id <30
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count > 10 and orders_count < 5
+  batch_plan: |
+    BatchValues { rows: [] }
+- name: merge cmp and eq condition
+  before:
+  - create_table_and_mv_ordered
+  sql: |
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count > 20 and orders_count < 30 and orders_count = 25
   batch_plan: |
     BatchExchange { order: [], dist: Single }
-    └─BatchFilter { predicate: (orders_count_by_user_ordered.user_id = 10:Int32) AND (orders_count_by_user_ordered.user_id < 30:Int32) }
-      └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(25)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: invalid range of merging cmp and eq condition
+  before:
+  - create_table_and_mv_ordered
+  sql: |
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count > 20 and orders_count < 30 and orders_count = 35
+  batch_plan: |
+    BatchValues { rows: [] }
+- name: merge cmp and const-in condition
+  before:
+  - create_table_and_mv_ordered
+  sql: |
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count in (10,20,30,40) and orders_count <30
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchScan { table: orders_count_by_user_ordered, columns: [orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date, orders_count_by_user_ordered.orders_count], scan_ranges: [orders_count_by_user_ordered.orders_count = Int64(10) , orders_count_by_user_ordered.orders_count = Int64(20)], distribution: UpstreamHashShard(orders_count_by_user_ordered.user_id, orders_count_by_user_ordered.date) }
+- name: invalid range of merging cmp and const-in condition
+  before:
+  - create_table_and_mv_ordered
+  sql: |
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count in (10,20,30,40) and orders_count > 50
+  batch_plan: |
+    BatchValues { rows: [] }
+- name: merge null and cmp condition
+  before:
+  - create_table_and_mv_ordered
+  sql: |
+    SELECT * FROM orders_count_by_user_ordered WHERE orders_count is null and orders_count < 30
+  batch_plan: |
+    BatchValues { rows: [] }
 - id: create_small
   sql: |
     CREATE TABLE t(x smallint);

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -382,36 +382,12 @@ impl Condition {
             }
         }
 
-        let order_column_ids = &table_desc.order_column_indices();
-        let num_cols = table_desc.columns.len();
+        let mut groups = Self::classify_conjunctions_by_pk(self.conjunctions, &table_desc);
 
-        let mut col_idx_to_pk_idx = vec![None; num_cols];
-        order_column_ids
-            .iter()
-            .enumerate()
-            .for_each(|(idx, pk_idx)| {
-                col_idx_to_pk_idx[*pk_idx] = Some(idx);
-            });
-
-        // The i-th group only has exprs that reference the i-th PK column.
-        // The last group contains all the other exprs.
-        let mut groups = vec![vec![]; order_column_ids.len() + 1];
-        for (key, group) in &self.conjunctions.into_iter().group_by(|expr| {
-            let input_bits = expr.collect_input_refs(num_cols);
-            if input_bits.count_ones(..) == 1 {
-                let col_idx = input_bits.ones().next().unwrap();
-                col_idx_to_pk_idx[col_idx].unwrap_or(order_column_ids.len())
-            } else {
-                order_column_ids.len()
-            }
-        }) {
-            groups[key].extend(group);
-        }
-
+        // Analyze each group and use result to update scan range.
         let mut scan_range = ScanRange::full_table_scan();
         let mut other_conds = groups.pop().unwrap();
-
-        for i in 0..order_column_ids.len() {
+        for i in 0..table_desc.order_column_indices().len() {
             let group = std::mem::take(&mut groups[i]);
             if group.is_empty() {
                 groups.push(other_conds);
@@ -426,140 +402,13 @@ impl Condition {
                     },
                 ));
             }
-            let mut lower_bound_conjunctions = vec![];
-            let mut upper_bound_conjunctions = vec![];
-            // values in eq_cond are OR'ed
-            let mut eq_conds = vec![];
 
-            // analyze exprs in the group. scan_range is not updated
-            for expr in group.clone() {
-                if let Some((input_ref, const_expr)) = expr.as_eq_const() {
-                    assert_eq!(input_ref.index, order_column_ids[i]);
-                    let new_expr = if let Ok(expr) = const_expr
-                        .clone()
-                        .cast_implicit(input_ref.data_type.clone())
-                    {
-                        expr
-                    } else {
-                        match self::cast_compare::cast_compare_for_eq(
-                            const_expr,
-                            input_ref.data_type,
-                        ) {
-                            Ok(ResultForEq::Success(expr)) => expr,
-                            Ok(ResultForEq::NeverEqual) => {
-                                return Ok(false_cond());
-                            }
-                            Err(_) => {
-                                other_conds.push(expr);
-                                continue;
-                            }
-                        }
-                    };
-
-                    let Some(new_cond) = new_expr.fold_const()? else {
-                        // column = NULL, the result is always NULL.
-                        return Ok(false_cond());
-                    };
-                    if Self::mutual_exclusive_with_eq_conds(&new_cond, &eq_conds) {
-                        return Ok(false_cond());
-                    }
-                    eq_conds = vec![Some(new_cond)];
-                } else if let Some(input_ref) = expr.as_is_null() {
-                    assert_eq!(input_ref.index, order_column_ids[i]);
-                    if !eq_conds.is_empty() && eq_conds.into_iter().all(|l| l.is_some()) {
-                        return Ok(false_cond());
-                    }
-                    eq_conds = vec![None];
-                } else if let Some((input_ref, in_const_list)) = expr.as_in_const_list() {
-                    assert_eq!(input_ref.index, order_column_ids[i]);
-                    let mut scalars = HashSet::new();
-                    for const_expr in in_const_list {
-                        // The cast should succeed, because otherwise the input_ref is casted
-                        // and thus `as_in_const_list` returns None.
-                        let const_expr = const_expr
-                            .cast_implicit(input_ref.data_type.clone())
-                            .unwrap();
-                        let value = const_expr.fold_const()?;
-                        let Some(value) = value else {
-                            continue;
-                        };
-                        scalars.insert(Some(value));
-                    }
-                    if scalars.is_empty() {
-                        // There're only NULLs in the in-list
-                        return Ok(false_cond());
-                    }
-                    if !eq_conds.is_empty() {
-                        scalars = scalars
-                            .intersection(&HashSet::from_iter(eq_conds))
-                            .cloned()
-                            .collect();
-                        if scalars.is_empty() {
-                            return Ok(false_cond());
-                        }
-                    }
-                    // Sort to ensure a deterministic result for planner test.
-                    eq_conds = scalars.into_iter().sorted().collect();
-                } else if let Some((input_ref, op, const_expr)) = expr.as_comparison_const() {
-                    assert_eq!(input_ref.index, order_column_ids[i]);
-                    let new_expr = if let Ok(expr) = const_expr
-                        .clone()
-                        .cast_implicit(input_ref.data_type.clone())
-                    {
-                        expr
-                    } else {
-                        match self::cast_compare::cast_compare_for_cmp(
-                            const_expr,
-                            input_ref.data_type,
-                            op,
-                        ) {
-                            Ok(ResultForCmp::Success(expr)) => expr,
-                            Ok(ResultForCmp::OutUpperBound) => {
-                                if op == ExprType::GreaterThan || op == ExprType::GreaterThanOrEqual
-                                {
-                                    return Ok(false_cond());
-                                }
-                                // op == < and <= means result is always true, don't need any extra
-                                // work.
-                                continue;
-                            }
-                            Ok(ResultForCmp::OutLowerBound) => {
-                                if op == ExprType::LessThan || op == ExprType::LessThanOrEqual {
-                                    return Ok(false_cond());
-                                }
-                                // op == > and >= means result is always true, don't need any extra
-                                // work.
-                                continue;
-                            }
-                            Err(_) => {
-                                other_conds.push(expr);
-                                continue;
-                            }
-                        }
-                    };
-                    let Some(value) = new_expr.fold_const()? else {
-                        // column compare with NULL, the result is always  NULL.
-                        return Ok(false_cond());
-                    };
-                    match op {
-                        ExprType::LessThan => {
-                            upper_bound_conjunctions.push(Bound::Excluded(value));
-                        }
-                        ExprType::LessThanOrEqual => {
-                            upper_bound_conjunctions.push(Bound::Included(value));
-                        }
-                        ExprType::GreaterThan => {
-                            lower_bound_conjunctions.push(Bound::Excluded(value));
-                        }
-                        ExprType::GreaterThanOrEqual => {
-                            lower_bound_conjunctions.push(Bound::Included(value));
-                        }
-                        _ => unreachable!(),
-                    }
-                } else {
-                    other_conds.push(expr);
-                }
-            }
+            let Some((lower_bound_conjunctions,upper_bound_conjunctions,eq_conds,part_of_other_conds)) = Self::analyze_group(
+                group,
+            )? else {
+                return Ok(false_cond());
+            };
+            other_conds.extend(part_of_other_conds.into_iter());
 
             let lower_bound = Self::merge_lower_bound_conjunctions(lower_bound_conjunctions);
             let upper_bound = Self::merge_upper_bound_conjunctions(upper_bound_conjunctions);
@@ -617,7 +466,10 @@ impl Condition {
         Ok((
             if scan_range.is_full_table_scan() {
                 vec![]
-            } else if table_desc.columns[order_column_ids[0]].data_type.is_int() {
+            } else if table_desc.columns[table_desc.order_column_indices()[0]]
+                .data_type
+                .is_int()
+            {
                 match scan_range.split_small_range(max_split_range_gap) {
                     Some(scan_ranges) => scan_ranges,
                     None => vec![scan_range],
@@ -629,6 +481,191 @@ impl Condition {
                 conjunctions: other_conds,
             },
         ))
+    }
+
+    /// classify conjunctions into groups:
+    /// The i-th group has exprs that only reference the i-th PK column.
+    /// The last group contains all the other exprs.
+    fn classify_conjunctions_by_pk(
+        conjunctions: Vec<ExprImpl>,
+        table_desc: &Rc<TableDesc>,
+    ) -> Vec<Vec<ExprImpl>> {
+        let pk_column_ids = &table_desc.order_column_indices();
+        let pk_cols_num = pk_column_ids.len();
+        let cols_num = table_desc.columns.len();
+
+        let mut col_idx_to_pk_idx = vec![None; cols_num];
+        pk_column_ids.iter().enumerate().for_each(|(idx, pk_idx)| {
+            col_idx_to_pk_idx[*pk_idx] = Some(idx);
+        });
+
+        let mut groups = vec![vec![]; pk_cols_num + 1];
+        for (key, group) in &conjunctions.into_iter().group_by(|expr| {
+            let input_bits = expr.collect_input_refs(cols_num);
+            if input_bits.count_ones(..) == 1 {
+                let col_idx = input_bits.ones().next().unwrap();
+                col_idx_to_pk_idx[col_idx].unwrap_or(pk_cols_num)
+            } else {
+                pk_cols_num
+            }
+        }) {
+            groups[key].extend(group);
+        }
+
+        groups
+    }
+
+    /// Extract the following information in a group of conjunctions:
+    /// 1. lower bound conjunctions
+    /// 2. upper bound conjunctions
+    /// 3. eq conditions
+    /// 4. other conditions
+    ///
+    /// return None indicates that this conjunctions is always false
+    #[allow(clippy::type_complexity)]
+    fn analyze_group(
+        group: Vec<ExprImpl>,
+    ) -> Result<
+        Option<(
+            Vec<Bound<ScalarImpl>>,
+            Vec<Bound<ScalarImpl>>,
+            Vec<Option<ScalarImpl>>,
+            Vec<ExprImpl>,
+        )>,
+    > {
+        let mut lower_bound_conjunctions = vec![];
+        let mut upper_bound_conjunctions = vec![];
+        // values in eq_cond are OR'ed
+        let mut eq_conds = vec![];
+        let mut other_conds = vec![];
+
+        // analyze exprs in the group. scan_range is not updated
+        for expr in group {
+            if let Some((input_ref, const_expr)) = expr.as_eq_const() {
+                let new_expr = if let Ok(expr) = const_expr
+                    .clone()
+                    .cast_implicit(input_ref.data_type.clone())
+                {
+                    expr
+                } else {
+                    match self::cast_compare::cast_compare_for_eq(const_expr, input_ref.data_type) {
+                        Ok(ResultForEq::Success(expr)) => expr,
+                        Ok(ResultForEq::NeverEqual) => {
+                            return Ok(None);
+                        }
+                        Err(_) => {
+                            other_conds.push(expr);
+                            continue;
+                        }
+                    }
+                };
+
+                let Some(new_cond) = new_expr.fold_const()? else {
+                        // column = NULL, the result is always NULL.
+                        return Ok(None);
+                    };
+                if Self::mutual_exclusive_with_eq_conds(&new_cond, &eq_conds) {
+                    return Ok(None);
+                }
+                eq_conds = vec![Some(new_cond)];
+            } else if expr.as_is_null().is_some() {
+                if !eq_conds.is_empty() && eq_conds.into_iter().all(|l| l.is_some()) {
+                    return Ok(None);
+                }
+                eq_conds = vec![None];
+            } else if let Some((input_ref, in_const_list)) = expr.as_in_const_list() {
+                let mut scalars = HashSet::new();
+                for const_expr in in_const_list {
+                    // The cast should succeed, because otherwise the input_ref is casted
+                    // and thus `as_in_const_list` returns None.
+                    let const_expr = const_expr
+                        .cast_implicit(input_ref.data_type.clone())
+                        .unwrap();
+                    let value = const_expr.fold_const()?;
+                    let Some(value) = value else {
+                            continue;
+                        };
+                    scalars.insert(Some(value));
+                }
+                if scalars.is_empty() {
+                    // There're only NULLs in the in-list
+                    return Ok(None);
+                }
+                if !eq_conds.is_empty() {
+                    scalars = scalars
+                        .intersection(&HashSet::from_iter(eq_conds))
+                        .cloned()
+                        .collect();
+                    if scalars.is_empty() {
+                        return Ok(None);
+                    }
+                }
+                // Sort to ensure a deterministic result for planner test.
+                eq_conds = scalars.into_iter().sorted().collect();
+            } else if let Some((input_ref, op, const_expr)) = expr.as_comparison_const() {
+                let new_expr = if let Ok(expr) = const_expr
+                    .clone()
+                    .cast_implicit(input_ref.data_type.clone())
+                {
+                    expr
+                } else {
+                    match self::cast_compare::cast_compare_for_cmp(
+                        const_expr,
+                        input_ref.data_type,
+                        op,
+                    ) {
+                        Ok(ResultForCmp::Success(expr)) => expr,
+                        Ok(ResultForCmp::OutUpperBound) => {
+                            if op == ExprType::GreaterThan || op == ExprType::GreaterThanOrEqual {
+                                return Ok(None);
+                            }
+                            // op == < and <= means result is always true, don't need any extra
+                            // work.
+                            continue;
+                        }
+                        Ok(ResultForCmp::OutLowerBound) => {
+                            if op == ExprType::LessThan || op == ExprType::LessThanOrEqual {
+                                return Ok(None);
+                            }
+                            // op == > and >= means result is always true, don't need any extra
+                            // work.
+                            continue;
+                        }
+                        Err(_) => {
+                            other_conds.push(expr);
+                            continue;
+                        }
+                    }
+                };
+                let Some(value) = new_expr.fold_const()? else {
+                        // column compare with NULL, the result is always  NULL.
+                        return Ok(None);
+                    };
+                match op {
+                    ExprType::LessThan => {
+                        upper_bound_conjunctions.push(Bound::Excluded(value));
+                    }
+                    ExprType::LessThanOrEqual => {
+                        upper_bound_conjunctions.push(Bound::Included(value));
+                    }
+                    ExprType::GreaterThan => {
+                        lower_bound_conjunctions.push(Bound::Excluded(value));
+                    }
+                    ExprType::GreaterThanOrEqual => {
+                        lower_bound_conjunctions.push(Bound::Included(value));
+                    }
+                    _ => unreachable!(),
+                }
+            } else {
+                other_conds.push(expr);
+            }
+        }
+        Ok(Some((
+            lower_bound_conjunctions,
+            upper_bound_conjunctions,
+            eq_conds,
+            other_conds,
+        )))
     }
 
     fn mutual_exclusive_with_eq_conds(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

1. complete the `TODO: simplify bounds:` in condition:
    - merge lower bound and upper bound 
    - filter eq conds using lower bound and upper bound
2. try to refine the split_to_scan_ranges by seperate out subprocess from it. ( Not sure whether it's a positive refine. I try make it look more tiny because I think its original len is so long to impact the readbility.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
