### PR TITLE
feat: user configurable memory control policy

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -737,8 +737,11 @@ template:
     # Total available memory for the compute node in bytes
     total-memory-bytes: 8589934592
 
+    # The policy for compute node memory control.
     memory-control-policy: streaming-only
 
+    #  The proportion of streaming memory to all available memory for computing. Only works when
+    # `memory_control_policy` is set to "streaming-batch".
     streaming-memory-proportion: 0.7
 
     # Parallelism of tasks per compute node

--- a/risedev.yml
+++ b/risedev.yml
@@ -737,6 +737,10 @@ template:
     # Total available memory for the compute node in bytes
     total-memory-bytes: 8589934592
 
+    memory-control-policy: streaming-only
+
+    streaming-memory-proportion: 0.7
+
     # Parallelism of tasks per compute node
     parallelism: 4
 

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -93,6 +93,22 @@ pub struct ComputeNodeOpts {
     #[clap(long, env = "RW_PARALLELISM", default_value_t = default_parallelism())]
     pub parallelism: usize,
 
+    /// The policy for compute node memory control. Valid values:
+    /// - streaming-only
+    /// - streaming-batch
+    #[clap(
+        long,
+        env = "RW_MEMORY_CONTROL_POLICY",
+        default_value = "streaming-only"
+    )]
+    pub memory_control_policy: String,
+
+    /// The proportion of streaming memory to all available memory for computing. Only works when
+    /// `memory_control_policy` is "streaming-batch". Ignored otherwise. See
+    /// [`FixedProportionPolicy`] for more details.
+    #[clap(long, env = "RW_STREAMING_MEMORY_PROPORTION", default_value_t = 0.7)]
+    pub streaming_memory_proportion: f64,
+
     #[clap(flatten)]
     override_config: OverrideConfigOpts,
 }

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -104,7 +104,7 @@ pub struct ComputeNodeOpts {
     pub memory_control_policy: String,
 
     /// The proportion of streaming memory to all available memory for computing. Only works when
-    /// `memory_control_policy` is "streaming-batch". Ignored otherwise. See
+    /// `memory_control_policy` is set to "streaming-batch". Ignored otherwise. See
     /// [`FixedProportionPolicy`] for more details.
     #[clap(long, env = "RW_STREAMING_MEMORY_PROPORTION", default_value_t = 0.7)]
     pub streaming_memory_proportion: f64,

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -42,6 +42,8 @@ pub struct ComputeNodeConfig {
     pub connector_rpc_endpoint: String,
 
     pub total_memory_bytes: usize,
+    pub memory_control_policy: String,
+    pub streaming_memory_proportion: f64,
     pub parallelism: usize,
 }
 

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -67,7 +67,7 @@ impl ComputeNodeService {
             .arg("--total-memory-bytes")
             .arg(&config.total_memory_bytes.to_string())
             .arg("--memory-control-policy")
-            .arg(&config.memory_control_policy.to_string())
+            .arg(&config.memory_control_policy)
             .arg("--streaming-memory-proportion")
             .arg(&config.streaming_memory_proportion.to_string());
 

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -65,7 +65,11 @@ impl ComputeNodeService {
             .arg("--parallelism")
             .arg(&config.parallelism.to_string())
             .arg("--total-memory-bytes")
-            .arg(&config.total_memory_bytes.to_string());
+            .arg(&config.total_memory_bytes.to_string())
+            .arg("--memory-control-policy")
+            .arg(&config.memory_control_policy.to_string())
+            .arg("--streaming-memory-proportion")
+            .arg(&config.streaming_memory_proportion.to_string());
 
         let provide_jaeger = config.provide_jaeger.as_ref().unwrap();
         match provide_jaeger.len() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

As title. Make the memory control policy configurable to users. See #8439 for details.

Closes #8439

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- RisingWave cluster configuration changes

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

2 more options for users to specify in `risedev.yml` for compute node configuration: `memory-control-policy` and `streaming-memory-proportion`. Currently, valid values for `memory-control-policy` are "streaming-only" and "streaming-batch". `streaming-memory-proportion` only works when `memory-control-policy` is set to "streaming-batch", and must fall in the range of `(0, 1)`.

</details>
