### PR TITLE
chore(ci): remove ci auto retry

### DIFF
--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -1,10 +1,3 @@
-auto-retry: &auto-retry
-  automatic:
-    - exit_status: -1  # Agent was lost
-      limit: 2
-    - exit_status: 255 # Forced agent shutdown
-      limit: 2
-
 steps:
   - label: "docker-build-push: amd64"
     command: "ci/scripts/docker.sh"
@@ -16,7 +9,6 @@ steps:
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
-    retry: *auto-retry
 
   - label: "docker-build-push: aarch64"
     command: "ci/scripts/docker.sh"
@@ -28,7 +20,6 @@ steps:
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
-    retry: *auto-retry
     agents:
       queue: "linux-arm64"
 
@@ -43,7 +34,6 @@ steps:
             GHCR_USERNAME: ghcr-username
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
-    retry: *auto-retry
 
   - label: "pre build binary"
     command: "ci/scripts/release.sh"
@@ -58,4 +48,3 @@ steps:
             - BINARY_NAME
             - BUILDKITE_SOURCE
             - GITHUB_TOKEN
-    retry: *auto-retry

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -12,13 +12,6 @@ cargo-cache: &cargo-cache
     - ".cargo/registry/cache"
     - ".cargo/git/db"
 
-auto-retry: &auto-retry
-  automatic:
-    - exit_status: -1  # Agent was lost
-      limit: 2
-    - exit_status: 255 # Forced agent shutdown
-      limit: 2
-
 steps:
   - label: "build"
     command: "ci/scripts/build.sh -t ci-release -p ci-release"
@@ -30,7 +23,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 20
-    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -46,7 +38,6 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -58,7 +49,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
   
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -70,7 +60,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (release)"
     command: "ci/scripts/cron-e2e-test.sh -p ci-release"
@@ -85,7 +74,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
-    retry: *auto-retry
 
   - label: "end-to-end source test (release)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
@@ -100,7 +88,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "unit test"
     command: "ci/scripts/unit-test.sh"
@@ -116,7 +103,6 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=100 timeout 15m ci/scripts/deterministic-unit-test.sh"
@@ -127,7 +113,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=60 timeout 70m ci/scripts/deterministic-scale-test.sh"
@@ -139,7 +124,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 70
-    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=64 timeout 55m ci/scripts/deterministic-e2e-test.sh"
@@ -157,7 +141,6 @@ steps:
             - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
-    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=12 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
@@ -170,7 +153,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
-    retry: *auto-retry
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
@@ -182,7 +164,6 @@ steps:
       - shellcheck#v1.2.0:
           files: ./**/*.sh
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run"
@@ -198,7 +179,6 @@ steps:
           environment:
             - S3_SOURCE_TEST_CONF
     timeout_in_minutes: 20
-    retry: *auto-retry  
     
   - label: "S3 source check on lyvecloud.seagate.com (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run"
@@ -214,7 +194,6 @@ steps:
           environment:
             - S3_SOURCE_TEST_CONF
     timeout_in_minutes: 20
-    retry: *auto-retry  
 
   - label: "S3 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run_csv"
@@ -230,7 +209,6 @@ steps:
           environment:
             - S3_SOURCE_TEST_CONF
     timeout_in_minutes: 20
-    retry: *auto-retry  
 
   - label: "S3 source on OpenDAL fs engine"
     command: "ci/scripts/s3-source-test-for-opendal-fs-engine.sh -p ci-release -s run"
@@ -246,4 +224,3 @@ steps:
           environment:
             - S3_SOURCE_TEST_CONF
     timeout_in_minutes: 20
-    retry: *auto-retry  

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -12,13 +12,6 @@ cargo-cache: &cargo-cache
     - ".cargo/registry/cache"
     - ".cargo/git/db"
 
-auto-retry: &auto-retry
-  automatic:
-    - exit_status: -1 # Agent was lost
-      limit: 2
-    - exit_status: 255 # Forced agent shutdown
-      limit: 2
-
 steps:
   - label: "build (dev mode)"
     command: "ci/scripts/build.sh -t ci-dev -p ci-dev"
@@ -30,7 +23,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "build (release mode)"
     command: "ci/scripts/build.sh -t ci-release -p ci-release"
@@ -44,7 +36,6 @@ steps:
           env:
             - BUILDKITE_COMMIT
     timeout_in_minutes: 20
-    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -60,7 +51,6 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -72,7 +62,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -84,7 +73,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (dev mode)"
     command: "ci/scripts/e2e-test.sh -p ci-dev"
@@ -105,7 +93,6 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (release mode)"
     command: "ci/scripts/e2e-test.sh -p ci-release"
@@ -126,7 +113,6 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (parallel) (dev mode)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
@@ -147,7 +133,6 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (parallel) (release mode)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
@@ -168,7 +153,6 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory) (release mode)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-release"
@@ -183,7 +167,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end source test (release mode)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
@@ -198,7 +181,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "unit test"
     command: "ci/scripts/pr-unit-test.sh"
