### PR TITLE
fix(common): decimal round digits test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6766,9 +6766,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.28.1"
+version = "1.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13cf35f7140155d02ba4ec3294373d513a3c7baa8364c162b030e33c61520a8"
+checksum = "2b1b21b8760b0ef8ae5b43d40913ff711a2053cb7ff892a34facff7a6365375a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -8251,7 +8251,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -79,8 +79,8 @@ mod tests {
         do_test("84818.15", 1, "84818.2");
         do_test("21.372736", -1, "0");
         // When digit extends past original scale, it should just return original scale.
-        // Intuitively, it does not make sense after rounding `0` it becomes `0.000`. Precision should always
-        // be less or equal, not more.
+        // Intuitively, it does not make sense after rounding `0` it becomes `0.000`. Precision
+        // should always be less or equal, not more.
         do_test("0", 340, "0");
     }
 

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -78,7 +78,9 @@ mod tests {
         do_test("84818.33333333333333333333333", 4, "84818.3333");
         do_test("84818.15", 1, "84818.2");
         do_test("21.372736", -1, "0");
-        // should be "0"
+        // When digit extends past original scale, it should just return original scale.
+        // Intuitively, it does not make sense after rounding `0` it becomes `0.000`. Precision should always
+        // be less or equal, not more.
         do_test("0", 340, "0");
     }
 

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -78,8 +78,8 @@ mod tests {
         do_test("84818.33333333333333333333333", 4, "84818.3333");
         do_test("84818.15", 1, "84818.2");
         do_test("21.372736", -1, "0");
-        // Maximum of 28 digits
-        do_test("0", 340, &format!("0.{}", "0".repeat(28)));
+        // should be "0"
+        do_test("0", 340, "0");
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
As discussed in #7819 , this unit test should be modified after upgrading `rust_decimal` to fix the rounding issue.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
