### PR TITLE
refactor(proto): unify protobuf types to represent column index and column ref

### DIFF
--- a/dashboard/proto/gen/batch_plan.ts
+++ b/dashboard/proto/gen/batch_plan.ts
@@ -1,8 +1,8 @@
 /* eslint-disable */
-import { ColumnIndex, StreamSourceInfo } from "./catalog";
+import { StreamSourceInfo } from "./catalog";
 import { BatchQueryEpoch, Buffer, HostAddress, WorkerNode } from "./common";
 import { IntervalUnit } from "./data";
-import { AggCall, ExprNode, InputRefExpr, ProjectSetSelectItem, TableFunction } from "./expr";
+import { AggCall, ExprNode, ProjectSetSelectItem, TableFunction } from "./expr";
 import {
   ColumnCatalog,
   ColumnDesc,
@@ -108,7 +108,7 @@ export interface InsertNode {
    * The `BatchInsertExecutor` should add a column with NULL value which will
    * be filled in streaming.
    */
-  rowIdIndex: ColumnIndex | undefined;
+  rowIdIndex?: number | undefined;
   returning: boolean;
 }
 
@@ -212,7 +212,7 @@ export interface SortMergeJoinNode {
 }
 
 export interface HopWindowNode {
-  timeCol: InputRefExpr | undefined;
+  timeCol: number;
   windowSlide: IntervalUnit | undefined;
   windowSize: IntervalUnit | undefined;
   outputIndices: number[];
@@ -757,7 +757,7 @@ export const InsertNode = {
       tableId: isSet(object.tableId) ? Number(object.tableId) : 0,
       tableVersionId: isSet(object.tableVersionId) ? Number(object.tableVersionId) : 0,
       columnIndices: Array.isArray(object?.columnIndices) ? object.columnIndices.map((e: any) => Number(e)) : [],
-      rowIdIndex: isSet(object.rowIdIndex) ? ColumnIndex.fromJSON(object.rowIdIndex) : undefined,
+      rowIdIndex: isSet(object.rowIdIndex) ? Number(object.rowIdIndex) : undefined,
       returning: isSet(object.returning) ? Boolean(object.returning) : false,
     };
   },
@@ -771,8 +771,7 @@ export const InsertNode = {
     } else {
       obj.columnIndices = [];
     }
-    message.rowIdIndex !== undefined &&
-      (obj.rowIdIndex = message.rowIdIndex ? ColumnIndex.toJSON(message.rowIdIndex) : undefined);
+    message.rowIdIndex !== undefined && (obj.rowIdIndex = Math.round(message.rowIdIndex));
     message.returning !== undefined && (obj.returning = message.returning);
     return obj;
   },
@@ -782,9 +781,7 @@ export const InsertNode = {
     message.tableId = object.tableId ?? 0;
     message.tableVersionId = object.tableVersionId ?? 0;
     message.columnIndices = object.columnIndices?.map((e) => e) || [];
-    message.rowIdIndex = (object.rowIdIndex !== undefined && object.rowIdIndex !== null)
-      ? ColumnIndex.fromPartial(object.rowIdIndex)
-      : undefined;
+    message.rowIdIndex = object.rowIdIndex ?? undefined;
     message.returning = object.returning ?? false;
     return message;
   },
