### PR TITLE
feat(common): add benchmark for `BitmapIter`

### DIFF
--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -39,22 +39,22 @@ fn bench_bitmap_iter(c: &mut Criterion) {
     fn bench_bitmap_iter(bench_id: &str, bitmap: Bitmap, c: &mut Criterion) {
         let bitmaps = vec![bitmap; N_CHUNKS];
         let iters = || make_iterators(&bitmaps);
-        let result= || vec![true; CHUNK_SIZE];
-        c.bench_function(bench_id, |b| b.iter(|| {
-            let mut result = result();
-            for iter in iters() {
-                for (i, bit_flag) in iter.enumerate() {
-                    result[i] = bit_flag;
+        let result = || vec![true; CHUNK_SIZE];
+        c.bench_function(bench_id, |b| {
+            b.iter(|| {
+                let mut result = result();
+                for iter in iters() {
+                    for (i, bit_flag) in iter.enumerate() {
+                        result[i] = bit_flag;
+                    }
                 }
-            }
-        }));
+            })
+        });
     }
     let zeros = Bitmap::zeros(CHUNK_SIZE);
     bench_bitmap_iter("zeros_iter", zeros, c);
     let ones = Bitmap::ones(CHUNK_SIZE);
     bench_bitmap_iter("ones_iter", ones, c);
-
-
 }
 
 criterion_group!(benches, bench_bitmap, bench_bitmap_iter);

--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -33,7 +33,7 @@ fn bench_bitmap(c: &mut Criterion) {
 fn bench_bitmap_iter(c: &mut Criterion) {
     const CHUNK_SIZE: usize = 1024;
     const N_CHUNKS: usize = 10_000;
-    fn make_iterators(bitmaps: &[Bitmap]) -> Vec<BitmapIter> {
+    fn make_iterators(bitmaps: &[Bitmap]) -> Vec<BitmapIter<'_>> {
         bitmaps.iter().map(|bitmap| bitmap.iter()).collect_vec()
     }
     fn bench_bitmap_iter(bench_id: &str, bitmap: Bitmap, c: &mut Criterion) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As per title.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
