### PR TITLE
chore: change storage log level to WARN for playground

### DIFF
--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -128,7 +128,7 @@ fn main() -> Result<()> {
             Box::new(move |_: Vec<String>| {
                 let settings = risingwave_rt::LoggerSettings::new()
                     .enable_tokio_console(false)
-                    .with_target("risingwave_storage", Level::INFO);
+                    .with_target("risingwave_storage", Level::WARN);
                 risingwave_rt::init_risingwave_logger(settings);
 
                 risingwave_rt::main_okk(playground())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
It's still too noisy:

```
2023-03-07T19:32:08.823380Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537836142592 is sealed
2023-03-07T19:32:08.823399Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537836142592 to seal has no data
2023-03-07T19:32:09.822730Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537901678592 is sealed
2023-03-07T19:32:09.822750Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537901678592 to seal has no data
2023-03-07T19:32:10.823186Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537967214592 is sealed
2023-03-07T19:32:10.823204Z  INFO risingwave_storage::hummock::event_handler::uploader: epoch 3996537967214592 to seal has no data
```

Note this is `info_in_release`, and I'm using docker playground

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
