### PR TITLE
fix(hummock manager): preserve SST order in `commit_epoch` (close #8875)

### DIFF
--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1347,20 +1347,20 @@ where
         new_hummock_version.id = new_version_delta.id;
         let mut incorrect_ssts = vec![];
         let mut new_sst_id_number = 0;
-        sstables.retain_mut(|local_sst_info| {
-            let ExtendedSstableInfo {
-                compaction_group_id,
-                sst_info: sst,
-                ..
-            } = local_sst_info;
-            let mut is_sst_belong_to_group_declared =
-                match old_version.levels.get(compaction_group_id) {
-                    Some(compaction_group) => sst
-                        .table_ids
-                        .iter()
-                        .all(|t| compaction_group.member_table_ids.contains(t)),
-                    None => false,
-                };
+        for ExtendedSstableInfo {
+            compaction_group_id,
+            sst_info: sst,
+            ..
+        } in &mut sstables
+        {
+            let is_sst_belong_to_group_declared = match old_version.levels.get(compaction_group_id)
+            {
+                Some(compaction_group) => sst
+                    .table_ids
+                    .iter()
+                    .all(|t| compaction_group.member_table_ids.contains(t)),
+                None => false,
+            };
             if !is_sst_belong_to_group_declared {
                 let mut group_table_ids: BTreeMap<_, Vec<u32>> = BTreeMap::new();
                 for table_id in sst.get_table_ids() {
@@ -1388,38 +1388,46 @@ where
                         == sst.get_table_ids().len();
                 if is_trivial_adjust {
                     *compaction_group_id = *group_table_ids.first_key_value().unwrap().0;
-                    is_sst_belong_to_group_declared = true;
+                    // is_sst_belong_to_group_declared = true;
                 } else {
                     new_sst_id_number += group_table_ids.len();
                     incorrect_ssts.push((std::mem::take(sst), group_table_ids));
+                    *compaction_group_id =
+                        StaticCompactionGroupId::NewCompactionGroup as CompactionGroupId;
                 }
             }
-            is_sst_belong_to_group_declared
-        });
+        }
         let mut new_sst_id = self
             .env
             .id_gen_manager()
             .generate_interval::<{ IdCategory::HummockSstableId }>(new_sst_id_number as u64)
             .await?;
         let mut branched_ssts = BTreeMapTransaction::new(&mut versioning.branched_ssts);
-        let mut branch_sstables = Vec::with_capacity(new_sst_id_number);
-        for (sst, group_table_ids) in incorrect_ssts {
-            let mut branch_groups = HashMap::new();
-            for (group_id, _match_ids) in group_table_ids {
-                let mut branch_sst = sst.clone();
-                branch_sst.sst_id = new_sst_id;
-                branch_sstables.push(ExtendedSstableInfo::with_compaction_group(
-                    group_id, branch_sst,
-                ));
-                branch_groups.insert(group_id, new_sst_id);
-                new_sst_id += 1;
-            }
-            if !branch_groups.is_empty() {
-                branched_ssts.insert(sst.get_object_id(), branch_groups);
+        let original_sstables = std::mem::take(&mut sstables);
+        sstables.reserve_exact(original_sstables.len() - incorrect_ssts.len() + new_sst_id_number);
+        let mut incorrect_ssts = incorrect_ssts.into_iter();
+        for original_sstable in original_sstables {
+            if original_sstable.compaction_group_id
+                == StaticCompactionGroupId::NewCompactionGroup as CompactionGroupId
+            {
+                let (sst, group_table_ids) = incorrect_ssts.next().unwrap();
+                let mut branch_groups = HashMap::new();
+                for (group_id, _match_ids) in group_table_ids {
+                    let mut branch_sst = sst.clone();
+                    branch_sst.sst_id = new_sst_id;
+                    sstables.push(ExtendedSstableInfo::with_compaction_group(
+                        group_id, branch_sst,
+                    ));
+                    branch_groups.insert(group_id, new_sst_id);
+                    new_sst_id += 1;
+                }
+                if !branch_groups.is_empty() {
+                    branched_ssts.insert(sst.get_object_id(), branch_groups);
+                }
+            } else {
+                sstables.push(original_sstable);
             }
         }
-
-        sstables.append(&mut branch_sstables);
 
         let mut modified_compaction_groups = vec![];
         // Append SSTs to a new version.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
fix(hummock manager): preserve SST order in `commit_epoch`

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
