### PR TITLE
refactor(meta): refine retry logic for meta client

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -104,6 +104,7 @@ pub async fn compute_node_serve(
         WorkerType::ComputeNode,
         &advertise_addr,
         opts.parallelism,
+        &config.meta,
     )
     .await
     .unwrap();

--- a/src/ctl/src/common/meta_service.rs
+++ b/src/ctl/src/common/meta_service.rs
@@ -15,6 +15,7 @@
 use std::env;
 
 use anyhow::{bail, Result};
+use risingwave_common::config::MetaConfig;
 use risingwave_common::util::addr::HostAddr;
 use risingwave_pb::common::WorkerType;
 use risingwave_rpc_client::MetaClient;
@@ -58,6 +59,7 @@ Note: the default value of `RW_META_ADDR` is 'http://127.0.0.1:5690'.";
             WorkerType::RiseCtl,
             &get_new_ctl_identity(),
             0,
+            &MetaConfig::default(),
         )
         .await?;
         let worker_id = client.worker_id();

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -191,6 +191,7 @@ impl FrontendEnv {
             WorkerType::Frontend,
             &frontend_address,
             0,
+            &config.meta,
         )
         .await?;
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -619,6 +619,8 @@ pub async fn start_service_as_election_leader<S: MetaStore>(
         }
     };
 
+    tracing::info!("Starting meta services");
+
     tonic::transport::Server::builder()
         .layer(MetricsMiddlewareLayer::new(meta_metrics))
         .add_service(HeartbeatServiceServer::new(heartbeat_srv))

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -25,7 +25,7 @@ use futures::stream::BoxStream;
 use itertools::Itertools;
 use lru::LruCache;
 use risingwave_common::catalog::{CatalogVersion, FunctionId, IndexId, TableId};
-use risingwave_common::config::MAX_CONNECTION_WINDOW_SIZE;
+use risingwave_common::config::{MetaConfig, MAX_CONNECTION_WINDOW_SIZE};
 use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::telemetry::report::TelemetryInfoFetcher;
 use risingwave_common::util::addr::HostAddr;
