### PR TITLE
feat (optimizer): optimizing vanilla `min`/`max` on index/pk

### DIFF
--- a/e2e_test/batch/aggregate/min_max.slt.part
+++ b/e2e_test/batch/aggregate/min_max.slt.part
@@ -2,7 +2,7 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-create table t(v1 smallint, v2 bigint, v3 real, v4 varchar)
+create table t(v1 smallint primary key, v2 bigint, v3 real, v4 varchar)
 
 statement ok
 insert into t values (3, 4, 1.5, 'bar'), (2, 5, 2.5, 'ba')
@@ -16,6 +16,22 @@ query IIRT
 select max(v1), max(v2), max(v3), max(v4) from t
 ----
 3 5 2.5 bar
+
+query I
+select min(v1) from t
+----
+2
+
+statement ok
+create index idx on t(v2 desc)
+
+statement ok
+insert into t values (1, null, 3.5, 'null v2')
+
+query I
+select max(v2) from t
+----
+5
 
 statement ok
 drop table t

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1008,19 +1008,33 @@
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
 - name: min/max on index
   sql: |
-    create table t (v1 int);
-    create index idx on t(v1 desc);
-    select max(v1) from t;
+    create table t (v1 varchar, v2 int);
+    create index idx on t(v2 desc);
+    select max(v2) from t;
   logical_plan: |
