### PR TITLE
fix(optimizer): ban scalar subquery for project set

### DIFF
--- a/src/frontend/planner_test/tests/testdata/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery.yaml
@@ -353,3 +353,6 @@
     Not supported: streaming nested-loop join
     HINT: The non-equal join in the query requires a nested-loop join executor, which could be very expensive to run. Consider rewriting the query to use dynamic filter as a substitute if possible.
     See also: https://github.com/risingwavelabs/rfcs/blob/main/rfcs/0033-dynamic-filter.md
+- sql: |
+    SELECT 1, (SELECT regexp_matches('barbeque barbeque', '(bar)(beque)', 'g'))
+  batch_error: 'internal error: Scalar subquery might produce more than one row.'

--- a/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
@@ -16,8 +16,8 @@ use std::collections::HashSet;
 
 use crate::optimizer::plan_node::{
     LogicalAgg, LogicalApply, LogicalExpand, LogicalFilter, LogicalHopWindow, LogicalLimit,
-    LogicalNow, LogicalProject, LogicalProjectSet, LogicalTopN, LogicalUnion, LogicalValues,
-    PlanTreeNodeBinary, PlanTreeNodeUnary,
+    LogicalNow, LogicalProject, LogicalProjectSet, LogicalScan, LogicalTopN, LogicalUnion,
+    LogicalValues, PlanTreeNodeBinary, PlanTreeNodeUnary,
 };
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::optimizer::PlanTreeNode;
@@ -77,8 +77,12 @@ impl PlanVisitor<bool> for MaxOneRowVisitor {
         plan.column_subsets().len() == 1 && self.visit(plan.input())
     }
 
-    fn visit_logical_project_set(&mut self, plan: &LogicalProjectSet) -> bool {
-        plan.select_list().len() == 1 && self.visit(plan.input())
+    fn visit_logical_project_set(&mut self, _plan: &LogicalProjectSet) -> bool {
+        false
+    }
+
+    fn visit_logical_scan(&mut self, _plan: &LogicalScan) -> bool {
+        false
     }
 
     fn visit_logical_hop_window(&mut self, _plan: &LogicalHopWindow) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- As titled.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

#8518 