### PR TITLE
refactor(streaming): only scan necessary columns in backfill

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -391,6 +391,8 @@ message ChainNode {
   repeated plan_common.Field upstream_fields = 2;
   // Which columns from upstream are used in this Chain node.
   repeated uint32 upstream_column_indices = 3;
+  // TODO
+  repeated int32 upstream_column_ids = 8;
   // Generally, the barrier needs to be rearranged during the MV creation process, so that data can
   // be flushed to shared buffer periodically, instead of making the first epoch from batch query extra
   // large. However, in some cases, e.g., shared state, the barrier cannot be rearranged in ChainNode.

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -389,9 +389,11 @@ message ChainNode {
   uint32 table_id = 1;
   // The schema of input stream, which will be used to build a MergeNode
   repeated plan_common.Field upstream_fields = 2;
-  // Which columns from upstream are used in this Chain node.
+  // The columns from the upstream table to output.
+  // TODO: rename this field.
   repeated uint32 upstream_column_indices = 3;
-  // TODO
+  // The columns from the upstream table that'll be internally required by this chain node.
+  // TODO: This is currently only used by backfill table scan. We should also apply it to the upstream dispatcher (#4529).
   repeated int32 upstream_column_ids = 8;
   // Generally, the barrier needs to be rearranged during the MV creation process, so that data can
   // be flushed to shared buffer periodically, instead of making the first epoch from batch query extra

--- a/src/common/src/catalog/column.rs
+++ b/src/common/src/catalog/column.rs
@@ -62,6 +62,11 @@ impl From<i32> for ColumnId {
         Self::new(column_id)
     }
 }
+impl From<&i32> for ColumnId {
+    fn from(column_id: &i32) -> Self {
+        Self::new(*column_id)
+    }
+}
 
 impl From<ColumnId> for i32 {
     fn from(id: ColumnId) -> i32 {

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -201,6 +201,18 @@ impl LogicalScan {
             .collect()
     }
 
+    /// Get the ids of the output columns and primary key columns.
+    pub fn output_and_pk_column_ids(&self) -> Vec<ColumnId> {
+        let mut ids = self.output_column_ids();
+        for column_order in self.primary_key() {
+            let id = self.table_desc().columns[column_order.column_index].column_id;
+            if !ids.contains(&id) {
+                ids.push(id);
+            }
+        }
+        ids
+    }
+
     pub fn output_column_indices(&self) -> &[usize] {
         &self.core.output_col_idx
     }

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -171,6 +171,16 @@ impl StreamTableScan {
 
         let stream_key = self.logical_pk().iter().map(|x| *x as u32).collect_vec();
 
+        // The required columns from the table (both scan and upstream).
+        let upstream_column_ids = match self.chain_type {
+            ChainType::Chain | ChainType::Rearrange | ChainType::UpstreamOnly => {
+                self.logical.output_column_ids()
+            }
+            // For backfill, we additionally need the primary key columns.
+            ChainType::Backfill => self.logical.output_and_pk_column_ids(),
+            ChainType::ChainUnspecified => unreachable!(),
+        };
+
         ProstStreamPlan {
             fields: self.schema().to_prost(),
             input: vec![
@@ -225,6 +235,7 @@ impl StreamTableScan {
                     .iter()
                     .map(|&i| i as _)
                     .collect(),
+                upstream_column_ids: upstream_column_ids.iter().map(|i| i.get_id()).collect(),
                 is_singleton: *self.distribution() == Distribution::Single,
                 // The table desc used by backfill executor
                 table_desc: Some(self.logical.table_desc().to_protobuf()),

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -287,6 +287,20 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
     pub fn pk_indices(&self) -> &[usize] {
         &self.pk_indices
     }
+
+    pub fn output_indices(&self) -> &[usize] {
+        &self.output_indices
+    }
+
+    /// Get the indices of the primary key columns in the output columns.
+    ///
+    /// Returns `None` if any of the primary key columns is not in the output columns.
+    pub fn pk_in_output_indices(&self) -> Option<Vec<usize>> {
+        self.pk_indices
+            .iter()
+            .map(|&i| self.output_indices.iter().position(|&j| i == j))
+            .collect()
+    }
 }
 
 /// Point get

--- a/src/stream/src/from_proto/chain.rs
+++ b/src/stream/src/from_proto/chain.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::catalog::{ColumnDesc, TableId, TableOption};
+use risingwave_common::catalog::{ColumnDesc, ColumnId, TableId, TableOption};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::plan_common::StorageTableDesc;
 use risingwave_pb::stream_plan::{ChainNode, ChainType};
@@ -98,7 +98,11 @@ impl ExecutorBuilder for ChainExecutorBuilder {
                     .iter()
                     .map(ColumnDesc::from)
                     .collect_vec();
-                let column_ids = column_descs.iter().map(|x| x.column_id).collect_vec();
+                let column_ids = node
+                    .upstream_column_ids
+                    .iter()
+                    .map(ColumnId::from)
+                    .collect_vec();
 
                 // Use indices based on full table instead of streaming executor output.
                 let pk_indices = table_desc


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This is a prerequisite of #4529. TL;DR:

```
CREATE TABLE t (k INT PRIMARY KEY, v1 INT, v2 INT);
CREATE MATERIALIZED VIEW mv AS SELECT v1 FROM t;

Before:
- dispatcher -> merge -> chain: [k, v1, v2]
- historical data
  - (non-backfill) batch-plan -> chain: [v1]
  - (backfill) table scan -> [k, v1, v2]
- chain -> ..: [v1]

After this PR:
- dispatcher -> merge -> chain: [k, v1, v2]
- historical data
  - (non-backfill) batch-plan -> chain: [v1]
  - (backfill) table scan -> [k, v1] (k is required for backfill)
- chain -> ..: [v1]

After #4529:
- dispatcher -> merge -> chain
  - (non-backfill) [v1]
  - (backfill) [k, v1]  (k is required for backfill)
- historical data: same schema as "dispatcher -> merge -> chain"
- chain -> ..: [v1]
```

So there'll be two fields in the `ChainNode` definition:
- `upstream_column_ids`: the schema of `dispatcher -> merge -> chain`, "required columns"
- `upstream_column_indices`: will be renamed, representing the output columns in the required columns.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
