### PR TITLE
fix: fix query hang when CN get killed

### DIFF
--- a/e2e_test/batch/basic/lookup_join.slt.part
+++ b/e2e_test/batch/basic/lookup_join.slt.part
@@ -2,9 +2,6 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-set rw_batch_enable_lookup_join to true;
-
-statement ok
 create table t1 (v1 int, v2 int);
 
 statement ok
@@ -270,6 +267,3 @@ drop materialized view mv;
 
 statement ok
 drop table t;
-
-statement ok
-set rw_batch_enable_lookup_join to false;

--- a/src/batch/src/task/task_execution.rs
+++ b/src/batch/src/task/task_execution.rs
@@ -498,7 +498,7 @@ impl<C: BatchTaskContext> BatchTaskExecution<C> {
         // Notify frontend the task status.
         state_tx
             .send(TaskInfoResponse {
-                task_id: Some(TaskId::default().to_prost()),
+                task_id: Some(self.task_id.to_prost()),
                 task_status: task_status.into(),
                 error_message: err_str.unwrap_or("".to_string()),
             })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This's a workaround to fix query hang in frontend found in deterministic recovery test. When CN nodes are killed during query execution, the control flow is not interrupted and there is no event emitted. IIUC, it should be handled by the following code block, but unfortunately not. I'm not sure if this has anything to do with madsim, Cc @wangrunji0408 . Anyways, Let's fix it and revert it if it is a madsim issue.
```
Err(e) => {
                    // rpc error here, we should also notify stage failure
                    error!(
                        "Fetching task status in stage {:?} failed, reason: {:?}",
                        self.stage.id,
                        e.message()
                    );
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

Fix #8361 