### PR TITLE
fix(risedev): remove download-connector task

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -371,7 +371,6 @@ cp "src/risedevtool/welcome.sh" "${PREFIX_BIN}/welcome.sh"
 category = "RiseDev - Components"
 description = "Download all available components at once"
 dependencies = [
-  "download-connector",
   "download-maven",
   "download-etcd",
   "download-grafana",
@@ -443,7 +442,7 @@ alias = "playground"
 [tasks.playground]
 category = "RiseDev - Start"
 description = "Start a lite RisingWave playground using risingwave all-in-one binary"
-dependencies = ["download-connector"]
+dependencies = ["build-connector-node"]
 script = '''
 #!/usr/bin/env bash
 
@@ -590,7 +589,7 @@ description = "Run unit tests"
 [tasks.build-connector-node]
 category = "RiseDev - Components"
 dependencies = ["prepare"]
-condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR"] }
+condition = { env_set = ["ENABLE_BUILD_RW_CONNECTOR"] }
 description = "Build RisingWave Connector from source"
 script = '''
 #!/usr/bin/env bash
@@ -610,13 +609,12 @@ if [[ ! -f ${TARGET_PATH} ]] || [[ ! -z ${REBUILD_CONNECTOR_NODE} ]]; then
   cd "${JAVA_DIR}"
   "${MAVEN_PATH}" --batch-mode --update-snapshots clean package -Dmaven.test.skip
 else
-  echo "Connector node was built already. Skipped. Set REBUILD_CONNECTOR_NODE=1 to enable rebuild"
+  echo "$(tput setaf 4)$(tput bold)[Reminder]$(tput sgr0) Connector node was built already, skipped build. Set $(tput setaf 4)REBUILD_CONNECTOR_NODE=1$(tput sgr0) to enable rebuild"
 fi
 rm -rf ${PREFIX_BIN}/connector-node
 mkdir -p "${PREFIX_BIN}/connector-node"
 tar xf ${TARGET_PATH} -C "${PREFIX_BIN}/connector-node"
 '''
-
 
 [tasks.sbuild]
 category = "RiseDev - Build in simulation mode"

--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -242,7 +242,7 @@ pub async fn playground() -> Result<()> {
                     let _stderr_handle = tokio::spawn(async move {
                         let mut reader = BufReader::new(stderr).lines();
                         while let Ok(Some(line)) = reader.next_line().await {
-                            tracing::error!(target: "risingwave_connector_node", "{}", line);
+                            tracing::info!(target: "risingwave_connector_node", "{}", line);
                         }
                     });
                 } else {

--- a/src/risedevtool/connector.toml
+++ b/src/risedevtool/connector.toml
@@ -1,50 +1,13 @@
 extend = "common.toml"
 
 [env]
-RW_CONNECTOR_VERSION = "0.1.17"
-RW_CONNECTOR_DOWNLOAD_PATH = "${PREFIX_TMP}/risingwave-connector-${RW_CONNECTOR_VERSION}.tar.gz"
-RW_CONNECTOR_RELEASE = "risingwave-connector-${RW_CONNECTOR_VERSION}.tar.gz"
-RW_CONNECTOR_BIN_PREFIX = "${PREFIX_BIN}/connector-node"
-
-RW_CONNECTOR_DOWNLOAD_URL = "https://github.com/risingwavelabs/risingwave-connector-release/raw/main/risingwave-connector-${RW_CONNECTOR_VERSION}.tar.gz"
-
 MAVEN_VERSION = "3.9.0"
 MAVEN_DOWNLOAD_PATH = "${PREFIX_TMP}/maven.tar.gz"
-
-[tasks.download-connector]
-category = "RiseDev - Components"
-dependencies = ["prepare"]
-condition = { env_set = [ "ENABLE_RW_CONNECTOR" ] }
-description = "Download RisingWave Connector"
-script = '''
-#!/usr/bin/env bash
-set -e
-if [ -f "${RW_CONNECTOR_BIN_PREFIX}/start-service.sh" ]; then
-    exit 0
-fi
-
-if [ -n "${ENABLE_BUILD_RW_CONNECTOR+x}" ]; then
-    echo "ENABLE_BUILD_RW_CONNECTOR is set, will build RisingWave Connector from source instead"
-    exit 0
-fi
-
-if [ -f "${RW_CONNECTOR_DOWNLOAD_PATH}" ]; then
-    mkdir -p "${PREFIX_BIN}/connector-node"
-    tar xf "${RW_CONNECTOR_DOWNLOAD_PATH}" -C "${PREFIX_BIN}/connector-node"
-    rm "${RW_CONNECTOR_DOWNLOAD_PATH}"
-else
-    echo "RisingWave Connector not found, download ${RW_CONNECTOR_RELEASE}"
-    curl -fL -o "${RW_CONNECTOR_DOWNLOAD_PATH}" "${RW_CONNECTOR_DOWNLOAD_URL}"
-    mkdir -p "${PREFIX_BIN}/connector-node"
-    tar xf "${RW_CONNECTOR_DOWNLOAD_PATH}" -C "${PREFIX_BIN}/connector-node"
-    rm "${RW_CONNECTOR_DOWNLOAD_PATH}"
-fi
-'''
 
 [tasks.download-maven]
 category = "RiseDev - Components"
 dependencies = ["prepare"]
-condition = { env_set = [ "ENABLE_RW_CONNECTOR", "ENABLE_BUILD_RW_CONNECTOR" ] }
+condition = { env_set = [ "ENABLE_BUILD_RW_CONNECTOR" ] }
 description = "Download Maven"
 script = '''
 #!/usr/bin/env bash

--- a/src/risedevtool/src/bin/risedev-config.rs
+++ b/src/risedevtool/src/bin/risedev-config.rs
@@ -65,10 +65,9 @@ pub enum Components {
     Kafka,
     Pubsub,
     Redis,
-    ConnectorNode,
-    BuildConnectorNode,
     Tracing,
     RustComponents,
+    BuildConnectorNode,
     Dashboard,
     Release,
     AllInOne,
@@ -85,8 +84,7 @@ impl Components {
             Self::Kafka => "[Component] Kafka",
             Self::Pubsub => "[Component] Google Pubsub",
             Self::Redis => "[Component] Redis",
-            Self::ConnectorNode => "[Component] RisingWave Connector",
-            Self::BuildConnectorNode => "[Build] Build RisingWave Connector from source",
+            Self::BuildConnectorNode => "[Build] Build RisingWave Connector (Java)",
             Self::RustComponents => "[Build] Rust components",
             Self::Dashboard => "[Build] Dashboard v2",
             Self::Tracing => "[Component] Tracing: Jaeger",
@@ -165,11 +163,6 @@ a dev cluster.
 Required if you want to sink data to redis.
                 "
             }
-            Self::ConnectorNode => {
-                "
-Required if you want to create CDC source from external Databases.
-                "
-            }
             Self::BuildConnectorNode => {
                 "
 Required if you want to build Connector Node from source locally.
@@ -194,7 +187,6 @@ Required if you want to build Connector Node from source locally.
             "ENABLE_ALL_IN_ONE" => Some(Self::AllInOne),
             "ENABLE_SANITIZER" => Some(Self::Sanitizer),
             "ENABLE_REDIS" => Some(Self::Redis),
-            "ENABLE_RW_CONNECTOR" => Some(Self::ConnectorNode),
             "ENABLE_BUILD_RW_CONNECTOR" => Some(Self::BuildConnectorNode),
             _ => None,
         }
@@ -215,7 +207,6 @@ Required if you want to build Connector Node from source locally.
             Self::Release => "ENABLE_RELEASE_PROFILE",
             Self::AllInOne => "ENABLE_ALL_IN_ONE",
             Self::Sanitizer => "ENABLE_SANITIZER",
-            Self::ConnectorNode => "ENABLE_RW_CONNECTOR",
             Self::BuildConnectorNode => "ENABLE_BUILD_RW_CONNECTOR",
         }
         .into()

--- a/src/risedevtool/src/task/connector_service.rs
+++ b/src/risedevtool/src/task/connector_service.rs
@@ -44,7 +44,7 @@ impl Task for ConnectorNodeService {
         ctx.pb.set_message("starting");
         let path = self.connector_path()?;
         if !path.exists() {
-            return Err(anyhow!("RisingWave connector binary not found in {:?}\nDid you enable risingwave connector feature in `./risedev configure`?", path));
+            return Err(anyhow!("RisingWave connector binary not found in {:?}\nPlease enable building RisingWave connector in `./risedev configure`?", path));
         }
         let mut cmd = Command::new(path);
         cmd.arg("-p").arg(self.config.port.to_string());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
- Since connector node is open-sourced, we don't need to download it from https://github.com/risingwavelabs/risingwave-connector-release. Just build it from source and copy binary to the `$PREFIX_BIN/connector-node`.
- Add build connector node to the default configuration

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

close https://github.com/risingwavelabs/risingwave/issues/8407
