### PR TITLE
fix(optimizer): `ApplyAggTransposeRule` should handle `CorrelatedInputRef` in agg filter

### DIFF
--- a/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
@@ -739,6 +739,22 @@
             ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
             | └─LogicalScan { table: strings, columns: [strings.v1] }
             └─LogicalScan { table: strings, columns: [strings.v1] }
+- name: issue 4762 correlated input in agg filter
+  sql: |
+    CREATE TABLE strings(v1 VARCHAR);
+    SELECT (SELECT STRING_AGG(v1, ',') FILTER (WHERE v1 < t.v1) FROM strings) FROM strings AS t;
+  optimized_logical_plan_for_batch: |
+    LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(strings.v1, strings.v1), output: [string_agg(strings.v1, ',':Varchar) filter((strings.v1 < strings.v1))] }
+    ├─LogicalScan { table: strings, columns: [strings.v1] }
+    └─LogicalAgg { group_key: [strings.v1], aggs: [string_agg(strings.v1, ',':Varchar) filter((strings.v1 < strings.v1))] }
+      └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(strings.v1, strings.v1), output: [strings.v1, strings.v1, ',':Varchar] }
+        ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
+        | └─LogicalScan { table: strings, columns: [strings.v1] }
+        └─LogicalProject { exprs: [strings.v1, strings.v1, ',':Varchar] }
+          └─LogicalJoin { type: Inner, on: true, output: all }
+            ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
+            | └─LogicalScan { table: strings, columns: [strings.v1] }
+            └─LogicalScan { table: strings, columns: [strings.v1] }
 - name: Existential join on outer join with correlated condition
   sql: |
     create table t1(x int, y int);

--- a/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
+++ b/src/frontend/src/optimizer/rule/apply_agg_transpose_rule.rs
@@ -16,11 +16,11 @@ use risingwave_common::types::DataType;
 use risingwave_expr::expr::AggKind;
 use risingwave_pb::plan_common::JoinType;
 
-use super::{BoxedRule, Rule};
+use super::{ApplyOffsetRewriter, BoxedRule, Rule};
 use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef};
 use crate::optimizer::plan_node::{LogicalAgg, LogicalApply, LogicalFilter, LogicalProject};
 use crate::optimizer::PlanRef;
-use crate::utils::{ColIndexMapping, Condition};
+use crate::utils::Condition;
 
 /// Transpose `LogicalApply` and `LogicalAgg`.
 ///
