### PR TITLE
perf(compaction): support partition in compaction group

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6441,6 +6441,7 @@ dependencies = [
  "minstant",
  "moka",
  "nix 0.25.1",
+ "num-integer",
  "parking_lot 0.12.1",
  "procfs 0.12.0",
  "prometheus",

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -293,6 +293,8 @@ message CompactTask {
   // Identifies whether the task is space_reclaim, if the compact_task_type increases, it will be refactored to enum
   TaskType task_type = 20;
   bool split_by_state_table = 21;
+  // Compaction needs to cut the state table every time 1/weight of vnodes in the table have been processed.
+  uint32 split_weight_by_vnode = 22;
 }
 
 message LevelHandler {
@@ -634,6 +636,8 @@ message CompactionConfig {
   uint32 max_sub_compaction = 12;
   uint64 max_space_reclaim_bytes = 13;
   bool split_by_state_table = 14;
+  // Compaction needs to cut the state table every time 1/weight of vnodes in the table have been processed.
+  uint32 split_weight_by_vnode = 6;
   // soft limit for max number of sub level number
   uint64 level0_stop_write_threshold_sub_level_number = 15;
   uint64 level0_max_compact_file_number = 16;

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -66,6 +66,7 @@ impl CompactionConfigBuilder {
                 max_sub_compaction: DEFAULT_MAX_SUB_COMPACTION,
                 max_space_reclaim_bytes: DEFAULT_MAX_SPACE_RECLAIM_BYTES,
                 split_by_state_table: false,
+                split_weight_by_vnode: 0,
                 level0_stop_write_threshold_sub_level_number:
                     DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER,
                 // This configure variable shall be larger than level0_tier_compact_file_number, and

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -176,6 +176,7 @@ impl CompactStatus {
             target_sub_level_id: ret.input.target_sub_level_id,
             task_type: ret.compaction_task_type as i32,
             split_by_state_table: group.compaction_config.split_by_state_table,
+            split_weight_by_vnode: group.compaction_config.split_weight_by_vnode,
         };
         Some(compact_task)
     }

--- a/src/meta/src/hummock/compaction_schedule_policy.rs
+++ b/src/meta/src/hummock/compaction_schedule_policy.rs
@@ -501,6 +501,7 @@ mod tests {
             target_sub_level_id: 0,
             task_type: compact_task::TaskType::Dynamic as i32,
             split_by_state_table: false,
+            split_weight_by_vnode: 0,
         }
     }
 

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -33,6 +33,7 @@ lz4 = "1.23.1"
 memcomparable = "0.1"
 minitrace = "0.4"
 minstant = "0.1"
+num-integer = "0.1"
 parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["process"] }
 prost = "0.11"

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -19,6 +19,7 @@ use criterion::async_executor::FuturesExecutor;
 use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_common::cache::CachePriority;
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_object_store::object::object_metrics::ObjectStoreMetrics;
@@ -67,7 +68,11 @@ pub fn default_writer_opts() -> SstableWriterOptions {
 pub fn test_key_of(idx: usize, epoch: u64) -> FullKey<Vec<u8>> {
     FullKey::for_test(
         TableId::default(),
-        format!("key_test_{:08}", idx * 2).as_bytes().to_vec(),
+        [
+            VirtualNode::ZERO.to_be_bytes().as_slice(),
+            format!("key_test_{:08}", idx * 2).as_bytes(),
+        ]
+        .concat(),
         epoch,
     )
 }
@@ -187,6 +192,7 @@ async fn compact<I: HummockIterator<Direction = Forward>>(iter: I, sstable_store
         task_type: compact_task::TaskType::Dynamic,
         is_target_l0_or_lbase: false,
         split_by_table: false,
+        split_weight_by_vnode: 0,
     };
     Compactor::compact_and_build_sst(
         &mut builder,

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -20,6 +20,7 @@ use futures::TryStreamExt;
 use parking_lot::RwLock;
 use risingwave_common::cache::CachePriority;
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::key::{map_table_key_range, FullKey, UserKey, TABLE_PREFIX_LEN};
 use risingwave_rpc_client::HummockMetaClient;
 use risingwave_storage::hummock::store::version::{read_filter_for_batch, read_filter_for_local};
@@ -42,8 +43,14 @@ async fn test_storage_basic() {
 
     // First batch inserts the anchor and others.
     let mut batch1 = vec![
-        (Bytes::from("aa"), StorageValue::new_put("111")),
-        (Bytes::from("bb"), StorageValue::new_put("222")),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
+            StorageValue::new_put("111"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bb"].concat()),
+            StorageValue::new_put("222"),
+        ),
     ];
 
     // Make sure the batch is sorted.
@@ -51,8 +58,14 @@ async fn test_storage_basic() {
 
     // Second batch modifies the anchor.
     let mut batch2 = vec![
-        (Bytes::from("cc"), StorageValue::new_put("333")),
-        (Bytes::from("aa"), StorageValue::new_put("111111")),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"cc"].concat()),
+            StorageValue::new_put("333"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
+            StorageValue::new_put("111111"),
+        ),
     ];
 
     // Make sure the batch is sorted.
@@ -60,9 +73,18 @@ async fn test_storage_basic() {
 
     // Third batch deletes the anchor
     let mut batch3 = vec![
-        (Bytes::from("dd"), StorageValue::new_put("444")),
-        (Bytes::from("ee"), StorageValue::new_put("555")),
-        (Bytes::from("aa"), StorageValue::new_delete()),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"dd"].concat()),
+            StorageValue::new_put("444"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"ee"].concat()),
+            StorageValue::new_put("555"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
+            StorageValue::new_delete(),
+        ),
     ];
 
     // Make sure the batch is sorted.
@@ -89,7 +111,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("aa"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
             epoch1,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -109,7 +131,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("bb"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bb"].concat()),
             epoch1,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -131,7 +153,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("ab"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"ab"].concat()),
             epoch1,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -166,7 +188,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("aa"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
             epoch2,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -203,7 +225,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("aa"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
             epoch3,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -224,7 +246,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("ff"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"ff"].concat()),
             epoch3,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -245,7 +267,12 @@ async fn test_storage_basic() {
     let iter = test_env
         .storage
         .iter(
-            (Unbounded, Included(Bytes::from("ee"))),
+            (
+                Unbounded,
+                Included(Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"ee"].concat(),
+                )),
+            ),
             epoch1,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -263,14 +290,26 @@ async fn test_storage_basic() {
     futures::pin_mut!(iter);
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"aa".to_vec().into(), epoch1),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa".as_slice()].concat()
+                ),
+                epoch1
+            ),
             Bytes::copy_from_slice(&b"111"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"bb".to_vec().into(), epoch1),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"bb".as_slice()].concat()
