### PR TITLE
perf(common): optimize `BitmapIter`

### DIFF
--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -36,7 +36,7 @@ fn bench_bitmap_iter(c: &mut Criterion) {
     fn make_iterators(bitmaps: &[Bitmap]) -> Vec<BitmapIter<'_>> {
         bitmaps.iter().map(|bitmap| bitmap.iter()).collect_vec()
     }
-    fn bench_bitmap_iter(bench_id: &str, bitmap: Bitmap, c: &mut Criterion) {
+    fn bench_bitmap_iter_inner(bench_id: &str, bitmap: Bitmap, c: &mut Criterion) {
         let bitmaps = vec![bitmap; N_CHUNKS];
         let make_iters = || make_iterators(&bitmaps);
         c.bench_function(bench_id, |b| {
@@ -54,9 +54,9 @@ fn bench_bitmap_iter(c: &mut Criterion) {
         });
     }
     let zeros = Bitmap::zeros(CHUNK_SIZE);
-    bench_bitmap_iter("zeros_iter", zeros, c);
+    bench_bitmap_iter_inner("zeros_iter", zeros, c);
     let ones = Bitmap::ones(CHUNK_SIZE);
-    bench_bitmap_iter("ones_iter", ones, c);
+    bench_bitmap_iter_inner("ones_iter", ones, c);
 }
 
 criterion_group!(benches, bench_bitmap, bench_bitmap_iter);

--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, black_box};
 use itertools::Itertools;
 use risingwave_common::buffer::{Bitmap, BitmapIter};
 
@@ -39,14 +39,13 @@ fn bench_bitmap_iter(c: &mut Criterion) {
     fn bench_bitmap_iter(bench_id: &str, bitmap: Bitmap, c: &mut Criterion) {
         let bitmaps = vec![bitmap; N_CHUNKS];
         let make_iters = || make_iterators(&bitmaps);
-        let mut result = vec![true; CHUNK_SIZE];
         c.bench_function(bench_id, |b| {
             b.iter_batched(
                 make_iters,
                 |iters| {
                     for iter in iters {
-                        for (i, bit_flag) in iter.enumerate() {
-                            result[i] = bit_flag;
+                        for bit_flag in iter {
+                            black_box(bit_flag);
                         }
                     }
                 },

--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion, black_box};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
 use itertools::Itertools;
 use risingwave_common::buffer::{Bitmap, BitmapIter};
 
@@ -23,9 +23,27 @@ fn bench_bitmap(c: &mut Criterion) {
     let i = 0x123;
     c.bench_function("zeros", |b| b.iter(|| Bitmap::zeros(CHUNK_SIZE)));
     c.bench_function("ones", |b| b.iter(|| Bitmap::ones(CHUNK_SIZE)));
-    c.bench_function("get", |b| b.iter(|| for _ in 0..1000 { black_box(x.is_set(i)); }));
-    c.bench_function("get_1000", |b| b.iter(|| for _ in 0..1000 { black_box(x.is_set(i)); }));
-    c.bench_function("get_1000_000", |b| b.iter(|| for _ in 0..1000_000 { black_box(x.is_set(i)); }));
+    c.bench_function("get", |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(x.is_set(i));
+            }
+        })
+    });
+    c.bench_function("get_1000", |b| {
+        b.iter(|| {
+            for _ in 0..1000 {
+                black_box(x.is_set(i));
+            }
+        })
+    });
+    c.bench_function("get_1000_000", |b| {
+        b.iter(|| {
+            for _ in 0..1_000_000 {
+                black_box(x.is_set(i));
+            }
+        })
+    });
     c.bench_function("and", |b| b.iter(|| &x & &y));
     c.bench_function("or", |b| b.iter(|| &x | &y));
     c.bench_function("not", |b| b.iter(|| !&x));

--- a/src/common/benches/bitmap.rs
+++ b/src/common/benches/bitmap.rs
@@ -23,7 +23,9 @@ fn bench_bitmap(c: &mut Criterion) {
     let i = 0x123;
     c.bench_function("zeros", |b| b.iter(|| Bitmap::zeros(CHUNK_SIZE)));
     c.bench_function("ones", |b| b.iter(|| Bitmap::ones(CHUNK_SIZE)));
-    c.bench_function("get", |b| b.iter(|| x.is_set(i)));
+    c.bench_function("get", |b| b.iter(|| for _ in 0..1000 { black_box(x.is_set(i)); }));
+    c.bench_function("get_1000", |b| b.iter(|| for _ in 0..1000 { black_box(x.is_set(i)); }));
+    c.bench_function("get_1000_000", |b| b.iter(|| for _ in 0..1000_000 { black_box(x.is_set(i)); }));
     c.bench_function("and", |b| b.iter(|| &x & &y));
     c.bench_function("or", |b| b.iter(|| &x | &y));
     c.bench_function("not", |b| b.iter(|| !&x));

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -180,6 +180,7 @@ pub struct Bitmap {
     // The number of high bits in the bitmap.
     count_ones: usize,
 
+    /// Bits are stored in a compact form via usize.
     bits: Box<[usize]>,
 }
 
@@ -565,9 +566,15 @@ impl<'a> iter::Iterator for BitmapIter<'a> {
         if self.idx >= self.num_bits {
             return None;
         }
-        let b = unsafe { self.bits.get_unchecked(self.idx / BITS) } & (1 << (self.idx % BITS)) != 0;
+        // Get the index of usize which the bit is located in
+        let usize_index = self.idx / BITS;
+        // Offset of the bit within the usize.
+        let usize_offset = self.idx % BITS;
+        let bit_mask = 1 << usize_offset;
+        let usize_containing_bit = unsafe { self.bits.get_unchecked(usize_index) };
+        let bit_flag = usize_containing_bit & bit_mask != 0;
         self.idx += 1;
-        Some(b)
+        Some(bit_flag)
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/common/src/buffer/bitmap.rs
+++ b/src/common/src/buffer/bitmap.rs
@@ -173,14 +173,15 @@ impl BitmapBuilder {
 /// An immutable bitmap. Use [`BitmapBuilder`] to build it.
 #[derive(Clone, PartialEq, Eq)]
 pub struct Bitmap {
-    // The useful bits in the bitmap. The total number of bits will usually
-    // be larger than the useful bits due to byte-padding.
+    /// The useful bits in the bitmap. The total number of bits will usually
+    /// be larger than the useful bits due to byte-padding.
     num_bits: usize,
 
-    // The number of high bits in the bitmap.
+    /// The number of high bits in the bitmap.
     count_ones: usize,
 
-    /// Bits are stored in a compact form via usize.
+    /// Bits are stored in a compact form.
+    /// They are packed into `usize`s.
     bits: Box<[usize]>,
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Before this PR, bitmap iter is shown to be expensive: https://github.com/risingwavelabs/risingwave/issues/7792#issuecomment-1481305388
- In this PR, we call it once for each usize, copy it into the iterator, and reference that instead.
- Save division calls by a factor of `usize`.
- Save calls to `get_unchecked` by a factor of `usize`.
- Incur cost of copy `usize` on to stack for buffering reads from memory
- Incur cost of conditional check of whether to fetch usize from memory or use the one buffered.
- Also fix benchmark inaccuracies.

Overall maybe save about 1% 🤣 
Saves about 17% for bitmap iter itself. See below: https://github.com/risingwavelabs/risingwave/pull/8848#issuecomment-1487925755.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
