### PR TITLE
fix(streaming): use xxhash64 for hash key in cache

### DIFF
--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -349,10 +349,10 @@ mod tests {
         let expect_exec = MockExecutor::with_chunk(
             DataChunk::from_pretty(
                 "i i I
-                 0 1 3
+                 1 0 1
                  0 0 3
-                 1 1 6
-                 1 0 1",
+                 0 1 3
+                 1 1 6",
             ),
             schema,
         );

--- a/src/batch/src/executor/hash_agg.rs
+++ b/src/batch/src/executor/hash_agg.rs
@@ -345,13 +345,13 @@ mod tests {
             ],
         };
 
-        // TODO: currently the order is fixed
+        // TODO: currently the order is fixed unless the hasher is changed
         let expect_exec = MockExecutor::with_chunk(
             DataChunk::from_pretty(
                 "i i I
+                 0 1 3
                  0 0 3
                  1 1 6
-                 0 1 3
                  1 0 1",
             ),
             schema,

--- a/src/batch/src/task/hash_shuffle_channel.rs
+++ b/src/batch/src/task/hash_shuffle_channel.rs
@@ -62,7 +62,7 @@ fn generate_hash_values(chunk: &DataChunk, hash_info: &HashInfo) -> BatchResult<
             hasher_builder,
         )
         .iter_mut()
-        .map(|hash_value| hash_value.hash_code() as usize % output_count)
+        .map(|hash_value| hash_value.value() as usize % output_count)
         .collect::<Vec<_>>();
     Ok(hash_values)
 }

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -83,6 +83,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 toml = "0.7"
 tonic = { version = "0.2", package = "madsim-tonic" }
 tracing = "0.1"
+twox-hash = "1"
 url = "2"
 uuid = "1.2.2"
 
@@ -103,7 +104,6 @@ criterion = "0.4"
 more-asserts = "0.3"
 rand = "0.8"
 tempfile = "3"
