### PR TITLE
feat(common): support from_binary and from_text in ScalarImpl

### DIFF
--- a/src/common/src/types/chrono_wrapper.rs
+++ b/src/common/src/types/chrono_wrapper.rs
@@ -61,6 +61,12 @@ macro_rules! impl_chrono_wrapper {
                 Ok($variant_name(s.parse()?))
             }
         }
+
+        impl From<$chrono> for $variant_name {
+            fn from(data: $chrono) -> Self {
+                $variant_name(data)
+            }
+        }
     };
 }
 

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -634,6 +634,12 @@ impl Zero for Decimal {
     }
 }
 
+impl From<RustDecimal> for Decimal {
+    fn from(d: RustDecimal) -> Self {
+        Self::Normalized(d)
+    }
+}
+
 #[cfg(test)]
 mod tests {
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -19,11 +19,12 @@ use std::sync::Arc;
 use bytes::{Buf, BufMut, Bytes};
 use num_traits::Float;
 use parse_display::{Display, FromStr};
+use postgres_types::FromSql;
 use risingwave_pb::data::DataType as ProstDataType;
 use serde::{Deserialize, Serialize};
 
 use crate::array::{ArrayError, ArrayResult, NULL_VAL_FOR_HASH};
-use crate::error::BoxedError;
+use crate::error::{BoxedError, ErrorCode};
 
 mod native_type;
 mod ops;
@@ -32,7 +33,7 @@ mod successor;
 
 use std::fmt::Debug;
 use std::io::Cursor;
-use std::str::FromStr;
+use std::str::{FromStr, Utf8Error};
 
 pub use native_type::*;
 use risingwave_pb::data::data_type::IntervalType::*;
@@ -749,6 +750,174 @@ impl From<&str> for ScalarImpl {
 impl From<&String> for ScalarImpl {
     fn from(s: &String) -> Self {
         Self::Utf8(s.as_str().into())
+    }
+}
+
+impl ScalarImpl {
+    pub fn from_binary(bytes: &Bytes, data_type: &DataType) -> RwResult<Self> {
+        let res = match data_type {
+            DataType::Varchar => Self::Utf8(
+                String::from_sql(&Type::VARCHAR, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Bytea => Self::Bytea(
+                Vec::<u8>::from_sql(&Type::BYTEA, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Boolean => Self::Bool(
+                bool::from_sql(&Type::BOOL, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?,
+            ),
+            DataType::Int16 => Self::Int16(
+                i16::from_sql(&Type::INT2, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?,
+            ),
+            DataType::Int32 => Self::Int32(
+                i32::from_sql(&Type::INT4, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?,
+            ),
+            DataType::Int64 => Self::Int64(
+                i64::from_sql(&Type::INT8, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?,
+            ),
+            DataType::Float32 => Self::Float32(
+                f32::from_sql(&Type::FLOAT4, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Float64 => Self::Float64(
+                f64::from_sql(&Type::FLOAT8, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Decimal => Self::Decimal(
+                rust_decimal::Decimal::from_sql(&Type::NUMERIC, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Date => Self::NaiveDate(
+                chrono::NaiveDate::from_sql(&Type::DATE, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Time => Self::NaiveTime(
+                chrono::NaiveTime::from_sql(&Type::TIME, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Timestamp => Self::NaiveDateTime(
+                chrono::NaiveDateTime::from_sql(&Type::TIMESTAMP, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .into(),
+            ),
+            DataType::Timestamptz => Self::Int64(
+                chrono::DateTime::<chrono::Utc>::from_sql(&Type::TIMESTAMPTZ, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?
+                    .timestamp_micros(),
+            ),
+            DataType::Interval => Self::Interval(
+                IntervalUnit::from_sql(&Type::INTERVAL, bytes)
+                    .map_err(|err| ErrorCode::InvalidInputSyntax(err.to_string()))?,
+            ),
+            DataType::Jsonb => {
+                Self::Jsonb(JsonbVal::value_deserialize(bytes).ok_or_else(|| {
+                    ErrorCode::InvalidInputSyntax("Invalid value of Jsonb".to_string())
+                })?)
+            }
+            DataType::Struct(_) | DataType::List { .. } => {
+                return Err(ErrorCode::NotSupported(
+                    format!("param type: {}", data_type),
+                    "".to_string(),
+                )
+                .into())
+            }
+        };
+        Ok(res)
+    }
+
+    pub fn cstr_to_str(b: &Bytes) -> Result<&str, Utf8Error> {
+        let without_null = if b.last() == Some(&0) {
+            &b[..b.len() - 1]
+        } else {
+            &b[..]
+        };
+        std::str::from_utf8(without_null)
+    }
+
+    pub fn from_text(bytes: &Bytes, data_type: &DataType) -> RwResult<Self> {
+        let str = Self::cstr_to_str(bytes).map_err(|_| {
+            ErrorCode::InvalidInputSyntax(format!("Invalid param string: {:?}", bytes))
+        })?;
+        let res = match data_type {
+            DataType::Varchar => Self::Utf8(str.to_string().into()),
+            DataType::Boolean => Self::Bool(bool::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Int16 => Self::Int16(i16::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Int32 => Self::Int32(i32::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Int64 => Self::Int64(i64::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Float32 => Self::Float32(
+                f32::from_str(str)
+                    .map_err(|_| {
+                        ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+                    })?
+                    .into(),
+            ),
+            DataType::Float64 => Self::Float64(
+                f64::from_str(str)
+                    .map_err(|_| {
+                        ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+                    })?
+                    .into(),
+            ),
+            DataType::Decimal => Self::Decimal(
+                rust_decimal::Decimal::from_str(str)
+                    .map_err(|_| {
+                        ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+                    })?
+                    .into(),
+            ),
+            DataType::Date => Self::NaiveDate(NaiveDateWrapper::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Time => Self::NaiveTime(NaiveTimeWrapper::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Timestamp => {
+                Self::NaiveDateTime(NaiveDateTimeWrapper::from_str(str).map_err(|_| {
+                    ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+                })?)
+            }
+            DataType::Timestamptz => Self::Int64(
+                chrono::DateTime::<chrono::Utc>::from_str(str)
+                    .map_err(|_| {
+                        ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+                    })?
+                    .timestamp_micros(),
+            ),
+            DataType::Interval => Self::Interval(IntervalUnit::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Jsonb => Self::Jsonb(JsonbVal::from_str(str).map_err(|_| {
+                ErrorCode::InvalidInputSyntax(format!("Invalid param string: {}", str))
+            })?),
+            DataType::Bytea | DataType::Struct(_) | DataType::List { .. } => {
+                return Err(ErrorCode::NotSupported(
+                    format!("param type: {}", data_type),
+                    "".to_string(),
+                )
+                .into())
+            }
+        };
+        Ok(res)
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

support `from_text` and `from_binary` to create ScalarImpl.
These function will be used later to convert a param to a ScalarImpl. #8112

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
