### PR TITLE
chore(common): add more benchmark cases for hash key

### DIFF
--- a/src/common/benches/bench_hash_key_encoding.rs
+++ b/src/common/benches/bench_hash_key_encoding.rs
@@ -25,7 +25,7 @@ use risingwave_common::test_utils::rand_array::seed_rand_array_ref;
 use risingwave_common::types::DataType;
 
 static SEED: u64 = 998244353u64;
-static CHUNK_SIZES: &[usize] = &[128, 1024, 8192];
+static CHUNK_SIZES: &[usize] = &[128, 1024];
 static NULL_RATIOS: &[f64] = &[0.0, 0.01, 0.1];
 
 trait Case: Send + 'static {

--- a/src/common/benches/bench_hash_key_encoding.rs
+++ b/src/common/benches/bench_hash_key_encoding.rs
@@ -25,7 +25,7 @@ use risingwave_common::test_utils::rand_array::seed_rand_array_ref;
 use risingwave_common::types::DataType;
 
 static SEED: u64 = 998244353u64;
-static CHUNK_SIZES: &[usize] = &[128, 1024];
+static CHUNK_SIZES: &[usize] = &[128, 1024, 8192];
 static NULL_RATIOS: &[f64] = &[0.0, 0.01, 0.1];
 
 trait Case: Send + 'static {
@@ -82,7 +82,7 @@ struct HashKeyBenchCase<K: HashKey> {
 
 impl<K: HashKey> HashKeyBenchCase<K> {
     pub fn new(id: String, input_chunk: DataChunk, data_types: Vec<DataType>) -> Self {
-        // please check the `bench_vec_dser` and `bench_deser` method when want to bench not full
+        // please reference the `bench_vec_deser` and `bench_deser` method for benchmarking partial
         // `col_idxes`
         let col_idxes = (0..input_chunk.columns().len()).collect_vec();
         let keys = HashKey::build(&col_idxes, &input_chunk).unwrap();
@@ -189,6 +189,10 @@ fn case_builders() -> Vec<HashKeyBenchCaseBuilder> {
             describe: "varchar".to_string(),
         },
         HashKeyBenchCaseBuilder {
+            data_types: vec![DataType::Varchar, DataType::Varchar],
+            describe: "composite varchar".to_string(),
+        },
+        HashKeyBenchCaseBuilder {
             data_types: vec![DataType::Int32, DataType::Int32, DataType::Int32],
             describe: "composite fixed".to_string(),
         },
@@ -203,6 +207,30 @@ fn case_builders() -> Vec<HashKeyBenchCaseBuilder> {
         HashKeyBenchCaseBuilder {
             data_types: vec![DataType::Int64, DataType::Varchar],
             describe: "mix fixed and not2".to_string(),
+        },
+        HashKeyBenchCaseBuilder {
+            data_types: vec![DataType::Int64; 8],
+            describe: "medium fixed".to_string(),
+        },
+        HashKeyBenchCaseBuilder {
+            data_types: {
+                let mut v = vec![DataType::Int64; 8];
+                v[7] = DataType::Varchar;
+                v
+            },
+            describe: "medium mixed".to_string(),
+        },
+        HashKeyBenchCaseBuilder {
+            data_types: vec![DataType::Int64; 16],
+            describe: "large fixed".to_string(),
+        },
+        HashKeyBenchCaseBuilder {
+            data_types: {
+                let mut v = vec![DataType::Int64; 16];
+                v[15] = DataType::Varchar;
+                v
+            },
+            describe: "large mixed".to_string(),
         },
     ]
 }

--- a/src/common/benches/bench_hash_key_encoding.rs
+++ b/src/common/benches/bench_hash_key_encoding.rs
@@ -202,11 +202,11 @@ fn case_builders() -> Vec<HashKeyBenchCaseBuilder> {
         },
         HashKeyBenchCaseBuilder {
             data_types: vec![DataType::Int32, DataType::Varchar],
-            describe: "mix fixed and not1".to_string(),
+            describe: "mix fixed and not fixed, case 1".to_string(),
         },
         HashKeyBenchCaseBuilder {
             data_types: vec![DataType::Int64, DataType::Varchar],
-            describe: "mix fixed and not2".to_string(),
+            describe: "mix fixed and not fixed, case 2".to_string(),
         },
         HashKeyBenchCaseBuilder {
             data_types: vec![DataType::Int64; 8],


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Cases with:
- 8 group keys (medium)
- 16 group keys (large)

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
