### PR TITLE
feat(meta): add internal table to pg_class

### DIFF
--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -397,12 +397,28 @@ impl SysCatalogReaderImpl {
                     })
                     .collect_vec();
 
+                let internal_tables = schema
+                    .iter_internal_table()
+                    .map(|table| {
+                        OwnedRow::new(vec![
+                            Some(ScalarImpl::Int32(table.id.table_id() as i32)),
+                            Some(ScalarImpl::Utf8(table.name.clone().into())),
+                            Some(ScalarImpl::Int32(schema_info.id as i32)),
+                            Some(ScalarImpl::Int32(table.owner as i32)),
+                            Some(ScalarImpl::Utf8("n".into())),
+                            Some(ScalarImpl::Int32(0)),
+                            Some(ScalarImpl::Int32(0)),
+                        ])
+                    })
+                    .collect_vec();
+
                 rows.into_iter()
                     .chain(mvs.into_iter())
                     .chain(indexes.into_iter())
                     .chain(sources.into_iter())
                     .chain(sys_tables.into_iter())
                     .chain(views.into_iter())
+                    .chain(internal_tables.into_iter())
                     .collect_vec()
             })
             .collect_vec())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- As titled.

Example:

```sql
dev=> select * from pg_class where relkind = 'n';
 oid  |                  relname                  | relnamespace | relowner | relkind | relam | reltablespace
------+-------------------------------------------+--------------+----------+---------+-------+---------------
 1005 | __internal_v_7_globalsimpleaggresult_1005 |            0 |        1 | n       |     0 |             0
(1 row)
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
