### PR TITLE
chore: `rust_decimal` feature -db-tokio-postgres +maths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4703,7 +4703,6 @@ dependencies = [
  "regex",
  "risingwave_common",
  "risingwave_sqlparser",
- "rust_decimal",
  "thiserror",
  "tokio-openssl",
  "tokio-postgres",
@@ -6882,7 +6881,6 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
- "tokio-postgres",
 ]
 
 [[package]]

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -59,7 +59,7 @@ rand = "0.8"
 regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 risingwave_pb = { path = "../prost" }
-rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
+rust_decimal = { version = "1", features = ["db-postgres", "maths"] }
 ryu = "1.0"
 serde = { version = "1", features = ["derive"] }
 serde_default = "0.1"

--- a/src/tests/e2e_extended_mode/Cargo.toml
+++ b/src/tests/e2e_extended_mode/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = { version = "1", features = ["backtrace"] }
 chrono = { version = "0.4", features = ['serde'] }
 clap = { version = "4", features = ["derive"] }
 pg_interval = "0.4"
-rust_decimal ={ version = "1.25", features = ["db-postgres","db-tokio-postgres"] }
+rust_decimal ={ version = "1.25", features = ["db-postgres"] }
 tokio = { version = "1", features = ["rt", "macros","rt-multi-thread"] }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4"] }
 tracing = "0.1"

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -28,7 +28,6 @@ postgres-types = { version = "0.2.4", features = ["derive","with-chrono-0_4"] }
 regex = "1.5"
 risingwave_common = { path = "../../common" }
 risingwave_sqlparser = { path = "../../sqlparser" }
-rust_decimal = { version = "1", features = ["db-tokio-postgres"] }
 thiserror = "1"
 tokio = { version = "0.2", package = "madsim-tokio", features = ["rt", "macros"] }
 tokio-openssl = "0.6.3"

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -84,7 +84,7 @@ regex = { version = "1" }
 regex-syntax = { version = "0.6" }
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"] }
 ring = { version = "0.16", features = ["std"] }
-rust_decimal = { version = "1", features = ["db-postgres", "db-tokio-postgres"] }
+rust_decimal = { version = "1", features = ["db-postgres", "maths"] }
 scopeguard = { version = "1" }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["alloc"] }
@@ -180,7 +180,7 @@ regex = { version = "1" }
 regex-syntax = { version = "0.6" }
 reqwest = { version = "0.11", features = ["blocking", "json", "rustls-tls"] }
 ring = { version = "0.16", features = ["std"] }
-rust_decimal = { version = "1", features = ["db-postgres", "db-tokio-postgres"] }
+rust_decimal = { version = "1", features = ["db-postgres", "maths"] }
 scopeguard = { version = "1" }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_json = { version = "1", features = ["alloc"] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Adjust the features of dependency `rust_decimal`:
* `db-tokio-postgres` = `db-postgres` + `tokio-postgres`. So we do not need both. Actually it only needs `postgres-types`.
* `maths` would enable `pow`, `exp`, `ln`, etc.

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.