### PR TITLE
fix(expr): correctly handle unicode for substr

### DIFF
--- a/e2e_test/batch/functions/substr.slt.part
+++ b/e2e_test/batch/functions/substr.slt.part
@@ -4,7 +4,7 @@ select substr('W7Jc3Vyufj', (INT '-2147483648'));
 ----
 W7Jc3Vyufj
 
-statement error length in substr should be non-negative
+statement error negative substring length not allowed
 select substr('W7Jc3Vyufj', INT '-2147483648', INT '-2147483648');
 
 query T

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -30,12 +30,6 @@ pub fn substr_start(s: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
     Ok(())
 }
 
-// #[function("substr(varchar, 1, int32) -> varchar")]
-// TODO: when is this function called?
-pub fn substr_for(s: &str, count: i32, writer: &mut dyn Write) -> Result<()> {
-    substr_start_for(s, 1, count, writer)
-}
-
 #[function("substr(varchar, int32, int32) -> varchar")]
 pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write) -> Result<()> {
     if count < 0 {
@@ -70,30 +64,28 @@ mod tests {
         let us = "上海自来水来自海上";
 
         let cases = [
-            (s, Some(4), None, "cgccdd"),
-            (s, None, Some(3), "cxs"),
-            (s, Some(4), Some(-2), "[unused result]"),
-            (s, Some(4), Some(2), "cg"),
-            (s, Some(-1), Some(-5), "[unused result]"),
-            (s, Some(-1), Some(0), ""),
-            (s, Some(-1), Some(1), ""),
-            (s, Some(-1), Some(2), ""),
-            (s, Some(-1), Some(3), "c"),
-            (s, Some(-1), Some(5), "cxs"),
+            (s, 4, None, "cgccdd"),
+            (s, 4, Some(-2), "[unused result]"),
+            (s, 4, Some(2), "cg"),
+            (s, -1, Some(-5), "[unused result]"),
+            (s, -1, Some(0), ""),
+            (s, -1, Some(1), ""),
+            (s, -1, Some(2), ""),
+            (s, -1, Some(3), "c"),
+            (s, -1, Some(5), "cxs"),
             // Unicode test
-            (us, Some(1), Some(3), "上海自"),
-            (us, Some(3), Some(3), "自来水"),
-            (us, None, Some(5), "上海自来水"),
-            (us, Some(6), Some(2), "来自"),
-            (us, Some(6), Some(100), "来自海上"),
-            (us, Some(6), None, "来自海上"),
-            ("Mér", Some(1), Some(2), "Mé"),
+            (us, 1, Some(3), "上海自"),
+            (us, 3, Some(3), "自来水"),
+            (us, 6, Some(2), "来自"),
+            (us, 6, Some(100), "来自海上"),
+            (us, 6, None, "来自海上"),
+            ("Mér", 1, Some(2), "Mé"),
         ];
 
         for (s, off, len, expected) in cases {
             let mut writer = String::new();
-            match (off, len) {
-                (Some(off), Some(len)) => {
+            match len {
+                Some(len) => {
                     let result = substr_start_for(s, off, len, &mut writer);
                     if len < 0 {
                         assert!(result.is_err());
@@ -102,9 +94,7 @@ mod tests {
                         result?
                     }
                 }
-                (Some(off), None) => substr_start(s, off, &mut writer)?,
-                (None, Some(len)) => substr_for(s, len, &mut writer)?,
-                _ => unreachable!(),
+                None => substr_start(s, off, &mut writer)?,
             }
             assert_eq!(writer, expected);
         }

--- a/src/expr/src/vector_op/substr.rs
+++ b/src/expr/src/vector_op/substr.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp::min;
 use std::fmt::Write;
 
 use risingwave_expr_macro::function;
@@ -50,7 +49,7 @@ pub fn substr_start_for(s: &str, start: i32, count: i32, writer: &mut dyn Write)
     let take = if start >= 1 {
         count as usize
     } else {
-        count.saturating_add(start.saturating_sub(1)) as usize
+        count.saturating_add(start.saturating_sub(1)).max(0) as usize
     };
 
     let substr = s.chars().skip(skip).take(take);
@@ -76,6 +75,10 @@ mod tests {
             (s, Some(4), Some(-2), "[unused result]"),
             (s, Some(4), Some(2), "cg"),
             (s, Some(-1), Some(-5), "[unused result]"),
+            (s, Some(-1), Some(0), ""),
+            (s, Some(-1), Some(1), ""),
+            (s, Some(-1), Some(2), ""),
+            (s, Some(-1), Some(3), "c"),
             (s, Some(-1), Some(5), "cxs"),
             // Unicode test
             (us, Some(1), Some(3), "上海自"),

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -64,7 +64,7 @@ fn is_numeric_overflow_error(db_error: &str) -> bool {
 
 /// Negative substr error
 fn is_neg_substr_error(db_error: &str) -> bool {
-    db_error.contains("length in substr should be non-negative")
+    db_error.contains("negative substring length not allowed")
 }
 
 /// Certain errors are permitted to occur. This is because:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Close #9065.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
