### PR TITLE
fix(conector-node): do not store sink row inside upsert iceberg sink

### DIFF
--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/SinkRowOp.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/SinkRowOp.java
@@ -14,14 +14,14 @@
 
 package com.risingwave.connector;
 
-import com.risingwave.connector.api.sink.SinkRow;
 import io.grpc.Status;
+import org.apache.iceberg.data.Record;
 
 public class SinkRowOp {
-    private final SinkRow delete;
-    private final SinkRow insert;
+    private final Record delete;
+    private final Record insert;
 
-    public static SinkRowOp insertOp(SinkRow row) {
+    public static SinkRowOp insertOp(Record row) {
         if (row == null) {
             throw Status.FAILED_PRECONDITION
                     .withDescription("row op must not be null to initialize insertOp")
@@ -30,7 +30,7 @@ public class SinkRowOp {
         return new SinkRowOp(null, row);
     }
 
-    public static SinkRowOp deleteOp(SinkRow row) {
+    public static SinkRowOp deleteOp(Record row) {
         if (row == null) {
             throw Status.FAILED_PRECONDITION
                     .withDescription("row op must not be null to initialize deleteOp")
@@ -39,7 +39,7 @@ public class SinkRowOp {
         return new SinkRowOp(row, null);
     }
 
-    public static SinkRowOp updateOp(SinkRow delete, SinkRow insert) {
+    public static SinkRowOp updateOp(Record delete, Record insert) {
         if (delete == null || insert == null) {
             throw Status.FAILED_PRECONDITION
                     .withDescription("row ops must not be null initialize updateOp")
@@ -48,7 +48,7 @@ public class SinkRowOp {
         return new SinkRowOp(delete, insert);
     }
 
-    private SinkRowOp(SinkRow delete, SinkRow insert) {
+    private SinkRowOp(Record delete, Record insert) {
         this.delete = delete;
         this.insert = insert;
     }
@@ -57,11 +57,11 @@ public class SinkRowOp {
         return insert == null && delete != null;
     }
 
-    public SinkRow getDelete() {
+    public Record getDelete() {
         return delete;
     }
 
-    public SinkRow getInsert() {
+    public Record getInsert() {
         return insert;
     }
 }

--- a/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/SinkRowMapTest.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/test/java/com/risingwave/connector/SinkRowMapTest.java
@@ -21,6 +21,10 @@ import com.risingwave.connector.api.sink.SinkRow;
 import com.risingwave.proto.Data;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Types;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,29 +35,42 @@ public class SinkRowMapTest {
         SinkRow row = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1);
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
 
-        sinkRowMap.insert(key, row);
+        sinkRowMap.insert(key, r);
         assertEquals(1, sinkRowMap.map.size());
         assertEquals(null, sinkRowMap.map.get(key).getDelete());
-        assertEquals(row, sinkRowMap.map.get(key).getInsert());
+        assertEquals(r, sinkRowMap.map.get(key).getInsert());
     }
 
     @Test
     public void testInsertAfterDelete() {
         SinkRowMap sinkRowMap = new SinkRowMap();
+        Schema schema =
+                new Schema(
+                        Types.NestedField.optional(0, "id", Types.IntegerType.get()),
+                        Types.NestedField.optional(1, "name", Types.StringType.get()));
 
         SinkRow row1 = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1, "Alice");
         List<Comparable<Object>> key1 = new ArrayList<>();
         key1.add((Comparable<Object>) row1.get(0));
+        Record r1 = GenericRecord.create(schema);
+        r1.set(0, row1.get(0));
+        r1.set(1, row1.get(1));
         SinkRow row2 = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1, "Bob");
         List<Comparable<Object>> key2 = new ArrayList<>();
         key2.add((Comparable<Object>) row2.get(0));
+        Record r2 = GenericRecord.create(schema);
+        r2.set(0, row2.get(0));
+        r2.set(1, row2.get(1));
 
-        sinkRowMap.delete(key1, row1);
-        sinkRowMap.insert(key1, row2);
+        sinkRowMap.delete(key1, r1);
+        sinkRowMap.insert(key1, r2);
         assertEquals(1, sinkRowMap.map.size());
-        assertEquals(row1, sinkRowMap.map.get(key1).getDelete());
-        assertEquals(row2, sinkRowMap.map.get(key1).getInsert());
+        assertEquals(r1, sinkRowMap.map.get(key1).getDelete());
+        assertEquals(r2, sinkRowMap.map.get(key1).getInsert());
     }
 
     @Test
@@ -62,11 +79,14 @@ public class SinkRowMapTest {
         SinkRow row = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1);
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
 
-        sinkRowMap.insert(key, row);
+        sinkRowMap.insert(key, r);
         boolean exceptionThrown = false;
         try {
-            sinkRowMap.insert(key, row);
+            sinkRowMap.insert(key, r);
         } catch (RuntimeException e) {
             exceptionThrown = true;
             Assert.assertTrue(
@@ -87,10 +107,14 @@ public class SinkRowMapTest {
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
 
-        sinkRowMap.delete(key, row);
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
+
+        sinkRowMap.delete(key, r);
         assertEquals(1, sinkRowMap.map.size());
         assertEquals(null, sinkRowMap.map.get(key).getInsert());
-        assertEquals(row, sinkRowMap.map.get(key).getDelete());
+        assertEquals(r, sinkRowMap.map.get(key).getDelete());
     }
 
     @Test
@@ -100,10 +124,14 @@ public class SinkRowMapTest {
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
 
-        sinkRowMap.delete(key, row);
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
+
+        sinkRowMap.delete(key, r);
         boolean exceptionThrown = false;
         try {
-            sinkRowMap.delete(key, row);
+            sinkRowMap.delete(key, r);
         } catch (RuntimeException e) {
             exceptionThrown = true;
             Assert.assertTrue(
@@ -122,8 +150,12 @@ public class SinkRowMapTest {
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
 
-        sinkRowMap.insert(key, row);
-        sinkRowMap.delete(key, row);
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
+
+        sinkRowMap.insert(key, r);
+        sinkRowMap.delete(key, r);
         assertEquals(0, sinkRowMap.map.size());
     }
 
@@ -131,19 +163,31 @@ public class SinkRowMapTest {
     public void testDeleteAfterUpdate() {
         SinkRowMap sinkRowMap = new SinkRowMap();
 
+        Schema schema =
+                new Schema(
+                        Types.NestedField.optional(0, "id", Types.IntegerType.get()),
+                        Types.NestedField.optional(1, "name", Types.StringType.get()));
+
         SinkRow row1 = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1, "Alice");
         List<Comparable<Object>> key1 = new ArrayList<>();
         key1.add((Comparable<Object>) row1.get(0));
+        Record r1 = GenericRecord.create(schema);
+        r1.set(0, row1.get(0));
+        r1.set(1, row1.get(1));
+
         SinkRow row2 = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1, "Clare");
         List<Comparable<Object>> key2 = new ArrayList<>();
         key2.add((Comparable<Object>) row2.get(0));
+        Record r2 = GenericRecord.create(schema);
+        r2.set(0, row2.get(0));
+        r2.set(1, row2.get(1));
 
-        sinkRowMap.delete(key1, row1);
-        sinkRowMap.insert(key2, row2);
-        sinkRowMap.delete(key2, row2);
+        sinkRowMap.delete(key1, r1);
+        sinkRowMap.insert(key2, r2);
+        sinkRowMap.delete(key2, r2);
         assertEquals(1, sinkRowMap.map.size());
         assertEquals(null, sinkRowMap.map.get(key1).getInsert());
-        assertEquals(row1, sinkRowMap.map.get(key1).getDelete());
+        assertEquals(r1, sinkRowMap.map.get(key1).getDelete());
     }
 
     @Test
@@ -153,7 +197,10 @@ public class SinkRowMapTest {
         SinkRow row = new ArraySinkRow(Data.Op.OP_UNSPECIFIED, 1);
         List<Comparable<Object>> key = new ArrayList<>();
         key.add((Comparable<Object>) row.get(0));
-        sinkRowMap.insert(key, row);
+        Schema schema = new Schema(Types.NestedField.optional(0, "id", Types.IntegerType.get()));
+        Record r = GenericRecord.create(schema);
+        r.set(0, row.get(0));
+        sinkRowMap.insert(key, r);
 
         sinkRowMap.clear();
         assertEquals(0, sinkRowMap.map.size());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled. The sink row is supposed to be closed after it has been processed and should not be stored in somewhere with longer lifetime. However, the current iceberg upsert sink hold the sink row in a buffer and will access the sink row after the row has been closed, which will cause segfault for stream chunk row.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
