### PR TITLE
perf(encoding): Comparing row and data_chunk benchmarks

### DIFF
--- a/src/common/benches/bench_data_chunk_encoding.rs
+++ b/src/common/benches/bench_data_chunk_encoding.rs
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 use criterion::{criterion_group, criterion_main, Criterion};
+use itertools::Itertools;
+use risingwave_common::row::Row;
 use risingwave_common::test_utils::rand_chunk;
 use risingwave_common::types::DataType;
 
@@ -52,12 +54,20 @@ fn bench_data_chunk_encoding(c: &mut Criterion) {
     for case in test_cases {
         for null_ratio in NULL_RATIOS {
             for chunk_size in CHUNK_SIZES {
-                let id = format!(
+                let chunk = rand_chunk::gen_chunk(&case.data_types, *chunk_size, SEED, *null_ratio);
+                let mut group = c.benchmark_group(&format!(
                     "data chunk encoding: {}, {} rows, Pr[null]={}",
                     case.name, chunk_size, null_ratio
-                );
-                let chunk = rand_chunk::gen_chunk(&case.data_types, *chunk_size, SEED, *null_ratio);
-                c.bench_function(&id, |b| b.iter(|| chunk.serialize()));
+                ));
+                group.bench_function("chunk serialize", |b| b.iter(|| chunk.serialize()));
+                group.bench_function("row serialize", |b| {
+                    b.iter(|| {
+                        chunk
+                            .rows()
+                            .map(|x| x.value_serialize_bytes())
+                            .collect_vec()
+                    })
+                });
             }
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

benchmark

```
data chunk encoding: Int16, 128 rows, Pr[null]=0/chunk serialize
                        time:   [5.0701 µs 5.0706 µs 5.0711 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
data chunk encoding: Int16, 128 rows, Pr[null]=0/row serialize
                        time:   [8.6078 µs 8.6085 µs 8.6093 µs]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  5 (5.00%) high severe

data chunk encoding: Int16, 1024 rows, Pr[null]=0/chunk serialize
                        time:   [69.156 µs 69.166 µs 69.176 µs]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
data chunk encoding: Int16, 1024 rows, Pr[null]=0/row serialize
                        time:   [83.726 µs 83.732 µs 83.737 µs]
Found 11 outliers among 100 measurements (11.00%)
  3 (3.00%) low severe
  6 (6.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

data chunk encoding: Int16, 128 rows, Pr[null]=0.01/chunk serialize
                        time:   [8.6909 µs 8.6925 µs 8.6948 µs]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  5 (5.00%) high mild
  3 (3.00%) high severe
data chunk encoding: Int16, 128 rows, Pr[null]=0.01/row serialize
                        time:   [8.5900 µs 8.5908 µs 8.5915 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

data chunk encoding: Int16, 1024 rows, Pr[null]=0.01/chunk serialize
                        time:   [62.904 µs 62.911 µs 62.920 µs]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe
data chunk encoding: Int16, 1024 rows, Pr[null]=0.01/row serialize
                        time:   [83.820 µs 83.826 µs 83.832 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  3 (3.00%) high severe

data chunk encoding: Int16, 128 rows, Pr[null]=0.1/chunk serialize
                        time:   [7.5266 µs 7.5301 µs 7.5366 µs]
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
data chunk encoding: Int16, 128 rows, Pr[null]=0.1/row serialize
                        time:   [8.5352 µs 8.5357 µs 8.5363 µs]
Found 13 outliers among 100 measurements (13.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  6 (6.00%) high mild
  3 (3.00%) high severe

data chunk encoding: Int16, 1024 rows, Pr[null]=0.1/chunk serialize
                        time:   [59.760 µs 59.767 µs 59.775 µs]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe
data chunk encoding: Int16, 1024 rows, Pr[null]=0.1/row serialize
                        time:   [83.034 µs 83.056 µs 83.080 µs]
Found 17 outliers among 100 measurements (17.00%)
  14 (14.00%) low mild
  3 (3.00%) high severe

data chunk encoding: String, 128 rows, Pr[null]=0/chunk serialize
                        time:   [10.809 µs 10.811 µs 10.813 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
data chunk encoding: String, 128 rows, Pr[null]=0/row serialize
                        time:   [9.5197 µs 9.5216 µs 9.5236 µs]
Found 15 outliers among 100 measurements (15.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  8 (8.00%) high severe

data chunk encoding: String, 1024 rows, Pr[null]=0/chunk serialize
                        time:   [95.931 µs 95.939 µs 95.948 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe
data chunk encoding: String, 1024 rows, Pr[null]=0/row serialize
                        time:   [80.815 µs 80.821 µs 80.828 µs]
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild
  3 (3.00%) high severe

data chunk encoding: String, 128 rows, Pr[null]=0.01/chunk serialize
                        time:   [10.917 µs 10.918 µs 10.920 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild
  2 (2.00%) high severe
data chunk encoding: String, 128 rows, Pr[null]=0.01/row serialize
                        time:   [10.779 µs 10.780 µs 10.782 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  1 (1.00%) high severe

data chunk encoding: String, 1024 rows, Pr[null]=0.01/chunk serialize
                        time:   [95.852 µs 95.861 µs 95.870 µs]
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
data chunk encoding: String, 1024 rows, Pr[null]=0.01/row serialize
                        time:   [80.384 µs 80.393 µs 80.402 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  3 (3.00%) high mild
  2 (2.00%) high severe

data chunk encoding: String, 128 rows, Pr[null]=0.1/chunk serialize
                        time:   [9.2865 µs 9.2876 µs 9.2887 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  3 (3.00%) high mild
  1 (1.00%) high severe
data chunk encoding: String, 128 rows, Pr[null]=0.1/row serialize
                        time:   [9.3390 µs 9.3404 µs 9.3418 µs]
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

data chunk encoding: String, 1024 rows, Pr[null]=0.1/chunk serialize
                        time:   [93.670 µs 93.686 µs 93.702 µs]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
data chunk encoding: String, 1024 rows, Pr[null]=0.1/row serialize
                        time:   [79.640 µs 79.649 µs 79.660 µs]
Found 15 outliers among 100 measurements (15.00%)
  3 (3.00%) low severe
  1 (1.00%) low mild
  7 (7.00%) high mild
  4 (4.00%) high severe

data chunk encoding: Int16 and String, 128 rows, Pr[null]=0/chunk serialize
                        time:   [10.868 µs 10.869 µs 10.870 µs]
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  4 (4.00%) high mild
data chunk encoding: Int16 and String, 128 rows, Pr[null]=0/row serialize
                        time:   [12.174 µs 12.175 µs 12.177 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  4 (4.00%) high mild

data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0/chunk serialize
                        time:   [105.91 µs 105.92 µs 105.94 µs]
Found 5 outliers among 100 measurements (5.00%)
  4 (4.00%) high mild
  1 (1.00%) high severe
data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0/row serialize
                        time:   [102.68 µs 102.69 µs 102.70 µs]
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

data chunk encoding: Int16 and String, 128 rows, Pr[null]=0.01/chunk serialize
                        time:   [10.801 µs 10.803 µs 10.805 µs]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low severe
  1 (1.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe
data chunk encoding: Int16 and String, 128 rows, Pr[null]=0.01/row serialize
                        time:   [12.182 µs 12.184 µs 12.185 µs]
Found 5 outliers among 100 measurements (5.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  2 (2.00%) high severe

data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0.01/chunk serialize
                        time:   [91.962 µs 91.978 µs 91.996 µs]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe
data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0.01/row serialize
                        time:   [102.06 µs 102.07 µs 102.08 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

data chunk encoding: Int16 and String, 128 rows, Pr[null]=0.1/chunk serialize
                        time:   [10.963 µs 10.964 µs 10.965 µs]
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe
data chunk encoding: Int16 and String, 128 rows, Pr[null]=0.1/row serialize
                        time:   [11.878 µs 11.879 µs 11.881 µs]
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  7 (7.00%) high mild
  1 (1.00%) high severe

data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0.1/chunk serialize
                        time:   [93.566 µs 93.578 µs 93.590 µs]
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe
data chunk encoding: Int16 and String, 1024 rows, Pr[null]=0.1/row serialize
                        time:   [100.13 µs 100.13 µs 100.14 µs]
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  6 (6.00%) high mild
  2 (2.00%) high severe

data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0/chunk serialize
                        time:   [16.025 µs 16.031 µs 16.039 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0/row serialize
                        time:   [17.625 µs 17.627 µs 17.630 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe

data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0/chunk serialize
                        time:   [129.43 µs 129.45 µs 129.47 µs]
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low severe
  1 (1.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0/row serialize
                        time:   [146.83 µs 146.85 µs 146.87 µs]
Found 10 outliers among 100 measurements (10.00%)
  3 (3.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild

data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0.01/chunk serialize
                        time:   [13.750 µs 13.752 µs 13.754 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0.01/row serialize
                        time:   [17.625 µs 17.626 µs 17.627 µs]
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  2 (2.00%) high mild
  2 (2.00%) high severe

data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0.01/chunk serialize
                        time:   [129.41 µs 129.43 µs 129.45 µs]
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0.01/row serialize
                        time:   [145.90 µs 145.93 µs 145.96 µs]
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe

data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0.1/chunk serialize
                        time:   [15.721 µs 15.723 µs 15.724 µs]
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 128 rows, Pr[null]=0.1/row serialize
                        time:   [17.050 µs 17.052 µs 17.054 µs]
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low severe
  6 (6.00%) high mild
  1 (1.00%) high severe

data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0.1/chunk serialize
                        time:   [132.81 µs 132.83 µs 132.84 µs]
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) low mild
  3 (3.00%) high severe
data chunk encoding: Int16, Int32, Int64 and String, 1024 rows, Pr[null]=0.1/row serialize
                        time:   [142.40 µs 142.42 µs 142.45 µs]
Found 7 outliers among 100 measurements (7.00%)
  1 (1.00%) low severe
  2 (2.00%) high mild
  4 (4.00%) high severe
```
