### PR TITLE
fix(state clean): state clean should not delete NULL

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -808,22 +808,27 @@ where
         } else {
             Some(self.pk_serde.prefix(1))
         };
-        let range_end_suffix = watermark.map(|watermark| {
+        let watermark_suffix = watermark.map(|watermark| {
             serialize_pk(
                 row::once(Some(watermark)),
                 prefix_serializer.as_ref().unwrap(),
             )
         });
-        if let Some(range_end_suffix) = range_end_suffix {
-            let range_begin_suffix = vec![];
-            trace!(table_id = %self.table_id, range_end = ?range_end_suffix, vnodes = ?{
+        if let Some(watermark_suffix) = watermark_suffix {
+            let range_begin_suffix =
+                if prefix_serializer.unwrap().get_order_types()[0].nulls_are_largest() {
+                    vec![]
+                } else {
+                    vec![1u8]
+                };
+            trace!(table_id = %self.table_id, watermark = ?watermark_suffix, vnodes = ?{
                 self.vnodes.iter_vnodes().collect_vec()
             }, "delete range");
             for vnode in self.vnodes.iter_vnodes() {
                 let mut range_begin = vnode.to_be_bytes().to_vec();
                 let mut range_end = range_begin.clone();
                 range_begin.extend(&range_begin_suffix);
-                range_end.extend(&range_end_suffix);
+                range_end.extend(&watermark_suffix);
                 delete_ranges.push((Bytes::from(range_begin), Bytes::from(range_end)));
             }
         }

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -815,12 +815,10 @@ where
             )
         });
         if let Some(watermark_suffix) = watermark_suffix {
-            let range_begin_suffix =
-                if prefix_serializer.unwrap().get_order_types()[0].nulls_are_largest() {
-                    vec![]
-                } else {
-                    vec![1u8]
-                };
+            let range_begin_suffix = watermark_suffix
+                .first()
+                .map(|bit| vec![*bit])
+                .unwrap_or_default();
             trace!(table_id = %self.table_id, watermark = ?watermark_suffix, vnodes = ?{
                 self.vnodes.iter_vnodes().collect_vec()
             }, "delete range");

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -815,6 +815,9 @@ where
             )
         });
         if let Some(watermark_suffix) = watermark_suffix {
+            // We either serialize null into `0u8`, data into `(1u8 || scalar)`, or serialize null
+            // into `1u8`, data into `(0u8 || scalar)`. We do not want to delete null
+            // here, so `range_begin_suffix` cannot be `vec![]` when null is represented as `0u8`.
             let range_begin_suffix = watermark_suffix
                 .first()
                 .map(|bit| vec![*bit])


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
When we delete all data where column_data < watermark, state clean should not delete data where column_data == NULL

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
