### PR TITLE
refactor(proto): auto derive a Pb-prefixed alias for proto message types

### DIFF
--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -15,9 +15,7 @@
 use std::borrow::Cow;
 
 use itertools::Itertools;
-use risingwave_pb::plan_common::{
-    ColumnCatalog as ProstColumnCatalog, ColumnDesc as ProstColumnDesc,
-};
+use risingwave_pb::plan_common::{PbColumnCatalog, PbColumnDesc};
 
 use super::row_id_column_desc;
 use crate::catalog::{Field, ROW_ID_COLUMN_ID};
@@ -104,8 +102,8 @@ impl ColumnDesc {
     }
 
     /// Convert to proto
-    pub fn to_protobuf(&self) -> ProstColumnDesc {
-        ProstColumnDesc {
+    pub fn to_protobuf(&self) -> PbColumnDesc {
+        PbColumnDesc {
             column_type: Some(self.data_type.to_protobuf()),
             column_id: self.column_id.get_id(),
             name: self.name.clone(),
@@ -199,8 +197,8 @@ impl ColumnDesc {
     }
 }
 
-impl From<ProstColumnDesc> for ColumnDesc {
-    fn from(prost: ProstColumnDesc) -> Self {
+impl From<PbColumnDesc> for ColumnDesc {
+    fn from(prost: PbColumnDesc) -> Self {
         let field_descs: Vec<ColumnDesc> = prost
             .field_descs
             .into_iter()
@@ -216,13 +214,13 @@ impl From<ProstColumnDesc> for ColumnDesc {
     }
 }
 
-impl From<&ProstColumnDesc> for ColumnDesc {
-    fn from(prost: &ProstColumnDesc) -> Self {
+impl From<&PbColumnDesc> for ColumnDesc {
+    fn from(prost: &PbColumnDesc) -> Self {
         prost.clone().into()
     }
 }
 
-impl From<&ColumnDesc> for ProstColumnDesc {
+impl From<&ColumnDesc> for PbColumnDesc {
     fn from(c: &ColumnDesc) -> Self {
         Self {
             column_type: c.data_type.to_protobuf().into(),
@@ -262,8 +260,8 @@ impl ColumnCatalog {
     }
 
     /// Convert column catalog to proto
-    pub fn to_protobuf(&self) -> ProstColumnCatalog {
-        ProstColumnCatalog {
+    pub fn to_protobuf(&self) -> PbColumnCatalog {
+        PbColumnCatalog {
             column_desc: Some(self.column_desc.to_protobuf()),
             is_hidden: self.is_hidden,
         }
@@ -278,8 +276,8 @@ impl ColumnCatalog {
     }
 }
 
-impl From<ProstColumnCatalog> for ColumnCatalog {
-    fn from(prost: ProstColumnCatalog) -> Self {
+impl From<PbColumnCatalog> for ColumnCatalog {
+    fn from(prost: PbColumnCatalog) -> Self {
         Self {
             column_desc: prost.column_desc.unwrap().into(),
             is_hidden: prost.is_hidden,
@@ -329,22 +327,22 @@ pub fn is_column_ids_dedup(columns: &[ColumnCatalog]) -> bool {
 
 #[cfg(test)]
 pub mod tests {
-    use risingwave_pb::plan_common::ColumnDesc as ProstColumnDesc;
+    use risingwave_pb::plan_common::PbColumnDesc;
 
     use crate::catalog::ColumnDesc;
     use crate::test_prelude::*;
     use crate::types::DataType;
 
-    pub fn build_prost_desc() -> ProstColumnDesc {
+    pub fn build_prost_desc() -> PbColumnDesc {
         let city = vec![
-            ProstColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.city.address", 2),
-            ProstColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.city.zipcode", 3),
+            PbColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.city.address", 2),
+            PbColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.city.zipcode", 3),
         ];
         let country = vec![
-            ProstColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.address", 1),
-            ProstColumnDesc::new_struct("country.city", 4, ".test.City", city),
+            PbColumnDesc::new_atomic(DataType::Varchar.to_protobuf(), "country.address", 1),
+            PbColumnDesc::new_struct("country.city", 4, ".test.City", city),
         ];
-        ProstColumnDesc::new_struct("country", 5, ".test.Country", country)
+        PbColumnDesc::new_struct("country", 5, ".test.Country", country)
     }
 
     pub fn build_desc() -> ColumnDesc {

--- a/src/prost/helpers/src/lib.rs
+++ b/src/prost/helpers/src/lib.rs
@@ -57,7 +57,7 @@ fn produce(ast: &DeriveInput) -> TokenStream2 {
     };
 
     // Add a `Pb`-prefixed alias for all types.
-    let use_pb = {
+    let pb_alias = {
         let pb_name = format_ident!("Pb{name}");
         let doc = format!("Alias for [`{name}`].");
         quote! {
@@ -67,7 +67,7 @@ fn produce(ast: &DeriveInput) -> TokenStream2 {
     };
 
     quote! {
-        #use_pb
+        #pb_alias
         #struct_get
     }
 }

--- a/src/prost/helpers/src/lib.rs
+++ b/src/prost/helpers/src/lib.rs
@@ -17,7 +17,7 @@
 use proc_macro::TokenStream;
 use proc_macro2::TokenStream as TokenStream2;
 use proc_macro_error::{proc_macro_error, ResultExt};
-use quote::quote;
+use quote::{format_ident, quote};
 use syn::{DataStruct, DeriveInput};
 
 mod generate;
@@ -44,7 +44,7 @@ fn produce(ast: &DeriveInput) -> TokenStream2 {
     let name = &ast.ident;
 
     // Is it a struct?
-    if let syn::Data::Struct(DataStruct { ref fields, .. }) = ast.data {
+    let struct_get = if let syn::Data::Struct(DataStruct { ref fields, .. }) = ast.data {
         let generated = fields.iter().map(generate::implement);
         quote! {
             impl #name {
@@ -54,5 +54,20 @@ fn produce(ast: &DeriveInput) -> TokenStream2 {
     } else {
         // Do nothing.
         quote! {}
+    };
+
+    // Add a `Pb`-prefixed alias for all types.
+    let use_pb = {
+        let pb_name = format_ident!("Pb{name}");
+        let doc = format!("Alias for [`{name}`].");
+        quote! {
+            #[doc = #doc]
+            pub type #pb_name = #name;
+        }
+    };
+
+    quote! {
+        #use_pb
+        #struct_get
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

...so that we don't need to manually `use Message as ProtoMessage` everywhere and the compiler will help us with auto-completion when we type `Pb`. Thanks @richardchien for the inspiration.

<img width="751" alt="image" src="https://user-images.githubusercontent.com/25862682/223672578-8d7e7794-650c-48b6-aab5-adffe85cb705.png">

An example is shown in `column.rs`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
