### PR TITLE
chore: filter visible columns for connector reader

### DIFF
--- a/src/connector/src/source/manager.rs
+++ b/src/connector/src/source/manager.rs
@@ -80,3 +80,19 @@ impl From<&SourceColumnDesc> for ColumnDesc {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_visible() {
+        let mut c = SourceColumnDesc::simple("a", DataType::Int32, ColumnId::new(0));
+        assert!(c.is_visible());
+        c.is_row_id = true;
+        assert!(!c.is_visible());
+        c.is_row_id = false;
+        c.is_meta = true;
+        assert!(!c.is_visible());
+    }
+}

--- a/src/connector/src/source/manager.rs
+++ b/src/connector/src/source/manager.rs
@@ -48,6 +48,11 @@ impl SourceColumnDesc {
             is_meta: false,
         }
     }
+
+    #[inline]
+    pub fn is_visible(&self) -> bool {
+        !self.is_row_id && !self.is_meta
+    }
 }
 
 impl From<&ColumnDesc> for SourceColumnDesc {

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -101,6 +101,7 @@ impl ConnectorSource {
             let data_gen_columns = Some(
                 columns
                     .iter()
+                    .filter(|col| col.is_visible())
                     .cloned()
                     .map(|col| Column {
                         name: col.name,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

## Description
This pull request adds a new method `is_visible` to the `SourceColumnDesc` struct. It is now utilized to filter out invisible columns in `ConnectorSource` when generating columns.

## Changes Made
- Added a new method `is_visible` to the `SourceColumnDesc` struct.
- Modified the `ConnectorSource` to filter out invisible columns when generating columns.

## Reasoning
The `is_visible` method allows for more granular control over column visibility in the `ConnectorSource` class. This implementation ensures that only visible columns are generated, providing a more efficient and streamlined process.

## Testing Done
Unit tests have been added to test the functionality of the `is_visible` method and the updated `ConnectorSource` class. All tests have passed successfully.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
