### PR TITLE
feat(expr): build expression from pretty string

### DIFF
--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -17,16 +17,8 @@ pub mod utils;
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, FilterExecutor};
 use risingwave_common::enable_jemalloc_on_unix;
-use risingwave_common::types::{DataType, ScalarImpl};
-use risingwave_common::util::value_encoding::serialize_datum;
-use risingwave_expr::expr::build_from_prost;
-use risingwave_pb::data::data_type::TypeName;
-use risingwave_pb::data::PbDatum;
-use risingwave_pb::expr::expr_node::RexNode;
-use risingwave_pb::expr::expr_node::Type::{
-    ConstantValue as TConstValue, Equal, InputRef, Modulus,
-};
-use risingwave_pb::expr::{ExprNode, FunctionCall};
+use risingwave_common::types::DataType;
+use risingwave_expr::expr::build_from_pretty;
 use tokio::runtime::Runtime;
 use utils::{create_input, execute_executor};
 
@@ -35,67 +27,8 @@ enable_jemalloc_on_unix!();
 fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor {
     const CHUNK_SIZE: usize = 1024;
     let input = create_input(&[DataType::Int64], chunk_size, chunk_num);
-
-    // Expression: $1 % 2 == 0
-    let expr = {
-        let input_ref1 = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-
-        let literal2 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(2)).as_ref()),
-            })),
-        };
-
-        // $1 % 2
-        let mod2 = ExprNode {
-            expr_type: Modulus as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![input_ref1, literal2],
-            })),
-        };
-
-        let literal0 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(0)).as_ref()),
-            })),
-        };
-
-        // $1 % 2 == 0
-        ExprNode {
-            expr_type: Equal as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Boolean as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![mod2, literal0],
-            })),
-        }
-    };
-
     Box::new(FilterExecutor::new(
-        build_from_prost(&expr).unwrap(),
+        build_from_pretty("(equal:boolean (modulus:int8 #0:int8 2:int8) 0:int8)"),
         input,
         "FilterBenchmark".to_string(),
         CHUNK_SIZE,

--- a/src/batch/benches/filter.rs
+++ b/src/batch/benches/filter.rs
@@ -28,7 +28,7 @@ fn create_filter_executor(chunk_size: usize, chunk_num: usize) -> BoxedExecutor 
     const CHUNK_SIZE: usize = 1024;
     let input = create_input(&[DataType::Int64], chunk_size, chunk_num);
     Box::new(FilterExecutor::new(
-        build_from_pretty("(equal:boolean (modulus:int8 #0:int8 2:int8) 0:int8)"),
+        build_from_pretty("(equal:boolean (modulus:int8 $0:int8 2:int8) 0:int8)"),
         input,
         "FilterBenchmark".to_string(),
         CHUNK_SIZE,

--- a/src/batch/benches/hash_join.rs
+++ b/src/batch/benches/hash_join.rs
@@ -19,17 +19,9 @@ use risingwave_batch::executor::hash_join::HashJoinExecutor;
 use risingwave_batch::executor::test_utils::{gen_projected_data, MockExecutor};
 use risingwave_batch::executor::{BoxedExecutor, JoinType};
 use risingwave_common::catalog::schema_test_utils::field_n;
-use risingwave_common::types::{DataType, ScalarImpl};
-use risingwave_common::util::value_encoding::serialize_datum;
+use risingwave_common::types::DataType;
 use risingwave_common::{enable_jemalloc_on_unix, hash};
-use risingwave_expr::expr::build_from_prost;
-use risingwave_pb::data::data_type::TypeName;
-use risingwave_pb::data::PbDatum;
-use risingwave_pb::expr::expr_node::RexNode;
-use risingwave_pb::expr::expr_node::Type::{
-    ConstantValue as TConstValue, GreaterThan, InputRef, Modulus,
-};
-use risingwave_pb::expr::{ExprNode, FunctionCall};
+use risingwave_expr::expr::build_from_pretty;
 use utils::bench_join;
 
 enable_jemalloc_on_unix!();
@@ -43,75 +35,16 @@ fn create_hash_join_executor(
     right_chunk_num: usize,
 ) -> BoxedExecutor {
     const CHUNK_SIZE: usize = 1024;
-    let left_mod123 = {
-        let input_ref = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-        let literal123 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(123)).as_ref()),
-            })),
-        };
-        ExprNode {
-            expr_type: Modulus as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![input_ref, literal123],
-            })),
-        }
-    };
-    let right_mod456 = {
-        let input_ref = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-        let literal456 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(456)).as_ref()),
-            })),
-        };
-        ExprNode {
-            expr_type: Modulus as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![input_ref, literal456],
-            })),
-        }
-    };
+
     let left_input = gen_projected_data(
         left_chunk_size,
         left_chunk_num,
-        build_from_prost(&left_mod123).unwrap(),
+        build_from_pretty("(modulus:int8 #0:int8 123:int8)"),
     );
     let right_input = gen_projected_data(
         right_chunk_size,
         right_chunk_num,
-        build_from_prost(&right_mod456).unwrap(),
+        build_from_pretty("(modulus:int8 #0:int8 456:int8)"),
     );
 
     let mut left_child = Box::new(MockExecutor::new(field_n::<1>(DataType::Int64)));
@@ -126,39 +59,7 @@ fn create_hash_join_executor(
         _ => vec![0, 1],
     };
 
