### PR TITLE
feat(frontend): support `DROP COLUMN`

### DIFF
--- a/e2e_test/ddl/alter_table_column.slt
+++ b/e2e_test/ddl/alter_table_column.slt
@@ -14,6 +14,15 @@ alter table t add column v1 int primary key;
 statement error is not a table or cannot be altered
 alter table mv add column v1 int;
 
+statement error not exist
+alter table t drop column v1;
+
+statement ok
+alter table t drop column if exists v1;
+
+statement error not yet implemented
+alter table t drop column v cascade;
+
 # Add column
 statement ok
 alter table t add column r real;
@@ -69,7 +78,7 @@ select * from mv3;
 ----
 1 1.1 a
 
-# Drop columns
+# Clean up
 statement ok
 drop materialized view mv;
 
@@ -78,6 +87,40 @@ drop materialized view mv2;
 
 statement ok
 drop materialized view mv3;
+
+statement ok
+drop table t;
+
+# Drop column
+statement ok
+create table t (v int, r real);
+
+statement ok
+alter table t add column s varchar;
+
+query TT
+show create table t;
+----
+public.t CREATE TABLE t (v INT, r REAL, s CHARACTER VARYING)
+
+statement ok
+alter table t drop column r;
+
+query TT
+show create table t;
+----
+public.t CREATE TABLE t (v INT, s CHARACTER VARYING)
+
+# TODO(#4529): create mview on partial columns and test whether dropping the unrefereced column works.
+statement ok
+create materialized view mv as select * from t;
+
+statement error being referenced
+alter table t drop column s;
+
+# Clean up
+statement ok
+drop materialized view mv;
 
 statement ok
 drop table t;

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -29,6 +29,8 @@ use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableType;
 use crate::{build_graph, Binder, OptimizerContext, TableCatalog};
 
+/// Handle `ALTER TABLE [ADD|DROP] COLUMN` statements. The `operation` must be either `AddColumn` or
+/// `DropColumn`.
 pub async fn handle_alter_table_column(
     handler_args: HandlerArgs,
     table_name: ObjectName,

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -13,13 +13,14 @@
 // limitations under the License.
 
 use anyhow::Context;
+use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::catalog::Table;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_pb::stream_plan::StreamFragmentGraph;
-use risingwave_sqlparser::ast::{ColumnDef, ObjectName, Statement};
+use risingwave_sqlparser::ast::{AlterTableOperation, ObjectName, Statement};
 use risingwave_sqlparser::parser::Parser;
 
 use super::create_table::{gen_create_table_plan, ColumnIdGenerator};
@@ -28,10 +29,10 @@ use crate::catalog::root_catalog::SchemaPath;
 use crate::catalog::table_catalog::TableType;
 use crate::{build_graph, Binder, OptimizerContext, TableCatalog};
 
-pub async fn handle_add_column(
+pub async fn handle_alter_table_column(
     handler_args: HandlerArgs,
     table_name: ObjectName,
-    new_column: ColumnDef,
+    operation: AlterTableOperation,
 ) -> Result<RwPgResponse> {
     let session = handler_args.session;
     let db_name = session.database();
@@ -48,7 +49,6 @@ pub async fn handle_add_column(
             reader.get_table_by_name(db_name, schema_path, &real_table_name)?;
 
         match table.table_type() {
-            TableType::Table if !table.has_associated_source() => {}
             // Do not allow altering a table with a connector. It should be done passively according
             // to the messages from the connector.
             TableType::Table if table.has_associated_source() => {
@@ -56,6 +56,8 @@ pub async fn handle_add_column(
                     "cannot alter table \"{table_name}\" because it has a connector"
                 )))?
             }
+            TableType::Table => {}
+
             _ => Err(ErrorCode::InvalidInputSyntax(format!(
                 "\"{table_name}\" is not a table or cannot be altered"
             )))?,
@@ -75,19 +77,62 @@ pub async fn handle_add_column(
         panic!("unexpected statement: {:?}", definition);
     };
 
-    // Duplicated names can actually be checked by `StreamMaterialize`. We do here for better error
-    // reporting.
-    let new_column_name = new_column.name.real_value();
-    if columns
-        .iter()
-        .any(|c| c.name.real_value() == new_column_name)
-    {
-        Err(ErrorCode::InvalidInputSyntax(format!(
-            "column \"{new_column_name}\" of table \"{table_name}\" already exists"
-        )))?
+    match operation {
+        AlterTableOperation::AddColumn {
+            column_def: new_column,
+        } => {
+            // Duplicated names can actually be checked by `StreamMaterialize`. We do here for
+            // better error reporting.
+            let new_column_name = new_column.name.real_value();
+            if columns
+                .iter()
+                .any(|c| c.name.real_value() == new_column_name)
+            {
+                Err(ErrorCode::InvalidInputSyntax(format!(
+                    "column \"{new_column_name}\" of table \"{table_name}\" already exists"
+                )))?
+            }
+            // Add the new column to the table definition.
+            columns.push(new_column);
+        }
+
+        AlterTableOperation::DropColumn {
+            column_name,
+            if_exists,
+            cascade,
+        } => {
+            if cascade {
+                Err(ErrorCode::NotImplemented(
+                    "drop column cascade".to_owned(),
+                    6903.into(),
+                ))?
+            }
+
+            // Locate the column by name and remove it.
+            let column_name = column_name.real_value();
+            let removed_column = columns
+                .drain_filter(|c| c.name.real_value() == column_name)
+                .at_most_one()
+                .ok()
+                .unwrap();
+
+            if removed_column.is_some() {
+                // PASS
+            } else if if_exists {
+                return Ok(PgResponse::empty_result_with_notice(
+                    StatementType::ALTER_TABLE,
+                    format!("column \"{}\" does not exist, skipping", column_name),
+                ));
+            } else {
+                Err(ErrorCode::InvalidInputSyntax(format!(
+                    "column \"{}\" of table \"{}\" does not exist",
+                    column_name, table_name
+                )))?
+            }
+        }
+
+        _ => unreachable!(),
     }
-    // Add the new column to the table definition.
-    columns.push(new_column);
 
     // Create handler args as if we're creating a new table with the altered definition.
     let handler_args = HandlerArgs::new(session.clone(), &definition, "")?;

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -31,7 +31,7 @@ use crate::session::SessionImpl;
 use crate::utils::WithOptions;
 
 mod alter_system;
-mod alter_table;
+mod alter_table_column;
 pub mod alter_user;
 mod create_database;
 pub mod create_function;
@@ -378,8 +378,10 @@ pub async fn handle(
         }
         Statement::AlterTable {
             name,
-            operation: AlterTableOperation::AddColumn { column_def },
-        } => alter_table::handle_add_column(handler_args, name, column_def).await,
+            operation:
+                operation @ (AlterTableOperation::AddColumn { .. }
+                | AlterTableOperation::DropColumn { .. }),
+        } => alter_table_column::handle_alter_table_column(handler_args, name, operation).await,
         Statement::AlterSystem { param, value } => {
             alter_system::handle_alter_system(handler_args, param, value).await
         }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Make the handler take an `Operation` to also support dropping columns.
- Tweak the error reporting for dropping a being-referenced column. This is naturally achieved by #8094 since we'll fail to map them with the index mapping so there's temporarily no need to implement some sort of column ref count unless we need a more detailed error message.
  - There are some false positives here since we always reference all columns when creating a materialized view now. We should fix this in #4529.
- Add some e2e tests.

Note: this is still not user-facing like #8063.
Close #8351.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
