### PR TITLE
fix: reduce debuginfo size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ aws-types = { version = "0.51", features = ["hardcoded-credentials"] }
 lto = 'off'
 
 [profile.release]
-debug = true
+debug = 1 # line tables only
 lto = 'thin'
 
 [profile.bench]
@@ -85,7 +85,7 @@ rpath = false
 # better catch bugs in CI.
 [profile.ci-release]
 inherits = "release"
-debug = true
+debug = 1 # line tables only
 debug-assertions = true
 overflow-checks = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,6 @@ rpath = false
 # better catch bugs in CI.
 [profile.ci-release]
 inherits = "release"
-debug = 1 # line tables only
 debug-assertions = true
 overflow-checks = true
 

--- a/ci/scripts/build.sh
+++ b/ci/scripts/build.sh
@@ -48,9 +48,6 @@ cargo build \
 # the file name suffix of artifact for risingwave_java_binding is so only for linux. It is dylib for MacOS
 artifacts=(risingwave sqlsmith compaction-test backup-restore risingwave_regress_test risedev-dev delete-range-test librisingwave_java_binding.so)
 
-echo "--- Compress debug info for artifacts"
-echo -n "${artifacts[*]}" | parallel -d ' ' "objcopy --compress-debug-sections=zlib-gnu target/$target/{} && echo \"compressed {}\""
-
 echo "--- Show link info"
 ldd target/"$target"/risingwave
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,11 +36,8 @@ RUN cargo fetch
 RUN mkdir -p /risingwave/bin/connector-node
 
 RUN cargo build -p risingwave_cmd -p risingwave_cmd_all --release --features "static-link static-log-level" && \
-  mv /risingwave/target/release/{frontend,compute-node,meta-node,compactor,risingwave} /risingwave/bin/ && \
+  mv /risingwave/target/release/risingwave /risingwave/bin/ && \
   cargo clean
-RUN for component in "risingwave" "compute-node" "meta-node" "frontend" "compactor"; do \
-  objcopy --compress-debug-sections=zlib-gnu /risingwave/bin/${component}; \
-  done
 
 RUN cd risingwave-connector-node && mvn -B package -Dmaven.test.skip=true
 RUN tar -zxvf /risingwave/risingwave-connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN rustup self update \
 RUN cargo fetch
 RUN mkdir -p /risingwave/bin/connector-node
 
-RUN cargo build -p risingwave_cmd -p risingwave_cmd_all --release --features "static-link static-log-level" && \
+RUN cargo build -p risingwave_cmd_all --release --features "static-link static-log-level" && \
   mv /risingwave/target/release/risingwave /risingwave/bin/ && \
   cargo clean
 

--- a/docker/aws/aws-build.sh
+++ b/docker/aws/aws-build.sh
@@ -11,7 +11,7 @@ fi
 
 cd "$DIR/../.."
 cargo build -p risingwave_cmd_all --release --features "static-link static-log-level"
-objcopy --compress-debug-sections=zlib-gnu target/release/risingwave "$DIR/risingwave"
+cp target/release/risingwave "$DIR/risingwave"
 
 cd "$DIR"
 docker build -t "${RW_REGISTRY}:latest" .


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR did 2 things:

1. Reduce the size of debuginfo in binary by setting `debug = 1`. Inspired by https://users.rust-lang.org/t/why-are-debug-symbols-so-huge/81117/2.

<details>
<summary>The stacktrace under `debug = 1` looks like...</summary>

