### PR TITLE
feat(frontend): support SET SESSION CHARACTERISTICS AS TRANSACTION

### DIFF
--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -18,7 +18,9 @@ use std::task::{Context, Poll};
 
 use futures::stream::{self, BoxStream};
 use futures::{Stream, StreamExt};
-use pgwire::pg_response::StatementType::{ABORT, BEGIN, COMMIT, ROLLBACK, START_TRANSACTION};
+use pgwire::pg_response::StatementType::{
+    ABORT, BEGIN, COMMIT, ROLLBACK, SET_TRANSACTION, START_TRANSACTION,
+};
 use pgwire::pg_response::{PgResponse, RowSetResult};
 use pgwire::pg_server::BoxedError;
 use pgwire::types::{Format, Row};
@@ -408,6 +410,10 @@ pub async fn handle(
         )),
         Statement::Rollback { .. } => Ok(PgResponse::empty_result_with_notice(
             ROLLBACK,
+            "Ignored temporarily. See detail in issue#2541".to_string(),
+        )),
+        Statement::SetTransaction { .. } => Ok(PgResponse::empty_result_with_notice(
+            SET_TRANSACTION,
             "Ignored temporarily. See detail in issue#2541".to_string(),
         )),
         _ => Err(

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -82,6 +82,7 @@ pub enum StatementType {
     BEGIN,
     COMMIT,
     ROLLBACK,
+    SET_TRANSACTION,
 }
 
 impl std::fmt::Display for StatementType {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix https://github.com/risingwavelabs/risingwave/issues/7976

With this PR
```
dev=> SHOW TRANSACTION ISOLATION LEVEL;
 transaction isolation level 
-----------------------------
 READ_COMMITTED
(1 row)

dev=> SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
NOTICE:  Ignored temporarily. See detail in issue#2541
SET_TRANSACTION

```

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

~- [x] My PR **DOES NOT** contain user-facing changes.~

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators
  - Support `SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL <ISOLATION LEVEL>`

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
