### PR TITLE
fix(batch): Fix task report status unspecified.

### DIFF
--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -537,6 +537,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
                                 // stage, it may early stop receiving data from downstream, which
                                 // leads to close of channel.
                                 warn!("Task receiver closed!");
+                                state = TaskStatus::Finished;
                                 break;
                             },
                             x => {

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -517,7 +517,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         state_tx: &mut StateReporter,
     ) -> Result<()> {
         let mut data_chunk_stream = root.execute();
-        let mut state = TaskStatus::Unspecified;
+        let state;
         let mut err_str = None;
         loop {
             tokio::select! {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix a bug which will report task status as unspecified.

Closes #8360 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.


## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.


### Release note

Fix #8360 
