### PR TITLE
fix: use a separate etcd option for election client

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -192,6 +192,7 @@ profile:
 
   3etcd-3meta:
     steps:
+      - use: minio
       - use: etcd
         unsafe-no-fsync: true
         port: 2388
@@ -219,9 +220,11 @@ profile:
         port: 25690
         dashboard-port: 25691
         exporter-port: 21250
+      - use: compactor
 
   3etcd-3meta-1cn-1fe:
     steps:
+      - use: minio
       - use: etcd
         unsafe-no-fsync: true
         port: 2388
@@ -249,6 +252,7 @@ profile:
         port: 25690
         dashboard-port: 25691
         exporter-port: 21250
+      - use: compactor
       - use: compute-node
       - use: frontend
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -123,10 +123,16 @@ pub async fn rpc_serve(
                     .map_err(|e| anyhow::anyhow!("failed to connect etcd {}", e))?;
             let meta_store = Arc::new(EtcdMetaStore::new(client));
 
+            // `with_keep_alive` option will break the long connection in election client.
+            let mut election_options = ConnectOptions::default();
+            if let Some((username, password)) = &credentials {
+                election_options = election_options.with_user(username, password)
+            }
+
             let election_client = Arc::new(
                 EtcdElectionClient::new(
                     endpoints,
-                    Some(options),
+                    Some(election_options),
                     auth_enabled,
                     address_info.advertise_addr.clone(),
                 )

--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -57,8 +57,6 @@ impl EtcdService {
             .arg(&advertise_peer_urls)
             .arg("--listen-metrics-urls")
             .arg(&exporter_urls)
-            .arg("--name")
-            .arg("risedev-meta")
             .arg("--max-txn-ops")
             .arg("999999")
             .arg("--max-request-bytes")


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

hotfix for etcd election client

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
