### PR TITLE
fix(agg): `stddev` uses `sqrt` for decimal support

### DIFF
--- a/e2e_test/batch/aggregate/stddev_and_variance.slt.part
+++ b/e2e_test/batch/aggregate/stddev_and_variance.slt.part
@@ -21,25 +21,40 @@ statement ok
 insert into t values (2), (3), (4), (5), (6)
 
 query RRRR
-select stddev_pop(v), stddev_samp(v), var_pop(v), var_samp(v) from t
+select
+	round(stddev_pop(v), 16),
+	round(stddev_samp(v), 16),
+	round(var_pop(v), 16),
+	round(var_samp(v), 1)
+from t
 ----
-1.707825127659933 1.8708286933869707 2.9166666666666666666666666667 3.50
+1.7078251276599331 1.8708286933869707 2.9166666666666667 3.5
 
 statement ok
 delete from t where v = 3
 
 query RRRR
-select stddev_pop(v), stddev_samp(v), var_pop(v), var_samp(v) from t
+select
+	round(stddev_pop(v), 16),
+	round(stddev_samp(v), 16),
+	round(var_pop(v), 2),
+	round(var_samp(v), 1)
+from t
 ----
-1.8547236990991407 2.073644135332772 3.44 4.30
+1.8547236990991408 2.0736441353327721 3.44 4.3
 
 statement ok
 update t set v = 7 where v = 4
 
 query RRRR
-select stddev_pop(v), stddev_samp(v), var_pop(v), var_samp(v) from t
+select
+	round(stddev_pop(v), 16),
+	round(stddev_samp(v), 16),
+	round(var_pop(v), 2),
+	round(var_samp(v), 1)
+from t
 ----
-2.3151673805580453 2.588435821108957 5.36 6.70
+2.3151673805580451 2.5884358211089569 5.36 6.7
 
 statement ok
 drop table t

--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1015,26 +1015,26 @@
     create table t (v1 int);
     select stddev_samp(v1), stddev_pop(v1) from t;
   logical_plan: |
-    LogicalProject { exprs: [Case((count(t.v1) <= 1:Int64), null:Decimal::Float64, Pow(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / (count(t.v1) - 1:Int64))::Float64, 0.5:Float64)) as $expr2, Pow(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / count(t.v1))::Float64, 0.5:Float64) as $expr3] }
+    LogicalProject { exprs: [Case((count(t.v1) <= 1:Int64), null:Decimal, Sqrt(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / (count(t.v1) - 1:Int64)))) as $expr2, Sqrt(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / count(t.v1))) as $expr3] }
     └─LogicalAgg { aggs: [sum($expr1), sum(t.v1), count(t.v1)] }
       └─LogicalProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1] }
         └─LogicalScan { table: t, columns: [t.v1, t._row_id] }
   batch_plan: |
-    BatchProject { exprs: [Case((sum0(count(t.v1)) <= 1:Int64), null:Float64, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / (sum0(count(t.v1)) - 1:Int64))::Float64, 0.5:Float64)) as $expr2, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / sum0(count(t.v1)))::Float64, 0.5:Float64) as $expr3] }
+    BatchProject { exprs: [Case((sum0(count(t.v1)) <= 1:Int64), null:Decimal, Sqrt(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / (sum0(count(t.v1)) - 1:Int64)))) as $expr2, Sqrt(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / sum0(count(t.v1)))) as $expr3] }
     └─BatchSimpleAgg { aggs: [sum(sum($expr1)), sum(sum(t.v1)), sum0(count(t.v1))] }
       └─BatchExchange { order: [], dist: Single }
         └─BatchSimpleAgg { aggs: [sum($expr1), sum(t.v1), count(t.v1)] }
           └─BatchProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1] }
             └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   batch_local_plan: |
-    BatchProject { exprs: [Case((count(t.v1) <= 1:Int64), null:Float64, Pow(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / (count(t.v1) - 1:Int64))::Float64, 0.5:Float64)) as $expr2, Pow(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / count(t.v1))::Float64, 0.5:Float64) as $expr3] }
+    BatchProject { exprs: [Case((count(t.v1) <= 1:Int64), null:Decimal, Sqrt(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / (count(t.v1) - 1:Int64)))) as $expr2, Sqrt(((sum($expr1)::Decimal - ((sum(t.v1)::Decimal * sum(t.v1)::Decimal) / count(t.v1))) / count(t.v1))) as $expr3] }
     └─BatchSimpleAgg { aggs: [sum($expr1), sum(t.v1), count(t.v1)] }
       └─BatchExchange { order: [], dist: Single }
         └─BatchProject { exprs: [t.v1, (t.v1 * t.v1) as $expr1] }
           └─BatchScan { table: t, columns: [t.v1], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [stddev_samp, stddev_pop], stream_key: [], pk_columns: [], pk_conflict: "NoCheck" }
