### PR TITLE
feat(source): Use a private link connection to create Kafka source

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -96,6 +96,7 @@ message Connection {
     string service_name = 2;
     string endpoint_id = 3;
     map<string, string> dns_entries = 4;
+    string endpoint_dns_name = 5;
   }
 
   uint32 id = 1;

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -257,7 +257,6 @@ message CreateConnectionRequest {
   message PrivateLink {
     string provider = 1;
     string service_name = 2;
-    repeated string availability_zones = 3;
   }
   string name = 1;
   oneof payload {

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -29,7 +29,7 @@ use crate::source::kinesis::config::AwsConfigInfo;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AwsPrivateLinkItem {
-    pub az: String,
+    pub az_id: Option<String>,
     pub port: u16,
 }
 

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -29,15 +29,8 @@ use crate::source::kinesis::config::AwsConfigInfo;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AwsPrivateLinkItem {
-    pub service_name: String,
-    pub availability_zone: String,
+    pub az: String,
     pub port: u16,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AwsPrivateLinks {
-    pub provider: String,
-    pub infos: Vec<AwsPrivateLinkItem>,
 }
 
 #[serde_as]

--- a/src/ctl/src/cmd_impl/meta/connection.rs
+++ b/src/ctl/src/cmd_impl/meta/connection.rs
@@ -23,20 +23,14 @@ pub async fn create_connection(
     connection_name: String,
     provider: String,
     service_name: String,
-    availability_zone: String,
 ) -> anyhow::Result<()> {
     let meta_client = context.meta_client().await?;
-    let availability_zones: Vec<String> = availability_zone
-        .split(',')
-        .map(|str| str.to_string())
-        .collect();
     let (conn_id, _) = meta_client
         .create_connection(
             connection_name,
             create_connection_request::Payload::PrivateLink(PrivateLink {
                 provider,
                 service_name,
-                availability_zones,
             }),
         )
         .await?;

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -355,16 +355,10 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             connection_name,
             provider,
             service_name,
-            availability_zones,
+            ..
         }) => {
-            cmd_impl::meta::create_connection(
-                context,
-                connection_name,
-                provider,
-                service_name,
-                availability_zones,
-            )
-            .await?
+            cmd_impl::meta::create_connection(context, connection_name, provider, service_name)
+                .await?
         }
         Commands::Meta(MetaCommands::ListConnections) => {
             cmd_impl::meta::list_connections(context).await?

--- a/src/frontend/src/handler/create_connection.rs
+++ b/src/frontend/src/handler/create_connection.rs
@@ -52,7 +52,6 @@ fn resolve_private_link_properties(
     Ok(create_connection_request::PrivateLink {
         provider,
         service_name,
-        availability_zones: vec![],
     })
 }
 

--- a/src/frontend/src/handler/create_connection.rs
+++ b/src/frontend/src/handler/create_connection.rs
@@ -20,7 +20,6 @@ use risingwave_common::error::{Result, RwError};
 use risingwave_connector::source::kafka::PRIVATELINK_CONNECTION;
 use risingwave_pb::ddl_service::create_connection_request;
 use risingwave_sqlparser::ast::CreateConnectionStatement;
-use serde_json;
 
 use super::RwPgResponse;
 use crate::binder::Binder;
@@ -30,7 +29,6 @@ use crate::handler::HandlerArgs;
 pub(crate) const CONNECTION_TYPE_PROP: &str = "type";
 pub(crate) const CONNECTION_PROVIDER_PROP: &str = "provider";
 pub(crate) const CONNECTION_SERVICE_NAME_PROP: &str = "service.name";
-pub(crate) const CONNECTION_AVAIL_ZONE_PROP: &str = "availability.zones";
 
 #[inline(always)]
 fn get_connection_property_required(
@@ -51,19 +49,10 @@ fn resolve_private_link_properties(
     let provider = get_connection_property_required(with_properties, CONNECTION_PROVIDER_PROP)?;
     let service_name =
         get_connection_property_required(with_properties, CONNECTION_SERVICE_NAME_PROP)?;
-    let availability_zones_str =
-        get_connection_property_required(with_properties, CONNECTION_AVAIL_ZONE_PROP)?;
-    let availability_zones: Vec<String> =
-        serde_json::from_str(&availability_zones_str).map_err(|e| {
-            RwError::from(ProtocolError(format!(
-                "Can not parse {}: {}",
-                CONNECTION_AVAIL_ZONE_PROP, e
-            )))
-        })?;
     Ok(create_connection_request::PrivateLink {
         provider,
         service_name,
-        availability_zones,
+        availability_zones: vec![],
     })
 }
 

--- a/src/meta/src/rpc/cloud_provider.rs
+++ b/src/meta/src/rpc/cloud_provider.rs
@@ -128,12 +128,8 @@ impl AwsEc2Client {
                             is_ready = true;
                         }
                         // forward-compatible with protocol change
-                        other @ _ if other.as_str() == "Available" => {
-                            // handles a case for `NewFeature`
+                        other @ _ => {
                             is_ready = other.as_str().eq_ignore_ascii_case("available");
-                        }
-                        _ => {
-                            is_ready = false;
                         }
                     }
                 }

--- a/src/meta/src/rpc/cloud_provider.rs
+++ b/src/meta/src/rpc/cloud_provider.rs
@@ -23,7 +23,7 @@ use tracing::info;
 
 use crate::{MetaError, MetaResult};
 
-const CLOUD_PROVIDER_AWS: &str = "aws";
+pub const CLOUD_PROVIDER_AWS: &str = "aws";
 
 #[derive(Clone)]
 pub struct AwsEc2Client {
@@ -49,11 +49,9 @@ impl AwsEc2Client {
     }
 
     /// `service_name`: The name of the endpoint service we want to access
-    /// `az_ids`: The AZs in which the service is available (deprecated)
     pub async fn create_aws_private_link(
         &self,
         service_name: &str,
-        _az_ids: &[String],
     ) -> MetaResult<PrivateLinkService> {
         // fetch the AZs of the endpoint service
         let service_azs = self.get_endpoint_service_az_names(service_name).await?;

--- a/src/meta/src/rpc/cloud_provider.rs
+++ b/src/meta/src/rpc/cloud_provider.rs
@@ -18,6 +18,7 @@ use aws_config::retry::RetryConfig;
 use aws_sdk_ec2::model::{Filter, VpcEndpointType};
 use itertools::Itertools;
 use risingwave_pb::catalog::connection::PrivateLinkService;
+use tracing::info;
 
 use crate::MetaResult;
 
@@ -143,6 +144,13 @@ impl AwsEc2Client {
 
         let endpoint = output.vpc_endpoint().unwrap();
         let mut dns_names = Vec::new();
+
+        if let Some(dns_entries) = endpoint.dns_entries() {
+            dns_entries.iter().for_each(|e| {
+                info!("endpoint dns name {}", e.dns_name().unwrap_or_default());
+            });
+        }
+
         if let Some(dns_entries) = endpoint.dns_entries() {
             dns_entries.iter().for_each(|e| {
                 if let Some(dns_name) = e.dns_name() {

--- a/src/meta/src/rpc/cloud_provider.rs
+++ b/src/meta/src/rpc/cloud_provider.rs
@@ -127,8 +127,10 @@ impl AwsEc2Client {
                         State::Available => {
                             is_ready = true;
                         }
-                        State::Unknown(str) => {
-                            is_ready = str.eq_ignore_ascii_case("available");
+                        // forward-compatible with protocol change
+                        other @ _ if other.as_str() == "Available" => {
+                            // handles a case for `NewFeature`
+                            is_ready = other.as_str().eq_ignore_ascii_case("available");
                         }
                         _ => {
                             is_ready = false;

--- a/src/meta/src/rpc/cloud_provider.rs
+++ b/src/meta/src/rpc/cloud_provider.rs
@@ -126,7 +126,7 @@ impl AwsEc2Client {
                             is_ready = true;
                         }
                         // forward-compatible with protocol change
-                        other @ _ => {
+                        other => {
                             is_ready = other.as_str().eq_ignore_ascii_case("available");
                         }
                     }

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -712,6 +712,14 @@ where
             let link_targets: Vec<AwsPrivateLinkItem> =
                 serde_json::from_str(link_target_value).map_err(|e| anyhow!(e))?;
 
+            if broker_addrs.len() != link_targets.len() {
+                return Err(MetaError::from(anyhow!(
+                    "The number of broker addrs {} does not match the number of private link targets {}",
+                    broker_addrs.len(),
+                    link_targets.len()
+                )));
+            }
+
             let conn = self
                 .catalog_manager
                 .get_connection_by_name(&private_link_name)

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -713,6 +713,15 @@ where
                 if let Some(info) = conn.info {
                     match info {
                         connection::Info::PrivateLinkService(svc) => {
+                            // check whether the VPC endpoint is ready
+                            let cli = self.aws_client.as_ref().unwrap();
+                            if !cli.is_vpc_endpoint_ready(&svc.endpoint_id).await? {
+                                return Err(MetaError::from(anyhow!(
+                                    "Private link endpoint {} is not ready",
+                                    svc.endpoint_id
+                                )));
+                            }
+
                             if svc.dns_entries.is_empty() {
                                 return Err(MetaError::from(anyhow!(
                                     "No available private link endpoints for Kafka broker {}",

--- a/src/meta/src/rpc/service/ddl_service.rs
+++ b/src/meta/src/rpc/service/ddl_service.rs
@@ -676,9 +676,9 @@ where
         properties: &mut HashMap<String, String>,
     ) -> MetaResult<()> {
         let mut broker_rewrite_map = HashMap::new();
-        const UPSTREAM_SOURCE_PRIVATE_LINK_KEY: &str = "privatelink.targets";
-        const PRIVATE_LINK_NAME: &str = "privatelink.name";
-        if let Some(prop) = properties.get(UPSTREAM_SOURCE_PRIVATE_LINK_KEY) {
+        const PRIVATE_LINK_TARGETS_KEY: &str = "privatelink.targets";
+        const PRIVATE_LINK_NAME_KEY: &str = "privatelink.name";
+        if let Some(link_target_value) = properties.get(PRIVATE_LINK_TARGETS_KEY) {
             if !is_kafka_connector(properties) {
                 return Err(MetaError::from(anyhow!(
                     "Private link is only supported for Kafka connector",
@@ -694,17 +694,17 @@ where
 
             let private_link_name =
                 properties
-                    .get(PRIVATE_LINK_NAME)
+                    .get(PRIVATE_LINK_NAME_KEY)
                     .cloned()
                     .ok_or(MetaError::from(anyhow!(
-                        "Must specify \"{PRIVATE_LINK_NAME}\" property in WITH clause",
+                        "Must specify \"{PRIVATE_LINK_NAME_KEY}\" property in WITH clause",
                     )))?;
 
             let broker_addrs = servers.split(',').collect_vec();
-            let link_info: Vec<AwsPrivateLinkItem> =
-                serde_json::from_str(prop).map_err(|e| anyhow!(e))?;
+            let link_targets: Vec<AwsPrivateLinkItem> =
+                serde_json::from_str(link_target_value).map_err(|e| anyhow!(e))?;
             // construct the rewrite mapping for brokers
-            for (link, broker) in link_info.iter().zip_eq_fast(broker_addrs.into_iter()) {
+            for (link, broker) in link_targets.iter().zip_eq_fast(broker_addrs.into_iter()) {
                 let conn = self
                     .catalog_manager
                     .get_connection_by_name(&private_link_name)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
- Support new syntax to create a Kafka source with the private link.
```sql
CREATE CONNECTION my_connection with (
    type = 'privatelink',
    provider = 'aws',
    service.name = 'xxx'
);

CREATE SOURCE tcp_metrics_rw (
    device_id VARCHAR,
    metric_name VARCHAR,
    report_time TIMESTAMP,
    metric_value DOUBLE PRECISION
) WITH (
  connector = 'kafka',
  topic = 'tcp_metrics',
  properties.bootstrap.server = 'ip1:9092,ip2:9092',
  connection.name = 'my_connection',
  privatelink.targets = '[{"port": 8001}, {"port": 8002}]',
  scan.startup.mode = 'earliest'
) ROW FORMAT JSON;
```

- And since users have to enable the cross-zone load balancing to allow private link works in our cloud, the `availability zone` arg in the WITH clause is useless, just remove it.
- The drop source procedure will decrease the refcnt of the connection. https://github.com/risingwavelabs/risingwave/pull/9128

https://github.com/risingwavelabs/risingwave/issues/8771

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.
- Connector (sources & sinks)
- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

- Add a new SQL command `CREATE CONNECTION` that allow users to create a privatelink connection in the cloud
- Support using a privatelink connection to create a Kafka source in the `CREATE SOURCE` SQL command



</details>
