### PR TITLE
test: harder unit tests for `ColumnAwareSerde`

### DIFF
--- a/src/common/src/util/value_encoding/column_aware_row_encoding.rs
+++ b/src/common/src/util/value_encoding/column_aware_row_encoding.rs
@@ -75,13 +75,13 @@ impl RowEncoding {
                 self.flag |= Flag::OFFSET16;
                 usize_offsets
                     .iter()
-                    .for_each(|m| self.offsets.put_u16(*m as u16));
+                    .for_each(|m| self.offsets.put_u16_le(*m as u16));
             }
             _n @ ..=const { u32::MAX as usize } => {
                 self.flag |= Flag::OFFSET32;
                 usize_offsets
                     .iter()
-                    .for_each(|m| self.offsets.put_u32(*m as u32));
+                    .for_each(|m| self.offsets.put_u32_le(*m as u32));
             }
             _ => unreachable!("encoding length exceeds u32"),
         }
@@ -339,5 +339,44 @@ mod tests {
             decoded.unwrap(),
             vec![Some(Int16(5)), Some(Utf8("abc".into()))]
         );
+    }
+    #[test]
+    fn test_row_hard1() {
+        let column_ids = (0..20000).map(ColumnId::new).collect_vec();
+        let row = OwnedRow::new(vec![Some(Int16(233)); 20000]);
+        let data_types = vec![DataType::Int16; 20000];
+        let serde = ColumnAwareSerde::new(&column_ids, Arc::from(data_types.into_boxed_slice()));
+        let encoded_bytes = serde.serialize(row);
+        let decoded_row = serde.deserialize(&encoded_bytes);
+        assert_eq!(decoded_row.unwrap(), vec![Some(Int16(233)); 20000]);
+    }
+    #[test]
+    fn test_row_hard2() {
+        let column_ids = (0..20000).map(ColumnId::new).collect_vec();
+        let mut data = vec![Some(Int16(233)); 5000];
+        data.extend(vec![None; 5000]);
+        data.extend(vec![Some(Utf8("risingwave risingwave".into())); 5000]);
+        data.extend(vec![None; 5000]);
+        let row = OwnedRow::new(data.clone());
+        let mut data_types = vec![DataType::Int16; 10000];
+        data_types.extend(vec![DataType::Varchar; 10000]);
+        let serde = ColumnAwareSerde::new(&column_ids, Arc::from(data_types.into_boxed_slice()));
+        let encoded_bytes = serde.serialize(row);
+        let decoded_row = serde.deserialize(&encoded_bytes);
+        assert_eq!(decoded_row.unwrap(), data);
+    }
+    #[test]
+    fn test_row_hard3() {
+        let column_ids = (0..1000000).map(ColumnId::new).collect_vec();
+        let mut data = vec![Some(Int64(233)); 500000];
+        data.extend(vec![None; 250000]);
+        data.extend(vec![Some(Utf8("risingwave risingwave".into())); 250000]);
+        let row = OwnedRow::new(data.clone());
+        let mut data_types = vec![DataType::Int64; 500000];
+        data_types.extend(vec![DataType::Varchar; 500000]);
+        let serde = ColumnAwareSerde::new(&column_ids, Arc::from(data_types.into_boxed_slice()));
+        let encoded_bytes = serde.serialize(row);
+        let decoded_row = serde.deserialize(&encoded_bytes);
+        assert_eq!(decoded_row.unwrap(), data);
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Add harder tests to cover `u16` and `u32` offsets for `ColumnAwareSerde`.

- Summarize your change (**mandatory**)
Add harder tests to cover `u16` and `u32` offsets for `ColumnAwareSerde`.

- Refer to a related PR or issue link (optional)
#8394 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.