### PR TITLE
perf(stream): add simple strategy for if the stream project compact the chunk

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -138,6 +138,19 @@ impl DataChunk {
         &self.vis2
     }
 
+    pub fn selectivity(&self) -> f64 {
+        match &self.vis2 {
+            Vis::Bitmap(b) => {
+                if b.len() == 0 {
+                    0.0
+                } else {
+                    b.count_ones() as f64 / b.len() as f64
+                }
+            }
+            Vis::Compact(_) => 1.0,
+        }
+    }
+
     pub fn with_visibility(&self, visibility: Bitmap) -> Self {
         DataChunk::new(self.columns.clone(), visibility)
     }

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -141,7 +141,7 @@ impl DataChunk {
     pub fn selectivity(&self) -> f64 {
         match &self.vis2 {
             Vis::Bitmap(b) => {
-                if b.len() == 0 {
+                if b.is_empty() {
                     0.0
                 } else {
                     b.count_ones() as f64 / b.len() as f64

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -133,6 +133,10 @@ impl StreamChunk {
         self.data.capacity()
     }
 
+    pub fn selectivity(&self) -> f64 {
+        self.data.selectivity()
+    }
+
     /// Get the reference of the underlying data chunk.
     pub fn data_chunk(&self) -> &DataChunk {
         &self.data

--- a/src/stream/src/executor/integration_tests.rs
+++ b/src/stream/src/executor/integration_tests.rs
@@ -196,6 +196,7 @@ async fn test_merger_sum_aggr() {
         ],
         3,
         MultiMap::new(),
+        0.0,
     );
 
     let items = Arc::new(Mutex::new(vec![]));

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -122,7 +122,6 @@ impl Inner {
             chunk
         };
         let (data_chunk, ops) = chunk.into_parts();
-
         let mut projected_columns = Vec::new();
 
         for expr in &self.exprs {
@@ -134,8 +133,9 @@ impl Inner {
             let new_column = Column::new(evaluated_expr);
             projected_columns.push(new_column);
         }
-
-        let new_chunk = StreamChunk::new(ops, projected_columns, None);
+        let (_, vis) = data_chunk.into_parts();
+        let vis = vis.into_visibility();
+        let new_chunk = StreamChunk::new(ops, projected_columns, vis);
         Ok(Some(new_chunk))
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

              I mean for q0, there can be no compact at all. The existing compact is done in the first project right after the filter, taking 10% of the flame graph.

_Originally posted by @lmatz in https://github.com/risingwavelabs/risingwave/issues/8742#issuecomment-1482308867_
            
https://github.com/risingwavelabs/risingwave/issues/8712

add some very simple strategy to not compact the chunk all the time.
I introduce a magic `materialize_selectivity_threshold` in this PR, but I do **NOT** think we should do any fine-tuning on the parameter now.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
