### PR TITLE
fix(frontend): show column data type correctly

### DIFF
--- a/src/frontend/src/handler/describe.rs
+++ b/src/frontend/src/handler/describe.rs
@@ -231,10 +231,10 @@ mod tests {
         }
 
         let expected_columns: HashMap<String, String> = maplit::hashmap! {
-            "v1".into() => "Int32".into(),
-            "v2".into() => "Int32".into(),
-            "v3".into() => "Int32".into(),
-            "v4".into() => "Int32".into(),
+            "v1".into() => "integer".into(),
+            "v2".into() => "integer".into(),
+            "v3".into() => "integer".into(),
+            "v4".into() => "integer".into(),
             "primary key".into() => "v3".into(),
             "idx1".into() => "index(v1 DESC, v2 ASC, v3 ASC) include(v4) distributed by(v1, v2)".into(),
         };

--- a/src/frontend/src/handler/util.rs
+++ b/src/frontend/src/handler/util.rs
@@ -177,7 +177,7 @@ pub fn col_descs_to_rows(columns: Vec<ColumnDesc>) -> Vec<Row> {
                     let type_name = if let DataType::Struct { .. } = c.data_type {
                         c.type_name.clone()
                     } else {
-                        format!("{:?}", &c.data_type)
+                        c.data_type.to_string()
                     };
                     Row::new(vec![Some(c.name.into()), Some(type_name.into())])
                 })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Before:

```
dev=> describe t_remote;
    Name     |   Type
-------------+-----------
 id          | Int32
 v_varchar   | Varchar
 v_smallint  | Int16
 v_integer   | Int32
 v_bigint    | Int64
 v_decimal   | Decimal
 v_float     | Float32
 v_double    | Float64
 v_timestamp | Timestamp
 primary key | id
(10 rows)
```

After:

```
dev=> describe t_remote;
    Name     |            Type
-------------+-----------------------------
 id          | integer
 v_varchar   | varchar
 v_smallint  | smallint
 v_integer   | integer
 v_bigint    | bigint
 v_decimal   | numeric
 v_float     | real
 v_double    | double precision
 v_timestamp | timestamp without time zone
 primary key | id
```


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

Contains minor user-facing changes. Please update https://www.risingwave.dev/docs/current/sql-describe/ accordingly.