### PR TITLE
refactor(config): check unrecognized fields during deser

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -17,10 +17,11 @@
 //! [`RwConfig`] corresponds to the whole config file and each other config struct corresponds to a
 //! section in `risingwave.toml`.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::fs;
 
 use clap::ValueEnum;
+use derivative::Derivative;
 use risingwave_pb::meta::SystemParams;
 use serde::{Deserialize, Serialize};
 use serde_default::DefaultFromSerde;
@@ -35,35 +36,46 @@ pub const STREAM_WINDOW_SIZE: u32 = 32 * 1024 * 1024; // 32 MB
 /// For non-user-facing components where the CLI arguments do not override the config file.
 pub const NO_OVERRIDE: Option<NoOverride> = None;
 
-macro_rules! for_all_config_sections {
-    ($macro:ident) => {
-        $macro! {
-            { server },
-            { meta },
-            { batch },
-            { streaming },
-            { storage },
-            { storage.file_cache },
-        }
-    };
+/// Unrecognized fields in a config section. Generic over the config section type to provide better
+/// error messages.
+///
+/// The current implementation will log warnings if there are unrecognized fields.
+#[derive(Derivative)]
+#[derivative(Clone, Debug, Default)]
+pub struct Unrecognized<T: 'static> {
+    inner: BTreeMap<String, Value>,
+    _marker: std::marker::PhantomData<&'static T>,
 }
 
-macro_rules! impl_warn_unrecognized_fields {
-    ($({ $($field_path:ident).+ },)*) => {
-        fn warn_unrecognized_fields(config: &RwConfig) {
-            if !config.unrecognized.is_empty() {
-                tracing::warn!("unrecognized fields in config: {:?}", config.unrecognized.keys());
-            }
-            $(
-                if !config.$($field_path).+.unrecognized.is_empty() {
-                    tracing::warn!("unrecognized fields in config section [{}]: {:?}", stringify!($($field_path).+), config.$($field_path).+.unrecognized.keys());
-                }
-            )*
+impl<'de, T> Deserialize<'de> for Unrecognized<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = BTreeMap::deserialize(deserializer)?;
+        if !inner.is_empty() {
+            // TODO: may reject unrecognized fields in the future.
+            tracing::warn!(
+                "unrecognized fields in `{}`: {:?}",
+                std::any::type_name::<T>(),
+                inner.keys()
+            );
         }
-    };
+        Ok(Unrecognized {
+            inner,
+            _marker: std::marker::PhantomData,
+        })
+    }
 }
 
-for_all_config_sections!(impl_warn_unrecognized_fields);
+impl<T> Serialize for Unrecognized<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
 
 pub fn load_config(path: &str, cli_override: Option<impl OverrideConfig>) -> RwConfig
 where
@@ -79,7 +91,6 @@ where
     if let Some(cli_override) = cli_override {
         cli_override.r#override(&mut config);
     }
-    warn_unrecognized_fields(&config);
     config
 }
 
@@ -118,7 +129,7 @@ pub struct RwConfig {
     pub system: SystemConfig,
 
     #[serde(flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 #[derive(Copy, Clone, Debug, Default, ValueEnum, Serialize, Deserialize)]
@@ -204,7 +215,7 @@ pub struct MetaConfig {
     pub max_compactor_task_multiplier: u32,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 /// The section `[server]` in `risingwave.toml`.
@@ -231,7 +242,7 @@ pub struct ServerConfig {
     pub telemetry_enabled: bool,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 /// The section `[batch]` in `risingwave.toml`.
@@ -249,7 +260,7 @@ pub struct BatchConfig {
     pub distributed_query_limit: Option<u64>,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 /// The section `[streaming]` in `risingwave.toml`.
@@ -280,7 +291,7 @@ pub struct StreamingConfig {
     pub unique_user_stream_errors: usize,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 /// The section `[storage]` in `risingwave.toml`.
@@ -359,7 +370,7 @@ pub struct StorageConfig {
     pub max_preload_wait_time_mill: u64,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 /// The subsection `[storage.file_cache]` in `risingwave.toml`.
@@ -386,7 +397,7 @@ pub struct FileCacheConfig {
     pub cache_file_max_write_size_mb: usize,
 
     #[serde(default, flatten)]
-    pub unrecognized: HashMap<String, Value>,
+    pub unrecognized: Unrecognized<Self>,
 }
 
 #[derive(Debug, Default, Clone, ValueEnum, Serialize, Deserialize)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we manually check whether all `unrecognized` maps are empty in the config using the macro of `for_all_config_sections`. It's possible that some newly added config section is missing.

This PR refactors the check into the `Deserialize` implementation. We may change the behavior to return an error if necessary in the future, to avoid #9153 from happening as much as possible.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
