### PR TITLE
fix(stream): fix TopN cache by only inserting into high if the row is top

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -757,7 +757,7 @@ else
 fi
 
 cd "${JAVA_DIR}"
-"${MAVEN_PATH}" spotless:check
+"${MAVEN_PATH}" spotless:check -q
 """
 
 [tasks.check-java-fix]

--- a/e2e_test/streaming/bug_fixes/issue_8570.slt
+++ b/e2e_test/streaming/bug_fixes/issue_8570.slt
@@ -1,0 +1,45 @@
+# https://github.com/risingwavelabs/risingwave/issues/8570
+# TopN cache invalidation issue
+
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t(x int);
+
+statement ok
+create materialized view t_singleton as select * from t order by x limit 100;
+
+statement ok
+create materialized view mv as select * from t_singleton order by x limit 1;
+
+statement ok
+insert into t values (1), (2), (3), (4);
+
+statement ok
+delete from t where x = 2;
+
+statement ok
+insert into t values (5);
+
+statement ok
+delete from t where x = 1;
+
+statement ok
+insert into t values (6);
+
+statement ok
+delete from t where x = 3;
+
+statement ok
+delete from t where x = 4;
+
+# Shouldn't panic here
+statement ok
+insert into t values (1);
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;

--- a/e2e_test/streaming/bug_fixes/issue_8570.slt
+++ b/e2e_test/streaming/bug_fixes/issue_8570.slt
@@ -42,4 +42,7 @@ statement ok
 drop materialized view mv;
 
 statement ok
+drop materialized view t_singleton;
+
+statement ok
 drop table t;

--- a/e2e_test/streaming/bug_fixes/issue_8570.slt
+++ b/e2e_test/streaming/bug_fixes/issue_8570.slt
@@ -31,10 +31,16 @@ insert into t values (6);
 statement ok
 delete from t where x = 3;
 
+# Shouldn't be 5
+query I
+select * from mv;
+----
+4
+
 statement ok
 delete from t where x = 4;
 
-# Shouldn't panic here
+# Shouldn't panic
 statement ok
 insert into t values (1);
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -61,15 +61,6 @@ impl Op {
         };
         Ok(op)
     }
-
-    pub fn to_pretty_str(&self) -> &str {
-        match self {
-            Op::Insert => "+",
-            Op::Delete => "-",
-            Op::UpdateDelete => "U-",
-            Op::UpdateInsert => "U+",
-        }
-    }
 }
 
 pub type Ops<'a> = &'a [Op];
@@ -235,7 +226,15 @@ impl StreamChunk {
         table.load_preset("||--+-++|    ++++++");
         for (op, row_ref) in self.rows() {
             let mut cells = Vec::with_capacity(row_ref.len() + 1);
-            cells.push(Cell::new(op.to_pretty_str()).set_alignment(CellAlignment::Right));
+            cells.push(
+                Cell::new(match op {
+                    Op::Insert => "+",
+                    Op::Delete => "-",
+                    Op::UpdateDelete => "U-",
+                    Op::UpdateInsert => "U+",
+                })
+                .set_alignment(CellAlignment::Right),
+            );
             for datum in row_ref.iter() {
                 let str = match datum {
                     None => "".to_owned(), // NULL

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -61,6 +61,15 @@ impl Op {
         };
         Ok(op)
     }
+
+    pub fn to_pretty_str(&self) -> &str {
+        match self {
+            Op::Insert => "+",
+            Op::Delete => "-",
+            Op::UpdateDelete => "U-",
+            Op::UpdateInsert => "U+",
+        }
+    }
 }
 
 pub type Ops<'a> = &'a [Op];
@@ -226,15 +235,7 @@ impl StreamChunk {
         table.load_preset("||--+-++|    ++++++");
         for (op, row_ref) in self.rows() {
             let mut cells = Vec::with_capacity(row_ref.len() + 1);
-            cells.push(
-                Cell::new(match op {
-                    Op::Insert => "+",
-                    Op::Delete => "-",
-                    Op::UpdateDelete => "U-",
-                    Op::UpdateInsert => "U+",
-                })
-                .set_alignment(CellAlignment::Right),
-            );
+            cells.push(Cell::new(op.to_pretty_str()).set_alignment(CellAlignment::Right));
             for datum in row_ref.iter() {
                 let str = match datum {
                     None => "".to_owned(), // NULL

--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -19,6 +19,7 @@ use bytes::{BufMut, Bytes, BytesMut};
 
 use self::empty::EMPTY;
 use crate::hash::HashCode;
+use crate::types::to_text::ToText;
 use crate::types::{hash_datum, DatumRef, ToDatumRef, ToOwnedDatum};
 use crate::util::ordered::OrderedRowSerde;
 use crate::util::value_encoding;
@@ -144,6 +145,18 @@ pub trait RowExt: Row {
         Self: Sized,
     {
         assert_row(Project::new(self, indices))
+    }
+
+    fn to_pretty_string(&self) -> String {
+        let mut s = Vec::with_capacity(self.len());
+        for datum in self.iter() {
+            let str = match datum {
+                None => "NULL".to_owned(),
+                Some(scalar) => scalar.to_text(),
+            };
+            s.push(str);
+        }
+        s.join(" | ")
     }
 }
 

--- a/src/stream/src/executor/managed_state/top_n/top_n_state.rs
+++ b/src/stream/src/executor/managed_state/top_n/top_n_state.rs
@@ -354,9 +354,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_managed_top_n_state_fill_cache() {
+        let data_types = vec![DataType::Varchar, DataType::Int64];
         let state_table = {
             let mut tb = create_in_memory_state_table(
-                &[DataType::Varchar, DataType::Int64],
+                &data_types,
                 &[OrderType::ascending(), OrderType::ascending()],
                 &[0, 1],
             )
@@ -382,7 +383,7 @@ mod tests {
         let rows = vec![row1, row2, row3, row4, row5];
         let ordered_rows = vec![row1_bytes, row2_bytes, row3_bytes, row4_bytes, row5_bytes];
 
-        let mut cache = TopNCache::<false>::new(1, 1);
+        let mut cache = TopNCache::<false>::new(1, 1, data_types);
 
         managed_state.insert(rows[3].clone());
         managed_state.insert(rows[1].clone());

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -191,7 +191,16 @@ where
             match op {
                 Op::Insert | Op::UpdateInsert => {
                     self.managed_state.insert(row_ref);
-                    cache.insert(cache_key, row_ref, &mut res_ops, &mut res_rows);
+                    cache
+                        .insert(
+                            Some(group_key),
+                            &mut self.managed_state,
+                            cache_key,
+                            row_ref,
+                            &mut res_ops,
+                            &mut res_rows,
+                        )
+                        .await?;
                 }
 
                 Op::Delete | Op::UpdateDelete => {

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -37,7 +37,7 @@ use crate::executor::{ActorContextRef, Executor, ExecutorInfo, PkIndices, Waterm
 use crate::task::AtomicU64Ref;
 
 pub type GroupTopNExecutor<K, S, const WITH_TIES: bool> =
-    TopNExecutorWrapper<InnerGroupTopNExecutorNew<K, S, WITH_TIES>>;
+    TopNExecutorWrapper<InnerGroupTopNExecutor<K, S, WITH_TIES>>;
 
 impl<K: HashKey, S: StateStore, const WITH_TIES: bool> GroupTopNExecutor<K, S, WITH_TIES> {
     #[allow(clippy::too_many_arguments)]
@@ -56,7 +56,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool> GroupTopNExecutor<K, S, W
         Ok(TopNExecutorWrapper {
             input,
             ctx,
-            inner: InnerGroupTopNExecutorNew::new(
+            inner: InnerGroupTopNExecutor::new(
                 info,
                 storage_key,
                 offset_and_limit,
@@ -70,7 +70,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool> GroupTopNExecutor<K, S, W
     }
 }
 
-pub struct InnerGroupTopNExecutorNew<K: HashKey, S: StateStore, const WITH_TIES: bool> {
+pub struct InnerGroupTopNExecutor<K: HashKey, S: StateStore, const WITH_TIES: bool> {
     info: ExecutorInfo,
 
     /// `LIMIT XXX`. None means no limit.
@@ -94,7 +94,7 @@ pub struct InnerGroupTopNExecutorNew<K: HashKey, S: StateStore, const WITH_TIES:
     cache_key_serde: CacheKeySerde,
 }
 
-impl<K: HashKey, S: StateStore, const WITH_TIES: bool> InnerGroupTopNExecutorNew<K, S, WITH_TIES> {
+impl<K: HashKey, S: StateStore, const WITH_TIES: bool> InnerGroupTopNExecutor<K, S, WITH_TIES> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         input_info: ExecutorInfo,
@@ -158,7 +158,7 @@ impl<K: HashKey, const WITH_TIES: bool> DerefMut for GroupTopNCache<K, WITH_TIES
 
 #[async_trait]
 impl<K: HashKey, S: StateStore, const WITH_TIES: bool> TopNExecutorBase
-    for InnerGroupTopNExecutorNew<K, S, WITH_TIES>
+    for InnerGroupTopNExecutor<K, S, WITH_TIES>
 where
     TopNCache<WITH_TIES>: TopNCacheTrait,
 {
@@ -178,7 +178,8 @@ where
             // If 'self.caches' does not already have a cache for the current group, create a new
             // cache for it and insert it into `self.caches`
             if !self.caches.contains(group_cache_key) {
-                let mut topn_cache = TopNCache::new(self.offset, self.limit);
+                let mut topn_cache =
+                    TopNCache::new(self.offset, self.limit, self.schema().data_types());
                 self.managed_state
                     .init_topn_cache(Some(group_key), &mut topn_cache)
                     .await?;

--- a/src/stream/src/executor/top_n/group_top_n.rs
+++ b/src/stream/src/executor/top_n/group_top_n.rs
@@ -191,16 +191,7 @@ where
             match op {
                 Op::Insert | Op::UpdateInsert => {
                     self.managed_state.insert(row_ref);
-                    cache
-                        .insert(
-                            Some(group_key),
-                            &mut self.managed_state,
-                            cache_key,
-                            row_ref,
-                            &mut res_ops,
-                            &mut res_rows,
-                        )
-                        .await?;
+                    cache.insert(cache_key, row_ref, &mut res_ops, &mut res_rows);
                 }
 
                 Op::Delete | Op::UpdateDelete => {

--- a/src/stream/src/executor/top_n/group_top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/group_top_n_appendonly.rs
@@ -54,7 +54,7 @@ use crate::task::AtomicU64Ref;
 /// to keep all the data records/rows that have been seen. As long as a record
 /// is no longer being in the result set, it can be deleted.
 pub type AppendOnlyGroupTopNExecutor<K, S, const WITH_TIES: bool> =
-    TopNExecutorWrapper<InnerAppendOnlyGroupTopNExecutorNew<K, S, WITH_TIES>>;
+    TopNExecutorWrapper<InnerAppendOnlyGroupTopNExecutor<K, S, WITH_TIES>>;
 
 impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
     AppendOnlyGroupTopNExecutor<K, S, WITH_TIES>
@@ -75,7 +75,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
         Ok(TopNExecutorWrapper {
             input,
             ctx,
-            inner: InnerAppendOnlyGroupTopNExecutorNew::new(
+            inner: InnerAppendOnlyGroupTopNExecutor::new(
                 info,
                 storage_key,
                 offset_and_limit,
@@ -89,7 +89,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
     }
 }
 
-pub struct InnerAppendOnlyGroupTopNExecutorNew<K: HashKey, S: StateStore, const WITH_TIES: bool> {
+pub struct InnerAppendOnlyGroupTopNExecutor<K: HashKey, S: StateStore, const WITH_TIES: bool> {
     info: ExecutorInfo,
 
     /// `LIMIT XXX`. None means no limit.
@@ -114,7 +114,7 @@ pub struct InnerAppendOnlyGroupTopNExecutorNew<K: HashKey, S: StateStore, const 
 }
 
 impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
-    InnerAppendOnlyGroupTopNExecutorNew<K, S, WITH_TIES>
+    InnerAppendOnlyGroupTopNExecutor<K, S, WITH_TIES>
 {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -153,7 +153,7 @@ impl<K: HashKey, S: StateStore, const WITH_TIES: bool>
 }
 #[async_trait]
 impl<K: HashKey, S: StateStore, const WITH_TIES: bool> TopNExecutorBase
-    for InnerAppendOnlyGroupTopNExecutorNew<K, S, WITH_TIES>
+    for InnerAppendOnlyGroupTopNExecutor<K, S, WITH_TIES>
 where
     TopNCache<WITH_TIES>: AppendOnlyTopNCacheTrait,
 {
@@ -164,7 +164,7 @@ where
         let keys = K::build(&self.group_by, chunk.data_chunk())?;
 
         let data_types = self.schema().data_types();
-        let row_deserializer = RowDeserializer::new(data_types);
+        let row_deserializer = RowDeserializer::new(data_types.clone());
 
         for ((op, row_ref), group_cache_key) in chunk.rows().zip_eq_debug(keys.iter()) {
             // The pk without group by
@@ -176,7 +176,7 @@ where
             // If 'self.caches' does not already have a cache for the current group, create a new
             // cache for it and insert it into `self.caches`
             if !self.caches.contains(group_cache_key) {
-                let mut topn_cache = TopNCache::new(self.offset, self.limit);
+                let mut topn_cache = TopNCache::new(self.offset, self.limit, data_types.clone());
                 self.managed_state
                     .init_topn_cache(Some(group_key), &mut topn_cache)
                     .await?;

--- a/src/stream/src/executor/top_n/top_n_appendonly.rs
+++ b/src/stream/src/executor/top_n/top_n_appendonly.rs
@@ -129,6 +129,7 @@ impl<S: StateStore, const WITH_TIES: bool> InnerAppendOnlyTopNExecutor<S, WITH_T
         let cache_key_serde =
             create_cache_key_serde(&storage_key, &pk_indices, &schema, &order_by, &[]);
         let managed_state = ManagedTopNState::<S>::new(state_table, cache_key_serde.clone());
+        let data_types = schema.data_types();
 
         Ok(Self {
             info: ExecutorInfo {
@@ -138,7 +139,7 @@ impl<S: StateStore, const WITH_TIES: bool> InnerAppendOnlyTopNExecutor<S, WITH_T
             },
             managed_state,
             storage_key_indices: storage_key.into_iter().map(|op| op.column_index).collect(),
-            cache: TopNCache::new(num_offset, num_limit),
+            cache: TopNCache::new(num_offset, num_limit, data_types),
             cache_key_serde,
         })
     }

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -227,10 +227,11 @@ impl<const WITH_TIES: bool> TopNCache<WITH_TIES> {
         cache_key: CacheKey,
         row: CompactedRow,
     ) -> StreamExecutorResult<()> {
-        let need_refill = match self.high.last_key_value() {
-            Some(high_last) => cache_key > *high_last.0 && self.is_high_cache_dirty,
-            None => true,
-        };
+        let need_refill = self.is_high_cache_dirty
+            && match self.high.last_key_value() {
+                Some(high_last) => cache_key > *high_last.0,
+                None => false,
+            };
         if need_refill {
             managed_state
                 .fill_high_cache(

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -85,9 +85,9 @@ impl<const WITH_TIES: bool> Debug for TopNCache<WITH_TIES> {
                 cache
                     .iter()
                     .format_with("\n    ", |item, f| f(&format_args!(
-                        "{:?}, {:?}",
+                        "{:?}, {}",
                         item.0,
-                        item.1.deserialize(data_types).unwrap().to_pretty_string(),
+                        item.1.deserialize(data_types).unwrap().display(),
                     )))
             )
         }

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -219,6 +219,32 @@ impl<const WITH_TIES: bool> TopNCache<WITH_TIES> {
         }
         full
     }
+
+    async fn refill_high_cache<S: StateStore>(
+        &mut self,
+        group_key: Option<impl GroupKey>,
+        managed_state: &mut ManagedTopNState<S>,
+        cache_key: CacheKey,
+        row: CompactedRow,
+    ) -> StreamExecutorResult<()> {
+        let need_refill = match self.high.last_key_value() {
+            Some(high_last) => cache_key > *high_last.0 && self.is_high_cache_dirty,
+            None => true,
+        };
+        if need_refill {
+            managed_state
+                .fill_high_cache(
+                    group_key,
+                    self,
+                    self.middle.last_key_value().unwrap().0.clone(),
+                    self.high_capacity,
+                )
+                .await?;
+            self.is_high_cache_dirty = false;
+        }
+        self.high.insert(cache_key, row);
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -276,22 +302,13 @@ impl TopNCacheTrait for TopNCache<false> {
         };
 
         if !self.is_high_cache_full() {
-            let need_refill = match self.high.last_key_value() {
-                Some(high_last) => elem_to_compare_with_high.0 > *high_last.0,
-                None => true,
-            };
-            if need_refill {
-                managed_state
-                    .fill_high_cache(
-                        group_key,
-                        self,
-                        self.middle.last_key_value().unwrap().0.clone(),
-                        self.high_capacity,
-                    )
-                    .await?;
-            }
-            self.high
-                .insert(elem_to_compare_with_high.0, elem_to_compare_with_high.1);
+            self.refill_high_cache(
+                group_key,
+                managed_state,
+                elem_to_compare_with_high.0,
+                elem_to_compare_with_high.1,
+            )
+            .await?;
         } else {
             let high_last = self.high.last_entry().unwrap();
             if elem_to_compare_with_high.0 <= *high_last.key() {
@@ -465,24 +482,13 @@ impl TopNCacheTrait for TopNCache<true> {
                 // The row is in high.
                 let elem_to_compare_with_high = elem_to_compare_with_middle;
                 if !self.is_high_cache_full() {
-                    let need_refill = match self.high.last_key_value() {
-                        Some(high_last) => elem_to_compare_with_high.0 > *high_last.0,
-                        None => true,
-                    };
-                    if need_refill {
-                        managed_state
-                            .fill_high_cache(
-                                group_key,
-                                self,
-                                self.middle.last_key_value().unwrap().0.clone(),
-                                self.high_capacity,
-                            )
-                            .await?;
-                    }
-                    self.high.insert(
+                    self.refill_high_cache(
+                        group_key,
+                        managed_state,
                         elem_to_compare_with_high.0,
-                        (&elem_to_compare_with_high.1).into(),
-                    );
+                        elem_to_compare_with_high.1.into(),
+                    )
+                    .await?;
                 } else {
                     let high_last = self.high.last_entry().unwrap();
                     if elem_to_compare_with_high.0 <= *high_last.key() {

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -92,11 +92,11 @@ impl<const WITH_TIES: bool> Debug for TopNCache<WITH_TIES> {
             )
         }
 
-        write!(f, "  low:\n")?;
+        writeln!(f, "  low:")?;
         format_cache(f, &self.low, &self.data_types)?;
-        write!(f, "\n  middle:\n")?;
+        writeln!(f, "\n  middle:")?;
         format_cache(f, &self.middle, &self.data_types)?;
-        write!(f, "\n  high:\n")?;
+        writeln!(f, "\n  high:")?;
         format_cache(f, &self.high, &self.data_types)?;
 
         write!(f, "\n}}")?;

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -57,6 +57,8 @@ pub struct TopNCache<const WITH_TIES: bool> {
     /// Assumption: `limit != 0`
     pub limit: usize,
 
+    is_high_cache_dirty: bool,
+
     /// Data types for the full row.
     ///
     /// For debug formatting only.
@@ -166,6 +168,7 @@ impl<const WITH_TIES: bool> TopNCache<WITH_TIES> {
                 .unwrap_or(usize::MAX),
             offset,
             limit,
+            is_high_cache_dirty: false,
             data_types,
         }
     }
@@ -314,6 +317,7 @@ impl TopNCacheTrait for TopNCache<false> {
         if self.is_middle_cache_full() && cache_key > *self.middle.last_key_value().unwrap().0 {
             // The row is in high
             self.high.remove(&cache_key);
+            self.is_high_cache_dirty = true;
         } else if self.is_low_cache_full()
             && (self.offset == 0 || cache_key > *self.low.last_key_value().unwrap().0)
         {
@@ -336,6 +340,7 @@ impl TopNCacheTrait for TopNCache<false> {
 
             // Bring one element, if any, from high cache to middle cache
             if !self.high.is_empty() {
+                self.is_high_cache_dirty = true;
                 let high_first = self.high.pop_first().unwrap();
                 res_ops.push(Op::Insert);
                 res_rows.push(high_first.1.clone());
@@ -366,6 +371,7 @@ impl TopNCacheTrait for TopNCache<false> {
 
                 // Bring one element, if any, from high cache to middle cache
                 if !self.high.is_empty() {
+                    self.is_high_cache_dirty = true;
                     let high_first = self.high.pop_first().unwrap();
                     res_ops.push(Op::Insert);
                     res_rows.push(high_first.1.clone());
@@ -512,6 +518,7 @@ impl TopNCacheTrait for TopNCache<true> {
         if sort_key > middle_last_order_by {
             // The row is in high.
             self.high.remove(&cache_key);
+            self.is_high_cache_dirty = true;
         } else {
             // The row is in middle
             self.middle.remove(&cache_key);
@@ -536,6 +543,7 @@ impl TopNCacheTrait for TopNCache<true> {
 
             // Bring elements with the same sort key, if any, from high cache to middle cache.
             if !self.high.is_empty() {
+                self.is_high_cache_dirty = true;
                 let high_first = self.high.pop_first().unwrap();
                 let high_first_order_by = high_first.0 .0.clone();
                 assert!(high_first_order_by > middle_last_order_by);

--- a/src/stream/src/executor/top_n/top_n_cache.rs
+++ b/src/stream/src/executor/top_n/top_n_cache.rs
@@ -503,6 +503,7 @@ impl TopNCacheTrait for TopNCache<true> {
         //
         // TODO: can we optimize fill_high_cache because we only need to fill one element?
         if self.high.len() == self.high_capacity - 1 {
+            assert!(!self.high.is_empty(), "high_capacity should >= 2");
             managed_state
                 .fill_high_cache(
                     group_key,

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -192,7 +192,15 @@ where
                     // First insert input row to state store
                     self.managed_state.insert(row_ref);
                     self.cache
-                        .insert(cache_key, row_ref, &mut res_ops, &mut res_rows)
+                        .insert(
+                            NO_GROUP_KEY,
+                            &mut self.managed_state,
+                            cache_key,
+                            row_ref,
+                            &mut res_ops,
+                            &mut res_rows,
+                        )
+                        .await?
                 }
 
                 Op::Delete | Op::UpdateDelete => {

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -1316,7 +1316,6 @@ mod tests {
             );
 
             let res = top_n_executor.next().await.unwrap().unwrap();
-            println!("{}", res.as_chunk().unwrap().to_pretty_string());
             assert_eq!(
                 *res.as_chunk().unwrap(),
                 StreamChunk::from_pretty(

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -111,7 +111,7 @@ impl<S: StateStore> TopNExecutor<S, true> {
             state_table,
         )?;
 
-        inner.cache.high_capacity = 1;
+        inner.cache.high_capacity = 2;
 
         Ok(TopNExecutorWrapper { input, ctx, inner })
     }
@@ -1080,10 +1080,11 @@ mod tests {
                 ),
                 StreamChunk::from_pretty(
                     "  I I
-                    +  3 8
-                    +  1 6
-                    +  2 7
-                    + 10 9",
+                    +  3 6
+                    +  3 7
+                    +  1 8
+                    +  2 9
+                    + 10 10",
                 ),
                 StreamChunk::from_pretty(
                     " I I
@@ -1091,7 +1092,7 @@ mod tests {
                 ),
                 StreamChunk::from_pretty(
                     " I I
-                    - 1 6",
+                    - 1 8",
                 ),
             ];
             let schema = Schema {
@@ -1169,11 +1170,13 @@ mod tests {
                 *res.as_chunk().unwrap(),
                 StreamChunk::from_pretty(
                     " I I
-                    + 3 8
-                    - 3 8
+                    + 3 6
+                    + 3 7
+                    - 3 7
+                    - 3 6
                     - 3 2
-                    + 1 6
-                    + 2 7"
+                    + 1 8
+                    + 2 9"
                 )
             );
 
@@ -1186,15 +1189,16 @@ mod tests {
                 )
             );
 
-            // High cache has only one capacity, but we need to trigger 2 inserts here!
+            // High cache has only 2 capacity, but we need to trigger 3 inserts here!
             let res = top_n_executor.next().await.unwrap().unwrap();
             assert_eq!(
                 *res.as_chunk().unwrap(),
                 StreamChunk::from_pretty(
                     " I I
-                    - 1 6
+                    - 1 8
                     + 3 2
-                    + 3 8
+                    + 3 6
+                    + 3 7
                     "
                 )
             );
@@ -1220,10 +1224,11 @@ mod tests {
                 ),
                 StreamChunk::from_pretty(
                     "  I I
-                    +  3 8
-                    +  1 6
-                    +  2 7
-                    + 10 9",
+                    +  3 6
+                    +  3 7
+                    +  1 8
+                    +  2 9
+                    + 10 10",
                 ),
             ];
             let schema = Schema {
@@ -1252,7 +1257,7 @@ mod tests {
                 ),
                 StreamChunk::from_pretty(
                     " I I
-                    - 1 6",
+                    - 1 8",
                 ),
             ];
             let schema = Schema {
@@ -1311,15 +1316,18 @@ mod tests {
             );
 
             let res = top_n_executor.next().await.unwrap().unwrap();
+            println!("{}", res.as_chunk().unwrap().to_pretty_string());
             assert_eq!(
                 *res.as_chunk().unwrap(),
                 StreamChunk::from_pretty(
                     " I I
-                    + 3 8
-                    - 3 8
+                    + 3 6
+                    + 3 7
+                    - 3 7
+                    - 3 6
                     - 3 2
-                    + 1 6
-                    + 2 7"
+                    + 1 8
+                    + 2 9"
                 )
             );
 
@@ -1367,15 +1375,16 @@ mod tests {
                 )
             );
 
-            // High cache has only one capacity, but we need to trigger 2 inserts here!
+            // High cache has only 2 capacity, but we need to trigger 3 inserts here!
             let res = top_n_executor.next().await.unwrap().unwrap();
             assert_eq!(
                 *res.as_chunk().unwrap(),
                 StreamChunk::from_pretty(
                     " I I
-                    - 1 6
+                    - 1 8
                     + 3 2
-                    + 3 8
+                    + 3 6
+                    + 3 7
                     "
                 )
             );

--- a/src/stream/src/executor/top_n/top_n_plain.rs
+++ b/src/stream/src/executor/top_n/top_n_plain.rs
@@ -192,15 +192,7 @@ where
                     // First insert input row to state store
                     self.managed_state.insert(row_ref);
                     self.cache
-                        .insert(
-                            NO_GROUP_KEY,
-                            &mut self.managed_state,
-                            cache_key,
-                            row_ref,
-                            &mut res_ops,
-                            &mut res_rows,
-                        )
-                        .await?
+                        .insert(cache_key, row_ref, &mut res_ops, &mut res_rows)
                 }
 
                 Op::Delete | Op::UpdateDelete => {
@@ -1396,7 +1388,7 @@ mod tests {
                     "
                 )
             );
-
+            println!("hello");
             // barrier
             assert_matches!(
                 top_n_executor.next().await.unwrap().unwrap(),

--- a/src/stream/src/from_proto/mod.rs
+++ b/src/stream/src/from_proto/mod.rs
@@ -127,7 +127,7 @@ pub async fn create_executor(
         NodeBody::Source => SourceExecutorBuilder,
         NodeBody::Sink => SinkExecutorBuilder,
         NodeBody::Project => ProjectExecutorBuilder,
-        NodeBody::TopN => TopNExecutorNewBuilder,
+        NodeBody::TopN => TopNExecutorBuilder,
         NodeBody::AppendOnlyTopN => AppendOnlyTopNExecutorBuilder,
         NodeBody::LocalSimpleAgg => LocalSimpleAggExecutorBuilder,
         NodeBody::GlobalSimpleAgg => GlobalSimpleAggExecutorBuilder,

--- a/src/stream/src/from_proto/top_n.rs
+++ b/src/stream/src/from_proto/top_n.rs
@@ -21,10 +21,10 @@ use super::*;
 use crate::common::table::state_table::StateTable;
 use crate::executor::TopNExecutor;
 
-pub struct TopNExecutorNewBuilder;
+pub struct TopNExecutorBuilder;
 
 #[async_trait::async_trait]
-impl ExecutorBuilder for TopNExecutorNewBuilder {
+impl ExecutorBuilder for TopNExecutorBuilder {
     type Node = TopNNode;
 
     async fn new_boxed_executor(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Quick fix #8570 -- without performance in mind! @@BugenZhao mentioned there's a `sync` flag in the Min/Max aggregation cache. I'm not sure whether we should do the same (or other methods) here. 

I manually tested the original case in #8570, and didn't find problem yet.

Also added some debug utilities.


<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
