### PR TITLE
fix(streaming): drop subtask on another blocking thread

### DIFF
--- a/src/compute/src/rpc/service/stream_service.rs
+++ b/src/compute/src/rpc/service/stream_service.rs
@@ -108,7 +108,7 @@ impl StreamService for StreamServiceImpl {
     ) -> std::result::Result<Response<DropActorsResponse>, Status> {
         let req = request.into_inner();
         let actors = req.actor_ids;
-        self.mgr.drop_actor(&actors).await?;
+        self.mgr.drop_actors(&actors).await?;
         Ok(Response::new(DropActorsResponse {
             request_id: req.request_id,
             status: None,

--- a/src/stream/src/executor/subtask.rs
+++ b/src/stream/src/executor/subtask.rs
@@ -19,7 +19,8 @@ use tokio::sync::mpsc::error::SendError;
 use tokio_stream::wrappers::ReceiverStream;
 
 use super::actor::spawn_blocking_drop_stream;
-use super::{BoxedExecutor, Executor, ExecutorInfo, MessageStreamItem};
+use super::{BoxedExecutor, Executor, ExecutorInfo, Message, MessageStreamItem};
+use crate::task::ActorId;
 
 /// Handle used to drive the subtask.
 pub type SubtaskHandle = impl Future<Output = ()> + Send + 'static;
@@ -60,7 +61,7 @@ impl Executor for SubtaskRxExecutor {
 /// Used when there're multiple stateful executors in an actor. These subtasks can be concurrently
 /// executed to improve the I/O performance, while the computing resource can be still bounded to a
 /// single thread.
-pub fn wrap(input: BoxedExecutor) -> (SubtaskHandle, SubtaskRxExecutor) {
+pub fn wrap(input: BoxedExecutor, actor_id: ActorId) -> (SubtaskHandle, SubtaskRxExecutor) {
     let (tx, rx) = mpsc::channel(1);
     let rx_executor = SubtaskRxExecutor {
         info: ExecutorInfo {
@@ -72,7 +73,18 @@ pub fn wrap(input: BoxedExecutor) -> (SubtaskHandle, SubtaskRxExecutor) {
 
     let handle = async move {
         let mut input = input.execute();
+
         while let Some(item) = input.next().await {
+            // Decide whether to stop the subtask. We explicitly do this instead of relying on the
+            // termination of the input stream, because we don't want to exhaust the stream, which
+            // causes the stream dropped in the scope of the current async task and blocks other
+            // actors. See `spawn_blocking_drop_stream` for more details.
+            let to_stop = match &item {
+                Ok(Message::Barrier(barrier)) => barrier.is_stop_or_update_drop_actor(actor_id),
+                Ok(_) => false,
+                Err(_) => true,
+            };
+
             // It's possible that the downstream itself yields an error (e.g. from remote input) and
             // finishes, so we may fail to send the message. In this case, we can simply ignore the
             // send error and exit as well. If the message itself is another error, log it.
@@ -85,7 +97,12 @@ pub fn wrap(input: BoxedExecutor) -> (SubtaskHandle, SubtaskRxExecutor) {
                 }
                 break;
             }
+
+            if to_stop {
+                break;
+            }
         }
+
         spawn_blocking_drop_stream(input).await;
     }
     .instrument_await("Subtask");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In the last PR (#8624), we fail to handle the drop of subtasks (😢): when we get `None` from the input stream, the local variables in the generator are already dropped (like executor caches). Thus, we also need to check whether it's a `to_drop` barrier to drop it earlier.

This PR also avoids calling `abort` on graceful-exiting actors.

After this PR, one should find the `DROP` command to be more responsive even if there's a large amount of data.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