@@ -89,6 +89,7 @@ pub struct MetaClient {
     worker_type: WorkerType,
     host_addr: HostAddr,
     inner: GrpcMetaClient,
+    meta_config: MetaConfig,
 }
 
 impl MetaClient {
@@ -116,12 +117,22 @@ impl MetaClient {
             host: Some(self.host_addr.to_protobuf()),
             worker_id: self.worker_id(),
         };
-        let retry_strategy = GrpcMetaClient::retry_strategy_for_request();
-        tokio_retry::Retry::spawn(retry_strategy, || async {
+
+        let retry_strategy = GrpcMetaClient::retry_strategy_to_bound(
+            Duration::from_secs(self.meta_config.max_heartbeat_interval_secs as u64),
+            true,
+        );
+
+        let result = tokio_retry::Retry::spawn(retry_strategy, || async {
             let request = request.clone();
             self.inner.subscribe(request).await
         })
-        .await
+        .await;
+        if let Err(_e) = result.as_ref() {
+            tracing::error!("debug error {}", self.host_addr.to_string())
+        }
+
+        result
     }
 
     pub async fn create_connection(&self, req: create_connection_request::Payload) -> Result<u32> {
@@ -188,34 +199,41 @@ impl MetaClient {
         worker_type: WorkerType,
         addr: &HostAddr,
         worker_node_parallelism: usize,
+        meta_config: &MetaConfig,
     ) -> Result<(Self, SystemParamsReader)> {
         let addr_strategy = Self::parse_meta_addr(meta_addr)?;
         tracing::info!("register meta client using strategy: {}", addr_strategy);
 
-        let grpc_meta_client = GrpcMetaClient::new(addr_strategy).await?;
+        // Retry until reaching `max_heartbeat_interval_secs`
+        let retry_strategy = GrpcMetaClient::retry_strategy_to_bound(
+            Duration::from_secs(meta_config.max_heartbeat_interval_secs as u64),
+            true,
+        );
 
-        let add_worker_request = AddWorkerNodeRequest {
-            worker_type: worker_type as i32,
-            host: Some(addr.to_protobuf()),
-            worker_node_parallelism: worker_node_parallelism as u64,
-        };
-        let add_worker_resp =
-            tokio_retry::Retry::spawn(GrpcMetaClient::retry_strategy_for_request(), || async {
-                let request = add_worker_request.clone();
-                grpc_meta_client.add_worker_node(request).await
-            })
-            .await?;
+        let init_result: Result<_> = tokio_retry::Retry::spawn(retry_strategy, || async {
+            let grpc_meta_client = GrpcMetaClient::new(&addr_strategy, meta_config.clone()).await?;
+
+            let add_worker_resp = grpc_meta_client
+                .add_worker_node(AddWorkerNodeRequest {
+                    worker_type: worker_type as i32,
+                    host: Some(addr.to_protobuf()),
+                    worker_node_parallelism: worker_node_parallelism as u64,
+                })
+                .await?;
+
+            let system_params_resp = grpc_meta_client
+                .get_system_params(GetSystemParamsRequest {})
+                .await?;
+
+            Ok((add_worker_resp, system_params_resp, grpc_meta_client))
+        })
+        .await;
+
+        let (add_worker_resp, system_params_resp, grpc_meta_client) = init_result?;
+
         let worker_node = add_worker_resp
             .node
             .expect("AddWorkerNodeResponse::node is empty");
-
-        let system_params_request = GetSystemParamsRequest {};
-        let system_params_resp =
-            tokio_retry::Retry::spawn(GrpcMetaClient::retry_strategy_for_request(), || async {
-                let request = system_params_request.clone();
-                grpc_meta_client.get_system_params(request).await
-            })
-            .await?;
 
         Ok((
             Self {
@@ -223,6 +241,7 @@ impl MetaClient {
                 worker_type,
                 host_addr: addr.clone(),
                 inner: grpc_meta_client,
+                meta_config: meta_config.to_owned(),
             },
             system_params_resp.params.unwrap().into(),
         ))
@@ -233,7 +252,10 @@ impl MetaClient {
         let request = ActivateWorkerNodeRequest {
             host: Some(addr.to_protobuf()),
         };
-        let retry_strategy = GrpcMetaClient::retry_strategy_for_request();
+        let retry_strategy = GrpcMetaClient::retry_strategy_to_bound(
+            Duration::from_secs(self.meta_config.max_heartbeat_interval_secs as u64),
+            true,
+        );
         tokio_retry::Retry::spawn(retry_strategy, || async {
             let request = request.clone();
             self.inner.activate_worker_node(request).await
@@ -1107,14 +1129,15 @@ struct MetaMemberGroup {
     members: LruCache<String, Option<MetaMemberClient>>,
 }
 
-struct ElectionMemberManagement {
+struct MetaMemberManagement {
     core_ref: Arc<RwLock<GrpcMetaClientCore>>,
     members: Either<MetaMemberClient, MetaMemberGroup>,
     current_leader: String,
+    meta_config: MetaConfig,
 }
 
-impl ElectionMemberManagement {
-    const ELECTION_MEMBER_REFRESH_PERIOD: Duration = Duration::from_secs(5);
+impl MetaMemberManagement {
+    const META_MEMBER_REFRESH_PERIOD: Duration = Duration::from_secs(5);
 
     fn host_address_to_url(addr: HostAddress) -> String {
         format!("http://{}:{}", addr.host, addr.port)
@@ -1193,8 +1216,17 @@ impl ElectionMemberManagement {
 
             if discovered_leader != self.current_leader {
                 tracing::info!("new meta leader {} discovered", discovered_leader);
-                let (channel, _) =
-                    GrpcMetaClient::try_build_rpc_channel(vec![discovered_leader.clone()]).await?;
+
+                let retry_strategy = GrpcMetaClient::retry_strategy_to_bound(
+                    Duration::from_secs(self.meta_config.meta_leader_lease_secs),
+                    false,
+                );
+
+                let channel = tokio_retry::Retry::spawn(retry_strategy, || async {
+                    let endpoint = GrpcMetaClient::addr_to_endpoint(discovered_leader.clone())?;
+                    GrpcMetaClient::connect_to_endpoint(endpoint).await
+                })
+                .await?;
 
                 self.recreate_core(channel).await;
                 self.current_leader = discovered_leader;
@@ -1206,44 +1238,39 @@ impl ElectionMemberManagement {
 }
 
 impl GrpcMetaClient {
-    // Retry base interval in ms for connecting to meta server.
-    const CONN_RETRY_BASE_INTERVAL_MS: u64 = 100;
-    // Max retry interval in ms for connecting to meta server.
-    const CONN_RETRY_MAX_INTERVAL_MS: u64 = 5000;
     // See `Endpoint::http2_keep_alive_interval`
     const ENDPOINT_KEEP_ALIVE_INTERVAL_SEC: u64 = 60;
     // See `Endpoint::keep_alive_timeout`
     const ENDPOINT_KEEP_ALIVE_TIMEOUT_SEC: u64 = 60;
-    // Max retry times for request to meta server.
-    const REQUEST_RETRY_BASE_INTERVAL_MS: u64 = 50;
+    // Retry base interval in ms for connecting to meta server.
+    const INIT_RETRY_BASE_INTERVAL_MS: u64 = 50;
     // Max retry times for connecting to meta server.
-    const REQUEST_RETRY_MAX_ATTEMPTS: usize = 10;
-    // Max retry interval in ms for request to meta server.
-    const REQUEST_RETRY_MAX_INTERVAL_MS: u64 = 5000;
+    const INIT_RETRY_MAX_INTERVAL_MS: u64 = 5000;
 
     async fn start_meta_member_monitor(
         &self,
         init_leader_addr: String,
         members: Either<MetaMemberClient, MetaMemberGroup>,
         force_refresh_receiver: Receiver<Sender<Result<()>>>,
+        meta_config: MetaConfig,
     ) -> Result<()> {
         let core_ref = self.core.clone();
         let current_leader = init_leader_addr;
 
         let enable_period_tick = matches!(members, Either::Right(_));
 
-        let member_management = ElectionMemberManagement {
+        let member_management = MetaMemberManagement {
             core_ref,
             members,
             current_leader,
+            meta_config,
         };
 
         let mut force_refresh_receiver = force_refresh_receiver;
 
         tokio::spawn(async move {
             let mut member_management = member_management;
-            let mut ticker =
-                time::interval(ElectionMemberManagement::ELECTION_MEMBER_REFRESH_PERIOD);
+            let mut ticker = time::interval(MetaMemberManagement::META_MEMBER_REFRESH_PERIOD);
 
             loop {
                 let result_sender: Option<Sender<Result<()>>> = if enable_period_tick {
@@ -1257,7 +1284,7 @@ impl GrpcMetaClient {
 
                 let tick_result = member_management.refresh_members().await;
                 if let Err(e) = tick_result.as_ref() {
-                    tracing::warn!("refresh election client failed {}", e);
+                    tracing::warn!("refresh meta member client failed {}", e);
                 }
 
                 if let Some(sender) = result_sender {
@@ -1282,8 +1309,8 @@ impl GrpcMetaClient {
     }
 
     /// Connect to the meta server from `addrs`.
-    pub async fn new(strategy: MetaAddressStrategy) -> Result<Self> {
-        let (channel, addr) = match &strategy {
+    pub async fn new(strategy: &MetaAddressStrategy, config: MetaConfig) -> Result<Self> {
+        let (channel, addr) = match strategy {
             MetaAddressStrategy::LoadBalance(addr) => {
                 Self::try_build_rpc_channel(vec![addr.clone()]).await
             }
@@ -1296,7 +1323,7 @@ impl GrpcMetaClient {
         };
 
         let meta_member_client = client.core.read().await.meta_member_client.clone();
-        let members = match &strategy {
+        let members = match strategy {
             MetaAddressStrategy::LoadBalance(_) => Either::Left(meta_member_client),
             MetaAddressStrategy::List(addrs) => {
                 let mut members = LruCache::new(20);
@@ -1310,12 +1337,10 @@ impl GrpcMetaClient {
         };
 
         client
-            .start_meta_member_monitor(addr, members, force_refresh_receiver)
+            .start_meta_member_monitor(addr, members, force_refresh_receiver, config)
             .await?;
 
-        if let Err(e) = client.force_refresh_leader().await {
-            tracing::warn!("force refresh leader failed {}, init leader may failed", e);
-        }
+        client.force_refresh_leader().await?;
 
         Ok(client)
     }
@@ -1332,35 +1357,27 @@ impl GrpcMetaClient {
             .map(|addr| Self::addr_to_endpoint(addr.clone()).map(|endpoint| (endpoint, addr)))
             .try_collect()?;
 
-        let retry_strategy = ExponentialBackoff::from_millis(Self::CONN_RETRY_BASE_INTERVAL_MS)
-            .max_delay(Duration::from_millis(Self::CONN_RETRY_MAX_INTERVAL_MS))
-            .map(jitter);
+        let endpoints = endpoints.clone();
 
-        let channel = tokio_retry::Retry::spawn(retry_strategy, || async {
-            let endpoints = endpoints.clone();
-
-            for (endpoint, addr) in endpoints {
-                match Self::connect_to_endpoint(endpoint).await {
-                    Ok(channel) => {
-                        tracing::info!("Connect to meta server {} successfully", addr);
-                        return Ok((channel, addr));
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            "Failed to connect to meta server {}, trying again: {}",
-                            addr,
-                            e
-                        )
-                    }
+        for (endpoint, addr) in endpoints {
+            match Self::connect_to_endpoint(endpoint).await {
+                Ok(channel) => {
+                    tracing::info!("Connect to meta server {} successfully", addr);
+                    return Ok((channel, addr));
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "Failed to connect to meta server {}, trying again: {}",
+                        addr,
+                        e
+                    )
                 }
             }
+        }
 
-            Err(RpcError::Internal(anyhow!(
-                "Failed to connect to meta server"
-            )))
-        })
-        .await?;
-        Ok(channel)
+        Err(RpcError::Internal(anyhow!(
+            "Failed to connect to meta server"
+        )))
     }
 
     async fn connect_to_endpoint(endpoint: Endpoint) -> Result<Channel> {
@@ -1373,12 +1390,25 @@ impl GrpcMetaClient {
             .map_err(RpcError::TransportError)
     }
 
-    /// Return retry strategy for retrying meta requests.
-    pub fn retry_strategy_for_request() -> impl Iterator<Item = Duration> {
-        ExponentialBackoff::from_millis(Self::REQUEST_RETRY_BASE_INTERVAL_MS)
-            .max_delay(Duration::from_millis(Self::REQUEST_RETRY_MAX_INTERVAL_MS))
-            .map(jitter)
-            .take(Self::REQUEST_RETRY_MAX_ATTEMPTS)
+    pub(crate) fn retry_strategy_to_bound(
+        high_bound: Duration,
+        exceed: bool,
+    ) -> impl Iterator<Item = Duration> {
+        let iter = ExponentialBackoff::from_millis(Self::INIT_RETRY_BASE_INTERVAL_MS)
+            .max_delay(Duration::from_millis(Self::INIT_RETRY_MAX_INTERVAL_MS))
+            .map(jitter);
+
+        let mut sum = Duration::default();
+
+        iter.take_while(move |duration| {
+            sum += *duration;
+
+            if exceed {
+                sum < high_bound + *duration
+            } else {
+                sum < high_bound
+            }
+        })
     }
 }
 

--- a/src/storage/compactor/src/server.rs
+++ b/src/storage/compactor/src/server.rs
@@ -70,9 +70,11 @@ pub async fn compactor_serve(
         WorkerType::Compactor,
         &advertise_addr,
         0,
+        &config.meta,
     )
     .await
     .unwrap();
+
     info!("Assigned compactor id {}", meta_client.worker_id());
     meta_client.activate(&advertise_addr).await.unwrap();
 

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -26,7 +26,9 @@ use clap::Parser;
 use futures::TryStreamExt;
 use risingwave_common::cache::CachePriority;
 use risingwave_common::catalog::TableId;
-use risingwave_common::config::{extract_storage_memory_config, load_config, NO_OVERRIDE};
+use risingwave_common::config::{
+    extract_storage_memory_config, load_config, MetaConfig, NO_OVERRIDE,
+};
 use risingwave_common::util::addr::HostAddr;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_hummock_sdk::{CompactionGroupId, HummockEpoch, FIRST_VERSION_ID};
@@ -230,13 +232,14 @@ async fn init_metadata_for_replay(
     // filter key manager will fail to acquire a key extractor.
     tokio::time::sleep(Duration::from_secs(2)).await;
 
+    let meta_config = MetaConfig::default();
     let meta_client: MetaClient;
     tokio::select! {
         _ = tokio::signal::ctrl_c() => {
             tracing::info!("Ctrl+C received, now exiting");
             std::process::exit(0);
         },
-        ret = MetaClient::register_new(cluster_meta_endpoint, WorkerType::RiseCtl, advertise_addr, 0) => {
+        ret = MetaClient::register_new(cluster_meta_endpoint, WorkerType::RiseCtl, advertise_addr, 0, &meta_config) => {
             (meta_client, _) = ret.unwrap();
         },
     }
@@ -246,8 +249,14 @@ async fn init_metadata_for_replay(
 
     let tables = meta_client.risectl_list_state_tables().await?;
 
-    let (new_meta_client, _) =
-        MetaClient::register_new(new_meta_endpoint, WorkerType::RiseCtl, advertise_addr, 0).await?;
+    let (new_meta_client, _) = MetaClient::register_new(
+        new_meta_endpoint,
+        WorkerType::RiseCtl,
+        advertise_addr,
+        0,
+        &meta_config,
+    )
+    .await?;
     new_meta_client.activate(advertise_addr).await.unwrap();
     if ci_mode {
         let table_to_check = tables.iter().find(|t| t.name == "nexmark_q7").unwrap();
@@ -277,6 +286,7 @@ async fn pull_version_deltas(
         WorkerType::RiseCtl,
         advertise_addr,
         0,
+        &MetaConfig::default(),
     )
     .await?;
     let worker_id = meta_client.worker_id();
@@ -325,9 +335,14 @@ async fn start_replay(
 
     // Register to the cluster.
     // We reuse the RiseCtl worker type here
-    let (meta_client, system_params) =
-        MetaClient::register_new(&opts.meta_address, WorkerType::RiseCtl, &advertise_addr, 0)
-            .await?;
+    let (meta_client, system_params) = MetaClient::register_new(
+        &opts.meta_address,
+        WorkerType::RiseCtl,
+        &advertise_addr,
+        0,
+        &config.meta,
+    )
+    .await?;
     let worker_id = meta_client.worker_id();
     tracing::info!("Assigned replay worker id {}", worker_id);
     meta_client.activate(&advertise_addr).await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

### Summary:

This pull request makes several key updates to our codebase to more effectively integrate with `MetaConfig`. First, we have added a new parameter of type `&MetaConfig` to several function calls that involve `MetaConfig`. This will ensure that our code is working seamlessly with this important configuration tool at all times.

In addition, we have modified our retry strategy for some requests to take `MetaConfig` into account. This will help to optimize our responses and ensure that we are handling user requests in the most efficient way possible.

Finally, we have renamed `ElectionMemberManagement` to `MetaMemberManagement`. We have also adjusted values such as `META_MEMBER_REFRESH_PERIOD` accordingly to reflect this change. Overall, these updates will help our codebase to work more smoothly and consistently with `MetaConfig` as we continue to build and improve our application.


## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
