### PR TITLE
feat(java-binding): support java binding on stream chunk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6229,6 +6229,7 @@ version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",
+ "itertools",
  "jni",
  "madsim-tokio",
  "prost 0.11.8",

--- a/ci/scripts/java-binding-test.sh
+++ b/ci/scripts/java-binding-test.sh
@@ -53,3 +53,6 @@ cargo make ingest-data-and-run-java-binding
 
 echo "--- Kill cluster"
 cargo make ci-kill
+
+echo "--- run stream chunk java binding"
+cargo make run-java-binding-stream-chunk-demo

--- a/java/com_risingwave_java_binding_Binding.h
+++ b/java/com_risingwave_java_binding_Binding.h
@@ -17,26 +17,26 @@ JNIEXPORT jint JNICALL Java_com_risingwave_java_binding_Binding_vnodeCount
 
 /*
  * Class:     com_risingwave_java_binding_Binding
- * Method:    iteratorNew
+ * Method:    hummockIteratorNew
  * Signature: ([B)J
  */
-JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_iteratorNew
+JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_hummockIteratorNew
   (JNIEnv *, jclass, jbyteArray);
 
 /*
  * Class:     com_risingwave_java_binding_Binding
- * Method:    iteratorNext
+ * Method:    hummockIteratorNext
  * Signature: (J)J
  */
-JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_iteratorNext
+JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_hummockIteratorNext
   (JNIEnv *, jclass, jlong);
 
 /*
  * Class:     com_risingwave_java_binding_Binding
- * Method:    iteratorClose
+ * Method:    hummockIteratorClose
  * Signature: (J)V
  */
-JNIEXPORT void JNICALL Java_com_risingwave_java_binding_Binding_iteratorClose
+JNIEXPORT void JNICALL Java_com_risingwave_java_binding_Binding_hummockIteratorClose
   (JNIEnv *, jclass, jlong);
 
 /*

--- a/java/com_risingwave_java_binding_Binding.h
+++ b/java/com_risingwave_java_binding_Binding.h
@@ -49,6 +49,14 @@ JNIEXPORT jbyteArray JNICALL Java_com_risingwave_java_binding_Binding_rowGetKey
 
 /*
  * Class:     com_risingwave_java_binding_Binding
+ * Method:    rowGetOp
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL Java_com_risingwave_java_binding_Binding_rowGetOp
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_risingwave_java_binding_Binding
  * Method:    rowIsNull
  * Signature: (JI)Z
  */
