### PR TITLE
chore(config): use proportion to setup memory limits for the componen…

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -310,20 +310,20 @@ pub struct StorageConfig {
 
     /// Maximum shared buffer size, writes attempting to exceed the capacity will stall until there
     /// is enough space.
-    #[serde(default = "default::storage::shared_buffer_capacity_mb")]
-    pub shared_buffer_capacity_mb: usize,
+    #[serde(default)]
+    pub shared_buffer_capacity_mb: Option<usize>,
 
     /// Whether to enable write conflict detection
     #[serde(default = "default::storage::write_conflict_detection_enabled")]
     pub write_conflict_detection_enabled: bool,
 
     /// Capacity of sstable block cache.
-    #[serde(default = "default::storage::block_cache_capacity_mb")]
-    pub block_cache_capacity_mb: usize,
+    #[serde(default)]
+    pub block_cache_capacity_mb: Option<usize>,
 
     /// Capacity of sstable meta cache.
-    #[serde(default = "default::storage::meta_cache_capacity_mb")]
-    pub meta_cache_capacity_mb: usize,
+    #[serde(default)]
+    pub meta_cache_capacity_mb: Option<usize>,
 
     #[serde(default = "default::storage::disable_remote_compactor")]
     pub disable_remote_compactor: bool,
@@ -340,8 +340,8 @@ pub struct StorageConfig {
     pub share_buffer_upload_concurrency: usize,
 
     /// Capacity of sstable meta cache.
-    #[serde(default = "default::storage::compactor_memory_limit_mb")]
-    pub compactor_memory_limit_mb: usize,
+    #[serde(default)]
+    pub compactor_memory_limit_mb: Option<usize>,
 
     /// Number of SST ids fetched from meta per RPC
     #[serde(default = "default::storage::sstable_id_remote_fetch_number")]
@@ -382,8 +382,8 @@ pub struct FileCacheConfig {
     #[serde(default = "default::file_cache::capacity_mb")]
     pub capacity_mb: usize,
 
-    #[serde(default = "default::file_cache::total_buffer_capacity_mb")]
-    pub total_buffer_capacity_mb: usize,
+    #[serde(default)]
+    pub total_buffer_capacity_mb: Option<usize>,
 
     #[serde(default = "default::file_cache::cache_file_fallocate_unit_mb")]
     pub cache_file_fallocate_unit_mb: usize,
@@ -791,5 +791,45 @@ mod default {
         pub fn telemetry_enabled() -> bool {
             system_param::default::telemetry_enabled()
         }
+    }
+}
+
+pub struct StorageMemoryConfig {
+    pub block_cache_capacity_mb: usize,
+    pub meta_cache_capacity_mb: usize,
+    pub shared_buffer_capacity_mb: usize,
+    pub file_cache_total_buffer_capacity_mb: usize,
+    pub compactor_memory_limit_mb: usize,
+}
+
+pub fn extract_storage_memory_config(s: &RwConfig) -> StorageMemoryConfig {
+    let block_cache_capacity_mb = s
+        .storage
+        .block_cache_capacity_mb
+        .unwrap_or(default::storage::block_cache_capacity_mb());
+    let meta_cache_capacity_mb = s
+        .storage
+        .meta_cache_capacity_mb
+        .unwrap_or(default::storage::meta_cache_capacity_mb());
+    let shared_buffer_capacity_mb = s
+        .storage
+        .shared_buffer_capacity_mb
+        .unwrap_or(default::storage::shared_buffer_capacity_mb());
+    let file_cache_total_buffer_capacity_mb = s
+        .storage
+        .file_cache
+        .total_buffer_capacity_mb
+        .unwrap_or(default::file_cache::total_buffer_capacity_mb());
+    let compactor_memory_limit_mb = s
+        .storage
+        .compactor_memory_limit_mb
+        .unwrap_or(default::storage::compactor_memory_limit_mb());
+
+    StorageMemoryConfig {
+        block_cache_capacity_mb,
+        meta_cache_capacity_mb,
+        shared_buffer_capacity_mb,
+        file_cache_total_buffer_capacity_mb,
+        compactor_memory_limit_mb,
     }
 }

--- a/src/compute/src/memory_management/memory_manager.rs
+++ b/src/compute/src/memory_management/memory_manager.rs
@@ -24,14 +24,7 @@ use risingwave_stream::task::LocalStreamManager;
 use super::MemoryControlPolicy;
 use crate::memory_management::MemoryControlStats;
 
-/// The minimal memory requirement of computing tasks in megabytes.
-pub const MIN_COMPUTE_MEMORY_MB: usize = 512;
-/// The memory reserved for system usage (stack and code segment of processes, allocation overhead,
-/// network buffer, etc.) in megabytes.
-pub const SYSTEM_RESERVED_MEMORY_MB: usize = 512;
-
-/// When `enable_managed_cache` is set, compute node will launch a [`GlobalMemoryManager`] to limit
-/// the memory usage.
+/// Compute node uses [`GlobalMemoryManager`] to limit the memory usage.
 pub struct GlobalMemoryManager {
     /// All cached data before the watermark should be evicted.
     watermark_epoch: Arc<AtomicU64>,

--- a/src/compute/src/memory_management/mod.rs
+++ b/src/compute/src/memory_management/mod.rs
@@ -23,10 +23,28 @@ use std::sync::atomic::AtomicU64;
 use std::sync::Arc;
 
 use risingwave_batch::task::BatchManager;
+use risingwave_common::config::{StorageConfig, StorageMemoryConfig};
 use risingwave_common::error::Result;
 use risingwave_stream::task::LocalStreamManager;
 
 use crate::ComputeNodeOpts;
+
+/// The minimal memory requirement of computing tasks in megabytes.
+pub const MIN_COMPUTE_MEMORY_MB: usize = 512;
+/// The memory reserved for system usage (stack and code segment of processes, allocation
+/// overhead, network buffer, etc.) in megabytes.
+pub const MIN_SYSTEM_RESERVED_MEMORY_MB: usize = 512;
+pub const MAX_SYSTEM_RESERVED_MEMORY_MB: usize = 2048;
+pub const SYSTEM_RESERVED_MEMORY_PROPORTION: f64 = 0.1;
+
+pub const STORAGE_MEMORY_PROPORTION: f64 = 0.3;
+
+pub const COMPACTOR_MEMORY_PROPORTION: f64 = 0.1;
+
+pub const STORAGE_BLOCK_CACHE_MEMORY_PROPORTION: f64 = 0.3;
+pub const STORAGE_META_CACHE_MEMORY_PROPORTION: f64 = 0.1;
+pub const STORAGE_SHARED_BUFFER_MEMORY_PROPORTION: f64 = 0.5;
+pub const STORAGE_FILE_CACHE_MEMORY_PROPORTION: f64 = 0.1;
 
 /// `MemoryControlStats` contains the necessary information for memory control, including both batch
 /// and streaming.
@@ -109,5 +127,119 @@ impl MemoryControl for DummyPolicy {
 
     fn describe(&self, _total_compute_memory_bytes: usize) -> String {
         "DummyPolicy".to_string()
+    }
+}
+
+/// Each compute node reserves some memory for stack and code segment of processes, allocation
+/// overhead, network buffer, etc. based on `SYSTEM_RESERVED_MEMORY_PROPORTION`. The reserve memory
+/// size belongs to [`MIN_SYSTEM_RESERVED_MEMORY_MB`, `MAX_SYSTEM_RESERVED_MEMORY_MB`]
+pub fn reserve_memory_bytes(total_memory_bytes: usize) -> (usize, usize) {
+    let reserved = std::cmp::min(
+        std::cmp::max(
+            (total_memory_bytes as f64 * SYSTEM_RESERVED_MEMORY_PROPORTION).ceil() as usize,
+            MIN_SYSTEM_RESERVED_MEMORY_MB << 20,
+        ),
+        MAX_SYSTEM_RESERVED_MEMORY_MB << 20,
+    );
+    (reserved, total_memory_bytes - reserved)
+}
+
+/// Decide the memory limit for each storage cache. If not specified in `StorageConfig`, memory
+/// limits are calculated based on the proportions to total `non_reserved_memory_bytes`.
+pub fn storage_memory_config(
+    non_reserved_memory_bytes: usize,
+    storage_config: &StorageConfig,
+) -> StorageMemoryConfig {
+    let block_cache_capacity_mb = storage_config.block_cache_capacity_mb.unwrap_or(
+        ((non_reserved_memory_bytes as f64
+            * STORAGE_MEMORY_PROPORTION
+            * STORAGE_BLOCK_CACHE_MEMORY_PROPORTION)
+            .ceil() as usize)
+            >> 20,
+    );
+    let meta_cache_capacity_mb = storage_config.meta_cache_capacity_mb.unwrap_or(
+        ((non_reserved_memory_bytes as f64
+            * STORAGE_MEMORY_PROPORTION
+            * STORAGE_META_CACHE_MEMORY_PROPORTION)
+            .ceil() as usize)
+            >> 20,
+    );
+    let shared_buffer_capacity_mb = storage_config.shared_buffer_capacity_mb.unwrap_or(
+        ((non_reserved_memory_bytes as f64
+            * STORAGE_MEMORY_PROPORTION
+            * STORAGE_SHARED_BUFFER_MEMORY_PROPORTION)
+            .ceil() as usize)
+            >> 20,
+    );
+    let file_cache_total_buffer_capacity_mb = storage_config
+        .file_cache
+        .total_buffer_capacity_mb
+        .unwrap_or(
+            ((non_reserved_memory_bytes as f64
+                * STORAGE_MEMORY_PROPORTION
+                * STORAGE_FILE_CACHE_MEMORY_PROPORTION)
+                .ceil() as usize)
+                >> 20,
+        );
+    let compactor_memory_limit_mb = storage_config.compactor_memory_limit_mb.unwrap_or(
+        ((non_reserved_memory_bytes as f64 * COMPACTOR_MEMORY_PROPORTION).ceil() as usize) >> 20,
+    );
+
+    StorageMemoryConfig {
+        block_cache_capacity_mb,
+        meta_cache_capacity_mb,
+        shared_buffer_capacity_mb,
+        file_cache_total_buffer_capacity_mb,
+        compactor_memory_limit_mb,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use risingwave_common::config::StorageConfig;
+
+    use super::{reserve_memory_bytes, storage_memory_config};
+
+    #[test]
+    fn test_reserve_memory_bytes() {
+        // at least 512 MB
+        let (reserved, non_reserved) = reserve_memory_bytes(2 << 30);
+        assert_eq!(reserved, 512 << 20);
+        assert_eq!(non_reserved, 1536 << 20);
+
+        // reserve based on proportion
+        let (reserved, non_reserved) = reserve_memory_bytes(10 << 30);
+        assert_eq!(reserved, 1 << 30);
+        assert_eq!(non_reserved, 9 << 30);
+
+        // at most 2 MB
+        let (reserved, non_reserved) = reserve_memory_bytes(100 << 30);
+        assert_eq!(reserved, 2 << 30);
+        assert_eq!(non_reserved, 98 << 30);
+    }
+
+    #[test]
+    fn test_storage_memory_config() {
+        let mut storage_config = StorageConfig::default();
+        let total_non_reserved_memory_bytes = 8 << 30;
+
+        let memory_config = storage_memory_config(total_non_reserved_memory_bytes, &storage_config);
+        assert_eq!(memory_config.block_cache_capacity_mb, 737);
+        assert_eq!(memory_config.meta_cache_capacity_mb, 245);
+        assert_eq!(memory_config.shared_buffer_capacity_mb, 1228);
+        assert_eq!(memory_config.file_cache_total_buffer_capacity_mb, 245);
+        assert_eq!(memory_config.compactor_memory_limit_mb, 819);
+
+        storage_config.block_cache_capacity_mb = Some(512);
+        storage_config.meta_cache_capacity_mb = Some(128);
+        storage_config.shared_buffer_capacity_mb = Some(1024);
+        storage_config.file_cache.total_buffer_capacity_mb = Some(128);
+        storage_config.compactor_memory_limit_mb = Some(512);
+        let memory_config = storage_memory_config(0, &storage_config);
+        assert_eq!(memory_config.block_cache_capacity_mb, 512);
+        assert_eq!(memory_config.meta_cache_capacity_mb, 128);
+        assert_eq!(memory_config.shared_buffer_capacity_mb, 1024);
+        assert_eq!(memory_config.file_cache_total_buffer_capacity_mb, 128);
+        assert_eq!(memory_config.compactor_memory_limit_mb, 512);
     }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -124,6 +124,14 @@ pub async fn compute_node_serve(
         reserved_memory_bytes,
         storage_memory_bytes,
     );
+    print_memory_config(
+        opts.total_memory_bytes,
+        compute_memory_bytes,
+        storage_memory_bytes,
+        &storage_memory_config,
+        embedded_compactor_enabled,
+    );
+
     let memory_control_policy = memory_control_policy_from_config(&opts).unwrap();
 
     let storage_opts = Arc::new(StorageOpts::from((
@@ -467,4 +475,46 @@ fn embedded_compactor_enabled(state_store_url: &str, disable_remote_compactor: b
     state_store_url == "hummock+memory"
         || state_store_url.starts_with("hummock+disk")
         || disable_remote_compactor
+}
+
+// Print out the memory outline of the compute node.
+fn print_memory_config(
+    cn_total_memory_bytes: usize,
+    compute_memory_bytes: usize,
+    storage_memory_bytes: usize,
+    storage_memory_config: &StorageMemoryConfig,
+    embedded_compactor_enabled: bool,
+) {
+    info!("Memory outline: ");
+    info!("> total_memory: {}", convert(cn_total_memory_bytes as _));
+    info!(
+        ">     storage_memory: {}",
+        convert(storage_memory_bytes as _)
+    );
+    info!(
+        ">         block_cache_capacity: {}",
+        convert((storage_memory_config.block_cache_capacity_mb << 20) as _)
+    );
+    info!(
+        ">         meta_cache_capacity: {}",
+        convert((storage_memory_config.meta_cache_capacity_mb << 20) as _)
+    );
+    info!(
+        ">         shared_buffer_capacity: {}",
+        convert((storage_memory_config.shared_buffer_capacity_mb << 20) as _)
+    );
+    info!(
+        ">         file_cache_total_buffer_capacity: {}",
+        convert((storage_memory_config.file_cache_total_buffer_capacity_mb << 20) as _)
+    );
+    if embedded_compactor_enabled {
+        info!(
+            ">         compactor_memory_limit: {}",
+            convert((storage_memory_config.compactor_memory_limit_mb << 20) as _)
+        );
+    }
+    info!(
+        ">     compute_memory: {}",
+        convert(compute_memory_bytes as _)
+    );
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -21,7 +21,7 @@ use risingwave_batch::executor::{BatchManagerMetrics, BatchTaskMetrics};
 use risingwave_batch::rpc::service::task_service::BatchServiceImpl;
 use risingwave_batch::task::{BatchEnvironment, BatchManager};
 use risingwave_common::config::{
-    load_config, AsyncStackTraceOption, StorageConfig, MAX_CONNECTION_WINDOW_SIZE,
+    load_config, AsyncStackTraceOption, StorageMemoryConfig, MAX_CONNECTION_WINDOW_SIZE,
     STREAM_WINDOW_SIZE,
 };
 use risingwave_common::monitor::process_linux::monitor_process;
@@ -60,9 +60,10 @@ use risingwave_stream::task::{LocalStreamManager, StreamEnvironment};
 use tokio::sync::oneshot::Sender;
 use tokio::task::JoinHandle;
 
-use crate::memory_management::memory_control_policy_from_config;
-use crate::memory_management::memory_manager::{
-    GlobalMemoryManager, MIN_COMPUTE_MEMORY_MB, SYSTEM_RESERVED_MEMORY_MB,
+use crate::memory_management::memory_manager::GlobalMemoryManager;
+use crate::memory_management::{
+    memory_control_policy_from_config, reserve_memory_bytes, storage_memory_config,
+    MIN_COMPUTE_MEMORY_MB,
 };
 use crate::observer::observer_manager::ComputeObserverNode;
 use crate::rpc::service::config_service::ConfigServiceImpl;
@@ -106,17 +107,30 @@ pub async fn compute_node_serve(
     )
     .await
     .unwrap();
-    let storage_opts = Arc::new(StorageOpts::from((&config, &system_params)));
 
     let state_store_url = system_params.state_store();
 
     let embedded_compactor_enabled =
         embedded_compactor_enabled(state_store_url, config.storage.disable_remote_compactor);
+
+    let (reserved_memory_bytes, non_reserved_memory_bytes) =
+        reserve_memory_bytes(opts.total_memory_bytes);
+    let storage_memory_config = storage_memory_config(non_reserved_memory_bytes, &config.storage);
+
     let storage_memory_bytes =
-        total_storage_memory_limit_bytes(&config.storage, embedded_compactor_enabled);
-    let compute_memory_bytes =
-        validate_compute_node_memory_config(opts.total_memory_bytes, storage_memory_bytes);
+        total_storage_memory_limit_bytes(&storage_memory_config, embedded_compactor_enabled);
+    let compute_memory_bytes = validate_compute_node_memory_config(
+        opts.total_memory_bytes,
+        reserved_memory_bytes,
+        storage_memory_bytes,
+    );
     let memory_control_policy = memory_control_policy_from_config(&opts).unwrap();
+
+    let storage_opts = Arc::new(StorageOpts::from((
+        &config,
+        &system_params,
+        &storage_memory_config,
+    )));
 
     let worker_id = meta_client.worker_id();
     info!("Assigned worker node id {}", worker_id);
@@ -400,10 +414,12 @@ pub async fn compute_node_serve(
 
 /// Check whether the compute node has enough memory to perform computing tasks. Apart from storage,
 /// it is recommended to reserve at least `MIN_COMPUTE_MEMORY_MB` for computing and
-/// `SYSTEM_RESERVED_MEMORY_MB` for other system usage. If the requirement is not met, we will print
-/// out a warning and enforce the memory used for computing tasks as `MIN_COMPUTE_MEMORY_MB`.
+/// `SYSTEM_RESERVED_MEMORY_PROPORTION` of total memory for other system usage. If the requirement
+/// is not met, we will print out a warning and enforce the memory used for computing tasks as
+/// `MIN_COMPUTE_MEMORY_MB`.
 fn validate_compute_node_memory_config(
     cn_total_memory_bytes: usize,
+    reserved_memory_bytes: usize,
     storage_memory_bytes: usize,
 ) -> usize {
     if storage_memory_bytes > cn_total_memory_bytes {
@@ -413,7 +429,7 @@ fn validate_compute_node_memory_config(
             convert(storage_memory_bytes as _)
         );
         MIN_COMPUTE_MEMORY_MB << 20
-    } else if storage_memory_bytes + ((MIN_COMPUTE_MEMORY_MB + SYSTEM_RESERVED_MEMORY_MB) << 20)
+    } else if storage_memory_bytes + (MIN_COMPUTE_MEMORY_MB << 20) + reserved_memory_bytes
         >= cn_total_memory_bytes
     {
         tracing::warn!(
@@ -423,24 +439,24 @@ fn validate_compute_node_memory_config(
         );
         MIN_COMPUTE_MEMORY_MB << 20
     } else {
-        cn_total_memory_bytes - storage_memory_bytes - (SYSTEM_RESERVED_MEMORY_MB << 20)
+        cn_total_memory_bytes - storage_memory_bytes - reserved_memory_bytes
     }
 }
 
 /// The maximal memory that storage components may use based on the configurations in bytes. Note
 /// that this is the total storage memory for one compute node instead of the whole cluster.
 fn total_storage_memory_limit_bytes(
-    storage_config: &StorageConfig,
+    storage_memory_config: &StorageMemoryConfig,
     embedded_compactor_enabled: bool,
 ) -> usize {
-    let total_memory = storage_config.block_cache_capacity_mb
-        + storage_config.meta_cache_capacity_mb
-        + storage_config.shared_buffer_capacity_mb
-        + storage_config.file_cache.total_buffer_capacity_mb;
+    let total_storage_memory_mb = storage_memory_config.block_cache_capacity_mb
+        + storage_memory_config.meta_cache_capacity_mb
+        + storage_memory_config.shared_buffer_capacity_mb
+        + storage_memory_config.file_cache_total_buffer_capacity_mb;
     if embedded_compactor_enabled {
-        (total_memory + storage_config.compactor_memory_limit_mb) << 20
+        (storage_memory_config.compactor_memory_limit_mb + total_storage_memory_mb) << 20
     } else {
-        total_memory << 20
+        total_storage_memory_mb << 20
     }
 }
 

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -16,7 +16,7 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use risingwave_common::config::load_config;
+use risingwave_common::config::{extract_storage_memory_config, load_config};
 use risingwave_common::monitor::process_linux::monitor_process;
 use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
 use risingwave_common::telemetry::manager::TelemetryManager;
@@ -90,7 +90,12 @@ pub async fn compactor_serve(
 
     let state_store_url = system_params_reader.state_store();
 
-    let storage_opts = Arc::new(StorageOpts::from((&config, &system_params_reader)));
+    let storage_memory_config = extract_storage_memory_config(&config);
+    let storage_opts = Arc::new(StorageOpts::from((
+        &config,
+        &system_params_reader,
+        &storage_memory_config,
+    )));
     let object_store = Arc::new(
         parse_remote_object_store(
             state_store_url

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::config::RwConfig;
+use risingwave_common::config::{extract_storage_memory_config, RwConfig, StorageMemoryConfig};
 use risingwave_common::system_param::default_system_params;
 use risingwave_common::system_param::reader::SystemParamsReader;
 
@@ -73,12 +73,13 @@ impl Default for StorageOpts {
     fn default() -> Self {
         let c = RwConfig::default();
         let p = default_system_params();
-        Self::from((&c, &p.into()))
+        let s = extract_storage_memory_config(&c);
+        Self::from((&c, &p.into(), &s))
     }
 }
 
-impl From<(&RwConfig, &SystemParamsReader)> for StorageOpts {
-    fn from((c, p): (&RwConfig, &SystemParamsReader)) -> Self {
+impl From<(&RwConfig, &SystemParamsReader, &StorageMemoryConfig)> for StorageOpts {
+    fn from((c, p, s): (&RwConfig, &SystemParamsReader, &StorageMemoryConfig)) -> Self {
         Self {
             sstable_size_mb: p.sstable_size_mb(),
             block_size_kb: p.block_size_kb(),
@@ -87,23 +88,23 @@ impl From<(&RwConfig, &SystemParamsReader)> for StorageOpts {
             share_buffer_compaction_worker_threads_number: c
                 .storage
                 .share_buffer_compaction_worker_threads_number,
-            shared_buffer_capacity_mb: c.storage.shared_buffer_capacity_mb,
+            shared_buffer_capacity_mb: s.shared_buffer_capacity_mb,
             data_directory: p.data_directory().to_string(),
             write_conflict_detection_enabled: c.storage.write_conflict_detection_enabled,
-            block_cache_capacity_mb: c.storage.block_cache_capacity_mb,
-            meta_cache_capacity_mb: c.storage.meta_cache_capacity_mb,
+            block_cache_capacity_mb: s.block_cache_capacity_mb,
+            meta_cache_capacity_mb: s.meta_cache_capacity_mb,
             disable_remote_compactor: c.storage.disable_remote_compactor,
             enable_local_spill: c.storage.enable_local_spill,
             local_object_store: c.storage.local_object_store.to_string(),
             share_buffer_upload_concurrency: c.storage.share_buffer_upload_concurrency,
-            compactor_memory_limit_mb: c.storage.compactor_memory_limit_mb,
+            compactor_memory_limit_mb: s.compactor_memory_limit_mb,
             sstable_id_remote_fetch_number: c.storage.sstable_id_remote_fetch_number,
             min_sst_size_for_streaming_upload: c.storage.min_sst_size_for_streaming_upload,
             max_sub_compaction: c.storage.max_sub_compaction,
             max_concurrent_compaction_task_number: c.storage.max_concurrent_compaction_task_number,
             file_cache_dir: c.storage.file_cache.dir.clone(),
             file_cache_capacity_mb: c.storage.file_cache.capacity_mb,
-            file_cache_total_buffer_capacity_mb: c.storage.file_cache.total_buffer_capacity_mb,
+            file_cache_total_buffer_capacity_mb: s.file_cache_total_buffer_capacity_mb,
             file_cache_file_fallocate_unit_mb: c.storage.file_cache.cache_file_fallocate_unit_mb,
             file_cache_meta_fallocate_unit_mb: c.storage.file_cache.cache_meta_fallocate_unit_mb,
             file_cache_file_max_write_size_mb: c.storage.file_cache.cache_file_max_write_size_mb,

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -25,7 +25,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 use clap::Parser;
 use futures::TryStreamExt;
 use risingwave_common::catalog::TableId;
-use risingwave_common::config::{load_config, NO_OVERRIDE};
+use risingwave_common::config::{extract_storage_memory_config, load_config, NO_OVERRIDE};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, FIRST_VERSION_ID};
@@ -350,7 +350,12 @@ async fn start_replay(
     }
 
     // Creates a hummock state store *after* we reset the hummock version
-    let storage_opts = Arc::new(StorageOpts::from((&config, &system_params)));
+    let storage_memory_config = extract_storage_memory_config(&config);
+    let storage_opts = Arc::new(StorageOpts::from((
+        &config,
+        &system_params,
+        &storage_memory_config,
+    )));
     let hummock = create_hummock_store_with_metrics(&meta_client, storage_opts, &opts).await?;
 
     // Replay version deltas from FIRST_VERSION_ID to the version before reset

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -25,7 +25,9 @@ use rand::rngs::StdRng;
 use rand::{RngCore, SeedableRng};
 use risingwave_common::catalog::hummock::PROPERTIES_RETENTION_SECOND_KEY;
 use risingwave_common::catalog::TableId;
-use risingwave_common::config::{load_config, RwConfig, NO_OVERRIDE};
+use risingwave_common::config::{
+    extract_storage_memory_config, load_config, RwConfig, NO_OVERRIDE,
+};
 use risingwave_hummock_sdk::compact::CompactorRuntimeConfig;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::filter_key_extractor::{
@@ -163,7 +165,12 @@ async fn compaction_test(
         ..Default::default()
     }
     .into();
-    let storage_opts = Arc::new(StorageOpts::from((&config, &system_params)));
+    let storage_memory_config = extract_storage_memory_config(&config);
+    let storage_opts = Arc::new(StorageOpts::from((
+        &config,
+        &system_params,
+        &storage_memory_config,
+    )));
     let state_store_metrics = Arc::new(HummockStateStoreMetrics::unused());
     let compactor_metrics = Arc::new(CompactorMetrics::unused());
     let object_store_metrics = Arc::new(ObjectStoreMetrics::unused());
@@ -176,8 +183,8 @@ async fn compaction_test(
     let sstable_store = Arc::new(SstableStore::new(
         Arc::new(remote_object_store),
         system_params.data_directory().to_string(),
-        config.storage.block_cache_capacity_mb * (1 << 20),
-        config.storage.meta_cache_capacity_mb * (1 << 20),
+        storage_memory_config.block_cache_capacity_mb * (1 << 20),
+        storage_memory_config.meta_cache_capacity_mb * (1 << 20),
         TieredCache::none(),
     ));
 

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -253,6 +253,8 @@ impl Cluster {
                 "0.0.0.0:5688",
                 "--advertise-addr",
                 &format!("192.168.3.{i}:5688"),
+                "--total-memory-bytes",
+                "7516192768",
                 "--parallelism",
                 &conf.compute_node_cores.to_string(),
             ]);

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -254,7 +254,7 @@ impl Cluster {
                 "--advertise-addr",
                 &format!("192.168.3.{i}:5688"),
                 "--total-memory-bytes",
-                "7516192768",
+                "6979321856",
                 "--parallelism",
                 &conf.compute_node_cores.to_string(),
             ]);


### PR DESCRIPTION
…ts in compute node

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

Use proportions to allocate memory for components in compute nodes, when not specified.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- RisingWave cluster configuration changes


</details>

## Refer to a related PR or issue link (optional)

https://github.com/risingwavelabs/risingwave/issues/7683
https://github.com/risingwavelabs/risingwave/issues/7610
