### PR TITLE
chore: add is_visible in column for connector

### DIFF
--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -363,6 +363,7 @@ pub type DataType = risingwave_common::types::DataType;
 pub struct Column {
     pub name: String,
     pub data_type: DataType,
+    pub is_visible: bool,
 }
 
 /// Split id resides in every source message, use `Arc` to avoid copying.

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -26,10 +26,16 @@ use risingwave_common::util::iter_util::ZipEqFast;
 
 use crate::source::{SourceFormat, SourceMessage, SourceMeta, SplitId, StreamChunkWithState};
 
+pub enum FieldDesc {
+    // field is invisible, generate None
+    Invisible,
+    Visible(FieldGeneratorImpl),
+}
+
 pub struct DatagenEventGenerator {
     // fields_map: HashMap<String, FieldGeneratorImpl>,
     field_names: Vec<String>,
-    fields_vec: Vec<FieldGeneratorImpl>,
+    fields_vec: Vec<FieldDesc>,
     source_format: SourceFormat,
     data_types: Vec<DataType>,
     offset: u64,
@@ -46,7 +52,7 @@ pub struct DatagenMeta {
 impl DatagenEventGenerator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        fields_vec: Vec<FieldGeneratorImpl>,
+        fields_vec: Vec<FieldDesc>,
         field_names: Vec<String>,
         source_format: SourceFormat,
         data_types: Vec<DataType>,
@@ -96,16 +102,23 @@ impl DatagenEventGenerator {
                                 .iter()
                                 .zip_eq_fast(self.fields_vec.iter_mut())
                             {
-                                let value = field_generator.generate_json(self.offset);
-                                if value.is_null() {
-                                    reach_end = true;
-                                    tracing::info!(
-                                        "datagen split {} stop generate, offset {}",
-                                        self.split_id,
-                                        self.offset
-                                    );
-                                    break 'outer;
-                                }
+                                let value = match field_generator {
+                                    FieldDesc::Invisible => continue,
+                                    FieldDesc::Visible(field_generator) => {
+                                        let value = field_generator.generate_json(self.offset);
+                                        if value.is_null() {
+                                            reach_end = true;
+                                            tracing::info!(
+                                                "datagen split {} stop generate, offset {}",
+                                                self.split_id,
+                                                self.offset
+                                            );
+                                            break 'outer;
+                                        }
+                                        value
+                                    }
+                                };
+
                                 map.insert(name.clone(), value);
                             }
                             Bytes::from(serde_json::Value::from(map).to_string())
@@ -159,16 +172,24 @@ impl DatagenEventGenerator {
                 'outer: for _ in 0..num_rows_to_generate {
                     let mut row = Vec::with_capacity(self.fields_vec.len());
                     for field_generator in &mut self.fields_vec {
-                        let datum = field_generator.generate_datum(self.offset);
-                        if datum.is_none() {
-                            reach_end = true;
-                            tracing::info!(
-                                "datagen split {} stop generate, offset {}",
-                                self.split_id,
-                                self.offset
-                            );
-                            break 'outer;
-                        }
+                        let datum = match field_generator {
+                            FieldDesc::Invisible => None,
+                            FieldDesc::Visible(field_generator) => {
+                                let datum = field_generator.generate_datum(self.offset);
+                                if datum.is_none() {
+                                    reach_end = true;
+                                    tracing::info!(
+                                        "datagen split {} stop generate, offset {}",
+                                        self.split_id,
+                                        self.offset
+                                    );
+                                    break 'outer;
+                                };
+
+                                datum
+                            }
+                        };
+
                         row.push(datum);
                     }
 
@@ -214,22 +235,26 @@ mod tests {
 
         let data_types = vec![DataType::Int32, DataType::Float32];
         let fields_vec = vec![
-            FieldGeneratorImpl::with_number_sequence(
-                data_types[0].clone(),
-                Some(start.to_string()),
-                Some(end.to_string()),
-                split_index,
-                split_num,
-            )
-            .unwrap(),
-            FieldGeneratorImpl::with_number_sequence(
-                data_types[1].clone(),
-                Some(start.to_string()),
-                Some(end.to_string()),
-                split_index,
-                split_num,
-            )
-            .unwrap(),
+            FieldDesc::Visible(
+                FieldGeneratorImpl::with_number_sequence(
+                    data_types[0].clone(),
+                    Some(start.to_string()),
+                    Some(end.to_string()),
+                    split_index,
+                    split_num,
+                )
+                .unwrap(),
+            ),
+            FieldDesc::Visible(
+                FieldGeneratorImpl::with_number_sequence(
+                    data_types[1].clone(),
+                    Some(start.to_string()),
+                    Some(end.to_string()),
+                    split_index,
+                    split_num,
+                )
+                .unwrap(),
+            ),
         ];
 
         let generator = DatagenEventGenerator::new(

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -26,7 +26,7 @@ use crate::impl_common_split_reader_logic;
 use crate::parser::{ParserConfig, SpecificParserConfig};
 use crate::source::data_gen_util::spawn_data_generation_stream;
 use crate::source::datagen::source::SEQUENCE_FIELD_KIND;
-use crate::source::datagen::{DatagenProperties, DatagenSplit};
+use crate::source::datagen::{DatagenProperties, DatagenSplit, FieldDesc};
 use crate::source::{
     BoxSourceStream, BoxSourceWithStateStream, Column, DataType, SourceContextRef, SplitId,
     SplitImpl, SplitMetaData, SplitReader,
@@ -106,13 +106,18 @@ impl SplitReader for DatagenSplitReader {
         for column in columns {
             // let name = column.name.clone();
             let data_type = column.data_type.clone();
-            let gen = generator_from_data_type(
-                column.data_type,
-                &fields_option_map,
-                &column.name,
-                split_index,
-                split_num,
-            )?;
+
+            let gen = if column.is_visible {
+                FieldDesc::Visible(generator_from_data_type(
+                    column.data_type,
+                    &fields_option_map,
+                    &column.name,
+                    split_index,
+                    split_num,
+                )?)
+            } else {
+                FieldDesc::Invisible
+            };
             fields_vec.push(gen);
             data_types.push(data_type);
             field_names.push(column.name);
@@ -284,14 +289,17 @@ mod tests {
             Column {
                 name: "random_int".to_string(),
                 data_type: DataType::Int32,
+                is_visible: true,
             },
             Column {
                 name: "random_float".to_string(),
                 data_type: DataType::Float32,
+                is_visible: true,
             },
             Column {
                 name: "sequence_int".to_string(),
                 data_type: DataType::Int32,
+                is_visible: true,
             },
             Column {
                 name: "struct".to_string(),
@@ -299,6 +307,7 @@ mod tests {
                     fields: vec![DataType::Int32],
                     field_names: vec!["random_int".to_string()],
                 })),
+                is_visible: true,
             },
         ];
         let state = vec![SplitImpl::Datagen(DatagenSplit {
@@ -364,10 +373,12 @@ mod tests {
             Column {
                 name: "_".to_string(),
                 data_type: DataType::Int64,
+                is_visible: true,
             },
             Column {
                 name: "random_int".to_string(),
                 data_type: DataType::Int32,
+                is_visible: true,
             },
         ];
         let state = vec![SplitImpl::Datagen(DatagenSplit {

--- a/src/connector/src/source/manager.rs
+++ b/src/connector/src/source/manager.rs
@@ -80,3 +80,19 @@ impl From<&SourceColumnDesc> for ColumnDesc {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_visible() {
+        let mut c = SourceColumnDesc::simple("a", DataType::Int32, ColumnId::new(0));
+        assert!(c.is_visible());
+        c.is_row_id = true;
+        assert!(!c.is_visible());
+        c.is_row_id = false;
+        c.is_meta = true;
+        assert!(!c.is_visible());
+    }
+}

--- a/src/connector/src/source/manager.rs
+++ b/src/connector/src/source/manager.rs
@@ -48,6 +48,11 @@ impl SourceColumnDesc {
             is_meta: false,
         }
     }
+
+    #[inline]
+    pub fn is_visible(&self) -> bool {
+        !self.is_row_id && !self.is_meta
+    }
 }
 
 impl From<&ColumnDesc> for SourceColumnDesc {

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -101,11 +101,10 @@ impl ConnectorSource {
             let data_gen_columns = Some(
                 columns
                     .iter()
-                    .filter(|col| col.is_visible())
-                    .cloned()
                     .map(|col| Column {
-                        name: col.name,
-                        data_type: col.data_type,
+                        name: col.name.clone(),
+                        data_type: col.data_type.clone(),
+                        is_visible: col.is_visible(),
                     })
                     .collect_vec(),
             );

--- a/src/source/src/connector_source.rs
+++ b/src/source/src/connector_source.rs
@@ -101,6 +101,7 @@ impl ConnectorSource {
             let data_gen_columns = Some(
                 columns
                     .iter()
+                    .filter(|col| col.is_visible())
                     .cloned()
                     .map(|col| Column {
                         name: col.name,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?


## Description

This pull request adds a new field `is_visible` to the existing `Column` struct and new enum variants `Invisible` and `Visible` with associated fields to the `FieldDesc` enum.

The `is_visible` field in `Column` is used in `DatagenSplitReader` to decide whether a field should be included in the generated data. It is set when creating `Column` from `SourceColumnDesc`.

## Changes Made

- Added `is_visible` field to `Column` struct.
- Added `Invisible` and `Visible` enum variants with associated fields to `FieldDesc` enum.
- `is_visible` field used in `DatagenSplitReader` to control data generation.
- `Column` created from `SourceColumnDesc` sets `is_visible` field.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
