### PR TITLE
feat(sst-dump): Add some useful args for sst dump

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -15,19 +15,23 @@
 use std::collections::HashMap;
 
 use bytes::{Buf, Bytes};
+use chrono::offset::Utc;
+use chrono::DateTime;
+use clap::Args;
 use itertools::Itertools;
 use risingwave_common::row::{Row, RowDeserializer};
 use risingwave_common::types::to_text::ToText;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_frontend::TableCatalog;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::key::FullKey;
-use risingwave_hummock_sdk::HummockSstableId;
 use risingwave_object_store::object::BlockLocation;
+use risingwave_pb::hummock::{Level, SstableInfo};
 use risingwave_rpc_client::MetaClient;
 use risingwave_storage::hummock::value::HummockValue;
 use risingwave_storage::hummock::{
-    Block, BlockHolder, BlockIterator, CompressionAlgorithm, SstableMeta, SstableStore,
+    Block, BlockHolder, BlockIterator, CompressionAlgorithm, Sstable, SstableStore,
 };
 use risingwave_storage::monitor::StoreLocalStatistic;
 
@@ -35,7 +39,28 @@ use crate::CtlContext;
 
 type TableData = HashMap<u32, TableCatalog>;
 
-pub async fn sst_dump(context: &CtlContext) -> anyhow::Result<()> {
+#[derive(Args, Debug)]
+pub struct SstDumpArgs {
+    #[clap(short, long = "sst-id")]
+    sst_id: Option<u64>,
+    #[clap(short, long = "block-id")]
+    block_id: Option<u64>,
+    #[clap(short = 'p', long = "print-entries")]
+    print_entries: bool,
+    #[clap(short = 'l', long = "print-level-info")]
+    print_level: bool,
+}
+
+fn print_level(level: &Level) {
+    println!("Level Type: {}", level.level_type);
+    println!("Level Idx: {}", level.level_idx);
+    if level.level_idx == 0 {
+        println!("L0 Sub-Level Idx: {}", level.sub_level_id);
+    }
+}
+
+pub async fn sst_dump(context: &CtlContext, args: SstDumpArgs) -> anyhow::Result<()> {
+    println!("Start sst dump with args: {:?}", args);
     // Retrieves the Sstable store so we can access the SstableMeta
     let meta_client = context.meta_client().await?;
     let hummock = context.hummock_store().await?;
@@ -43,37 +68,91 @@ pub async fn sst_dump(context: &CtlContext) -> anyhow::Result<()> {
 
     let table_data = load_table_schemas(&meta_client).await?;
     let sstable_store = &*hummock.sstable_store();
+
+    // TODO: We can avoid reading meta if `print_level` is false with the new block format.
     for level in version.get_combined_levels() {
         for sstable_info in &level.table_infos {
-            let id = sstable_info.id;
+            if let Some(sst_id) = &args.sst_id {
+                if *sst_id == sstable_info.id {
+                    if args.print_level {
+                        print_level(level);
+                    }
 
-            let sstable_cache = sstable_store
-                .sstable(sstable_info, &mut StoreLocalStatistic::default())
-                .await?;
-            let sstable = sstable_cache.value().as_ref();
-            let sstable_meta = &sstable.meta;
-
-            println!("SST id: {}", id);
-            println!("-------------------------------------");
-            println!("Level: {}", level.level_type);
-            println!("File Size: {}", sstable_info.file_size);
-
-            if let Some(key_range) = sstable_info.key_range.as_ref() {
-                println!("Key Range:");
-                println!(
-                    "\tleft:\t{:?}\n\tright:\t{:?}\n\t",
-                    key_range.left, key_range.right,
-                );
+                    sst_dump_via_sstable_store(
+                        sstable_store,
+                        sstable_info.id,
+                        sstable_info.meta_offset,
+                        sstable_info.file_size,
+                        &table_data,
+                        &args,
+                    )
+                    .await?;
+                    return Ok(());
+                }
             } else {
-                println!("Key Range: None");
+                if args.print_level {
+                    print_level(level);
+                }
+
+                sst_dump_via_sstable_store(
+                    sstable_store,
+                    sstable_info.id,
+                    sstable_info.meta_offset,
+                    sstable_info.file_size,
+                    &table_data,
+                    &args,
+                )
+                .await?;
             }
+        }
+    }
+    Ok(())
+}
 
-            println!("Estimated Table Size: {}", sstable_meta.estimated_size);
-            println!("Bloom Filter Size: {}", sstable_meta.bloom_filter.len());
-            println!("Key Count: {}", sstable_meta.key_count);
-            println!("Version: {}", sstable_meta.version);
+pub async fn sst_dump_via_sstable_store(
+    sstable_store: &SstableStore,
+    sst_id: u64,
+    meta_offset: u64,
+    file_size: u64,
+    table_data: &TableData,
+    args: &SstDumpArgs,
+) -> anyhow::Result<()> {
+    let sstable_info = SstableInfo {
+        id: sst_id,
+        meta_offset,
+        file_size,
+        ..Default::default()
+    };
+    let sstable_cache = sstable_store
+        .sstable(&sstable_info, &mut StoreLocalStatistic::default())
+        .await?;
+    let sstable = sstable_cache.value().as_ref();
+    let sstable_meta = &sstable.meta;
 
-            print_blocks(id, &table_data, sstable_store, sstable_meta).await?;
+    println!("SST id: {}", sst_id);
+    println!("-------------------------------------");
+    println!("File Size: {}", sstable.estimate_size());
+
+    println!("Key Range:");
+    println!(
+        "\tleft:\t{:?}\n\tright:\t{:?}\n\t",
+        sstable_meta.smallest_key, sstable_meta.largest_key,
+    );
+
+    println!("Estimated Table Size: {}", sstable_meta.estimated_size);
+    println!("Bloom Filter Size: {}", sstable_meta.bloom_filter.len());
+    println!("Key Count: {}", sstable_meta.key_count);
+    println!("Version: {}", sstable_meta.version);
+
+    println!("Blocks:");
+    for i in 0..sstable.block_count() {
+        if let Some(block_id) = &args.block_id {
+            if *block_id == i as u64 {
+                print_block(i, table_data, sstable_store, sstable, args).await?;
+                return Ok(());
+            }
+        } else {
+            print_block(i, table_data, sstable_store, sstable, args).await?;
         }
     }
     Ok(())
@@ -92,38 +171,39 @@ async fn load_table_schemas(meta_client: &MetaClient) -> anyhow::Result<TableDat
     Ok(tables)
 }
 
-/// Prints all blocks of a given SST including all contained KV-pairs.
-async fn print_blocks(
-    id: HummockSstableId,
+/// Prints a block of a given SST including all contained KV-pairs.
+async fn print_block(
+    block_idx: usize,
     table_data: &TableData,
     sstable_store: &SstableStore,
-    sstable_meta: &SstableMeta,
+    sst: &Sstable,
+    args: &SstDumpArgs,
 ) -> anyhow::Result<()> {
-    let data_path = sstable_store.get_sst_data_path(id);
+    println!("\tBlock {}", block_idx);
+    println!("\t-----------");
 
-    println!("Blocks:");
-    for (i, block_meta) in sstable_meta.block_metas.iter().enumerate() {
-        println!("\tBlock {}", i);
-        println!("\t-----------");
+    let block_meta = &sst.meta.block_metas[block_idx];
+    let data_path = sstable_store.get_sst_data_path(sst.id);
 
-        // Retrieve encoded block data in bytes
-        let store = sstable_store.store();
-        let block_loc = BlockLocation {
-            offset: block_meta.offset as usize,
-            size: block_meta.len as usize,
-        };
-        let block_data = store.read(&data_path, Some(block_loc)).await?;
+    // Retrieve encoded block data in bytes
+    let store = sstable_store.store();
+    let block_loc = BlockLocation {
+        offset: block_meta.offset as usize,
+        size: block_meta.len as usize,
+    };
+    let block_data = store.read(&data_path, Some(block_loc)).await?;
 
-        // Retrieve checksum and compression algorithm used from the encoded block data
-        let len = block_data.len();
-        let checksum = (&block_data[len - 8..]).get_u64_le();
-        let compression = CompressionAlgorithm::decode(&mut &block_data[len - 9..len - 8])?;
+    // Retrieve checksum and compression algorithm used from the encoded block data
+    let len = block_data.len();
+    let checksum = (&block_data[len - 8..]).get_u64_le();
+    let compression = CompressionAlgorithm::decode(&mut &block_data[len - 9..len - 8])?;
 
-        println!(
-            "\tOffset: {}, Size: {}, Checksum: {}, Compression Algorithm: {:?}",
-            block_meta.offset, block_meta.len, checksum, compression
-        );
+    println!(
+        "\tOffset: {}, Size: {}, Checksum: {}, Compression Algorithm: {:?}",
+        block_meta.offset, block_meta.len, checksum, compression
+    );
 
+    if args.print_entries {
         print_kv_pairs(
             block_data,
             table_data,
@@ -159,13 +239,18 @@ fn print_kv_pairs(
             HummockValue::Delete => (false, &[] as &[u8]),
         };
 
-        let epoch = full_key.epoch;
+        let epoch = Epoch::from(full_key.epoch);
+        let date_time = DateTime::<Utc>::from(epoch.as_system_time());
 
-        println!("\t\t  full key: {:02x?}", raw_full_key);
-        println!("\t\tfull value: {:02x?}", full_val);
+        println!(
+            "\t\t  full key: {:02x?}, len={}",
+            raw_full_key,
+            raw_full_key.len()
+        );
+        println!("\t\tfull value: {:02x?}, len={}", full_val, full_val.len());
         println!("\t\t  user key: {:02x?}", raw_user_key);
         println!("\t\tuser value: {:02x?}", user_val);
-        println!("\t\t     epoch: {}", epoch);
+        println!("\t\t     epoch: {} ({})", epoch, date_time);
         println!("\t\t      type: {}", if is_put { "Put" } else { "Delete" });
 
         print_table_column(full_key, user_val, table_data, is_put)?;

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -15,6 +15,7 @@
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use cmd_impl::bench::BenchCommands;
+use cmd_impl::hummock::SstDumpArgs;
 
 use crate::cmd_impl::hummock::{
     build_compaction_config_vec, list_pinned_snapshots, list_pinned_versions,
@@ -95,7 +96,7 @@ enum HummockCommands {
         #[clap(short, long = "table-id")]
         table_id: u32,
     },
-    SstDump,
+    SstDump(SstDumpArgs),
     /// trigger a targeted compaction through compaction_group_id
     TriggerManualCompaction {
         #[clap(short, long = "compaction-group-id", default_value_t = 2)]
@@ -229,8 +230,8 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
         Commands::Hummock(HummockCommands::ListKv { epoch, table_id }) => {
             cmd_impl::hummock::list_kv(context, epoch, table_id).await?;
         }
-        Commands::Hummock(HummockCommands::SstDump) => {
-            cmd_impl::hummock::sst_dump(context).await.unwrap()
+        Commands::Hummock(HummockCommands::SstDump(args)) => {
+            cmd_impl::hummock::sst_dump(context, args).await.unwrap()
         }
         Commands::Hummock(HummockCommands::TriggerManualCompaction {
             compaction_group_id,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#8020 
- Support specifying `sst-id` and `block-id`
- Add opts `print-entries` to control whether to print the payload
- Add opts `print-level-info` to contaol whether to print the level info. In the future with #8252, we can avoid talking to meta in sst-dump if `print-level-info==false`.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