-    └─StreamProject { exprs: [Case((sum0(count(t.v1)) <= 1:Int64), null:Float64, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / (sum0(count(t.v1)) - 1:Int64))::Float64, 0.5:Float64)) as $expr2, Pow(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / sum0(count(t.v1)))::Float64, 0.5:Float64) as $expr3] }
+    └─StreamProject { exprs: [Case((sum0(count(t.v1)) <= 1:Int64), null:Decimal, Sqrt(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / (sum0(count(t.v1)) - 1:Int64)))) as $expr2, Sqrt(((sum(sum($expr1))::Decimal - ((sum(sum(t.v1))::Decimal * sum(sum(t.v1))::Decimal) / sum0(count(t.v1)))) / sum0(count(t.v1)))) as $expr3] }
       └─StreamGlobalSimpleAgg { aggs: [sum(sum($expr1)), sum(sum(t.v1)), sum0(count(t.v1)), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessLocalSimpleAgg { aggs: [sum($expr1), sum(t.v1), count(t.v1)] }
@@ -1044,7 +1044,7 @@
   sql: |
     select count(''), stddev_samp(1);
   logical_plan: |
-    LogicalProject { exprs: [count('':Varchar), Case((count(1:Int32) <= 1:Int64), null:Decimal::Float64, Pow(((sum($expr1)::Decimal - ((sum(1:Int32)::Decimal * sum(1:Int32)::Decimal) / count(1:Int32))) / (count(1:Int32) - 1:Int64))::Float64, 0.5:Float64)) as $expr2] }
+    LogicalProject { exprs: [count('':Varchar), Case((count(1:Int32) <= 1:Int64), null:Decimal, Sqrt(((sum($expr1)::Decimal - ((sum(1:Int32)::Decimal * sum(1:Int32)::Decimal) / count(1:Int32))) / (count(1:Int32) - 1:Int64)))) as $expr2] }
     └─LogicalAgg { aggs: [count('':Varchar), sum($expr1), sum(1:Int32), count(1:Int32)] }
       └─LogicalProject { exprs: ['':Varchar, 1:Int32, (1:Int32 * 1:Int32) as $expr1] }
         └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
@@ -1053,7 +1053,7 @@
     create table t(v int, w float);
     select stddev_samp(v) from t group by w;
   logical_plan: |
-    LogicalProject { exprs: [Case((count(t.v) <= 1:Int64), null:Decimal::Float64, Pow(((sum($expr1)::Decimal - ((sum(t.v)::Decimal * sum(t.v)::Decimal) / count(t.v))) / (count(t.v) - 1:Int64))::Float64, 0.5:Float64)) as $expr2] }
+    LogicalProject { exprs: [Case((count(t.v) <= 1:Int64), null:Decimal, Sqrt(((sum($expr1)::Decimal - ((sum(t.v)::Decimal * sum(t.v)::Decimal) / count(t.v))) / (count(t.v) - 1:Int64)))) as $expr2] }
     └─LogicalAgg { group_key: [t.w], aggs: [sum($expr1), sum(t.v), count(t.v)] }
       └─LogicalProject { exprs: [t.w, t.v, (t.v * t.v) as $expr1] }
         └─LogicalScan { table: t, columns: [t.v, t.w, t._row_id] }

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -18,7 +18,7 @@ use std::fmt;
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, Result, TrackingIssue};
-use risingwave_common::types::{DataType, Datum, ScalarImpl, F64};
+use risingwave_common::types::{DataType, Datum, ScalarImpl};
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_expr::expr::AggKind;
 
@@ -732,19 +732,7 @@ impl LogicalAggBuilder {
                 // stddev = sqrt(variance)
                 if matches!(agg_kind, AggKind::StddevPop | AggKind::StddevSamp) {
                     target_expr = ExprImpl::from(
-                        FunctionCall::new(
-                            ExprType::Pow,
-                            vec![
-                                target_expr.clone(),
-                                // TODO: The decimal implementation now still relies on float64, so
-                                // float64 is still used here
-                                ExprImpl::from(Literal::new(
-                                    Datum::from(ScalarImpl::Float64(F64::from(0.5))),
-                                    DataType::Float64,
-                                )),
-                            ],
-                        )
-                        .unwrap(),
+                        FunctionCall::new(ExprType::Sqrt, vec![target_expr]).unwrap(),
                     );
                 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

A `stddev` aggregate may return `decimal` or `double precision`. But in the last step of taking square root, we used to be restricted to `power(double precision, 0.5) -> double precision` and cannot support decimal correctly. This PR switches to the newly supported `sqrt` function directly.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
