### PR TITLE
fix: correctly handle graceful shutdown after losing leader

### DIFF
--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -254,18 +254,37 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
         .await
         .unwrap();
 
-        let res = tokio::select! {
-            _ = tokio::signal::ctrl_c() => {
-                tracing::info!("receive ctrl+c");
-                shutdown_send.send(()).unwrap();
-                join_handle.await
+        match leader_lost_handle {
+            None => {
+                tokio::select! {
+                    _ = tokio::signal::ctrl_c() => {
+                        tracing::info!("receive ctrl+c");
+                        shutdown_send.send(()).unwrap();
+                        join_handle.await.unwrap()
+                    }
+                    res = &mut join_handle => res.unwrap(),
+                };
             }
-            res = &mut join_handle => res,
+            Some(mut handle) => {
+                tokio::select! {
+                    _ = &mut handle => {
+                        tracing::info!("receive leader lost signal");
+                        shutdown_send.send(()).unwrap();
+                        join_handle.await.unwrap()
+                    }
+                    _ = tokio::signal::ctrl_c() => {
+                        tracing::info!("receive ctrl+c");
+                        shutdown_send.send(()).unwrap();
+                        join_handle.await.unwrap();
+                        handle.abort();
+                    }
+                    res = &mut join_handle => {
+                        res.unwrap();
+                        handle.abort();
+                    },
+                };
+            }
         };
-        res.unwrap();
-        if let Some(leader_lost_handle) = leader_lost_handle {
-            leader_lost_handle.abort();
-        }
     })
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

This pull request involves adding new code changes that expand the functionality of a previously implemented mechanism. Specifically, the changes add a new match statement designed to handle cases where a leader_lost_handle is present. When a leader_lost_handle is present, the code will utilize tokio::select! to handle several different scenarios. These include completing the join_handle, receiving a leader lost signal and completing the join_handle, or receiving a ctrl+c signal, completing the join_handle, and aborting the leader_lost_handle.

If a leader_lost_handle is not present, the code will instead use tokio::select! to handle either receiving a ctrl+c signal or completing the join_handle. The final step in the changes is to return the result of the match statement.

Overall, these changes expand the functionality of the code to handle additional scenarios in which a leader_lost_handle is present. This will help to ensure that the code functions correctly in a wider range of situations, and should be beneficial for anyone who works with the code in the future.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