-    LogicalProject { exprs: [max(t.v1)] }
-    └─LogicalAgg { aggs: [max(t.v1)] }
-      └─LogicalProject { exprs: [t.v1] }
-        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+    LogicalProject { exprs: [max(t.v2)] }
+    └─LogicalAgg { aggs: [max(t.v2)] }
+      └─LogicalProject { exprs: [t.v2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan_for_batch: |
-    LogicalAgg { aggs: [max(idx.v1)] }
+    LogicalAgg { aggs: [max(idx.v2)] }
     └─LogicalLimit { limit: 1, offset: 0 }
-      └─LogicalFilter { predicate: IsNotNull(idx.v1) }
-        └─LogicalScan { table: idx, columns: [idx.v1] }
+      └─LogicalFilter { predicate: IsNotNull(idx.v2) }
+        └─LogicalScan { table: idx, columns: [idx.v2] }
+- name: min/max on index with group by, shall NOT optimize
+  sql: |
+    create table t (v1 int, v2 int);
+    create index idx on t(v2 desc);
+    select max(v2) from t group by v1;
+  logical_plan: |
+    LogicalProject { exprs: [max(t.v2)] }
+    └─LogicalAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+      └─LogicalProject { exprs: [t.v1, t.v2] }
+        └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+  optimized_logical_plan_for_batch: |
+    LogicalProject { exprs: [max(t.v2)] }
+    └─LogicalAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+      └─LogicalScan { table: t, columns: [t.v1, t.v2] }
 - name: min/max on primary key
   sql: |
     create table t (v1 int primary key);

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1006,6 +1006,35 @@
       └─LogicalAgg { group_key: [t.v2], aggs: [min(t.v1)] }
         └─LogicalProject { exprs: [t.v2, t.v1] }
           └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
+- name: min/max on index
+  sql: |
+    create table t (v1 int);
+    create index idx on t(v1 desc);
+    select max(v1) from t;
+  logical_plan: |
+    LogicalProject { exprs: [max(t.v1)] }
+    └─LogicalAgg { aggs: [max(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
+  optimized_logical_plan_for_batch: |
+    LogicalAgg { aggs: [max(idx.v1)] }
+    └─LogicalLimit { limit: 1, offset: 0 }
+      └─LogicalFilter { predicate: IsNotNull(idx.v1) }
+        └─LogicalScan { table: idx, columns: [idx.v1] }
+- name: min/max on primary key
+  sql: |
+    create table t (v1 int primary key);
+    select min(v1) from t;
+  logical_plan: |
+    LogicalProject { exprs: [min(t.v1)] }
+    └─LogicalAgg { aggs: [min(t.v1)] }
+      └─LogicalProject { exprs: [t.v1] }
+        └─LogicalScan { table: t, columns: [t.v1] }
+  optimized_logical_plan_for_batch: |
+    LogicalAgg { aggs: [min(t.v1)] }
+    └─LogicalLimit { limit: 1, offset: 0 }
+      └─LogicalFilter { predicate: IsNotNull(t.v1) }
+        └─LogicalScan { table: t, columns: [t.v1] }
 - name: stddev_samp
   sql: |
     create table t (v1 int);

--- a/src/frontend/src/optimizer/logical_optimization.rs
+++ b/src/frontend/src/optimizer/logical_optimization.rs
@@ -236,9 +236,15 @@ lazy_static! {
         ApplyOrder::TopDown,
     );
 
-    static ref AGG_ON_INDEX: OptimizationStage = OptimizationStage::new(
+    static ref TOP_N_ON_INDEX: OptimizationStage = OptimizationStage::new(
         "Agg on Index",
         vec![TopNOnIndexRule::create()],
+        ApplyOrder::TopDown,
+    );
+
+    static ref MIN_MAX_ON_INDEX: OptimizationStage = OptimizationStage::new(
+        "Min/Max on Index",
+        vec![MinMaxOnIndexRule::create()],
         ApplyOrder::TopDown,
     );
 }
@@ -470,7 +476,9 @@ impl LogicalOptimizer {
 
         plan = plan.optimize_by_rules(&DEDUP_GROUP_KEYS);
 
-        plan = plan.optimize_by_rules(&AGG_ON_INDEX);
+        plan = plan.optimize_by_rules(&TOP_N_ON_INDEX);
+
+        plan = plan.optimize_by_rules(&MIN_MAX_ON_INDEX);
 
         #[cfg(debug_assertions)]
         InputRefValidator.validate(plan.clone());

--- a/src/frontend/src/optimizer/rule/min_max_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/min_max_on_index_rule.rs
@@ -1,0 +1,225 @@
+//  Copyright 2023 RisingWave Labs
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+// Copyright (c) 2011-present, Facebook, Inc.  All rights reserved.
+// This source code is licensed under both the GPLv2 (found in the
+// COPYING file in the root directory) and Apache 2.0 License
+// (found in the LICENSE.Apache file in the root directory).
+
+use std::collections::BTreeMap;
+
+use risingwave_common::types::DataType;
+use risingwave_common::util::sort_util::OrderType;
+use risingwave_expr::expr::AggKind;
+
+use super::{BoxedRule, Rule};
+use crate::expr::{AggCall, ExprImpl, ExprType, FunctionCall, InputRef};
+use crate::optimizer::plan_node::{
+    LogicalAgg, LogicalFilter, LogicalLimit, LogicalScan, PlanAggCall, PlanTreeNodeUnary,
+};
+use crate::optimizer::property::{Direction, FieldOrder, Order};
+use crate::optimizer::PlanRef;
+use crate::utils::Condition;
+
+pub struct MinMaxOnIndexRule {}
+
+impl Rule for MinMaxOnIndexRule {
+    fn apply(&self, plan: PlanRef) -> Option<PlanRef> {
+        let logical_agg: &LogicalAgg = plan.as_logical_agg()?;
+        let calls = logical_agg.agg_calls();
+        if calls.len() == 1 && matches!(calls.first()?.agg_kind, AggKind::Min | AggKind::Max) {
+            let logical_scan: LogicalScan = logical_agg.input().as_logical_scan()?.to_owned();
+            let kind = calls.first()?.agg_kind;
+            if !logical_scan.predicate().always_true() {
+                return None;
+            }
+            let output_col_map = logical_scan
+                .output_col_idx()
+                .iter()
+                .cloned()
+                .enumerate()
+                .map(|(id, col)| (col, id))
+                .collect::<BTreeMap<_, _>>();
+            let order = Order {
+                field_order: vec![FieldOrder {
+                    index: calls.first()?.inputs.first()?.index(),
+                    direct: if kind == AggKind::Min {
+                        Direction::Asc
+                    } else {
+                        Direction::Desc
+                    },
+                }],
+            };
+            if let Some(p) =
+                self.try_on_index(logical_agg, logical_scan.clone(), &order, &output_col_map)
+            {
+                Some(p)
+            } else {
+                self.try_on_pk(logical_agg, logical_scan, &order, &output_col_map)
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl MinMaxOnIndexRule {
+    pub fn create() -> BoxedRule {
+        Box::new(MinMaxOnIndexRule {})
+    }
+
+    fn try_on_index(
+        &self,
+        logical_agg: &LogicalAgg,
+        logical_scan: LogicalScan,
+        order: &Order,
+        output_col_map: &BTreeMap<usize, usize>,
+    ) -> Option<PlanRef> {
+        let unmatched_idx = output_col_map.len();
+        let index = logical_scan.indexes().iter().find(|idx| {
+            let s2p_mapping = idx.secondary_to_primary_mapping();
+            Order {
+                field_order: idx
+                    .index_table
+                    .pk()
+                    .iter()
+                    .map(|idx_item| FieldOrder {
+                        index: *output_col_map
+                            .get(
+                                s2p_mapping
+                                    .get(&idx_item.index)
+                                    .expect("should be in s2p mapping"),
+                            )
+                            .unwrap_or(&unmatched_idx),
+                        direct: idx_item.direct,
+                    })
+                    .collect(),
+            }
+            .satisfies(order)
+        })?;
+
+        let p2s_mapping = index.primary_to_secondary_mapping();
+
+        let index_scan = if logical_scan
+            .required_col_idx()
+            .iter()
+            .all(|x| p2s_mapping.contains_key(x))
+        {
+            Some(logical_scan.to_index_scan(
+                &index.name,
+                index.index_table.table_desc().into(),
+                p2s_mapping,
+            ))
+        } else {
+            None
+        }?;
+
+        let non_null_filter = LogicalFilter::create_with_expr(
+            index_scan.into(),
+            FunctionCall::new_unchecked(
+                ExprType::IsNotNull,
+                vec![ExprImpl::InputRef(Box::new(InputRef::new(
+                    0,
+                    logical_agg.schema().fields[0].data_type.clone(),
+                )))],
+                DataType::Boolean,
+            )
+            .into(),
+        );
+
+        let limit = LogicalLimit::create(non_null_filter.into(), 1, 0);
+
+        let formatting_agg = LogicalAgg::new(
+            vec![PlanAggCall {
+                agg_kind: logical_agg.agg_calls().first()?.agg_kind,
+                return_type: logical_agg.schema().fields[0].data_type.clone(),
+                inputs: vec![InputRef::new(
+                    0,
+                    logical_agg.schema().fields[0].data_type.clone(),
+                )],
+                order_by_fields: vec![],
+                distinct: false,
+                filter: Condition {
+                    conjunctions: vec![],
+                },
+            }],
+            vec![],
+            limit.into(),
+        );
+
+        Some(formatting_agg.into())
+    }
+
+    fn try_on_pk(
+        &self,
+        logical_agg: &LogicalAgg,
+        logical_scan: LogicalScan,
+        order: &Order,
+        output_col_map: &BTreeMap<usize, usize>,
+    ) -> Option<PlanRef> {
+        let unmatched_idx = output_col_map.len();
+        let primary_key = logical_scan.primary_key();
+        let primary_key_order = Order {
+            field_order: primary_key
+                .into_iter()
+                .map(|op| FieldOrder {
+                    index: *output_col_map.get(&op.column_idx).unwrap_or(&unmatched_idx),
+                    direct: if op.order_type == OrderType::Ascending {
+                        Direction::Asc
+                    } else {
+                        Direction::Desc
+                    },
+                })
+                .collect::<Vec<_>>(),
+        };
+        if primary_key_order.satisfies(order) {
+            let non_null_filter = LogicalFilter::create_with_expr(
+                logical_scan.into(),
+                FunctionCall::new_unchecked(
+                    ExprType::IsNotNull,
+                    vec![ExprImpl::InputRef(Box::new(InputRef::new(
+                        0,
+                        logical_agg.schema().fields[0].data_type.clone(),
+                    )))],
+                    DataType::Boolean,
+                )
+                .into(),
+            );
+
+            let limit = LogicalLimit::create(non_null_filter.into(), 1, 0);
+
+            let formatting_agg = LogicalAgg::new(
+                vec![PlanAggCall {
+                    agg_kind: logical_agg.agg_calls().first()?.agg_kind,
+                    return_type: logical_agg.schema().fields[0].data_type.clone(),
+                    inputs: vec![InputRef::new(
+                        0,
+                        logical_agg.schema().fields[0].data_type.clone(),
+                    )],
+                    order_by_fields: vec![],
+                    distinct: false,
+                    filter: Condition {
+                        conjunctions: vec![],
+                    },
+                }],
+                vec![],
+                limit.into(),
+            );
+
+            Some(formatting_agg.into())
+        } else {
+            None
+        }
+    }
+}

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -93,6 +93,8 @@ mod rewrite_like_expr_rule;
 pub use rewrite_like_expr_rule::*;
 mod avoid_exchange_share_rule;
 pub use avoid_exchange_share_rule::*;
+mod min_max_on_index_rule;
+pub use min_max_on_index_rule::*;
 
 #[macro_export]
 macro_rules! for_all_rules {
@@ -130,6 +132,7 @@ macro_rules! for_all_rules {
             , { UnionInputValuesMergeRule }
             , { RewriteLikeExprRule }
             , { AvoidExchangeShareRule }
+            , { MinMaxOnIndexRule }
         }
     };
 }


### PR DESCRIPTION
Signed-off-by: Clearlove <yifei.c.wei@gmail.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Vanilla `min` and `max` on index/pk for batch execution is optimized.

- Summarize your change (**mandatory**)
An optimizer rule `MinMaxOnIndexRule` that optimizes "no group key, no distinct, no filter, no order_by, single-fielded" `min` and `max`.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.

## Related Issues
#7991, #7481 
