### PR TITLE
fix(stream): Better cache handling for temporal join.

### DIFF
--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -31,7 +31,7 @@ use risingwave_storage::table::batch_table::storage_table::StorageTable;
 use risingwave_storage::StateStore;
 
 use super::{Barrier, Executor, Message, MessageStream, StreamExecutorError, StreamExecutorResult};
-use crate::cache::{new_with_hasher_in, ManagedLruCache};
+use crate::cache::{cache_may_stale, new_with_hasher_in, ExecutorCache};
 use crate::common::StreamChunkBuilder;
 use crate::executor::monitor::StreamingMetrics;
 use crate::executor::{ActorContextRef, BoxedExecutor, JoinType, JoinTypePrimitive, PkIndices};
@@ -59,7 +59,7 @@ pub struct TemporalJoinExecutor<S: StateStore, const T: JoinTypePrimitive> {
 struct TemporalSide<S: StateStore> {
     source: StorageTable<S>,
     table_output_indices: Vec<usize>,
-    cache: ManagedLruCache<OwnedRow, Option<OwnedRow>, DefaultHasher, SharedStatsAlloc<Global>>,
+    cache: ExecutorCache<OwnedRow, Option<OwnedRow>, DefaultHasher, SharedStatsAlloc<Global>>,
 }
 
 impl<S: StateStore> TemporalSide<S> {
@@ -83,7 +83,7 @@ impl<S: StateStore> TemporalSide<S> {
         })
     }
 
-    fn update(&mut self, payload: Vec<StreamChunk>, join_keys: &[usize], epoch: u64) {
+    fn update(&mut self, payload: Vec<StreamChunk>, join_keys: &[usize]) {
         payload.iter().flat_map(|c| c.rows()).for_each(|(op, row)| {
             let key = row.project(join_keys).into_owned_row();
             if let Some(value) = self.cache.get_mut(&key) {
@@ -93,7 +93,6 @@ impl<S: StateStore> TemporalSide<S> {
                 };
             }
         });
-        self.cache.update_epoch(epoch);
     }
 }
 
@@ -195,7 +194,11 @@ impl<S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor<S, T> {
 
         let alloc = StatsAlloc::new(Global).shared();
 
-        let cache = new_with_hasher_in(watermark_epoch, DefaultHasher::default(), alloc);
+        let cache = ExecutorCache::new(new_with_hasher_in(
+            watermark_epoch,
+            DefaultHasher::default(),
+            alloc,
+        ));
 
         Self {
             ctx,
@@ -277,9 +280,18 @@ impl<S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor<S, T> {
                     }
                 }
                 InternalMessage::Barrier(updates, barrier) => {
-                    prev_epoch = Some(barrier.epoch.curr);
+                    self.right_table.cache.evict();
+                    if let Some(vnodes) = barrier.as_update_vnode_bitmap(self.ctx.id) {
+                        let prev_vnodes =
+                            self.right_table.source.update_vnode_bitmap(vnodes.clone());
+                        if cache_may_stale(&prev_vnodes, &vnodes) {
+                            self.right_table.cache.clear();
+                        }
+                    }
+                    self.right_table.cache.update_epoch(barrier.epoch.curr);
                     self.right_table
                         .update(updates, &self.right_join_keys, barrier.epoch.curr);
+                    prev_epoch = Some(barrier.epoch.curr);
                     yield Message::Barrier(barrier)
                 }
             }

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -289,8 +289,7 @@ impl<S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor<S, T> {
                         }
                     }
                     self.right_table.cache.update_epoch(barrier.epoch.curr);
-                    self.right_table
-                        .update(updates, &self.right_join_keys, barrier.epoch.curr);
+                    self.right_table.update(updates, &self.right_join_keys);
                     prev_epoch = Some(barrier.epoch.curr);
                     yield Message::Barrier(barrier)
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Attempt to evict cache and update vnodes on every epoch for the temporal join executor.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
