### PR TITLE
fix: Fix task leak when task failed

### DIFF
--- a/proto/task_service.proto
+++ b/proto/task_service.proto
@@ -17,7 +17,7 @@ message TaskId {
   uint32 task_id = 3;
 }
 
-message TaskInfo {
+message TaskInfoResponse {
   enum TaskStatus {
     // Note: Requirement of proto3: first enum must be 0.
     UNSPECIFIED = 0;
@@ -29,6 +29,8 @@ message TaskInfo {
   }
   batch_plan.TaskId task_id = 1;
   TaskStatus task_status = 2;
+  // Optional error message for failed task.
+  string error_message = 3;
 }
 
 message CreateTaskRequest {
@@ -49,13 +51,7 @@ message GetTaskInfoRequest {
   batch_plan.TaskId task_id = 1;
 }
 
-message TaskInfoResponse {
-  common.Status status = 1;
-  TaskInfo task_info = 2;
-}
-
 message GetDataResponse {
-  common.Status status = 1;
   data.DataChunk record_batch = 2;
 }
 

--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -117,7 +117,6 @@ mod tests {
             self.rpc_called.store(true, Ordering::SeqCst);
             for _ in 0..3 {
                 tx.send(Ok(GetDataResponse {
-                    status: None,
                     record_batch: Some(DataChunk::default()),
                 }))
                 .await

--- a/src/batch/src/rpc/service/task_service.rs
+++ b/src/batch/src/rpc/service/task_service.rs
@@ -43,12 +43,14 @@ impl BatchServiceImpl {
         BatchServiceImpl { mgr, env }
     }
 }
-pub(crate) type TaskInfoResponseResult = std::result::Result<TaskInfoResponse, Status>;
-pub(crate) type GetDataResponseResult = std::result::Result<GetDataResponse, Status>;
+
+pub type TaskInfoResponseResult = Result<TaskInfoResponse, Status>;
+pub type GetDataResponseResult = Result<GetDataResponse, Status>;
+
 #[async_trait::async_trait]
 impl TaskService for BatchServiceImpl {
     type CreateTaskStream = ReceiverStream<TaskInfoResponseResult>;
-    type ExecuteStream = ReceiverStream<std::result::Result<GetDataResponse, Status>>;
+    type ExecuteStream = ReceiverStream<GetDataResponseResult>;
 
     #[cfg_attr(coverage, no_coverage)]
     async fn create_task(

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -27,8 +27,8 @@ use risingwave_pb::batch_plan::{
     PlanFragment, TaskId as ProstTaskId, TaskOutputId as ProstOutputId,
 };
 use risingwave_pb::common::BatchQueryEpoch;
-use risingwave_pb::task_service::task_info::TaskStatus;
-use risingwave_pb::task_service::{GetDataResponse, TaskInfo, TaskInfoResponse};
+use risingwave_pb::task_service::task_info_response::TaskStatus;
+use risingwave_pb::task_service::{GetDataResponse, TaskInfoResponse};
 use task_stats_alloc::{TaskLocalBytesAllocated, BYTES_ALLOCATED};
 use tokio::runtime::Runtime;
 use tokio::sync::oneshot::{Receiver, Sender};
@@ -103,17 +103,19 @@ pub enum StateReporter {
 }
 
 impl StateReporter {
-    pub async fn send(&mut self, val: TaskInfoResponseResult) -> BatchResult<()> {
+    pub async fn send(&mut self, val: TaskInfoResponse) -> BatchResult<()> {
         match self {
             Self::Local(s) => {
-                if let Err(e) = val {
-                    s.send(Err(e)).await.map_err(|_| SenderError)
-                } else {
-                    // do nothing and just return.
-                    Ok(())
+                // A hack here to convert task failure message to data error
+                match val.task_status() {
+                    TaskStatus::Failed => s
+                        .send(Err(Status::internal(val.error_message)))
+                        .await
+                        .map_err(|_| SenderError),
+                    _ => Ok(()),
                 }
             }
-            Self::Distributed(s) => s.send(val).await.map_err(|_| SenderError),
+            Self::Distributed(s) => s.send(Ok(val)).await.map_err(|_| SenderError),
             Self::Mock() => Ok(()),
         }
     }
@@ -225,7 +227,6 @@ impl TaskOutput {
                     );
                     let pb = chunk.to_protobuf().await;
                     let resp = GetDataResponse {
-                        status: Default::default(),
                         record_batch: Some(pb),
                     };
                     writer.write(resp).await?;
@@ -306,7 +307,7 @@ pub struct BatchTaskExecution<C> {
 
     /// State receivers. Will be moved out by `.state_receivers()`. Returned back to client.
     /// This is a hack, cuz there is no easy way to get out the receiver.
-    state_rx: Mutex<Option<tokio::sync::mpsc::Receiver<TaskInfoResponseResult>>>,
+    state_rx: Mutex<Option<tokio::sync::mpsc::Receiver<TaskInfoResponse>>>,
 
     epoch: BatchQueryEpoch,
 
@@ -494,21 +495,14 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         err_str: Option<String>,
     ) -> BatchResult<()> {
         self.change_state(task_status);
-        if let Some(err_str) = err_str {
-            state_tx.send(Err(Status::internal(err_str))).await
-        } else {
-            // Notify frontend the task status.
-            state_tx
-                .send(Ok(TaskInfoResponse {
-                    task_info: Some(TaskInfo {
-                        task_id: Some(TaskId::default().to_prost()),
-                        task_status: task_status.into(),
-                    }),
-                    // TODO: Fill the real status.
-                    ..Default::default()
-                }))
-                .await
-        }
+        // Notify frontend the task status.
+        state_tx
+            .send(TaskInfoResponse {
+                task_id: Some(TaskId::default().to_prost()),
+                task_status: task_status.into(),
+                error_message: err_str.unwrap_or("".to_string()),
+            })
+            .await
     }
 
     pub fn change_state(&self, task_status: TaskStatus) {
@@ -637,7 +631,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         }
     }
 
-    pub fn state_receiver(&self) -> tokio::sync::mpsc::Receiver<TaskInfoResponseResult> {
+    pub fn state_receiver(&self) -> tokio::sync::mpsc::Receiver<TaskInfoResponse> {
         self.state_rx
             .lock()
             .take()

--- a/src/batch/src/task/task_manager.rs
+++ b/src/batch/src/task/task_manager.rs
@@ -25,14 +25,13 @@ use risingwave_pb::batch_plan::{
     PlanFragment, TaskId as ProstTaskId, TaskOutputId as ProstTaskOutputId,
 };
 use risingwave_pb::common::BatchQueryEpoch;
-use risingwave_pb::task_service::GetDataResponse;
+use risingwave_pb::task_service::{GetDataResponse, TaskInfoResponse};
 use tokio::runtime::Runtime;
 use tokio::sync::mpsc::Sender;
 use tonic::Status;
 
 use crate::executor::BatchManagerMetrics;
 use crate::rpc::service::exchange::GrpcExchangeWriter;
-use crate::rpc::service::task_service::TaskInfoResponseResult;
 use crate::task::{
     BatchTaskExecution, ComputeNodeContext, StateReporter, TaskId, TaskOutput, TaskOutputId,
 };
@@ -200,7 +199,7 @@ impl BatchManager {
     pub fn get_task_receiver(
         &self,
         task_id: &TaskId,
-    ) -> tokio::sync::mpsc::Receiver<TaskInfoResponseResult> {
+    ) -> tokio::sync::mpsc::Receiver<TaskInfoResponse> {
         self.tasks.lock().get(task_id).unwrap().state_receiver()
     }
 

--- a/src/frontend/src/scheduler/error.rs
+++ b/src/frontend/src/scheduler/error.rs
@@ -34,6 +34,9 @@ pub enum SchedulerError {
     #[error("{0}")]
     TaskExecutionError(String),
 
+    #[error("Task got killed because compute node running out of memory")]
+    TaskRunningOutOfMemory,
+
     /// Used when receive cancel request (ctrl-c) from user.
     #[error("Canceled by user")]
     QueryCancelError,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix scheduler logic to avoid task leak when batch task failed.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->



