### PR TITLE
fix(pgwire): process empty query correctly

### DIFF
--- a/src/utils/pgwire/tests/js/test/pgwire.test.ts
+++ b/src/utils/pgwire/tests/js/test/pgwire.test.ts
@@ -11,13 +11,36 @@ describe('PgwireTest', () => {
     try {
       const conn = await pool.connect();
       try {
-        // FIXME: RisingWave currently will fail on this test due to the lacking support of prepared statement.
-        // Related issue: https://github.com/risingwavelabs/risingwave/issues/5293
         const res = await conn.query({
           text: 'SELECT $1::int AS number',
           values: ['1'],
         });
         expect(res.rowCount).toBe(1);
+      } finally {
+        await conn.release();
+      }
+    } finally {
+      await pool.end();
+    }
+  });
+
+  test('empty query', async () => {
+    const pool = new Pool({
+      host: '127.0.0.1',
+      database: 'dev',
+      port: 4566,
+      user: 'root',
+    });
+    try {
+      const conn = await pool.connect();
+      try {
+        const query = {
+          name: 'empty',
+          text: '',
+          values: [],
+        };
+        const res = await conn.query(query);
+        expect(res.rowCount).toBe(null);
       } finally {
         await conn.release();
       }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix #8530. 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
