### PR TITLE
feat: add a command to risedev to display source split information

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6102,6 +6102,7 @@ dependencies = [
  "madsim-tokio",
  "regex",
  "risingwave_common",
+ "risingwave_connector",
  "risingwave_frontend",
  "risingwave_hummock_sdk",
  "risingwave_object_store",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -23,6 +23,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 itertools = "0.10"
 regex = "1.6.0"
 risingwave_common = { path = "../common" }
+risingwave_connector = { path = "../connector" }
 risingwave_frontend = { path = "../frontend" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
 risingwave_object_store = { path = "../object_store" }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -183,6 +183,8 @@ enum MetaCommands {
     Resume,
     /// get cluster info
     ClusterInfo,
+    /// get source split info
+    SourceSplitInfo,
     /// Reschedule the parallel unit in the stream graph
     ///
     /// The format is `fragment_id-[removed]+[added]`
@@ -337,6 +339,9 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
         Commands::Meta(MetaCommands::Pause) => cmd_impl::meta::pause(context).await?,
         Commands::Meta(MetaCommands::Resume) => cmd_impl::meta::resume(context).await?,
         Commands::Meta(MetaCommands::ClusterInfo) => cmd_impl::meta::cluster_info(context).await?,
+        Commands::Meta(MetaCommands::SourceSplitInfo) => {
+            cmd_impl::meta::source_split_info(context).await?
+        }
         Commands::Meta(MetaCommands::Reschedule { plan, dry_run }) => {
             cmd_impl::meta::reschedule(context, plan, dry_run).await?
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds a simple command-line tool to display basic split allocation information of actors in source fragments within risingwave.

```
CREATE table bid (auction BIGINT, bidder BIGINT, price BIGINT, "channel" VARCHAR, "url" VARCHAR, "date_time" TIMESTAMP, "extra" VARCHAR)
with (
  connector = 'nexmark',
  nexmark.table.type = 'Bid',
  nexmark.split.num = '50',
  nexmark.min.event.gap.in.ns = '1000000000'
);
```

then 

```
# ./risedev ctl meta source-split-info

Table #1002
	Fragment #2
		Actor #37 (2): [50-7,50-28]
		Actor #38 (2): [50-9,50-10]
		Actor #39 (1): [50-12]
		Actor #40 (1): [50-6]
		Actor #41 (1): [50-16]
		Actor #42 (1): [50-13]
		Actor #43 (1): [50-31]
		Actor #44 (1): [50-2]
		Actor #45 (1): [50-39]
		Actor #46 (1): [50-22]
		Actor #47 (2): [50-35,50-29]
		Actor #48 (1): [50-11]
		Actor #49 (2): [50-44,50-33]
		Actor #50 (1): [50-32]
		Actor #51 (1): [50-8]
		Actor #52 (2): [50-21,50-41]
		Actor #53 (1): [50-36]
		Actor #54 (2): [50-48,50-49]
		Actor #55 (1): [50-37]
		Actor #56 (1): [50-42]
		Actor #57 (1): [50-25]
		Actor #58 (2): [50-17,50-38]
		Actor #59 (1): [50-26]
		Actor #60 (2): [50-3,50-24]
		Actor #61 (2): [50-1,50-4]
		Actor #62 (1): [50-27]
		Actor #63 (2): [50-43,50-19]
		Actor #64 (1): [50-34]
		Actor #65 (1): [50-40]
		Actor #66 (1): [50-18]
		Actor #67 (1): [50-45]
		Actor #68 (2): [50-0,50-5]
		Actor #69 (1): [50-46]
		Actor #70 (2): [50-30,50-15]
		Actor #71 (2): [50-14,50-47]
		Actor #72 (2): [50-20,50-23]
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
