### PR TITLE
perf(encoding): add estimate size for value encoding

### DIFF
--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -447,7 +447,8 @@ impl<'a> ListRef<'a> {
         })
     }
 
-    pub fn estimate_value_encoding_size_inner(&self) -> usize {
+    /// estimate the serialized size with value encoding
+    pub fn estimate_serialize_size_inner(&self) -> usize {
         iter_elems_ref!(self, it, {
             it.fold(0, |acc, datum_ref| {
                 acc + estimate_serialize_datum_size(datum_ref)

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -29,6 +29,7 @@ use crate::row::Row;
 use crate::types::to_text::ToText;
 use crate::types::{hash_datum, DataType, Datum, DatumRef, Scalar, ScalarRefImpl, ToDatumRef};
 use crate::util::memcmp_encoding;
+use crate::util::value_encoding::estimate_encoded_size;
 
 #[derive(Debug)]
 pub struct ListArrayBuilder {
@@ -443,6 +444,12 @@ impl<'a> ListRef<'a> {
             for datum_ref in it {
                 hash_datum(datum_ref, state);
             }
+        })
+    }
+
+    pub fn estimate_value_encoding_size_inner(&self) -> usize {
+        iter_elems_ref!(self, it, {
+            it.fold(0, |acc, datum_ref| acc + estimate_encoded_size(datum_ref))
         })
     }
 }

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -29,7 +29,7 @@ use crate::row::Row;
 use crate::types::to_text::ToText;
 use crate::types::{hash_datum, DataType, Datum, DatumRef, Scalar, ScalarRefImpl, ToDatumRef};
 use crate::util::memcmp_encoding;
-use crate::util::value_encoding::estimate_encoded_size;
+use crate::util::value_encoding::estimate_serialize_datum_size;
 
 #[derive(Debug)]
 pub struct ListArrayBuilder {
@@ -449,7 +449,9 @@ impl<'a> ListRef<'a> {
 
     pub fn estimate_value_encoding_size_inner(&self) -> usize {
         iter_elems_ref!(self, it, {
-            it.fold(0, |acc, datum_ref| acc + estimate_encoded_size(datum_ref))
+            it.fold(0, |acc, datum_ref| {
+                acc + estimate_serialize_datum_size(datum_ref)
+            })
         })
     }
 }

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -29,7 +29,7 @@ use crate::types::to_text::ToText;
 use crate::types::{hash_datum, DataType, Datum, DatumRef, Scalar, ScalarRefImpl, ToDatumRef};
 use crate::util::iter_util::ZipEqFast;
 use crate::util::memcmp_encoding;
-use crate::util::value_encoding::estimate_encoded_size;
+use crate::util::value_encoding::estimate_serialize_datum_size;
 
 #[derive(Debug)]
 pub struct StructArrayBuilder {
@@ -399,7 +399,9 @@ impl<'a> StructRef<'a> {
 
     pub fn estimate_value_encoding_size_inner(&self) -> usize {
         iter_fields_ref!(self, it, {
-            it.fold(0, |acc, datum_ref| acc + estimate_encoded_size(datum_ref))
+            it.fold(0, |acc, datum_ref| {
+                acc + estimate_serialize_datum_size(datum_ref)
+            })
         })
     }
 }

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -397,7 +397,7 @@ impl<'a> StructRef<'a> {
         })
     }
 
-    pub fn estimate_value_encoding_size_inner(&self) -> usize {
+    pub fn estimate_serialize_size_inner(&self) -> usize {
         iter_fields_ref!(self, it, {
             it.fold(0, |acc, datum_ref| {
                 acc + estimate_serialize_datum_size(datum_ref)

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -29,6 +29,7 @@ use crate::types::to_text::ToText;
 use crate::types::{hash_datum, DataType, Datum, DatumRef, Scalar, ScalarRefImpl, ToDatumRef};
 use crate::util::iter_util::ZipEqFast;
 use crate::util::memcmp_encoding;
+use crate::util::value_encoding::estimate_encoded_size;
 
 #[derive(Debug)]
 pub struct StructArrayBuilder {
@@ -393,6 +394,12 @@ impl<'a> StructRef<'a> {
             for datum_ref in it {
                 hash_datum(datum_ref, state);
             }
+        })
+    }
+
+    pub fn estimate_value_encoding_size_inner(&self) -> usize {
+        iter_fields_ref!(self, it, {
+            it.fold(0, |acc, datum_ref| acc + estimate_encoded_size(datum_ref))
         })
     }
 }

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -183,9 +183,9 @@ pub fn serialize_datum_into(datum_ref: impl ToDatumRef, buf: &mut impl BufMut) {
     }
 }
 
-pub fn estimate_encoded_size(datum_ref: impl ToDatumRef) -> usize {
+pub fn estimate_serialize_datum_size(datum_ref: impl ToDatumRef) -> usize {
     if let Some(d) = datum_ref.to_datum_ref() {
-        1 + estimate_encoded_scalar_size(d)
+        1 + estimate_serialize_scalar_size(d)
     } else {
         1
     }
@@ -233,7 +233,7 @@ fn serialize_scalar(value: ScalarRefImpl<'_>, buf: &mut impl BufMut) {
     }
 }
 
-fn estimate_encoded_scalar_size(value: ScalarRefImpl<'_>) -> usize {
+fn estimate_serialize_scalar_size(value: ScalarRefImpl<'_>) -> usize {
     match value {
         ScalarRefImpl::Int16(_) => 2,
         ScalarRefImpl::Int32(_) => 4,
@@ -439,3 +439,6 @@ fn deserialize_decimal(data: &mut impl Buf) -> Result<Decimal> {
     data.copy_to_slice(&mut bytes);
     Ok(Decimal::unordered_deserialize(bytes))
 }
+
+#[cfg(test)]
+mod tests {}

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -242,16 +242,16 @@ fn estimate_serialize_scalar_size(value: ScalarRefImpl<'_>) -> usize {
         ScalarRefImpl::Float32(_) => 4,
         ScalarRefImpl::Float64(_) => 8,
         ScalarRefImpl::Utf8(v) => v.as_bytes().len(),
-        ScalarRefImpl::Bytea(v) => estimate_encoded_str_size(v),
+        ScalarRefImpl::Bytea(v) => estimate_serialize_str_size(v),
         ScalarRefImpl::Bool(_) => 1,
-        ScalarRefImpl::Decimal(_) => estimate_encoded_decimal_size(),
-        ScalarRefImpl::Interval(_) => estimate_encoded_interval_size(),
-        ScalarRefImpl::NaiveDate(_) => estimate_encoded_naivedate_size(),
-        ScalarRefImpl::NaiveDateTime(_) => estimate_encoded_naivedatetime_size(),
-        ScalarRefImpl::NaiveTime(_) => estimate_encoded_naivetime_size(),
+        ScalarRefImpl::Decimal(_) => estimate_serialize_decimal_size(),
+        ScalarRefImpl::Interval(_) => estimate_serialize_interval_size(),
+        ScalarRefImpl::NaiveDate(_) => estimate_serialize_naivedate_size(),
+        ScalarRefImpl::NaiveDateTime(_) => estimate_serialize_naivedatetime_size(),
+        ScalarRefImpl::NaiveTime(_) => estimate_serialize_naivetime_size(),
         ScalarRefImpl::Jsonb(_) => 8,
-        ScalarRefImpl::Struct(s) => estimate_encoded_struct_size(s),
-        ScalarRefImpl::List(v) => estimate_encoded_list_size(v),
+        ScalarRefImpl::Struct(s) => estimate_serialize_struct_size(s),
+        ScalarRefImpl::List(v) => estimate_serialize_list_size(v),
     }
 }
 
@@ -265,8 +265,8 @@ fn serialize_struct(value: StructRef<'_>, buf: &mut impl BufMut) {
         .collect_vec();
 }
 
-fn estimate_encoded_struct_size(s: StructRef<'_>) -> usize {
-    4 + s.estimate_value_encoding_size_inner()
+fn estimate_serialize_struct_size(s: StructRef<'_>) -> usize {
+    4 + s.estimate_serialize_size_inner()
 }
 fn serialize_list(value: ListRef<'_>, buf: &mut impl BufMut) {
     let values_ref = value.values_ref();
@@ -279,8 +279,8 @@ fn serialize_list(value: ListRef<'_>, buf: &mut impl BufMut) {
         })
         .collect_vec();
 }
-fn estimate_encoded_list_size(list: ListRef<'_>) -> usize {
-    4 + list.estimate_value_encoding_size_inner()
+fn estimate_serialize_list_size(list: ListRef<'_>) -> usize {
+    4 + list.estimate_serialize_size_inner()
 }
 
 fn serialize_str(bytes: &[u8], buf: &mut impl BufMut) {
@@ -288,7 +288,7 @@ fn serialize_str(bytes: &[u8], buf: &mut impl BufMut) {
     buf.put_slice(bytes);
 }
 
-fn estimate_encoded_str_size(bytes: &[u8]) -> usize {
+fn estimate_serialize_str_size(bytes: &[u8]) -> usize {
     4 + bytes.len()
 }
 
@@ -298,7 +298,7 @@ fn serialize_interval(interval: &IntervalUnit, buf: &mut impl BufMut) {
     buf.put_i64_le(interval.get_usecs());
 }
 
-fn estimate_encoded_interval_size() -> usize {
+fn estimate_serialize_interval_size() -> usize {
     4 + 4 + 8
 }
 
@@ -306,7 +306,7 @@ fn serialize_naivedate(days: i32, buf: &mut impl BufMut) {
     buf.put_i32_le(days);
 }
 
-fn estimate_encoded_naivedate_size() -> usize {
+fn estimate_serialize_naivedate_size() -> usize {
     4
 }
 
@@ -315,7 +315,7 @@ fn serialize_naivedatetime(secs: i64, nsecs: u32, buf: &mut impl BufMut) {
     buf.put_u32_le(nsecs);
 }
 
-fn estimate_encoded_naivedatetime_size() -> usize {
+fn estimate_serialize_naivedatetime_size() -> usize {
     8 + 4
 }
 
@@ -324,7 +324,7 @@ fn serialize_naivetime(secs: u32, nano: u32, buf: &mut impl BufMut) {
     buf.put_u32_le(nano);
 }
 
-fn estimate_encoded_naivetime_size() -> usize {
+fn estimate_serialize_naivetime_size() -> usize {
     4 + 4
 }
 
@@ -332,7 +332,7 @@ fn serialize_decimal(decimal: &Decimal, buf: &mut impl BufMut) {
     buf.put_slice(&decimal.unordered_serialize());
 }
 
-fn estimate_encoded_decimal_size() -> usize {
+fn estimate_serialize_decimal_size() -> usize {
     16
 }
 

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -490,7 +490,6 @@ mod tests {
         test_estimate_serialize_scalar_size(ScalarImpl::Interval(
             IntervalUnit::from_month_day_usec(2, 3, 3333),
         ));
-        // test_estimate_serialize_scalar_size(ScalarImpl::Jsonb(JsonbVal::dummy()));
         test_estimate_serialize_scalar_size(ScalarImpl::Struct(StructValue::new(vec![
             ScalarImpl::Int64(233).into(),
             ScalarImpl::Float64(23.33.into()).into(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

add function to estimate the value encoding size of the datum
prepare for https://github.com/risingwavelabs/risingwave/issues/8683

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
