### PR TITLE
fix(test): fix memory leak in simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,12 +3589,13 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.19"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baac280a8f0a7760cfbf788dc523f8784a26550582b07e05ea92b62093c9a72b"
+checksum = "e0296e75e03fc45c2e0bd30a11eb023a6b5698c781355ae526a01478bb09dd83"
 dependencies = [
  "ahash 0.7.6",
  "async-channel",
+ "async-stream",
  "async-task",
  "bincode",
  "bytes",
@@ -3635,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-etcd-client"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b3894525ac4b7d5732b2123f9d29d018005c96a218e5a7c38d1f42601b927d"
+checksum = "99d983cdf1cd40f94b64cbf89e17f9113a77846a19afaec77d6c9a16ad487a50"
 dependencies = [
  "etcd-client",
  "futures-util",
@@ -3701,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-tonic"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a0d4e7468777e5885b6c3b88a97e3dd81547e0f3304324126c1a07ae89be470"
+checksum = "189f256e4ce279a6635b323d2b9652f0cd530c89916ac9b1c08228141104cddd"
 dependencies = [
  "async-stream",
  "chrono",
@@ -8361,7 +8362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -13,7 +13,7 @@ pbjson = "0.5"
 prost = "0.11"
 prost-helpers = { path = "helpers" }
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.2.18", package = "madsim-tonic" }
+tonic = { version = "0.2.20", package = "madsim-tonic" }
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -16,12 +16,12 @@ async-trait = "0.1"
 aws-sdk-s3 = { version = "0.2.17", package = "madsim-aws-sdk-s3" }
 clap = { version = "4", features = ["derive"] }
 console = "0.15"
-etcd-client = { version = "0.2.18", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2.20", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"
 lru = { git = "https://github.com/risingwavelabs/lru-rs.git", branch = "evict_by_timestamp" }
-madsim = "0.2.19"
+madsim = "0.2.20"
 paste = "1"
 pin-project = "1.0"
 pretty_assertions = "1"

--- a/src/tests/simulation/src/slt.rs
+++ b/src/tests/simulation/src/slt.rs
@@ -107,6 +107,10 @@ pub async fn run_slt_task(cluster: Arc<Cluster>, glob: &str, opts: &KillOpts) {
             .then(|| hack_kafka_test(path));
         let path = tempfile.as_ref().map(|p| p.path()).unwrap_or(path);
         for record in sqllogictest::parse_file(path).expect("failed to parse file") {
+            // uncomment to print metrics for task counts
+            // let metrics = madsim::runtime::Handle::current().metrics();
+            // println!("{:#?}", metrics);
+            // println!("{}", metrics.num_tasks_by_node_by_spawn());
             if let sqllogictest::Record::Halt { .. } = record {
                 break;
             }

--- a/src/tests/simulation/src/utils/timed_future.rs
+++ b/src/tests/simulation/src/utils/timed_future.rs
@@ -40,7 +40,7 @@ where
 {
     type Output = Fut::Output;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
         let start = this.start.get_or_insert_with(Instant::now);
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR updates madsim to fix #8868 and a more serious leak introduced by madsim v0.2.19. 🥵

There are two sources of memory leaks:

- Madsim v0.2.19 introduced a circular reference to task, resulting in all task structures being leaked.
- RPC servers like tonic and etcd did not handle client disconnection. For example, for etcd campaign, observe, and other server streaming RPCs, if the client is disconnected, the server's RPC task will not be canceled.

Detailed fixes in madsim:
https://github.com/madsim-rs/madsim/pull/138
https://github.com/madsim-rs/madsim/pull/139

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
