### PR TITLE
fix: run complex query containing system tables in local mode

### DIFF
--- a/e2e_test/batch/catalog/issue_8791.slt.part
+++ b/e2e_test/batch/catalog/issue_8791.slt.part
@@ -1,0 +1,5 @@
+# UNION should also be in local mode
+query I
+SELECT name FROM pg_catalog.pg_settings union select 'a';
+----
+a

--- a/e2e_test/batch/catalog/issue_8791.slt.part
+++ b/e2e_test/batch/catalog/issue_8791.slt.part
@@ -1,5 +1,16 @@
-# UNION should also be in local mode
+# UNION and other complex queries should also be in local mode
 query I
 SELECT name FROM pg_catalog.pg_settings union select 'a';
 ----
 a
+
+query T
+SELECT name FROM  (SELECT pg_catalog.lower(name) AS name FROM pg_catalog.pg_settings UNION ALL SELECT 'session authorization'   UNION ALL SELECT 'all') ss  WHERE substring(name,1,0)=''
+LIMIT 1000
+----
+session authorization
+all
+
+query I
+with q as ( select name FROM pg_catalog.pg_settings ) select * from q;
+----

--- a/src/frontend/src/binder/query.rs
+++ b/src/frontend/src/binder/query.rs
@@ -95,6 +95,10 @@ impl BoundQuery {
         self.body
             .collect_correlated_indices_by_depth_and_assign_id(depth, correlated_id)
     }
+
+    pub fn contains_sys_table(&self) -> bool {
+        self.body.contains_sys_table()
+    }
 }
 
 impl RewriteExprsRecursive for BoundQuery {

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -30,7 +30,7 @@ use risingwave_sqlparser::ast::{
 use self::watermark::is_watermark_func;
 use super::bind_context::ColumnBinding;
 use super::statement::RewriteExprsRecursive;
-use crate::binder::{Binder, BoundSetExpr};
+use crate::binder::Binder;
 use crate::catalog::function_catalog::FunctionKind;
 use crate::catalog::system_catalog::pg_catalog::{
     PG_GET_KEYWORDS_FUNC_NAME, PG_KEYWORDS_TABLE_NAME,
@@ -92,17 +92,9 @@ impl Relation {
     pub fn contains_sys_table(&self) -> bool {
         match self {
             Relation::SystemTable(_) => true,
-            Relation::Subquery(s) => {
-                if let BoundSetExpr::Select(select) = &s.query.body
-                    && let Some(relation) = &select.from {
-                    relation.contains_sys_table()
-                } else {
-                    false
-                }
-            },
-            Relation::Join(j) => {
-                j.left.contains_sys_table() || j.right.contains_sys_table()
-            },
+            Relation::Subquery(s) => s.query.contains_sys_table(),
+            Relation::Join(j) => j.left.contains_sys_table() || j.right.contains_sys_table(),
+            Relation::Share(s) => s.input.contains_sys_table(),
             _ => false,
         }
     }

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -112,8 +112,8 @@ impl BoundSetExpr {
     pub fn contains_sys_table(&self) -> bool {
         match self {
             BoundSetExpr::Select(s) => {
-                if let Some(relation) = &s.from && relation.contains_sys_table() {
-                    true
+                if let Some(relation) = &s.from {
+                    relation.contains_sys_table()
                 } else {
                     false
                 }

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -108,6 +108,23 @@ impl BoundSetExpr {
             }
         }
     }
+
+    pub fn contains_sys_table(&self) -> bool {
+        match self {
+            BoundSetExpr::Select(s) => {
+                if let Some(relation) = &s.from && relation.contains_sys_table() {
+                    true
+                } else {
+                    false
+                }
+            }
+            BoundSetExpr::Values(_) => false,
+            BoundSetExpr::Query(q) => q.contains_sys_table(),
+            BoundSetExpr::SetOperation { left, right, .. } => {
+                left.contains_sys_table() || right.contains_sys_table()
+            }
+        }
+    }
 }
 
 impl Binder {

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -29,7 +29,7 @@ use risingwave_sqlparser::ast::{SetExpr, Statement};
 
 use super::extended_handle::{Portal, PrepareStatement};
 use super::{PgResponseStream, RwPgResponse};
-use crate::binder::{Binder, BoundSetExpr, BoundStatement};
+use crate::binder::{Binder, BoundStatement};
 use crate::handler::flush::do_flush;
 use crate::handler::privilege::resolve_privileges;
 use crate::handler::util::{to_pg_field, DataChunkToRowSetAdapter};
@@ -77,17 +77,11 @@ fn must_run_in_distributed_mode(stmt: &Statement) -> Result<bool> {
 }
 
 fn must_run_in_local_mode(bound: &BoundStatement) -> bool {
-    let mut must_local = false;
-
     if let BoundStatement::Query(query) = &bound {
-        if let BoundSetExpr::Select(select) = &query.body
-            && let Some(relation) = &select.from
-            && relation.contains_sys_table() {
-                must_local = true;
-        }
+        return query.contains_sys_table();
     }
 
-    must_local
+    false
 }
 
 pub fn gen_batch_query_plan(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
fix #8791
Previously, setops like `UNION`, and subquery are not considered.
<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
