### PR TITLE
fix(optimizer): `PlanCorrelatedIdFinder` should be aware of agg filte…

### DIFF
--- a/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
+++ b/src/frontend/planner_test/tests/testdata/subquery_expr_correlated.yaml
@@ -755,6 +755,23 @@
             ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
             | └─LogicalScan { table: strings, columns: [strings.v1] }
             └─LogicalScan { table: strings, columns: [strings.v1] }
+- name: issue 7574 correlated input in agg filter in having
+  sql: |
+    CREATE TABLE strings(v1 VARCHAR);
+    SELECT (SELECT 1 FROM strings HAVING COUNT(v1) FILTER (WHERE t.v1 < 'b') > 2) FROM strings AS t;
+  optimized_logical_plan_for_batch: |
+    LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(strings.v1, strings.v1), output: [1:Int32] }
+    ├─LogicalScan { table: strings, columns: [strings.v1] }
+    └─LogicalProject { exprs: [strings.v1, 1:Int32] }
+      └─LogicalFilter { predicate: (count(strings.v1) filter((strings.v1 < 'b':Varchar)) > 2:Int32) }
+        └─LogicalAgg { group_key: [strings.v1], aggs: [count(strings.v1) filter((strings.v1 < 'b':Varchar))] }
+          └─LogicalJoin { type: LeftOuter, on: IsNotDistinctFrom(strings.v1, strings.v1), output: [strings.v1, strings.v1] }
+            ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
+            | └─LogicalScan { table: strings, columns: [strings.v1] }
+            └─LogicalJoin { type: Inner, on: true, output: all }
+              ├─LogicalAgg { group_key: [strings.v1], aggs: [] }
+              | └─LogicalScan { table: strings, columns: [strings.v1] }
+              └─LogicalScan { table: strings, columns: [strings.v1] }
 - name: Existential join on outer join with correlated condition
   sql: |
     create table t1(x int, y int);

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -15,7 +15,9 @@
 use std::collections::HashSet;
 
 use crate::expr::{CorrelatedId, CorrelatedInputRef, ExprVisitor};
-use crate::optimizer::plan_node::{LogicalFilter, LogicalJoin, LogicalProject, PlanTreeNode};
+use crate::optimizer::plan_node::{
+    LogicalAgg, LogicalFilter, LogicalJoin, LogicalProject, PlanTreeNode,
+};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
 
@@ -37,8 +39,8 @@ impl PlanCorrelatedIdFinder {
 }
 
 impl PlanVisitor<()> for PlanCorrelatedIdFinder {
-    /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter` and
-    /// `LogicalJoin` now.
+    /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter`,
+    /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
 
     fn merge(_: (), _: ()) {}
 
@@ -65,6 +67,18 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     fn visit_logical_project(&mut self, plan: &LogicalProject) {
         let mut finder = ExprCorrelatedIdFinder::default();
         plan.exprs().iter().for_each(|expr| finder.visit_expr(expr));
+        self.correlated_id_set.extend(finder.correlated_id_set);
+
+        plan.inputs()
+            .into_iter()
+            .for_each(|input| self.visit(input));
+    }
+
+    fn visit_logical_agg(&mut self, plan: &LogicalAgg) {
+        let mut finder = ExprCorrelatedIdFinder::default();
+        plan.agg_calls()
+            .iter()
+            .for_each(|agg_call| agg_call.filter.visit_expr(&mut finder));
         self.correlated_id_set.extend(finder.correlated_id_set);
 
         plan.inputs()


### PR DESCRIPTION
…r (#8667)

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
