### PR TITLE
perf(connector): use Vec<u8> instead of Bytes and &[u8]

### DIFF
--- a/src/connector/src/macros.rs
+++ b/src/connector/src/macros.rs
@@ -200,7 +200,7 @@ macro_rules! impl_common_parser_logic {
 
                             let old_op_num = builder.op_num();
 
-                            if let Err(e) = self.parse_inner(content.as_ref(), builder.row_writer())
+                            if let Err(e) = self.parse_inner(content, builder.row_writer())
                                 .await
                             {
                                 tracing::warn!("message parsing failed {}, skipping", e.to_string());

--- a/src/connector/src/parser/avro/parser.rs
+++ b/src/connector/src/parser/avro/parser.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt::Debug;
 use std::sync::Arc;
@@ -175,7 +176,7 @@ impl AvroParser {
 
     pub(crate) async fn parse_inner(
         &self,
-        payload: &[u8],
+        payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
         enum Op {
@@ -184,7 +185,7 @@ impl AvroParser {
         }
 
         let (_payload, op) = if self.is_enable_upsert() {
-            let msg: UpsertMessage<'_> = bincode::deserialize(payload).map_err(|e| {
+            let msg: UpsertMessage<'_> = bincode::deserialize(&payload).map_err(|e| {
                 RwError::from(ProtocolError(format!(
                     "extract payload err {:?}, you may need to check the 'upsert' parameter",
                     e
@@ -196,7 +197,7 @@ impl AvroParser {
                 (msg.primary_key, Op::Delete)
             }
         } else {
-            (payload.into(), Op::Insert)
+            (Cow::from(&payload), Op::Insert)
         };
 
         // parse payload to avro value
@@ -212,7 +213,7 @@ impl AvroParser {
             from_avro_datum(writer_schema.as_ref(), &mut raw_payload, reader_schema)
                 .map_err(|e| RwError::from(ProtocolError(e.to_string())))?
         } else {
-            let mut reader = Reader::with_schema(&self.schema, payload as &[u8])
+            let mut reader = Reader::with_schema(&self.schema, &payload as &[u8])
                 .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
             match reader.next() {
                 Some(Ok(v)) => v,
@@ -237,7 +238,7 @@ impl AvroParser {
                 from_avro_value(tuple.1.clone(), field_schema).map_err(|e| {
                     tracing::error!(
                         "failed to process value ({}): {}",
-                        String::from_utf8_lossy(payload),
+                        String::from_utf8_lossy(&payload),
                         e
                     );
                     e
@@ -271,7 +272,7 @@ impl AvroParser {
                         .map_err(|e| {
                             tracing::error!(
                                 "failed to process value ({}): {}",
-                                String::from_utf8_lossy(payload),
+                                String::from_utf8_lossy(&payload),
                                 e
                             );
                             e
@@ -388,10 +389,7 @@ mod test {
         let mut builder = SourceStreamChunkBuilder::with_capacity(columns, 1);
         {
             let writer = builder.row_writer();
-            avro_parser
-                .parse_inner(&input_data[..], writer)
-                .await
-                .unwrap();
+            avro_parser.parse_inner(input_data, writer).await.unwrap();
         }
         let chunk = builder.finish();
         let (op, row) = chunk.rows().next().unwrap();

--- a/src/connector/src/parser/canal/simd_json_parser.rs
+++ b/src/connector/src/parser/canal/simd_json_parser.rs
@@ -54,11 +54,10 @@ impl CanalJsonParser {
     #[allow(clippy::unused_async)]
     pub async fn parse_inner(
         &self,
-        payload: &[u8],
+        mut payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let mut payload_mut = payload.to_vec();
-        let event: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
+        let event: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
         let is_ddl = event.get(IS_DDL).and_then(|v| v.as_bool()).ok_or_else(|| {
@@ -263,7 +262,7 @@ mod tests {
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 2);
 
         let writer = builder.row_writer();
-        parser.parse_inner(payload, writer).await.unwrap();
+        parser.parse_inner(payload.to_vec(), writer).await.unwrap();
 
         let chunk = builder.finish();
 
@@ -340,7 +339,7 @@ mod tests {
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 2);
 
         let writer = builder.row_writer();
-        parser.parse_inner(payload, writer).await.unwrap();
+        parser.parse_inner(payload.to_vec(), writer).await.unwrap();
 
         let chunk = builder.finish();
 

--- a/src/connector/src/parser/csv_parser.rs
+++ b/src/connector/src/parser/csv_parser.rs
@@ -113,10 +113,10 @@ impl CsvParser {
     #[allow(clippy::unused_async)]
     pub async fn parse_inner(
         &mut self,
-        payload: &[u8],
+        payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let mut fields = self.read_row(payload)?;
+        let mut fields = self.read_row(&payload)?;
         if let Some(headers) = &mut self.headers {
             if headers.is_empty() {
                 *headers = fields;
@@ -161,7 +161,7 @@ mod tests {
     use crate::parser::SourceStreamChunkBuilder;
     #[tokio::test]
     async fn test_csv_without_headers() {
-        let data = [
+        let data = vec![
             r#"1,a,2"#,
             r#""15541","a,1,1,",4"#,
             r#"0,"""0",0"#,
@@ -185,7 +185,7 @@ mod tests {
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 4);
         for item in data {
             parser
-                .parse_inner(item.as_bytes(), builder.row_writer())
+                .parse_inner(item.as_bytes().to_vec(), builder.row_writer())
                 .await
                 .unwrap();
         }
@@ -292,7 +292,7 @@ mod tests {
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 4);
         for item in data {
             let _ = parser
-                .parse_inner(item.as_bytes(), builder.row_writer())
+                .parse_inner(item.as_bytes().to_vec(), builder.row_writer())
                 .await;
         }
         let chunk = builder.finish();

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -189,10 +189,10 @@ impl DebeziumAvroParser {
 
     pub(crate) async fn parse_inner(
         &self,
-        payload: &[u8],
+        payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let (schema_id, mut raw_payload) = extract_schema_id(payload)?;
+        let (schema_id, mut raw_payload) = extract_schema_id(&payload)?;
         let writer_schema = self.schema_resolver.get(schema_id).await?;
 
         let avro_value = from_avro_datum(writer_schema.as_ref(), &mut raw_payload, None)
@@ -296,7 +296,7 @@ mod tests {
     async fn parse_one(
         parser: DebeziumAvroParser,
         columns: Vec<SourceColumnDesc>,
-        payload: &[u8],
+        payload: Vec<u8>,
     ) -> Vec<(Op, OwnedRow)> {
         let mut builder = SourceStreamChunkBuilder::with_capacity(columns, 2);
         {
@@ -442,7 +442,7 @@ mod tests {
 
         let parser =
             DebeziumAvroParser::new(columns.clone(), config, Arc::new(Default::default()))?;
-        let [(op, row)]: [_; 1] = parse_one(parser, columns, DEBEZIUM_AVRO_DATA)
+        let [(op, row)]: [_; 1] = parse_one(parser, columns, DEBEZIUM_AVRO_DATA.to_vec())
             .await
             .try_into()
             .unwrap();

--- a/src/connector/src/parser/maxwell/simd_json_parser.rs
+++ b/src/connector/src/parser/maxwell/simd_json_parser.rs
@@ -48,11 +48,10 @@ impl MaxwellParser {
     #[allow(clippy::unused_async)]
     pub async fn parse_inner(
         &self,
-        payload: &[u8],
+        mut payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        let mut payload_mut = payload.to_vec();
-        let event: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload_mut)
+        let event: BorrowedValue<'_> = simd_json::to_borrowed_value(&mut payload)
             .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
 
         let op = event.get(OP).and_then(|v| v.as_str()).ok_or_else(|| {
@@ -139,9 +138,9 @@ mod tests {
 
         let mut builder = SourceStreamChunkBuilder::with_capacity(descs, 4);
         let payloads = vec![
-            br#"{"database":"test","table":"t","type":"insert","ts":1666937996,"xid":1171,"commit":true,"data":{"id":1,"name":"tom","is_adult":0,"birthday":"2017-12-31 16:00:01"}}"#.as_slice(),
-            br#"{"database":"test","table":"t","type":"insert","ts":1666938023,"xid":1254,"commit":true,"data":{"id":2,"name":"alex","is_adult":1,"birthday":"1999-12-31 16:00:01"}}"#.as_slice(),
-            br#"{"database":"test","table":"t","type":"update","ts":1666938068,"xid":1373,"commit":true,"data":{"id":2,"name":"chi","is_adult":1,"birthday":"1999-12-31 16:00:01"},"old":{"name":"alex"}}"#.as_slice()
+            br#"{"database":"test","table":"t","type":"insert","ts":1666937996,"xid":1171,"commit":true,"data":{"id":1,"name":"tom","is_adult":0,"birthday":"2017-12-31 16:00:01"}}"#.to_vec(),
+            br#"{"database":"test","table":"t","type":"insert","ts":1666938023,"xid":1254,"commit":true,"data":{"id":2,"name":"alex","is_adult":1,"birthday":"1999-12-31 16:00:01"}}"#.to_vec(),
+            br#"{"database":"test","table":"t","type":"update","ts":1666938068,"xid":1373,"commit":true,"data":{"id":2,"name":"chi","is_adult":1,"birthday":"1999-12-31 16:00:01"},"old":{"name":"alex"}}"#.to_vec()
         ];
 
         for payload in payloads {

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -188,13 +188,14 @@ impl ProtobufParser {
     #[allow(clippy::unused_async)]
     pub async fn parse_inner(
         &self,
-        mut payload: &[u8],
+        payload: Vec<u8>,
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<WriteGuard> {
-        if self.confluent_wire_type {
-            let raw_payload = resolve_pb_header(payload)?;
-            payload = raw_payload;
-        }
+        let payload = if self.confluent_wire_type {
+            resolve_pb_header(&payload)?
+        } else {
+            &payload
+        };
 
         let message = DynamicMessage::decode(self.message_descriptor.clone(), payload)
             .map_err(|e| ProtocolError(format!("parse message failed: {}", e)))?;

--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -376,7 +376,7 @@ pub type SplitId = Arc<str>;
 /// The third-party message structs will eventually be transformed into this struct.
 #[derive(Debug, Clone)]
 pub struct SourceMessage {
-    pub payload: Option<Bytes>,
+    pub payload: Option<Vec<u8>>,
     pub offset: String,
     pub split_id: SplitId,
 

--- a/src/connector/src/source/cdc/source/message.rs
+++ b/src/connector/src/source/cdc/source/message.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Bytes;
 use risingwave_pb::connector_service::CdcMessage;
 
 use crate::source::base::SourceMessage;
@@ -21,7 +20,7 @@ use crate::source::SourceMeta;
 impl From<CdcMessage> for SourceMessage {
     fn from(message: CdcMessage) -> Self {
         SourceMessage {
-            payload: Some(Bytes::from(message.payload)),
+            payload: Some(message.payload.as_bytes().to_vec()),
             offset: message.offset,
             split_id: message.partition.into(),
             meta: SourceMeta::Empty,

--- a/src/connector/src/source/datagen/source/generator.rs
+++ b/src/connector/src/source/datagen/source/generator.rs
@@ -14,7 +14,6 @@
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anyhow::Result;
-use bytes::Bytes;
 use futures_async_stream::try_stream;
 use maplit::hashmap;
 use risingwave_common::array::{Op, StreamChunk};
@@ -121,7 +120,7 @@ impl DatagenEventGenerator {
 
                                 map.insert(name.clone(), value);
                             }
-                            Bytes::from(serde_json::Value::from(map).to_string())
+                            serde_json::Value::from(map).to_string().as_bytes().to_vec()
                         }
                         _ => {
                             unimplemented!("only json format is supported for now")

--- a/src/connector/src/source/filesystem/nd_streaming.rs
+++ b/src/connector/src/source/filesystem/nd_streaming.rs
@@ -84,7 +84,7 @@ impl<T> NdByteStreamWrapper<T> {
                     let msg: SourceMessage = std::mem::take(&mut last_message).unwrap();
                     let last_payload = msg.payload.unwrap();
                     offset -= last_payload.len();
-                    line = String::from_utf8(last_payload.into()).unwrap() + &line;
+                    line = String::from_utf8(last_payload).unwrap() + &line;
                 }
                 let len = line.as_bytes().len();
 
@@ -148,7 +148,7 @@ mod tests {
                 Ok(e.chunks(N3)
                     .enumerate()
                     .map(|(j, buf)| SourceMessage {
-                        payload: Some(buf.to_owned().into()),
+                        payload: Some(buf.to_owned()),
                         offset: (i * N2 + j * N3).to_string(),
                         split_id: split_id.clone(),
                         meta: crate::source::SourceMeta::Empty,
@@ -164,7 +164,7 @@ mod tests {
         let items = msg_stream
             .into_iter()
             .flatten()
-            .map(|e| String::from_utf8(e.payload.unwrap().into()).unwrap())
+            .map(|e| String::from_utf8(e.payload.unwrap()).unwrap())
             .collect::<Vec<_>>();
         assert_eq!(items.len(), N1);
         let text = items.join("");

--- a/src/connector/src/source/filesystem/s3/source/reader.rs
+++ b/src/connector/src/source/filesystem/s3/source/reader.rs
@@ -81,7 +81,7 @@ impl S3FileReader {
             let bytes = read?;
             let len = bytes.len();
             let msg = SourceMessage {
-                payload: Some(bytes),
+                payload: Some(bytes.as_ref().to_vec()),
                 offset: offset.to_string(),
                 split_id: split.id(),
                 meta: SourceMeta::Empty,

--- a/src/connector/src/source/google_pubsub/source/message.rs
+++ b/src/connector/src/source/google_pubsub/source/message.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use google_cloud_pubsub::subscriber::ReceivedMessage;
 
@@ -47,7 +46,7 @@ impl From<TaggedReceivedMessage> for SourceMessage {
                 let payload = message.message.data;
                 match payload.len() {
                     0 => None,
-                    _ => Some(Bytes::from(payload)),
+                    _ => Some(payload),
                 }
             },
             offset: timestamp.timestamp_nanos().to_string(),

--- a/src/connector/src/source/kafka/source/message.rs
+++ b/src/connector/src/source/kafka/source/message.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use bytes::Bytes;
 use rdkafka::message::BorrowedMessage;
 use rdkafka::Message;
 
@@ -35,7 +34,7 @@ impl SourceMessage {
         .unwrap();
         SourceMessage {
             // TODO(TaoWu): Possible performance improvement: avoid memory copying here.
-            payload: Some(encoded.into()),
+            payload: Some(encoded),
             offset: message.offset().to_string(),
             split_id: message.partition().to_string().into(),
             meta: SourceMeta::Kafka(KafkaMeta {
@@ -49,7 +48,7 @@ impl<'a> From<BorrowedMessage<'a>> for SourceMessage {
     fn from(message: BorrowedMessage<'a>) -> Self {
         SourceMessage {
             // TODO(TaoWu): Possible performance improvement: avoid memory copying here.
-            payload: message.payload().map(Bytes::copy_from_slice),
+            payload: message.payload().map(|p| p.to_vec()),
             offset: message.offset().to_string(),
             split_id: message.partition().to_string().into(),
             meta: SourceMeta::Kafka(KafkaMeta {

--- a/src/connector/src/source/kinesis/source/message.rs
+++ b/src/connector/src/source/kinesis/source/message.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use aws_sdk_kinesis::model::Record;
-use bytes::Bytes;
 
 use crate::source::{SourceMessage, SourceMeta, SplitId};
 
@@ -22,7 +21,7 @@ pub struct KinesisMessage {
     pub shard_id: SplitId,
     pub sequence_number: String,
     pub partition_key: String,
-    pub payload: Bytes,
+    pub payload: Vec<u8>,
 }
 
 impl From<KinesisMessage> for SourceMessage {
@@ -42,7 +41,7 @@ impl KinesisMessage {
             shard_id,
             sequence_number: message.sequence_number.unwrap(),
             partition_key: message.partition_key.unwrap(),
-            payload: message.data.unwrap().into_inner().into(),
+            payload: message.data.unwrap().into_inner(),
         }
     }
 }

--- a/src/connector/src/source/nexmark/source/message.rs
+++ b/src/connector/src/source/nexmark/source/message.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bytes::Bytes;
 use nexmark::event::Event;
 
 use crate::source::nexmark::source::combined_event::CombinedEvent;
@@ -26,7 +25,7 @@ pub struct NexmarkMeta {
 pub struct NexmarkMessage {
     pub split_id: SplitId,
     pub sequence_number: String,
-    pub payload: Bytes,
+    pub payload: Vec<u8>,
 }
 
 impl From<NexmarkMessage> for SourceMessage {
@@ -53,12 +52,11 @@ impl NexmarkMessage {
             split_id,
             sequence_number: offset.to_string(),
             payload: match &event {
-                Event::Person(p) => serde_json::to_string(p),
-                Event::Auction(a) => serde_json::to_string(a),
-                Event::Bid(b) => serde_json::to_string(b),
+                Event::Person(p) => serde_json::to_vec(p),
+                Event::Auction(a) => serde_json::to_vec(a),
+                Event::Bid(b) => serde_json::to_vec(b),
             }
-            .unwrap()
-            .into(),
+            .unwrap(),
         }
     }
 

--- a/src/connector/src/source/pulsar/source/message.rs
+++ b/src/connector/src/source/pulsar/source/message.rs
@@ -21,7 +21,7 @@ impl From<Message<Vec<u8>>> for SourceMessage {
         let message_id = msg.message_id.id;
 
         SourceMessage {
-            payload: Some(msg.payload.data.into()),
+            payload: Some(msg.payload.data),
             offset: format!(
                 "{}:{}:{}:{}",
                 message_id.ledger_id,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #8712 
![SCR-20230323-ktx](https://user-images.githubusercontent.com/5791930/227127390-ea1d3acb-a1a1-4a28-a29a-df03d39fa4d9.png)

https://g-2927a1b4d9.grafana-workspace.us-east-1.amazonaws.com/d/EpkBw5W4k/risingwave-bench-dashboard?orgId=1&var-namespace=nexmark-bs-0-no-to-vec&from=1679553815503&to=1679554775882

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
