### PR TITLE
fix: also enable jemalloc on macOS

### DIFF
--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -62,7 +62,7 @@ criterion = { version = "0.4", features = ["async_tokio", "async"] }
 rand = "0.8"
 tempfile = "3"
 
-[target.'cfg(target_os = "linux")'.dev-dependencies]
+[target.'cfg(unix)'.dev-dependencies]
 tikv-jemallocator = "0.5"
 
 [[bench]]

--- a/src/batch/benches/expand.rs
+++ b/src/batch/benches/expand.rs
@@ -15,12 +15,12 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, ExpandExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::DataType;
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_expand_executor(
     column_subsets: Vec<Vec<usize>>,

--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -16,7 +16,7 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, FilterExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::value_encoding::serialize_datum;
 use risingwave_expr::expr::build_from_prost;
@@ -30,7 +30,7 @@ use risingwave_pb::expr::{ExprNode, FunctionCall};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor {
     const CHUNK_SIZE: usize = 1024;

--- a/src/batch/benches/hash_agg.rs
+++ b/src/batch/benches/hash_agg.rs
@@ -18,14 +18,14 @@ use itertools::Itertools;
 use risingwave_batch::executor::{BoxedExecutor, HashAggExecutor};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
-use risingwave_common::{enable_jemalloc_on_linux, hash};
+use risingwave_common::{enable_jemalloc_on_unix, hash};
 use risingwave_expr::expr::AggKind;
 use risingwave_expr::vector_op::agg::AggStateFactory;
 use risingwave_pb::expr::{AggCall, InputRef};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_agg_call(
     input_schema: &Schema,

--- a/src/batch/benches/hash_join.rs
+++ b/src/batch/benches/hash_join.rs
@@ -21,7 +21,7 @@ use risingwave_batch::executor::{BoxedExecutor, JoinType};
 use risingwave_common::catalog::schema_test_utils::field_n;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::value_encoding::serialize_datum;
-use risingwave_common::{enable_jemalloc_on_linux, hash};
+use risingwave_common::{enable_jemalloc_on_unix, hash};
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::PbDatum;
@@ -32,7 +32,7 @@ use risingwave_pb::expr::expr_node::Type::{
 use risingwave_pb::expr::{ExprNode, FunctionCall};
 use utils::bench_join;
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_hash_join_executor(
     join_type: JoinType,

--- a/src/batch/benches/limit.rs
+++ b/src/batch/benches/limit.rs
@@ -16,12 +16,12 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, LimitExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::DataType;
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_limit_executor(
     chunk_size: usize,

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -15,7 +15,7 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, JoinType, NestedLoopJoinExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::value_encoding::serialize_datum;
 use risingwave_expr::expr::build_from_prost;
@@ -28,7 +28,7 @@ use risingwave_pb::expr::expr_node::Type::{
 use risingwave_pb::expr::{ExprNode, FunctionCall};
 use utils::{bench_join, create_input};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_nested_loop_join_executor(
     join_type: JoinType,

--- a/src/batch/benches/sort.rs
+++ b/src/batch/benches/sort.rs
@@ -16,13 +16,13 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, SortExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_order_by_executor(
     chunk_size: usize,

--- a/src/batch/benches/top_n.rs
+++ b/src/batch/benches/top_n.rs
@@ -16,13 +16,13 @@ pub mod utils;
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, TopNExecutor};
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 use risingwave_common::types::DataType;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 fn create_top_n_executor(
     chunk_size: usize,

--- a/src/cmd/Cargo.toml
+++ b/src/cmd/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 workspace-config = { path = "../utils/workspace-config", optional = true }
 workspace-hack = { path = "../workspace-hack" }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"] }
 
 [[bin]]

--- a/src/cmd/src/bin/compactor.rs
+++ b/src/cmd/src/bin/compactor.rs
@@ -14,9 +14,9 @@
 
 #![cfg_attr(coverage, feature(no_coverage))]
 
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 #[cfg_attr(coverage, no_coverage)]
 fn main() {

--- a/src/cmd/src/bin/compute_node.rs
+++ b/src/cmd/src/bin/compute_node.rs
@@ -14,9 +14,9 @@
 
 #![cfg_attr(coverage, feature(no_coverage))]
 
-use risingwave_common::enable_task_local_jemalloc_on_linux;
+use risingwave_common::enable_task_local_jemalloc_on_unix;
 
-enable_task_local_jemalloc_on_linux!();
+enable_task_local_jemalloc_on_unix!();
 
 #[cfg_attr(coverage, no_coverage)]
 fn main() {

--- a/src/cmd/src/bin/ctl.rs
+++ b/src/cmd/src/bin/ctl.rs
@@ -15,9 +15,9 @@
 #![cfg_attr(coverage, feature(no_coverage))]
 
 use anyhow::Result;
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 #[cfg_attr(coverage, no_coverage)]
 fn main() -> Result<()> {

--- a/src/cmd/src/bin/frontend_node.rs
+++ b/src/cmd/src/bin/frontend_node.rs
@@ -14,9 +14,9 @@
 
 #![cfg_attr(coverage, feature(no_coverage))]
 
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 #[cfg_attr(coverage, no_coverage)]
 fn main() {

--- a/src/cmd/src/bin/meta_node.rs
+++ b/src/cmd/src/bin/meta_node.rs
@@ -14,9 +14,9 @@
 
 #![cfg_attr(coverage, feature(no_coverage))]
 
-use risingwave_common::enable_jemalloc_on_linux;
+use risingwave_common::enable_jemalloc_on_unix;
 
-enable_jemalloc_on_linux!();
+enable_jemalloc_on_unix!();
 
 #[cfg_attr(coverage, no_coverage)]
 fn main() {

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -43,7 +43,7 @@ tracing = { version = "0.1" }
 workspace-config = { path = "../utils/workspace-config", optional = true }
 workspace-hack = { path = "../workspace-hack" }
 
-[target.'cfg(target_os = "linux")'.dependencies]
+[target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.5", features = ["profiling", "stats"] }
 
 [[bin]]

--- a/src/cmd_all/src/bin/risingwave.rs
+++ b/src/cmd_all/src/bin/risingwave.rs
@@ -21,10 +21,10 @@ use std::env;
 use anyhow::{bail, Result};
 use clap::Parser;
 use risingwave_cmd_all::playground;
-use risingwave_common::enable_task_local_jemalloc_on_linux;
+use risingwave_common::enable_task_local_jemalloc_on_unix;
 use tracing::Level;
 
-enable_task_local_jemalloc_on_linux!();
+enable_task_local_jemalloc_on_unix!();
 
 type RwFns = HashMap<&'static str, Box<dyn Fn(Vec<String>) -> Result<()>>>;
 

--- a/src/common/src/jemalloc.rs
+++ b/src/common/src/jemalloc.rs
@@ -14,18 +14,18 @@
 
 /// If <https://github.com/tikv/jemallocator/issues/22> is resolved, we may inline this
 #[macro_export]
-macro_rules! enable_jemalloc_on_linux {
+macro_rules! enable_jemalloc_on_unix {
     () => {
-        #[cfg(target_os = "linux")]
+        #[cfg(unix)]
         #[global_allocator]
         static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
     };
 }
 
 #[macro_export]
-macro_rules! enable_task_local_jemalloc_on_linux {
+macro_rules! enable_task_local_jemalloc_on_unix {
     () => {
-        #[cfg(target_os = "linux")]
+        #[cfg(unix)]
         #[global_allocator]
         static GLOBAL: task_stats_alloc::TaskLocalAlloc<tikv_jemallocator::Jemalloc> =
             task_stats_alloc::TaskLocalAlloc(tikv_jemallocator::Jemalloc);

--- a/src/compute/src/memory_management/mod.rs
+++ b/src/compute/src/memory_management/mod.rs
@@ -13,6 +13,9 @@
 // limitations under the License.
 
 pub mod memory_manager;
+
+// Only enable the non-trivial policies on Linux as it relies on statistics from `jemalloc-ctl`
+// which might be inaccurate on other platforms.
 #[cfg(target_os = "linux")]
 pub mod policy;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

It's said that `jemalloc-ctl` reports inaccurate statistics on macOS, but it's not bad to just enable the allocator itself on macOS since it performs much better even for some local tests.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