-    let cond = if with_cond {
-        let left_input_ref = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-        let literal100 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(100)).as_ref()),
-            })),
-        };
-        Some(ExprNode {
-            expr_type: GreaterThan as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![left_input_ref, literal100],
-            })),
-        })
-    } else {
-        None
-    }
-    .map(|expr| build_from_prost(&expr).unwrap());
+    let cond = with_cond.then(|| build_from_pretty("(greater_than:int8 #0:int8 100:int8)"));
 
     Box::new(HashJoinExecutor::<hash::Key64>::new(
         join_type,

--- a/src/batch/benches/hash_join.rs
+++ b/src/batch/benches/hash_join.rs
@@ -39,12 +39,12 @@ fn create_hash_join_executor(
     let left_input = gen_projected_data(
         left_chunk_size,
         left_chunk_num,
-        build_from_pretty("(modulus:int8 #0:int8 123:int8)"),
+        build_from_pretty("(modulus:int8 $0:int8 123:int8)"),
     );
     let right_input = gen_projected_data(
         right_chunk_size,
         right_chunk_num,
-        build_from_pretty("(modulus:int8 #0:int8 456:int8)"),
+        build_from_pretty("(modulus:int8 $0:int8 456:int8)"),
     );
 
     let mut left_child = Box::new(MockExecutor::new(field_n::<1>(DataType::Int64)));
@@ -59,7 +59,7 @@ fn create_hash_join_executor(
         _ => vec![0, 1],
     };
 
-    let cond = with_cond.then(|| build_from_pretty("(greater_than:int8 #0:int8 100:int8)"));
+    let cond = with_cond.then(|| build_from_pretty("(greater_than:int8 $0:int8 100:int8)"));
 
     Box::new(HashJoinExecutor::<hash::Key64>::new(
         join_type,

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -43,8 +43,8 @@ fn create_nested_loop_join_executor(
     Box::new(NestedLoopJoinExecutor::new(
         build_from_pretty(
             "(equal:boolean
-                (modulus:int8 #0:int8 2:int8) 
-                (modulus:int8 #1:int8 3:int8))",
+                (modulus:int8 $0:int8 2:int8) 
+                (modulus:int8 $1:int8 3:int8))",
         ),
         join_type,
         output_indices,

--- a/src/batch/benches/nested_loop_join.rs
+++ b/src/batch/benches/nested_loop_join.rs
@@ -16,16 +16,8 @@ pub mod utils;
 use criterion::{criterion_group, criterion_main, Criterion};
 use risingwave_batch::executor::{BoxedExecutor, JoinType, NestedLoopJoinExecutor};
 use risingwave_common::enable_jemalloc_on_unix;
-use risingwave_common::types::{DataType, ScalarImpl};
-use risingwave_common::util::value_encoding::serialize_datum;
-use risingwave_expr::expr::build_from_prost;
-use risingwave_pb::data::data_type::TypeName;
-use risingwave_pb::data::PbDatum;
-use risingwave_pb::expr::expr_node::RexNode;
-use risingwave_pb::expr::expr_node::Type::{
-    ConstantValue as TConstValue, Equal, InputRef, Modulus,
-};
-use risingwave_pb::expr::{ExprNode, FunctionCall};
+use risingwave_common::types::DataType;
+use risingwave_expr::expr::build_from_pretty;
 use utils::{bench_join, create_input};
 
 enable_jemalloc_on_unix!();
@@ -42,85 +34,6 @@ fn create_nested_loop_join_executor(
     let left_input = create_input(&[DataType::Int64], left_chunk_size, left_chunk_num);
     let right_input = create_input(&[DataType::Int64], right_chunk_size, right_chunk_num);
 
-    // Expression: $1 % 2 == $2 % 3
-    let join_expr = {
-        let left_input_ref = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-
-        let right_input_ref = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(1)),
-        };
-
-        let literal2 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(2)).as_ref()),
-            })),
-        };
-
-        let literal3 = ExprNode {
-            expr_type: TConstValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(Some(ScalarImpl::Int64(3)).as_ref()),
-            })),
-        };
-
-        // $1 % 2
-        let left_mod2 = ExprNode {
-            expr_type: Modulus as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![left_input_ref, literal2],
-            })),
-        };
-
-        // $2 % 3
-        let right_mod3 = ExprNode {
-            expr_type: Modulus as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int64 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![right_input_ref, literal3],
-            })),
-        };
-
-        // $1 % 2 == $2 % 3
-        ExprNode {
-            expr_type: Equal as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Boolean as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::FuncCall(FunctionCall {
-                children: vec![left_mod2, right_mod3],
-            })),
-        }
-    };
-
     let output_indices = match join_type {
         JoinType::LeftSemi | JoinType::LeftAnti => vec![0],
         JoinType::RightSemi | JoinType::RightAnti => vec![0],
@@ -128,7 +41,11 @@ fn create_nested_loop_join_executor(
     };
 
     Box::new(NestedLoopJoinExecutor::new(
-        build_from_prost(&join_expr).unwrap(),
+        build_from_pretty(
+            "(equal:boolean
+                (modulus:int8 #0:int8 2:int8) 
+                (modulus:int8 #1:int8 3:int8))",
+        ),
         join_type,
         output_indices,
         left_input,

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -124,17 +124,11 @@ impl FilterExecutor {
 mod tests {
     use assert_matches::assert_matches;
     use futures::stream::StreamExt;
-    use risingwave_common::array::{Array, DataChunk, ListValue};
+    use risingwave_common::array::{Array, DataChunk};
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::test_prelude::DataChunkTestExt;
-    use risingwave_common::types::{DataType, Scalar};
-    use risingwave_common::util::value_encoding::serialize_datum;
-    use risingwave_expr::expr::build_from_prost;
-    use risingwave_pb::data::data_type::TypeName;
-    use risingwave_pb::data::PbDatum;
-    use risingwave_pb::expr::expr_node::Type::InputRef;
-    use risingwave_pb::expr::expr_node::{RexNode, Type};
-    use risingwave_pb::expr::{ExprNode, FunctionCall};
+    use risingwave_common::types::DataType;
+    use risingwave_expr::expr::build_from_pretty;
 
     use crate::executor::test_utils::MockExecutor;
     use crate::executor::{Executor, FilterExecutor};
@@ -174,9 +168,8 @@ mod tests {
         mock_executor.add(chunk);
 
         // Initialize filter executor
-        let expr = make_filter_expression(Type::GreaterThan);
         let filter_executor = Box::new(FilterExecutor {
-            expr: build_from_prost(&expr).unwrap(),
+            expr: build_from_pretty("(greater_than:boolean #0:int4[] {2}:int4[])"),
             child: Box::new(mock_executor),
             identity: "FilterExecutor".to_string(),
             chunk_size: CHUNK_SIZE,
@@ -217,54 +210,6 @@ mod tests {
         assert_matches!(res, None);
     }
 
-    fn make_filter_expression(kind: Type) -> ExprNode {
-        use risingwave_common::types::ScalarImpl;
-        let lhs = ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::List as i32,
-                field_type: vec![risingwave_pb::data::DataType {
-                    type_name: TypeName::Int32 as i32,
-                    is_nullable: true,
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(0)),
-        };
-        let rhs = ExprNode {
-            expr_type: Type::ConstantValue as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::List as i32,
-                field_type: vec![risingwave_pb::data::DataType {
-                    type_name: TypeName::Int32 as i32,
-                    ..Default::default()
-                }],
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::Constant(PbDatum {
-                body: serialize_datum(
-                    Some(ScalarImpl::List(ListValue::new(vec![Some(
-                        2.to_scalar_value(),
-                    )])))
-                    .as_ref(),
-                ),
-            })),
-        };
-        let function_call = FunctionCall {
-            children: vec![lhs, rhs],
-        };
-        let return_type = risingwave_pb::data::DataType {
-            type_name: risingwave_pb::data::data_type::TypeName::Boolean as i32,
-            ..Default::default()
-        };
-        ExprNode {
-            expr_type: kind as i32,
-            return_type: Some(return_type),
-            rex_node: Some(RexNode::FuncCall(function_call)),
-        }
-    }
-
     #[tokio::test]
     async fn test_filter_executor() {
         let schema = Schema {
@@ -281,9 +226,8 @@ mod tests {
              4 1
              3 3",
         ));
-        let expr = make_expression(Type::Equal);
         let filter_executor = Box::new(FilterExecutor {
-            expr: build_from_prost(&expr).unwrap(),
+            expr: build_from_pretty("(equal:boolean #0:int4 #1:int4)"),
             child: Box::new(mock_executor),
             identity: "FilterExecutor".to_string(),
             chunk_size: CHUNK_SIZE,
@@ -304,33 +248,5 @@ mod tests {
         }
         let res = stream.next().await;
         assert_matches!(res, None);
-    }
-
-    fn make_expression(kind: Type) -> ExprNode {
-        let lhs = make_inputref(0);
-        let rhs = make_inputref(1);
-        let function_call = FunctionCall {
-            children: vec![lhs, rhs],
-        };
-        let return_type = risingwave_pb::data::DataType {
-            type_name: risingwave_pb::data::data_type::TypeName::Boolean as i32,
-            ..Default::default()
-        };
-        ExprNode {
-            expr_type: kind as i32,
-            return_type: Some(return_type),
-            rex_node: Some(RexNode::FuncCall(function_call)),
-        }
-    }
-
-    fn make_inputref(idx: usize) -> ExprNode {
-        ExprNode {
-            expr_type: InputRef as i32,
-            return_type: Some(risingwave_pb::data::DataType {
-                type_name: TypeName::Int32 as i32,
-                ..Default::default()
-            }),
-            rex_node: Some(RexNode::InputRef(idx as _)),
-        }
     }
 }

--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -169,7 +169,7 @@ mod tests {
 
         // Initialize filter executor
         let filter_executor = Box::new(FilterExecutor {
-            expr: build_from_pretty("(greater_than:boolean #0:int4[] {2}:int4[])"),
+            expr: build_from_pretty("(greater_than:boolean $0:int4[] {2}:int4[])"),
             child: Box::new(mock_executor),
             identity: "FilterExecutor".to_string(),
             chunk_size: CHUNK_SIZE,
@@ -227,7 +227,7 @@ mod tests {
              3 3",
         ));
         let filter_executor = Box::new(FilterExecutor {
-            expr: build_from_pretty("(equal:boolean #0:int4 #1:int4)"),
+            expr: build_from_pretty("(equal:boolean $0:int4 $1:int4)"),
             child: Box::new(mock_executor),
             identity: "FilterExecutor".to_string(),
             chunk_size: CHUNK_SIZE,

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -1799,8 +1799,7 @@ mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
     use risingwave_common::util::iter_util::ZipEqDebug;
-    use risingwave_expr::expr::{build, BoxedExpression, Expression, InputRefExpression};
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::{build_from_pretty, BoxedExpression};
 
     use super::{
         ChunkedData, HashJoinExecutor, JoinType, LeftNonEquiJoinState, RightNonEquiJoinState, RowId,
@@ -1985,15 +1984,7 @@ mod tests {
         }
 
         fn create_cond() -> BoxedExpression {
-            build(
-                PbType::LessThan,
-                DataType::Boolean,
-                vec![
-                    InputRefExpression::new(DataType::Float32, 1).boxed(),
-                    InputRefExpression::new(DataType::Float64, 3).boxed(),
-                ],
-            )
-            .unwrap()
+            build_from_pretty("(less_than:boolean #1:float4 #3:float8)")
         }
 
         fn create_join_executor_with_chunk_size_and_executors(

--- a/src/batch/src/executor/join/hash_join.rs
+++ b/src/batch/src/executor/join/hash_join.rs
@@ -1984,7 +1984,7 @@ mod tests {
         }
 
         fn create_cond() -> BoxedExpression {
-            build_from_pretty("(less_than:boolean #1:float4 #3:float8)")
+            build_from_pretty("(less_than:boolean $1:float4 $3:float8)")
         }
 
         fn create_join_executor_with_chunk_size_and_executors(

--- a/src/batch/src/executor/join/local_lookup_join.rs
+++ b/src/batch/src/executor/join/local_lookup_join.rs
@@ -458,13 +458,10 @@ mod tests {
     use risingwave_common::array::{DataChunk, DataChunkTestExt};
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::hash::HashKeyDispatcher;
-    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::types::DataType;
     use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
     use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
-    use risingwave_expr::expr::{
-        build, BoxedExpression, Expression, InputRefExpression, LiteralExpression,
-    };
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::{build_from_pretty, BoxedExpression};
 
     use super::LocalLookupJoinExecutorArgs;
     use crate::executor::join::JoinType;
@@ -674,20 +671,9 @@ mod tests {
              2 5.5 2 5.5
              2 8.4 2 5.5",
         );
+        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
 
-        let condition = Some(
-            build(
-                PbType::LessThan,
-                DataType::Boolean,
-                vec![
-                    LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(5))).boxed(),
-                    InputRefExpression::new(DataType::Float32, 3).boxed(),
-                ],
-            )
-            .unwrap(),
-        );
-
-        do_test(JoinType::Inner, condition, false, expected).await;
+        do_test(JoinType::Inner, Some(condition), false, expected).await;
     }
 
     #[tokio::test]
@@ -702,20 +688,9 @@ mod tests {
              5 9.1 . .
              . .   . .",
         );
+        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
 
-        let condition = Some(
-            build(
-                PbType::LessThan,
-                DataType::Boolean,
-                vec![
-                    LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(5))).boxed(),
-                    InputRefExpression::new(DataType::Float32, 3).boxed(),
-                ],
-            )
-            .unwrap(),
-        );
-
-        do_test(JoinType::LeftOuter, condition, false, expected).await;
+        do_test(JoinType::LeftOuter, Some(condition), false, expected).await;
     }
 
     #[tokio::test]
@@ -726,20 +701,9 @@ mod tests {
              2 5.5
              2 8.4",
         );
+        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
 
-        let condition = Some(
-            build(
-                PbType::LessThan,
-                DataType::Boolean,
-                vec![
-                    LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(5))).boxed(),
-                    InputRefExpression::new(DataType::Float32, 3).boxed(),
-                ],
-            )
-            .unwrap(),
-        );
-
-        do_test(JoinType::LeftSemi, condition, false, expected).await;
+        do_test(JoinType::LeftSemi, Some(condition), false, expected).await;
     }
 
     #[tokio::test]
@@ -751,19 +715,8 @@ mod tests {
             5 9.1
             . .",
         );
+        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
 
-        let condition = Some(
-            build(
-                PbType::LessThan,
-                DataType::Boolean,
-                vec![
-                    LiteralExpression::new(DataType::Int32, Some(ScalarImpl::Int32(5))).boxed(),
-                    InputRefExpression::new(DataType::Float32, 3).boxed(),
-                ],
-            )
-            .unwrap(),
-        );
-
-        do_test(JoinType::LeftAnti, condition, false, expected).await;
+        do_test(JoinType::LeftAnti, Some(condition), false, expected).await;
     }
 }

--- a/src/batch/src/executor/join/local_lookup_join.rs
+++ b/src/batch/src/executor/join/local_lookup_join.rs
@@ -671,7 +671,7 @@ mod tests {
              2 5.5 2 5.5
              2 8.4 2 5.5",
         );
-        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
+        let condition = build_from_pretty("(less_than:boolean 5:int4 $3:float4)");
 
         do_test(JoinType::Inner, Some(condition), false, expected).await;
     }
@@ -688,7 +688,7 @@ mod tests {
              5 9.1 . .
              . .   . .",
         );
-        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
+        let condition = build_from_pretty("(less_than:boolean 5:int4 $3:float4)");
 
         do_test(JoinType::LeftOuter, Some(condition), false, expected).await;
     }
@@ -701,7 +701,7 @@ mod tests {
              2 5.5
              2 8.4",
         );
-        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
+        let condition = build_from_pretty("(less_than:boolean 5:int4 $3:float4)");
 
         do_test(JoinType::LeftSemi, Some(condition), false, expected).await;
     }
@@ -715,7 +715,7 @@ mod tests {
             5 9.1
             . .",
         );
-        let condition = build_from_pretty("(less_than:boolean 5:int4 #3:float4)");
+        let condition = build_from_pretty("(less_than:boolean 5:int4 $3:float4)");
 
         do_test(JoinType::LeftAnti, Some(condition), false, expected).await;
     }

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -586,7 +586,7 @@ mod tests {
             };
 
             Box::new(NestedLoopJoinExecutor::new(
-                build_from_pretty("(equal:boolean #0:int4 #2:int4)"),
+                build_from_pretty("(equal:boolean $0:int4 $2:int4)"),
                 join_type,
                 output_indices,
                 left_child,

--- a/src/batch/src/executor/join/nested_loop_join.rs
+++ b/src/batch/src/executor/join/nested_loop_join.rs
@@ -470,8 +470,7 @@ mod tests {
     use risingwave_common::array::*;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
-    use risingwave_expr::expr::{build, InputRefExpression};
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::build_from_pretty;
 
     use crate::executor::join::nested_loop_join::NestedLoopJoinExecutor;
     use crate::executor::join::JoinType;
@@ -587,15 +586,7 @@ mod tests {
             };
 
             Box::new(NestedLoopJoinExecutor::new(
-                build(
-                    PbType::Equal,
-                    DataType::Boolean,
-                    vec![
-                        Box::new(InputRefExpression::new(DataType::Int32, 0)),
-                        Box::new(InputRefExpression::new(DataType::Int32, 2)),
-                    ],
-                )
-                .unwrap(),
+                build_from_pretty("(equal:boolean #0:int4 #2:int4)"),
                 join_type,
                 output_indices,
                 left_child,

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -287,13 +287,11 @@ mod tests {
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::DataType;
-    use risingwave_expr::expr::build_from_prost;
+    use risingwave_expr::expr::build_from_pretty;
     use risingwave_pb::data::data_type::TypeName;
     use risingwave_pb::data::PbDataType;
     use risingwave_pb::expr::agg_call::Type;
-    use risingwave_pb::expr::expr_node::RexNode;
-    use risingwave_pb::expr::expr_node::Type::InputRef;
-    use risingwave_pb::expr::{AggCall, ExprNode, PbInputRef};
+    use risingwave_pb::expr::{AggCall, PbInputRef};
 
     use super::*;
     use crate::executor::test_utils::MockExecutor;
@@ -439,17 +437,8 @@ mod tests {
 
         let count_star = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| {
-                build_from_prost(&ExprNode {
-                    expr_type: InputRef as i32,
-                    return_type: Some(PbDataType {
-                        type_name: TypeName::Int32 as i32,
-                        ..Default::default()
-                    }),
-                    rex_node: Some(RexNode::InputRef(idx as _)),
-                })
-            })
-            .try_collect()?;
+            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .collect();
 
         let sorted_groupers: Vec<_> = group_exprs
             .iter()
@@ -653,17 +642,8 @@ mod tests {
 
         let sum_agg = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| {
-                build_from_prost(&ExprNode {
-                    expr_type: InputRef as i32,
-                    return_type: Some(PbDataType {
-                        type_name: TypeName::Int32 as i32,
-                        ..Default::default()
-                    }),
-                    rex_node: Some(RexNode::InputRef(idx as _)),
-                })
-            })
-            .try_collect()?;
+            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .collect();
 
         let sorted_groupers: Vec<_> = group_exprs
             .iter()
@@ -777,17 +757,8 @@ mod tests {
 
         let sum_agg = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| {
-                build_from_prost(&ExprNode {
-                    expr_type: InputRef as i32,
-                    return_type: Some(PbDataType {
-                        type_name: TypeName::Int32 as i32,
-                        ..Default::default()
-                    }),
-                    rex_node: Some(RexNode::InputRef(idx as _)),
-                })
-            })
-            .try_collect()?;
+            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .collect();
 
         let sorted_groupers: Vec<_> = group_exprs
             .iter()

--- a/src/batch/src/executor/sort_agg.rs
+++ b/src/batch/src/executor/sort_agg.rs
@@ -437,7 +437,7 @@ mod tests {
 
         let count_star = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .map(|idx| build_from_pretty(format!("${idx}:int4")))
             .collect();
 
         let sorted_groupers: Vec<_> = group_exprs
@@ -642,7 +642,7 @@ mod tests {
 
         let sum_agg = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .map(|idx| build_from_pretty(format!("${idx}:int4")))
             .collect();
 
         let sorted_groupers: Vec<_> = group_exprs
@@ -757,7 +757,7 @@ mod tests {
 
         let sum_agg = AggStateFactory::new(&prost)?.create_agg_state();
         let group_exprs: Vec<_> = (1..=2)
-            .map(|idx| build_from_pretty(format!("#{idx}:int4")))
+            .map(|idx| build_from_pretty(format!("${idx}:int4")))
             .collect();
 
         let sorted_groupers: Vec<_> = group_exprs

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -23,13 +23,13 @@ use risingwave_pb::data::PbDataChunk;
 use super::{ArrayResult, Vis};
 use crate::array::column::Column;
 use crate::array::data_chunk_iter::RowRef;
-use crate::array::{ArrayBuilderImpl, StructValue};
+use crate::array::ArrayBuilderImpl;
 use crate::buffer::{Bitmap, BitmapBuilder};
 use crate::hash::HashCode;
 use crate::row::Row;
 use crate::types::struct_type::StructType;
 use crate::types::to_text::ToText;
-use crate::types::{DataType, Datum, NaiveDateTimeWrapper, ToOwnedDatum};
+use crate::types::{DataType, ToOwnedDatum};
 use crate::util::hash_util::finalize_hashers;
 use crate::util::iter_util::{ZipEqDebug, ZipEqFast};
 use crate::util::value_encoding::{serialize_datum_into, ValueRowSerializer};
@@ -552,7 +552,6 @@ impl DataChunkTestExt for DataChunk {
                 "F" => DataType::Float64,
                 "f" => DataType::Float32,
                 "TS" => DataType::Timestamp,
-                "TSZ" => DataType::Timestamptz,
                 "T" => DataType::Varchar,
                 "SRL" => DataType::Serial,
                 array if array.starts_with('{') && array.ends_with('}') => {
@@ -571,10 +570,13 @@ impl DataChunkTestExt for DataChunk {
         let mut lines = s.split('\n').filter(|l| !l.trim().is_empty());
         // initialize array builders from the first line
         let header = lines.next().unwrap().trim();
-        let mut array_builders = header
+        let datatypes = header
             .split_ascii_whitespace()
             .take_while(|c| *c != "//")
             .map(parse_type)
+            .collect::<Vec<_>>();
+        let mut array_builders = datatypes
+            .iter()
             .map(|ty| ty.create_array_builder(1))
             .collect::<Vec<_>>();
         let mut visibility = vec![];
@@ -582,64 +584,16 @@ impl DataChunkTestExt for DataChunk {
             let mut token = line.trim().split_ascii_whitespace();
             // allow `zip` since `token` may longer than `array_builders`
             #[allow(clippy::disallowed_methods)]
-            for (builder, val_str) in array_builders.iter_mut().zip(&mut token) {
-                fn parse_datum(s: &str, builder: &ArrayBuilderImpl) -> Datum {
-                    if s == "." {
-                        return None;
-                    }
-                    Some(match builder {
-                        ArrayBuilderImpl::Bool(_) => ScalarImpl::Bool(match s {
-                            "t" => true,
-                            "f" => false,
-                            _ => panic!("invalid bool: {s:?}"),
-                        }),
-                        ArrayBuilderImpl::Int32(_) => ScalarImpl::Int32(
-                            s.parse()
-                                .map_err(|_| panic!("invalid int32: {s:?}"))
-                                .unwrap(),
-                        ),
-                        ArrayBuilderImpl::Int64(_) => ScalarImpl::Int64(
-                            s.parse()
-                                .map_err(|_| panic!("invalid int64: {s:?}"))
-                                .unwrap(),
-                        ),
-                        ArrayBuilderImpl::Float32(_) => ScalarImpl::Float32(
-                            s.parse()
-                                .map_err(|_| panic!("invalid float32: {s:?}"))
-                                .unwrap(),
-                        ),
-                        ArrayBuilderImpl::Float64(_) => ScalarImpl::Float64(
-                            s.parse()
-                                .map_err(|_| panic!("invalid float64: {s:?}"))
-                                .unwrap(),
-                        ),
-                        ArrayBuilderImpl::NaiveDateTime(_) => {
-                            ScalarImpl::NaiveDateTime(NaiveDateTimeWrapper(
-                                s.parse()
-                                    .map_err(|_| panic!("invalid datetime: {s:?}"))
-                                    .unwrap(),
-                            ))
-                        }
-                        ArrayBuilderImpl::Utf8(_) => ScalarImpl::Utf8(s.into()),
-                        ArrayBuilderImpl::Serial(_) => ScalarImpl::Serial(
-                            s.parse::<i64>()
-                                .map_err(|_| panic!("invalid serial: {s:?}"))
-                                .unwrap()
-                                .into(),
-                        ),
-                        ArrayBuilderImpl::Struct(builder) => {
-                            assert!(s.starts_with('{') && s.ends_with('}'));
-                            let fields = s[1..s.len() - 1]
-                                .split(',')
-                                .zip_eq_debug(&builder.children_array)
-                                .map(|(s, builder)| parse_datum(s, builder))
-                                .collect_vec();
-                            ScalarImpl::Struct(StructValue::new(fields))
-                        }
-                        b => panic!("invalid data type: {b:?}"),
-                    })
-                }
-                builder.append_datum(&parse_datum(val_str, builder));
+            for ((builder, ty), val_str) in
+                array_builders.iter_mut().zip(&datatypes).zip(&mut token)
+            {
+                let datum = match val_str {
+                    "." => None,
+                    "t" => Some(true.into()),
+                    "f" => Some(false.into()),
+                    _ => Some(ScalarImpl::from_text(val_str.as_bytes(), ty).unwrap()),
+                };
+                builder.append_datum(datum);
             }
             let visible = match token.next() {
                 None | Some("//") => true,

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -341,7 +341,6 @@ impl StreamChunkTestExt for StreamChunk {
     /// //     f: f32
     /// //     T: str
     /// //    TS: Timestamp
-    /// //   TSZ: Timestamptz
     /// //   SRL: Serial
     /// // {i,f}: struct
     /// ```

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -837,7 +837,7 @@ impl ScalarImpl {
         let without_null = if b.last() == Some(&0) {
             &b[..b.len() - 1]
         } else {
-            &b[..]
+            b
         };
         std::str::from_utf8(without_null)
     }

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -832,7 +832,7 @@ impl ScalarImpl {
         Ok(res)
     }
 
-    pub fn cstr_to_str(b: &Bytes) -> Result<&str, Utf8Error> {
+    pub fn cstr_to_str(b: &[u8]) -> Result<&str, Utf8Error> {
         let without_null = if b.last() == Some(&0) {
             &b[..b.len() - 1]
         } else {
@@ -841,7 +841,7 @@ impl ScalarImpl {
         std::str::from_utf8(without_null)
     }
 
-    pub fn from_text(bytes: &Bytes, data_type: &DataType) -> RwResult<Self> {
+    pub fn from_text(bytes: &[u8], data_type: &DataType) -> RwResult<Self> {
         let str = Self::cstr_to_str(bytes).map_err(|_| {
             ErrorCode::InvalidInputSyntax(format!("Invalid param string: {:?}", bytes))
         })?;

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -148,15 +148,7 @@ mod tests {
         let col1 = NaiveDateArray::from_iter(&lhs).into();
         let col2 = IntervalArray::from_iter(&rhs).into();
         let data_chunk = DataChunk::new(vec![col1, col2], 100);
-        let expr = build(
-            kind,
-            DataType::Timestamp,
-            vec![
-                InputRefExpression::new(DataType::Date, 0).boxed(),
-                InputRefExpression::new(DataType::Interval, 1).boxed(),
-            ],
-        )
-        .unwrap();
+        let expr = build_from_pretty(format!("({kind:?}:timestamp #0:date #1:interval)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {

--- a/src/expr/src/expr/expr_binary_nonnull.rs
+++ b/src/expr/src/expr/expr_binary_nonnull.rs
@@ -148,7 +148,7 @@ mod tests {
         let col1 = NaiveDateArray::from_iter(&lhs).into();
         let col2 = IntervalArray::from_iter(&rhs).into();
         let data_chunk = DataChunk::new(vec![col1, col2], 100);
-        let expr = build_from_pretty(format!("({kind:?}:timestamp #0:date #1:interval)"));
+        let expr = build_from_pretty(format!("({kind:?}:timestamp $0:date $1:interval)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -154,7 +154,7 @@ mod tests {
         ",
         )
         .split_column_at(2);
-        let expr = build_from_pretty("(and:boolean #0:boolean #1:boolean)");
+        let expr = build_from_pretty("(and:boolean $0:boolean $1:boolean)");
         let result = expr.eval(&input).await.unwrap();
         assert_eq!(result, target.column_at(0).array());
     }
@@ -176,7 +176,7 @@ mod tests {
         ",
         )
         .split_column_at(2);
-        let expr = build_from_pretty("(or:boolean #0:boolean #1:boolean)");
+        let expr = build_from_pretty("(or:boolean $0:boolean $1:boolean)");
         let result = expr.eval(&input).await.unwrap();
         assert_eq!(result, target.column_at(0).array());
     }
@@ -194,7 +194,7 @@ mod tests {
         ",
         )
         .split_column_at(2);
-        let expr = build_from_pretty("(is_distinct_from:boolean #0:int4 #1:int4)");
+        let expr = build_from_pretty("(is_distinct_from:boolean $0:int4 $1:int4)");
         let result = expr.eval(&input).await.unwrap();
         assert_eq!(result, target.column_at(0).array());
     }
@@ -212,7 +212,7 @@ mod tests {
             ",
         )
         .split_column_at(2);
-        let expr = build_from_pretty("(is_not_distinct_from:boolean #0:int4 #1:int4)");
+        let expr = build_from_pretty("(is_not_distinct_from:boolean $0:int4 $1:int4)");
         let result = expr.eval(&input).await.unwrap();
         assert_eq!(result, target.column_at(0).array());
     }
@@ -229,7 +229,7 @@ mod tests {
             ",
         )
         .split_column_at(2);
-        let expr = build_from_pretty("(format_type:varchar #0:int4 #1:int4)");
+        let expr = build_from_pretty("(format_type:varchar $0:int4 $1:int4)");
         let result = expr.eval(&input).await.unwrap();
         assert_eq!(result, target.column_at(0).array());
     }

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -160,10 +160,9 @@ impl<'a> TryFrom<&'a ExprNode> for CaseExpression {
 mod tests {
     use risingwave_common::test_prelude::DataChunkTestExt;
     use risingwave_common::types::Scalar;
-    use risingwave_pb::expr::expr_node::PbType;
 
     use super::*;
-    use crate::expr::{build, InputRefExpression, LiteralExpression};
+    use crate::expr::build_from_pretty;
 
     async fn test_eval_row(expr: CaseExpression, row_inputs: Vec<i32>, expected: Vec<Option<f32>>) {
         for (i, row_input) in row_inputs.iter().enumerate() {
@@ -177,27 +176,12 @@ mod tests {
     #[tokio::test]
     async fn test_eval_searched_case() {
         let ret_type = DataType::Float32;
-        // when x <= 2 then 3.1
+        // when x <= 2 then 3.1 else 4.1
         let when_clauses = vec![WhenClause {
-            when: build(
-                PbType::LessThanOrEqual,
-                DataType::Boolean,
-                vec![
-                    Box::new(InputRefExpression::new(DataType::Int32, 0)),
-                    Box::new(LiteralExpression::new(DataType::Float32, Some(2f32.into()))),
-                ],
-            )
-            .unwrap(),
-            then: Box::new(LiteralExpression::new(
-                DataType::Float32,
-                Some(3.1f32.into()),
-            )),
+            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 2:float4)"),
+            then: build_from_pretty("3.1:float4"),
         }];
-        // else 4.1
-        let els = Box::new(LiteralExpression::new(
-            DataType::Float32,
-            Some(4.1f32.into()),
-        ));
+        let els = build_from_pretty("4.1:float4");
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, Some(els));
         let input = DataChunk::from_pretty(
             "i
@@ -220,19 +204,8 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 3 then 3.1
         let when_clauses = vec![WhenClause {
-            when: build(
-                PbType::LessThanOrEqual,
-                DataType::Boolean,
-                vec![
-                    Box::new(InputRefExpression::new(DataType::Int32, 0)),
-                    Box::new(LiteralExpression::new(DataType::Float32, Some(3f32.into()))),
-                ],
-            )
-            .unwrap(),
-            then: Box::new(LiteralExpression::new(
-                DataType::Float32,
-                Some(3.1f32.into()),
-            )),
+            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 3:float4)"),
+            then: build_from_pretty("3.1:float4"),
         }];
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, None);
         let input = DataChunk::from_pretty(
@@ -252,27 +225,12 @@ mod tests {
     #[tokio::test]
     async fn test_eval_row_searched_case() {
         let ret_type = DataType::Float32;
-        // when x <= 2 then 3.1
+        // when x <= 2 then 3.1 else 4.1
         let when_clauses = vec![WhenClause {
-            when: build(
-                PbType::LessThanOrEqual,
-                DataType::Boolean,
-                vec![
-                    Box::new(InputRefExpression::new(DataType::Int32, 0)),
-                    Box::new(LiteralExpression::new(DataType::Float32, Some(2f32.into()))),
-                ],
-            )
-            .unwrap(),
-            then: Box::new(LiteralExpression::new(
-                DataType::Float32,
-                Some(3.1f32.into()),
-            )),
+            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 2:float4)"),
+            then: build_from_pretty("3.1:float4"),
         }];
-        // else 4.1
-        let els = Box::new(LiteralExpression::new(
-            DataType::Float32,
-            Some(4.1f32.into()),
-        ));
+        let els = build_from_pretty("4.1:float4");
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, Some(els));
 
         let row_inputs = vec![1, 2, 3, 4, 5];
@@ -292,19 +250,8 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 3 then 3.1
         let when_clauses = vec![WhenClause {
-            when: build(
-                PbType::LessThanOrEqual,
-                DataType::Boolean,
-                vec![
-                    Box::new(InputRefExpression::new(DataType::Int32, 0)),
-                    Box::new(LiteralExpression::new(DataType::Float32, Some(3f32.into()))),
-                ],
-            )
-            .unwrap(),
-            then: Box::new(LiteralExpression::new(
-                DataType::Float32,
-                Some(3.1f32.into()),
-            )),
+            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 3:float4)"),
+            then: build_from_pretty("3.1:float4"),
         }];
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, None);
 

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -178,7 +178,7 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 2 then 3.1 else 4.1
         let when_clauses = vec![WhenClause {
-            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 2:float4)"),
+            when: build_from_pretty("(less_than_or_equal:boolean $0:int4 2:float4)"),
             then: build_from_pretty("3.1:float4"),
         }];
         let els = build_from_pretty("4.1:float4");
@@ -204,7 +204,7 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 3 then 3.1
         let when_clauses = vec![WhenClause {
-            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 3:float4)"),
+            when: build_from_pretty("(less_than_or_equal:boolean $0:int4 3:float4)"),
             then: build_from_pretty("3.1:float4"),
         }];
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, None);
@@ -227,7 +227,7 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 2 then 3.1 else 4.1
         let when_clauses = vec![WhenClause {
-            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 2:float4)"),
+            when: build_from_pretty("(less_than_or_equal:boolean $0:int4 2:float4)"),
             then: build_from_pretty("3.1:float4"),
         }];
         let els = build_from_pretty("4.1:float4");
@@ -250,7 +250,7 @@ mod tests {
         let ret_type = DataType::Float32;
         // when x <= 3 then 3.1
         let when_clauses = vec![WhenClause {
-            when: build_from_pretty("(less_than_or_equal:boolean #0:int4 3:float4)"),
+            when: build_from_pretty("(less_than_or_equal:boolean $0:int4 3:float4)"),
             then: build_from_pretty("3.1:float4"),
         }];
         let searched_case_expr = CaseExpression::new(ret_type, when_clauses, None);

--- a/src/expr/src/expr/expr_some_all.rs
+++ b/src/expr/src/expr/expr_some_all.rs
@@ -23,7 +23,7 @@ use risingwave_common::{bail, ensure};
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::{ExprNode, FunctionCall};
 
-use super::build_expr_from_prost::get_children_and_return_type;
+use super::build::get_children_and_return_type;
 use super::{build_from_prost, BoxedExpression, Expression};
 use crate::{ExprError, Result};
 

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -46,12 +46,7 @@ mod tests {
         }
         let col1 = I16Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build(
-            PbType::Cast,
-            DataType::Int32,
-            vec![InputRefExpression::new(DataType::Int16, 0).boxed()],
-        )
-        .unwrap();
+        let expr = build_from_pretty("(cast:int4 #0:int2)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &I32Array = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -82,12 +77,7 @@ mod tests {
 
         let col1 = I32Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 3);
-        let expr = build(
-            PbType::Neg,
-            DataType::Int32,
-            vec![InputRefExpression::new(DataType::Int32, 0).boxed()],
-        )
-        .unwrap();
+        let expr = build_from_pretty("(neg:int4 #0:int4)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &I32Array = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -125,12 +115,7 @@ mod tests {
         let col1_data = &input.iter().map(|x| x.as_ref().map(|x| &**x)).collect_vec();
         let col1 = Utf8Array::from_iter(col1_data).into();
         let data_chunk = DataChunk::new(vec![col1], 1);
-        let expr = build(
-            PbType::Cast,
-            DataType::Int16,
-            vec![InputRefExpression::new(DataType::Varchar, 0).boxed()],
-        )
-        .unwrap();
+        let expr = build_from_pretty("(cast:int2 #0:varchar)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -173,12 +158,7 @@ mod tests {
 
         let col1 = BoolArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build(
-            kind,
-            DataType::Boolean,
-            vec![InputRefExpression::new(DataType::Boolean, 0).boxed()],
-        )
-        .unwrap();
+        let expr = build_from_pretty(format!("({kind:?}:boolean #0:boolean)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -216,12 +196,7 @@ mod tests {
 
         let col1 = NaiveDateArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build(
-            kind,
-            DataType::Timestamp,
-            vec![InputRefExpression::new(DataType::Date, 0).boxed()],
-        )
-        .unwrap();
+        let expr = build_from_pretty(format!("({kind:?}:timestamp #0:date)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {

--- a/src/expr/src/expr/expr_unary.rs
+++ b/src/expr/src/expr/expr_unary.rs
@@ -46,7 +46,7 @@ mod tests {
         }
         let col1 = I16Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build_from_pretty("(cast:int4 #0:int2)");
+        let expr = build_from_pretty("(cast:int4 $0:int2)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &I32Array = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -77,7 +77,7 @@ mod tests {
 
         let col1 = I32Array::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 3);
-        let expr = build_from_pretty("(neg:int4 #0:int4)");
+        let expr = build_from_pretty("(neg:int4 $0:int4)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &I32Array = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -115,7 +115,7 @@ mod tests {
         let col1_data = &input.iter().map(|x| x.as_ref().map(|x| &**x)).collect_vec();
         let col1 = Utf8Array::from_iter(col1_data).into();
         let data_chunk = DataChunk::new(vec![col1], 1);
-        let expr = build_from_pretty("(cast:int2 #0:varchar)");
+        let expr = build_from_pretty("(cast:int2 $0:varchar)");
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -158,7 +158,7 @@ mod tests {
 
         let col1 = BoolArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build_from_pretty(format!("({kind:?}:boolean #0:boolean)"));
+        let expr = build_from_pretty(format!("({kind:?}:boolean $0:boolean)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {
@@ -196,7 +196,7 @@ mod tests {
 
         let col1 = NaiveDateArray::from_iter(&input).into();
         let data_chunk = DataChunk::new(vec![col1], 100);
-        let expr = build_from_pretty(format!("({kind:?}:timestamp #0:date)"));
+        let expr = build_from_pretty(format!("({kind:?}:timestamp $0:date)"));
         let res = expr.eval(&data_chunk).await.unwrap();
         let arr: &A = res.as_ref().into();
         for (idx, item) in arr.iter().enumerate() {

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -58,7 +58,7 @@ mod expr_unary;
 mod expr_vnode;
 
 mod agg;
-mod build_expr_from_prost;
+mod build;
 pub(crate) mod data_types;
 pub(crate) mod template;
 pub(crate) mod template_fast;
@@ -72,7 +72,7 @@ use risingwave_common::types::{DataType, Datum};
 use static_assertions::const_assert;
 
 pub use self::agg::AggKind;
-pub use self::build_expr_from_prost::{build, build_from_prost};
+pub use self::build::*;
 pub use self::expr_input_ref::InputRefExpression;
 pub use self::expr_literal::LiteralExpression;
 use super::{ExprError, Result};

--- a/src/expr/src/vector_op/agg/filter.rs
+++ b/src/expr/src/vector_op/agg/filter.rs
@@ -114,10 +114,9 @@ mod tests {
     use std::sync::Arc;
 
     use risingwave_common::test_prelude::DataChunkTestExt;
-    use risingwave_pb::expr::expr_node::PbType;
 
     use super::*;
-    use crate::expr::{build, Expression, InputRefExpression, LiteralExpression};
+    use crate::expr::{build_from_pretty, Expression, LiteralExpression};
 
     #[derive(Clone)]
     struct MockAgg {
@@ -185,16 +184,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_selective_agg() -> Result<()> {
-        // filter (where $1 > 5)
-        let expr = build(
-            PbType::GreaterThan,
-            DataType::Boolean,
-            vec![
-                InputRefExpression::new(DataType::Int64, 0).boxed(),
-                LiteralExpression::new(DataType::Int64, Some(ScalarImpl::Int64(5))).boxed(),
-            ],
-        )
-        .unwrap();
+        let expr = build_from_pretty("(greater_than:boolean #0:int8 5:int8)");
         let condition = Arc::from(expr);
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
@@ -229,15 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_selective_agg_null_condition() -> Result<()> {
-        let expr = build(
-            PbType::Equal,
-            DataType::Boolean,
-            vec![
-                InputRefExpression::new(DataType::Int64, 0).boxed(),
-                LiteralExpression::new(DataType::Int64, None).boxed(),
-            ],
-        )
-        .unwrap();
+        let expr = build_from_pretty("(equal:boolean #0:int8 null:int8)");
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
             Arc::from(expr),

--- a/src/expr/src/vector_op/agg/filter.rs
+++ b/src/expr/src/vector_op/agg/filter.rs
@@ -184,7 +184,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_selective_agg() -> Result<()> {
-        let expr = build_from_pretty("(greater_than:boolean #0:int8 5:int8)");
+        let expr = build_from_pretty("(greater_than:boolean $0:int8 5:int8)");
         let condition = Arc::from(expr);
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
@@ -219,7 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_selective_agg_null_condition() -> Result<()> {
-        let expr = build_from_pretty("(equal:boolean #0:int8 null:int8)");
+        let expr = build_from_pretty("(equal:boolean $0:int8 null:int8)");
         let agg_count = Arc::new(AtomicUsize::new(0));
         let mut agg = Filter::new(
             Arc::from(expr),

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -233,7 +233,7 @@ mod tests {
         };
         let source = MockSource::with_chunks(schema, PkIndices::new(), vec![chunk1, chunk2]);
 
-        let test_expr = build_from_pretty("(greater_than:boolean #0:int8 #1:int8)");
+        let test_expr = build_from_pretty("(greater_than:boolean $0:int8 $1:int8)");
 
         let filter = Box::new(FilterExecutor::new(
             ActorContext::create(123),

--- a/src/stream/src/executor/filter.rs
+++ b/src/stream/src/executor/filter.rs
@@ -199,8 +199,7 @@ mod tests {
     use risingwave_common::array::StreamChunk;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
-    use risingwave_expr::expr::{build, InputRefExpression};
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::build_from_pretty;
 
     use super::super::test_utils::MockSource;
     use super::super::*;
@@ -234,15 +233,7 @@ mod tests {
         };
         let source = MockSource::with_chunks(schema, PkIndices::new(), vec![chunk1, chunk2]);
 
-        let test_expr = build(
-            PbType::GreaterThan,
-            DataType::Boolean,
-            vec![
-                Box::new(InputRefExpression::new(DataType::Int64, 0)),
-                Box::new(InputRefExpression::new(DataType::Int64, 1)),
-            ],
-        )
-        .unwrap();
+        let test_expr = build_from_pretty("(greater_than:boolean #0:int8 #1:int8)");
 
         let filter = Box::new(FilterExecutor::new(
             ActorContext::create(123),

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -1057,8 +1057,7 @@ mod tests {
     use risingwave_common::hash::{Key128, Key64};
     use risingwave_common::types::ScalarImpl;
     use risingwave_common::util::sort_util::OrderType;
-    use risingwave_expr::expr::{build, InputRefExpression};
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::build_from_pretty;
     use risingwave_storage::memory::MemoryStateStore;
 
     use super::*;
@@ -1111,15 +1110,7 @@ mod tests {
     }
 
     fn create_cond() -> BoxedExpression {
-        build(
-            PbType::LessThan,
-            DataType::Boolean,
-            vec![
-                Box::new(InputRefExpression::new(DataType::Int64, 1)),
-                Box::new(InputRefExpression::new(DataType::Int64, 3)),
-            ],
-        )
-        .unwrap()
+        build_from_pretty("(less_than:boolean #1:int8 #3:int8)")
     }
 
     async fn create_executor<const T: JoinTypePrimitive>(

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -1110,7 +1110,7 @@ mod tests {
     }
 
     fn create_cond() -> BoxedExpression {
-        build_from_pretty("(less_than:boolean #1:int8 #3:int8)")
+        build_from_pretty("(less_than:boolean $1:int8 $3:int8)")
     }
 
     async fn create_executor<const T: JoinTypePrimitive>(

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -204,7 +204,7 @@ mod tests {
         assert_eq!(
             chunk_msg.into_chunk().unwrap().compact(),
             StreamChunk::from_pretty(
-                " TSZ
+                " I
                 + 1617235200001000"
             )
         );
@@ -233,7 +233,7 @@ mod tests {
         assert_eq!(
             chunk_msg.into_chunk().unwrap().compact(),
             StreamChunk::from_pretty(
-                " TSZ
+                " I
                 - 1617235200001000
                 + 1617235200002000"
             )

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -197,8 +197,7 @@ mod tests {
     use risingwave_common::array::StreamChunk;
     use risingwave_common::catalog::{Field, Schema};
     use risingwave_common::types::DataType;
-    use risingwave_expr::expr::{build, Expression, InputRefExpression, LiteralExpression};
-    use risingwave_pb::expr::expr_node::PbType;
+    use risingwave_expr::expr::build_from_pretty;
 
     use super::super::test_utils::MockSource;
     use super::super::*;
@@ -225,15 +224,7 @@ mod tests {
         };
         let source = MockSource::with_chunks(schema, PkIndices::new(), vec![chunk1, chunk2]);
 
-        let test_expr = build(
-            PbType::Add,
-            DataType::Int64,
-            vec![
-                InputRefExpression::new(DataType::Int64, 0).boxed(),
-                InputRefExpression::new(DataType::Int64, 1).boxed(),
-            ],
-        )
-        .unwrap();
+        let test_expr = build_from_pretty("(add:int8 #0:int8 #1:int8)");
 
         let project = Box::new(ProjectExecutor::new(
             ActorContext::create(123),
@@ -279,28 +270,8 @@ mod tests {
         };
         let (mut tx, source) = MockSource::channel(schema, PkIndices::new());
 
-        let a_expr = build(
-            PbType::Add,
-            DataType::Int64,
-            vec![
-                InputRefExpression::new(DataType::Int64, 0).boxed(),
-                LiteralExpression::new(DataType::Int64, Some(ScalarImpl::Int64(1))).boxed(),
-            ],
-        )
-        .unwrap();
-
-        let b_expr = build(
-            PbType::Subtract,
-            DataType::Int64,
-            vec![
-                Box::new(InputRefExpression::new(DataType::Int64, 0)),
-                Box::new(LiteralExpression::new(
-                    DataType::Int64,
-                    Some(ScalarImpl::Int64(1)),
-                )),
-            ],
-        )
-        .unwrap();
+        let a_expr = build_from_pretty("(add:int8 #0:int8 1:int8)");
+        let b_expr = build_from_pretty("(subtract:int8 #0:int8 1:int8)");
 
         let project = Box::new(ProjectExecutor::new(
             ActorContext::create(123),

--- a/src/stream/src/executor/project.rs
+++ b/src/stream/src/executor/project.rs
@@ -224,7 +224,7 @@ mod tests {
         };
         let source = MockSource::with_chunks(schema, PkIndices::new(), vec![chunk1, chunk2]);
 
-        let test_expr = build_from_pretty("(add:int8 #0:int8 #1:int8)");
+        let test_expr = build_from_pretty("(add:int8 $0:int8 $1:int8)");
 
         let project = Box::new(ProjectExecutor::new(
             ActorContext::create(123),
@@ -270,8 +270,8 @@ mod tests {
         };
         let (mut tx, source) = MockSource::channel(schema, PkIndices::new());
 
-        let a_expr = build_from_pretty("(add:int8 #0:int8 1:int8)");
-        let b_expr = build_from_pretty("(subtract:int8 #0:int8 1:int8)");
+        let a_expr = build_from_pretty("(add:int8 $0:int8 1:int8)");
+        let b_expr = build_from_pretty("(subtract:int8 $0:int8 1:int8)");
 
         let project = Box::new(ProjectExecutor::new(
             ActorContext::create(123),

--- a/src/stream/src/executor/watermark_filter.rs
+++ b/src/stream/src/executor/watermark_filter.rs
@@ -334,7 +334,7 @@ mod tests {
             ],
         };
 
-        let watermark_expr = build_from_pretty("(subtract:timestamp #1:timestamp 1day:interval)");
+        let watermark_expr = build_from_pretty("(subtract:timestamp $1:timestamp 1day:interval)");
 
         let table = create_in_memory_state_table(
             mem_state,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR introduces a simple DSL for expressions, so that we can build expressions painless in unit tests. (resolve #7881)

The language is defined as follows:
```
inputref := #<index>:<type>
constant := <value>:<type>
function := (<name>:<type> <child1> <child2>...)
```

For example:
```
#0 % 2 == 0
(equal:boolean (modulus:int8 #0:int8 2:int8) 0:int8)
```

The overall design follows the [egg](https://docs.rs/egg/latest/egg/index.html#simple-example). Except that we have to explicitly specify the return type of each node. It might not be the best and is subject to be changed if anyone has a better idea.

This PR contains a small lexer and parser for the DSL (mainly generated by GPT), and replaces boilerplate code with the new language whenever possible.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] ~~I have added necessary unit tests and integration tests~~
- [x] ~~I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] ~~I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.


