### PR TITLE
fix(expr): fix `lpad` and `rpad` on empty fill string

### DIFF
--- a/src/expr/src/vector_op/string.rs
+++ b/src/expr/src/vector_op/string.rs
@@ -109,6 +109,11 @@ pub fn lpad(s: &str, length: i32, writer: &mut dyn Write) {
 /// select lpad('hi', 5, 'xy');
 /// ----
 /// xyxhi
+///
+/// query T
+/// select lpad('hi', 5, '');
+/// ----
+/// hi
 /// ```
 #[function("lpad(varchar, int32, varchar) -> varchar")]
 pub fn lpad_fill(s: &str, length: i32, fill: &str, writer: &mut dyn Write) {
@@ -122,6 +127,8 @@ pub fn lpad_fill(s: &str, length: i32, fill: &str, writer: &mut dyn Write) {
         for c in s.chars().take(length as usize) {
             write!(writer, "{c}").unwrap();
         }
+    } else if fill_len == 0 {
+        write!(writer, "{s}").unwrap();
     } else {
         let mut remaining_length = length as usize - s_len;
         while remaining_length >= fill_len {
@@ -177,6 +184,12 @@ pub fn rpad(s: &str, length: i32, writer: &mut dyn Write) {
 /// select rpad('abcdef', 3, '0');
 /// ----
 /// abc
+///
+/// query T
+/// select rpad('hi', 5, '');
+/// ----
+/// hi
+/// ```
 #[function("rpad(varchar, int32, varchar) -> varchar")]
 pub fn rpad_fill(s: &str, length: i32, fill: &str, writer: &mut dyn Write) {
     let s_len = s.chars().count();
@@ -190,6 +203,8 @@ pub fn rpad_fill(s: &str, length: i32, fill: &str, writer: &mut dyn Write) {
         for c in s.chars().take(length as usize) {
             write!(writer, "{c}").unwrap();
         }
+    } else if fill_len == 0 {
+        write!(writer, "{s}").unwrap();
     } else {
         write!(writer, "{s}").unwrap();
         let mut remaining_length = length as usize - s_len;

--- a/src/tests/regress/data/sql/strings.sql
+++ b/src/tests/regress/data/sql/strings.sql
@@ -712,13 +712,13 @@ SELECT lpad('hi', 5, 'xy');
 SELECT lpad('hi', 5);
 SELECT lpad('hi', -5, 'xy');
 SELECT lpad('hello', 2);
---@ SELECT lpad('hi', 5, '');
+SELECT lpad('hi', 5, '');
 
 SELECT rpad('hi', 5, 'xy');
 SELECT rpad('hi', 5);
 SELECT rpad('hi', -5, 'xy');
 SELECT rpad('hello', 2);
---@ SELECT rpad('hi', 5, '');
+SELECT rpad('hi', 5, '');
 
 SELECT ltrim('zzzytrim', 'xyz');
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix #8949

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
Note that for `lpad` and `rpad` function:
```
lpad(string text, length int, fill text)
rpad(string text, length int, fill text)
```

If `fill` is given an empty string and `length` > length of `string`, the function will return `string` directly.

</details>
