### PR TITLE
perf(hash agg): use `get_mut` instead of `pop`+`put` pattern

### DIFF
--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -439,13 +439,14 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
                 let futs = keys_in_batch.into_iter().map(|key| {
                     // Get agg group of the key.
                     let agg_group = {
-                        let mut cache_ptr: NonNull<_> = (&mut vars.agg_group_cache).into();
-                        // SAFETY: `key`s in `keys_in_batch` are unique by nature, because they're
-                        // from `group_change_set` which is a set.
-                        let cache = unsafe { cache_ptr.as_mut() };
-                        cache
+                        let mut ptr: NonNull<_> = vars
+                            .agg_group_cache
                             .get_mut(&key)
                             .expect("changed group must have corresponding AggGroup")
+                            .into();
+                        // SAFETY: `key`s in `keys_in_batch` are unique by nature, because they're
+                        // from `group_change_set` which is a set.
+                        unsafe { ptr.as_mut() }
                     };
                     async {
                         let curr_outputs = agg_group.get_outputs(&this.storages).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This fixes #8687. The safety concern was resolved in https://github.com/risingwavelabs/risingwave/pull/7752#discussion_r1099567114.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