@@ -53,7 +53,6 @@ impl Rule for ApplyAggTransposeRule {
         let agg: &LogicalAgg = right.as_logical_agg()?;
         let (mut agg_calls, agg_group_key, agg_input) = agg.clone().decompose();
         let is_scalar_agg = agg_group_key.is_empty();
-        let agg_input_len = agg_input.schema().len();
         let apply_left_len = left.schema().len();
 
         if !is_scalar_agg && max_one_row {
@@ -102,7 +101,7 @@ impl Rule for ApplyAggTransposeRule {
                 JoinType::LeftOuter,
                 Condition::true_cond(),
                 correlated_id,
-                correlated_indices,
+                correlated_indices.clone(),
                 false,
             )
             .translate_apply(left, eq_predicates)
@@ -113,7 +112,7 @@ impl Rule for ApplyAggTransposeRule {
                 JoinType::Inner,
                 Condition::true_cond(),
                 correlated_id,
-                correlated_indices,
+                correlated_indices.clone(),
                 false,
             )
             .into()
@@ -122,7 +121,8 @@ impl Rule for ApplyAggTransposeRule {
         let group_agg = {
             // shift index of agg_calls' `InputRef` with `apply_left_len`.
             let offset = apply_left_len as isize;
-            let mut shift_index = ColIndexMapping::with_shift_offset(agg_input_len, offset);
+            let mut rewriter =
+                ApplyOffsetRewriter::new(apply_left_len, &correlated_indices, correlated_id);
             agg_calls.iter_mut().for_each(|agg_call| {
                 agg_call.inputs.iter_mut().for_each(|input_ref| {
                     input_ref.shift_with_offset(offset);
@@ -131,7 +131,7 @@ impl Rule for ApplyAggTransposeRule {
                     .order_by
                     .iter_mut()
                     .for_each(|o| o.shift_with_offset(offset));
-                agg_call.filter = agg_call.filter.clone().rewrite_expr(&mut shift_index);
+                agg_call.filter = agg_call.filter.clone().rewrite_expr(&mut rewriter);
             });
             if is_scalar_agg {
                 // convert count(*) to count(1).

--- a/src/frontend/src/optimizer/rule/apply_offset_rewriter.rs
+++ b/src/frontend/src/optimizer/rule/apply_offset_rewriter.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use itertools::Itertools;
+
+use crate::expr::{CorrelatedId, CorrelatedInputRef, Expr, ExprImpl, ExprRewriter, InputRef};
+use crate::utils::ColIndexMapping;
+
+/// Convert `CorrelatedInputRef` to `InputRef` and shift `InputRef` with offset.
+pub struct ApplyOffsetRewriter {
+    offset: usize,
+    index_mapping: ColIndexMapping,
+    has_correlated_input_ref: bool,
+    correlated_id: CorrelatedId,
+}
+
+impl ExprRewriter for ApplyOffsetRewriter {
+    fn rewrite_correlated_input_ref(
+        &mut self,
+        correlated_input_ref: CorrelatedInputRef,
+    ) -> ExprImpl {
+        let found = correlated_input_ref.correlated_id() == self.correlated_id;
+        self.has_correlated_input_ref |= found;
+        if found {
+            InputRef::new(
+                self.index_mapping.map(correlated_input_ref.index()),
+                correlated_input_ref.return_type(),
+            )
+            .into()
+        } else {
+            correlated_input_ref.into()
+        }
+    }
+
+    fn rewrite_input_ref(&mut self, input_ref: InputRef) -> ExprImpl {
+        InputRef::new(input_ref.index() + self.offset, input_ref.return_type()).into()
+    }
+}
+
+impl ApplyOffsetRewriter {
+    pub fn new(offset: usize, correlated_indices: &[usize], correlated_id: CorrelatedId) -> Self {
+        Self {
+            offset,
+            index_mapping: ColIndexMapping::new(
+                correlated_indices.iter().copied().map(Some).collect_vec(),
+            )
+            .inverse(),
+            has_correlated_input_ref: false,
+            correlated_id,
+        }
+    }
+
+    pub fn has_correlated_input_ref(&self) -> bool {
+        self.has_correlated_input_ref
+    }
+
+    pub fn reset_state(&mut self) {
+        self.has_correlated_input_ref = false;
+    }
+}

--- a/src/frontend/src/optimizer/rule/mod.rs
+++ b/src/frontend/src/optimizer/rule/mod.rs
@@ -97,6 +97,9 @@ pub use avoid_exchange_share_rule::*;
 mod min_max_on_index_rule;
 pub use min_max_on_index_rule::*;
 
+mod apply_offset_rewriter;
+use apply_offset_rewriter::ApplyOffsetRewriter;
+
 #[macro_export]
 macro_rules! for_all_rules {
     ($macro:ident) => {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #4762

We used to only support `agg(inputs)` but later extended it to `agg(inputs ORDER BY exprs) FILTER (WHERE cond)`. When constructing the `LogicalAgg` node, all complex expressions in `inputs` and `order_by` are all extracted to a child `LogicalProject`, so that they are pure `InputRef`s in later stages. However, the `filter condition` remains unchanged in this process.

During subquery decorrelation, a common operation is to transpose with `LogicalApply`, where the original expressions need to shift their `InputRef` to accommodate extra columns on the left, and map their `CorrelatedInputRef` to a normal `InputRef` to one of the extra columns.

Before this PR, `ApplyFilterTransposeRule` and `ApplyProjectTransposeRule` implemented the same logic twice. And `ApplyAggTransposeRule` implemented a simplified version of it, which only handles `InputRefs` (enough to cover `inputs` and `order_by`) but not `CorrelatedInputRef` in filter condition, thus causing the panic.

This PR makes all 3 rules to use the same shared expr rewriter.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.