### PR TITLE
deprecate(config): deprecate state store url on worker nodes

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,6 @@ services:
       - "0.0.0.0:1260"
       - "--metrics-level"
       - "1"
-      - "--state-store"
-      - "hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001"
       - "--meta-address"
       - "http://meta-node-0:5690"
       - "--config-path"
@@ -52,8 +50,6 @@ services:
       - "0.0.0.0:1222"
       - "--metrics-level"
       - "1"
-      - "--state-store"
-      - "hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001"
       - "--meta-address"
       - "http://meta-node-0:5690"
       - "--connector-rpc-endpoint"
@@ -203,6 +199,8 @@ services:
       - "etcd-0:2388"
       - "--connector-rpc-endpoint"
       - "connector-node:50051"
+      - "--state-store"
+      - "hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001"
       - "--config-path"
       - /risingwave.toml
     expose:

--- a/risedev.yml
+++ b/risedev.yml
@@ -489,18 +489,16 @@ profile:
       - use: etcd
         unsafe-no-fsync: true
       - use: meta-node
+        enable-in-memory-kv-state-backend: true
       - use: compute-node
         port: 5687
         exporter-port: 1222
-        enable-in-memory-kv-state-backend: true
       - use: compute-node
         port: 5688
         exporter-port: 1223
-        enable-in-memory-kv-state-backend: true
       - use: compute-node
         port: 5689
         exporter-port: 1224
-        enable-in-memory-kv-state-backend: true
       - use: frontend
         port: 4565
         exporter-port: 2222
@@ -770,17 +768,8 @@ template:
     # Jaeger used by this compute node
     provide-jaeger: "jaeger*"
 
-    # Sanity check: should use shared storage if there're multiple compute nodes
-    provide-compute-node: "compute-node*"
-
-    # Sanity check: should start at lease one compactor if using shared object store
-    provide-compactor: "compactor*"
-
     # If `user-managed` is true, this service will be started by user with the above config
     user-managed: false
-
-    # Whether to enable in-memory pure KV state backend
-    enable-in-memory-kv-state-backend: false
 
     # Total available memory for the compute node in bytes
     total-memory-bytes: 8589934592
@@ -825,6 +814,24 @@ template:
 
     # Prometheus nodes used by dashboard service
     provide-prometheus: "prometheus*"
+
+    # Sanity check: should use shared storage if there're multiple compute nodes
+    provide-compute-node: "compute-node*"
+
+    # Sanity check: should start at lease one compactor if using shared object store
+    provide-compactor: "compactor*"
+
+    # Minio instances used by the cluster
+    provide-minio: "minio*"
+
+    # OpenDAL storage backend used by the cluster
+    provide-opendal: "opendal*"
+
+    # AWS s3 bucket used by the cluster
+    provide-aws-s3: "aws-s3*"
+
+    # Whether to enable in-memory pure KV state backend
+    enable-in-memory-kv-state-backend: false
 
   prometheus:
     # Advertise address of Prometheus
@@ -910,13 +917,8 @@ template:
     # Id of this instance
     id: compactor-${port}
 
-    # Minio instances used by this compute node
+    # Minio instances used by this compactor
     provide-minio: "minio*"
-
-    # OpenDAL storage backend used by this compute node
-    provide-opendal: "opendal*"
-    # AWS s3 bucket used by this compute node
-    provide-aws-s3: "aws-s3*"
 
     # Meta-nodes used by this compute node
     provide-meta-node: "meta-node*"

--- a/src/common/src/system_param/reader.rs
+++ b/src/common/src/system_param/reader.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use risingwave_pb::meta::PbSystemParams;
-use tracing::warn;
 
 use super::system_params_to_kv;
 
@@ -53,15 +52,8 @@ impl SystemParamsReader {
         self.prost.bloom_false_positive.unwrap()
     }
 
