### PR TITLE
feat(generated_columns): cast expr by user specified type

### DIFF
--- a/batch-ddl-debug-junit.xml
+++ b/batch-ddl-debug-junit.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="batch-ddl-debug" tests="1" failures="0" errors="0" timestamp="2023-03-27T06:22:15.690+00:00">
-    <testsuite name="sqllogictest" tests="1" disabled="0" errors="0" failures="0" timestamp="2023-03-27T06:22:15.690+00:00">
-        <testcase name="e2e_test_ddl_table_slt" classname="batch-ddl-debug" timestamp="2023-03-27T06:22:24.766+00:00" time="9.073">
-        </testcase>
-    </testsuite>
-</testsuites>

--- a/batch-ddl-debug-junit.xml
+++ b/batch-ddl-debug-junit.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="batch-ddl-debug" tests="1" failures="0" errors="0" timestamp="2023-03-27T06:22:15.690+00:00">
+    <testsuite name="sqllogictest" tests="1" disabled="0" errors="0" failures="0" timestamp="2023-03-27T06:22:15.690+00:00">
+        <testcase name="e2e_test_ddl_table_slt" classname="batch-ddl-debug" timestamp="2023-03-27T06:22:24.766+00:00" time="9.073">
+        </testcase>
+    </testsuite>
+</testsuites>

--- a/e2e_test/ddl/table/generated_columns.slt.part
+++ b/e2e_test/ddl/table/generated_columns.slt.part
@@ -1,6 +1,6 @@
 # Create a table with generated columns.
 statement ok
-create table t1 (v1 int as v2-1, v2 int, v3 int as v2+1);
+create table t1 (v1 int as v2-1, v2 int, v3 int as v2+1.02, v4 double as v2 + 1.02);
 
 statement ok
 insert into t1 (v2) values (1), (2);
@@ -8,11 +8,11 @@ insert into t1 (v2) values (1), (2);
 statement ok
 flush;
 
-query III
+query IIIR
 select * from t1;
 ----
-0 1 2
-1 2 3
+0 1 2 2.02
+1 2 3 3.02
 
 statement ok
 drop table t1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- cast generated column expr by user-specified type

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