@@ -117,6 +125,30 @@ JNIEXPORT jstring JNICALL Java_com_risingwave_java_binding_Binding_rowGetStringV
  * Signature: (J)V
  */
 JNIEXPORT void JNICALL Java_com_risingwave_java_binding_Binding_rowClose
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_risingwave_java_binding_Binding
+ * Method:    streamChunkIteratorNew
+ * Signature: ([B)J
+ */
+JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_streamChunkIteratorNew
+  (JNIEnv *, jclass, jbyteArray);
+
+/*
+ * Class:     com_risingwave_java_binding_Binding
+ * Method:    streamChunkIteratorNext
+ * Signature: (J)J
+ */
+JNIEXPORT jlong JNICALL Java_com_risingwave_java_binding_Binding_streamChunkIteratorNext
+  (JNIEnv *, jclass, jlong);
+
+/*
+ * Class:     com_risingwave_java_binding_Binding
+ * Method:    streamChunkIteratorClose
+ * Signature: (J)V
+ */
+JNIEXPORT void JNICALL Java_com_risingwave_java_binding_Binding_streamChunkIteratorClose
   (JNIEnv *, jclass, jlong);
 
 #ifdef __cplusplus

--- a/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/StreamChunkDemo.java
+++ b/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/StreamChunkDemo.java
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.risingwave.java.binding;
 
 import static com.risingwave.java.binding.Utils.validateRow;

--- a/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/StreamChunkDemo.java
+++ b/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/StreamChunkDemo.java
@@ -1,0 +1,29 @@
+package com.risingwave.java.binding;
+
+import static com.risingwave.java.binding.Utils.validateRow;
+
+import java.io.IOException;
+
+public class StreamChunkDemo {
+
+    public static void main(String[] args) throws IOException {
+        byte[] payload = System.in.readAllBytes();
+        try (StreamChunkIterator iter = new StreamChunkIterator(payload)) {
+            int count = 0;
+            while (true) {
+                try (StreamChunkRow row = iter.next()) {
+                    if (row == null) {
+                        break;
+                    }
+                    count += 1;
+                    validateRow(row);
+                }
+            }
+            int expectedCount = 30000;
+            if (count != expectedCount) {
+                throw new RuntimeException(
+                        String.format("row count is %s, should be %s", count, expectedCount));
+            }
+        }
+    }
+}

--- a/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/Utils.java
+++ b/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/Utils.java
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.risingwave.java.binding;
 
 public class Utils {

--- a/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/Utils.java
+++ b/java/java-binding-integration-test/src/main/java/com/risingwave/java/binding/Utils.java
@@ -1,0 +1,42 @@
+package com.risingwave.java.binding;
+
+public class Utils {
+    public static void validateRow(BaseRow row) {
+        // The validation of row data are according to the data generation rule
+        // defined in ${REPO_ROOT}/src/java_binding/gen-demo-insert-data.py
+        short rowIndex = row.getShort(0);
+        if (row.getInt(1) != rowIndex) {
+            throw new RuntimeException(
+                    String.format("invalid int value: %s %s", row.getInt(1), rowIndex));
+        }
+        if (row.getLong(2) != rowIndex) {
+            throw new RuntimeException(
+                    String.format("invalid long value: %s %s", row.getLong(2), rowIndex));
+        }
+        if (row.getFloat(3) != (float) rowIndex) {
+            throw new RuntimeException(
+                    String.format("invalid float value: %s %s", row.getFloat(3), rowIndex));
+        }
+        if (row.getDouble(4) != (double) rowIndex) {
+            throw new RuntimeException(
+                    String.format("invalid double value: %s %s", row.getDouble(4), rowIndex));
+        }
+        if (row.getBoolean(5) != (rowIndex % 3 == 0)) {
+            throw new RuntimeException(
+                    String.format(
+                            "invalid bool value: %s %s", row.getBoolean(5), (rowIndex % 3 == 0)));
+        }
+        if (!row.getString(6).equals(((Short) rowIndex).toString().repeat((rowIndex % 10) + 1))) {
+            throw new RuntimeException(
+                    String.format(
+                            "invalid string value: %s %s",
+                            row.getString(6),
+                            ((Short) rowIndex).toString().repeat((rowIndex % 10) + 1)));
+        }
+        if (row.isNull(7) != (rowIndex % 5 == 0)) {
+            throw new RuntimeException(
+                    String.format(
+                            "invalid isNull value: %s %s", row.isNull(7), (rowIndex % 5 == 0)));
+        }
+    }
+}

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/BaseRow.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/BaseRow.java
@@ -1,0 +1,51 @@
+package com.risingwave.java.binding;
+
+public class BaseRow implements AutoCloseable {
+    protected final long pointer;
+    private boolean isClosed;
+
+    protected BaseRow(long pointer) {
+        this.pointer = pointer;
+        this.isClosed = false;
+    }
+
+    public boolean isNull(int index) {
+        return Binding.rowIsNull(pointer, index);
+    }
+
+    public short getShort(int index) {
+        return Binding.rowGetInt16Value(pointer, index);
+    }
+
+    public int getInt(int index) {
+        return Binding.rowGetInt32Value(pointer, index);
+    }
+
+    public long getLong(int index) {
+        return Binding.rowGetInt64Value(pointer, index);
+    }
+
+    public float getFloat(int index) {
+        return Binding.rowGetFloatValue(pointer, index);
+    }
+
+    public double getDouble(int index) {
+        return Binding.rowGetDoubleValue(pointer, index);
+    }
+
+    public boolean getBoolean(int index) {
+        return Binding.rowGetBooleanValue(pointer, index);
+    }
+
+    public String getString(int index) {
+        return Binding.rowGetStringValue(pointer, index);
+    }
+
+    @Override
+    public void close() {
+        if (!isClosed) {
+            isClosed = true;
+            Binding.rowClose(pointer);
+        }
+    }
+}

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/BaseRow.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/BaseRow.java
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.risingwave.java.binding;
 
 public class BaseRow implements AutoCloseable {

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/Binding.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/Binding.java
@@ -21,16 +21,16 @@ public class Binding {
 
     public static native int vnodeCount();
 
-    // iterator method
+    // hummock iterator method
     // Return a pointer to the iterator
-    static native long iteratorNew(byte[] readPlan);
+    static native long hummockIteratorNew(byte[] readPlan);
 
     // return a pointer to the next row
-    static native long iteratorNext(long pointer);
+    static native long hummockIteratorNext(long pointer);
 
     // Since the underlying rust does not have garbage collection, we will have to manually call
     // close on the iterator to release the iterator instance pointed by the pointer.
-    static native void iteratorClose(long pointer);
+    static native void hummockIteratorClose(long pointer);
 
     // row method
     static native byte[] rowGetKey(long pointer);

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/Binding.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/Binding.java
@@ -35,6 +35,8 @@ public class Binding {
     // row method
     static native byte[] rowGetKey(long pointer);
 
+    static native int rowGetOp(long pointer);
+
     static native boolean rowIsNull(long pointer, int index);
 
     static native short rowGetInt16Value(long pointer, int index);
@@ -54,4 +56,11 @@ public class Binding {
     // Since the underlying rust does not have garbage collection, we will have to manually call
     // close on the row to release the row instance pointed by the pointer.
     static native void rowClose(long pointer);
+
+    // stream chunk iterator method
+    static native long streamChunkIteratorNew(byte[] streamChunkPayload);
+
+    static native long streamChunkIteratorNext(long pointer);
+
+    static native void streamChunkIteratorClose(long pointer);
 }

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/HummockIterator.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/HummockIterator.java
@@ -16,17 +16,17 @@ package com.risingwave.java.binding;
 
 import com.risingwave.proto.JavaBinding.ReadPlan;
 
-public class Iterator implements AutoCloseable {
+public class HummockIterator implements AutoCloseable {
     private final long pointer;
     private boolean isClosed;
 
-    public Iterator(ReadPlan readPlan) {
-        this.pointer = Binding.iteratorNew(readPlan.toByteArray());
+    public HummockIterator(ReadPlan readPlan) {
+        this.pointer = Binding.hummockIteratorNew(readPlan.toByteArray());
         this.isClosed = false;
     }
 
     public KeyedRow next() {
-        long pointer = Binding.iteratorNext(this.pointer);
+        long pointer = Binding.hummockIteratorNext(this.pointer);
         if (pointer == 0) {
             return null;
         }
@@ -37,7 +37,7 @@ public class Iterator implements AutoCloseable {
     public void close() {
         if (!isClosed) {
             isClosed = true;
-            Binding.iteratorClose(pointer);
+            Binding.hummockIteratorClose(pointer);
         }
     }
 }

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/KeyedRow.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/KeyedRow.java
@@ -14,56 +14,12 @@
 
 package com.risingwave.java.binding;
 
-public class KeyedRow implements AutoCloseable {
-    private final long pointer;
-    private boolean isClosed;
-
-    KeyedRow(long pointer) {
-        this.pointer = pointer;
-        this.isClosed = false;
+public class KeyedRow extends BaseRow {
+    public KeyedRow(long pointer) {
+        super(pointer);
     }
 
     public byte[] getKey() {
         return Binding.rowGetKey(pointer);
-    }
-
-    public boolean isNull(int index) {
-        return Binding.rowIsNull(pointer, index);
-    }
-
-    public short getShort(int index) {
-        return Binding.rowGetInt16Value(pointer, index);
-    }
-
-    public int getInt(int index) {
-        return Binding.rowGetInt32Value(pointer, index);
-    }
-
-    public long getLong(int index) {
-        return Binding.rowGetInt64Value(pointer, index);
-    }
-
-    public float getFloat(int index) {
-        return Binding.rowGetFloatValue(pointer, index);
-    }
-
-    public double getDouble(int index) {
-        return Binding.rowGetDoubleValue(pointer, index);
-    }
-
-    public boolean getBoolean(int index) {
-        return Binding.rowGetBooleanValue(pointer, index);
-    }
-
-    public String getString(int index) {
-        return Binding.rowGetStringValue(pointer, index);
-    }
-
-    @Override
-    public void close() {
-        if (!isClosed) {
-            isClosed = true;
-            Binding.rowClose(pointer);
-        }
     }
 }

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkIterator.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkIterator.java
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.risingwave.java.binding;
 
 public class StreamChunkIterator implements AutoCloseable {

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkIterator.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkIterator.java
@@ -1,0 +1,27 @@
+package com.risingwave.java.binding;
+
+public class StreamChunkIterator implements AutoCloseable {
+    private final long pointer;
+    private boolean isClosed;
+
+    public StreamChunkIterator(byte[] streamChunkPayload) {
+        this.pointer = Binding.streamChunkIteratorNew(streamChunkPayload);
+        this.isClosed = false;
+    }
+
+    public StreamChunkRow next() {
+        long pointer = Binding.streamChunkIteratorNext(this.pointer);
+        if (pointer == 0) {
+            return null;
+        }
+        return new StreamChunkRow(pointer);
+    }
+
+    @Override
+    public void close() {
+        if (!isClosed) {
+            isClosed = true;
+            Binding.streamChunkIteratorClose(pointer);
+        }
+    }
+}

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkRow.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkRow.java
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.risingwave.java.binding;
 
 import com.risingwave.proto.Data;

--- a/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkRow.java
+++ b/java/java-binding/src/main/java/com/risingwave/java/binding/StreamChunkRow.java
@@ -1,0 +1,13 @@
+package com.risingwave.java.binding;
+
+import com.risingwave.proto.Data;
+
+public class StreamChunkRow extends BaseRow {
+    public StreamChunkRow(long pointer) {
+        super(pointer);
+    }
+
+    public Data.Op getOp() {
+        return Data.Op.forNumber(Binding.rowGetOp(pointer));
+    }
+}

--- a/src/common/src/row/owned_row.rs
+++ b/src/common/src/row/owned_row.rs
@@ -92,6 +92,61 @@ impl OwnedRow {
     }
 }
 
+impl OwnedRow {
+    pub fn is_null(&self, idx: usize) -> bool {
+        self[idx].is_none()
+    }
+
+    pub fn get_int16(&self, idx: usize) -> i16 {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Int16(num) => *num,
+            _ => unreachable!("type is not int16 at index: {}", idx),
+        }
+    }
+
+    pub fn get_int32(&self, idx: usize) -> i32 {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Int32(num) => *num,
+            _ => unreachable!("type is not int32 at index: {}", idx),
+        }
+    }
+
+    pub fn get_int64(&self, idx: usize) -> i64 {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Int64(num) => *num,
+            _ => unreachable!("type is not int64 at index: {}", idx),
+        }
+    }
+
+    pub fn get_f32(&self, idx: usize) -> f32 {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Float32(num) => num.into_inner(),
+            _ => unreachable!("type is not float32 at index: {}", idx),
+        }
+    }
+
+    pub fn get_f64(&self, idx: usize) -> f64 {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Float64(num) => num.into_inner(),
+            _ => unreachable!("type is not float64 at index: {}", idx),
+        }
+    }
+
+    pub fn get_bool(&self, idx: usize) -> bool {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Bool(num) => *num,
+            _ => unreachable!("type is not boolean at index: {}", idx),
+        }
+    }
+
+    pub fn get_utf8(&self, idx: usize) -> &str {
+        match self[idx].as_ref().unwrap() {
+            ScalarImpl::Utf8(s) => s.as_ref(),
+            _ => unreachable!("type is not utf8 at index: {}", idx),
+        }
+    }
+}
+
 impl EstimateSize for OwnedRow {
     fn estimated_heap_size(&self) -> usize {
         // FIXME(bugen): this is not accurate now as the heap size of some `Scalar` is not counted.

--- a/src/java_binding/Cargo.toml
+++ b/src/java_binding/Cargo.toml
@@ -12,6 +12,7 @@ normal = ["workspace-hack"]
 [dependencies]
 bytes = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
+itertools = "0.10"
 jni = "0.20.0"
 prost = "0.11"
 risingwave_common = { path = "../common" }

--- a/src/java_binding/Cargo.toml
+++ b/src/java_binding/Cargo.toml
@@ -34,3 +34,8 @@ tracing = "0.1"
 
 [lib]
 crate_type = ["cdylib"]
+
+[[bin]]
+name = "data-chunk-payload-generator"
+test = false
+bench = false

--- a/src/java_binding/make-java-binding.toml
+++ b/src/java_binding/make-java-binding.toml
@@ -22,6 +22,7 @@ script = '''
 set -ex
 cd java
 mvn clean install --pl java-binding-integration-test --am -DskipTests=true
+mvn dependency:copy-dependencies --pl java-binding-integration-test
 '''
 
 [tasks.start-java-binding-demo-cluster]
@@ -76,3 +77,24 @@ dependencies = [
     "ingest-data-and-run-java-binding",
     "kill-java-binding-demo-cluster"
 ]
+
+[tasks.run-java-binding-stream-chunk-demo]
+description = "Run the java binding stream chunk demo"
+dependencies = [
+    "build-java-binding-rust",
+    "build-java-binding-java",
+]
+script = '''
+#!/usr/bin/env bash
+set -ex
+
+RISINGWAVE_ROOT=$(git rev-parse --show-toplevel)
+
+cd ${RISINGWAVE_ROOT}/java
+
+(cd ${RISINGWAVE_ROOT} && cargo run --bin data-chunk-payload-generator) | \
+    java -cp "./java-binding-integration-test/target/dependency/*:./java-binding-integration-test/target/classes" \
+     -Djava.library.path=${RISINGWAVE_ROOT}/target/debug  com.risingwave.java.binding.StreamChunkDemo
+
+
+'''

--- a/src/java_binding/run_demo.sh
+++ b/src/java_binding/run_demo.sh
@@ -19,13 +19,8 @@ set -x
 
 cd ${RISINGWAVE_ROOT}/java
 
-mvn exec:exec \
-    -pl java-binding-integration-test \
-    -Dexec.executable=java \
-    -Dexec.args=" \
-        -cp %classpath:java-binding/target*.jar:proto/target/*.jar \
-        -Djava.library.path=${RISINGWAVE_ROOT}/target/debug \
-         com.risingwave.java.binding.Demo"
+java -cp "./java-binding-integration-test/target/dependency/*:./java-binding-integration-test/target/classes" \
+    -Djava.library.path=${RISINGWAVE_ROOT}/target/debug  com.risingwave.java.binding.HummockReadDemo
 
 psql -d dev -h localhost -p 4566 -U root << EOF
 DROP TABLE ${TABLE_NAME};

--- a/src/java_binding/src/bin/data-chunk-payload-generator.rs
+++ b/src/java_binding/src/bin/data-chunk-payload-generator.rs
@@ -1,0 +1,78 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io::Write;
+
+use prost::Message;
+use risingwave_common::array::{Op, StreamChunk};
+use risingwave_common::row::OwnedRow;
+use risingwave_common::types::{DataType, OrderedF32, OrderedF64, ScalarImpl};
+use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
+
+fn build_row(index: usize) -> OwnedRow {
+    let mut row_value = Vec::with_capacity(8);
+    row_value.push(Some(ScalarImpl::Int16(index as i16)));
+    row_value.push(Some(ScalarImpl::Int32(index as i32)));
+    row_value.push(Some(ScalarImpl::Int64(index as i64)));
+    row_value.push(Some(ScalarImpl::Float32(OrderedF32::from(index as f32))));
+    row_value.push(Some(ScalarImpl::Float64(OrderedF64::from(index as f64))));
+    row_value.push(Some(ScalarImpl::Bool(index % 3 == 0)));
+    row_value.push(Some(ScalarImpl::Utf8(
+        format!("{}", index).repeat((index % 10) + 1).into(),
+    )));
+    row_value.push(if index % 5 == 0 {
+        None
+    } else {
+        Some(ScalarImpl::Int64(index as i64))
+    });
+
+    OwnedRow::new(row_value)
+}
+
+fn main() {
+    let row_count = 30000;
+    let data_types = vec![
+        DataType::Int16,
+        DataType::Int32,
+        DataType::Int64,
+        DataType::Float32,
+        DataType::Float64,
+        DataType::Boolean,
+        DataType::Varchar,
+        DataType::Int64,
+    ];
+    let mut ops = Vec::with_capacity(row_count);
+    let mut builder = DataChunkBuilder::new(data_types, row_count * 1024);
+    for i in 0..row_count {
+        assert!(
+            builder.append_one_row(build_row(i)).is_none(),
+            "should not finish"
+        );
+        if i % 2 == 0 {
+            ops.push(Op::Insert);
+        } else {
+            ops.push(Op::Delete);
+        }
+    }
+
+    let data_chunk = builder.consume_all().expect("should not be empty");
+    let stream_chunk = StreamChunk::from_parts(ops, data_chunk);
+    let prost_stream_chunk = stream_chunk.to_protobuf();
+
+    let payload = Message::encode_to_vec(&prost_stream_chunk);
+
+    std::io::stdout()
+        .write_all(&payload)
+        .expect("should success");
+}

--- a/src/java_binding/src/hummock_iterator.rs
+++ b/src/java_binding/src/hummock_iterator.rs
@@ -47,7 +47,7 @@ fn select_all_vnode_stream(
     select_all(streams.into_iter().map(Box::pin))
 }
 
-pub struct Iterator {
+pub struct HummockJavaBindingIterator {
     row_serde: EitherSerde,
     stream: SelectAllIterStream,
 }
@@ -67,7 +67,7 @@ impl KeyedRow {
     }
 }
 
-impl Iterator {
+impl HummockJavaBindingIterator {
     pub async fn new(read_plan: ReadPlan) -> StorageResult<Self> {
         // Note(bugen): should we forward the implementation to the `StorageTable`?
         let object_store = Arc::new(

--- a/src/java_binding/src/iterator.rs
+++ b/src/java_binding/src/iterator.rs
@@ -19,7 +19,7 @@ use futures::TryStreamExt;
 use risingwave_common::catalog::ColumnId;
 use risingwave_common::hash::VirtualNode;
 use risingwave_common::row::OwnedRow;
-use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::types::DataType;
 use risingwave_common::util::select_all;
 use risingwave_common::util::value_encoding::column_aware_row_encoding::ColumnAwareSerde;
 use risingwave_common::util::value_encoding::{
@@ -62,57 +62,8 @@ impl KeyedRow {
         self.key.as_ref()
     }
 
-    pub fn is_null(&self, idx: usize) -> bool {
-        self.row[idx].is_none()
-    }
-
-    pub fn get_int16(&self, idx: usize) -> i16 {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Int16(num) => *num,
-            _ => unreachable!("type is not int16 at index: {}", idx),
-        }
-    }
-
-    pub fn get_int32(&self, idx: usize) -> i32 {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Int32(num) => *num,
-            _ => unreachable!("type is not int32 at index: {}", idx),
-        }
-    }
-
-    pub fn get_int64(&self, idx: usize) -> i64 {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Int64(num) => *num,
-            _ => unreachable!("type is not int64 at index: {}", idx),
-        }
-    }
-
-    pub fn get_f32(&self, idx: usize) -> f32 {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Float32(num) => num.into_inner(),
-            _ => unreachable!("type is not float32 at index: {}", idx),
-        }
-    }
-
-    pub fn get_f64(&self, idx: usize) -> f64 {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Float64(num) => num.into_inner(),
-            _ => unreachable!("type is not float64 at index: {}", idx),
-        }
-    }
-
-    pub fn get_bool(&self, idx: usize) -> bool {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Bool(num) => *num,
-            _ => unreachable!("type is not boolean at index: {}", idx),
-        }
-    }
-
-    pub fn get_utf8(&self, idx: usize) -> &str {
-        match self.row[idx].as_ref().unwrap() {
-            ScalarImpl::Utf8(s) => s.as_ref(),
-            _ => unreachable!("type is not utf8 at index: {}", idx),
-        }
+    pub fn row(&self) -> &OwnedRow {
+        &self.row
     }
 }
 

--- a/src/java_binding/src/lib.rs
+++ b/src/java_binding/src/lib.rs
@@ -261,7 +261,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_vnodeCount(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNew<'a>(
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_hummockIteratorNew<'a>(
     env: EnvParam<'a>,
     read_plan: JByteArray<'a>,
 ) -> Pointer<'static, Iterator> {
@@ -273,7 +273,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNew<'a>(
 }
 
 #[no_mangle]
-pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNext<'a>(
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_hummockIteratorNext<'a>(
     env: EnvParam<'a>,
     mut pointer: Pointer<'a, Iterator>,
 ) -> Pointer<'static, JavaBindingRow> {
@@ -286,7 +286,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNext<'a>
 }
 
 #[no_mangle]
-pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorClose(
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_hummockIteratorClose(
     _env: EnvParam<'_>,
     pointer: Pointer<'_, Iterator>,
 ) {

--- a/src/java_binding/src/lib.rs
+++ b/src/java_binding/src/lib.rs
@@ -18,6 +18,7 @@
 #![feature(type_alias_impl_trait)]
 
 mod iterator;
+mod stream_chunk_iterator;
 
 use std::backtrace::Backtrace;
 use std::marker::PhantomData;
@@ -31,10 +32,14 @@ use jni::objects::{AutoArray, JClass, JObject, JString, ReleaseMode};
 use jni::sys::{jboolean, jbyte, jbyteArray, jdouble, jfloat, jint, jlong, jshort};
 use jni::JNIEnv;
 use prost::{DecodeError, Message};
+use risingwave_common::array::{ArrayError, StreamChunk};
 use risingwave_common::hash::VirtualNode;
+use risingwave_common::row::OwnedRow;
 use risingwave_storage::error::StorageError;
 use thiserror::Error;
 use tokio::runtime::Runtime;
+
+use crate::stream_chunk_iterator::{StreamChunkIterator, StreamChunkRow};
 
 static RUNTIME: LazyLock<Runtime> = LazyLock::new(|| tokio::runtime::Runtime::new().unwrap());
 
@@ -58,6 +63,13 @@ enum BindingError {
     Decode {
         #[from]
         error: DecodeError,
+        backtrace: Backtrace,
+    },
+
+    #[error("StreamChunkArrayError {error}")]
+    StreamChunkArray {
+        #[from]
+        error: ArrayError,
         backtrace: Backtrace,
     },
 }
@@ -209,6 +221,38 @@ where
     }
 }
 
+pub enum JavaBindingRow {
+    Keyed(KeyedRow),
+    StreamChunk(StreamChunkRow),
+}
+
+impl JavaBindingRow {
+    fn as_keyed(&self) -> &KeyedRow {
+        match &self {
+            JavaBindingRow::Keyed(r) => r,
+            _ => unreachable!("can only call as_keyed for KeyedRow"),
+        }
+    }
+
+    fn as_stream_chunk(&self) -> &StreamChunkRow {
+        match &self {
+            JavaBindingRow::StreamChunk(r) => r,
+            _ => unreachable!("can only call as_stream_chunk for StreamChunkRow"),
+        }
+    }
+}
+
+impl Deref for JavaBindingRow {
+    type Target = OwnedRow;
+
+    fn deref(&self) -> &Self::Target {
+        match &self {
+            JavaBindingRow::Keyed(r) => r.row(),
+            JavaBindingRow::StreamChunk(r) => r.row(),
+        }
+    }
+}
+
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_vnodeCount(
     _env: EnvParam<'_>,
@@ -232,11 +276,11 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNew<'a>(
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorNext<'a>(
     env: EnvParam<'a>,
     mut pointer: Pointer<'a, Iterator>,
-) -> Pointer<'static, KeyedRow> {
+) -> Pointer<'static, JavaBindingRow> {
     execute_and_catch(env, move || {
         match RUNTIME.block_on(pointer.as_mut().next())? {
             None => Ok(Pointer::null()),
-            Some(row) => Ok(row.into()),
+            Some(row) => Ok(JavaBindingRow::Keyed(row).into()),
         }
     })
 }
@@ -250,21 +294,63 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_iteratorClose(
 }
 
 #[no_mangle]
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_streamChunkIteratorNew<'a>(
+    env: EnvParam<'a>,
+    stream_chunk_payload: JByteArray<'a>,
+) -> Pointer<'static, StreamChunkIterator> {
+    execute_and_catch(env, move || {
+        let prost_stream_chumk =
+            Message::decode(stream_chunk_payload.to_guarded_slice(*env)?.deref())?;
+        let iter = StreamChunkIterator::new(StreamChunk::from_protobuf(&prost_stream_chumk)?);
+        Ok(iter.into())
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_streamChunkIteratorNext<'a>(
+    env: EnvParam<'a>,
+    mut pointer: Pointer<'a, StreamChunkIterator>,
+) -> Pointer<'static, JavaBindingRow> {
+    execute_and_catch(env, move || match pointer.as_mut().next() {
+        None => Ok(Pointer::null()),
+        Some(row) => Ok(JavaBindingRow::StreamChunk(row).into()),
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_streamChunkIteratorClose(
+    _env: EnvParam<'_>,
+    pointer: Pointer<'_, StreamChunkIterator>,
+) {
+    pointer.drop();
+}
+
+#[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetKey<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
 ) -> JByteArray<'a> {
     execute_and_catch(env, move || {
-        Ok(JByteArray::from(
-            env.byte_array_from_slice(pointer.as_ref().key())?,
-        ))
+        Ok(JByteArray::from(env.byte_array_from_slice(
+            pointer.as_ref().as_keyed().key(),
+        )?))
+    })
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetOp<'a>(
+    env: EnvParam<'a>,
+    pointer: Pointer<'a, JavaBindingRow>,
+) -> jint {
+    execute_and_catch(env, move || {
+        Ok(pointer.as_ref().as_stream_chunk().op() as jint)
     })
 }
 
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowIsNull<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jboolean {
     execute_and_catch(env, move || {
@@ -275,7 +361,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowIsNull<'a>(
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt16Value<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jshort {
     execute_and_catch(env, move || Ok(pointer.as_ref().get_int16(idx as usize)))
@@ -284,7 +370,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt16Value
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt32Value<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jint {
     execute_and_catch(env, move || Ok(pointer.as_ref().get_int32(idx as usize)))
@@ -293,7 +379,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt32Value
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt64Value<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jlong {
     execute_and_catch(env, move || Ok(pointer.as_ref().get_int64(idx as usize)))
@@ -302,7 +388,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetInt64Value
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetFloatValue<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jfloat {
     execute_and_catch(env, move || Ok(pointer.as_ref().get_f32(idx as usize)))
@@ -311,7 +397,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetFloatValue
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetDoubleValue<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jdouble {
     execute_and_catch(env, move || Ok(pointer.as_ref().get_f64(idx as usize)))
@@ -320,7 +406,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetDoubleValu
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetBooleanValue<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> jboolean {
     execute_and_catch(env, move || {
@@ -331,7 +417,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetBooleanVal
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetStringValue<'a>(
     env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
     idx: jint,
 ) -> JString<'a> {
     execute_and_catch(env, move || {
@@ -342,7 +428,7 @@ pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowGetStringValu
 #[no_mangle]
 pub extern "system" fn Java_com_risingwave_java_binding_Binding_rowClose<'a>(
     _env: EnvParam<'a>,
-    pointer: Pointer<'a, KeyedRow>,
+    pointer: Pointer<'a, JavaBindingRow>,
 ) {
     pointer.drop()
 }

--- a/src/java_binding/src/stream_chunk_iterator.rs
+++ b/src/java_binding/src/stream_chunk_iterator.rs
@@ -1,0 +1,58 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+use risingwave_common::array::StreamChunk;
+use risingwave_common::row::{OwnedRow, Row};
+use risingwave_pb::data::Op;
+
+pub struct StreamChunkRow {
+    op: Op,
+    row: OwnedRow,
+}
+
+impl StreamChunkRow {
+    pub fn op(&self) -> Op {
+        self.op
+    }
+
+    pub fn row(&self) -> &OwnedRow {
+        &self.row
+    }
+}
+
+type StreamChunkRowIterator = impl Iterator<Item = StreamChunkRow> + 'static;
+
+pub struct StreamChunkIterator {
+    iter: StreamChunkRowIterator,
+}
+
+impl StreamChunkIterator {
+    pub(crate) fn new(stream_chunk: StreamChunk) -> Self {
+        Self {
+            iter: stream_chunk
+                .rows()
+                .map(|(op, row_ref)| StreamChunkRow {
+                    op: op.to_protobuf(),
+                    row: row_ref.to_owned_row(),
+                })
+                .collect_vec()
+                .into_iter(),
+        }
+    }
+
+    pub(crate) fn next(&mut self) -> Option<StreamChunkRow> {
+        self.iter.next()
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In this PR, we add java binding support to read rust `StreamChunk` from java. We can now access rust `StreamChunk` via `StreamChunkIterator.java`.

Besides, the PR involves the following changes.
- Introduce `StreamChunkRow` in rust, and combine `StreamChunkRow` and `KeyedRow` into an enum as the return type for all row types returned to java so that the `StreamChunkRow` and `KeyedRow` can share the same java binding method to access row. `BaseRow.java` is introduced to support the `get<Type>` method for `StreamChunkRow` to share row acess method with `KeyedRow`.
- Rename the previous `Iterator.java` to `HummockIterator.java` to make the name less general.
- Add demo ci for stream chunk iterator. To run the demo, run `cargo make run-java-binding-stream-chunk-demo`.
- Avoid using `mvn exec` to run the demos.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
