### PR TITLE
fix(ci): quick fix for main cron ci

### DIFF
--- a/ci/scripts/e2e-iceberg-sink-test.sh
+++ b/ci/scripts/e2e-iceberg-sink-test.sh
@@ -101,5 +101,5 @@ else
 fi
 
 echo "--- Kill cluster"
-pkill -f connector-node
 cargo make ci-kill
+pkill -f connector-node

--- a/ci/scripts/e2e-sink-test.sh
+++ b/ci/scripts/e2e-sink-test.sh
@@ -117,5 +117,5 @@ else
 fi
 
 echo "--- Kill cluster"
-pkill -f connector-node
 cargo make ci-kill
+pkill -f connector-node

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -93,11 +93,11 @@ do
 done
 sleep 2
 
-echo "---- mysql & postgres cdc validate test"
+echo "--- mysql & postgres cdc validate test"
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.validate.mysql.slt'
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.validate.postgres.slt'
 
-echo "---- mysql & postgres load and check"
+echo "--- mysql & postgres load and check"
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.load.slt'
 # wait for cdc loading
 sleep 10
@@ -118,8 +118,8 @@ echo "check mviews after cluster recovery"
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'
 
 echo "--- Kill cluster"
-pkill -f connector-node
 cargo make ci-kill
+pkill -f connector-node
 
 echo "--- e2e, ci-1cn-1fe, nexmark endless"
 cargo make ci-start ci-1cn-1fe


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

Kill cluster before connector node to prevent broken pipe error in compute node.
Test run: https://buildkite.com/risingwavelabs/main/builds/3658#01874256-a6f0-45c2-b701-7a4cab842ffb

After https://github.com/risingwavelabs/risingwave/pull/8920, CN will print full stack trace of connector errors. The error report log should be improved, it is verbose to print full stack trace. 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

