### PR TITLE
fix(storage): fix `mem_store.flush(delete_ranges)`

### DIFF
--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::ops::{Bound, RangeBounds};
@@ -580,12 +580,30 @@ impl<R: RangeKv> StateStoreWrite for RangeKvStateStore<R> {
 
     fn ingest_batch(
         &self,
-        kv_pairs: Vec<(Bytes, StorageValue)>,
-        _delete_ranges: Vec<(Bytes, Bytes)>,
+        mut kv_pairs: Vec<(Bytes, StorageValue)>,
+        delete_ranges: Vec<(Bytes, Bytes)>,
         write_options: WriteOptions,
     ) -> Self::IngestBatchFuture<'_> {
         async move {
             let epoch = write_options.epoch;
+
+            let mut delete_keys = BTreeSet::new();
+            for del_range in delete_ranges {
+                let fullkey_start =
+                    FullKey::new(write_options.table_id, TableKey(del_range.0), epoch);
+                let fullkey_end =
+                    FullKey::new(write_options.table_id, TableKey(del_range.1), epoch);
+                for (key, _) in self.inner.range(
+                    (Bound::Included(fullkey_start), Bound::Excluded(fullkey_end)),
+                    None,
+                )? {
+                    delete_keys.insert(key);
+                }
+            }
+            for key in delete_keys {
+                kv_pairs.push((key.user_key.table_key.0, StorageValue::new_delete()));
+            }
+
             let mut size = 0;
             self.inner
                 .ingest_batch(kv_pairs.into_iter().map(|(key, value)| {

--- a/src/storage/src/memory.rs
+++ b/src/storage/src/memory.rs
@@ -597,11 +597,11 @@ impl<R: RangeKv> StateStoreWrite for RangeKvStateStore<R> {
                     (Bound::Included(fullkey_start), Bound::Excluded(fullkey_end)),
                     None,
                 )? {
-                    delete_keys.insert(key);
+                    delete_keys.insert(key.user_key.table_key.0);
                 }
             }
             for key in delete_keys {
-                kv_pairs.push((key.user_key.table_key.0, StorageValue::new_delete()));
+                kv_pairs.push((key, StorageValue::new_delete()));
             }
 
             let mut size = 0;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Delete keys in given `delete_ranges` in `RangeKvStateStore`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
