### PR TITLE
chore(frontend): dedup dist key from pk

### DIFF
--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -69,7 +69,11 @@ pub fn infer_left_internal_table_catalog(
     let read_prefix_len_hint = pk_indices.len();
 
     // TODO(yuhao): dedup the dist key and pk.
-    pk_indices.extend(me.logical_pk());
+    for i in me.logical_pk() {
+        if *i != left_key_index {
+            pk_indices.push(*i);
+        }
+    }
 
     let mut internal_table_catalog_builder =
         TableCatalogBuilder::new(me.ctx().with_options().internal_table_subset());

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -68,7 +68,6 @@ pub fn infer_left_internal_table_catalog(
     let mut pk_indices = vec![left_key_index];
     let read_prefix_len_hint = pk_indices.len();
 
-    // TODO(yuhao): dedup the dist key and pk.
     for i in me.logical_pk() {
         if *i != left_key_index {
             pk_indices.push(*i);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Redundant duplication of dist key

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [X] My PR **DOES NOT** contain user-facing changes.

