### PR TITLE
refactor(common): cleanup unused methods on `IntervalUnit`

### DIFF
--- a/src/common/src/array/interval_array.rs
+++ b/src/common/src/array/interval_array.rs
@@ -34,19 +34,16 @@ mod tests {
         }
         let ret_arr = array_builder.finish();
         for v in ret_arr.iter().flatten() {
-            assert_eq!(v.get_years(), 1);
             assert_eq!(v.get_months(), 12);
             assert_eq!(v.get_days(), 0);
         }
         let ret_arr = IntervalArray::from_iter([Some(IntervalUnit::from_ymd(1, 0, 0)), None]);
         let v = ret_arr.value_at(0).unwrap();
-        assert_eq!(v.get_years(), 1);
         assert_eq!(v.get_months(), 12);
         assert_eq!(v.get_days(), 0);
         let v = ret_arr.value_at(1);
         assert_eq!(v, None);
         let v = unsafe { ret_arr.value_at_unchecked(0).unwrap() };
-        assert_eq!(v.get_years(), 1);
         assert_eq!(v.get_months(), 12);
         assert_eq!(v.get_days(), 0);
     }

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -68,10 +68,6 @@ impl IntervalUnit {
         self.months
     }
 
-    pub fn get_years(&self) -> i32 {
-        self.months / 12
-    }
-
     pub fn get_ms(&self) -> i64 {
         self.ms
     }

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -435,6 +435,8 @@ impl IntervalUnit {
     }
 }
 
+/// Wrapper so that `Debug for IntervalUnitDisplay` would use the concise format of `Display for
+/// IntervalUnit`.
 #[derive(Clone, Copy)]
 pub struct IntervalUnitDisplay<'a> {
     pub core: &'a IntervalUnit,
@@ -452,6 +454,8 @@ impl std::fmt::Debug for IntervalUnitDisplay<'_> {
     }
 }
 
+/// Loss of information during the process due to `justify`. Only intended for memcomparable
+/// encoding.
 impl Serialize for IntervalUnit {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -473,6 +477,7 @@ impl<'de> Deserialize<'de> for IntervalUnit {
     }
 }
 
+/// Duplicated logic only used by `HopWindow`. See #8452.
 #[expect(clippy::from_over_into)]
 impl Into<IntervalUnitProto> for IntervalUnit {
     fn into(self) -> IntervalUnitProto {

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -80,7 +80,8 @@ impl IntervalUnit {
     /// If day is positive, complement the ms negative value.
     /// These rules only use in interval comparison.
     pub fn justify_interval(&mut self) {
-        let total_ms = self.total_ms();
+        #[expect(deprecated)]
+        let total_ms = self.as_ms_i64();
         *self = Self {
             months: 0,
             days: (total_ms / DAY_MS) as i32,
@@ -94,8 +95,8 @@ impl IntervalUnit {
         interval
     }
 
-    #[must_use]
-    pub fn from_total_ms(ms: i64) -> Self {
+    #[deprecated]
+    fn from_total_ms(ms: i64) -> Self {
         let mut remaining_ms = ms;
         let months = remaining_ms / MONTH_MS;
         remaining_ms -= months * MONTH_MS;
@@ -106,10 +107,6 @@ impl IntervalUnit {
             days: (days as i32),
             ms: remaining_ms,
         }
-    }
-
-    pub fn total_ms(&self) -> i64 {
-        self.months as i64 * MONTH_MS + self.days as i64 * DAY_MS + self.ms
     }
 
     #[must_use]
@@ -184,10 +181,13 @@ impl IntervalUnit {
             return None;
         }
 
+        #[expect(deprecated)]
         let ms = self.as_ms_i64();
+        #[expect(deprecated)]
         Some(IntervalUnit::from_total_ms((ms as f64 / rhs).round() as i64))
     }
 
+    #[deprecated]
     fn as_ms_i64(&self) -> i64 {
         self.months as i64 * MONTH_MS + self.days as i64 * DAY_MS + self.ms
     }
@@ -200,7 +200,9 @@ impl IntervalUnit {
         let rhs = rhs.try_into().ok()?;
         let rhs = rhs.0;
 
+        #[expect(deprecated)]
         let ms = self.as_ms_i64();
+        #[expect(deprecated)]
         Some(IntervalUnit::from_total_ms((ms as f64 * rhs).round() as i64))
     }
 

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -32,12 +32,10 @@ mod scalar_impl;
 mod successor;
 
 use std::fmt::Debug;
-use std::io::Cursor;
 use std::str::{FromStr, Utf8Error};
 
 pub use native_type::*;
-use risingwave_pb::data::data_type::IntervalType::*;
-use risingwave_pb::data::data_type::{IntervalType, TypeName};
+use risingwave_pb::data::data_type::TypeName;
 pub use scalar_impl::*;
 pub use successor::*;
 pub mod chrono_wrapper;
@@ -68,8 +66,8 @@ use self::to_binary::ToBinary;
 use self::to_text::ToText;
 use crate::array::serial_array::Serial;
 use crate::array::{
-    read_interval_unit, ArrayBuilderImpl, JsonbRef, JsonbVal, ListRef, ListValue,
-    PrimitiveArrayItemType, StructRef, StructValue,
+    ArrayBuilderImpl, JsonbRef, JsonbVal, ListRef, ListValue, PrimitiveArrayItemType, StructRef,
+    StructValue,
 };
 use crate::error::Result as RwResult;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In preparation of #4514, we first cleanup some unused methods to make the update easier.
* `from_protobuf_bytes` and `to_protobuf_owned` no longer used. See #8452 for current implementation in use. There have been 3 versions and we are removing one here, leaving 2 to be consolidated later.
* `get_years` can be confusing and thus removed.
* `total_ms` is same as `as_ms_i64`.
* `as_ms_i64` and `from_total_ms` marked as deprecated. They completely defeat the purpose of defining `IntervalUnit` rather than using `Duration`. Actually fixes to replace them will be done after the ms -> us update.

The whole plan is:
* Cleanups that effectively have no effect.
* Change from ms to us. Minimal visible differences.
* Fix related issues:
  * #8041
  * #8355
  * #8438

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
