### PR TITLE
fix: turn panic into warning when there's no enough memory for computing tasks

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -110,8 +110,8 @@ pub async fn compute_node_serve(
         embedded_compactor_enabled(&state_store_url, config.storage.disable_remote_compactor);
     let storage_memory_bytes =
         total_storage_memory_limit_bytes(&config.storage, embedded_compactor_enabled);
-
-    validate_compute_node_memory_config(opts.total_memory_bytes, storage_memory_bytes);
+    let compute_memory_bytes =
+        validate_compute_node_memory_config(opts.total_memory_bytes, storage_memory_bytes);
 
     let worker_id = meta_client.worker_id();
     info!("Assigned worker node id {}", worker_id);
@@ -232,18 +232,16 @@ pub async fn compute_node_serve(
     // Spawn LRU Manager that have access to collect memory from batch mgr and stream mgr.
     let batch_mgr_clone = batch_mgr.clone();
     let stream_mgr_clone = stream_mgr.clone();
-    let compute_memory_bytes =
-        opts.total_memory_bytes - storage_memory_bytes - (SYSTEM_RESERVED_MEMORY_MB << 20);
-    let mgr = GlobalMemoryManager::new(
+    let memory_mgr = GlobalMemoryManager::new(
         compute_memory_bytes,
         system_params.barrier_interval_ms(),
         streaming_metrics.clone(),
         Box::new(StreamingOnlyPolicy {}),
     );
     // Run a background memory monitor
-    tokio::spawn(mgr.clone().run(batch_mgr_clone, stream_mgr_clone));
+    tokio::spawn(memory_mgr.clone().run(batch_mgr_clone, stream_mgr_clone));
 
-    let watermark_epoch = mgr.get_watermark_epoch();
+    let watermark_epoch = memory_mgr.get_watermark_epoch();
     // Set back watermark epoch to stream mgr. Executor will read epoch from stream manager instead
     // of lru manager.
     stream_mgr.set_watermark_epoch(watermark_epoch).await;
@@ -347,23 +345,31 @@ pub async fn compute_node_serve(
 }
 
 /// Check whether the compute node has enough memory to perform computing tasks. Apart from storage,
-/// it must reserve at least `MIN_COMPUTE_MEMORY_MB` for computing and `SYSTEM_RESERVED_MEMORY_MB`
-/// for other system usage. Otherwise, it is not allowed to start.
-fn validate_compute_node_memory_config(cn_total_memory_bytes: usize, storage_memory_bytes: usize) {
+/// it is recommended to reserve at least `MIN_COMPUTE_MEMORY_MB` for computing and
+/// `SYSTEM_RESERVED_MEMORY_MB` for other system usage. If the requirement is not met, we will print
+/// out a warning and enforce the memory used for computing tasks as `MIN_COMPUTE_MEMORY_MB`.
+fn validate_compute_node_memory_config(
+    cn_total_memory_bytes: usize,
+    storage_memory_bytes: usize,
+) -> usize {
     if storage_memory_bytes > cn_total_memory_bytes {
-        panic!(
-            "The storage memory exceeds the total compute node memory:\nTotal compute node memory: {}\nStorage memory: {}\nAt least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations and restart the compute node.",
+        tracing::warn!(
+            "The storage memory exceeds the total compute node memory:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations.",
             convert(cn_total_memory_bytes as _),
             convert(storage_memory_bytes as _)
         );
+        MIN_COMPUTE_MEMORY_MB << 20
     } else if storage_memory_bytes + ((MIN_COMPUTE_MEMORY_MB + SYSTEM_RESERVED_MEMORY_MB) << 20)
         >= cn_total_memory_bytes
     {
-        panic!(
-            "No enough memory for computing and other system usage:\nTotal compute node memory: {}\nStorage memory: {}\nAt least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations and restart the compute node.",
+        tracing::warn!(
+            "No enough memory for computing and other system usage:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations.",
             convert(cn_total_memory_bytes as _),
             convert(storage_memory_bytes as _)
         );
+        MIN_COMPUTE_MEMORY_MB << 20
+    } else {
+        cn_total_memory_bytes - storage_memory_bytes - (SYSTEM_RESERVED_MEMORY_MB << 20)
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -354,7 +354,7 @@ fn validate_compute_node_memory_config(
 ) -> usize {
     if storage_memory_bytes > cn_total_memory_bytes {
         tracing::warn!(
-            "The storage memory exceeds the total compute node memory:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations.",
+            "The storage memory exceeds the total compute node memory:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 4 GiB memory should be reserved for RisingWave. Please increase the total compute node memory or decrease the storage memory in configurations.",
             convert(cn_total_memory_bytes as _),
             convert(storage_memory_bytes as _)
         );

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -363,7 +363,7 @@ fn validate_compute_node_memory_config(
         >= cn_total_memory_bytes
     {
         tracing::warn!(
-            "No enough memory for computing and other system usage:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 1 GiB memory should be reserved apart from the storage memory. Please increase the total compute node memory or decrease the storage memory in configurations.",
+            "No enough memory for computing and other system usage:\nTotal compute node memory: {}\nStorage memory: {}\nWe recommend that at least 4 GiB memory should be reserved for RisingWave. Please increase the total compute node memory or decrease the storage memory in configurations.",
             convert(cn_total_memory_bytes as _),
             convert(storage_memory_bytes as _)
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

As title. When there's no enough memory for computing tasks, we use 512MB as the default total value for computing memory control.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

User will get a warning in the log instead of panicking when there's no enough memory for computing tasks.

</details>