-    // TODO(zhidong): Only read from system params in v0.1.18.
-    pub fn state_store(&self, from_local: String) -> String {
-        let from_prost = self.prost.state_store.as_ref().unwrap();
-        if from_prost.is_empty() {
-            warn!("--state-store is not specified on meta node, reading from CLI instead");
-            from_local
-        } else {
-            from_prost.clone()
-        }
+    pub fn state_store(&self) -> &str {
+        self.prost.state_store.as_ref().unwrap()
     }
 
     pub fn data_directory(&self) -> &str {

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -70,15 +70,6 @@ pub struct ComputeNodeOpts {
     #[clap(long, env = "RW_CONNECTOR_RPC_SINK_PAYLOAD_FORMAT")]
     pub connector_rpc_sink_payload_format: Option<String>,
 
-    /// One of:
-    /// 1. `hummock+{object_store}` where `object_store`
-    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`,
-    /// `memory` or `memory-shared`.
-    /// 2. `in-memory`
-    /// 3. `sled://{path}`
-    #[clap(long, env = "RW_STATE_STORE")]
-    pub state_store: Option<String>,
-
     /// The path of `risingwave.toml` configuration file.
     ///
     /// If empty, default configuration values will be used.
@@ -173,7 +164,6 @@ pub fn start(opts: ComputeNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> 
     // slow compile in release mode.
     Box::pin(async move {
         tracing::info!("options: {:?}", opts);
-        warn_future_deprecate_options(&opts);
         validate_opts(&opts);
 
         let listen_addr = opts.listen_addr.parse().unwrap();
@@ -205,10 +195,4 @@ fn default_total_memory_bytes() -> usize {
 
 fn default_parallelism() -> usize {
     total_cpu_available().ceil() as usize
-}
-
-fn warn_future_deprecate_options(opts: &ComputeNodeOpts) {
-    if opts.state_store.is_some() {
-        tracing::warn!("`--state-store` will not be accepted by compute node in the next release. Please consider moving this argument to the meta node.");
-    }
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -108,16 +108,10 @@ pub async fn compute_node_serve(
     .unwrap();
     let storage_opts = Arc::new(StorageOpts::from((&config, &system_params)));
 
-    let state_store_url = {
-        let from_local = opts
-            .state_store
-            .clone()
-            .unwrap_or_else(|| "hummock+memory".to_string());
-        system_params.state_store(from_local)
-    };
+    let state_store_url = system_params.state_store();
 
     let embedded_compactor_enabled =
-        embedded_compactor_enabled(&state_store_url, config.storage.disable_remote_compactor);
+        embedded_compactor_enabled(state_store_url, config.storage.disable_remote_compactor);
     let storage_memory_bytes =
         total_storage_memory_limit_bytes(&config.storage, embedded_compactor_enabled);
     let compute_memory_bytes =
@@ -152,7 +146,7 @@ pub async fn compute_node_serve(
     let mut join_handle_vec = vec![];
 
     let state_store = StateStoreImpl::new(
-        &state_store_url,
+        state_store_url,
         storage_opts.clone(),
         hummock_meta_client.clone(),
         state_store_metrics.clone(),

--- a/src/risedevtool/src/compose.rs
+++ b/src/risedevtool/src/compose.rs
@@ -154,11 +154,7 @@ fn health_check_port(port: u16) -> HealthCheck {
 impl Compose for ComputeNodeConfig {
     fn compose(&self, config: &ComposeConfig) -> Result<ComposeService> {
         let mut command = Command::new("compute-node");
-        ComputeNodeService::apply_command_args(
-            &mut command,
-            self,
-            HummockInMemoryStrategy::Disallowed,
-        )?;
+        ComputeNodeService::apply_command_args(&mut command, self)?;
         if self.enable_tiered_cache {
             command.arg("--file-cache-dir").arg("/filecache");
         }
@@ -201,7 +197,11 @@ impl Compose for ComputeNodeConfig {
 impl Compose for MetaNodeConfig {
     fn compose(&self, config: &ComposeConfig) -> Result<ComposeService> {
         let mut command = Command::new("meta-node");
-        MetaNodeService::apply_command_args(&mut command, self)?;
+        MetaNodeService::apply_command_args(
+            &mut command,
+            self,
+            HummockInMemoryStrategy::Disallowed,
+        )?;
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");
@@ -264,11 +264,7 @@ impl Compose for FrontendConfig {
 impl Compose for CompactorConfig {
     fn compose(&self, config: &ComposeConfig) -> Result<ComposeService> {
         let mut command = Command::new("compactor-node");
-        CompactorService::apply_command_args(
-            &mut command,
-            self,
-            HummockInMemoryStrategy::Disallowed,
-        )?;
+        CompactorService::apply_command_args(&mut command, self)?;
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -36,9 +36,7 @@ pub struct ComputeNodeConfig {
     pub provide_opendal: Option<Vec<OpendalConfig>>,
     pub provide_aws_s3: Option<Vec<AwsS3Config>>,
     pub provide_jaeger: Option<Vec<JaegerConfig>>,
-    pub provide_compactor: Option<Vec<CompactorConfig>>,
     pub user_managed: bool,
-    pub enable_in_memory_kv_state_backend: bool,
     pub connector_rpc_endpoint: String,
 
     pub total_memory_bytes: usize,
@@ -67,6 +65,14 @@ pub struct MetaNodeConfig {
     pub connector_rpc_endpoint: String,
     pub provide_etcd_backend: Option<Vec<EtcdConfig>>,
     pub provide_prometheus: Option<Vec<PrometheusConfig>>,
+
+    pub provide_compute_node: Option<Vec<ComputeNodeConfig>>,
+    pub provide_compactor: Option<Vec<CompactorConfig>>,
+
+    pub provide_aws_s3: Option<Vec<AwsS3Config>>,
+    pub provide_minio: Option<Vec<MinioConfig>>,
+    pub provide_opendal: Option<Vec<OpendalConfig>>,
+    pub enable_in_memory_kv_state_backend: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -103,8 +109,6 @@ pub struct CompactorConfig {
     pub exporter_port: u16,
 
     pub provide_minio: Option<Vec<MinioConfig>>,
-    pub provide_opendal: Option<Vec<OpendalConfig>>,
-    pub provide_aws_s3: Option<Vec<AwsS3Config>>,
 
     pub provide_meta_node: Option<Vec<MetaNodeConfig>>,
     pub user_managed: bool,

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -20,7 +20,7 @@ use anyhow::{anyhow, Result};
 
 use super::{ExecuteContext, Task};
 use crate::util::{get_program_args, get_program_env_cmd, get_program_name};
-use crate::{add_meta_node, add_storage_backend, ComputeNodeConfig, HummockInMemoryStrategy};
+use crate::{add_meta_node, ComputeNodeConfig};
 
 pub struct ComputeNodeService {
     config: ComputeNodeConfig,
@@ -42,11 +42,7 @@ impl ComputeNodeService {
     }
 
     /// Apply command args according to config
-    pub fn apply_command_args(
-        cmd: &mut Command,
-        config: &ComputeNodeConfig,
-        hummock_in_memory_strategy: HummockInMemoryStrategy,
-    ) -> Result<()> {
+    pub fn apply_command_args(cmd: &mut Command, config: &ComputeNodeConfig) -> Result<()> {
         cmd.arg("--listen-addr")
             .arg(format!("{}:{}", config.listen_address, config.port))
             .arg("--prometheus-listener-addr")
@@ -85,58 +81,8 @@ impl ComputeNodeService {
             }
         }
 
-        let provide_minio = config.provide_minio.as_ref().unwrap();
-        let provide_opendal = config.provide_opendal.as_ref().unwrap();
-        let provide_aws_s3 = config.provide_aws_s3.as_ref().unwrap();
-
-        let provide_compute_node = config.provide_compute_node.as_ref().unwrap();
-
-        let is_shared_backend = match (
-            config.enable_in_memory_kv_state_backend,
-            provide_minio.as_slice(),
-            provide_aws_s3.as_slice(),
-            provide_opendal.as_slice(),
-        ) {
-            (true, [], [], []) => {
-                cmd.arg("--state-store").arg("in-memory");
-                false
-            }
-            (true, _, _, _) => {
-                return Err(anyhow!(
-                    "When `enable_in_memory_kv_state_backend` is enabled, no minio and aws-s3 should be provided.",
-                ));
-            }
-            (_, provide_minio, provide_aws_s3, provide_opendal) => add_storage_backend(
-                &config.id,
-                provide_opendal,
-                provide_minio,
-                provide_aws_s3,
-                hummock_in_memory_strategy,
-                cmd,
-            )?,
-        };
-
-        if provide_compute_node.len() > 1 && !is_shared_backend {
-            if config.enable_in_memory_kv_state_backend {
-                // Using a non-shared backend with multiple compute nodes will be problematic for
-                // state sharing like scaling. However, for distributed end-to-end tests with
-                // in-memory state store, this is acceptable.
-            } else {
-                return Err(anyhow!(
-                    "Hummock storage may behave incorrectly with in-memory backend for multiple compute-node configuration. Should use a shared backend (e.g. MinIO) instead. Consider adding `use: minio` in risedev config."
-                ));
-            }
-        }
-
         let provide_meta_node = config.provide_meta_node.as_ref().unwrap();
         add_meta_node(provide_meta_node, cmd)?;
-
-        let provide_compactor = config.provide_compactor.as_ref().unwrap();
-        if is_shared_backend && provide_compactor.is_empty() {
-            return Err(anyhow!(
-                "When using a shared backend (minio, aws-s3, or shared in-memory with `risedev playground`), at least one compactor is required. Consider adding `use: compactor` in risedev config."
-            ));
-        }
 
         Ok(())
     }
@@ -172,7 +118,7 @@ impl Task for ComputeNodeService {
 
         cmd.arg("--config-path")
             .arg(Path::new(&prefix_config).join("risingwave.toml"));
-        Self::apply_command_args(&mut cmd, &self.config, HummockInMemoryStrategy::Isolated)?;
+        Self::apply_command_args(&mut cmd, &self.config)?;
         if self.config.enable_tiered_cache {
             let prefix_data = env::var("PREFIX_DATA")?;
             cmd.arg("--file-cache-dir").arg(

--- a/src/storage/compactor/src/lib.rs
+++ b/src/storage/compactor/src/lib.rs
@@ -52,12 +52,6 @@ pub struct CompactorOpts {
     #[clap(long, env = "RW_META_ADDR", default_value = "http://127.0.0.1:5690")]
     pub meta_address: String,
 
-    /// Of the form `hummock+{object_store}` where `object_store`
-    /// is one of `s3://{path}`, `s3-compatible://{path}`, `minio://{path}`, `disk://{path}`,
-    /// `memory` or `memory-shared`.
-    #[clap(long, env = "RW_STATE_STORE")]
-    pub state_store: Option<String>,
-
     #[clap(long, env = "RW_COMPACTION_WORKER_THREADS_NUMBER")]
     pub compaction_worker_threads_number: Option<usize>,
 
@@ -95,7 +89,6 @@ pub fn start(opts: CompactorOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
     // slow compile in release mode.
     Box::pin(async move {
         tracing::info!("Compactor node options: {:?}", opts);
-        warn_future_deprecate_options(&opts);
         tracing::info!("meta address: {}", opts.meta_address.clone());
 
         let listen_addr = opts.listen_addr.parse().unwrap();
@@ -118,10 +111,4 @@ pub fn start(opts: CompactorOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         join_handle.await.unwrap();
         observer_join_handle.abort();
     })
-}
-
-fn warn_future_deprecate_options(opts: &CompactorOpts) {
-    if opts.state_store.is_some() {
-        tracing::warn!("`--state-store` will not be accepted by compactor node in the next release. Please consider moving this argument to the meta node.");
-    }
 }

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -88,10 +88,7 @@ pub async fn compactor_serve(
         hummock_metrics.clone(),
     ));
 
-    let state_store_url = {
-        let from_local = opts.state_store.unwrap_or("".to_string());
-        system_params_reader.state_store(from_local)
-    };
+    let state_store_url = system_params_reader.state_store();
 
     let storage_opts = Arc::new(StorageOpts::from((&config, &system_params_reader)));
     let object_store = Arc::new(

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -82,6 +82,7 @@ pub async fn compaction_test_main(
 
     let _meta_handle = tokio::spawn(start_meta_node(
         meta_listen_addr.clone(),
+        opts.state_store.clone(),
         opts.config_path_for_meta.clone(),
     ));
 
@@ -124,7 +125,7 @@ pub async fn compaction_test_main(
     Ok(())
 }
 
-pub async fn start_meta_node(listen_addr: String, config_path: String) {
+pub async fn start_meta_node(listen_addr: String, state_store: String, config_path: String) {
     let meta_opts = risingwave_meta::MetaNodeOpts::parse_from([
         "meta-node",
         "--listen-addr",
@@ -135,6 +136,8 @@ pub async fn start_meta_node(listen_addr: String, config_path: String) {
         "mem",
         "--checkpoint-frequency",
         &CHECKPOINT_FREQ_FOR_REPLAY.to_string(),
+        "--state-store",
+        &state_store,
         "--config-path",
         &config_path,
     ]);

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -210,6 +210,8 @@ impl Cluster {
                 "etcd",
                 "--etcd-endpoints",
                 "etcd:2388",
+                "--state-store",
+                "hummock+minio://hummockadmin:hummockadmin@192.168.12.1:9301/hummock001",
             ]);
             handle
                 .create_node()
@@ -251,8 +253,6 @@ impl Cluster {
                 "0.0.0.0:5688",
                 "--advertise-addr",
                 &format!("192.168.3.{i}:5688"),
-                "--state-store",
-                "hummock+minio://hummockadmin:hummockadmin@192.168.12.1:9301/hummock001",
                 "--parallelism",
                 &conf.compute_node_cores.to_string(),
             ]);
@@ -275,8 +275,6 @@ impl Cluster {
                 "0.0.0.0:6660",
                 "--advertise-addr",
                 &format!("192.168.4.{i}:6660"),
-                "--state-store",
-                "hummock+minio://hummockadmin:hummockadmin@192.168.12.1:9301/hummock001",
             ]);
             handle
                 .create_node()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. In risedev, the sanity checks are moved to `MetaNodeService::apply_command_args`.

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- RisingWave cluster configuration changes

### Release note

Remove `--state-store` from the CLI of compute nodes and compactors. Now it must be specified on the meta node.
