### PR TITLE
fix(parser): disable single-quoted strings as aliases for column or table

### DIFF
--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2715,19 +2715,6 @@ impl Parser {
             Token::Word(w) if after_as || (!reserved_kwds.contains(&w.keyword)) => {
                 Ok(Some(w.to_ident()?))
             }
-            // MSSQL supports single-quoted strings as aliases for columns
-            // We accept them as table aliases too, although MSSQL does not.
-            //
-            // Note, that this conflicts with an obscure rule from the SQL
-            // standard, which we don't implement:
-            // https://crate.io/docs/sql-99/en/latest/chapters/07.html#character-string-literal-s
-            //    "[Obscure Rule] SQL allows you to break a long <character
-            //    string literal> up into two or more smaller <character string
-            //    literal>s, split by a <separator> that includes a newline
-            //    character. When it sees such a <literal>, your DBMS will
-            //    ignore the <separator> and treat the multiple strings as
-            //    a single <literal>."
-            Token::SingleQuotedString(s) => Ok(Some(Ident::with_quote_unchecked('\'', s))),
             not_an_ident => {
                 if after_as {
                     return self.expected("an identifier after AS", not_an_ident);

--- a/src/sqlparser/tests/sqlparser_postgres.rs
+++ b/src/sqlparser/tests/sqlparser_postgres.rs
@@ -1177,3 +1177,21 @@ fn parse_incorrect_dollar_quoted_string() {
     let sql = "SELECT $$$";
     assert!(parse_sql_statements(sql).is_err());
 }
+
+#[test]
+fn parse_incorrect_single_quoted_string_as_alias() {
+    let sql = "SELECT x FROM t 't1'";
+    assert!(parse_sql_statements(sql).is_err());
+
+    let sql = "SELECT x 'x1‘ FROM t";
+    assert!(parse_sql_statements(sql).is_err());
+}
+
+#[test]
+fn parse_double_quoted_string_as_alias() {
+    let sql = "SELECT x FROM t \"t1\"";
+    assert!(parse_sql_statements(sql).is_ok());
+
+    let sql = "SELECT x \"x1\" FROM t";
+    assert!(parse_sql_statements(sql).is_ok());
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

disable single-quoted strings as aliases for column or table

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

### Types of user-facing changes
- SQL commands, functions, and operators
### Release note
disable single-quoted strings as aliases for column or table
</details>
