### PR TITLE
refactor(common): interval memcomparable with i128 directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,9 +3777,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memcomparable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dd02b54456b9372f039971b5cfa505e0f53e00227184096deca7dceeddaf5"
+checksum = "d853845987d5f2b7ebf64789cc45b4108e2e76bab6b860d1aad1cbc39c686e76"
 dependencies = [
  "bytes",
  "rust_decimal",
@@ -8361,7 +8361,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -730,12 +730,7 @@ impl Serialize for Interval {
         S: serde::Serializer,
     {
         let cmp_value = IntervalCmpValue::from(*self);
-        // split i128 as (i64, u64), which is equivalent
-        (
-            (cmp_value.0 >> 64) as i64,
-            cmp_value.0 as u64, // truncate to get the lower part
-        )
-            .serialize(serializer)
+        cmp_value.0.serialize(serializer)
     }
 }
 
@@ -811,8 +806,7 @@ impl<'de> Deserialize<'de> for Interval {
     where
         D: serde::Deserializer<'de>,
     {
-        let (hi, lo) = <(i64, u64)>::deserialize(deserializer)?;
-        let cmp_value = IntervalCmpValue(((hi as i128) << 64) | (lo as i128));
+        let cmp_value = IntervalCmpValue(i128::deserialize(deserializer)?);
         let interval = cmp_value
             .as_justified()
             .or_else(|| cmp_value.as_alternate());


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Bump `memcomparable` to `0.1.1` so that we can encode `i128` directly rather than as `(hi: i64, lo: u64)`.

Order by of `interval` is covered by regress tests:
https://github.com/risingwavelabs/risingwave/blob/9bf890a9999993c126302b7a98db221a9d9db723/src/tests/regress/data/sql/interval.sql#L58-L61

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
