### PR TITLE
refactor(risedev): replace std::fs with fs_err

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5662,6 +5662,7 @@ dependencies = [
  "console",
  "dialoguer",
  "enum-iterator",
+ "fs-err",
  "google-cloud-pubsub",
  "indicatif",
  "isahc",

--- a/src/risedevtool/Cargo.toml
+++ b/src/risedevtool/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "4", features = ["derive"] }
 console = "0.15"
 dialoguer = "0.10"
 enum-iterator = "1"
+fs-err = "2.9.0"
 google-cloud-pubsub = "0.7.0"
 indicatif = "0.17"
 isahc = { version = "1", default-features = false, features = ["text-decoding"] }

--- a/src/risedevtool/src/bin/risedev-compose.rs
+++ b/src/risedevtool/src/bin/risedev-compose.rs
@@ -13,13 +13,13 @@
 // limitations under the License.
 
 use std::collections::BTreeMap;
-use std::fs::{self, File};
 use std::io::Read;
 use std::path::Path;
 
 use anyhow::{anyhow, Result};
 use clap::Parser;
 use console::style;
+use fs_err::{self, File};
 use itertools::Itertools;
 use risedev::{
     compose_deploy, compute_risectl_env, Compose, ComposeConfig, ComposeDeployConfig, ComposeFile,
@@ -92,7 +92,7 @@ fn main() -> Result<()> {
 
     let compose_config = ComposeConfig {
         image: load_docker_image_config(
-            &std::fs::read_to_string(RISEDEV_CONFIG_FILE)?,
+            &fs_err::read_to_string(RISEDEV_CONFIG_FILE)?,
             compose_deploy_config
                 .as_ref()
                 .and_then(|x| x.risingwave_image_override.as_ref()),
@@ -164,7 +164,7 @@ fn main() -> Result<()> {
                         .green(),
                         style(&arg).green()
                     )?;
-                    fs::write(
+                    fs_err::write(
                         Path::new(&opts.directory).join("tpch-bench-args-frontend"),
                         arg,
                     )?;
@@ -213,7 +213,7 @@ fn main() -> Result<()> {
                         "-- Redpanda --\ntpch-bench: {}\n",
                         style(&arg).green()
                     )?;
-                    fs::write(
+                    fs_err::write(
                         Path::new(&opts.directory).join("tpch-bench-args-kafka"),
                         arg,
                     )?;
@@ -271,7 +271,7 @@ fn main() -> Result<()> {
                 )?;
             }
 
-            fs::write(
+            fs_err::write(
                 Path::new(&opts.directory).join(format!("{}.yml", node)),
                 yaml,
             )?;
@@ -290,7 +290,7 @@ fn main() -> Result<()> {
 
         println!("\n{}", log_buffer);
 
-        std::fs::write(
+        fs_err::write(
             Path::new(&opts.directory).join("_message.partial.sh"),
             log_buffer,
         )?;
@@ -310,7 +310,7 @@ fn main() -> Result<()> {
 
         let yaml = serde_yaml::to_string(&compose_file)?;
 
-        fs::write(Path::new(&opts.directory).join("docker-compose.yml"), yaml)?;
+        fs_err::write(Path::new(&opts.directory).join("docker-compose.yml"), yaml)?;
     }
 
     Ok(())

--- a/src/risedevtool/src/bin/risedev-config.rs
+++ b/src/risedevtool/src/bin/risedev-config.rs
@@ -14,7 +14,6 @@
 
 #![allow(clippy::needless_question_mark)]
 
-use std::fs::OpenOptions;
 use std::io::{BufRead, BufReader, BufWriter, Write};
 
 use anyhow::{Context, Result};
@@ -22,6 +21,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use console::style;
 use dialoguer::MultiSelect;
 use enum_iterator::{all, Sequence};
+use fs_err::OpenOptions;
 use itertools::Itertools;
 use risedev::RISEDEV_CONFIG_FILE;
 

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -14,13 +14,13 @@
 
 use std::env;
 use std::fmt::Write;
-use std::fs::OpenOptions;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
 use console::style;
+use fs_err::OpenOptions;
 use indicatif::ProgressBar;
 use risedev::util::{complete_spin, fail_spin};
 use risedev::{
@@ -376,14 +376,14 @@ fn main() -> Result<()> {
 
     if let Some(config_path) = &config_path {
         let target = Path::new(&env::var("PREFIX_CONFIG")?).join("risingwave.toml");
-        std::fs::copy(config_path, target).context("config file not found")?;
+        fs_err::copy(config_path, target).context("config file not found")?;
     }
 
     {
         let mut out_str = String::new();
         let mut emitter = YamlEmitter::new(&mut out_str);
         emitter.dump(&risedev_config)?;
-        std::fs::write(
+        fs_err::write(
             Path::new(&env::var("PREFIX_CONFIG")?).join("risedev-expanded.yml"),
             &out_str,
         )?;
@@ -434,7 +434,7 @@ fn main() -> Result<()> {
                 Err(_) => "".into(),
             };
 
-            std::fs::write(
+            fs_err::write(
                 Path::new(&env::var("PREFIX_CONFIG")?).join("risectl-env"),
                 risectl_env,
             )?;

--- a/src/risedevtool/src/bin/risedev-docslt.rs
+++ b/src/risedevtool/src/bin/risedev-docslt.rs
@@ -130,9 +130,9 @@ fn generate_slt_files(package_name: &str) -> Result<()> {
         }
     }
 
-    let rustdoc: JsonValue = serde_json::from_reader(std::io::BufReader::new(
-        std::fs::File::open(format!("target/doc/{}.json", package_name))?,
-    ))?;
+    let rustdoc: JsonValue = serde_json::from_reader(std::io::BufReader::new(fs_err::File::open(
+        format!("target/doc/{}.json", package_name),
+    )?))?;
     let index = rustdoc["index"]
         .as_object()
         .ok_or_else(|| anyhow!("failed to access `index` field as object"))?;
@@ -174,9 +174,9 @@ fn generate_slt_files(package_name: &str) -> Result<()> {
     }
 
     let slt_dir = PathBuf::from(format!("e2e_test/generated/docslt/{}", package_name));
-    std::fs::remove_dir_all(&slt_dir).ok();
+    fs_err::remove_dir_all(&slt_dir).ok();
     if !slt_blocks_per_file.is_empty() {
-        std::fs::create_dir_all(&slt_dir)?;
+        fs_err::create_dir_all(&slt_dir)?;
     }
 
     for filename in slt_blocks_per_file.keys() {
@@ -186,7 +186,7 @@ fn generate_slt_files(package_name: &str) -> Result<()> {
             .components()
             .filter_map(|comp| comp.as_os_str().to_str().filter(|s| *s != "src"))
             .join("__");
-        let mut slt_file = std::fs::File::create(slt_dir.join(slt_filename))?;
+        let mut slt_file = fs_err::File::create(slt_dir.join(slt_filename))?;
         write!(
             slt_file,
             "\

--- a/src/risedevtool/src/compose.rs
+++ b/src/risedevtool/src/compose.rs
@@ -161,7 +161,7 @@ impl Compose for ComputeNodeConfig {
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");
-            std::fs::copy(c, target)?;
+            fs_err::copy(c, target)?;
             command.arg("--config-path").arg("/risingwave.toml");
         }
 
@@ -205,7 +205,7 @@ impl Compose for MetaNodeConfig {
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");
-            std::fs::copy(c, target)?;
+            fs_err::copy(c, target)?;
             command.arg("--config-path").arg("/risingwave.toml");
         }
 
@@ -238,7 +238,7 @@ impl Compose for FrontendConfig {
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");
-            std::fs::copy(c, target)?;
+            fs_err::copy(c, target)?;
             command.arg("--config-path").arg("/risingwave.toml");
         }
 
@@ -268,7 +268,7 @@ impl Compose for CompactorConfig {
 
         if let Some(c) = &config.rw_config_path {
             let target = Path::new(&config.config_directory).join("risingwave.toml");
-            std::fs::copy(c, target)?;
+            fs_err::copy(c, target)?;
             command.arg("--config-path").arg("/risingwave.toml");
         }
 
@@ -404,7 +404,7 @@ impl Compose for PrometheusConfig {
             ..Default::default()
         };
 
-        std::fs::write(
+        fs_err::write(
             Path::new(&config.config_directory).join("prometheus.yaml"),
             prometheus_config,
         )?;
@@ -419,17 +419,17 @@ impl Compose for PrometheusConfig {
 impl Compose for GrafanaConfig {
     fn compose(&self, config: &ComposeConfig) -> Result<ComposeService> {
         let config_root = Path::new(&config.config_directory);
-        std::fs::write(
+        fs_err::write(
             config_root.join("grafana.ini"),
             GrafanaGen.gen_custom_ini(self),
         )?;
 
-        std::fs::write(
+        fs_err::write(
             config_root.join("grafana-risedev-datasource.yml"),
             GrafanaGen.gen_datasource_yml(self)?,
         )?;
 
-        std::fs::write(
+        fs_err::write(
             config_root.join("grafana-risedev-dashboard.yml"),
             GrafanaGen.gen_dashboard_yml(self, config_root, "/")?,
         )?;

--- a/src/risedevtool/src/compose_deploy.rs
+++ b/src/risedevtool/src/compose_deploy.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap};
-use std::fs;
 use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
 
@@ -136,7 +135,7 @@ fi
                 r#"echo "{id}: $(tput setaf 2)done sync config$(tput sgr0)""#,
             )?;
             let sh = format!("_deploy.{id}.partial.sh");
-            std::fs::write(Path::new(output_directory).join(&sh), y)?;
+            fs_err::write(Path::new(output_directory).join(&sh), y)?;
             writeln!(x, "{sh}")?;
         }
         writeln!(x, "EOF")?;
@@ -182,7 +181,7 @@ fi
             }
 
             let sh = format!("_stop.{id}.partial.sh");
-            std::fs::write(Path::new(output_directory).join(&sh), y)?;
+            fs_err::write(Path::new(output_directory).join(&sh), y)?;
             writeln!(x, "{sh}")?;
         }
         writeln!(x, "EOF")?;
@@ -233,7 +232,7 @@ fi
             writeln!(y, "ssh {ssh_extra_args} ubuntu@{public_ip} \"bash -c 'cd {base_folder} && docker compose ps'\"")?;
 
             let sh = format!("_check.{id}.partial.sh");
-            std::fs::write(Path::new(output_directory).join(&sh), y)?;
+            fs_err::write(Path::new(output_directory).join(&sh), y)?;
             writeln!(x, "{sh}")?;
         }
         writeln!(x, "EOF")?;
@@ -241,9 +240,9 @@ fi
         x
     };
     let deploy_sh = Path::new(output_directory).join("deploy.sh");
-    fs::write(&deploy_sh, shell_script)?;
-    let mut perms = fs::metadata(&deploy_sh)?.permissions();
+    fs_err::write(&deploy_sh, shell_script)?;
+    let mut perms = fs_err::metadata(&deploy_sh)?.permissions();
     perms.set_mode(perms.mode() | 0o755);
-    fs::set_permissions(&deploy_sh, perms)?;
+    fs_err::set_permissions(&deploy_sh, perms)?;
     Ok(())
 }

--- a/src/risedevtool/src/config.rs
+++ b/src/risedevtool/src/config.rs
@@ -41,7 +41,7 @@ impl ConfigExpander {
     /// Load a single document YAML file.
     fn load_yaml(path: impl AsRef<Path>) -> Result<Yaml> {
         let path = path.as_ref();
-        let content = std::fs::read_to_string(path)?;
+        let content = fs_err::read_to_string(path)?;
         let [config]: [_; 1] = YamlLoader::load_from_str(&content)?
             .try_into()
             .map_err(|_| anyhow!("expect `{}` to have only one section", path.display()))?;

--- a/src/risedevtool/src/config_gen/grafana_gen.rs
+++ b/src/risedevtool/src/config_gen/grafana_gen.rs
@@ -90,7 +90,7 @@ datasources:
         let filename = "risingwave-dashboard.json";
         let generate_path = generate_path.as_ref();
         let dashboard_path = Path::new(generate_path).join(filename);
-        std::fs::copy("grafana/risingwave-dashboard.json", dashboard_path)?;
+        fs_err::copy("grafana/risingwave-dashboard.json", dashboard_path)?;
 
         let grafana_read_path = grafana_read_path.as_ref();
         let dashboard_path = Path::new(grafana_read_path).join(filename);

--- a/src/risedevtool/src/task/etcd_service.rs
+++ b/src/risedevtool/src/task/etcd_service.rs
@@ -109,7 +109,7 @@ impl Task for EtcdService {
         Self::apply_command_args(&mut cmd, &self.config)?;
 
         let path = Path::new(&env::var("PREFIX_DATA")?).join(self.id());
-        std::fs::create_dir_all(&path)?;
+        fs_err::create_dir_all(&path)?;
         cmd.arg("--data-dir").arg(&path);
 
         ctx.run_command(ctx.tmux_run(cmd)?)?;

--- a/src/risedevtool/src/task/grafana_service.rs
+++ b/src/risedevtool/src/task/grafana_service.rs
@@ -57,28 +57,28 @@ impl GrafanaService {
     ) -> Result<()> {
         let config_root = config_root.as_ref();
 
-        std::fs::write(
+        fs_err::write(
             config_root.join("custom.ini"),
             GrafanaGen.gen_custom_ini(config),
         )?;
 
         let config_datasources_dir = config_root.join("provisioning").join("datasources");
-        std::fs::remove_dir_all(&config_datasources_dir)?;
-        std::fs::create_dir_all(&config_datasources_dir)?;
-        std::fs::write(
+        fs_err::remove_dir_all(&config_datasources_dir)?;
+        fs_err::create_dir_all(&config_datasources_dir)?;
+        fs_err::write(
             config_datasources_dir.join("risedev-prometheus.yml"),
             GrafanaGen.gen_datasource_yml(config)?,
         )?;
 
         let prefix_config = prefix_config.as_ref();
         let config_dashboards_dir = config_root.join("provisioning").join("dashboards");
-        std::fs::remove_dir_all(&config_dashboards_dir)?;
-        std::fs::create_dir_all(&config_dashboards_dir)?;
-        std::fs::write(
+        fs_err::remove_dir_all(&config_dashboards_dir)?;
+        fs_err::create_dir_all(&config_dashboards_dir)?;
+        fs_err::write(
             config_dashboards_dir.join("risingwave-dashboard.yaml"),
             GrafanaGen.gen_dashboard_yml(config, prefix_config, prefix_config)?,
         )?;
-        // std::fs::write(
+        // fs_err::write(
         //     config_dashboards_dir.join("aws-s3-dashboards.yaml"),
         //     &GrafanaGen.gen_s3_dashboard_yml(config, prefix_config)?,
         // )?;

--- a/src/risedevtool/src/task/kafka_service.rs
+++ b/src/risedevtool/src/task/kafka_service.rs
@@ -59,13 +59,13 @@ impl Task for KafkaService {
             Path::new(&env::var("PREFIX_DATA")?).join(self.id())
         } else {
             let path = Path::new("/tmp/risedev").join(self.id());
-            std::fs::remove_dir_all(&path).ok();
+            fs_err::remove_dir_all(&path).ok();
             path
         };
-        std::fs::create_dir_all(&path)?;
+        fs_err::create_dir_all(&path)?;
 
         let config_path = Path::new(&prefix_config).join(format!("{}.properties", self.id()));
-        std::fs::write(
+        fs_err::write(
             &config_path,
             KafkaGen.gen_server_properties(&self.config, &path.to_string_lossy()),
         )?;

--- a/src/risedevtool/src/task/minio_service.rs
+++ b/src/risedevtool/src/task/minio_service.rs
@@ -90,7 +90,7 @@ impl Task for MinioService {
         let prefix_config = env::var("PREFIX_CONFIG")?;
 
         let data_path = Path::new(&env::var("PREFIX_DATA")?).join(self.id());
-        std::fs::create_dir_all(&data_path)?;
+        fs_err::create_dir_all(&data_path)?;
 
         cmd.arg("--config-dir")
             .arg(Path::new(&prefix_config).join("minio"))

--- a/src/risedevtool/src/task/prometheus_service.rs
+++ b/src/risedevtool/src/task/prometheus_service.rs
@@ -63,7 +63,7 @@ impl Task for PrometheusService {
         let prefix_config = env::var("PREFIX_CONFIG")?;
         let prefix_data = env::var("PREFIX_DATA")?;
 
-        std::fs::write(
+        fs_err::write(
             Path::new(&prefix_config).join("prometheus.yml"),
             PrometheusGen.gen_prometheus_yml(&self.config),
         )?;

--- a/src/risedevtool/src/task/zookeeper_service.rs
+++ b/src/risedevtool/src/task/zookeeper_service.rs
@@ -59,13 +59,13 @@ impl Task for ZooKeeperService {
             Path::new(&env::var("PREFIX_DATA")?).join(self.id())
         } else {
             let path = Path::new("/tmp/risedev").join(self.id());
-            std::fs::remove_dir_all(&path).ok();
+            fs_err::remove_dir_all(&path).ok();
             path
         };
-        std::fs::create_dir_all(&path)?;
+        fs_err::create_dir_all(&path)?;
 
         let config_path = Path::new(&prefix_config).join(format!("{}.properties", self.id()));
-        std::fs::write(
+        fs_err::write(
             &config_path,
             ZooKeeperGen.gen_server_properties(&self.config, &path.to_string_lossy()),
         )?;

--- a/src/risedevtool/src/wait.rs
+++ b/src/risedevtool/src/wait.rs
@@ -54,7 +54,7 @@ pub fn wait(
 
         if detect_failure && p.exists() {
             let mut buf = String::new();
-            std::fs::File::open(p)?.read_to_string(&mut buf)?;
+            fs_err::File::open(p)?.read_to_string(&mut buf)?;
 
             return Err(anyhow!(
                 "{} exited while waiting for connection: {}",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at 58b1b15</samp>

### Summary
📁🐛🚀

<!--
1.  📁 - This emoji represents the file system operations and the use of the `fs_err` crate for better error handling and reporting.
2.  🐛 - This emoji represents the bug fixes and improvements in the error handling and debugging of the `risedevtool` project.
3.  🚀 - This emoji represents the enhancement and performance of the RisingWave services by using the `fs_err` crate for file operations.
-->
This pull request replaces the use of the `std::fs` module with the `fs_err` crate for file system operations in the `risedevtool` project. The `fs_err` crate provides better error messages and context for file system errors, which improves the error handling and debugging of the `risedevtool` project. The pull request affects various files that generate, write, read, or copy files for the RisingWave services.

> _Sing, O Muse, of the valiant `risedevtool` and its deeds,_
> _How it tamed the mighty services of RisingWave with skill and speed,_
> _How it faced the errors of the file system with `fs_err` crate,_
> _And how it made the paths and contents clear with messages more great._

### Walkthrough
*  Add `fs-err` crate as a dependency for better error handling of file system operations ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-e027ade1129742352b117864d899a8066478765e1f919f79e40a5f7b7abf75e0R23))
*  Replace `std::fs` functions with `fs_err` functions in various files and functions to provide more information and context in case of errors ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL16), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL139-R138), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL185-R184), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL236-R235), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL244-R246), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L164-R164), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L208-R208), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L241-R241), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L271-R271), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L407-R407), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L422-R432), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-a0b86f76ab974415b54c9d794c8f837a9ddc8b6dd14a00628e0e728de45572b5L93-R93), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-55511385c5fc4c341d26944262a18662cf23038beebc60888a15868c1e164c83L44-R44), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-7afa728c3174a03366e71f23547d94c086b84bd1c5e51483071436515adbc11dL112-R112), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL60-R60), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL66-R68), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL75-R81), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-f8df9e0ae071d45928ac3b6f3f0be7c2771d20d11b9d1f5b9bb4e7ab6c68e946L62-R68), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-45d14e102646a1822f1da9f468a4fdf075f04056b2ea900ebc749ffeb5719249L93-R93), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-2d83bf14797c47a1e76287c3a695b763a60ea6566c1079475beb3df669f72374L66-R66), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-74a6978f73210f9168d8a06515b7ed9529784448c48e2870d9f2f30c2a090a8cL62-R68), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-e48e681b9a74f3b1b00fbd03b738ca0633872ab9fa718be2232fddbcd4805211L57-R57))
*  Remove unused import of `std::fs` module in `compose_deploy.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL16))
*  Generate and write shell scripts for deploying, stopping, and checking the RisingWave services on remote hosts in `compose_deploy.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL139-R138), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL185-R184), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL236-R235), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-bd11ef20121e1dcc69109924778d8b405e01a59f6f1607a0a3b267b6fa980f3fL244-R246))
*  Generate and write docker-compose configuration files for the RisingWave services based on the `ComposeConfig` struct in `compose.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L164-R164), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L208-R208), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L241-R241), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L271-R271), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L407-R407), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-9c334a4fc6b251944c2985e91c9f2534a41634e8fcb4db89fe4c587725f6b6a7L422-R432))
*  Generate and write Grafana configuration files based on the `GrafanaConfig` struct in `grafana_gen.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-a0b86f76ab974415b54c9d794c8f837a9ddc8b6dd14a00628e0e728de45572b5L93-R93))
*  Read and parse YAML configuration files into `Yaml` structs in `config.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-55511385c5fc4c341d26944262a18662cf23038beebc60888a15868c1e164c83L44-R44))
*  Create and execute `Command` structs for running the service binaries with the appropriate arguments in various files implementing the `Task` trait ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-7afa728c3174a03366e71f23547d94c086b84bd1c5e51483071436515adbc11dL112-R112), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL60-R60), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL66-R68), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-3052b2c7d6f7393b2a92f7a56f021f931a3b8d556af7987efda7a8b3a3169f6fL75-R81), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-f8df9e0ae071d45928ac3b6f3f0be7c2771d20d11b9d1f5b9bb4e7ab6c68e946L62-R68), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-45d14e102646a1822f1da9f468a4fdf075f04056b2ea900ebc749ffeb5719249L93-R93), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-2d83bf14797c47a1e76287c3a695b763a60ea6566c1079475beb3df669f72374L66-R66), [link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-74a6978f73210f9168d8a06515b7ed9529784448c48e2870d9f2f30c2a090a8cL62-R68))
*  Wait for a service to start or stop by checking its log file for a specific pattern in `wait.rs` ([link](https://github.com/risingwavelabs/risingwave/pull/8955/files?diff=unified&w=0#diff-e48e681b9a74f3b1b00fbd03b738ca0633872ab9fa718be2232fddbcd4805211L57-R57))



<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
