### PR TITLE
perf(hash_agg): bench q17 + always compact

### DIFF
--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -418,6 +418,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         vars: &mut ExecutionVars<K, S, E>,
         chunk: StreamChunk,
     ) -> StreamExecutorResult<()> {
+        let chunk = chunk.compact();
         // Find groups in this chunk and generate visibility for each group key.
         let keys = K::build(&this.group_key_indices, chunk.data_chunk())?;
         let group_visibilities = Self::get_group_visibilities(keys, chunk.visibility());

--- a/src/stream/src/executor/test_utils.rs
+++ b/src/stream/src/executor/test_utils.rs
@@ -560,13 +560,19 @@ pub fn gen_data(
         for _ in 0..chunk_size {
             ops.push(Op::Insert);
         }
+        // Generate columns of this chunk.
         for data_type in data_types {
-            let mut data_gen =
-                FieldGeneratorImpl::with_number_random(data_type.clone(), None, None, SEED)
-                    .unwrap();
+            // FIXME(kwannoel): This is specific to q17, this should be a configurable parameter.
+            // varchar (overwrite default, we want to simulate a fixed date string.
             let mut array_builder = data_type.create_array_builder(chunk_size);
             for j in 0..chunk_size {
-                array_builder.append_datum(&data_gen.generate_datum(((i + 1) * (j + 1)) as u64));
+                if *data_type == DataType::Varchar {
+                    array_builder.append_datum(&Some("2022-02-02".into()));
+                } else {
+                    let mut data_gen = FieldGeneratorImpl::with_number_random(data_type.clone(), None, None, SEED).unwrap();
+                    let datum = data_gen.generate_datum(((i + 1) * (j + 1)) as u64);
+                    array_builder.append_datum(datum);
+                }
             }
             columns.push(array_builder.finish().into());
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Always compact to avoid overhead of bitmap iter.

It's a one liner, easy to revert. 5% improvement

Results:
```
Benchmarking Q17/benchmark_hash_agg: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 79.5s.
Q17/benchmark_hash_agg  time:   [7.2422 s 7.4257 s 7.6168 s]
                        change: [-4.4767% -1.2583% +2.0850%] (p = 0.48 > 0.05)
                        No change in performance detected.

noelkwan@Noels-MacBook-Pro benches % RUST_BACKTRACE=1 cargo bench --bench hash_agg
   Compiling risingwave_stream v1.0.0-alpha (/Users/noelkwan/projects/risingwave/src/stream)
    Finished bench [optimized] target(s) in 1m 38s
     Running benches/hash_agg.rs (/Users/noelkwan/projects/risingwave/target/release/deps/hash_agg-5c6e8b27363c376a)
Benchmarking Q17/benchmark_hash_agg: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 77.3s.
Q17/benchmark_hash_agg  time:   [7.0622 s 7.0787 s 7.0950 s]
                        change: [-7.0811% -4.6725% -2.2193%] (p = 0.00 < 0.05)
                        Performance has improved.
```

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
