### PR TITLE
feat(expr): support for sqrt function

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6182,6 +6182,7 @@ dependencies = [
  "risingwave_expr_macro",
  "risingwave_pb",
  "risingwave_udf",
+ "rust_decimal",
  "serde_json",
  "speedate",
  "static_assertions",

--- a/e2e_test/batch/functions/sqrt.slt.part
+++ b/e2e_test/batch/functions/sqrt.slt.part
@@ -1,0 +1,26 @@
+# testing sqrt(double precision) 
+query T
+SELECT abs(sqrt('1004.3') - '31.690692639953454') < 1e-12;
+----
+t
+
+query T
+SELECT abs(sqrt('1.2345678901234e+200') - '1.1111111061110856e+100') < 1e-12;
+----
+t
+
+query T
+SELECT abs(sqrt('1.2345678901234e-200') - '1.1111111061110855e-100') < 1e-12;
+----
+t
+
+# testing sqrt(numeric)
+query T
+SELECT abs(sqrt(1004.3) - 31.690692639953453690117860318) < 1e-15;
+----
+t
+
+query T
+SELECT abs(sqrt(82416.3252::decimal) - 287.08243624436518286386154499) < 1e-15;
+----
+t

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -114,6 +114,7 @@ message ExprNode {
     ACOS = 250;
     ATAN = 251;
     ATAN2 = 252;
+    SQRT = 253;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -37,6 +37,7 @@ risingwave_common = { path = "../common" }
 risingwave_expr_macro = { path = "macro" }
 risingwave_pb = { path = "../prost" }
 risingwave_udf = { path = "../udf" }
+rust_decimal = { version = "1", features = ["db-postgres", "maths"] }
 speedate = "0.7.0"
 static_assertions = "1"
 thiserror = "1"

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -354,7 +354,8 @@ impl Binder {
                 ("asin", raw_call(ExprType::Asin)), 
                 ("acos", raw_call(ExprType::Acos)), 
                 ("atan", raw_call(ExprType::Atan)), 
-                ("atan2", raw_call(ExprType::Atan2)),      
+                ("atan2", raw_call(ExprType::Atan2)), 
+                ("sqrt", raw_call(ExprType::Sqrt)),     
 
                 (
                     "to_timestamp",

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -224,6 +224,7 @@ impl Binder {
             UnaryOperator::Plus => {
                 return self.rewrite_positive(expr);
             }
+            UnaryOperator::PGSquareRoot => ExprType::Sqrt,
             _ => {
                 return Err(ErrorCode::NotImplemented(
                     format!("unsupported unary expression: {:?}", op),

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -106,9 +106,9 @@ select floor(f1) as floor_f1 from float8_tbl f;
 SET extra_float_digits = 0;
 
 -- square root
---@ SELECT sqrt(double precision '64') AS eight;
+SELECT sqrt(double precision '64') AS eight;
 
---@ SELECT |/ double precision '64' AS eight;
+SELECT |/ double precision '64' AS eight;
 
 --@ SELECT f.f1, |/f.f1 AS sqrt_f1
 --@    FROM FLOAT8_TBL f


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

fixes: https://github.com/risingwavelabs/risingwave/issues/8899

## What's changed and what's your intention?

enable the the sqrt  calculation of a decimal or a float.
according to [postgres  doc ](https://www.postgresql.org/docs/current/functions-math.html) sqrt function can take either numeric or double precisions
```
sqrt ( numeric ) → numeric

sqrt ( double precision ) → double precision

Square root

sqrt(2) → 1.4142135623730951
```

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
