### PR TITLE
refactor(optimizer): merge `limit` and `with_ties` info in top-n plan node

### DIFF
--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -1152,6 +1152,63 @@
     ├── distribution key: [ 7 ]
     └── read pk prefix len hint: 1
 
+- id: nexmark_q18_rank
+  before:
+  - create_tables
+  sql: |
+    SELECT auction, bidder, price, channel, url, date_time, extra
+    FROM (SELECT *, RANK() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
+          FROM bid)
+    WHERE rank_number <= 1;
+  logical_plan: |
+    LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra] }
+    └─LogicalFilter { predicate: (RANK <= 1:Int32) }
+      └─LogicalProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, RANK] }
+        └─LogicalOverAgg { window_function: RANK() OVER(PARTITION BY bid.bidder, bid.auction ORDER BY bid.date_time DESC) }
+          └─LogicalScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra] }
+      └─BatchGroupTopN { order: "[bid.date_time DESC]", limit: 1, offset: 0, with_ties: true, group_key: [1, 0] }
+        └─BatchExchange { order: [], dist: HashShard(bid.bidder, bid.auction) }
+          └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], distribution: UpstreamHashShard(bid._row_id) }
+  stream_plan: |
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
+    └─StreamExchange { dist: HashShard(bid._row_id) }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+        └─StreamAppendOnlyGroupTopN { order: "[bid.date_time DESC]", limit: 1, offset: 0, group_key: [1, 0], with_ties: true }
+          └─StreamExchange { dist: HashShard(bid.bidder, bid.auction) }
+            └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
+    ├── materialized table: 4294967294
+    └──  StreamExchange Hash([7]) from 1
+
+    Fragment 1
+    StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id] }
+    └── StreamAppendOnlyGroupTopN { order: "[bid.date_time DESC]", limit: 1, offset: 0, group_key: [1, 0], with_ties: true } { state table: 0 }
+        └──  StreamExchange Hash([1, 0]) from 2
+
+    Fragment 2
+    Chain { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    ├──  Upstream
+    └──  BatchPlanNode
+
+    Table 0
+    ├── columns: [ bid_auction, bid_bidder, bid_price, bid_channel, bid_url, bid_date_time, bid_extra, bid__row_id ]
+    ├── primary key: [ $1 ASC, $0 ASC, $5 DESC, $7 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+    ├── distribution key: [ 1, 0 ]
+    └── read pk prefix len hint: 2
+
+    Table 4294967294
+    ├── columns: [ auction, bidder, price, channel, url, date_time, extra, bid._row_id ]
+    ├── primary key: [ $7 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+    ├── distribution key: [ 7 ]
+    └── read pk prefix len hint: 1
+
 - id: nexmark_q19
   before:
   - create_tables

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -1170,6 +1170,65 @@
     ├── distribution key: [ 7 ]
     └── read pk prefix len hint: 1
 
+- id: nexmark_q18_rank
+  before:
+  - create_sources
+  sql: |
+    SELECT auction, bidder, price, channel, url, date_time, extra
+    FROM (SELECT *, RANK() OVER (PARTITION BY bidder, auction ORDER BY date_time DESC) AS rank_number
+          FROM bid)
+    WHERE rank_number <= 1;
+  logical_plan: |
+    LogicalProject { exprs: [auction, bidder, price, channel, url, date_time, extra] }
+    └─LogicalFilter { predicate: (RANK <= 1:Int32) }
+      └─LogicalProject { exprs: [auction, bidder, price, channel, url, date_time, extra, RANK] }
+        └─LogicalOverAgg { window_function: RANK() OVER(PARTITION BY bidder, auction ORDER BY date_time DESC) }
+          └─LogicalSource { source: bid, columns: [auction, bidder, price, channel, url, date_time, extra, _row_id], time_range: [(Unbounded, Unbounded)] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchProject { exprs: [auction, bidder, price, channel, url, date_time, extra] }
+      └─BatchGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, with_ties: true, group_key: [1, 0] }
+        └─BatchExchange { order: [], dist: HashShard(bidder, auction) }
+          └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
+  stream_plan: |
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck" }
+    └─StreamExchange { dist: HashShard(_row_id) }
+      └─StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
+        └─StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0], with_ties: true }
+          └─StreamExchange { dist: HashShard(bidder, auction) }
+            └─StreamRowIdGen { row_id_index: 7 }
+              └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
+  stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [auction, bidder, price, channel, url, date_time, extra, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck" }
+    ├── materialized table: 4294967294
+    └──  StreamExchange Hash([7]) from 1
+
+    Fragment 1
+    StreamProject { exprs: [auction, bidder, price, channel, url, date_time, extra, _row_id] }
+    └── StreamAppendOnlyGroupTopN { order: "[date_time DESC]", limit: 1, offset: 0, group_key: [1, 0], with_ties: true } { state table: 0 }
+        └──  StreamExchange Hash([1, 0]) from 2
+
+    Fragment 2
+    StreamRowIdGen { row_id_index: 7 }
+    └──  StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] } { source state table: 1 }
+
+    Table 0
+    ├── columns: [ auction, bidder, price, channel, url, date_time, extra, _row_id ]
+    ├── primary key: [ $1 ASC, $0 ASC, $5 DESC, $7 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+    ├── distribution key: [ 1, 0 ]
+    └── read pk prefix len hint: 2
+
+    Table 1 { columns: [ partition_id, offset_info ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
+
+    Table 4294967294
+    ├── columns: [ auction, bidder, price, channel, url, date_time, extra, _row_id ]
+    ├── primary key: [ $7 ASC ]
+    ├── value indices: [ 0, 1, 2, 3, 4, 5, 6, 7 ]
+    ├── distribution key: [ 7 ]
+    └── read pk prefix len hint: 1
+
 - id: nexmark_q19
   before:
   - create_sources

--- a/src/frontend/src/optimizer/plan_node/batch_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_group_topn.rs
@@ -84,11 +84,11 @@ impl ToBatchPb for BatchGroupTopN {
     fn to_batch_prost_body(&self) -> NodeBody {
         let column_orders = self.logical.order.to_protobuf();
         NodeBody::GroupTopN(GroupTopNNode {
-            limit: self.logical.limit,
+            limit: self.logical.limit_attr.limit(),
             offset: self.logical.offset,
             column_orders,
             group_key: self.group_key().iter().map(|c| *c as u32).collect(),
-            with_ties: self.logical.with_ties,
+            with_ties: self.logical.limit_attr.with_ties(),
         })
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -194,7 +194,9 @@ impl Limit {
         }
     }
 
-    pub fn one_record_per_value(&self) -> bool {
+    /// Whether this [`Limit`] returns at most one record for each value. Only `LIMIT 1` without
+    /// `WITH TIES` satisfies this condition.
+    pub fn max_one_row(&self) -> bool {
         match self {
             Limit::Simple(limit) => *limit == 1,
             Limit::WithTies(_) => false,

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -27,9 +27,8 @@ use crate::TableCatalog;
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TopN<PlanRef> {
     pub input: PlanRef,
-    pub limit: u64,
+    pub limit_attr: Limit,
     pub offset: u64,
-    pub with_ties: bool,
     pub order: Order,
     pub group_key: Vec<usize>,
 }
@@ -90,18 +89,27 @@ impl<PlanRef: stream::StreamPlanRef> TopN<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> TopN<PlanRef> {
-    pub fn without_group(
+    pub fn with_group(
         input: PlanRef,
-        limit: u64,
+        limit_attr: Limit,
         offset: u64,
-        with_ties: bool,
         order: Order,
+        group_key: Vec<usize>,
     ) -> Self {
         Self {
             input,
-            limit,
+            limit_attr,
             offset,
-            with_ties,
+            order,
+            group_key,
+        }
+    }
+
+    pub fn without_group(input: PlanRef, limit_attr: Limit, offset: u64, order: Order) -> Self {
+        Self {
+            input,
+            limit_attr,
+            offset,
             order,
             group_key: vec![],
         }
@@ -121,11 +129,9 @@ impl<PlanRef: GenericPlanRef> TopN<PlanRef> {
             ),
         );
         builder
-            .field("limit", &self.limit)
+            .field("limit", &self.limit_attr.limit())
+            .field("with_ties", &self.limit_attr.with_ties())
             .field("offset", &self.offset);
-        if self.with_ties {
-            builder.field("with_ties", &true);
-        }
         if !self.group_key.is_empty() {
             builder.field("group_key", &self.group_key);
         }
@@ -148,5 +154,48 @@ impl<PlanRef: GenericPlanRef> GenericPlanNode for TopN<PlanRef> {
 
     fn functional_dependency(&self) -> FunctionalDependencySet {
         self.input.functional_dependency().clone()
+    }
+}
+
+/// [`Limit`] is used to specify the number of records to return.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub enum Limit {
+    /// The number of records returned is exactly the same as the number after `LIMIT` in the SQL
+    /// query.
+    Simple(u64),
+    /// If the SQL query contains `WITH TIES`, then it is supposed to bring all records with the
+    /// same value even if the number of records exceeds the number specified after `LIMIT` in the
+    /// query.
+    WithTies(u64),
+}
+
+impl Limit {
+    pub fn new(limit: u64, with_ties: bool) -> Self {
+        if with_ties {
+            Self::WithTies(limit)
+        } else {
+            Self::Simple(limit)
+        }
+    }
+
+    pub fn limit(&self) -> u64 {
+        match self {
+            Limit::Simple(limit) => *limit,
+            Limit::WithTies(limit) => *limit,
+        }
+    }
+
+    pub fn with_ties(&self) -> bool {
+        match self {
+            Limit::Simple(_) => false,
+            Limit::WithTies(_) => true,
+        }
+    }
+
+    pub fn one_record_per_value(&self) -> bool {
+        match self {
+            Limit::Simple(limit) => *limit == 1,
+            Limit::WithTies(_) => false,
+        }
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -130,8 +130,10 @@ impl<PlanRef: GenericPlanRef> TopN<PlanRef> {
         );
         builder
             .field("limit", &self.limit_attr.limit())
-            .field("with_ties", &self.limit_attr.with_ties())
             .field("offset", &self.offset);
+        if self.limit_attr.with_ties() {
+            builder.field("with_ties", &true);
+        }
         if !self.group_key.is_empty() {
             builder.field("group_key", &self.group_key);
         }

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::sort_util::ColumnOrder;
 
-use super::generic::GenericPlanNode;
+use super::generic::{GenericPlanNode, Limit};
 use super::{
     gen_filter_and_pushdown, generic, BatchGroupTopN, ColPrunable, ExprRewritable, PlanBase,
     PlanRef, PlanTreeNodeUnary, PredicatePushdown, StreamGroupTopN, StreamProject, ToBatch,
@@ -48,7 +48,8 @@ impl LogicalTopN {
             assert!(offset == 0, "WITH TIES is not supported with OFFSET");
         }
 
-        let core = generic::TopN::without_group(input, limit, offset, with_ties, order);
+        let limit_attr = Limit::new(limit, with_ties);
+        let core = generic::TopN::without_group(input, limit_attr, offset, order);
 
         let ctx = core.ctx();
         let schema = core.schema();
@@ -90,16 +91,12 @@ impl LogicalTopN {
         Ok(Self::new(input, limit, offset, with_ties, order).into())
     }
 
-    pub fn limit(&self) -> u64 {
-        self.core.limit
+    pub fn limit_attr(&self) -> Limit {
+        self.core.limit_attr
     }
 
     pub fn offset(&self) -> u64 {
         self.core.offset
-    }
-
-    pub fn with_ties(&self) -> bool {
-        self.core.with_ties
     }
 
     /// `topn_order` returns the order of the Top-N operator. This naming is because `order()`
@@ -175,22 +172,20 @@ impl LogicalTopN {
         );
         let vnode_col_idx = exprs.len() - 1;
         let project = StreamProject::new(LogicalProject::new(stream_input, exprs.clone()));
-        let mut logical_top_n = generic::TopN::without_group(
-            project.into(),
-            self.limit() + self.offset(),
-            0,
-            self.with_ties(),
-            self.topn_order().clone(),
+        let limit = Limit::new(
+            self.limit_attr().limit() + self.offset(),
+            self.limit_attr().with_ties(),
         );
+        let mut logical_top_n =
+            generic::TopN::without_group(project.into(), limit, 0, self.topn_order().clone());
         logical_top_n.group_key = vec![vnode_col_idx];
         let local_top_n = StreamGroupTopN::new(logical_top_n, Some(vnode_col_idx));
         let exchange =
             RequiredDist::single().enforce_if_not_satisfies(local_top_n.into(), &Order::any())?;
         let global_top_n = generic::TopN::without_group(
             exchange,
-            self.limit(),
+            self.limit_attr(),
             self.offset(),
-            self.with_ties(),
             self.topn_order().clone(),
         );
         let global_top_n = StreamTopN::new(global_top_n);
@@ -210,9 +205,9 @@ impl PlanTreeNodeUnary for LogicalTopN {
     fn clone_with_input(&self, input: PlanRef) -> Self {
         Self::with_group(
             input,
-            self.limit(),
+            self.limit_attr().limit(),
             self.offset(),
-            self.with_ties(),
+            self.limit_attr().with_ties(),
             self.topn_order().clone(),
             self.group_key().to_vec(),
         )
@@ -227,9 +222,9 @@ impl PlanTreeNodeUnary for LogicalTopN {
         (
             Self::with_group(
                 input,
-                self.limit(),
+                self.limit_attr().limit(),
                 self.offset(),
-                self.with_ties(),
+                self.limit_attr().with_ties(),
                 input_col_change
                     .rewrite_required_order(self.topn_order())
                     .unwrap(),
@@ -294,9 +289,9 @@ impl ColPrunable for LogicalTopN {
         let new_input = self.input().prune_col(&input_required_cols, ctx);
         let top_n = Self::with_group(
             new_input,
-            self.limit(),
+            self.limit_attr().limit(),
             self.offset(),
-            self.with_ties(),
+            self.limit_attr().with_ties(),
             new_order,
             new_group_key,
         )
@@ -347,12 +342,12 @@ impl ToBatch for LogicalTopN {
 
 impl ToStream for LogicalTopN {
     fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<PlanRef> {
-        if self.offset() != 0 && self.limit() == LIMIT_ALL_COUNT {
+        if self.offset() != 0 && self.limit_attr().limit() == LIMIT_ALL_COUNT {
             return Err(RwError::from(ErrorCode::InvalidInputSyntax(
                 "OFFSET without LIMIT in streaming mode".to_string(),
             )));
         }
-        if self.limit() == 0 {
+        if self.limit_attr().limit() == 0 {
             return Err(RwError::from(ErrorCode::InvalidInputSyntax(
                 "LIMIT 0 in streaming mode".to_string(),
             )));

--- a/src/frontend/src/optimizer/plan_node/logical_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_topn.rs
@@ -172,12 +172,12 @@ impl LogicalTopN {
         );
         let vnode_col_idx = exprs.len() - 1;
         let project = StreamProject::new(LogicalProject::new(stream_input, exprs.clone()));
-        let limit = Limit::new(
+        let limit_attr = Limit::new(
             self.limit_attr().limit() + self.offset(),
             self.limit_attr().with_ties(),
         );
         let mut logical_top_n =
-            generic::TopN::without_group(project.into(), limit, 0, self.topn_order().clone());
+            generic::TopN::without_group(project.into(), limit_attr, 0, self.topn_order().clone());
         logical_top_n.group_key = vec![vnode_col_idx];
         let local_top_n = StreamGroupTopN::new(logical_top_n, Some(vnode_col_idx));
         let exchange =

--- a/src/frontend/src/optimizer/plan_node/stream.rs
+++ b/src/frontend/src/optimizer/plan_node/stream.rs
@@ -588,9 +588,9 @@ pub fn to_stream_prost_body(
                 .infer_internal_table_catalog(base, me.vnode_col_idx)
                 .with_id(state.gen_table_id_wrapped());
             let group_topn_node = GroupTopNNode {
-                limit: me.core.limit,
+                limit: me.core.limit_attr.limit(),
                 offset: me.core.offset,
-                with_ties: me.core.with_ties,
+                with_ties: me.core.limit_attr.with_ties(),
                 group_key: me.core.group_key.iter().map(|idx| *idx as u32).collect(),
                 table: Some(table.to_internal_table_prost()),
                 order_by: me.core.order.to_protobuf(),
@@ -725,9 +725,9 @@ pub fn to_stream_prost_body(
         Node::TopN(me) => {
             let me = &me.core;
             let topn_node = TopNNode {
-                limit: me.limit,
+                limit: me.limit_attr.limit(),
                 offset: me.offset,
-                with_ties: me.with_ties,
+                with_ties: me.limit_attr.with_ties(),
                 table: Some(
                     me.infer_internal_table_catalog(base, None)
                         .with_id(state.gen_table_id_wrapped())
@@ -735,9 +735,7 @@ pub fn to_stream_prost_body(
                 ),
                 order_by: me.order.to_protobuf(),
             };
-            // TODO: support with ties for append only TopN
-            // <https://github.com/risingwavelabs/risingwave/issues/5642>
-            if me.input.0.append_only && !me.with_ties {
+            if me.input.0.append_only {
                 PbNodeBody::AppendOnlyTopN(topn_node)
             } else {
                 PbNodeBody::TopN(topn_node)

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -84,10 +84,6 @@ impl StreamGroupTopN {
     pub fn group_key(&self) -> &[usize] {
         &self.logical.group_key
     }
-
-    pub fn with_ties(&self) -> bool {
-        self.logical.limit_attr.with_ties()
-    }
 }
 
 impl StreamNode for StreamGroupTopN {

--- a/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_group_topn.rs
@@ -135,9 +135,11 @@ impl fmt::Display for StreamGroupTopN {
         );
         builder
             .field("limit", &self.limit_attr().limit())
-            .field("with_ties", &self.limit_attr().with_ties())
             .field("offset", &self.offset())
             .field("group_key", &self.group_key());
+        if self.limit_attr().with_ties() {
+            builder.field("with_ties", &true);
+        }
         let watermark_columns = &self.base.watermark_columns;
         if self.base.watermark_columns.count_ones(..) > 0 {
             let schema = self.schema();

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -17,6 +17,7 @@ use std::fmt;
 use fixedbitset::FixedBitSet;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
+use super::generic::Limit;
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::optimizer::property::{Distribution, Order};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -31,7 +32,7 @@ pub struct StreamTopN {
 impl StreamTopN {
     pub fn new(logical: generic::TopN<PlanRef>) -> Self {
         assert!(logical.group_key.is_empty());
-        assert!(logical.limit > 0);
+        assert!(logical.limit_attr.limit() > 0);
         let base = PlanBase::new_logical_with_core(&logical);
         let ctx = base.ctx;
         let input = &logical.input;
@@ -54,16 +55,12 @@ impl StreamTopN {
         StreamTopN { base, logical }
     }
 
-    pub fn limit(&self) -> u64 {
-        self.logical.limit
+    pub fn limit_attr(&self) -> Limit {
+        self.logical.limit_attr
     }
 
     pub fn offset(&self) -> u64 {
         self.logical.offset
-    }
-
-    pub fn with_ties(&self) -> bool {
-        self.logical.with_ties
     }
 
     pub fn topn_order(&self) -> &Order {
@@ -99,9 +96,9 @@ impl StreamNode for StreamTopN {
     fn to_stream_prost_body(&self, state: &mut BuildFragmentGraphState) -> PbNodeBody {
         use risingwave_pb::stream_plan::*;
         let topn_node = TopNNode {
-            limit: self.limit(),
+            limit: self.limit_attr().limit(),
             offset: self.offset(),
-            with_ties: self.with_ties(),
+            with_ties: self.limit_attr().with_ties(),
             table: Some(
                 self.logical
                     .infer_internal_table_catalog(&self.base, None)

--- a/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
@@ -52,7 +52,7 @@ impl PlanVisitor<bool> for MaxOneRowVisitor {
     }
 
     fn visit_logical_top_n(&mut self, plan: &LogicalTopN) -> bool {
-        plan.limit_attr().one_record_per_value() || self.visit(plan.input())
+        plan.limit_attr().max_one_row() || self.visit(plan.input())
     }
 
     fn visit_logical_filter(&mut self, plan: &LogicalFilter) -> bool {

--- a/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
@@ -52,7 +52,7 @@ impl PlanVisitor<bool> for MaxOneRowVisitor {
     }
 
     fn visit_logical_top_n(&mut self, plan: &LogicalTopN) -> bool {
-        (plan.limit() <= 1 && !plan.with_ties()) || self.visit(plan.input())
+        plan.limit_attr().one_record_per_value() || self.visit(plan.input())
     }
 
     fn visit_logical_filter(&mut self, plan: &LogicalFilter) -> bool {

--- a/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
@@ -62,12 +62,14 @@ impl TopNOnIndexRule {
         for index in order_satisfied_index {
             if let Some(mut index_scan) = logical_scan.to_index_scan_if_index_covered(index) {
                 index_scan.set_chunk_size(
-                    ((u32::MAX as u64).min(logical_top_n.limit() + logical_top_n.offset())) as u32,
+                    ((u32::MAX as u64)
+                        .min(logical_top_n.limit_attr().limit() + logical_top_n.offset()))
+                        as u32,
                 );
 
                 let logical_limit = LogicalLimit::create(
                     index_scan.into(),
-                    logical_top_n.limit(),
+                    logical_top_n.limit_attr().limit(),
                     logical_top_n.offset(),
                 );
                 return Some(logical_limit);
@@ -107,11 +109,12 @@ impl TopNOnIndexRule {
         };
         if primary_key_order.satisfies(order) {
             logical_scan.set_chunk_size(
-                ((u32::MAX as u64).min(logical_top_n.limit() + logical_top_n.offset())) as u32,
+                ((u32::MAX as u64).min(logical_top_n.limit_attr().limit() + logical_top_n.offset()))
+                    as u32,
             );
             let logical_limit = LogicalLimit::create(
                 logical_scan.into(),
-                logical_top_n.limit(),
+                logical_top_n.limit_attr().limit(),
                 logical_top_n.offset(),
             );
             Some(logical_limit)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

1. Merge `limit` and `with_ties` info in top N plan node. The `with_ties` in a top-n operator should be an attribute of `limit`.
2. Add planner tests for nexmark q18 using `RANK()` instead of `ROW_NUMBER()`.

Intend to resolve scaling test failure in #9082.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