```
Custom backtrace:
   0: risingwave_frontend::handler::explain::handle_explain::{{closure}}
             at ./src/frontend/src/handler/explain.rs:46:42
   1: risingwave_frontend::handler::handle::{{closure}}
             at ./src/frontend/src/handler/mod.rs:164:81
   2: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/future/future.rs:125:9
   3: <risingwave_frontend::session::SessionImpl as pgwire::pg_server::Session<risingwave_frontend::handler::PgResponseStream>>::run_one_query::{{closure}}
             at ./src/frontend/src/session.rs:759:27
   4: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/future/future.rs:125:9
   5: pgwire::pg_protocol::PgProtocol<S,SM,VS>::process_query_msg::{{closure}}
             at ./src/utils/pgwire/src/pg_protocol.rs:340:17
   6: pgwire::pg_protocol::PgProtocol<S,SM,VS>::do_process_inner::{{closure}}
             at ./src/utils/pgwire/src/pg_protocol.rs:218:87
   7: pgwire::pg_protocol::PgProtocol<S,SM,VS>::do_process::{{closure}}
             at ./src/utils/pgwire/src/pg_protocol.rs:160:41
   8: pgwire::pg_protocol::PgProtocol<S,SM,VS>::process::{{closure}}
             at ./src/utils/pgwire/src/pg_protocol.rs:156:29
   9: pgwire::pg_server::handle_connection::{{closure}}::{{closure}}
             at ./src/utils/pgwire/src/pg_server.rs:156:44
  10: pgwire::pg_server::handle_connection::{{closure}}
             at ./src/utils/pgwire/src/pg_server.rs:140:1
  11: pgwire::pg_server::pg_serve::{{closure}}::{{closure}}
             at ./src/utils/pgwire/src/pg_server.rs:127:40
  12: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/src/instrument.rs:272:9
  13: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:223:17
  14: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/loom/std/unsafe_cell.rs:14:9
  15: tokio::runtime::task::core::Core<T,S>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:212:13
  16: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:476:19
  17: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/panic/unwind_safe.rs:271:9
  18: std::panicking::try::do_call
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:487:40
  19: std::panicking::try
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:451:19
  20: std::panic::catch_unwind
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panic.rs:140:14
  21: tokio::runtime::task::harness::poll_future
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:464:18
  22: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:198:27
  23: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:152:15
  24: tokio::runtime::task::raw::RawTask::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/raw.rs:200:18
  25: tokio::runtime::task::LocalNotified<S>::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/mod.rs:394:9
  26: tokio::runtime::scheduler::multi_thread::worker::Context::run_task::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:464:13
  27: tokio::runtime::coop::with_budget
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/coop.rs:102:5
  28: tokio::runtime::coop::budget
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/coop.rs:68:5
  29: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:463:9
  30: tokio::runtime::scheduler::multi_thread::worker::Context::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:426:24
  31: tokio::runtime::scheduler::multi_thread::worker::run::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:406:17
  32: tokio::macros::scoped_tls::ScopedKey<T>::set
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/macros/scoped_tls.rs:61:9
  33: tokio::runtime::scheduler::multi_thread::worker::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:403:5
  34: tokio::runtime::scheduler::multi_thread::worker::Launch::launch::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/scheduler/multi_thread/worker.rs:365:45
  35: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/blocking/task.rs:42:21
  36: <tracing::instrument::Instrumented<T> as core::future::future::Future>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tracing-0.1.37/src/instrument.rs:272:9
  37: tokio::runtime::task::core::Core<T,S>::poll::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:223:17
  38: tokio::loom::std::unsafe_cell::UnsafeCell<T>::with_mut
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/loom/std/unsafe_cell.rs:14:9
  39: tokio::runtime::task::core::Core<T,S>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/core.rs:212:13
  40: tokio::runtime::task::harness::poll_future::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:476:19
  41: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/panic/unwind_safe.rs:271:9
  42: std::panicking::try::do_call
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:487:40
  43: std::panicking::try
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:451:19
  44: std::panic::catch_unwind
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panic.rs:140:14
  45: tokio::runtime::task::harness::poll_future
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:464:18
  46: tokio::runtime::task::harness::Harness<T,S>::poll_inner
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:198:27
  47: tokio::runtime::task::harness::Harness<T,S>::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/harness.rs:152:15
  48: tokio::runtime::task::raw::RawTask::poll
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/raw.rs:200:18
  49: tokio::runtime::task::UnownedTask<S>::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/task/mod.rs:431:9
  50: tokio::runtime::blocking::pool::Task::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/blocking/pool.rs:159:9
  51: tokio::runtime::blocking::pool::Inner::run
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/blocking/pool.rs:511:17
  52: tokio::runtime::blocking::pool::Spawner::spawn_thread::{{closure}}
             at /home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.25.0/src/runtime/blocking/pool.rs:469:13
  53: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/sys_common/backtrace.rs:121:18
  54: std::thread::Builder::spawn_unchecked_::{{closure}}::{{closure}}
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/thread/mod.rs:560:17
  55: <core::panic::unwind_safe::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/panic/unwind_safe.rs:271:9
  56: std::panicking::try::do_call
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:487:40
  57: std::panicking::try
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panicking.rs:451:19
  58: std::panic::catch_unwind
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/panic.rs:140:14
  59: std::thread::Builder::spawn_unchecked_::{{closure}}
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/thread/mod.rs:559:30
  60: core::ops::function::FnOnce::call_once{{vtable.shim}}
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/core/src/ops/function.rs:250:5
  61: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/alloc/src/boxed.rs:1988:9
  62: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/alloc/src/boxed.rs:1988:9
  63: std::sys::unix::thread::Thread::new::thread_start
             at /rustc/31f858d9a511f24fedb8ed997b28304fec809630/library/std/src/sys/unix/thread.rs:108:17
  64: <unknown>
  65: <unknown>

```
</details>

2. Disabled debuginfo compression because it exacerbates the problem, as pointed out by https://github.com/risingwavelabs/risingwave/issues/8270#issuecomment-1452914135 
  - After the PR the binary size is 1.2 GB. Before it, the compression version is 643 MB and uncompressed version is 2.7G GB.

Overall, after the PR the memory usage of cached debuginfo is ~360 MB.

```
 ubuntu@ip-172-31-18-73  ~  ps -o pid,user,vsz,rss $(pidof frontend-node)
    PID USER        VSZ   RSS
 225703 ubuntu   2475160 40544

  (... trigger a backtrace manually ...)

 ubuntu@ip-172-31-18-73  ~  ps -o pid,user,vsz,rss $(pidof frontend-node)
    PID USER        VSZ   RSS
 225703 ubuntu   3815148 404244
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