+                ),
+                epoch1
+            ),
             Bytes::copy_from_slice(&b"222"[..])
         )),
         iter.try_next().await.unwrap()
@@ -281,7 +320,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("aa"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
             epoch1,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -303,7 +342,7 @@ async fn test_storage_basic() {
     let value = test_env
         .storage
         .get(
-            Bytes::from("aa"),
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa"].concat()),
             epoch2,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -324,7 +363,12 @@ async fn test_storage_basic() {
     let iter = test_env
         .storage
         .iter(
-            (Unbounded, Included(Bytes::from("ee"))),
+            (
+                Unbounded,
+                Included(Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"ee"].concat(),
+                )),
+            ),
             epoch2,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -342,21 +386,39 @@ async fn test_storage_basic() {
     futures::pin_mut!(iter);
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"aa".to_vec().into(), epoch2),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"aa".as_slice()].concat()
+                ),
+                epoch2
+            ),
             Bytes::copy_from_slice(&b"111111"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"bb".to_vec().into(), epoch1),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"bb".as_slice()].concat()
+                ),
+                epoch1
+            ),
             Bytes::copy_from_slice(&b"222"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"cc".to_vec().into(), epoch2),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"cc".as_slice()].concat()
+                ),
+                epoch2
+            ),
             Bytes::copy_from_slice(&b"333"[..])
         )),
         iter.try_next().await.unwrap()
