### PR TITLE
feat(frontend): support infer param in binder

### DIFF
--- a/src/frontend/src/expr/expr_mutator.rs
+++ b/src/frontend/src/expr/expr_mutator.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::{
-    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Subquery,
+    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Parameter, Subquery,
     TableFunction, UserDefinedFunction, WindowFunction,
 };
 
@@ -30,6 +30,7 @@ pub trait ExprMutator {
             ExprImpl::TableFunction(inner) => self.visit_table_function(inner),
             ExprImpl::WindowFunction(inner) => self.visit_window_function(inner),
             ExprImpl::UserDefinedFunction(inner) => self.visit_user_defined_function(inner),
+            ExprImpl::Parameter(inner) => self.visit_parameter(inner),
         }
     }
     fn visit_function_call(&mut self, func_call: &mut FunctionCall) {
@@ -47,6 +48,7 @@ pub trait ExprMutator {
         agg_call.filter_mut().visit_expr_mut(self);
     }
     fn visit_literal(&mut self, _: &mut Literal) {}
+    fn visit_parameter(&mut self, _: &mut Parameter) {}
     fn visit_input_ref(&mut self, _: &mut InputRef) {}
     fn visit_subquery(&mut self, _: &mut Subquery) {}
     fn visit_correlated_input_ref(&mut self, _: &mut CorrelatedInputRef) {}

--- a/src/frontend/src/expr/expr_rewriter.rs
+++ b/src/frontend/src/expr/expr_rewriter.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::{
-    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Subquery,
+    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Parameter, Subquery,
     TableFunction, UserDefinedFunction, WindowFunction,
 };
 
@@ -32,6 +32,7 @@ pub trait ExprRewriter {
             ExprImpl::TableFunction(inner) => self.rewrite_table_function(*inner),
             ExprImpl::WindowFunction(inner) => self.rewrite_window_function(*inner),
             ExprImpl::UserDefinedFunction(inner) => self.rewrite_user_defined_function(*inner),
+            ExprImpl::Parameter(inner) => self.rewrite_parameter(*inner),
         }
     }
     fn rewrite_function_call(&mut self, func_call: FunctionCall) -> ExprImpl {
@@ -53,6 +54,9 @@ pub trait ExprRewriter {
         AggCall::new(func_type, inputs, distinct, order_by, filter)
             .unwrap()
             .into()
+    }
+    fn rewrite_parameter(&mut self, parameter: Parameter) -> ExprImpl {
+        parameter.into()
     }
     fn rewrite_literal(&mut self, literal: Literal) -> ExprImpl {
         literal.into()

--- a/src/frontend/src/expr/expr_visitor.rs
+++ b/src/frontend/src/expr/expr_visitor.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use super::{
-    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Subquery,
+    AggCall, CorrelatedInputRef, ExprImpl, FunctionCall, InputRef, Literal, Parameter, Subquery,
     TableFunction, UserDefinedFunction, WindowFunction,
 };
 
@@ -42,6 +42,7 @@ pub trait ExprVisitor<R: Default> {
             ExprImpl::TableFunction(inner) => self.visit_table_function(inner),
             ExprImpl::WindowFunction(inner) => self.visit_window_function(inner),
             ExprImpl::UserDefinedFunction(inner) => self.visit_user_defined_function(inner),
+            ExprImpl::Parameter(inner) => self.visit_parameter(inner),
         }
     }
     fn visit_function_call(&mut self, func_call: &FunctionCall) -> R {
@@ -62,6 +63,9 @@ pub trait ExprVisitor<R: Default> {
         r = Self::merge(r, agg_call.order_by().visit_expr(self));
         r = Self::merge(r, agg_call.filter().visit_expr(self));
         r
+    }
+    fn visit_parameter(&mut self, _: &Parameter) -> R {
+        R::default()
     }
     fn visit_literal(&mut self, _: &Literal) -> R {
         R::default()

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -111,10 +111,14 @@ impl FunctionCall {
 
     /// Create a cast expr over `child` to `target` type in `allows` context.
     pub fn new_cast(
-        child: ExprImpl,
+        mut child: ExprImpl,
         target: DataType,
         allows: CastContext,
     ) -> Result<ExprImpl, CastError> {
+        if let ExprImpl::Parameter(expr) = &mut child && !expr.has_infer() {
+            expr.cast_infer_type(target);
+            return Ok(child);
+        }
         if is_row_function(&child) {
             // Row function will have empty fields in Datatype::Struct at this point. Therefore,
             // we will need to take some special care to generate the cast types. For normal struct

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -27,6 +27,7 @@ mod correlated_input_ref;
 mod function_call;
 mod input_ref;
 mod literal;
+mod parameter;
 mod subquery;
 mod table_function;
 mod user_defined_function;
@@ -50,6 +51,7 @@ pub use expr_visitor::ExprVisitor;
 pub use function_call::{is_row_function, FunctionCall, FunctionCallDisplay};
 pub use input_ref::{input_ref_to_column_indices, InputRef, InputRefDisplay};
 pub use literal::Literal;
+pub use parameter::Parameter;
 pub use risingwave_pb::expr::expr_node::Type as ExprType;
 pub use session_timezone::SessionTimezone;
 pub use subquery::{Subquery, SubqueryKind};
@@ -96,7 +98,8 @@ impl_expr_impl!(
     Subquery,
     TableFunction,
     WindowFunction,
-    UserDefinedFunction
+    UserDefinedFunction,
+    Parameter
 );
 
 impl ExprImpl {
@@ -174,6 +177,7 @@ impl ExprImpl {
     /// Check whether self is a literal NULL or literal string.
     pub fn is_unknown(&self) -> bool {
         matches!(self, ExprImpl::Literal(literal) if literal.return_type() == DataType::Varchar)
+            || matches!(self, ExprImpl::Parameter(parameter) if !parameter.has_infer())
     }
 
     /// Shorthand to create cast expr to `target` type in implicit context.
@@ -761,6 +765,7 @@ impl Expr for ExprImpl {
             ExprImpl::TableFunction(expr) => expr.return_type(),
             ExprImpl::WindowFunction(expr) => expr.return_type(),
             ExprImpl::UserDefinedFunction(expr) => expr.return_type(),
+            ExprImpl::Parameter(expr) => expr.return_type(),
         }
     }
 
@@ -779,6 +784,7 @@ impl Expr for ExprImpl {
                 unreachable!("Window function should not be converted to ExprNode")
             }
             ExprImpl::UserDefinedFunction(e) => e.to_expr_proto(),
+            ExprImpl::Parameter(e) => e.to_expr_proto(),
         }
     }
 }
@@ -813,6 +819,7 @@ impl std::fmt::Debug for ExprImpl {
                 Self::UserDefinedFunction(arg0) => {
                     f.debug_tuple("UserDefinedFunction").field(arg0).finish()
                 }
+                Self::Parameter(arg0) => f.debug_tuple("Parameter").field(arg0).finish(),
             };
         }
         match self {
@@ -825,6 +832,7 @@ impl std::fmt::Debug for ExprImpl {
             Self::TableFunction(x) => write!(f, "{:?}", x),
             Self::WindowFunction(x) => write!(f, "{:?}", x),
             Self::UserDefinedFunction(x) => write!(f, "{:?}", x),
+            Self::Parameter(x) => write!(f, "{:?}", x),
         }
     }
 }
@@ -867,6 +875,7 @@ impl std::fmt::Debug for ExprDisplay<'_> {
                 write!(f, "{:?}", x)
             }
             ExprImpl::UserDefinedFunction(x) => write!(f, "{:?}", x),
+            ExprImpl::Parameter(x) => write!(f, "{:?}", x),
         }
     }
 }

