### PR TITLE
refactor(plan_node): simplify more structures

### DIFF
--- a/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
@@ -47,13 +47,13 @@ pub struct BatchHashJoin {
 impl BatchHashJoin {
     pub fn new(logical: generic::Join<PlanRef>, eq_join_predicate: EqJoinPredicate) -> Self {
         let base = PlanBase::new_logical_with_core(&logical);
-        let ctx = base.ctx.clone();
+        let ctx = base.ctx;
         let dist = Self::derive_dist(
             logical.left.distribution(),
             logical.right.distribution(),
             &logical,
         );
-        let base = PlanBase::new_batch(ctx, base.schema().clone(), dist, Order::any());
+        let base = PlanBase::new_batch(ctx, base.schema, dist, Order::any());
 
         Self {
             base,

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -19,13 +19,13 @@ use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{DistributedLookupJoinNode, LocalLookupJoinNode};
 
-use super::generic::GenericPlanRef;
+use super::generic::{self, GenericPlanRef};
 use super::ExprRewritable;
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::utils::IndicesDisplay;
 use crate::optimizer::plan_node::{
-    EqJoinPredicate, EqJoinPredicateDisplay, LogicalJoin, PlanBase, PlanTreeNodeBinary,
-    PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch, ToLocalBatch,
+    EqJoinPredicate, EqJoinPredicateDisplay, PlanBase, PlanTreeNodeUnary, ToBatchPb,
+    ToDistributedBatch, ToLocalBatch,
 };
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
 use crate::optimizer::PlanRef;
@@ -34,7 +34,7 @@ use crate::utils::ColIndexMappingRewriteExt;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BatchLookupJoin {
     pub base: PlanBase,
-    logical: LogicalJoin,
+    logical: generic::Join<PlanRef>,
 
     /// The join condition must be equivalent to `logical.on`, but separated into equal and
     /// non-equal parts to facilitate execution later
@@ -56,20 +56,20 @@ pub struct BatchLookupJoin {
 
 impl BatchLookupJoin {
     pub fn new(
-        logical: LogicalJoin,
+        logical: generic::Join<PlanRef>,
         eq_join_predicate: EqJoinPredicate,
         right_table_desc: TableDesc,
         right_output_column_ids: Vec<ColumnId>,
         lookup_prefix_len: usize,
         distributed_lookup: bool,
     ) -> Self {
+        let base = PlanBase::new_logical_with_core(&logical);
         // We cannot create a `BatchLookupJoin` without any eq keys. We require eq keys to do the
         // lookup.
         assert!(eq_join_predicate.has_eq());
         assert!(eq_join_predicate.eq_keys_are_type_aligned());
-        let ctx = logical.base.ctx.clone();
-        let dist = Self::derive_dist(logical.left().distribution(), &logical);
-        let base = PlanBase::new_batch(ctx, logical.schema().clone(), dist, Order::any());
+        let dist = Self::derive_dist(logical.left.distribution(), &logical);
+        let base = PlanBase::new_batch(base.ctx, base.schema, dist, Order::any());
         Self {
             base,
             logical,
@@ -81,7 +81,7 @@ impl BatchLookupJoin {
         }
     }
 
-    fn derive_dist(left: &Distribution, logical: &LogicalJoin) -> Distribution {
+    fn derive_dist(left: &Distribution, logical: &generic::Join<PlanRef>) -> Distribution {
         match left {
             Distribution::Single => Distribution::Single,
             Distribution::HashShard(_) | Distribution::UpstreamHashShard(_, _) => {
@@ -117,10 +117,10 @@ impl fmt::Display for BatchLookupJoin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("BatchLookupJoin");
-        builder.field("type", &self.logical.join_type());
+        builder.field("type", &self.logical.join_type);
 
-        let mut concat_schema = self.logical.left().schema().fields.clone();
-        concat_schema.extend(self.logical.right().schema().fields.clone());
+        let mut concat_schema = self.logical.left.schema().fields.clone();
+        concat_schema.extend(self.logical.right.schema().fields.clone());
         let concat_schema = Schema::new(concat_schema);
         builder.field(
             "predicate",
@@ -133,7 +133,7 @@ impl fmt::Display for BatchLookupJoin {
         if verbose {
             if self
                 .logical
-                .output_indices()
+                .output_indices
                 .iter()
                 .copied()
                 .eq(0..self.logical.internal_column_num())
@@ -143,7 +143,7 @@ impl fmt::Display for BatchLookupJoin {
                 builder.field(
                     "output",
                     &IndicesDisplay {
-                        indices: self.logical.output_indices(),
+                        indices: &self.logical.output_indices,
                         input_schema: &concat_schema,
                     },
                 );
@@ -156,14 +156,15 @@ impl fmt::Display for BatchLookupJoin {
 
 impl PlanTreeNodeUnary for BatchLookupJoin {
     fn input(&self) -> PlanRef {
-        self.logical.left()
+        self.logical.left.clone()
     }
 
     // Only change left side
     fn clone_with_input(&self, input: PlanRef) -> Self {
+        let mut logical = self.logical.clone();
+        logical.left = input;
         Self::new(
-            self.logical
-                .clone_with_left_right(input, self.logical.right()),
+            logical,
             self.eq_join_predicate.clone(),
             self.right_table_desc.clone(),
             self.right_output_column_ids.clone(),
@@ -196,7 +197,7 @@ impl ToBatchPb for BatchLookupJoin {
     fn to_batch_prost_body(&self) -> NodeBody {
         if self.distributed_lookup {
             NodeBody::DistributedLookupJoin(DistributedLookupJoinNode {
-                join_type: self.logical.join_type() as i32,
+                join_type: self.logical.join_type as i32,
                 condition: self
                     .eq_join_predicate
                     .other_cond()
@@ -222,7 +223,7 @@ impl ToBatchPb for BatchLookupJoin {
                     .collect(),
                 output_indices: self
                     .logical
-                    .output_indices()
+                    .output_indices
                     .iter()
                     .map(|&x| x as u32)
                     .collect(),
@@ -231,7 +232,7 @@ impl ToBatchPb for BatchLookupJoin {
             })
         } else {
             NodeBody::LocalLookupJoin(LocalLookupJoinNode {
-                join_type: self.logical.join_type() as i32,
+                join_type: self.logical.join_type as i32,
                 condition: self
                     .eq_join_predicate
                     .other_cond()
@@ -258,7 +259,7 @@ impl ToBatchPb for BatchLookupJoin {
                     .collect(),
                 output_indices: self
                     .logical
-                    .output_indices()
+                    .output_indices
                     .iter()
                     .map(|&x| x as u32)
                     .collect(),
@@ -285,14 +286,12 @@ impl ExprRewritable for BatchLookupJoin {
     }
 
     fn rewrite_exprs(&self, r: &mut dyn ExprRewriter) -> PlanRef {
+        let base = self.base.clone_with_new_plan_id();
+        let mut logical = self.logical.clone();
+        logical.rewrite_exprs(r);
         Self {
-            base: self.base.clone_with_new_plan_id(),
-            logical: self
-                .logical
-                .rewrite_exprs(r)
-                .as_logical_join()
-                .unwrap()
-                .clone(),
+            base,
+            logical,
             eq_join_predicate: self.eq_join_predicate.rewrite_exprs(r),
             ..Self::clone(self)
         }

--- a/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
@@ -19,11 +19,8 @@ use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::NestedLoopJoinNode;
 
-use super::generic::GenericPlanRef;
-use super::{
-    ExprRewritable, LogicalJoin, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatchPb,
-    ToDistributedBatch,
-};
+use super::generic::{self, GenericPlanRef};
+use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatchPb, ToDistributedBatch};
 use crate::expr::{Expr, ExprImpl, ExprRewriter};
 use crate::optimizer::plan_node::utils::IndicesDisplay;
 use crate::optimizer::plan_node::ToLocalBatch;
@@ -35,17 +32,15 @@ use crate::utils::ConditionDisplay;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct BatchNestedLoopJoin {
     pub base: PlanBase,
-    logical: LogicalJoin,
+    logical: generic::Join<PlanRef>,
 }
 
 impl BatchNestedLoopJoin {
-    pub fn new(logical: LogicalJoin) -> Self {
-        let ctx = logical.base.ctx.clone();
-        let dist = Self::derive_dist(
-            logical.left().distribution(),
-            logical.right().distribution(),
-        );
-        let base = PlanBase::new_batch(ctx, logical.schema().clone(), dist, Order::any());
+    pub fn new(logical: generic::Join<PlanRef>) -> Self {
+        let base = PlanBase::new_logical_with_core(&logical);
+        let ctx = base.ctx;
+        let dist = Self::derive_dist(logical.left.distribution(), logical.right.distribution());
+        let base = PlanBase::new_batch(ctx, base.schema, dist, Order::any());
         Self { base, logical }
     }
 
@@ -61,7 +56,7 @@ impl fmt::Display for BatchNestedLoopJoin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut builder = f.debug_struct("BatchNestedLoopJoin");
-        builder.field("type", &self.logical.join_type());
+        builder.field("type", &self.logical.join_type);
 
         let mut concat_schema = self.left().schema().fields.clone();
         concat_schema.extend(self.right().schema().fields.clone());
@@ -69,7 +64,7 @@ impl fmt::Display for BatchNestedLoopJoin {
         builder.field(
             "predicate",
             &ConditionDisplay {
-                condition: self.logical.on(),
+                condition: &self.logical.on,
                 input_schema: &concat_schema,
             },
         );
@@ -77,7 +72,7 @@ impl fmt::Display for BatchNestedLoopJoin {
         if verbose {
             if self
                 .logical
-                .output_indices()
+                .output_indices
                 .iter()
                 .copied()
                 .eq(0..self.logical.internal_column_num())
@@ -87,7 +82,7 @@ impl fmt::Display for BatchNestedLoopJoin {
                 builder.field(
                     "output",
                     &IndicesDisplay {
-                        indices: self.logical.output_indices(),
+                        indices: &self.logical.output_indices,
                         input_schema: &concat_schema,
                     },
                 );
@@ -100,15 +95,18 @@ impl fmt::Display for BatchNestedLoopJoin {
 
 impl PlanTreeNodeBinary for BatchNestedLoopJoin {
     fn left(&self) -> PlanRef {
-        self.logical.left()
+        self.logical.left.clone()
     }
 
     fn right(&self) -> PlanRef {
-        self.logical.right()
+        self.logical.right.clone()
     }
 
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new(self.logical.clone_with_left_right(left, right))
+        let mut logical = self.logical.clone();
+        logical.left = left;
+        logical.right = right;
+        Self::new(logical)
     }
 }
 
@@ -130,11 +128,11 @@ impl ToDistributedBatch for BatchNestedLoopJoin {
 impl ToBatchPb for BatchNestedLoopJoin {
     fn to_batch_prost_body(&self) -> NodeBody {
         NodeBody::NestedLoopJoin(NestedLoopJoinNode {
-            join_type: self.logical.join_type() as i32,
-            join_cond: Some(ExprImpl::from(self.logical.on().clone()).to_expr_proto()),
+            join_type: self.logical.join_type as i32,
+            join_cond: Some(ExprImpl::from(self.logical.on.clone()).to_expr_proto()),
             output_indices: self
                 .logical
-                .output_indices()
+                .output_indices
                 .iter()
                 .map(|&x| x as u32)
                 .collect(),
@@ -160,13 +158,8 @@ impl ExprRewritable for BatchNestedLoopJoin {
     }
 
     fn rewrite_exprs(&self, r: &mut dyn ExprRewriter) -> PlanRef {
-        Self::new(
-            self.logical
-                .rewrite_exprs(r)
-                .as_logical_join()
-                .unwrap()
-                .clone(),
-        )
-        .into()
+        let mut logical = self.logical.clone();
+        logical.rewrite_exprs(r);
+        Self::new(logical).into()
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/join.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/join.rs
@@ -37,9 +37,31 @@ pub struct Join<PlanRef> {
     pub output_indices: Vec<usize>,
 }
 
+pub(crate) fn has_repeated_element(slice: &[usize]) -> bool {
+    (1..slice.len()).any(|i| slice[i..].contains(&slice[i - 1]))
+}
+
 impl<PlanRef> Join<PlanRef> {
     pub(crate) fn rewrite_exprs(&mut self, r: &mut dyn ExprRewriter) {
         self.on = self.on.clone().rewrite_expr(r);
+    }
+
+    pub fn new(
+        left: PlanRef,
+        right: PlanRef,
+        on: Condition,
+        join_type: JoinType,
+        output_indices: Vec<usize>,
+    ) -> Self {
+        // We cannot deal with repeated output indices in join
+        debug_assert!(!has_repeated_element(&output_indices));
+        Self {
+            left,
+            right,
+            on,
+            join_type,
+            output_indices,
+        }
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -486,7 +486,7 @@ impl LogicalJoin {
         );
 
         Some(BatchLookupJoin::new(
-            new_logical_join,
+            new_logical_join.core,
             new_predicate,
             table_desc,
             new_scan_output_column_ids,

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1189,13 +1189,9 @@ impl LogicalJoin {
         }
     }
 
-    fn to_batch_hash_join(
-        &self,
-        predicate: EqJoinPredicate,
-        logical_join: LogicalJoin,
-    ) -> Result<PlanRef> {
+    fn into_batch_hash_join(self, predicate: EqJoinPredicate) -> Result<PlanRef> {
         assert!(predicate.has_eq());
-        Ok(BatchHashJoin::new(logical_join.core, predicate).into())
+        Ok(BatchHashJoin::new(self.core, predicate).into())
     }
 
     pub fn index_lookup_join_to_batch_lookup_join(&self) -> Result<PlanRef> {
@@ -1216,13 +1212,9 @@ impl LogicalJoin {
             .into())
     }
 
-    fn to_batch_nested_loop_join(
-        &self,
-        predicate: EqJoinPredicate,
-        logical_join: LogicalJoin,
-    ) -> Result<PlanRef> {
+    fn into_batch_nested_loop_join(self, predicate: EqJoinPredicate) -> Result<PlanRef> {
         assert!(!predicate.has_eq());
-        Ok(BatchNestedLoopJoin::new(logical_join).into())
+        Ok(BatchNestedLoopJoin::new(self.core).into())
     }
 }
 
@@ -1256,10 +1248,10 @@ impl ToBatch for LogicalJoin {
                 }
             }
 
-            self.to_batch_hash_join(predicate, logical_join)
+            logical_join.into_batch_hash_join(predicate)
         } else {
             // Convert to Nested-loop Join for non-equal joins
-            self.to_batch_nested_loop_join(predicate, logical_join)
+            logical_join.into_batch_nested_loop_join(predicate)
         }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -137,16 +137,6 @@ impl LogicalJoin {
         self.core.i2r_col_mapping_ignore_join_type()
     }
 
-    /// Get the Mapping of columnIndex from left column index to internal column index.
-    pub fn l2i_col_mapping(&self) -> ColIndexMapping {
-        self.core.l2i_col_mapping()
-    }
-
-    /// get the Mapping of columnIndex from internal column index to output column index
-    pub fn i2o_col_mapping(&self) -> ColIndexMapping {
-        self.core.i2o_col_mapping()
-    }
-
     /// Get a reference to the logical join's on.
     pub fn on(&self) -> &Condition {
         &self.core.on
@@ -859,7 +849,7 @@ impl PredicatePushdown for LogicalJoin {
             self.output_indices().clone(),
         );
 
-        let mut mapping = self.i2o_col_mapping();
+        let mut mapping = self.core.i2o_col_mapping();
         predicate = predicate.rewrite_expr(&mut mapping);
         LogicalFilter::create(new_join.into(), predicate)
     }
@@ -1379,11 +1369,11 @@ impl ToStream for LogicalJoin {
             let l2o = join_with_pk
                 .core
                 .l2i_col_mapping()
-                .composite(&join_with_pk.i2o_col_mapping());
+                .composite(&join_with_pk.core.i2o_col_mapping());
             let r2o = join_with_pk
                 .core
                 .r2i_col_mapping()
-                .composite(&join_with_pk.i2o_col_mapping());
+                .composite(&join_with_pk.core.i2o_col_mapping());
             let left_right_stream_keys = join_with_pk
                 .left()
                 .logical_pk()

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -1087,11 +1087,11 @@ impl LogicalJoin {
         let right = RequiredDist::no_shuffle(new_stream_table_scan.into());
 
         // Construct a new logical join, because we have change its RHS.
-        let new_logical_join = LogicalJoin::with_output_indices(
+        let new_logical_join = generic::Join::new(
             left,
             right,
-            self.join_type(),
             new_join_on,
+            self.join_type(),
             new_join_output_indices,
         );
 

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -45,7 +45,7 @@ pub struct StreamDeltaJoin {
 impl StreamDeltaJoin {
     pub fn new(logical: generic::Join<PlanRef>, eq_join_predicate: EqJoinPredicate) -> Self {
         let base = PlanBase::new_logical_with_core(&logical);
-        let ctx = base.ctx.clone();
+        let ctx = base.ctx;
         // Inner join won't change the append-only behavior of the stream. The rest might.
         let append_only = match logical.join_type {
             JoinType::Inner => logical.left.append_only() && logical.right.append_only(),
@@ -71,9 +71,9 @@ impl StreamDeltaJoin {
         // TODO: derive from input
         let base = PlanBase::new_stream(
             ctx,
-            base.schema().clone(),
-            base.logical_pk.to_vec(),
-            base.functional_dependency().clone(),
+            base.schema,
+            base.logical_pk,
+            base.functional_dependency,
             dist,
             append_only,
             watermark_columns,

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -66,7 +66,7 @@ pub struct StreamHashJoin {
 impl StreamHashJoin {
     pub fn new(logical: generic::Join<PlanRef>, eq_join_predicate: EqJoinPredicate) -> Self {
         let base = PlanBase::new_logical_with_core(&logical);
-        let ctx = base.ctx.clone();
+        let ctx = base.ctx;
         // Inner join won't change the append-only behavior of the stream. The rest might.
         let append_only = match logical.join_type {
             JoinType::Inner => logical.left.append_only() && logical.right.append_only(),
@@ -182,9 +182,9 @@ impl StreamHashJoin {
         // TODO: derive from input
         let base = PlanBase::new_stream(
             ctx,
-            base.schema().clone(),
-            base.logical_pk.to_vec(),
-            base.functional_dependency().clone(),
+            base.schema,
+            base.logical_pk,
+            base.functional_dependency,
             dist,
             append_only,
             watermark_columns,

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -20,7 +20,7 @@ use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::TemporalJoinNode;
 
-use super::{ExprRewritable, LogicalJoin, PlanBase, PlanRef, PlanTreeNodeBinary, StreamNode};
+use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, StreamNode};
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::plan_tree_node::PlanTreeNodeUnary;
@@ -35,18 +35,16 @@ use crate::utils::ColIndexMappingRewriteExt;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct StreamTemporalJoin {
     pub base: PlanBase,
-    logical: LogicalJoin,
+    logical: generic::Join<PlanRef>,
     eq_join_predicate: EqJoinPredicate,
 }
 
 impl StreamTemporalJoin {
-    pub fn new(logical: LogicalJoin, eq_join_predicate: EqJoinPredicate) -> Self {
-        assert!(
-            logical.join_type() == JoinType::Inner || logical.join_type() == JoinType::LeftOuter
-        );
-        assert!(logical.left().append_only());
-        assert!(logical.right().logical_pk() == eq_join_predicate.right_eq_indexes());
-        let right = logical.right();
+    pub fn new(logical: generic::Join<PlanRef>, eq_join_predicate: EqJoinPredicate) -> Self {
+        assert!(logical.join_type == JoinType::Inner || logical.join_type == JoinType::LeftOuter);
+        assert!(logical.left.append_only());
+        assert!(logical.right.logical_pk() == eq_join_predicate.right_eq_indexes());
+        let right = logical.right.clone();
         let exchange: &StreamExchange = right
             .as_stream_exchange()
             .expect("should be a no shuffle stream exchange");
@@ -57,24 +55,25 @@ impl StreamTemporalJoin {
             .expect("should be a stream table scan");
         assert!(scan.logical().for_system_time_as_of_now());
 
-        let ctx = logical.base.ctx.clone();
+        let base = PlanBase::new_logical_with_core(&logical);
+        let ctx = base.ctx;
         let l2o = logical
             .l2i_col_mapping()
             .composite(&logical.i2o_col_mapping());
-        let dist = l2o.rewrite_provided_distribution(logical.left().distribution());
+        let dist = l2o.rewrite_provided_distribution(logical.left.distribution());
 
         // Use left side watermark directly.
         let watermark_columns = logical.i2o_col_mapping().rewrite_bitset(
             &logical
                 .l2i_col_mapping()
-                .rewrite_bitset(logical.left().watermark_columns()),
+                .rewrite_bitset(logical.left.watermark_columns()),
         );
 
         let base = PlanBase::new_stream(
             ctx,
-            logical.schema().clone(),
-            logical.base.logical_pk.to_vec(),
-            logical.functional_dependency().clone(),
+            base.schema,
+            base.logical_pk,
+            base.functional_dependency,
             dist,
             true,
             watermark_columns,
@@ -89,7 +88,7 @@ impl StreamTemporalJoin {
 
     /// Get join type
     pub fn join_type(&self) -> JoinType {
-        self.logical.join_type()
+        self.logical.join_type
     }
 
     pub fn eq_join_predicate(&self) -> &EqJoinPredicate {
@@ -102,7 +101,7 @@ impl fmt::Display for StreamTemporalJoin {
         let mut builder = f.debug_struct("StreamTemporalJoin");
 
         let verbose = self.base.ctx.is_explain_verbose();
-        builder.field("type", &self.logical.join_type());
+        builder.field("type", &self.logical.join_type);
 
         let mut concat_schema = self.left().schema().fields.clone();
         concat_schema.extend(self.right().schema().fields.clone());
@@ -130,7 +129,7 @@ impl fmt::Display for StreamTemporalJoin {
         if verbose {
             if self
                 .logical
-                .output_indices()
+                .output_indices
                 .iter()
                 .copied()
                 .eq(0..self.logical.internal_column_num())
@@ -140,7 +139,7 @@ impl fmt::Display for StreamTemporalJoin {
                 builder.field(
                     "output",
                     &IndicesDisplay {
-                        indices: self.logical.output_indices(),
+                        indices: &self.logical.output_indices,
                         input_schema: &concat_schema,
                     },
                 );
@@ -153,18 +152,18 @@ impl fmt::Display for StreamTemporalJoin {
 
 impl PlanTreeNodeBinary for StreamTemporalJoin {
     fn left(&self) -> PlanRef {
-        self.logical.left()
+        self.logical.left.clone()
     }
 
     fn right(&self) -> PlanRef {
-        self.logical.right()
+        self.logical.right.clone()
     }
 
     fn clone_with_left_right(&self, left: PlanRef, right: PlanRef) -> Self {
-        Self::new(
-            self.logical.clone_with_left_right(left, right),
-            self.eq_join_predicate.clone(),
-        )
+        let mut logical = self.logical.clone();
+        logical.left = left;
+        logical.right = right;
+        Self::new(logical, self.eq_join_predicate.clone())
     }
 }
 
@@ -190,7 +189,7 @@ impl StreamNode for StreamTemporalJoin {
             .expect("should be a stream table scan");
 
         NodeBody::TemporalJoin(TemporalJoinNode {
-            join_type: self.logical.join_type() as i32,
+            join_type: self.logical.join_type as i32,
             left_key: left_jk_indices_prost,
             right_key: right_jk_indices_prost,
             null_safe: null_safe_prost,
@@ -201,7 +200,7 @@ impl StreamNode for StreamTemporalJoin {
                 .map(|x| x.to_expr_proto()),
             output_indices: self
                 .logical
-                .output_indices()
+                .output_indices
                 .iter()
                 .map(|&x| x as u32)
                 .collect(),
@@ -222,14 +221,8 @@ impl ExprRewritable for StreamTemporalJoin {
     }
 
     fn rewrite_exprs(&self, r: &mut dyn ExprRewriter) -> PlanRef {
-        Self::new(
-            self.logical
-                .rewrite_exprs(r)
-                .as_logical_join()
-                .unwrap()
-                .clone(),
-            self.eq_join_predicate.rewrite_exprs(r),
-        )
-        .into()
+        let mut logical = self.logical.clone();
+        logical.rewrite_exprs(r);
+        Self::new(logical, self.eq_join_predicate.rewrite_exprs(r)).into()
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Deduplicate structures. This is a followup of #8870 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)