### PR TITLE
feat(risedev): risedev support for connector node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,12 +18,6 @@
 cmake-build-debug/
 /cmake-build-wsl_profile/
 
-# Java
-connector_node/target/
-connector_node/risingwave-sink-jdbc/test_db/
-connector_node/risingwave-sink-jdbc/*.log
-connector_node/risingwave-connector-service/*.log
-
 # build
 *.exe
 *.app

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@
 cmake-build-debug/
 /cmake-build-wsl_profile/
 
+# Java
+connector_node/target/
+connector_node/risingwave-sink-jdbc/test_db/
+connector_node/risingwave-sink-jdbc/*.log
+connector_node/risingwave-connector-service/*.log
+
 # build
 *.exe
 *.app

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -369,6 +369,8 @@ category = "RiseDev - Components"
 description = "Download all available components at once"
 dependencies = [
   "download-connector",
+  "download-maven",
+  "build-connector-node",
   "download-etcd",
   "download-grafana",
   "download-jaeger",
@@ -580,6 +582,29 @@ set -e
 cargo nextest run "$@"
 """
 description = "Run unit tests"
+
+[tasks.build-connector-node]
+category = "RiseDev - Components"
+dependencies = ["prepare"]
+condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR"] }
+description = "Build RisingWave Connector from source"
+script = '''
+#!/usr/bin/env bash
+set -e
+
+if command -v mvn &> /dev/null; then
+  MAVEN_PATH="$(command -v mvn)"
+else
+  MAVEN_PATH="${PREFIX_BIN}/maven/bin/mvn"
+fi
+
+artifact="risingwave-connector-1.0.0.tar.gz"
+
+cd "${CONNECTOR_NODE_DIR}"
+"${MAVEN_PATH}" --batch-mode --update-snapshots clean package -Dmaven.test.skip
+tar xf "assembly/target/${artifact}" -C "${PREFIX_BIN}/connector-node"
+'''
+
 
 [tasks.sbuild]
 category = "RiseDev - Build in simulation mode"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -598,11 +598,11 @@ else
   MAVEN_PATH="${PREFIX_BIN}/maven/bin/mvn"
 fi
 
-artifact="risingwave-connector-1.0.0.tar.gz"
+ARTIFACT="risingwave-connector-1.0.0.tar.gz"
 
 cd "${CONNECTOR_NODE_DIR}"
 "${MAVEN_PATH}" --batch-mode --update-snapshots clean package -Dmaven.test.skip
-tar xf "assembly/target/${artifact}" -C "${PREFIX_BIN}/connector-node"
+tar xf "assembly/target/${ARTIFACT}" -C "${PREFIX_BIN}/connector-node"
 '''
 
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -731,6 +731,44 @@ set -e
 cargo llvm-cov run -p risingwave_simulation --html "$@"
 """
 
+[tasks.check-connector-node]
+category = "RiseDev - Check"
+description = "Run mvn spotless:check in connector-node"
+dependencies = ["warn-on-missing-tools"]
+condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR"] }
+script = """
+#!/usr/bin/env bash
+set -e
+
+if command -v mvn &> /dev/null; then
+  MAVEN_PATH="$(command -v mvn)"
+else
+  MAVEN_PATH="${PREFIX_BIN}/maven/bin/mvn"
+fi
+
+cd "${CONNECTOR_NODE_DIR}"
+"${MAVEN_PATH}" spotless:check
+"""
+
+[tasks.check-connector-node-fix]
+category = "RiseDev - Check"
+description = "Run mvn spotless:apply in connector-node"
+dependencies = ["warn-on-missing-tools"]
+condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR"] }
+script = """
+#!/usr/bin/env bash
+set -e
+
+if command -v mvn &> /dev/null; then
+  MAVEN_PATH="$(command -v mvn)"
+else
+  MAVEN_PATH="${PREFIX_BIN}/maven/bin/mvn"
+fi
+
+cd "${CONNECTOR_NODE_DIR}"
+"${MAVEN_PATH}" spotless:apply
+"""
+
 [tasks.check-hakari]
 category = "RiseDev - Check"
 description = "Run cargo hakari check and attempt to fix"
@@ -839,6 +877,7 @@ dependencies = [
   "check-fmt",
   "check-clippy",
   "check-typos",
+  "check-connector-node",
 ]
 script = """
 #!/usr/bin/env bash
@@ -860,6 +899,7 @@ dependencies = [
   "check-fmt",
   "check-clippy-fix",
   "check-typos",
+  "check-connector-node-fix",
 ]
 script = """
 #!/usr/bin/env bash

--- a/connector_node/.gitignore
+++ b/connector_node/.gitignore
@@ -1,0 +1,5 @@
+# Java
+target/
+risingwave-sink-jdbc/test_db/
+risingwave-sink-jdbc/*.log
+risingwave-connector-service/*.log

--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -4,6 +4,7 @@ ARCH = { source = "${CARGO_MAKE_RUST_TARGET_ARCH}", mapping = { x86_64 = "amd64"
 SYSTEM = "${OS}-${ARCH}"
 SYSTEM_AMD64 = "${OS}-amd64" # some components do not support darwin-arm64 for now, use amd64 for fallback
 PREFIX = "${PWD}/.risingwave"
+CONNECTOR_NODE_DIR = "${PWD}/connector_node"
 PREFIX_USR_BIN = "${PWD}/.bin"
 PREFIX_BIN = "${PREFIX}/bin"
 PREFIX_CONFIG = "${PREFIX}/config"

--- a/src/risedevtool/connector.toml
+++ b/src/risedevtool/connector.toml
@@ -8,6 +8,9 @@ RW_CONNECTOR_BIN_PREFIX = "${PREFIX_BIN}/connector-node"
 
 RW_CONNECTOR_DOWNLOAD_URL = "https://github.com/risingwavelabs/risingwave-connector-release/raw/main/risingwave-connector-${RW_CONNECTOR_VERSION}.tar.gz"
 
+MAVEN_VERSION = "3.9.0"
+MAVEN_DOWNLOAD_PATH = "${PREFIX_TMP}/maven.tar.gz"
+
 [tasks.download-connector]
 category = "RiseDev - Components"
 dependencies = ["prepare"]
@@ -17,6 +20,11 @@ script = '''
 #!/usr/bin/env bash
 set -e
 if [ -f "${RW_CONNECTOR_BIN_PREFIX}/start-service.sh" ]; then
+    exit 0
+fi
+
+if [ -n "${ENABLE_BUILD_RW_CONNECTOR+x}" ]; then
+    echo "ENABLE_BUILD_RW_CONNECTOR is set, will build RisingWave Connector from source instead"
     exit 0
 fi
 
@@ -30,5 +38,29 @@ else
     mkdir -p "${PREFIX_BIN}/connector-node"
     tar xf "${RW_CONNECTOR_DOWNLOAD_PATH}" -C "${PREFIX_BIN}/connector-node"
     rm "${RW_CONNECTOR_DOWNLOAD_PATH}"
+fi
+'''
+
+[tasks.download-maven]
+category = "RiseDev - Components"
+dependencies = ["prepare"]
+condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR" ] }
+description = "Download Maven"
+script = '''
+#!/usr/bin/env bash
+
+if !(command -v javac &> /dev/null && [[ "$(javac -version 2>&1 | awk '{print $2}')" =~ "11" ]]); then
+  echo "JDK 11 is not installed. Please install JDK 11 first."
+  exit 1
+fi
+
+if command -v mvn &> /dev/null; then
+    exit 0
+else
+    echo "Maven is not installed. Downloading now..."
+    curl -sSL "https://downloads.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -o "${MAVEN_DOWNLOAD_PATH}"
+    tar -xzf "${MAVEN_DOWNLOAD_PATH}" -C "${PREFIX_TMP}"
+    mv "${PREFIX_TMP}/apache-maven-${MAVEN_VERSION}" "${PREFIX_BIN}/maven"
+    echo "Maven has been installed to ${PREFIX_BIN}."
 fi
 '''

--- a/src/risedevtool/src/bin/risedev-config.rs
+++ b/src/risedevtool/src/bin/risedev-config.rs
@@ -66,6 +66,7 @@ pub enum Components {
     Pubsub,
     Redis,
     ConnectorNode,
+    BuildConnectorNode,
     Tracing,
     RustComponents,
     Dashboard,
@@ -85,6 +86,7 @@ impl Components {
             Self::Pubsub => "[Component] Google Pubsub",
             Self::Redis => "[Component] Redis",
             Self::ConnectorNode => "[Component] RisingWave Connector",
+            Self::BuildConnectorNode => "[Build] Build RisingWave Connector from source",
             Self::RustComponents => "[Build] Rust components",
             Self::Dashboard => "[Build] Dashboard v2",
             Self::Tracing => "[Component] Tracing: Jaeger",
@@ -168,6 +170,11 @@ Required if you want to sink data to redis.
 Required if you want to create CDC source from external Databases.
                 "
             }
+            Self::BuildConnectorNode => {
+                "
+Required if you want to build Connector Node from source locally.
+                "
+            }
         }
         .into()
     }
@@ -188,6 +195,7 @@ Required if you want to create CDC source from external Databases.
             "ENABLE_SANITIZER" => Some(Self::Sanitizer),
             "ENABLE_REDIS" => Some(Self::Redis),
             "ENABLE_RW_CONNECTOR" => Some(Self::ConnectorNode),
+            "ENABLE_BUILD_RW_CONNECTOR" => Some(Self::BuildConnectorNode),
             _ => None,
         }
     }
@@ -208,6 +216,7 @@ Required if you want to create CDC source from external Databases.
             Self::AllInOne => "ENABLE_ALL_IN_ONE",
             Self::Sanitizer => "ENABLE_SANITIZER",
             Self::ConnectorNode => "ENABLE_RW_CONNECTOR",
+            Self::BuildConnectorNode => "ENABLE_BUILD_RW_CONNECTOR",
         }
         .into()
     }


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

add new option `Build RisingWave Connector from source` in `risedev configure` to allow building connector node from source each time. 

if you just want to use connector node, it is ok to just open `[Component] RisingWave Connector`. It will download the latest release from the Internet. 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
