### PR TITLE
fix(common): set struct oid -1

### DIFF
--- a/src/common/src/types/postgres_type.rs
+++ b/src/common/src/types/postgres_type.rs
@@ -127,9 +127,8 @@ impl DataType {
             DataType::Timestamp => 1114,
             DataType::Timestamptz => 1184,
             DataType::Interval => 1186,
-            // NOTE: Struct type don't have oid in postgres, here we use varchar oid so that struct
-            // will be considered as a varchar.
-            DataType::Struct(_) => 1043,
+            // TODO: Support to give a new oid for custom struct type.
+            DataType::Struct(_) => -1,
             DataType::Jsonb => 3802,
             DataType::Bytea => 17,
             DataType::List { datatype } => match unnested_list_type(datatype.as_ref().clone()) {
@@ -150,7 +149,7 @@ impl DataType {
                 DataType::Timestamptz => 1185,
                 DataType::Interval => 1187,
                 DataType::Jsonb => 3807,
-                DataType::Struct(_) => 1015,
+                DataType::Struct(_) => -1,
                 DataType::List { .. } => unreachable!("Never reach here!"),
             },
         }

--- a/src/frontend/src/handler/extended_handle.rs
+++ b/src/frontend/src/handler/extended_handle.rs
@@ -145,8 +145,8 @@ pub fn handle_bind(
         }
         PrepareStatement::PureStatement(stmt) => {
             assert!(
-                params.is_empty() && param_formats.is_empty(),
-                "params and param_formats should be empty for pure statement"
+                params.is_empty(),
+                "params should be empty for pure statement"
             );
             Ok(Portal::PureStatement(stmt))
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

1. a quick fix for #8821
2. remove uncorrect assert in extended mode 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
