### PR TITLE
fix(streaming): drop actor on another blocking thread

### DIFF
--- a/src/stream/src/executor/actor.rs
+++ b/src/stream/src/executor/actor.rs
@@ -15,6 +15,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use await_tree::InstrumentAwait;
 use futures::future::join_all;
 use hytra::TrAdder;
@@ -175,25 +176,30 @@ where
         let mut stream = Box::pin(Box::new(self.consumer).execute());
 
         // Drive the streaming task with an infinite loop
-        while let Some(barrier) = stream
-            .try_next()
-            .in_span(span)
-            .instrument_await(
-                last_epoch.map_or("Epoch <initial>".into(), |e| format!("Epoch {}", e.curr)),
-            )
-            .await?
-        {
-            last_epoch = Some(barrier.epoch);
+        let result = loop {
+            let barrier = match stream
+                .try_next()
+                .in_span(span)
+                .instrument_await(
+                    last_epoch.map_or("Epoch <initial>".into(), |e| format!("Epoch {}", e.curr)),
+                )
+                .await
+            {
+                Ok(Some(barrier)) => barrier,
+                Ok(None) => break Err(anyhow!("actor exited unexpectedly").into()),
+                Err(err) => break Err(err),
+            };
 
             // Collect barriers to local barrier manager
             self.context.lock_barrier_manager().collect(id, &barrier);
 
             // Then stop this actor if asked
             if barrier.is_stop_or_update_drop_actor(id) {
-                break;
+                break Ok(());
             }
 
             // Tracing related work
+            last_epoch = Some(barrier.epoch);
             span = {
                 let mut span = Span::enter_with_local_parent("actor_poll");
                 span.add_property(|| ("otel.name", span_name.to_string()));
@@ -202,12 +208,12 @@ where
                 span.add_property(|| ("epoch", barrier.epoch.curr.to_string()));
                 span
             };
-        }
+        };
 
         spawn_blocking_drop_stream(stream).await;
 
         tracing::trace!(actor_id = id, "actor exit");
-        Ok(())
+        result
     }
 }
 
@@ -215,9 +221,9 @@ where
 ///
 /// Logically the actor is dropped after we send the barrier with `Drop` mutation to the
 /// downstream，thus making the `drop`'s progress asynchronous. However, there might be a
-/// considerable of data in the executors' in-memory cache, dropping these structures might be a
-/// CPU-intensive task. This may lead to the runtime being unable to schedule other actors if the
-/// `drop` is called on the current thread.
+/// considerable amount of data in the executors' in-memory cache, dropping these structures might
+/// be a CPU-intensive task. This may lead to the runtime being unable to schedule other actors if
+/// the `drop` is called on the current thread.
 pub async fn spawn_blocking_drop_stream<T: Send + 'static>(stream: T) {
     let _ = tokio::task::spawn_blocking(move || drop(stream))
         .instrument_await("drop_stream")

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -262,15 +262,12 @@ impl StreamConsumer for DispatchExecutor {
             #[for_await]
             for msg in input {
                 let msg: Message = msg?;
-                let (barrier, message) = match msg {
+                let (barrier, span) = match msg {
                     Message::Chunk(_) => (None, "dispatch_chunk"),
                     Message::Barrier(ref barrier) => (Some(barrier.clone()), "dispatch_barrier"),
                     Message::Watermark(_) => (None, "dispatch_watermark"),
                 };
-                self.inner
-                    .dispatch(msg)
-                    .verbose_instrument_await(message)
-                    .await?;
+                self.inner.dispatch(msg).instrument_await(span).await?;
                 if let Some(barrier) = barrier {
                     yield barrier;
                 }

--- a/src/stream/src/executor/subtask.rs
+++ b/src/stream/src/executor/subtask.rs
@@ -18,6 +18,7 @@ use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
 use tokio_stream::wrappers::ReceiverStream;
 
+use super::actor::spawn_blocking_drop_stream;
 use super::{BoxedExecutor, Executor, ExecutorInfo, MessageStreamItem};
 
 /// Handle used to drive the subtask.
@@ -85,6 +86,7 @@ pub fn wrap(input: BoxedExecutor) -> (SubtaskHandle, SubtaskRxExecutor) {
                 break;
             }
         }
+        spawn_blocking_drop_stream(input).await;
     }
     .instrument_await("Subtask");
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Logically the actor is dropped after we send the barrier with `Drop` mutation to the downstream，thus making the `drop`'s progress asynchronous. However, there might be a considerable amount of data in the executors' in-memory cache, dropping these structures might be a CPU-intensive task. This may lead to the runtime being unable to schedule other actors if the `drop` is called on the current thread.

Note: There's no evidence for this to be related to #8474. :(

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
