### PR TITLE
fix(ci): run entire snapshot in `main`, `pr` and `main-cron` workflows

### DIFF
--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -19,7 +19,7 @@ popd
 echo "--- Extract data for SqlSmith"
 pushd ./src/tests/sqlsmith/tests
 git clone https://"$GITHUB_TOKEN"@github.com/risingwavelabs/sqlsmith-query-snapshots.git
-git checkout stage
+pushd sqlsmith-query-snapshots && git checkout stage && popd
 popd
 
 export RUST_LOG=info

--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -19,7 +19,6 @@ popd
 echo "--- Extract data for SqlSmith"
 pushd ./src/tests/sqlsmith/tests
 git clone https://"$GITHUB_TOKEN"@github.com/risingwavelabs/sqlsmith-query-snapshots.git
-pushd sqlsmith-query-snapshots && git checkout stage && popd
 popd
 
 export RUST_LOG=info

--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -45,4 +45,4 @@ echo "--- deterministic simulation e2e, ci-3cn-2fe, parallel, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation -j 16 ./e2e_test/batch/\*\*/\*.slt 2> $LOGDIR/parallel-batch-{}.log && rm $LOGDIR/parallel-batch-{}.log'
 
 echo "--- deterministic simulation e2e, ci-3cn-2fe, fuzzing (pre-generated-queries)"
-seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation  --run-sqlsmith-queries ./src/tests/sqlsmith/tests/sqlsmith-query-snapshots/{} 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'
+seq 100 | parallel MADSIM_TEST_SEED={} './risingwave_simulation  --run-sqlsmith-queries ./src/tests/sqlsmith/tests/sqlsmith-query-snapshots/{} 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'

--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -19,6 +19,7 @@ popd
 echo "--- Extract data for SqlSmith"
 pushd ./src/tests/sqlsmith/tests
 git clone https://"$GITHUB_TOKEN"@github.com/risingwavelabs/sqlsmith-query-snapshots.git
+git checkout stage
 popd
 
 export RUST_LOG=info

--- a/ci/scripts/deterministic-e2e-test.sh
+++ b/ci/scripts/deterministic-e2e-test.sh
@@ -46,4 +46,4 @@ echo "--- deterministic simulation e2e, ci-3cn-2fe, parallel, batch"
 seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation -j 16 ./e2e_test/batch/\*\*/\*.slt 2> $LOGDIR/parallel-batch-{}.log && rm $LOGDIR/parallel-batch-{}.log'
 
 echo "--- deterministic simulation e2e, ci-3cn-2fe, fuzzing (pre-generated-queries)"
-seq 100 | parallel MADSIM_TEST_SEED={} './risingwave_simulation  --run-sqlsmith-queries ./src/tests/sqlsmith/tests/sqlsmith-query-snapshots/{} 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'
+seq 64 | parallel MADSIM_TEST_SEED={} './risingwave_simulation  --run-sqlsmith-queries ./src/tests/sqlsmith/tests/sqlsmith-query-snapshots/{} 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -228,6 +228,7 @@ steps:
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
     retry: *auto-retry
+    soft_fail: true
 
   - label: "check"
     command: "ci/scripts/check.sh"

--- a/src/tests/sqlsmith/scripts/gen_queries.sh
+++ b/src/tests/sqlsmith/scripts/gen_queries.sh
@@ -142,13 +142,25 @@ check_failed_to_generate_queries() {
   fi
 }
 
+# sync step
+# Some queries maybe be added
+sync_queries() {
+  set +x
+  pushd $OUTDIR
+  git checkout main
+  git pull
+  set +e
+  git branch -D stage
+  set -e
+  git checkout -b stage
+  popd
+  set -x
+}
+
 # Upload step
 upload_queries() {
   set +x
   pushd "$OUTDIR"
-  git checkout main
-  git pull
-  git checkout -b stage
   git add .
   git commit -m 'update queries'
   git push -f origin stage
@@ -211,6 +223,11 @@ validate() {
   echo_err "[INFO] Passed checks"
 }
 
+sync() {
+  sync_queries
+  echo_err "[INFO] Synced"
+}
+
 upload() {
   upload_queries
   echo_err "[INFO] Uploaded"
@@ -225,6 +242,7 @@ main() {
   setup
 
   build
+  sync
   generate
   validate
   upload

--- a/src/tests/sqlsmith/scripts/gen_queries.sh
+++ b/src/tests/sqlsmith/scripts/gen_queries.sh
@@ -146,6 +146,8 @@ check_failed_to_generate_queries() {
 upload_queries() {
   set +x
   pushd "$OUTDIR"
+  git checkout main
+  git pull
   git checkout -b stage
   git add .
   git commit -m 'update queries'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Fuzz testing for sqlsmith is still useful, can see if we caused something severe. But don't want it to block PR.
- Use `soft_fail` instead, so we can still merge even if fuzz testing fails.
- Ensure snapshot for `main`, `pr` and `main-cron` is run entirely, to avoid discrepancies.

## Checklist For Contributors

- [ ] Merge `staged` changes into `main`.
- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
