### PR TITLE
fix(optimizer): fix hash join distribution

### DIFF
--- a/src/frontend/planner_test/tests/testdata/join.yaml
+++ b/src/frontend/planner_test/tests/testdata/join.yaml
@@ -677,3 +677,27 @@
      Table 6 { columns: [t_src, t_dst, t__row_id], primary key: [$0 ASC, $2 ASC], value indices: [0, 1, 2], distribution key: [0], read pk prefix len hint: 1 }
      Table 7 { columns: [t_src, t__row_id, _degree], primary key: [$0 ASC, $1 ASC], value indices: [2], distribution key: [0], read pk prefix len hint: 1 }
      Table 4294967294 { columns: [p1, p2, p3, t._row_id, t._row_id#1, t.src, t._row_id#2], primary key: [$3 ASC, $4 ASC, $1 ASC, $6 ASC, $5 ASC, $0 ASC], value indices: [0, 1, 2, 3, 4, 5, 6], distribution key: [0], read pk prefix len hint: 6 }
+- name: Fix hash join distribution key (https://github.com/risingwavelabs/risingwave/issues/8537)
+  sql: |
+    CREATE TABLE part (
+      p INTEGER,
+      c VARCHAR,
+      PRIMARY KEY (p)
+    );
+    CREATE TABLE B (
+      b INTEGER,
+      d VARCHAR,
+      PRIMARY KEY (b)
+    );
+    select B.* from part join B on part.c = B.d join part p1 on p1.p = part.p and p1.p = B.b;
+  stream_plan: |
+    StreamMaterialize { columns: [b, d, part.p(hidden), part.c(hidden), part.p#1(hidden)], pk_columns: [part.p, b, part.c, part.p#1], pk_conflict: "no check" }
+    └─StreamHashJoin { type: Inner, predicate: part.p = part.p AND b.b = part.p, output: [b.b, b.d, part.p, part.c, part.p] }
+      ├─StreamExchange { dist: HashShard(part.p, b.b) }
+      | └─StreamHashJoin { type: Inner, predicate: part.c = b.d, output: [part.p, b.b, b.d, part.c] }
+      |   ├─StreamExchange { dist: HashShard(part.c) }
+      |   | └─StreamTableScan { table: part, columns: [part.p, part.c], pk: [part.p], dist: UpstreamHashShard(part.p) }
+      |   └─StreamExchange { dist: HashShard(b.d) }
+      |     └─StreamTableScan { table: b, columns: [b.b, b.d], pk: [b.b], dist: UpstreamHashShard(b.b) }
+      └─StreamExchange { dist: HashShard(part.p, part.p) }
+        └─StreamTableScan { table: part, columns: [part.p], pk: [part.p], dist: UpstreamHashShard(part.p) }

--- a/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
@@ -173,7 +173,9 @@ impl ToDistributedBatch for BatchHashJoin {
         let r2l = self
             .eq_join_predicate()
             .r2l_eq_columns_mapping(left.schema().len(), right.schema().len());
-        let l2r = r2l.inverse();
+        let l2r = self
+            .eq_join_predicate()
+            .l2r_eq_columns_mapping(left.schema().len());
 
         let right_dist = right.distribution();
         match right_dist {

--- a/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -228,10 +228,7 @@ impl EqJoinPredicate {
     }
 
     /// return the eq columns index mapping from left inputs to right inputs
-    pub fn l2r_eq_columns_mapping(
-        &self,
-        left_cols_num: usize,
-    ) -> ColIndexMapping {
+    pub fn l2r_eq_columns_mapping(&self, left_cols_num: usize) -> ColIndexMapping {
         let mut map = vec![None; left_cols_num];
         for (left, right, _) in self.eq_keys() {
             map[left.index] = Some(right.index - left_cols_num);

--- a/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
+++ b/src/frontend/src/optimizer/plan_node/eq_join_predicate.rs
@@ -227,6 +227,18 @@ impl EqJoinPredicate {
         ColIndexMapping::new(map)
     }
 
+    /// return the eq columns index mapping from left inputs to right inputs
+    pub fn l2r_eq_columns_mapping(
+        &self,
+        left_cols_num: usize,
+    ) -> ColIndexMapping {
+        let mut map = vec![None; left_cols_num];
+        for (left, right, _) in self.eq_keys() {
+            map[left.index] = Some(right.index - left_cols_num);
+        }
+        ColIndexMapping::new(map)
+    }
+
     /// Reorder the `eq_keys` according to the `reorder_idx`.
     pub fn reorder(self, reorder_idx: &[usize]) -> Self {
         assert!(reorder_idx.len() <= self.eq_keys.len());

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -891,7 +891,7 @@ impl LogicalJoin {
         let mut left = self.left();
 
         let r2l = predicate.r2l_eq_columns_mapping(left.schema().len(), right.schema().len());
-        let l2r = r2l.inverse();
+        let l2r = predicate.l2r_eq_columns_mapping(left.schema().len());
 
         let right_dist = right.distribution();
         match right_dist {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Fix hash join distribution. #8537

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

