### PR TITLE
chore(common): Replace `Copy` with `Clone` in `ScalarRef`

### DIFF
--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -754,7 +754,7 @@ mod tests {
     where
         T1: PrimitiveArrayItemType + AsPrimitive<T3>,
         T2: PrimitiveArrayItemType + AsPrimitive<T3>,
-        T3: PrimitiveArrayItemType + CheckedAdd,
+        T3: PrimitiveArrayItemType + CheckedAdd + Copy,
     {
         let mut builder = PrimitiveArrayBuilder::<T3>::new(a.len());
         for (a, b) in a.iter().zip_eq_fast(b.iter()) {

--- a/src/common/src/array/primitive_array.rs
+++ b/src/common/src/array/primitive_array.rs
@@ -175,7 +175,7 @@ impl<T: PrimitiveArrayItemType> Array for PrimitiveArray<T> {
     type RefItem<'a> = T;
 
     unsafe fn raw_value_at_unchecked(&self, idx: usize) -> Self::RefItem<'_> {
-        *self.data.get_unchecked(idx)
+        (*self.data.get_unchecked(idx)).clone()
     }
 
     fn raw_iter(&self) -> impl DoubleEndedIterator<Item = Self::RefItem<'_>> {

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -467,7 +467,7 @@ pub fn option_as_scalar_ref<S: Scalar>(scalar: &Option<S>) -> Option<S::ScalarRe
 /// `ScalarRef` is reciprocal to `Scalar`. Use `to_owned_scalar` to get an
 /// owned scalar.
 pub trait ScalarRef<'a>:
-    Copy
+    Clone
     + std::fmt::Debug
     + Send
     + Sync

--- a/src/expr/src/table_function/generate_series.rs
+++ b/src/expr/src/table_function/generate_series.rs
@@ -85,7 +85,9 @@ where
             cur < stop
         } {
             builder.append(Some(cur.as_scalar_ref()));
-            cur = cur.checked_add(step).ok_or(ExprError::NumericOutOfRange)?;
+            cur = cur
+                .checked_add(step.clone())
+                .ok_or(ExprError::NumericOutOfRange)?;
         }
 
         Ok(Arc::new(builder.finish().into()))

--- a/src/expr/src/vector_op/agg/functions.rs
+++ b/src/expr/src/vector_op/agg/functions.rs
@@ -77,7 +77,7 @@ pub fn min<'a, T>(result: Option<T>, input: Option<T>) -> Result<Option<T>>
 where
     T: ScalarRef<'a> + PartialOrd,
 {
-    let res = match (result, input) {
+    let res = match (result.clone(), input.clone()) {
         (None, _) => input,
         (_, None) => result,
         (Some(r), Some(i)) => Some(if r < i { r } else { i }),
@@ -104,7 +104,7 @@ pub fn max<'a, T>(result: Option<T>, input: Option<T>) -> Result<Option<T>>
 where
     T: ScalarRef<'a> + PartialOrd,
 {
-    let res = match (result, input) {
+    let res = match (result.clone(), input.clone()) {
         (None, _) => input,
         (_, None) => result,
         (Some(r), Some(i)) => Some(if r > i { r } else { i }),

--- a/src/expr/src/vector_op/agg/general_distinct_agg.rs
+++ b/src/expr/src/vector_op/agg/general_distinct_agg.rs
@@ -89,7 +89,9 @@ where
             .take(end_row_id - start_row_id)
             .filter(|scalar_ref| {
                 self.exists.insert(
-                    scalar_ref.map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value()),
+                    scalar_ref
+                        .clone()
+                        .map(|scalar_ref| scalar_ref.to_owned_scalar().to_scalar_value()),
                 )
             });
         let mut cur = self.result.as_ref().map(|x| x.as_scalar_ref());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR attempts to replace `Copy` with `Clone` in `ScalarRef`, which will allow the `PrimitiveItemType` to be used with a wider range of types.


<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at e6226f6</samp>

### Summary
🧮🐑🌟

<!--
1.  🧮 This emoji represents the `CheckedAdd` trait and the overflow checking for arithmetic operations. It also suggests the use of generic types and traits for primitive arrays.
2. 🐑 This emoji represents the `Clone` trait and the cloning of values instead of copying or referencing them. It also suggests the use of scalar types and values for primitive arrays.
3. 🌟 This emoji represents the `distinct` function and the filtering of scalar values. It also suggests the use of table functions and aggregation functions for primitive arrays.
-->
Fixed various issues related to cloning and copying scalar values and primitive arrays. Changed the `ScalarRef` trait to require `Clone` instead of `Copy` and updated the corresponding functions.

> _`Clone` not `Copy`_
> _Overflow checked with `Option`_
> _Traits change like seasons_

### Walkthrough
*  Add `CheckedAdd` and `Copy` traits to generic type `T3` in `add` function for primitive arrays to enable overflow checking and value copying ([link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-2b302a0fdfb8a9f50e8c9b0ba4ce80a917b1e30b05eab979be8c9adc0d770382L757-R757))
*  Change `RefItem` type for primitive arrays from `&T` to `T` and clone dereferenced values in `raw_value_at_unchecked` method to avoid lifetime issues and enable cloning ([link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-9748baa49da1ac4affde4f9b548d0fa0ef019f72e4a5f136a65ea627be81ece2L178-R178))
*  Change `ScalarRef` trait from requiring `Copy` to requiring `Clone` to allow for more flexible and consistent handling of scalar types ([link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-eaafd1f1b7bcfbb3f1f1a20e2064755bdd0867314889c0150ccb19e9f00dddf2L470-R470))
*  Clone values before passing them to `checked_add` method or matching them in `generate_series`, `min`, `max`, and `distinct` functions to avoid moving values that are used later or require `Clone` ([link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-78d825c7ad2e25bcf31c4582d7c649fdeb365b591cc8d94ec7c9149a7a5b6ee6L88-R90), [link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-dd7cd329f5c6e50e70fa03cb86191aad00f633178126b7605a3c9597e52cf7b9L80-R80), [link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-dd7cd329f5c6e50e70fa03cb86191aad00f633178126b7605a3c9597e52cf7b9L107-R107), [link](https://github.com/risingwavelabs/risingwave/pull/9021/files?diff=unified&w=0#diff-32dc467af83e612043711312942d16fe0cfea9e8feebe9dfaac60ff4bb376464L92-R94))






## Checklist For Contributors

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
