### PR TITLE
fix(common): only warn on dropping non-empty builder

### DIFF
--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -233,7 +233,10 @@ impl Drop for DataChunkBuilder {
     fn drop(&mut self) {
         // Possible to fail when async task gets cancelled.
         if self.buffered_count != 0 {
-            tracing::warn!("dropping non-empty data chunk builder");
+            tracing::warn!(
+                remaining = self.buffered_count,
+                "dropping non-empty data chunk builder"
+            );
         }
     }
 }

--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -45,8 +45,10 @@ pub struct StreamChunkBuilder {
 
 impl Drop for StreamChunkBuilder {
     fn drop(&mut self) {
-        // Possible to fail in some corner cases but should not in unit tests
-        debug_assert_eq!(self.size, 0, "dropping non-empty stream chunk builder");
+        // Possible to fail when async task gets cancelled.
+        if self.size != 0 {
+            tracing::warn!("dropping non-empty stream chunk builder");
+        }
     }
 }
 

--- a/src/stream/src/common/builder.rs
+++ b/src/stream/src/common/builder.rs
@@ -47,7 +47,10 @@ impl Drop for StreamChunkBuilder {
     fn drop(&mut self) {
         // Possible to fail when async task gets cancelled.
         if self.size != 0 {
-            tracing::warn!("dropping non-empty stream chunk builder");
+            tracing::warn!(
+                remaining = self.size,
+                "dropping non-empty stream chunk builder"
+            );
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Do not panic but only warn about dropping a non-empty builder or iterator. See #8491 for more details.

- Close #8491.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
