### PR TITLE
chore: fix unstable unit test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,6 +6721,7 @@ dependencies = [
  "tokio-metrics",
  "tokio-stream",
  "tracing",
+ "tracing-test",
  "workspace-hack",
 ]
 
@@ -8225,6 +8226,29 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a2c0ff408fe918a94c428a3f2ad04e4afd5c95bbc08fcf868eff750c15728a4"
+dependencies = [
+ "lazy_static",
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bc1c4f8e2e73a977812ab339d503e6feeb92700f6d07a6de4d321522d5c08"
+dependencies = [
+ "lazy_static",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -66,6 +66,7 @@ pub fn gen_sorted_data(
     batch_num: usize,
     start: String,
     step: u64,
+    offset: u64,
 ) -> Vec<DataChunk> {
     let mut data_gen = FieldGeneratorImpl::with_number_sequence(
         DataType::Int64,
@@ -73,6 +74,7 @@ pub fn gen_sorted_data(
         Some(i64::MAX.to_string()),
         0,
         step,
+        offset,
     )
     .unwrap();
     let mut ret = Vec::<DataChunk>::with_capacity(batch_num);

--- a/src/common/src/field_generator/mod.rs
+++ b/src/common/src/field_generator/mod.rs
@@ -52,7 +52,13 @@ pub trait NumericFieldRandomGenerator {
 
 /// fields that can be continuously generated impl this trait
 pub trait NumericFieldSequenceGenerator {
-    fn new(start: Option<String>, end: Option<String>, offset: u64, step: u64) -> Result<Self>
+    fn new(
+        start: Option<String>,
+        end: Option<String>,
+        offset: u64,
+        step: u64,
+        event_offset: u64,
+    ) -> Result<Self>
     where
         Self: Sized;
 
@@ -93,6 +99,7 @@ impl FieldGeneratorImpl {
         end: Option<String>,
         split_index: u64,
         split_num: u64,
+        offset: u64,
     ) -> Result<Self> {
         match data_type {
             DataType::Int16 => Ok(FieldGeneratorImpl::I16Sequence(I16SequenceField::new(
@@ -100,30 +107,35 @@ impl FieldGeneratorImpl {
                 end,
                 split_index,
                 split_num,
+                offset,
             )?)),
             DataType::Int32 => Ok(FieldGeneratorImpl::I32Sequence(I32SequenceField::new(
                 start,
                 end,
                 split_index,
                 split_num,
+                offset,
             )?)),
             DataType::Int64 => Ok(FieldGeneratorImpl::I64Sequence(I64SequenceField::new(
                 start,
                 end,
                 split_index,
                 split_num,
+                offset,
             )?)),
             DataType::Float32 => Ok(FieldGeneratorImpl::F32Sequence(F32SequenceField::new(
                 start,
                 end,
                 split_index,
                 split_num,
+                offset,
             )?)),
             DataType::Float64 => Ok(FieldGeneratorImpl::F64Sequence(F64SequenceField::new(
                 start,
                 end,
                 split_index,
                 split_num,
+                offset,
             )?)),
             _ => unimplemented!(),
         }
@@ -265,6 +277,7 @@ mod tests {
                     Some("20".to_string()),
                     split_index,
                     split_num,
+                    0,
                 )
                 .unwrap(),
             );

--- a/src/common/src/field_generator/numeric.rs
+++ b/src/common/src/field_generator/numeric.rs
@@ -107,6 +107,7 @@ where
         end_option: Option<String>,
         offset: u64,
         step: u64,
+        event_offset: u64,
     ) -> Result<Self>
     where
         Self: Sized,
@@ -127,7 +128,9 @@ where
             end,
             offset,
             step,
-            ..Default::default()
+            cur: T::from(event_offset).ok_or_else(|| {
+                anyhow::anyhow!("event offset is too big, offset: {}", event_offset,)
+            })?,
         })
     }
 
@@ -194,7 +197,7 @@ mod tests {
     #[test]
     fn test_sequence_field_generator() {
         let mut i16_field =
-            I16SequenceField::new(Some("5".to_string()), Some("10".to_string()), 0, 1).unwrap();
+            I16SequenceField::new(Some("5".to_string()), Some("10".to_string()), 0, 1, 0).unwrap();
         for i in 5..=10 {
             assert_eq!(i16_field.generate(), json!(i));
         }
@@ -222,7 +225,8 @@ mod tests {
     #[test]
     fn test_sequence_datum_generator() {
         let mut f32_field =
-            F32SequenceField::new(Some("5.0".to_string()), Some("10.0".to_string()), 0, 1).unwrap();
+            F32SequenceField::new(Some("5.0".to_string()), Some("10.0".to_string()), 0, 1, 0)
+                .unwrap();
 
         for i in 5..=10 {
             assert_eq!(
@@ -247,13 +251,13 @@ mod tests {
     #[test]
     fn test_sequence_field_generator_float() {
         let mut f64_field =
-            F64SequenceField::new(Some("0".to_string()), Some("10".to_string()), 0, 1).unwrap();
+            F64SequenceField::new(Some("0".to_string()), Some("10".to_string()), 0, 1, 0).unwrap();
         for i in 0..=10 {
             assert_eq!(f64_field.generate(), json!(i as f64));
         }
 
         let mut f32_field =
-            F32SequenceField::new(Some("-5".to_string()), Some("5".to_string()), 0, 1).unwrap();
+            F32SequenceField::new(Some("-5".to_string()), Some("5".to_string()), 0, 1, 0).unwrap();
         for i in -5..=5 {
             assert_eq!(f32_field.generate(), json!(i as f32));
         }

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -242,6 +242,7 @@ mod tests {
                     Some(end.to_string()),
                     split_index,
                     split_num,
+                    0,
                 )
                 .unwrap(),
             ),
@@ -252,6 +253,7 @@ mod tests {
                     Some(end.to_string()),
                     split_index,
                     split_num,
+                    0,
                 )
                 .unwrap(),
             ),

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -59,7 +59,7 @@ impl SplitReader for DatagenSplitReader {
         let mut events_so_far = u64::default();
         tracing::debug!("Splits for datagen found! {:?}", splits);
 
-        assert!(splits.len() == 1);
+        debug_assert!(splits.len() == 1);
         let split = splits.into_iter().next().unwrap();
         // TODO: currently, assume there's only on split in one reader
         let split_id = split.id();
@@ -114,6 +114,7 @@ impl SplitReader for DatagenSplitReader {
                     &column.name,
                     split_index,
                     split_num,
+                    events_so_far,
                 )?)
             } else {
                 FieldDesc::Invisible
@@ -172,6 +173,7 @@ fn generator_from_data_type(
     name: &String,
     split_index: u64,
     split_num: u64,
+    offset: u64,
 ) -> Result<FieldGeneratorImpl> {
     let random_seed_key = format!("fields.{}.seed", name);
     let random_seed: u64 = match fields_option_map
@@ -236,6 +238,7 @@ fn generator_from_data_type(
                             &format!("{}.{}", name, field_name),
                             split_index,
                             split_num,
+                            offset,
                         )?;
                         Ok((field_name, gen))
                     })
@@ -251,6 +254,7 @@ fn generator_from_data_type(
                 &format!("{}._", name),
                 split_index,
                 split_num,
+                offset,
             )?;
             FieldGeneratorImpl::with_list(generator, length_value)
         }
@@ -267,7 +271,8 @@ fn generator_from_data_type(
                     start_value,
                     end_value,
                     split_index,
-                    split_num
+                    split_num,
+                    offset,
                 )
             } else {
                 let min_key = format!("fields.{}.min", name);

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -76,5 +76,5 @@ workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"
-tracing-test = "0.2"
 risingwave_hummock_test = { path = "../storage/hummock_test", features = ["test"] }
+tracing-test = "0.2"

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -76,4 +76,5 @@ workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 assert_matches = "1"
+tracing-test = "0.2"
 risingwave_hummock_test = { path = "../storage/hummock_test", features = ["test"] }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -490,7 +490,6 @@ impl<S: StateStore> Debug for SourceExecutor<S> {
 mod tests {
     use std::sync::atomic::AtomicU64;
     use std::time::Duration;
-    use tracing_test::traced_test;
 
     use maplit::{convert_args, hashmap};
     use risingwave_common::array::StreamChunk;
@@ -504,6 +503,7 @@ mod tests {
     use risingwave_source::connector_test_utils::create_source_desc_builder;
     use risingwave_storage::memory::MemoryStateStore;
     use tokio::sync::mpsc::unbounded_channel;
+    use tracing_test::traced_test;
 
     use super::*;
     use crate::executor::ActorContext;

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -719,6 +719,11 @@ mod tests {
                 split_num: 3,
                 start_offset: None,
             }),
+            SplitImpl::Datagen(DatagenSplit {
+                split_index: 2,
+                split_num: 3,
+                start_offset: None,
+            }),
         ];
 
         let change_split_mutation =
@@ -756,10 +761,13 @@ mod tests {
                 " i
                 + 11
                 + 12
+                + 13
                 + 14
                 + 15
+                + 16
                 + 17
                 + 18
+                + 19
                 + 20",
             )
         );

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -490,6 +490,7 @@ impl<S: StateStore> Debug for SourceExecutor<S> {
 mod tests {
     use std::sync::atomic::AtomicU64;
     use std::time::Duration;
+    use tracing_test::traced_test;
 
     use maplit::{convert_args, hashmap};
     use risingwave_common::array::StreamChunk;
@@ -600,6 +601,7 @@ mod tests {
         );
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_split_change_mutation() {
         let table_id = TableId::default();

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -615,9 +615,9 @@ mod tests {
         };
         let properties = convert_args!(hashmap!(
             "connector" => "datagen",
-            "fields.v1.min" => "1",
-            "fields.v1.max" => "1000",
-            "fields.v1.seed" => "12345",
+            "fields.v1.kind" => "sequence",
+            "fields.v1.start" => "11",
+            "fields.v1.end" => "11111",
         ));
 
         let source_desc_builder = create_source_desc_builder(
@@ -701,10 +701,10 @@ mod tests {
             chunk_1,
             StreamChunk::from_pretty(
                 " i
-                + 533
-                + 833
-                + 738
-                + 344",
+                + 11
+                + 14
+                + 17
+                + 20",
             )
         );
 
@@ -754,13 +754,13 @@ mod tests {
             // mixed from datagen split 0 and 1
             StreamChunk::from_pretty(
                 " i
-                + 29
-                + 201
-                + 344
-                + 425
-                + 525
-                + 533
-                + 833",
+                + 11
+                + 12
+                + 14
+                + 15
+                + 17
+                + 18
+                + 20",
             )
         );
 


### PR DESCRIPTION
Signed-off-by: tabVersion <tabvision@bupt.icu>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title, change a test case, related to #7888 

& bug fix: datagen seq can start generating from an offset

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

~~- [ ] I have written necessary rustdoc comments~~
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