@@ -367,7 +429,12 @@ async fn test_storage_basic() {
     let iter = test_env
         .storage
         .iter(
-            (Unbounded, Included(Bytes::from("ee"))),
+            (
+                Unbounded,
+                Included(Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"ee"].concat(),
+                )),
+            ),
             epoch3,
             ReadOptions {
                 ignore_range_tombstone: false,
@@ -385,28 +452,52 @@ async fn test_storage_basic() {
     futures::pin_mut!(iter);
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"bb".to_vec().into(), epoch1),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"bb".as_slice()].concat()
+                ),
+                epoch1
+            ),
             Bytes::copy_from_slice(&b"222"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"cc".to_vec().into(), epoch2),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"cc".as_slice()].concat()
+                ),
+                epoch2
+            ),
             Bytes::copy_from_slice(&b"333"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"dd".to_vec().into(), epoch3),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"dd".as_slice()].concat()
+                ),
+                epoch3
+            ),
             Bytes::copy_from_slice(&b"444"[..])
         )),
         iter.try_next().await.unwrap()
     );
     assert_eq!(
         Some((
-            FullKey::for_test(TEST_TABLE_ID, b"ee".to_vec().into(), epoch3),
+            FullKey::for_test(
+                TEST_TABLE_ID,
+                Bytes::from(
+                    [VirtualNode::ZERO.to_be_bytes().as_slice(), b"ee".as_slice()].concat()
+                ),
+                epoch3
+            ),
             Bytes::copy_from_slice(&b"555"[..])
         )),
         iter.try_next().await.unwrap()
@@ -433,8 +524,14 @@ async fn test_state_store_sync() {
 
     // ingest 16B batch
     let mut batch1 = vec![
-        (Bytes::from("aaaa"), StorageValue::new_put("1111")),
-        (Bytes::from("bbbb"), StorageValue::new_put("2222")),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaaa"].concat()),
+            StorageValue::new_put("1111"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bbbb"].concat()),
+            StorageValue::new_put("2222"),
+        ),
     ];
 
     batch1.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
@@ -452,9 +549,18 @@ async fn test_state_store_sync() {
 
     // ingest 24B batch
     let mut batch2 = vec![
-        (Bytes::from("cccc"), StorageValue::new_put("3333")),
-        (Bytes::from("dddd"), StorageValue::new_put("4444")),
-        (Bytes::from("eeee"), StorageValue::new_put("5555")),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"cccc"].concat()),
+            StorageValue::new_put("3333"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"dddd"].concat()),
+            StorageValue::new_put("4444"),
+        ),
+        (
+            Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat()),
+            StorageValue::new_put("5555"),
+        ),
     ];
     batch2.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
     hummock_storage