-twox-hash = "1"
 
 [[bench]]
 name = "bench_encoding"

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -340,7 +340,7 @@ impl DataChunk {
         &self,
         column_idxes: &[usize],
         hasher_builder: H,
-    ) -> Vec<HashCode> {
+    ) -> Vec<HashCode<H>> {
         let mut states = Vec::with_capacity(self.capacity());
         states.resize_with(self.capacity(), || hasher_builder.build_hasher());
         // Compute hash for the specified columns.

--- a/src/common/src/hash/consistent_hash/vnode.rs
+++ b/src/common/src/hash/consistent_hash/vnode.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use parse_display::Display;
 
 use crate::array::{Array, ArrayImpl, DataChunk};
-use crate::hash::HashCode;
+use crate::hash::Crc32HashCode;
 use crate::row::{Row, RowExt};
 use crate::types::ScalarRefImpl;
 use crate::util::hash_util::Crc32FastBuilder;
@@ -37,11 +37,11 @@ pub struct VirtualNode(VirtualNodeInner);
 type VirtualNodeInner = u16;
 static_assertions::const_assert!(VirtualNodeInner::BITS >= VirtualNode::BITS as u32);
 
-impl From<HashCode> for VirtualNode {
-    fn from(hash_code: HashCode) -> Self {
+impl From<Crc32HashCode> for VirtualNode {
+    fn from(hash_code: Crc32HashCode) -> Self {
         // Take the least significant bits of the hash code.
         // TODO: should we use the most significant bits?
-        let inner = (hash_code.0 % Self::COUNT as u64) as VirtualNodeInner;
+        let inner = (hash_code.value() % Self::COUNT as u64) as VirtualNodeInner;
         VirtualNode(inner)
     }
 }

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -234,9 +234,9 @@ impl<T: BuildHasher> HashCode<T> {
     }
 }
 
-/// Hash code from the CRC32 hasher. Used for hash-shuffle exchange.
+/// Hash code from the `Crc32` hasher. Used for hash-shuffle exchange.
 pub type Crc32HashCode = HashCode<Crc32FastBuilder>;
-/// Hash code from the XxHash64 hasher. Used for in-memory hash map cache.
+/// Hash code from the `XxHash64` hasher. Used for in-memory hash map cache.
 pub type XxHash64HashCode = HashCode<XxHash64Builder>;
 
 pub trait HashKeySerializer {

--- a/src/common/src/hash/key.rs
+++ b/src/common/src/hash/key.rs
@@ -26,8 +26,10 @@ use std::default::Default;
 use std::fmt::Debug;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::io::{Cursor, Read};
+use std::marker::PhantomData;
 
 use chrono::{Datelike, Timelike};
+use derivative::Derivative;
 use fixedbitset::FixedBitSet;
 use smallbitset::Set64;
 use static_assertions::const_assert_eq;
@@ -41,7 +43,7 @@ use crate::collection::estimate_size::EstimateSize;
 use crate::row::{OwnedRow, RowDeserializer};
 use crate::types::num256::Int256Ref;
 use crate::types::{DataType, Date, Decimal, ScalarRef, Time, Timestamp, F32, F64};
-use crate::util::hash_util::Xxhash64Builder;
+use crate::util::hash_util::{Crc32FastBuilder, XxHash64Builder};
 use crate::util::iter_util::ZipEqFast;
 use crate::util::value_encoding::{deserialize_datum, serialize_datum_into};
 
@@ -208,25 +210,38 @@ impl<T: AsRef<[bool]> + IntoIterator<Item = bool>> From<T> for HeapNullBitmap {
     }
 }
 
-/// A wrapper for u64 hash result.
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-pub struct HashCode(pub u64);
+/// A wrapper for u64 hash result. Generic over the hasher.
+#[derive(Derivative)]
+#[derivative(Default, Clone, Copy, Debug, PartialEq)]
+pub struct HashCode<T: 'static + BuildHasher> {
+    value: u64,
+    #[derivative(Debug = "ignore")]
+    _phantom: PhantomData<&'static T>,
+}
 
-impl From<u64> for HashCode {
+impl<T: BuildHasher> From<u64> for HashCode<T> {
     fn from(hash_code: u64) -> Self {
-        Self(hash_code)
+        Self {
+            value: hash_code,
+            _phantom: PhantomData,
+        }
     }
 }
 
-impl HashCode {
-    pub fn hash_code(self) -> u64 {
-        self.0
+impl<T: BuildHasher> HashCode<T> {
+    pub fn value(self) -> u64 {
+        self.value
     }
 }
+
+/// Hash code from the CRC32 hasher. Used for hash-shuffle exchange.
+pub type Crc32HashCode = HashCode<Crc32FastBuilder>;
+/// Hash code from the XxHash64 hasher. Used for in-memory hash map cache.
+pub type XxHash64HashCode = HashCode<XxHash64Builder>;
 
 pub trait HashKeySerializer {
     type K: HashKey;
-    fn from_hash_code(hash_code: HashCode, estimated_key_size: usize) -> Self;
+    fn from_hash_code(hash_code: XxHash64HashCode, estimated_key_size: usize) -> Self;
     fn append<'a, D: HashKeySerDe<'a>>(&mut self, data: Option<D>);
     fn into_hash_key(self) -> Self::K;
 }
@@ -268,7 +283,7 @@ pub trait HashKey:
     type S: HashKeySerializer<K = Self>;
 
     fn build(column_idxes: &[usize], data_chunk: &DataChunk) -> ArrayResult<Vec<Self>> {
-        let hash_codes = data_chunk.get_hash_values(column_idxes, Xxhash64Builder);
+        let hash_codes = data_chunk.get_hash_values(column_idxes, XxHash64Builder);
         Ok(Self::build_from_hash_code(
             column_idxes,
             data_chunk,
@@ -279,7 +294,7 @@ pub trait HashKey:
     fn build_from_hash_code(
         column_idxes: &[usize],
         data_chunk: &DataChunk,
-        hash_codes: Vec<HashCode>,
+        hash_codes: Vec<XxHash64HashCode>,
     ) -> Vec<Self> {
         let estimated_key_size = data_chunk.estimate_value_encoding_size(column_idxes);
         // Construct serializers for each row.
@@ -687,13 +702,13 @@ impl<const N: usize, B: NullBitmap> HashKeySerializer for FixedSizeKeySerializer
 
     /// We already know the estimated key size statically, no need
     /// to use runtime parameter: `estimated_key_size`.
-    fn from_hash_code(hash_code: HashCode, _estimated_key_size: usize) -> Self {
+    fn from_hash_code(hash_code: XxHash64HashCode, _estimated_key_size: usize) -> Self {
         Self {
             buffer: [0u8; N],
             null_bitmap: NullBitmap::empty(),
             null_bitmap_idx: 0,
             data_len: 0,
-            hash_code: hash_code.0,
+            hash_code: hash_code.value(),
         }
     }
 
@@ -763,10 +778,10 @@ pub struct SerializedKeySerializer<B: NullBitmap> {
 impl<B: NullBitmap> HashKeySerializer for SerializedKeySerializer<B> {
     type K = SerializedKey<B>;
 
-    fn from_hash_code(hash_code: HashCode, estimated_value_encoding_size: usize) -> Self {
+    fn from_hash_code(hash_code: XxHash64HashCode, estimated_value_encoding_size: usize) -> Self {
         Self {
             buffer: Vec::with_capacity(estimated_value_encoding_size),
-            hash_code: hash_code.0,
+            hash_code: hash_code.value(),
             null_bitmap: NullBitmap::empty(),
             null_bitmap_idx: 0,
         }

--- a/src/common/src/row/mod.rs
+++ b/src/common/src/row/mod.rs
@@ -117,12 +117,12 @@ pub trait Row: Sized + std::fmt::Debug + PartialEq + Eq {
 
     /// Returns the hash code of the row.
     #[inline]
-    fn hash<H: BuildHasher>(&self, hash_builder: H) -> HashCode {
+    fn hash<H: BuildHasher>(&self, hash_builder: H) -> HashCode<H> {
         let mut hasher = hash_builder.build_hasher();
         for datum in self.iter() {
             hash_datum(datum, &mut hasher);
         }
-        HashCode(hasher.finish())
+        hasher.finish().into()
     }
 
     /// Determines whether the datums of this row are equal to those of another.
@@ -226,7 +226,7 @@ macro_rules! deref_forward_row {
             (**self).memcmp_serialize(serde)
         }
 
-        fn hash<H: std::hash::BuildHasher>(&self, hash_builder: H) -> $crate::hash::HashCode {
+        fn hash<H: std::hash::BuildHasher>(&self, hash_builder: H) -> $crate::hash::HashCode<H> {
             (**self).hash(hash_builder)
         }
 

--- a/src/common/src/row/owned_row.rs
+++ b/src/common/src/row/owned_row.rs
@@ -227,6 +227,6 @@ mod tests {
         assert_ne!(row1.hash(hash_builder), row2.hash(hash_builder));
 
         let row_default = OwnedRow::default();
-        assert_eq!(row_default.hash(hash_builder).0, 0);
+        assert_eq!(row_default.hash(hash_builder).value(), 0);
     }
 }

--- a/src/common/src/util/hash_util.rs
+++ b/src/common/src/util/hash_util.rs
@@ -31,3 +31,14 @@ impl BuildHasher for Crc32FastBuilder {
         crc32fast::Hasher::new()
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct Xxhash64Builder;
+
+impl BuildHasher for Xxhash64Builder {
+    type Hasher = twox_hash::XxHash64;
+
+    fn build_hasher(&self) -> Self::Hasher {
+        twox_hash::XxHash64::with_seed(0)
+    }
+}

--- a/src/common/src/util/hash_util.rs
+++ b/src/common/src/util/hash_util.rs
@@ -33,9 +33,9 @@ impl BuildHasher for Crc32FastBuilder {
 }
 
 #[derive(Clone, Copy)]
-pub struct Xxhash64Builder;
+pub struct XxHash64Builder;
 
-impl BuildHasher for Xxhash64Builder {
+impl BuildHasher for XxHash64Builder {
     type Hasher = twox_hash::XxHash64;
 
     fn build_hasher(&self) -> Self::Hasher {

--- a/src/common/src/util/hash_util.rs
+++ b/src/common/src/util/hash_util.rs
@@ -39,6 +39,6 @@ impl BuildHasher for XxHash64Builder {
     type Hasher = twox_hash::XxHash64;
 
     fn build_hasher(&self) -> Self::Hasher {
-        twox_hash::XxHash64::with_seed(0)
+        twox_hash::XxHash64::with_seed(0x20210401)
     }
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolve the long-standing issue of #5579. Also, add a generic for `HashCode` to avoid misusing between different hashers.

We may perform some benchmarks to see whether...
- xxHash is fast enough,
- and there are frequent key conflicts before (cc @kwannoel)

This PR does not introduce breaking changes, as this only affects the hash code for hash maps and the hasher of hash-shuffle or consistent hash is still `Crc32`.

Close #5579.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
