### PR TITLE
perf(encoding): use estimate size to reserve memory in row encoding

### DIFF
--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -78,10 +78,7 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     /// Serializes the row with value encoding and returns the bytes.
     #[inline]
     fn value_serialize(&self) -> Vec<u8> {
-        let mut estimate_size: usize = 0;
-        for item in self.iter() {
-            estimate_size += value_encoding::estimate_serialize_datum_size(item);
-        }
+        let estimate_size = self.iter().map(|item| value_encoding::estimate_serialize_datum_size(item)).sum();
         let mut buf = Vec::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
         buf

--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -78,7 +78,11 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     /// Serializes the row with value encoding and returns the bytes.
     #[inline]
     fn value_serialize(&self) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(self.len()); // each datum is at least 1 byte
+        let mut estimate_size: usize = 0;
+        for item in self.iter() {
+            estimate_size += value_encoding::estimate_serialize_datum_size(item);
+        }
+        let mut buf = Vec::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
         buf
     }
@@ -86,7 +90,11 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     /// Serializes the row with value encoding and returns the bytes.
     #[inline]
     fn value_serialize_bytes(&self) -> Bytes {
-        let mut buf = BytesMut::with_capacity(self.len()); // each datum is at least 1 byte
+        let mut estimate_size: usize = 0;
+        for item in self.iter() {
+            estimate_size += value_encoding::estimate_serialize_datum_size(item);
+        }
+        let mut buf = BytesMut::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
         buf.freeze()
     }

--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -78,7 +78,10 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     /// Serializes the row with value encoding and returns the bytes.
     #[inline]
     fn value_serialize(&self) -> Vec<u8> {
-        let estimate_size = self.iter().map(|item| value_encoding::estimate_serialize_datum_size(item)).sum();
+        let estimate_size = self
+            .iter()
+            .map(|item| value_encoding::estimate_serialize_datum_size(item))
+            .sum();
         let mut buf = Vec::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
         buf
@@ -87,10 +90,10 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     /// Serializes the row with value encoding and returns the bytes.
     #[inline]
     fn value_serialize_bytes(&self) -> Bytes {
-        let mut estimate_size: usize = 0;
-        for item in self.iter() {
-            estimate_size += value_encoding::estimate_serialize_datum_size(item);
-        }
+        let estimate_size = self
+            .iter()
+            .map(|item| value_encoding::estimate_serialize_datum_size(item))
+            .sum();
         let mut buf = BytesMut::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
         buf.freeze()

--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -80,7 +80,7 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     fn value_serialize(&self) -> Vec<u8> {
         let estimate_size = self
             .iter()
-            .map(|item| value_encoding::estimate_serialize_datum_size(item))
+            .map(value_encoding::estimate_serialize_datum_size)
             .sum();
         let mut buf = Vec::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);
@@ -92,7 +92,7 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
     fn value_serialize_bytes(&self) -> Bytes {
         let estimate_size = self
             .iter()
-            .map(|item| value_encoding::estimate_serialize_datum_size(item))
+            .map(value_encoding::estimate_serialize_datum_size)
             .sum();
         let mut buf = BytesMut::with_capacity(estimate_size);
         self.value_serialize_into(&mut buf);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

close #8877

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

bench:

```
basic encoding on Int16 time:   [5.6287 ms 5.6303 ms 5.6320 ms]
                        change: [-5.4826% -5.4502% -5.4183%] (p = 0.00 < 0.05)
                        Performance has improved.

basic encoding on Int16 and String
                        time:   [10.036 ms 10.037 ms 10.038 ms]
                        change: [-22.249% -22.226% -22.205%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

basic encoding on Int16 and String (Only need String)
                        time:   [10.061 ms 10.069 ms 10.081 ms]
                        change: [-22.094% -21.948% -21.819%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe
```

