### PR TITLE
feat: make gen timestamp deterministic

### DIFF
--- a/src/common/src/field_generator/mod.rs
+++ b/src/common/src/field_generator/mod.rs
@@ -328,8 +328,10 @@ mod tests {
     #[test]
     fn test_deterministic_timestamp() {
         let seed = 1234;
-        let base_time: DateTime<FixedOffset> = DateTime::parse_from_rfc3339("2020-01-01T00:00:00+00:00").unwrap();
-        let mut generator = FieldGeneratorImpl::with_timestamp(Some(base_time), None, None, seed).unwrap();
+        let base_time: DateTime<FixedOffset> =
+            DateTime::parse_from_rfc3339("2020-01-01T00:00:00+00:00").unwrap();
+        let mut generator =
+            FieldGeneratorImpl::with_timestamp(Some(base_time), None, None, seed).unwrap();
         let val1 = generator.generate_json(1);
         let val2 = generator.generate_json(1);
         assert_eq!(val1, val2);

--- a/src/common/src/field_generator/timestamp.rs
+++ b/src/common/src/field_generator/timestamp.rs
@@ -22,7 +22,6 @@ use serde_json::{json, Value};
 use tracing::debug;
 
 use super::DEFAULT_MAX_PAST;
-use crate::array::Op;
 use crate::types::{Datum, NaiveDateTimeWrapper, Scalar};
 
 #[derive(Debug)]

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use chrono::{DateTime, FixedOffset};
 use futures::{StreamExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::field_generator::FieldGeneratorImpl;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

add a new field for datagen connector to prevent use `now` when generating times

the field is only valid when generating `DataType::Timestamp`.

* `fields.{}.basetime`: Optional. if set, datagen will see the given time as `now`. the format is subject to [rfc3399](https://docs.rs/chrono/latest/chrono/struct.DateTime.html#method.parse_from_rfc3339) (example `1996-12-19T16:39:57-08:00`)

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Connector (sources & sinks)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

described above. 

</details>
