### PR TITLE
fix(streaming): only disable sanity check for schema changable table

### DIFF
--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -85,13 +85,17 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
 
         let schema = input.schema().clone();
 
-        // TODO: If we do some `Delete` after schema change, we cannot ensure the encoded value
-        // with the new version of serializer is the same as the old one, even if they can be
-        // decoded into the same value. The table is now performing consistency check on the raw
-        // bytes, so we need to turn off the check here. We may turn it on if we can compare the
-        // decoded row.
-        let state_table =
-            StateTableInner::from_table_catalog_inconsistent_op(table_catalog, store, vnodes).await;
+        let state_table = if table_catalog.version.is_some() {
+            // TODO: If we do some `Delete` after schema change, we cannot ensure the encoded value
+            // with the new version of serializer is the same as the old one, even if they can be
+            // decoded into the same value. The table is now performing consistency check on the raw
+            // bytes, so we need to turn off the check here. We may turn it on if we can compare the
+            // decoded row.
+            StateTableInner::from_table_catalog_inconsistent_op(table_catalog, store, vnodes).await
+        } else {
+            StateTableInner::from_table_catalog(table_catalog, store, vnodes).await
+        };
+
         let actor_id = actor_context.id;
         let table_id = table_catalog.id;
         Self {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This is previously disabled in https://github.com/risingwavelabs/risingwave/pull/8394#discussion_r1129182626. However, for tables (materialized views) that do not support schema change (determined by `version` field), we can still enable it for better debugging (like #9082).

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