@@ -473,7 +579,10 @@ async fn test_state_store_sync() {
     hummock_storage.seal_current_epoch(epoch2);
 
     // ingest more 8B then will trigger a sync behind the scene
-    let mut batch3 = vec![(Bytes::from("eeee"), StorageValue::new_put("6666"))];
+    let mut batch3 = vec![(
+        Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat()),
+        StorageValue::new_put("6666"),
+    )];
     batch3.sort_by(|(k1, _), (k2, _)| k1.cmp(k2));
     hummock_storage
         .ingest_batch(
@@ -503,18 +612,33 @@ async fn test_state_store_sync() {
 
     {
         let kv_map = [
-            ("aaaa", "1111"),
-            ("bbbb", "2222"),
-            ("cccc", "3333"),
-            ("dddd", "4444"),
-            ("eeee", "5555"),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaaa"].concat()),
+                "1111",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bbbb"].concat()),
+                "2222",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"cccc"].concat()),
+                "3333",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"dddd"].concat()),
+                "4444",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat()),
+                "5555",
+            ),
         ];
 
         for (k, v) in kv_map {
             let value = test_env
                 .storage
                 .get(
-                    Bytes::from(k.to_owned()),
+                    k,
                     epoch1,
                     ReadOptions {
                         ignore_range_tombstone: false,
@@ -550,18 +674,33 @@ async fn test_state_store_sync() {
 
     {
         let kv_map = [
-            ("aaaa", "1111"),
-            ("bbbb", "2222"),
-            ("cccc", "3333"),
-            ("dddd", "4444"),
-            ("eeee", "6666"),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaaa"].concat()),
+                "1111",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bbbb"].concat()),
+                "2222",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"cccc"].concat()),
+                "3333",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"dddd"].concat()),
+                "4444",
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat()),
+                "6666",
+            ),
         ];
 
         for (k, v) in kv_map {
             let value = test_env
                 .storage
                 .get(
-                    Bytes::from(k.to_owned()),
+                    k,
                     epoch2,
                     ReadOptions {
                         ignore_range_tombstone: false,
@@ -586,7 +725,12 @@ async fn test_state_store_sync() {
         let iter = test_env
             .storage
             .iter(
-                (Unbounded, Included(Bytes::from("eeee"))),
+                (
+                    Unbounded,
+                    Included(Bytes::from(
+                        [VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat(),
+                    )),
+                ),
                 epoch1,
                 ReadOptions {
                     ignore_range_tombstone: false,
@@ -604,21 +748,38 @@ async fn test_state_store_sync() {
         futures::pin_mut!(iter);
 
         let kv_map = [
-            (b"aaaa", "1111", epoch1),
-            (b"bbbb", "2222", epoch1),
-            (b"cccc", "3333", epoch1),
-            (b"dddd", "4444", epoch1),
-            (b"eeee", "5555", epoch1),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaaa"].concat()),
+                "1111",
+                epoch1,
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"bbbb"].concat()),
+                "2222",
+                epoch1,
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"cccc"].concat()),
+                "3333",
+                epoch1,
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"dddd"].concat()),
+                "4444",
+                epoch1,
+            ),
+            (
+                Bytes::from([VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat()),
+                "5555",
+                epoch1,
+            ),
         ];
 
         for (k, v, e) in kv_map {
             let result = iter.try_next().await.unwrap();
             assert_eq!(
                 result,
-                Some((
-                    FullKey::for_test(TEST_TABLE_ID, k.to_vec().into(), e),
-                    Bytes::from(v)
-                ))
+                Some((FullKey::for_test(TEST_TABLE_ID, k, e), Bytes::from(v)))
             );
         }
 
@@ -629,7 +790,12 @@ async fn test_state_store_sync() {
         let iter = test_env
             .storage
             .iter(
-                (Unbounded, Included(Bytes::from("eeee"))),
+                (
+                    Unbounded,
+                    Included(Bytes::from(
+                        [VirtualNode::ZERO.to_be_bytes().as_slice(), b"eeee"].concat(),
+                    )),
+                ),
                 epoch2,
                 ReadOptions {
                     ignore_range_tombstone: false,
@@ -660,7 +826,13 @@ async fn test_state_store_sync() {
             assert_eq!(
                 result,
                 Some((
-                    FullKey::for_test(TEST_TABLE_ID, k.to_vec().into(), e),
+                    FullKey::for_test(
+                        TEST_TABLE_ID,
+                        Bytes::from(
+                            [VirtualNode::ZERO.to_be_bytes().as_slice(), k.as_slice()].concat()
+                        ),
+                        e
+                    ),
                     Bytes::from(v)
                 ))
             );

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -126,6 +126,7 @@ pub struct TaskConfig {
     pub task_type: compact_task::TaskType,
     pub is_target_l0_or_lbase: bool,
     pub split_by_table: bool,
+    pub split_weight_by_vnode: u32,
 }
 
 pub fn estimate_state_for_compaction(task: &CompactTask) -> (u64, usize) {

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -73,6 +73,7 @@ impl CompactorRunner {
                 is_target_l0_or_lbase: task.target_level == 0
                     || task.target_level == task.base_level,
                 split_by_table: task.split_by_state_table,
+                split_weight_by_vnode: task.split_weight_by_vnode,
             },
         );
 

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -895,6 +895,7 @@ impl Compactor {
             self.task_config.key_range.clone(),
             self.task_config.is_target_l0_or_lbase,
             self.task_config.split_by_table,
+            self.task_config.split_weight_by_vnode,
         );
         let compaction_statistics = Compactor::compact_and_build_sst(
             &mut sst_builder,

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -433,6 +433,7 @@ impl SharedBufferCompactRunner {
                 task_type: compact_task::TaskType::SharedBuffer,
                 is_target_l0_or_lbase: true,
                 split_by_table: false,
+                split_weight_by_vnode: 0,
             },
         );
         Self {

--- a/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/backward_sstable_iterator.rs
@@ -178,6 +178,7 @@ mod tests {
     use itertools::Itertools;
     use rand::prelude::*;
     use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
 
     use super::*;
     use crate::assert_bytes_eq;
@@ -253,7 +254,11 @@ mod tests {
 
         let largest_key = FullKey::for_test(
             TableId::default(),
-            format!("key_zzzz_{:05}", 0).as_bytes().to_vec(),
+            [
+                VirtualNode::ZERO.to_be_bytes().as_slice(),
+                format!("key_zzzz_{:05}", 0).as_bytes(),
+            ]
+            .concat(),
             233,
         );
         sstable_iter.seek(largest_key.to_ref()).await.unwrap();
@@ -263,7 +268,11 @@ mod tests {
         // Seek to > last key
         let smallest_key = FullKey::for_test(
             TableId::default(),
-            format!("key_aaaa_{:05}", 0).as_bytes().to_vec(),
+            [
+                VirtualNode::ZERO.to_be_bytes().as_slice(),
+                format!("key_aaaa_{:05}", 0).as_bytes(),
+            ]
+            .concat(),
             233,
         );
         sstable_iter.seek(smallest_key.to_ref()).await.unwrap();
@@ -279,7 +288,11 @@ mod tests {
                 .seek(
                     FullKey::for_test(
                         TableId::default(),
-                        format!("key_test_{:05}", idx * 2 - 1).as_bytes().to_vec(),
+                        [
+                            VirtualNode::ZERO.to_be_bytes().as_slice(),
+                            format!("key_test_{:05}", idx * 2 - 1).as_bytes(),
+                        ]
+                        .concat(),
                         0,
                     )
                     .to_ref(),

--- a/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
+++ b/src/storage/src/hummock/sstable/forward_sstable_iterator.rs
@@ -358,6 +358,7 @@ mod tests {
     use rand::prelude::*;
     use risingwave_common::cache::CachePriority;
     use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
 
     use super::*;
     use crate::assert_bytes_eq;
@@ -447,7 +448,11 @@ mod tests {
         // Seek to < first key
         let smallest_key = FullKey::for_test(
             TableId::default(),
-            format!("key_aaaa_{:05}", 0).as_bytes().to_vec(),
+            [
+                VirtualNode::ZERO.to_be_bytes().as_slice(),
+                format!("key_aaaa_{:05}", 0).as_bytes(),
+            ]
+            .concat(),
             233,
         );
         sstable_iter.seek(smallest_key.to_ref()).await.unwrap();
@@ -457,7 +462,11 @@ mod tests {
         // Seek to > last key
         let largest_key = FullKey::for_test(
             TableId::default(),
-            format!("key_zzzz_{:05}", 0).as_bytes().to_vec(),
+            [
+                VirtualNode::ZERO.to_be_bytes().as_slice(),
+                format!("key_zzzz_{:05}", 0).as_bytes(),
+            ]
+            .concat(),
             233,
         );
         sstable_iter.seek(largest_key.to_ref()).await.unwrap();
@@ -473,7 +482,11 @@ mod tests {
                 .seek(
                     FullKey::for_test(
                         TableId::default(),
-                        format!("key_test_{:05}", idx * 2 - 1).as_bytes().to_vec(),
+                        [
+                            VirtualNode::ZERO.to_be_bytes().as_slice(),
+                            format!("key_test_{:05}", idx * 2 - 1).as_bytes(),
+                        ]
+                        .concat(),
                         0,
                     )
                     .to_ref(),

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -16,6 +16,8 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::SeqCst;
 use std::sync::Arc;
 
+use num_integer::Integer;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::key::{FullKey, UserKey};
 use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::LocalSstableInfo;
@@ -73,6 +75,10 @@ where
     last_table_id: u32,
     is_target_level_l0_or_lbase: bool,
     split_by_table: bool,
+    split_weight_by_vnode: u32,
+    /// When vnode of the coming key is greater than `largest_vnode_in_current_partition`, we will
+    /// switch SST.
+    largest_vnode_in_current_partition: usize,
 }
 
 impl<F> CapacitySplitTableBuilder<F>
@@ -80,6 +86,7 @@ where
     F: TableBuilderFactory,
 {
     /// Creates a new [`CapacitySplitTableBuilder`] using given configuration generator.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         builder_factory: F,
         compactor_metrics: Arc<CompactorMetrics>,
@@ -87,13 +94,22 @@ where
         del_agg: Arc<CompactionDeleteRanges>,
         key_range: KeyRange,
         is_target_level_l0_or_lbase: bool,
-        split_by_table: bool,
+        mut split_by_table: bool,
+        mut split_weight_by_vnode: u32,
     ) -> Self {
         let start_key = if key_range.left.is_empty() {
             UserKey::default()
         } else {
             FullKey::decode(&key_range.left).user_key.to_vec()
         };
+
+        if !is_target_level_l0_or_lbase {
+            split_weight_by_vnode = 0;
+        }
+
+        if split_weight_by_vnode > 0 {
+            split_by_table = true;
+        }
 
         Self {
             builder_factory,
@@ -107,6 +123,8 @@ where
             last_table_id: 0,
             is_target_level_l0_or_lbase,
             split_by_table,
+            split_weight_by_vnode,
+            largest_vnode_in_current_partition: VirtualNode::MAX.to_index(),
         }
     }
 
@@ -123,6 +141,8 @@ where
             last_table_id: 0,
             is_target_level_l0_or_lbase: false,
             split_by_table: false,
+            split_weight_by_vnode: 0,
+            largest_vnode_in_current_partition: VirtualNode::MAX.to_index(),
         }
     }
 
@@ -162,6 +182,29 @@ where
         if self.split_by_table && full_key.user_key.table_id.table_id != self.last_table_id {
             self.last_table_id = full_key.user_key.table_id.table_id;
             switch_builder = true;
+
+            if self.split_weight_by_vnode > 1 {
+                self.largest_vnode_in_current_partition =
+                    VirtualNode::COUNT / (self.split_weight_by_vnode as usize) - 1;
+            }
+        }
+        if self.largest_vnode_in_current_partition != VirtualNode::MAX.to_index() {
+            let key_vnode = full_key.user_key.get_vnode_id();
+            if key_vnode > self.largest_vnode_in_current_partition {
+                switch_builder = true;
+
+                // SAFETY: `self.split_weight_by_vnode > 1` here.
+                let (basic, remainder) =
+                    VirtualNode::COUNT.div_rem(&(self.split_weight_by_vnode as usize));
+                let small_segments_area = basic * (self.split_weight_by_vnode as usize - remainder);
+                self.largest_vnode_in_current_partition = (if key_vnode < small_segments_area {
+                    (key_vnode / basic + 1) * basic
+                } else {
+                    ((key_vnode - small_segments_area) / (basic + 1) + 1) * (basic + 1)
+                        + small_segments_area
+                }) - 1;
+                debug_assert!(key_vnode <= self.largest_vnode_in_current_partition);
+            }
         }
         if let Some(builder) = self.current_builder.as_ref() {
             if is_new_user_key
@@ -314,6 +357,7 @@ impl TableBuilderFactory for LocalTableBuilderFactory {
 #[cfg(test)]
 mod tests {
     use risingwave_common::catalog::TableId;
+    use risingwave_common::hash::VirtualNode;
 
     use super::*;
     use crate::hummock::iterator::test_utils::mock_sstable_store;
@@ -437,8 +481,30 @@ mod tests {
         let table_id = TableId::default();
         let mut builder = CompactionDeleteRangesBuilder::default();
         let events = create_monotonic_events(vec![
-            DeleteRangeTombstone::new_for_test(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
-            DeleteRangeTombstone::new_for_test(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
+            DeleteRangeTombstone::new(
+                table_id,
+                [VirtualNode::ZERO.to_be_bytes().as_slice(), b"k"]
+                    .concat()
+                    .to_vec(),
+                false,
+                [VirtualNode::ZERO.to_be_bytes().as_slice(), b"kkk"]
+                    .concat()
+                    .to_vec(),
+                false,
+                100,
+            ),
+            DeleteRangeTombstone::new(
+                table_id,
+                [VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaa"]
+                    .concat()
+                    .to_vec(),
+                false,
+                [VirtualNode::ZERO.to_be_bytes().as_slice(), b"ddd"]
+                    .concat()
+                    .to_vec(),
+                false,
+                200,
+            ),
         ]);
         builder.add_delete_events(events);
         let mut builder = CapacitySplitTableBuilder::new(
@@ -449,10 +515,15 @@ mod tests {
             KeyRange::inf(),
             false,
             false,
+            0,
         );
         builder
-            .add_full_key_for_test(
-                FullKey::for_test(table_id, b"k", 233),
+            .add_full_key(
+                FullKey::for_test(
+                    table_id,
+                    &[VirtualNode::ZERO.to_be_bytes().as_slice(), b"k"].concat(),
+                    233,
+                ),
                 HummockValue::put(b"v"),
                 false,
             )
@@ -468,11 +539,21 @@ mod tests {
             .unwrap();
         assert_eq!(
             key_range.left,
-            FullKey::for_test(table_id, b"aaa", u64::MAX).encode()
+            FullKey::for_test(
+                table_id,
+                &[VirtualNode::ZERO.to_be_bytes().as_slice(), b"aaa"].concat(),
+                u64::MAX,
+            )
+            .encode()
         );
         assert_eq!(
             key_range.right,
-            FullKey::for_test(table_id, b"kkk", u64::MAX).encode()
+            FullKey::for_test(
+                table_id,
+                &[VirtualNode::ZERO.to_be_bytes().as_slice(), b"kkk"].concat(),
+                u64::MAX
+            )
+            .encode()
         );
     }
 
@@ -490,8 +571,8 @@ mod tests {
         let table_id = TableId::new(1);
         let mut builder = CompactionDeleteRangesBuilder::default();
         builder.add_delete_events(create_monotonic_events(vec![
-            DeleteRangeTombstone::new(table_id, b"k".to_vec(), false, b"kkk".to_vec(), true, 100),
-            DeleteRangeTombstone::new(table_id, b"aaa".to_vec(), true, b"ddd".to_vec(), true, 200),
+            DeleteRangeTombstone::new_for_test(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
+            DeleteRangeTombstone::new_for_test(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
         ]));
         let builder = CapacitySplitTableBuilder::new(
             LocalTableBuilderFactory::new(1001, mock_sstable_store(), opts),
@@ -501,6 +582,7 @@ mod tests {
             KeyRange::inf(),
             false,
             false,
+            0,
         );
         let results = builder.finish().await.unwrap();
         assert_eq!(results[0].sst_info.sst_info.table_ids, vec![1]);

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -19,6 +19,7 @@ use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_common::must_match;
 use risingwave_hummock_sdk::key::{FullKey, PointRange, UserKey};
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
@@ -335,7 +336,8 @@ pub fn test_user_key(table_key: impl AsRef<[u8]>) -> UserKey<Vec<u8>> {
 
 /// Generates a user key with table id 0 and table key format of `key_test_{idx * 2}`
 pub fn test_user_key_of(idx: usize) -> UserKey<Vec<u8>> {
-    let table_key = format!("key_test_{:05}", idx * 2).as_bytes().to_vec();
+    let mut table_key = VirtualNode::ZERO.to_be_bytes().to_vec();
+    table_key.extend_from_slice(format!("key_test_{:05}", idx * 2).as_bytes());
     UserKey::for_test(TableId::default(), table_key)
 }
 

--- a/src/storage/src/storage_failpoints/test_sstable.rs
+++ b/src/storage/src/storage_failpoints/test_sstable.rs
@@ -15,6 +15,7 @@
 use std::sync::Arc;
 
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::key::FullKey;
 
 use crate::assert_bytes_eq;
@@ -65,7 +66,11 @@ async fn test_failpoints_table_read() {
 
     let seek_key = FullKey::for_test(
         TableId::default(),
-        format!("key_test_{:05}", 600 * 2 - 1).as_bytes().to_vec(),
+        [
+            VirtualNode::ZERO.to_be_bytes().as_slice(),
+            format!("key_test_{:05}", 600 * 2 - 1).as_bytes(),
+        ]
+        .concat(),
         0,
     );
     let result = sstable_iter.seek(seek_key.to_ref()).await;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Support partition in compaction group.
State table will be partitioned by vnode.
View https://github.com/risingwavelabs/risingwave/pull/5335 as reference.
Partition setting can either be static or be dynamic.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
