### PR TITLE
feat(binder): support some alternate names for existing exprs

### DIFF
--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -342,6 +342,7 @@ impl Binder {
                 // "power" is the function name used in PG.
                 ("power", raw_call(ExprType::Pow)),
                 ("ceil", raw_call(ExprType::Ceil)),
+                ("ceiling", raw_call(ExprType::Ceil)),
                 ("floor", raw_call(ExprType::Floor)),
                 ("abs", raw_call(ExprType::Abs)),
                 ("exp", raw_call(ExprType::Exp)),

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -381,6 +381,7 @@ impl Binder {
                     rewrite(ExprType::ConcatWs, Binder::rewrite_concat_to_concat_ws),
                 ),
                 ("concat_ws", raw_call(ExprType::ConcatWs)),
+                ("translate", raw_call(ExprType::Translate)),
                 ("split_part", raw_call(ExprType::SplitPart)),
                 ("char_length", raw_call(ExprType::CharLength)),
                 ("character_length", raw_call(ExprType::CharLength)),

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -214,6 +214,7 @@ impl Binder {
         let func_type = match op {
             UnaryOperator::Not => ExprType::Not,
             UnaryOperator::Minus => ExprType::Neg,
+            UnaryOperator::PGAbs => ExprType::Abs,
             UnaryOperator::PGBitwiseNot => ExprType::BitwiseNot,
             UnaryOperator::Plus => {
                 return self.rewrite_positive(expr);

--- a/src/tests/regress/data/sql/float4.sql
+++ b/src/tests/regress/data/sql/float4.sql
@@ -86,7 +86,7 @@ SELECT f.f1, f.f1 - '-10' AS x FROM FLOAT4_TBL f
 SELECT * FROM FLOAT4_TBL;
 
 -- test the unary float4abs operator
---@ SELECT f.f1, @f.f1 AS abs_f1 FROM FLOAT4_TBL f;
+SELECT f.f1, @f.f1 AS abs_f1 FROM FLOAT4_TBL f;
 
 UPDATE FLOAT4_TBL
    SET f1 = FLOAT4_TBL.f1 * '-1'

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -94,7 +94,7 @@ SELECT f.f1, round(f.f1) AS round_f1
 
 -- ceil / ceiling
 select ceil(f1) as ceil_f1 from float8_tbl f;
---@ select ceiling(f1) as ceiling_f1 from float8_tbl f;
+select ceiling(f1) as ceiling_f1 from float8_tbl f;
 
 -- floor
 select floor(f1) as floor_f1 from float8_tbl f;

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -81,8 +81,8 @@ SELECT f.f1, f.f1 - '-10' AS x
 --@    FROM FLOAT8_TBL f where f.f1 = '1004.3';
 
 -- absolute value
---@ SELECT f.f1, @f.f1 AS abs_f1
---@    FROM FLOAT8_TBL f;
+SELECT f.f1, @f.f1 AS abs_f1
+   FROM FLOAT8_TBL f;
 
 -- truncate
 --@ SELECT f.f1, trunc(f.f1) AS trunc_f1

--- a/src/tests/regress/data/sql/strings.sql
+++ b/src/tests/regress/data/sql/strings.sql
@@ -722,8 +722,8 @@ SELECT rpad('hi', 5, '');
 
 SELECT ltrim('zzzytrim', 'xyz');
 
---@ SELECT translate('', '14', 'ax');
---@ SELECT translate('12345', '14', 'ax');
+SELECT translate('', '14', 'ax');
+SELECT translate('12345', '14', 'ax');
 
 SELECT ascii('x');
 SELECT ascii('');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

* `translate` is implemented but not exposed by frontend
* `@` is the same as `abs`
* `ceiling` is the same as `ceil`

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support `translate`, `@` and `ceiling`.