@@ -1376,13 +1373,13 @@ export const SortMergeJoinNode = {
 };
 
 function createBaseHopWindowNode(): HopWindowNode {
-  return { timeCol: undefined, windowSlide: undefined, windowSize: undefined, outputIndices: [] };
+  return { timeCol: 0, windowSlide: undefined, windowSize: undefined, outputIndices: [] };
 }
 
 export const HopWindowNode = {
   fromJSON(object: any): HopWindowNode {
     return {
-      timeCol: isSet(object.timeCol) ? InputRefExpr.fromJSON(object.timeCol) : undefined,
+      timeCol: isSet(object.timeCol) ? Number(object.timeCol) : 0,
       windowSlide: isSet(object.windowSlide) ? IntervalUnit.fromJSON(object.windowSlide) : undefined,
       windowSize: isSet(object.windowSize) ? IntervalUnit.fromJSON(object.windowSize) : undefined,
       outputIndices: Array.isArray(object?.outputIndices) ? object.outputIndices.map((e: any) => Number(e)) : [],
@@ -1391,7 +1388,7 @@ export const HopWindowNode = {
 
   toJSON(message: HopWindowNode): unknown {
     const obj: any = {};
-    message.timeCol !== undefined && (obj.timeCol = message.timeCol ? InputRefExpr.toJSON(message.timeCol) : undefined);
+    message.timeCol !== undefined && (obj.timeCol = Math.round(message.timeCol));
     message.windowSlide !== undefined &&
       (obj.windowSlide = message.windowSlide ? IntervalUnit.toJSON(message.windowSlide) : undefined);
     message.windowSize !== undefined &&
@@ -1406,9 +1403,7 @@ export const HopWindowNode = {
 
   fromPartial<I extends Exact<DeepPartial<HopWindowNode>, I>>(object: I): HopWindowNode {
     const message = createBaseHopWindowNode();
-    message.timeCol = (object.timeCol !== undefined && object.timeCol !== null)
-      ? InputRefExpr.fromPartial(object.timeCol)
-      : undefined;
+    message.timeCol = object.timeCol ?? 0;
     message.windowSlide = (object.windowSlide !== undefined && object.windowSlide !== null)
       ? IntervalUnit.fromPartial(object.windowSlide)
       : undefined;

--- a/dashboard/proto/gen/expr.ts
+++ b/dashboard/proto/gen/expr.ts
@@ -7,7 +7,7 @@ export const protobufPackage = "expr";
 export interface ExprNode {
   exprType: ExprNode_Type;
   returnType: DataType | undefined;
-  rexNode?: { $case: "inputRef"; inputRef: InputRefExpr } | { $case: "constant"; constant: Datum } | {
+  rexNode?: { $case: "inputRef"; inputRef: number } | { $case: "constant"; constant: Datum } | {
     $case: "funcCall";
     funcCall: FunctionCall;
   } | { $case: "udf"; udf: UserDefinedFunction };
@@ -687,8 +687,10 @@ export function tableFunction_TypeToJSON(object: TableFunction_Type): string {
   }
 }
 
-export interface InputRefExpr {
-  columnIdx: number;
+/** Reference to a column, containing its index and data type. */
+export interface ColumnRef {
+  index: number;
+  type: DataType | undefined;
 }
 
 /**
@@ -730,7 +732,7 @@ export interface FunctionCall {
 /** Aggregate Function Calls for Aggregation */
 export interface AggCall {
   type: AggCall_Type;
-  args: AggCall_Arg[];
+  args: ColumnRef[];
   returnType: DataType | undefined;
   distinct: boolean;
   orderByFields: AggCall_OrderByField[];
@@ -850,14 +852,8 @@ export function aggCall_TypeToJSON(object: AggCall_Type): string {
   }
 }
 
-export interface AggCall_Arg {
-  input: InputRefExpr | undefined;
-  type: DataType | undefined;
-}
-
 export interface AggCall_OrderByField {
-  input: InputRefExpr | undefined;
-  type: DataType | undefined;
+  input: number;
   direction: OrderType;
   nullsFirst: boolean;
 }
@@ -881,7 +877,7 @@ export const ExprNode = {
       exprType: isSet(object.exprType) ? exprNode_TypeFromJSON(object.exprType) : ExprNode_Type.UNSPECIFIED,
       returnType: isSet(object.returnType) ? DataType.fromJSON(object.returnType) : undefined,
       rexNode: isSet(object.inputRef)
-        ? { $case: "inputRef", inputRef: InputRefExpr.fromJSON(object.inputRef) }
+        ? { $case: "inputRef", inputRef: Number(object.inputRef) }
         : isSet(object.constant)
         ? { $case: "constant", constant: Datum.fromJSON(object.constant) }
         : isSet(object.funcCall)
@@ -897,8 +893,7 @@ export const ExprNode = {
     message.exprType !== undefined && (obj.exprType = exprNode_TypeToJSON(message.exprType));
     message.returnType !== undefined &&
       (obj.returnType = message.returnType ? DataType.toJSON(message.returnType) : undefined);
-    message.rexNode?.$case === "inputRef" &&
-      (obj.inputRef = message.rexNode?.inputRef ? InputRefExpr.toJSON(message.rexNode?.inputRef) : undefined);
+    message.rexNode?.$case === "inputRef" && (obj.inputRef = Math.round(message.rexNode?.inputRef));
     message.rexNode?.$case === "constant" &&
       (obj.constant = message.rexNode?.constant ? Datum.toJSON(message.rexNode?.constant) : undefined);
     message.rexNode?.$case === "funcCall" &&
@@ -919,7 +914,7 @@ export const ExprNode = {
       object.rexNode?.inputRef !== undefined &&
       object.rexNode?.inputRef !== null
     ) {
-      message.rexNode = { $case: "inputRef", inputRef: InputRefExpr.fromPartial(object.rexNode.inputRef) };
+      message.rexNode = { $case: "inputRef", inputRef: object.rexNode.inputRef };
     }
     if (
       object.rexNode?.$case === "constant" &&
@@ -983,24 +978,29 @@ export const TableFunction = {
   },
 };
 
-function createBaseInputRefExpr(): InputRefExpr {
-  return { columnIdx: 0 };
+function createBaseColumnRef(): ColumnRef {
+  return { index: 0, type: undefined };
 }
 
-export const InputRefExpr = {
-  fromJSON(object: any): InputRefExpr {
-    return { columnIdx: isSet(object.columnIdx) ? Number(object.columnIdx) : 0 };
+export const ColumnRef = {
+  fromJSON(object: any): ColumnRef {
+    return {
+      index: isSet(object.index) ? Number(object.index) : 0,
+      type: isSet(object.type) ? DataType.fromJSON(object.type) : undefined,
+    };
   },
 
-  toJSON(message: InputRefExpr): unknown {
+  toJSON(message: ColumnRef): unknown {
     const obj: any = {};
-    message.columnIdx !== undefined && (obj.columnIdx = Math.round(message.columnIdx));
+    message.index !== undefined && (obj.index = Math.round(message.index));
+    message.type !== undefined && (obj.type = message.type ? DataType.toJSON(message.type) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<InputRefExpr>, I>>(object: I): InputRefExpr {
-    const message = createBaseInputRefExpr();
-    message.columnIdx = object.columnIdx ?? 0;
+  fromPartial<I extends Exact<DeepPartial<ColumnRef>, I>>(object: I): ColumnRef {
+    const message = createBaseColumnRef();
+    message.index = object.index ?? 0;
+    message.type = (object.type !== undefined && object.type !== null) ? DataType.fromPartial(object.type) : undefined;
     return message;
   },
 };
@@ -1092,7 +1092,7 @@ export const AggCall = {
   fromJSON(object: any): AggCall {
     return {
       type: isSet(object.type) ? aggCall_TypeFromJSON(object.type) : AggCall_Type.UNSPECIFIED,
-      args: Array.isArray(object?.args) ? object.args.map((e: any) => AggCall_Arg.fromJSON(e)) : [],
+      args: Array.isArray(object?.args) ? object.args.map((e: any) => ColumnRef.fromJSON(e)) : [],
       returnType: isSet(object.returnType) ? DataType.fromJSON(object.returnType) : undefined,
       distinct: isSet(object.distinct) ? Boolean(object.distinct) : false,
       orderByFields: Array.isArray(object?.orderByFields)
@@ -1106,7 +1106,7 @@ export const AggCall = {
     const obj: any = {};
     message.type !== undefined && (obj.type = aggCall_TypeToJSON(message.type));
     if (message.args) {
-      obj.args = message.args.map((e) => e ? AggCall_Arg.toJSON(e) : undefined);
+      obj.args = message.args.map((e) => e ? ColumnRef.toJSON(e) : undefined);
     } else {
       obj.args = [];
     }
@@ -1125,7 +1125,7 @@ export const AggCall = {
   fromPartial<I extends Exact<DeepPartial<AggCall>, I>>(object: I): AggCall {
     const message = createBaseAggCall();
     message.type = object.type ?? AggCall_Type.UNSPECIFIED;
-    message.args = object.args?.map((e) => AggCall_Arg.fromPartial(e)) || [];
+    message.args = object.args?.map((e) => ColumnRef.fromPartial(e)) || [];
     message.returnType = (object.returnType !== undefined && object.returnType !== null)
       ? DataType.fromPartial(object.returnType)
       : undefined;
@@ -1138,44 +1138,14 @@ export const AggCall = {
   },
 };
 
-function createBaseAggCall_Arg(): AggCall_Arg {
-  return { input: undefined, type: undefined };
-}
-
-export const AggCall_Arg = {
-  fromJSON(object: any): AggCall_Arg {
-    return {
-      input: isSet(object.input) ? InputRefExpr.fromJSON(object.input) : undefined,
-      type: isSet(object.type) ? DataType.fromJSON(object.type) : undefined,
-    };
-  },
-
-  toJSON(message: AggCall_Arg): unknown {
-    const obj: any = {};
-    message.input !== undefined && (obj.input = message.input ? InputRefExpr.toJSON(message.input) : undefined);
-    message.type !== undefined && (obj.type = message.type ? DataType.toJSON(message.type) : undefined);
-    return obj;
-  },
-
-  fromPartial<I extends Exact<DeepPartial<AggCall_Arg>, I>>(object: I): AggCall_Arg {
-    const message = createBaseAggCall_Arg();
-    message.input = (object.input !== undefined && object.input !== null)
-      ? InputRefExpr.fromPartial(object.input)
-      : undefined;
-    message.type = (object.type !== undefined && object.type !== null) ? DataType.fromPartial(object.type) : undefined;
-    return message;
-  },
-};
-
 function createBaseAggCall_OrderByField(): AggCall_OrderByField {
-  return { input: undefined, type: undefined, direction: OrderType.ORDER_UNSPECIFIED, nullsFirst: false };
+  return { input: 0, direction: OrderType.ORDER_UNSPECIFIED, nullsFirst: false };
 }
 
 export const AggCall_OrderByField = {
   fromJSON(object: any): AggCall_OrderByField {
     return {
-      input: isSet(object.input) ? InputRefExpr.fromJSON(object.input) : undefined,
-      type: isSet(object.type) ? DataType.fromJSON(object.type) : undefined,
+      input: isSet(object.input) ? Number(object.input) : 0,
       direction: isSet(object.direction) ? orderTypeFromJSON(object.direction) : OrderType.ORDER_UNSPECIFIED,
       nullsFirst: isSet(object.nullsFirst) ? Boolean(object.nullsFirst) : false,
     };
@@ -1183,8 +1153,7 @@ export const AggCall_OrderByField = {
 
   toJSON(message: AggCall_OrderByField): unknown {
     const obj: any = {};
-    message.input !== undefined && (obj.input = message.input ? InputRefExpr.toJSON(message.input) : undefined);
-    message.type !== undefined && (obj.type = message.type ? DataType.toJSON(message.type) : undefined);
+    message.input !== undefined && (obj.input = Math.round(message.input));
     message.direction !== undefined && (obj.direction = orderTypeToJSON(message.direction));
     message.nullsFirst !== undefined && (obj.nullsFirst = message.nullsFirst);
     return obj;
@@ -1192,10 +1161,7 @@ export const AggCall_OrderByField = {
 
   fromPartial<I extends Exact<DeepPartial<AggCall_OrderByField>, I>>(object: I): AggCall_OrderByField {
     const message = createBaseAggCall_OrderByField();
-    message.input = (object.input !== undefined && object.input !== null)
-      ? InputRefExpr.fromPartial(object.input)
-      : undefined;
-    message.type = (object.type !== undefined && object.type !== null) ? DataType.fromPartial(object.type) : undefined;
+    message.input = object.input ?? 0;
     message.direction = object.direction ?? OrderType.ORDER_UNSPECIFIED;
     message.nullsFirst = object.nullsFirst ?? false;
     return message;

--- a/dashboard/proto/gen/expr.ts
+++ b/dashboard/proto/gen/expr.ts
@@ -687,8 +687,8 @@ export function tableFunction_TypeToJSON(object: TableFunction_Type): string {
   }
 }
 
-/** Reference to a column, containing its index and data type. */
-export interface ColumnRef {
+/** Reference to an upstream column, containing its index and data type. */
+export interface InputRef {
   index: number;
   type: DataType | undefined;
 }
@@ -732,7 +732,7 @@ export interface FunctionCall {
 /** Aggregate Function Calls for Aggregation */
 export interface AggCall {
   type: AggCall_Type;
-  args: ColumnRef[];
+  args: InputRef[];
   returnType: DataType | undefined;
   distinct: boolean;
   orderByFields: AggCall_OrderByField[];
@@ -978,27 +978,27 @@ export const TableFunction = {
   },
 };
 
-function createBaseColumnRef(): ColumnRef {
+function createBaseInputRef(): InputRef {
   return { index: 0, type: undefined };
 }
 
-export const ColumnRef = {
-  fromJSON(object: any): ColumnRef {
+export const InputRef = {
+  fromJSON(object: any): InputRef {
     return {
       index: isSet(object.index) ? Number(object.index) : 0,
       type: isSet(object.type) ? DataType.fromJSON(object.type) : undefined,
     };
   },
 
-  toJSON(message: ColumnRef): unknown {
+  toJSON(message: InputRef): unknown {
     const obj: any = {};
     message.index !== undefined && (obj.index = Math.round(message.index));
     message.type !== undefined && (obj.type = message.type ? DataType.toJSON(message.type) : undefined);
     return obj;
   },
 
-  fromPartial<I extends Exact<DeepPartial<ColumnRef>, I>>(object: I): ColumnRef {
-    const message = createBaseColumnRef();
+  fromPartial<I extends Exact<DeepPartial<InputRef>, I>>(object: I): InputRef {
+    const message = createBaseInputRef();
     message.index = object.index ?? 0;
     message.type = (object.type !== undefined && object.type !== null) ? DataType.fromPartial(object.type) : undefined;
     return message;
@@ -1092,7 +1092,7 @@ export const AggCall = {
   fromJSON(object: any): AggCall {
     return {
       type: isSet(object.type) ? aggCall_TypeFromJSON(object.type) : AggCall_Type.UNSPECIFIED,
-      args: Array.isArray(object?.args) ? object.args.map((e: any) => ColumnRef.fromJSON(e)) : [],
+      args: Array.isArray(object?.args) ? object.args.map((e: any) => InputRef.fromJSON(e)) : [],
       returnType: isSet(object.returnType) ? DataType.fromJSON(object.returnType) : undefined,
       distinct: isSet(object.distinct) ? Boolean(object.distinct) : false,
       orderByFields: Array.isArray(object?.orderByFields)
@@ -1106,7 +1106,7 @@ export const AggCall = {
     const obj: any = {};
     message.type !== undefined && (obj.type = aggCall_TypeToJSON(message.type));
     if (message.args) {
-      obj.args = message.args.map((e) => e ? ColumnRef.toJSON(e) : undefined);
+      obj.args = message.args.map((e) => e ? InputRef.toJSON(e) : undefined);
     } else {
       obj.args = [];
     }
@@ -1125,7 +1125,7 @@ export const AggCall = {
   fromPartial<I extends Exact<DeepPartial<AggCall>, I>>(object: I): AggCall {
     const message = createBaseAggCall();
     message.type = object.type ?? AggCall_Type.UNSPECIFIED;
-    message.args = object.args?.map((e) => ColumnRef.fromPartial(e)) || [];
+    message.args = object.args?.map((e) => InputRef.fromPartial(e)) || [];
     message.returnType = (object.returnType !== undefined && object.returnType !== null)
       ? DataType.fromPartial(object.returnType)
       : undefined;

--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -2,7 +2,7 @@
 import { SinkType, sinkTypeFromJSON, sinkTypeToJSON, StreamSourceInfo, Table, WatermarkDesc } from "./catalog";
 import { Buffer } from "./common";
 import { Datum, Epoch, IntervalUnit, StreamChunk } from "./data";
-import { AggCall, ColumnRef, ExprNode, ProjectSetSelectItem } from "./expr";
+import { AggCall, ExprNode, InputRef, ProjectSetSelectItem } from "./expr";
 import {
   ColumnCatalog,
   ColumnDesc,
@@ -361,7 +361,7 @@ export interface Barrier {
 export interface Watermark {
   /** The reference to the watermark column in the stream's schema. */
   column:
-    | ColumnRef
+    | InputRef
     | undefined;
   /** The watermark value, there will be no record having a greater value in the watermark column. */
   val: Datum | undefined;
@@ -1645,14 +1645,14 @@ function createBaseWatermark(): Watermark {
 export const Watermark = {
   fromJSON(object: any): Watermark {
     return {
-      column: isSet(object.column) ? ColumnRef.fromJSON(object.column) : undefined,
+      column: isSet(object.column) ? InputRef.fromJSON(object.column) : undefined,
       val: isSet(object.val) ? Datum.fromJSON(object.val) : undefined,
     };
   },
 
   toJSON(message: Watermark): unknown {
     const obj: any = {};
-    message.column !== undefined && (obj.column = message.column ? ColumnRef.toJSON(message.column) : undefined);
+    message.column !== undefined && (obj.column = message.column ? InputRef.toJSON(message.column) : undefined);
     message.val !== undefined && (obj.val = message.val ? Datum.toJSON(message.val) : undefined);
     return obj;
   },
@@ -1660,7 +1660,7 @@ export const Watermark = {
   fromPartial<I extends Exact<DeepPartial<Watermark>, I>>(object: I): Watermark {
     const message = createBaseWatermark();
     message.column = (object.column !== undefined && object.column !== null)
-      ? ColumnRef.fromPartial(object.column)
+      ? InputRef.fromPartial(object.column)
       : undefined;
     message.val = (object.val !== undefined && object.val !== null) ? Datum.fromPartial(object.val) : undefined;
     return message;

--- a/dashboard/proto/gen/stream_plan.ts
+++ b/dashboard/proto/gen/stream_plan.ts
@@ -1,16 +1,8 @@
 /* eslint-disable */
-import {
-  ColumnIndex,
-  SinkType,
-  sinkTypeFromJSON,
-  sinkTypeToJSON,
-  StreamSourceInfo,
-  Table,
-  WatermarkDesc,
-} from "./catalog";
+import { SinkType, sinkTypeFromJSON, sinkTypeToJSON, StreamSourceInfo, Table, WatermarkDesc } from "./catalog";
 import { Buffer } from "./common";
-import { DataType, Datum, Epoch, IntervalUnit, StreamChunk } from "./data";
-import { AggCall, ExprNode, InputRefExpr, ProjectSetSelectItem } from "./expr";
+import { Datum, Epoch, IntervalUnit, StreamChunk } from "./data";
+import { AggCall, ColumnRef, ExprNode, ProjectSetSelectItem } from "./expr";
 import {
   ColumnCatalog,
   ColumnDesc,
@@ -367,11 +359,9 @@ export interface Barrier {
 }
 
 export interface Watermark {
-  /** The watermark column's index in the stream's schema. */
-  colIdx: number;
-  /** The watermark type, used for deserialization of the watermark value. */
-  dataType:
-    | DataType
+  /** The reference to the watermark column in the stream's schema. */
+  column:
+    | ColumnRef
     | undefined;
   /** The watermark value, there will be no record having a greater value in the watermark column. */
   val: Datum | undefined;
@@ -393,7 +383,7 @@ export interface ActorMapping {
 export interface StreamSource {
   sourceId: number;
   stateTable: Table | undefined;
-  rowIdIndex: ColumnIndex | undefined;
+  rowIdIndex?: number | undefined;
   columns: ColumnCatalog[];
   pkColumnIds: number[];
   properties: { [key: string]: string };
@@ -648,7 +638,7 @@ export interface DeltaIndexJoinNode {
 }
 
 export interface HopWindowNode {
-  timeCol: InputRefExpr | undefined;
+  timeCol: number;
   windowSlide: IntervalUnit | undefined;
   windowSize: IntervalUnit | undefined;
   outputIndices: number[];
@@ -1649,31 +1639,28 @@ export const Barrier = {
 };
 
 function createBaseWatermark(): Watermark {
-  return { colIdx: 0, dataType: undefined, val: undefined };
+  return { column: undefined, val: undefined };
 }
 
 export const Watermark = {
   fromJSON(object: any): Watermark {
     return {
-      colIdx: isSet(object.colIdx) ? Number(object.colIdx) : 0,
-      dataType: isSet(object.dataType) ? DataType.fromJSON(object.dataType) : undefined,
+      column: isSet(object.column) ? ColumnRef.fromJSON(object.column) : undefined,
       val: isSet(object.val) ? Datum.fromJSON(object.val) : undefined,
     };
   },
 
   toJSON(message: Watermark): unknown {
     const obj: any = {};
-    message.colIdx !== undefined && (obj.colIdx = Math.round(message.colIdx));
-    message.dataType !== undefined && (obj.dataType = message.dataType ? DataType.toJSON(message.dataType) : undefined);
+    message.column !== undefined && (obj.column = message.column ? ColumnRef.toJSON(message.column) : undefined);
     message.val !== undefined && (obj.val = message.val ? Datum.toJSON(message.val) : undefined);
     return obj;
   },
 
   fromPartial<I extends Exact<DeepPartial<Watermark>, I>>(object: I): Watermark {
     const message = createBaseWatermark();
-    message.colIdx = object.colIdx ?? 0;
-    message.dataType = (object.dataType !== undefined && object.dataType !== null)
-      ? DataType.fromPartial(object.dataType)
+    message.column = (object.column !== undefined && object.column !== null)
+      ? ColumnRef.fromPartial(object.column)
       : undefined;
     message.val = (object.val !== undefined && object.val !== null) ? Datum.fromPartial(object.val) : undefined;
     return message;
@@ -1794,7 +1781,7 @@ export const StreamSource = {
     return {
       sourceId: isSet(object.sourceId) ? Number(object.sourceId) : 0,
       stateTable: isSet(object.stateTable) ? Table.fromJSON(object.stateTable) : undefined,
-      rowIdIndex: isSet(object.rowIdIndex) ? ColumnIndex.fromJSON(object.rowIdIndex) : undefined,
+      rowIdIndex: isSet(object.rowIdIndex) ? Number(object.rowIdIndex) : undefined,
       columns: Array.isArray(object?.columns) ? object.columns.map((e: any) => ColumnCatalog.fromJSON(e)) : [],
       pkColumnIds: Array.isArray(object?.pkColumnIds) ? object.pkColumnIds.map((e: any) => Number(e)) : [],
       properties: isObject(object.properties)
@@ -1813,8 +1800,7 @@ export const StreamSource = {
     message.sourceId !== undefined && (obj.sourceId = Math.round(message.sourceId));
     message.stateTable !== undefined &&
       (obj.stateTable = message.stateTable ? Table.toJSON(message.stateTable) : undefined);
-    message.rowIdIndex !== undefined &&
-      (obj.rowIdIndex = message.rowIdIndex ? ColumnIndex.toJSON(message.rowIdIndex) : undefined);
+    message.rowIdIndex !== undefined && (obj.rowIdIndex = Math.round(message.rowIdIndex));
     if (message.columns) {
       obj.columns = message.columns.map((e) => e ? ColumnCatalog.toJSON(e) : undefined);
     } else {
@@ -1842,9 +1828,7 @@ export const StreamSource = {
     message.stateTable = (object.stateTable !== undefined && object.stateTable !== null)
       ? Table.fromPartial(object.stateTable)
       : undefined;
-    message.rowIdIndex = (object.rowIdIndex !== undefined && object.rowIdIndex !== null)
-      ? ColumnIndex.fromPartial(object.rowIdIndex)
-      : undefined;
+    message.rowIdIndex = object.rowIdIndex ?? undefined;
     message.columns = object.columns?.map((e) => ColumnCatalog.fromPartial(e)) || [];
     message.pkColumnIds = object.pkColumnIds?.map((e) => e) || [];
     message.properties = Object.entries(object.properties ?? {}).reduce<{ [key: string]: string }>(
@@ -2884,13 +2868,13 @@ export const DeltaIndexJoinNode = {
 };
 
 function createBaseHopWindowNode(): HopWindowNode {
-  return { timeCol: undefined, windowSlide: undefined, windowSize: undefined, outputIndices: [] };
+  return { timeCol: 0, windowSlide: undefined, windowSize: undefined, outputIndices: [] };
 }
 
 export const HopWindowNode = {
   fromJSON(object: any): HopWindowNode {
     return {
-      timeCol: isSet(object.timeCol) ? InputRefExpr.fromJSON(object.timeCol) : undefined,
+      timeCol: isSet(object.timeCol) ? Number(object.timeCol) : 0,
       windowSlide: isSet(object.windowSlide) ? IntervalUnit.fromJSON(object.windowSlide) : undefined,
       windowSize: isSet(object.windowSize) ? IntervalUnit.fromJSON(object.windowSize) : undefined,
       outputIndices: Array.isArray(object?.outputIndices) ? object.outputIndices.map((e: any) => Number(e)) : [],
@@ -2899,7 +2883,7 @@ export const HopWindowNode = {
 
   toJSON(message: HopWindowNode): unknown {
     const obj: any = {};
-    message.timeCol !== undefined && (obj.timeCol = message.timeCol ? InputRefExpr.toJSON(message.timeCol) : undefined);
+    message.timeCol !== undefined && (obj.timeCol = Math.round(message.timeCol));
     message.windowSlide !== undefined &&
       (obj.windowSlide = message.windowSlide ? IntervalUnit.toJSON(message.windowSlide) : undefined);
     message.windowSize !== undefined &&
@@ -2914,9 +2898,7 @@ export const HopWindowNode = {
 
   fromPartial<I extends Exact<DeepPartial<HopWindowNode>, I>>(object: I): HopWindowNode {
     const message = createBaseHopWindowNode();
-    message.timeCol = (object.timeCol !== undefined && object.timeCol !== null)
-      ? InputRefExpr.fromPartial(object.timeCol)
-      : undefined;
+    message.timeCol = object.timeCol ?? 0;
     message.windowSlide = (object.windowSlide !== undefined && object.windowSlide !== null)
       ? IntervalUnit.fromPartial(object.windowSlide)
       : undefined;

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -83,7 +83,7 @@ message InsertNode {
   // An optional field and will be `None` for tables without user-defined pk.
   // The `BatchInsertExecutor` should add a column with NULL value which will
   // be filled in streaming.
-  catalog.ColumnIndex row_id_index = 3;
+  optional uint32 row_id_index = 3;
   bool returning = 4;
 }
 
@@ -183,7 +183,7 @@ message SortMergeJoinNode {
 }
 
 message HopWindowNode {
-  expr.InputRefExpr time_col = 1;
+  uint32 time_col = 1;
   data.IntervalUnit window_slide = 2;
   data.IntervalUnit window_size = 3;
   repeated uint32 output_indices = 4;

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -9,13 +9,6 @@ import "plan_common.proto";
 option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
-// The rust prost library always treats uint64 as required and message as
-// optional. In order to allow `row_id_index` as an optional field, we wrap
-// uint64 inside this message.
-message ColumnIndex {
-  uint64 index = 1;
-}
-
 // A mapping of column indices.
 message ColIndexMapping {
   // The size of the target space.
@@ -49,7 +42,7 @@ message Source {
   string name = 4;
   // The column index of row ID. If the primary key is specified by the user,
   // this will be `None`.
-  ColumnIndex row_id_index = 5;
+  optional uint32 row_id_index = 5;
   // Columns of the source.
   repeated plan_common.ColumnCatalog columns = 6;
   // Column id of the primary key specified by the user. If the user does not
@@ -156,10 +149,10 @@ message Table {
   uint32 fragment_id = 17;
   // an optional column index which is the vnode of each row computed by the
   // table's consistent hash distribution
-  ColumnIndex vnode_col_index = 18;
+  optional uint32 vnode_col_index = 18;
   // An optional column index of row id. If the primary key is specified by users,
   // this will be `None`.
-  ColumnIndex row_id_index = 19;
+  optional uint32 row_id_index = 19;
   // The column indices which are stored in the state store's value with
   // row-encoding. Currently is not supported yet and expected to be
   // `[0..columns.len()]`.

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -161,8 +161,8 @@ message TableFunction {
   data.DataType return_type = 3;
 }
 
-// Reference to a column, containing its index and data type.
-message ColumnRef {
+// Reference to an upstream column, containing its index and data type.
+message InputRef {
   uint32 index = 1;
   data.DataType type = 2;
 }
@@ -224,7 +224,7 @@ message AggCall {
     STDDEV_SAMP = 14;
   }
   Type type = 1;
-  repeated ColumnRef args = 2;
+  repeated InputRef args = 2;
   data.DataType return_type = 3;
   bool distinct = 4;
   message OrderByField {

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -141,7 +141,7 @@ message ExprNode {
   Type expr_type = 1;
   data.DataType return_type = 3;
   oneof rex_node {
-    InputRefExpr input_ref = 4;
+    uint32 input_ref = 4;
     data.Datum constant = 5;
     FunctionCall func_call = 6;
     UserDefinedFunction udf = 7;
@@ -161,8 +161,10 @@ message TableFunction {
   data.DataType return_type = 3;
 }
 
-message InputRefExpr {
-  int32 column_idx = 1;
+// Reference to a column, containing its index and data type.
+message ColumnRef {
+  uint32 index = 1;
+  data.DataType type = 2;
 }
 
 // The items which can occur in the select list of `ProjectSet` operator.
@@ -221,16 +223,12 @@ message AggCall {
     STDDEV_POP = 13;
     STDDEV_SAMP = 14;
   }
-  message Arg {
-    InputRefExpr input = 1;
-    data.DataType type = 2;
-  }
   Type type = 1;
-  repeated Arg args = 2;
+  repeated ColumnRef args = 2;
   data.DataType return_type = 3;
   bool distinct = 4;
   message OrderByField {
-    InputRefExpr input = 1;
+    uint32 input = 1;
     plan_common.OrderType direction = 3;
     bool nulls_first = 4;
   }

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -231,7 +231,6 @@ message AggCall {
   bool distinct = 4;
   message OrderByField {
     InputRefExpr input = 1;
-    data.DataType type = 2;
     plan_common.OrderType direction = 3;
     bool nulls_first = 4;
   }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -101,7 +101,7 @@ message Barrier {
 
 message Watermark {
   // The reference to the watermark column in the stream's schema.
-  expr.ColumnRef column = 1;
+  expr.InputRef column = 1;
   // The watermark value, there will be no record having a greater value in the watermark column.
   data.Datum val = 3;
 }

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -100,10 +100,8 @@ message Barrier {
 }
 
 message Watermark {
-  // The watermark column's index in the stream's schema.
-  uint32 col_idx = 1;
-  // The watermark type, used for deserialization of the watermark value.
-  data.DataType data_type = 2;
+  // The reference to the watermark column in the stream's schema.
+  expr.ColumnRef column = 1;
   // The watermark value, there will be no record having a greater value in the watermark column.
   data.Datum val = 3;
 }
@@ -125,7 +123,7 @@ message ActorMapping {
 message StreamSource {
   uint32 source_id = 1;
   catalog.Table state_table = 2;
-  catalog.ColumnIndex row_id_index = 3;
+  optional uint32 row_id_index = 3;
   repeated plan_common.ColumnCatalog columns = 4;
   repeated int32 pk_column_ids = 5;
   map<string, string> properties = 6;
@@ -326,7 +324,7 @@ message DeltaIndexJoinNode {
 }
 
 message HopWindowNode {
-  expr.InputRefExpr time_col = 1;
+  uint32 time_col = 1;
   data.IntervalUnit window_slide = 2;
   data.IntervalUnit window_size = 3;
   repeated uint32 output_indices = 4;

--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -26,7 +26,7 @@ use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{
     ConstantValue as TConstValue, Equal, InputRef, Modulus,
 };
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ExprNode, FunctionCall};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
@@ -44,7 +44,7 @@ fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor 
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
 
         let literal2 = ExprNode {

--- a/src/batch/benches/hash_agg.rs
+++ b/src/batch/benches/hash_agg.rs
@@ -21,8 +21,7 @@ use risingwave_common::types::DataType;
 use risingwave_common::{enable_jemalloc_on_linux, hash};
 use risingwave_expr::expr::AggKind;
 use risingwave_expr::vector_op::agg::AggStateFactory;
-use risingwave_pb::expr::agg_call::Arg;
-use risingwave_pb::expr::{AggCall, InputRefExpr};
+use risingwave_pb::expr::{AggCall, ColumnRef};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
@@ -38,10 +37,8 @@ fn create_agg_call(
         r#type: agg_kind.to_prost() as i32,
         args: args
             .into_iter()
-            .map(|col_idx| Arg {
-                input: Some(InputRefExpr {
-                    column_idx: col_idx as i32,
-                }),
+            .map(|col_idx| ColumnRef {
+                index: col_idx as _,
                 r#type: Some(input_schema.fields()[col_idx].data_type().to_protobuf()),
             })
             .collect(),

--- a/src/batch/benches/hash_agg.rs
+++ b/src/batch/benches/hash_agg.rs
@@ -21,7 +21,7 @@ use risingwave_common::types::DataType;
 use risingwave_common::{enable_jemalloc_on_linux, hash};
 use risingwave_expr::expr::AggKind;
 use risingwave_expr::vector_op::agg::AggStateFactory;
-use risingwave_pb::expr::{AggCall, ColumnRef};
+use risingwave_pb::expr::{AggCall, InputRef};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
@@ -37,7 +37,7 @@ fn create_agg_call(
         r#type: agg_kind.to_prost() as i32,
         args: args
             .into_iter()
-            .map(|col_idx| ColumnRef {
+            .map(|col_idx| InputRef {
                 index: col_idx as _,
                 r#type: Some(input_schema.fields()[col_idx].data_type().to_protobuf()),
             })

--- a/src/batch/benches/hash_join.rs
+++ b/src/batch/benches/hash_join.rs
@@ -29,7 +29,7 @@ use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{
     ConstantValue as TConstValue, GreaterThan, InputRef, Modulus,
 };
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ExprNode, FunctionCall};
 use utils::bench_join;
 
 enable_jemalloc_on_linux!();
@@ -50,7 +50,7 @@ fn create_hash_join_executor(
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let literal123 = ExprNode {
             expr_type: TConstValue as i32,
@@ -80,7 +80,7 @@ fn create_hash_join_executor(
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let literal456 = ExprNode {
             expr_type: TConstValue as i32,
@@ -133,7 +133,7 @@ fn create_hash_join_executor(
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let literal100 = ExprNode {
             expr_type: TConstValue as i32,

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -25,7 +25,7 @@ use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{
     ConstantValue as TConstValue, Equal, InputRef, Modulus,
 };
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ExprNode, FunctionCall};
 use utils::{bench_join, create_input};
 
 enable_jemalloc_on_linux!();
@@ -50,7 +50,7 @@ fn create_nested_loop_join_executor(
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
 
         let right_input_ref = ExprNode {
@@ -59,7 +59,7 @@ fn create_nested_loop_join_executor(
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 1 })),
+            rex_node: Some(RexNode::InputRef(1)),
         };
 
         let literal2 = ExprNode {

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -134,7 +134,7 @@ mod tests {
     use risingwave_pb::data::Datum as ProstDatum;
     use risingwave_pb::expr::expr_node::Type::InputRef;
     use risingwave_pb::expr::expr_node::{RexNode, Type};
-    use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+    use risingwave_pb::expr::{ExprNode, FunctionCall};
 
     use crate::executor::test_utils::MockExecutor;
     use crate::executor::{Executor, FilterExecutor};
@@ -230,7 +230,7 @@ mod tests {
                 }],
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let rhs = ExprNode {
             expr_type: Type::ConstantValue as i32,
@@ -323,14 +323,14 @@ mod tests {
         }
     }
 
-    fn make_inputref(idx: i32) -> ExprNode {
+    fn make_inputref(idx: usize) -> ExprNode {
         ExprNode {
             expr_type: InputRef as i32,
             return_type: Some(risingwave_pb::data::DataType {
                 type_name: TypeName::Int32 as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+            rex_node: Some(RexNode::InputRef(idx as _)),
         }
     }
 }

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -272,7 +272,7 @@ mod tests {
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
     use risingwave_pb::expr::agg_call::Type;
-    use risingwave_pb::expr::{AggCall, ColumnRef};
+    use risingwave_pb::expr::{AggCall, InputRef};
 
     use super::*;
     use crate::executor::test_utils::{diff_executor_output, MockExecutor};
@@ -307,7 +307,7 @@ mod tests {
 
         let agg_call = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![ColumnRef {
+            args: vec![InputRef {
                 index: 2,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -271,8 +271,8 @@ mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
-    use risingwave_pb::expr::agg_call::{Arg, Type};
-    use risingwave_pb::expr::{AggCall, InputRefExpr};
+    use risingwave_pb::expr::agg_call::Type;
+    use risingwave_pb::expr::{AggCall, ColumnRef};
 
     use super::*;
     use crate::executor::test_utils::{diff_executor_output, MockExecutor};
@@ -307,8 +307,8 @@ mod tests {
 
         let agg_call = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![Arg {
-                input: Some(InputRefExpr { column_idx: 2 }),
+            args: vec![ColumnRef {
+                index: 2,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
                     ..Default::default()

--- a/src/batch/src/executor/hop_window.rs
+++ b/src/batch/src/executor/hop_window.rs
@@ -55,7 +55,7 @@ impl BoxedExecutorBuilder for HopWindowExecutor {
             source.plan_node().get_node_body().unwrap(),
             NodeBody::HopWindow
         )?;
-        let time_col = hop_window_node.get_time_col()?.column_idx as usize;
+        let time_col = hop_window_node.get_time_col() as usize;
         let window_slide = hop_window_node.get_window_slide()?.into();
         let window_size = hop_window_node.get_window_size()?.into();
         let output_indices = hop_window_node
@@ -403,14 +403,14 @@ mod tests {
         assert_eq!(
             chunk,
             DataChunk::from_pretty(
-                &" I TS        TS        TS        
-                   1 ^09:45:00 ^10:15:00 ^10:00:00 
-                   3 ^09:45:00 ^10:15:00 ^10:05:00 
-                   2 ^09:45:00 ^10:15:00 ^10:14:00 
-                   1 ^10:00:00 ^10:30:00 ^10:22:00 
-                   3 ^10:15:00 ^10:45:00 ^10:33:00 
-                   2 ^10:15:00 ^10:45:00 ^10:42:00 
-                   1 ^10:30:00 ^11:00:00 ^10:51:00 
+                &" I TS        TS        TS
+                   1 ^09:45:00 ^10:15:00 ^10:00:00
+                   3 ^09:45:00 ^10:15:00 ^10:05:00
+                   2 ^09:45:00 ^10:15:00 ^10:14:00
+                   1 ^10:00:00 ^10:30:00 ^10:22:00
+                   3 ^10:15:00 ^10:45:00 ^10:33:00
+                   2 ^10:15:00 ^10:45:00 ^10:42:00
+                   1 ^10:30:00 ^11:00:00 ^10:51:00
                    3 ^10:45:00 ^11:15:00 ^11:02:00"
                     .replace('^', "2022-2-2T"),
             )
@@ -420,7 +420,7 @@ mod tests {
         assert_eq!(
             chunk,
             DataChunk::from_pretty(
-                &"I TS        TS        TS       
+                &"I TS        TS        TS
                   1 ^10:00:00 ^10:30:00 ^10:00:00
                   3 ^10:00:00 ^10:30:00 ^10:05:00
                   2 ^10:00:00 ^10:30:00 ^10:14:00

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -198,10 +198,7 @@ impl BoxedExecutorBuilder for InsertExecutor {
             source.context.get_config().developer.batch_chunk_size,
             source.plan_node().get_identity().clone(),
             column_indices,
-            insert_node
-                .row_id_index
-                .as_ref()
-                .map(|index| index.index as _),
+            insert_node.row_id_index.as_ref().map(|index| *index as _),
             insert_node.returning,
         )))
     }

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -291,10 +291,10 @@ mod tests {
     use risingwave_expr::expr::build_from_prost;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::DataType as ProstDataType;
-    use risingwave_pb::expr::agg_call::{Arg, Type};
+    use risingwave_pb::expr::agg_call::Type;
     use risingwave_pb::expr::expr_node::RexNode;
     use risingwave_pb::expr::expr_node::Type::InputRef;
-    use risingwave_pb::expr::{AggCall, ExprNode, InputRefExpr};
+    use risingwave_pb::expr::{AggCall, ColumnRef, ExprNode};
 
     use super::*;
     use crate::executor::test_utils::MockExecutor;
@@ -447,7 +447,7 @@ mod tests {
                         type_name: TypeName::Int32 as i32,
                         ..Default::default()
                     }),
-                    rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+                    rex_node: Some(RexNode::InputRef(idx as _)),
                 })
             })
             .try_collect()?;
@@ -551,8 +551,8 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![Arg {
-                input: Some(InputRefExpr { column_idx: 0 }),
+            args: vec![ColumnRef {
+                index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
                     ..Default::default()
@@ -636,8 +636,8 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![Arg {
-                input: Some(InputRefExpr { column_idx: 0 }),
+            args: vec![ColumnRef {
+                index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
                     ..Default::default()
@@ -661,7 +661,7 @@ mod tests {
                         type_name: TypeName::Int32 as i32,
                         ..Default::default()
                     }),
-                    rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+                    rex_node: Some(RexNode::InputRef(idx as _)),
                 })
             })
             .try_collect()?;
@@ -760,8 +760,8 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![Arg {
-                input: Some(InputRefExpr { column_idx: 0 }),
+            args: vec![ColumnRef {
+                index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
                     ..Default::default()
@@ -785,7 +785,7 @@ mod tests {
                         type_name: TypeName::Int32 as i32,
                         ..Default::default()
                     }),
-                    rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+                    rex_node: Some(RexNode::InputRef(idx as _)),
                 })
             })
             .try_collect()?;

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -294,7 +294,7 @@ mod tests {
     use risingwave_pb::expr::agg_call::Type;
     use risingwave_pb::expr::expr_node::RexNode;
     use risingwave_pb::expr::expr_node::Type::InputRef;
-    use risingwave_pb::expr::{AggCall, ColumnRef, ExprNode};
+    use risingwave_pb::expr::{AggCall, ExprNode, InputRef as ProstInputRef};
 
     use super::*;
     use crate::executor::test_utils::MockExecutor;
@@ -551,7 +551,7 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![ColumnRef {
+            args: vec![ProstInputRef {
                 index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
@@ -636,7 +636,7 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![ColumnRef {
+            args: vec![ProstInputRef {
                 index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,
@@ -760,7 +760,7 @@ mod tests {
 
         let prost = AggCall {
             r#type: Type::Sum as i32,
-            args: vec![ColumnRef {
+            args: vec![ProstInputRef {
                 index: 0,
                 r#type: Some(ProstDataType {
                     type_name: TypeName::Int32 as i32,

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -125,7 +125,7 @@ async fn test_table_materialize() -> StreamResult<()> {
     let source_builder = create_source_desc_builder(
         &schema,
         pk_column_ids,
-        Some(row_id_index as _),
+        Some(row_id_index),
         source_info,
         properties,
     );

--- a/src/expr/benches/expr.rs
+++ b/src/expr/benches/expr.rs
@@ -178,19 +178,19 @@ fn bench_expr(c: &mut Criterion) {
             .find(|r| r.return_type() == ty)
             .expect("expression not found")
     };
-    const TIMEZONE: i32 = 14;
-    const TIME_FIELD: i32 = 15;
-    const EXTRACT_FIELD_DATE: i32 = 16;
-    const EXTRACT_FIELD_TIME: i32 = 17;
-    const EXTRACT_FIELD_TIMESTAMP: i32 = 16;
-    const EXTRACT_FIELD_TIMESTAMPTZ: i32 = 18;
-    const BOOL_STRING: i32 = 19;
-    const NUMBER_STRING: i32 = 12;
-    const DATE_STRING: i32 = 20;
-    const TIME_STRING: i32 = 21;
-    const TIMESTAMP_STRING: i32 = 22;
-    const TIMESTAMPTZ_STRING: i32 = 23;
-    const INTERVAL_STRING: i32 = 24;
+    const TIMEZONE: usize = 14;
+    const TIME_FIELD: usize = 15;
+    const EXTRACT_FIELD_DATE: usize = 16;
+    const EXTRACT_FIELD_TIME: usize = 17;
+    const EXTRACT_FIELD_TIMESTAMP: usize = 16;
+    const EXTRACT_FIELD_TIMESTAMPTZ: usize = 18;
+    const BOOL_STRING: usize = 19;
+    const NUMBER_STRING: usize = 12;
+    const DATE_STRING: usize = 20;
+    const TIME_STRING: usize = 21;
+    const TIMESTAMP_STRING: usize = 22;
+    const TIMESTAMPTZ_STRING: usize = 23;
+    const INTERVAL_STRING: usize = 24;
 
     c.bench_function("inputref", |bencher| {
         let inputref = inputrefs[0].clone().boxed();
@@ -234,7 +234,7 @@ fn bench_expr(c: &mut Criterion) {
                         DataTypeName::Timestamptz => EXTRACT_FIELD_TIMESTAMPTZ,
                         t => panic!("unexpected type: {t:?}"),
                     },
-                    _ => inputref_for_type((*t).into()).index() as i32,
+                    _ => inputref_for_type((*t).into()).index(),
                 })
                 .collect_vec(),
         );
@@ -297,7 +297,7 @@ fn bench_expr(c: &mut Criterion) {
                         continue;
                     }
                 };
-                InputRefExpression::new(DataType::Varchar, idx as usize).boxed()
+                InputRefExpression::new(DataType::Varchar, idx).boxed()
             } else {
                 inputref_for_type(sig.from_type.into()).clone().boxed()
             },

--- a/src/expr/src/expr/build_expr_from_prost.rs
+++ b/src/expr/src/expr/build_expr_from_prost.rs
@@ -16,7 +16,7 @@ use risingwave_common::try_match_expand;
 use risingwave_common::types::DataType;
 use risingwave_common::util::value_encoding::deserialize_datum;
 use risingwave_pb::expr::expr_node::{RexNode, Type};
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ExprNode, FunctionCall};
 
 use super::expr_array_concat::ArrayConcatExpression;
 use super::expr_binary_bytes::{
@@ -393,12 +393,12 @@ pub fn build_some_all_expr_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         let left_expr_input_ref = ExprNode {
             expr_type: Type::InputRef as i32,
             return_type: Some(left_expr.return_type().to_protobuf()),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 0 })),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let right_expr_input_ref = ExprNode {
             expr_type: Type::InputRef as i32,
             return_type: Some(right_expr_return_type.to_protobuf()),
-            rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: 1 })),
+            rex_node: Some(RexNode::InputRef(1)),
         };
         let mut root_expr_node = ExprNode {
             expr_type: inner_expr_type as i32,

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -129,21 +129,20 @@ mod tests {
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::{DataType as ProstDataType, Datum as ProstDatum};
     use risingwave_pb::expr::expr_node::{RexNode, Type};
-    use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+    use risingwave_pb::expr::{ExprNode, FunctionCall};
 
     use crate::expr::expr_in::InExpression;
     use crate::expr::{Expression, InputRefExpression};
 
     #[test]
     fn test_in_expr() {
-        let input_ref = InputRefExpr { column_idx: 0 };
         let input_ref_expr_node = ExprNode {
             expr_type: Type::InputRef as i32,
             return_type: Some(ProstDataType {
                 type_name: TypeName::Varchar as i32,
                 ..Default::default()
             }),
-            rex_node: Some(RexNode::InputRef(input_ref)),
+            rex_node: Some(RexNode::InputRef(0)),
         };
         let constant_values = vec![
             ExprNode {

--- a/src/expr/src/expr/expr_input_ref.rs
+++ b/src/expr/src/expr/expr_input_ref.rs
@@ -67,10 +67,10 @@ impl<'a> TryFrom<&'a ExprNode> for InputRefExpression {
         ensure!(prost.get_expr_type().unwrap() == Type::InputRef);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
-        if let RexNode::InputRef(input_ref_node) = prost.get_rex_node().unwrap() {
+        if let RexNode::InputRef(input_col_idx) = prost.get_rex_node().unwrap() {
             Ok(Self {
                 return_type: ret_type,
-                idx: input_ref_node.column_idx as usize,
+                idx: *input_col_idx as _,
             })
         } else {
             bail!("Expect an input ref node")

--- a/src/expr/src/expr/test_utils.rs
+++ b/src/expr/src/expr/test_utils.rs
@@ -21,9 +21,9 @@ use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::{DataType as ProstDataType, DataType, Datum as ProstDatum};
 use risingwave_pb::expr::expr_node::Type::{Field, InputRef};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
-use risingwave_pb::expr::{ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{ExprNode, FunctionCall};
 
-pub fn make_expression(kind: Type, rets: &[TypeName], indices: &[i32]) -> ExprNode {
+pub fn make_expression(kind: Type, rets: &[TypeName], indices: &[usize]) -> ExprNode {
     let mut exprs = Vec::new();
     for (idx, ret) in indices.iter().zip_eq_fast(rets.iter()) {
         exprs.push(make_input_ref(*idx, *ret));
@@ -40,14 +40,14 @@ pub fn make_expression(kind: Type, rets: &[TypeName], indices: &[i32]) -> ExprNo
     }
 }
 
-pub fn make_input_ref(idx: i32, ret: TypeName) -> ExprNode {
+pub fn make_input_ref(idx: usize, ret: TypeName) -> ExprNode {
     ExprNode {
         expr_type: InputRef as i32,
         return_type: Some(DataType {
             type_name: ret as i32,
             ..Default::default()
         }),
-        rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+        rex_node: Some(RexNode::InputRef(idx as _)),
     }
 }
 

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -75,7 +75,7 @@ impl AggStateFactory {
             .get_order_by_fields()
             .iter()
             .map(|field| {
-                let col_idx = field.get_input().unwrap().get_column_idx() as usize;
+                let col_idx = field.get_input() as usize;
                 let order_type =
                     OrderType::from_prost(&ProstOrderType::from_i32(field.direction).unwrap());
                 // TODO(yuchao): `nulls first/last` is not supported yet, so it's ignore here,
@@ -87,7 +87,7 @@ impl AggStateFactory {
         let initial_agg_state: BoxedAggState = match (agg_kind, &prost.get_args()[..]) {
             (AggKind::Count, []) => Box::new(CountStar::new(return_type.clone())),
             (AggKind::ApproxCountDistinct, [arg]) => {
-                let input_col_idx = arg.get_input()?.get_column_idx() as usize;
+                let input_col_idx = arg.get_index() as usize;
                 Box::new(ApproxCountDistinct::new(return_type.clone(), input_col_idx))
             }
             (AggKind::StringAgg, [agg_arg, delim_arg]) => {
@@ -99,18 +99,18 @@ impl AggStateFactory {
                     DataType::from(delim_arg.get_type().unwrap()),
                     DataType::Varchar
                 );
-                let agg_col_idx = agg_arg.get_input()?.get_column_idx() as usize;
-                let delim_col_idx = delim_arg.get_input()?.get_column_idx() as usize;
+                let agg_col_idx = agg_arg.get_index() as usize;
+                let delim_col_idx = delim_arg.get_index() as usize;
                 create_string_agg_state(agg_col_idx, delim_col_idx, order_pairs)?
             }
             (AggKind::ArrayAgg, [arg]) => {
-                let agg_col_idx = arg.get_input()?.get_column_idx() as usize;
+                let agg_col_idx = arg.get_index() as usize;
                 create_array_agg_state(return_type.clone(), agg_col_idx, order_pairs)?
             }
             (agg_kind, [arg]) => {
                 // other unary agg call
                 let input_type = DataType::from(arg.get_type()?);
-                let input_col_idx = arg.get_input()?.get_column_idx() as usize;
+                let input_col_idx = arg.get_index() as usize;
                 create_agg_state_unary(
                     input_type,
                     input_col_idx,

--- a/src/frontend/src/catalog/index_catalog.rs
+++ b/src/frontend/src/catalog/index_catalog.rs
@@ -58,8 +58,8 @@ impl IndexCatalog {
             .index_item
             .iter()
             .map(|x| match x.rex_node.as_ref().unwrap() {
-                RexNode::InputRef(input_ref_expr) => InputRef {
-                    index: input_ref_expr.column_idx as usize,
+                RexNode::InputRef(input_col_idx) => InputRef {
+                    index: *input_col_idx as usize,
                     data_type: DataType::from(x.return_type.as_ref().unwrap()),
                 },
                 RexNode::FuncCall(_) => unimplemented!(),

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -50,10 +50,7 @@ impl From<&ProstSource> for SourceCatalog {
             .collect();
         let with_options = WithOptions::new(prost.properties.clone());
         let columns = prost_columns.into_iter().map(ColumnCatalog::from).collect();
-        let row_id_index = prost
-            .row_id_index
-            .clone()
-            .map(|row_id_index| row_id_index.index as _);
+        let row_id_index = prost.row_id_index.map(|idx| idx as _);
 
         let append_only = row_id_index.is_some();
         let owner = prost.owner;

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -22,7 +22,7 @@ use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_pb::catalog::table::{
     OptionalAssociatedSourceId, TableType as ProstTableType, TableVersion as ProstTableVersion,
 };
-use risingwave_pb::catalog::{ColumnIndex as ProstColumnIndex, Table as ProstTable};
+use risingwave_pb::catalog::Table as ProstTable;
 
 use super::{ColumnId, ConflictBehaviorType, DatabaseId, FragmentId, RelationCatalog, SchemaId};
 use crate::optimizer::property::FieldOrder;
@@ -356,12 +356,8 @@ impl TableCatalog {
             owner: self.owner,
             properties: self.properties.inner().clone().into_iter().collect(),
             fragment_id: self.fragment_id,
-            vnode_col_index: self
-                .vnode_col_index
-                .map(|i| ProstColumnIndex { index: i as _ }),
-            row_id_index: self
-                .row_id_index
-                .map(|i| ProstColumnIndex { index: i as _ }),
+            vnode_col_index: self.vnode_col_index.map(|i| i as _),
+            row_id_index: self.row_id_index.map(|i| i as _),
             value_indices: self.value_indices.iter().map(|x| *x as _).collect(),
             definition: self.definition.clone(),
             read_prefix_len_hint: self.read_prefix_len_hint as u32,
@@ -418,8 +414,8 @@ impl From<ProstTable> for TableCatalog {
             owner: tb.owner,
             properties: WithOptions::new(tb.properties),
             fragment_id: tb.fragment_id,
-            vnode_col_index: tb.vnode_col_index.map(|x| x.index as usize),
-            row_id_index: tb.row_id_index.map(|x| x.index as usize),
+            vnode_col_index: tb.vnode_col_index.map(|x| x as usize),
+            row_id_index: tb.row_id_index.map(|x| x as usize),
             value_indices: tb.value_indices.iter().map(|x| *x as _).collect(),
             definition: tb.definition,
             conflict_behavior_type,

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -17,7 +17,7 @@ use std::fmt;
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
-use risingwave_pb::expr::ColumnRef as ProstColumnRef;
+use risingwave_pb::expr::InputRef as ProstInputRef;
 
 use super::Expr;
 use crate::expr::ExprType;
@@ -112,8 +112,8 @@ impl InputRef {
     }
 
     /// Convert to a `ColumnRef` in proto.
-    pub fn to_column_ref_proto(&self) -> ProstColumnRef {
-        ProstColumnRef {
+    pub fn to_input_ref_proto(&self) -> ProstInputRef {
+        ProstInputRef {
             index: self.index as _,
             r#type: Some(self.data_type.to_protobuf()),
         }

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -23,6 +23,7 @@ use super::Expr;
 use crate::expr::ExprType;
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct InputRef {
+    // TODO(rc): remove `pub`, use `new()`, `index()` and `data_type()` instead
     pub index: usize,
     pub data_type: DataType,
 }
@@ -106,13 +107,8 @@ impl InputRef {
         self.index = (self.index as isize + offset) as usize;
     }
 
-    /// Convert to uint32 used in proto.
-    pub fn to_proto(&self) -> u32 {
-        self.index as _
-    }
-
-    /// Convert to a `ColumnRef` in proto.
-    pub fn to_input_ref_proto(&self) -> ProstInputRef {
+    /// Convert to protobuf.
+    pub fn to_proto(&self) -> ProstInputRef {
         ProstInputRef {
             index: self.index as _,
             r#type: Some(self.data_type.to_protobuf()),
@@ -141,7 +137,7 @@ impl Expr for InputRef {
         ExprNode {
             expr_type: ExprType::InputRef.into(),
             return_type: Some(self.return_type().to_protobuf()),
-            rex_node: Some(RexNode::InputRef(self.to_proto())),
+            rex_node: Some(RexNode::InputRef(self.index() as _)),
         }
     }
 }

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -17,8 +17,7 @@ use std::fmt;
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
 use risingwave_common::types::DataType;
-use risingwave_pb::expr::agg_call::Arg as ProstAggCallArg;
-use risingwave_pb::expr::InputRefExpr;
+use risingwave_pb::expr::ColumnRef as ProstColumnRef;
 
 use super::Expr;
 use crate::expr::ExprType;
@@ -107,27 +106,25 @@ impl InputRef {
         self.index = (self.index as isize + offset) as usize;
     }
 
-    /// Convert to [`InputRefExpr`].
-    pub fn to_proto(&self) -> InputRefExpr {
-        InputRefExpr {
-            column_idx: self.index as i32,
-        }
+    /// Convert to uint32 used in proto.
+    pub fn to_proto(&self) -> u32 {
+        self.index as _
     }
 
-    /// Convert [`InputRef`] to an arg of agg call.
-    pub fn to_agg_arg_proto(&self) -> ProstAggCallArg {
-        ProstAggCallArg {
-            input: Some(self.to_proto()),
+    /// Convert to a `ColumnRef` in proto.
+    pub fn to_column_ref_proto(&self) -> ProstColumnRef {
+        ProstColumnRef {
+            index: self.index as _,
             r#type: Some(self.data_type.to_protobuf()),
         }
     }
 
     pub(super) fn from_expr_proto(
-        input_ref: &risingwave_pb::expr::InputRefExpr,
+        column_index: usize,
         ret_type: DataType,
     ) -> risingwave_common::error::Result<Self> {
         Ok(Self {
-            index: input_ref.get_column_idx() as usize,
+            index: column_index,
             data_type: ret_type,
         })
     }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -734,9 +734,10 @@ impl ExprImpl {
         let ret_type = proto.get_return_type()?.into();
         let expr_type = proto.get_expr_type()?;
         Ok(match rex_node {
-            RexNode::InputRef(input_ref) => {
-                Self::InputRef(Box::new(InputRef::from_expr_proto(input_ref, ret_type)?))
-            }
+            RexNode::InputRef(column_index) => Self::InputRef(Box::new(InputRef::from_expr_proto(
+                *column_index as _,
+                ret_type,
+            )?)),
             RexNode::Constant(_) => Self::Literal(Box::new(Literal::from_expr_proto(proto)?)),
             RexNode::Udf(udf) => Self::UserDefinedFunction(Box::new(
                 UserDefinedFunction::from_expr_proto(udf, ret_type)?,

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -34,9 +34,7 @@ use risingwave_connector::source::{
     GOOGLE_PUBSUB_CONNECTOR, KAFKA_CONNECTOR, KINESIS_CONNECTOR, NEXMARK_CONNECTOR,
     PULSAR_CONNECTOR,
 };
-use risingwave_pb::catalog::{
-    ColumnIndex as ProstColumnIndex, Source as ProstSource, StreamSourceInfo, WatermarkDesc,
-};
+use risingwave_pb::catalog::{Source as ProstSource, StreamSourceInfo, WatermarkDesc};
 use risingwave_pb::plan_common::RowFormatType;
 use risingwave_sqlparser::ast::{
     AvroSchema, CreateSourceStatement, DebeziumAvroSchema, ProtobufSchema, SourceSchema,
@@ -622,7 +620,7 @@ pub async fn handle_create_source(
     // TODO(yuhao): allow multiple watermark on source.
     assert!(watermark_descs.len() <= 1);
 
-    let row_id_index = row_id_index.map(|index| ProstColumnIndex { index: index as _ });
+    let row_id_index = row_id_index.map(|index| index as _);
     let pk_column_ids = pk_column_ids.into_iter().map(Into::into).collect();
 
     let columns = columns.into_iter().map(|c| c.to_protobuf()).collect_vec();

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -24,8 +24,7 @@ use risingwave_common::catalog::{
 };
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::catalog::{
-    ColumnIndex as ProstColumnIndex, Source as ProstSource, StreamSourceInfo, Table as ProstTable,
-    WatermarkDesc,
+    Source as ProstSource, StreamSourceInfo, Table as ProstTable, WatermarkDesc,
 };
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_sqlparser::ast::{
@@ -420,7 +419,7 @@ fn gen_table_plan_inner(
         schema_id,
         database_id,
         name: name.clone(),
-        row_id_index: row_id_index.map(|i| ProstColumnIndex { index: i as _ }),
+        row_id_index: row_id_index.map(|i| i as _),
         columns: columns
             .iter()
             .map(|column| column.to_protobuf())

--- a/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
@@ -99,7 +99,7 @@ impl ToDistributedBatch for BatchHopWindow {
 impl ToBatchProst for BatchHopWindow {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::HopWindow(HopWindowNode {
-            time_col: Some(self.logical.core.time_col.to_proto()),
+            time_col: self.logical.core.time_col.to_proto(),
             window_slide: Some(self.logical.core.window_slide.into()),
             window_size: Some(self.logical.core.window_size.into()),
             output_indices: self

--- a/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hop_window.rs
@@ -99,7 +99,7 @@ impl ToDistributedBatch for BatchHopWindow {
 impl ToBatchProst for BatchHopWindow {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::HopWindow(HopWindowNode {
-            time_col: self.logical.core.time_col.to_proto(),
+            time_col: self.logical.core.time_col.index() as _,
             window_slide: Some(self.logical.core.window_slide.into()),
             window_size: Some(self.logical.core.window_size.into()),
             output_indices: self

--- a/src/frontend/src/optimizer/plan_node/batch_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_insert.rs
@@ -17,7 +17,6 @@ use std::fmt;
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::InsertNode;
-use risingwave_pb::catalog::ColumnIndex;
 
 use super::{
     ExprRewritable, LogicalInsert, PlanRef, PlanTreeNodeUnary, ToBatchProst, ToDistributedBatch,
@@ -84,10 +83,7 @@ impl ToBatchProst for BatchInsert {
             table_id: self.logical.table_id().table_id(),
             table_version_id: self.logical.table_version_id(),
             column_indices,
-            row_id_index: self
-                .logical
-                .row_id_index()
-                .map(|index| ColumnIndex { index: index as _ }),
+            row_id_index: self.logical.row_id_index().map(|index| index as _),
             returning: self.logical.has_returning(),
         })
     }

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -519,7 +519,7 @@ impl fmt::Display for PlanAggOrderByFieldDisplay<'_> {
 impl PlanAggOrderByField {
     fn to_protobuf(&self) -> ProstAggOrderByField {
         ProstAggOrderByField {
-            input: Some(self.input.to_proto()),
+            input: self.input.to_proto(),
             direction: self.direction.to_protobuf() as i32,
             nulls_first: self.nulls_first,
         }
@@ -611,7 +611,11 @@ impl PlanAggCall {
         ProstAggCall {
             r#type: self.agg_kind.to_prost().into(),
             return_type: Some(self.return_type.to_protobuf()),
-            args: self.inputs.iter().map(InputRef::to_agg_arg_proto).collect(),
+            args: self
+                .inputs
+                .iter()
+                .map(InputRef::to_column_ref_proto)
+                .collect(),
             distinct: self.distinct,
             order_by_fields: self
                 .order_by_fields

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -520,7 +520,6 @@ impl PlanAggOrderByField {
     fn to_protobuf(&self) -> ProstAggOrderByField {
         ProstAggOrderByField {
             input: Some(self.input.to_proto()),
-            r#type: Some(self.input.data_type.to_protobuf()),
             direction: self.direction.to_protobuf() as i32,
             nulls_first: self.nulls_first,
         }

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -614,7 +614,7 @@ impl PlanAggCall {
             args: self
                 .inputs
                 .iter()
-                .map(InputRef::to_column_ref_proto)
+                .map(InputRef::to_input_ref_proto)
                 .collect(),
             distinct: self.distinct,
             order_by_fields: self

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -519,7 +519,7 @@ impl fmt::Display for PlanAggOrderByFieldDisplay<'_> {
 impl PlanAggOrderByField {
     fn to_protobuf(&self) -> ProstAggOrderByField {
         ProstAggOrderByField {
-            input: self.input.to_proto(),
+            input: self.input.index() as _,
             direction: self.direction.to_protobuf() as i32,
             nulls_first: self.nulls_first,
         }
@@ -611,11 +611,7 @@ impl PlanAggCall {
         ProstAggCall {
             r#type: self.agg_kind.to_prost().into(),
             return_type: Some(self.return_type.to_protobuf()),
-            args: self
-                .inputs
-                .iter()
-                .map(InputRef::to_input_ref_proto)
-                .collect(),
+            args: self.inputs.iter().map(InputRef::to_proto).collect(),
             distinct: self.distinct,
             order_by_fields: self
                 .order_by_fields

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -684,7 +684,7 @@ pub fn to_stream_prost_body(
         Node::HopWindow(me) => {
             let me = &me.core;
             ProstNode::HopWindow(HopWindowNode {
-                time_col: me.time_col.to_proto(),
+                time_col: me.time_col.index() as _,
                 window_slide: Some(me.window_slide.into()),
                 window_size: Some(me.window_size.into()),
                 output_indices: me.output_indices.iter().map(|&x| x as u32).collect(),

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -19,7 +19,6 @@ use risingwave_common::catalog::{ColumnDesc, Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_connector::sink::catalog::desc::SinkDesc;
-use risingwave_pb::catalog::ColumnIndex;
 use risingwave_pb::stream_plan as pb;
 use smallvec::SmallVec;
 
@@ -685,7 +684,7 @@ pub fn to_stream_prost_body(
         Node::HopWindow(me) => {
             let me = &me.core;
             ProstNode::HopWindow(HopWindowNode {
-                time_col: Some(me.time_col.to_proto()),
+                time_col: me.time_col.to_proto(),
                 window_slide: Some(me.window_slide.into()),
                 window_size: Some(me.window_size.into()),
                 output_indices: me.output_indices.iter().map(|&x| x as u32).collect(),
@@ -754,9 +753,7 @@ pub fn to_stream_prost_body(
                         .to_internal_table_prost(),
                 ),
                 info: Some(me.info.clone()),
-                row_id_index: me
-                    .row_id_index
-                    .map(|index| ColumnIndex { index: index as _ }),
+                row_id_index: me.row_id_index.map(|index| index as _),
                 columns: me.columns.iter().map(|c| c.to_protobuf()).collect(),
                 pk_column_ids: me.pk_col_ids.iter().map(Into::into).collect(),
                 properties: me.properties.clone().into_iter().collect(),

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -79,7 +79,7 @@ impl_plan_tree_node_for_unary! {StreamHopWindow}
 impl StreamNode for StreamHopWindow {
     fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> ProstStreamNode {
         ProstStreamNode::HopWindow(HopWindowNode {
-            time_col: self.logical.core.time_col.to_proto(),
+            time_col: self.logical.core.time_col.index() as _,
             window_slide: Some(self.logical.core.window_slide.into()),
             window_size: Some(self.logical.core.window_size.into()),
             output_indices: self

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -79,7 +79,7 @@ impl_plan_tree_node_for_unary! {StreamHopWindow}
 impl StreamNode for StreamHopWindow {
     fn to_stream_prost_body(&self, _state: &mut BuildFragmentGraphState) -> ProstStreamNode {
         ProstStreamNode::HopWindow(HopWindowNode {
-            time_col: Some(self.logical.core.time_col.to_proto()),
+            time_col: self.logical.core.time_col.to_proto(),
             window_slide: Some(self.logical.core.window_slide.into()),
             window_size: Some(self.logical.core.window_size.into()),
             output_indices: self

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -16,7 +16,6 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use risingwave_pb::catalog::ColumnIndex;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 use risingwave_pb::stream_plan::{SourceNode, StreamSource as ProstStreamSource};
 
@@ -93,9 +92,7 @@ impl StreamNode for StreamSource {
                     .to_internal_table_prost(),
             ),
             info: Some(source_catalog.info.clone()),
-            row_id_index: source_catalog
-                .row_id_index
-                .map(|index| ColumnIndex { index: index as _ }),
+            row_id_index: source_catalog.row_id_index.map(|index| index as _),
             columns: source_catalog
                 .columns
                 .iter()

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -25,7 +25,7 @@ use risingwave_pb::data::DataType;
 use risingwave_pb::expr::agg_call::Type;
 use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{Add, GreaterThan, InputRef};
-use risingwave_pb::expr::{AggCall, ColumnRef, ExprNode, FunctionCall};
+use risingwave_pb::expr::{AggCall, ExprNode, FunctionCall, InputRef as ProstInputRef};
 use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, ColumnOrder, Field, OrderType};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -56,7 +56,7 @@ fn make_inputref(idx: u32) -> ExprNode {
 fn make_sum_aggcall(idx: u32) -> AggCall {
     AggCall {
         r#type: Type::Sum as i32,
-        args: vec![ColumnRef {
+        args: vec![ProstInputRef {
             index: idx,
             r#type: Some(DataType {
                 type_name: TypeName::Int64 as i32,

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -22,10 +22,10 @@ use risingwave_pb::catalog::Table as ProstTable;
 use risingwave_pb::common::{ParallelUnit, WorkerNode};
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::DataType;
-use risingwave_pb::expr::agg_call::{Arg, Type};
+use risingwave_pb::expr::agg_call::Type;
 use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::expr::expr_node::Type::{Add, GreaterThan, InputRef};
-use risingwave_pb::expr::{AggCall, ExprNode, FunctionCall, InputRefExpr};
+use risingwave_pb::expr::{AggCall, ColumnRef, ExprNode, FunctionCall};
 use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, ColumnOrder, Field, OrderType};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -42,22 +42,22 @@ use crate::stream::{
 };
 use crate::MetaResult;
 
-fn make_inputref(idx: i32) -> ExprNode {
+fn make_inputref(idx: u32) -> ExprNode {
     ExprNode {
         expr_type: InputRef as i32,
         return_type: Some(DataType {
             type_name: TypeName::Int32 as i32,
             ..Default::default()
         }),
-        rex_node: Some(RexNode::InputRef(InputRefExpr { column_idx: idx })),
+        rex_node: Some(RexNode::InputRef(idx)),
     }
 }
 
-fn make_sum_aggcall(idx: i32) -> AggCall {
+fn make_sum_aggcall(idx: u32) -> AggCall {
     AggCall {
         r#type: Type::Sum as i32,
-        args: vec![Arg {
-            input: Some(InputRefExpr { column_idx: idx }),
+        args: vec![ColumnRef {
+            index: idx,
             r#type: Some(DataType {
                 type_name: TypeName::Int64 as i32,
                 ..Default::default()

--- a/src/storage/hummock_sdk/src/filter_key_extractor.rs
+++ b/src/storage/hummock_sdk/src/filter_key_extractor.rs
@@ -351,7 +351,7 @@ mod tests {
     use risingwave_common::util::ordered::OrderedRowSerde;
     use risingwave_common::util::sort_util::OrderType;
     use risingwave_pb::catalog::table::TableType;
-    use risingwave_pb::catalog::{ColumnIndex, Table as ProstTable};
+    use risingwave_pb::catalog::Table as ProstTable;
     use risingwave_pb::plan_common::{ColumnCatalog as ProstColumnCatalog, ColumnOrder};
     use tokio::task;
 
@@ -459,7 +459,7 @@ mod tests {
             )]),
             fragment_id: 0,
             vnode_col_index: None,
-            row_id_index: Some(ColumnIndex { index: 0 }),
+            row_id_index: Some(0),
             value_indices: vec![0],
             definition: "".into(),
             handle_pk_conflict_behavior: 0,

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -188,14 +188,10 @@ impl<S: StateStore, W: WatermarkBufferStrategy> StateTable<S, W> {
             },
             None => Distribution::fallback(),
         };
-        let vnode_col_idx_in_pk =
-            table_catalog
-                .vnode_col_index
-                .as_ref()
-                .and_then(|vnode_col_idx| {
-                    let vnode_col_idx = vnode_col_idx.index as usize;
-                    pk_indices.iter().position(|&i| vnode_col_idx == i)
-                });
+        let vnode_col_idx_in_pk = table_catalog.vnode_col_index.as_ref().and_then(|idx| {
+            let vnode_col_idx = *idx as usize;
+            pk_indices.iter().position(|&i| vnode_col_idx == i)
+        });
         let input_value_indices = table_catalog
             .value_indices
             .iter()

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -34,7 +34,7 @@ use risingwave_connector::source::SplitImpl;
 use risingwave_expr::expr::BoxedExpression;
 use risingwave_expr::ExprError;
 use risingwave_pb::data::{Datum as ProstDatum, Epoch as ProstEpoch};
-use risingwave_pb::expr::ColumnRef as ProstColumnRef;
+use risingwave_pb::expr::InputRef as ProstInputRef;
 use risingwave_pb::stream_plan::add_mutation::Dispatchers;
 use risingwave_pb::stream_plan::barrier::Mutation as ProstMutation;
 use risingwave_pb::stream_plan::stream_message::StreamMessage;
@@ -615,7 +615,7 @@ impl Watermark {
 
     pub fn to_protobuf(&self) -> ProstWatermark {
         ProstWatermark {
-            column: Some(ProstColumnRef {
+            column: Some(ProstInputRef {
                 index: self.col_idx as _,
                 r#type: Some(self.data_type.to_protobuf()),
             }),

--- a/src/stream/src/from_proto/agg_common.rs
+++ b/src/stream/src/from_proto/agg_common.rs
@@ -51,21 +51,18 @@ pub fn build_agg_call_from_prost(
         ),
         _ => bail!("Too many/few arguments for {:?}", agg_kind),
     };
-    let mut order_pairs = vec![];
-    let mut order_col_types = vec![];
-    agg_call_proto
+    let order_pairs = agg_call_proto
         .get_order_by_fields()
         .iter()
-        .for_each(|field| {
+        .map(|field| {
             let col_idx = field.get_input().unwrap().get_column_idx() as usize;
-            let col_type = DataType::from(field.get_type().unwrap());
             let order_type =
                 OrderType::from_prost(&ProstOrderType::from_i32(field.direction).unwrap());
             // TODO(yuchao): `nulls first/last` is not supported yet, so it's ignore here,
             // see also `risingwave_common::util::sort_util::compare_values`
-            order_pairs.push(OrderPair::new(col_idx, order_type));
-            order_col_types.push(col_type);
-        });
+            OrderPair::new(col_idx, order_type)
+        })
+        .collect();
     let filter = match agg_call_proto.filter {
         Some(ref prost_filter) => Some(Arc::from(build_from_prost(prost_filter)?)),
         None => None,

--- a/src/stream/src/from_proto/hop_window.rs
+++ b/src/stream/src/from_proto/hop_window.rs
@@ -47,7 +47,7 @@ impl ExecutorBuilder for HopWindowExecutorBuilder {
             .map(|&x| x as usize)
             .collect_vec();
 
-        let time_col = node.get_time_col()?.column_idx as usize;
+        let time_col = node.get_time_col() as usize;
         let time_col_data_type = input.schema().fields()[time_col].data_type();
         let output_type = DataType::window_of(&time_col_data_type).unwrap();
         let original_schema: Schema = input

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -52,7 +52,7 @@ impl ExecutorBuilder for SourceExecutorBuilder {
                 source.columns.clone(),
                 params.env.source_metrics(),
                 source.pk_column_ids.clone(),
-                source.row_id_index.clone(),
+                source.row_id_index.map(|x| x as _),
                 source.properties.clone(),
                 source.get_info()?.clone(),
                 params.env.connector_params(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Remove unused `type` field of `AggCall::OrderByField` (will remove this type later)
- Use `optional uint32` to replace `catalog.ColumnIndex` for `row_id_index` and `vnode_col_index` (optional column)
- Use `uint32` for required column index
- Add `ColumnRef` type to replace `AggCall::Arg` and `Watermark::col_idx` + `Watermark::data_type`

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
