### PR TITLE
fix(common): interval overflow panic / wrap during comparison and justify

### DIFF
--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -122,7 +122,9 @@ select '1 mons 1 days 00:00:00.0000001'::INTERVAL;
 
 # Tests moved from regress tests due to not matching exactly.
 
-# PostgreSQL outputs `-1 mons +1 day` while we output `-1 mons 1 day`.
+# In mixed sign intervals, PostgreSQL displays positive sign after negative
+# (e.g. `-1 mons +1 day`) while we display it without sign
+# (e.g. `-1 mons 1 day`).
 # But the main purpose of this test case is ordering of large values.
 
 statement ok

--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -74,20 +74,20 @@ SELECT INTERVAL '3 mins' * 1.5;
 00:04:30
 
 # https://github.com/risingwavelabs/risingwave/issues/3873
-query TTTTT
+query T
 select distinct * from (values (interval '1' month), (interval '30' day)) as t;
 ----
-30 days
+1 mon
 
-query TTTTT
+query T
 select distinct * from (values (interval '30' day), (interval '1' month)) as t;
 ----
-30 days
+1 mon
 
-query TTTTT
+query T
 select distinct * from (values (interval '720' hour), (interval '1' month)) as t;
 ----
-30 days
+1 mon
 
 query TTTTTT
 select interval '1 year 1 month 1 day 1';
@@ -119,3 +119,42 @@ query T
 select '1 mons 1 days 00:00:00.0000001'::INTERVAL;
 ----
 1 mon 1 day
+
+# Tests moved from regress tests due to not matching exactly.
+
+# PostgreSQL outputs `-1 mons +1 day` while we output `-1 mons 1 day`.
+# But the main purpose of this test case is ordering of large values.
+
+statement ok
+CREATE TABLE INTERVAL_TBL_OF (f1 interval);
+
+statement ok
+INSERT INTO INTERVAL_TBL_OF (f1) VALUES
+  ('2147483647 days 2147483647 months'),
+  ('2147483647 days -2147483648 months'),
+  ('1 year'),
+  ('-2147483648 days 2147483647 months'),
+  ('-2147483648 days -2147483648 months');
+
+statement ok
+FLUSH;
+
+query TT
+SELECT r1.*, r2.*
+   FROM INTERVAL_TBL_OF r1, INTERVAL_TBL_OF r2
+   WHERE r1.f1 > r2.f1
+   ORDER BY r1.f1, r2.f1;
+----
+-178956970 years -8 mons 2147483647 days -178956970 years -8 mons -2147483648 days
+1 year                                   -178956970 years -8 mons -2147483648 days
+1 year                                   -178956970 years -8 mons 2147483647 days
+178956970 years 7 mons -2147483648 days  -178956970 years -8 mons -2147483648 days
+178956970 years 7 mons -2147483648 days  -178956970 years -8 mons 2147483647 days
+178956970 years 7 mons -2147483648 days  1 year
+178956970 years 7 mons 2147483647 days   -178956970 years -8 mons -2147483648 days
+178956970 years 7 mons 2147483647 days   -178956970 years -8 mons 2147483647 days
+178956970 years 7 mons 2147483647 days   1 year
+178956970 years 7 mons 2147483647 days   178956970 years 7 mons -2147483648 days
+
+statement ok
+DROP TABLE INTERVAL_TBL_OF;

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -39,8 +39,8 @@ use crate::collection::estimate_size::EstimateSize;
 use crate::hash::VirtualNode;
 use crate::row::{OwnedRow, RowDeserializer};
 use crate::types::{
-    DataType, Decimal, IntervalUnit, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper,
-    OrderedF32, OrderedF64, ScalarRef,
+    DataType, Decimal, NaiveDateTimeWrapper, NaiveDateWrapper, NaiveTimeWrapper, OrderedF32,
+    OrderedF64, ScalarRef,
 };
 use crate::util::hash_util::Crc32FastBuilder;
 use crate::util::iter_util::ZipEqFast;
@@ -354,29 +354,6 @@ impl HashKeySerDe<'_> for Decimal {
     fn deserialize<R: Read>(source: &mut R) -> Self {
         let value = Self::read_fixed_size_bytes::<R, 16>(source);
         Self::unordered_deserialize(value)
-    }
-}
-
-impl HashKeySerDe<'_> for IntervalUnit {
-    type S = [u8; 16];
-
-    fn serialize(mut self) -> Self::S {
-        self.justify_interval();
-        let mut ret = [0; 16];
-        ret[0..4].copy_from_slice(&self.get_months().to_ne_bytes());
-        ret[4..8].copy_from_slice(&self.get_days().to_ne_bytes());
-        ret[8..16].copy_from_slice(&self.get_usecs().to_ne_bytes());
-
-        ret
-    }
-
-    fn deserialize<R: Read>(source: &mut R) -> Self {
-        let value = Self::read_fixed_size_bytes::<R, 16>(source);
-        IntervalUnit::from_month_day_usec(
-            i32::from_ne_bytes(value[0..4].try_into().unwrap()),
-            i32::from_ne_bytes(value[4..8].try_into().unwrap()),
-            i64::from_ne_bytes(value[8..16].try_into().unwrap()),
-        )
     }
 }
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -85,6 +85,9 @@ impl IntervalUnit {
     /// Also makes signs of all fields to be the same.
     ///
     /// <https://github.com/postgres/postgres/blob/REL_15_2/src/backend/utils/adt/timestamp.c#L2740>
+    ///
+    /// Be careful when using this as the normalized form, as it is not a total function and may not
+    /// exist for certain values (e.g. [`Self::MIN`]). See [`IntervalCmpValue`] for details.
     pub fn justify_interval(&self) -> Option<Self> {
         let mut v = *self;
         // When `days` and `usecs` have the same sign, `usecs` could potentially push `days` over


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Intervals have non-trivial rules for their equality and ordering. The previous implementation does not handle overflows carefully and may result in panics or wrapping to a wrong result (and panic in later stage #8355). This PR fixes all such issues during **comparison**.

Note there are other issues in **arithmetic** and **parsing**. This PR only focuses on comparison.

The previous implementation relies on `justify_interval`, which is not a total function that selects a representative from each equivalence class.

The new implementation uses `usecs: i128` and an alternate representative as complement to this. All comparison is no longer depending on the `justify_interval` SQL function and it has been removed to avoid misuse. The deserialized interval may still be a justified interval if one exists.

This PR contains a **breaking change** to the memcomparable encoding.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
