### PR TITLE
feat(frontend): ban `update` statements modifying pk columns

### DIFF
--- a/e2e_test/batch/basic/dml.slt.part
+++ b/e2e_test/batch/basic/dml.slt.part
@@ -70,3 +70,24 @@ select count(*) from t;
 
 statement ok
 drop table t;
+
+statement ok
+create table t (v1 int, v2 int primary key, v3 varchar);
+
+statement ok
+insert into t values (0, 1, 'a'), (1, 2, 'b');
+
+statement ok
+update t set (v1, v3) = (v1+v2, v3||v3);
+
+query IIT
+select * from t;
+----
+1 1 aa
+3 2 bb
+
+statement error QueryError: Bind error: update modifying the PK column is banned
+update t set (v3, v2) = (v3||v3, v1+v2);
+
+statement ok
+drop table t;

--- a/e2e_test/batch/basic/dml.slt.part
+++ b/e2e_test/batch/basic/dml.slt.part
@@ -81,7 +81,7 @@ statement ok
 update t set (v1, v3) = (v1+v2, v3||v3);
 
 query IIT
-select * from t;
+select * from t order by v1;
 ----
 1 1 aa
 3 2 bb

--- a/e2e_test/ddl/invalid_operation.slt
+++ b/e2e_test/ddl/invalid_operation.slt
@@ -274,7 +274,7 @@ delete from t;
 statement error cannot change materialized view
 insert into mv values (1);
 
-statement error cannot change materialized view
+statement error QueryError: Bind error: update modifying the PK column is banned
 update mv set v = 2;
 
 statement error cannot change materialized view

--- a/e2e_test/ddl/invalid_operation.slt
+++ b/e2e_test/ddl/invalid_operation.slt
@@ -274,7 +274,7 @@ delete from t;
 statement error cannot change materialized view
 insert into mv values (1);
 
-statement error QueryError: Bind error: update modifying the PK column is banned
+statement error cannot change materialized view
 update mv set v = 2;
 
 statement error cannot change materialized view

--- a/e2e_test/ddl/invalid_operation.slt
+++ b/e2e_test/ddl/invalid_operation.slt
@@ -264,7 +264,7 @@ SELECT * from v limit 0;
 statement ok
 insert into t values (1);
 
-statement ok
+statement error QueryError: Bind error: update modifying the PK column is banned
 update t set v = 2;
 
 statement ok

--- a/e2e_test/ddl/table.slt
+++ b/e2e_test/ddl/table.slt
@@ -120,6 +120,9 @@ create table "T2" ("V1" int);
 statement ok
 insert into "T2" ("V1") values (1);
 
+statement ok
+drop table "T2"
+
 statement error
 create table C1 (c1 varchar(5));
 

--- a/src/frontend/planner_test/tests/testdata/update.yaml
+++ b/src/frontend/planner_test/tests/testdata/update.yaml
@@ -60,3 +60,7 @@
         └─BatchExchange { order: [], dist: Single }
           └─BatchFilter { predicate: (t.v1 <> t.v2) }
             └─BatchScan { table: t, columns: [t.v1, t.v2, t._row_id], distribution: UpstreamHashShard(t._row_id) }
+- sql: |
+    create table t (v1 int primary key, v2 int);
+    update t set (v2, v1) = (v1, v2);
+  binder_error: 'Bind error: update modifying the PK column is banned'

--- a/src/frontend/src/binder/update.rs
+++ b/src/frontend/src/binder/update.rs
@@ -91,6 +91,11 @@ impl Binder {
             Self::resolve_schema_qualified_name(&self.db_name, name.clone())?;
 
         let table_catalog = self.resolve_dml_table(schema_name.as_deref(), &table_name, false)?;
+        let pk_indices = table_catalog
+            .pk()
+            .iter()
+            .map(|column_order| column_order.column_index)
+            .collect_vec();
         let table_id = table_catalog.id;
         let owner = table_catalog.owner;
         let table_version_id = table_catalog.version_id().expect("table must be versioned");
@@ -131,6 +136,18 @@ impl Binder {
 
             for (id, value) in assignments {
                 let id_expr = self.bind_expr(Expr::Identifier(id.clone()))?;
+                if let Some(id_input_ref) = id_expr.clone().as_input_ref() {
+                    let id_index = id_input_ref.index;
+                    for &pk in &pk_indices {
+                        if id_index == pk {
+                            return Err(ErrorCode::BindError(
+                                "update modifying the PK column is banned".to_owned(),
+                            )
+                            .into());
+                        }
+                    }
+                }
+
                 let value_expr = self.bind_expr(value)?.cast_assign(id_expr.return_type())?;
 
                 match assignment_exprs.entry(id_expr) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
ban `update` statements modifying pk columns

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
A bind error is returned if the binder finds any pk column is to be assigned by `update` statements;

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
With this pr, users cannot have `update` statements affecting primary key columns