### PR TITLE
fix(udf): fix wrong number of rows

### DIFF
--- a/src/expr/src/expr/expr_udf.rs
+++ b/src/expr/src/expr/expr_udf.rs
@@ -52,15 +52,21 @@ impl Expression for UdfExpression {
             columns.push(array.as_ref().into());
         }
         let opts =
-            arrow_array::RecordBatchOptions::default().with_row_count(Some(input.cardinality()));
+            arrow_array::RecordBatchOptions::default().with_row_count(Some(input.capacity()));
         let input =
             arrow_array::RecordBatch::try_new_with_options(self.arg_schema.clone(), columns, &opts)
                 .expect("failed to build record batch");
         let output = self.client.call(&self.identifier, input).await?;
-        let arrow_array = output
-            .columns()
-            .get(0)
-            .ok_or(risingwave_udf::Error::NoColumn)?;
+        if output.num_rows() != vis.len() {
+            bail!(
+                "UDF returned {} rows, but expected {}",
+                output.num_rows(),
+                vis.len(),
+            );
+        }
+        let Some(arrow_array) = output.columns().get(0) else {
+            bail!("UDF returned no columns");
+        };
         let mut array = ArrayImpl::from(arrow_array);
         array.set_bitmap(array.null_bitmap() & vis);
         Ok(Arc::new(array))

--- a/src/udf/src/lib.rs
+++ b/src/udf/src/lib.rs
@@ -159,8 +159,6 @@ pub enum Error {
     },
     #[error("UDF service returned no data")]
     NoReturned,
-    #[error("UDF service returned a batch with no column")]
-    NoColumn,
 }
 
 /// Check if two list of data types match, ignoring field names.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR fixes a bug with row numbers in UDF. Since we are sending the entire chunk to UDF server, regardless of visibility, the number of rows should be obtained by `capacity` rather than `cardinality`.

We also added a check to make sure the input and output chunk have the same number of rows. It should return an error and never panic no matter what the UDF server returns, following the principle in #9002.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