@@ -214,7 +196,6 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=50 timeout 10m ci/scripts/deterministic-unit-test.sh"
@@ -225,7 +206,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=30 timeout 40m ci/scripts/deterministic-scale-test.sh"
@@ -237,7 +217,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 40 # TODO: split into multiple jobs
-    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=32 timeout 25m ci/scripts/deterministic-e2e-test.sh"
@@ -255,7 +234,6 @@ steps:
             - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 30
-    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=16 KILL_RATE=0.5 timeout 25m ci/scripts/deterministic-recovery-test.sh"
@@ -274,7 +252,6 @@ steps:
       #     format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 30
-    retry: *auto-retry
 
   - label: "end-to-end sink test (release mode)"
     command: "ci/scripts/e2e-sink-test.sh -p ci-release"
@@ -289,7 +266,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "end-to-end iceberg sink test (release mode)"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-release"
@@ -304,7 +280,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "e2e java-binding test (at release)"
     command: "ci/scripts/java-binding-test.sh -p ci-release"
@@ -317,7 +292,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "release"
     command: "ci/scripts/release.sh"
@@ -336,7 +310,6 @@ steps:
             - BUILDKITE_TAG
             - BUILDKITE_SOURCE
     timeout_in_minutes: 60
-    retry: *auto-retry
 
   - label: "release docker image: amd64"
     command: "ci/scripts/docker.sh"
@@ -352,7 +325,6 @@ steps:
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
     timeout_in_minutes: 60
-    retry: *auto-retry
 
   - label: "docker-build-push: aarch64"
     command: "ci/scripts/docker.sh"
@@ -368,7 +340,6 @@ steps:
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
     timeout_in_minutes: 60
-    retry: *auto-retry
     agents:
       queue: "linux-arm64"
 
@@ -385,4 +356,3 @@ steps:
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
     timeout_in_minutes: 10
-    retry: *auto-retry

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -12,13 +12,6 @@ cargo-cache: &cargo-cache
     - ".cargo/registry/cache"
     - ".cargo/git/db"
 
-auto-retry: &auto-retry
-  automatic:
-    - exit_status: -1 # Agent was lost
-      limit: 2
-    - exit_status: 255 # Forced agent shutdown
-      limit: 2
-
 steps:
   - label: "check ci image rebuild"
     plugins:
@@ -41,7 +34,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -57,7 +49,6 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -69,7 +60,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -81,7 +71,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test"
     command: "ci/scripts/e2e-test.sh -p ci-dev"
@@ -96,7 +85,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "end-to-end test (parallel)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
@@ -111,7 +99,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "end-to-end test for opendal (parallel)"
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-dev"
@@ -126,7 +113,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-dev"
@@ -139,7 +125,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "end-to-end source test"
     command: "ci/scripts/e2e-source-test.sh -p ci-dev"
@@ -154,7 +139,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 18
-    retry: *auto-retry
 
   - label: "end-to-end sink test"
     command: "ci/scripts/e2e-sink-test.sh -p ci-dev"
@@ -169,7 +153,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "end-to-end iceberg sink test"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-dev"
@@ -184,7 +167,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "e2e java-binding test"
     command: "ci/scripts/java-binding-test.sh -p ci-dev"
@@ -197,7 +179,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "regress test"
     command: "ci/scripts/regress-test.sh -p ci-dev"
@@ -210,7 +191,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
-    retry: *auto-retry
 
   - label: "unit test"
     command: "ci/scripts/pr-unit-test.sh"
@@ -226,7 +206,6 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 12
-    retry: *auto-retry
 
   - label: "fuzz test"
     command: "ci/scripts/pr-fuzz-test.sh -p ci-dev"
@@ -242,7 +221,6 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
-    retry: *auto-retry
     soft_fail: true
 
   - label: "check"
@@ -253,7 +231,6 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
     timeout_in_minutes: 20
-    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-unit-test.sh"
@@ -264,7 +241,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-scale-test.sh"
@@ -276,7 +252,6 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
-    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=16 timeout 14m ci/scripts/deterministic-e2e-test.sh"
@@ -294,7 +269,6 @@ steps:
             - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
-    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=8 KILL_RATE=0.5 timeout 20m ci/scripts/deterministic-recovery-test.sh"
@@ -313,7 +287,6 @@ steps:
       #     format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 18
-    retry: *auto-retry
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
@@ -325,4 +298,3 @@ steps:
       - shellcheck#v1.2.0:
           files: ./**/*.sh
     timeout_in_minutes: 5
-    retry: *auto-retry


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The automatic retry of ci is removed because:

1. timeout and agent-lost will trigger retry, which may miss some faults;
2. Can save a lot of buildkite job minutes；
3. If the pipeline fails, you should troubleshoot the problem or manually retry；

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->