--- a/src/frontend/src/expr/parameter.rs
+++ b/src/frontend/src/expr/parameter.rs
@@ -1,0 +1,79 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::{Debug, Formatter};
+use std::hash::{Hash, Hasher};
+
+use risingwave_common::types::DataType;
+
+use super::Expr;
+use crate::binder::ParameterTypes;
+
+#[derive(Clone)]
+pub struct Parameter {
+    pub index: u64,
+    param_types: ParameterTypes,
+}
+
+impl Debug for Parameter {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Parameter(index: {}, type: {:?})",
+            self.index,
+            self.param_types.read_type(self.index)
+        )
+    }
+}
+
+impl PartialEq for Parameter {
+    fn eq(&self, other: &Self) -> bool {
+        self.index == other.index
+    }
+}
+
+impl Eq for Parameter {}
+
+impl Hash for Parameter {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.index.hash(state);
+    }
+}
+
+impl Expr for Parameter {
+    fn return_type(&self) -> DataType {
+        self.param_types
+            .read_type(self.index)
+            .unwrap_or(DataType::Varchar)
+    }
+
+    fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
+        unreachable!("Parameter should not be serialized to ExprNode")
+    }
+}
+
+impl Parameter {
+    pub fn new(index: u64, mut param_types: ParameterTypes) -> Self {
+        param_types.record_new_param(index);
+        Self { index, param_types }
+    }
+
+    pub fn has_infer(&self) -> bool {
+        self.param_types.has_infer(self.index)
+    }
+
+    pub fn cast_infer_type(&mut self, data_type: DataType) {
+        self.param_types.record_infer_type(self.index, data_type);
+    }
+}

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -446,7 +446,8 @@ impl WatermarkAnalyzer {
             ExprImpl::Subquery(_)
             | ExprImpl::AggCall(_)
             | ExprImpl::CorrelatedInputRef(_)
-            | ExprImpl::WindowFunction(_) => unreachable!(),
+            | ExprImpl::WindowFunction(_)
+            | ExprImpl::Parameter(_) => unreachable!(),
             ExprImpl::UserDefinedFunction(_) => WatermarkDerivation::None,
         }
     }

--- a/src/frontend/src/optimizer/plan_expr_rewriter/const_eval_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_expr_rewriter/const_eval_rewriter.rs
@@ -44,6 +44,7 @@ impl ExprRewriter for ConstEvalRewriter {
                 ExprImpl::TableFunction(inner) => self.rewrite_table_function(*inner),
                 ExprImpl::WindowFunction(inner) => self.rewrite_window_function(*inner),
                 ExprImpl::UserDefinedFunction(inner) => self.rewrite_user_defined_function(*inner),
+                ExprImpl::Parameter(_) => unreachable!("Parameter should not appear here. It will be replaced by a literal before this step."),
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

To complete #8112, We need to support infer the parameter and bind the parameter. This PR
- add Parameter expr
- infer param type and collect in param_types in binder 

Summarize the rule of infer the parameter:
1. param type provide by user explicitly
2. param type infer from cast. We will infer the type from the first cast, the latter will be consider as cast.
e.g. `select $1::int,$1::varchar`, $1 will be considered as INT4, the $1::varchar will be consider as cast int to varchar.
3. param as varchar

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
