### PR TITLE
refactor(compact task): add new task status `InputOutdatedCanceled`

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -247,9 +247,10 @@ message CompactTask {
     SEND_FAIL_CANCELED = 6;
     MANUAL_CANCELED = 7;
     INVALID_GROUP_CANCELED = 8;
-    EXECUTE_FAILED = 9;
-    JOIN_HANDLE_FAILED = 10;
-    TRACK_SST_OBJECT_ID_FAILED = 11;
+    INPUT_OUTDATED_CANCELED = 9;
+    EXECUTE_FAILED = 10;
+    JOIN_HANDLE_FAILED = 11;
+    TRACK_SST_OBJECT_ID_FAILED = 12;
   }
   // SSTs to be compacted, which will be removed from LSM after compaction
   repeated InputLevel input_ssts = 1;

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1164,7 +1164,7 @@ where
                     .unwrap_or(true)
                     || Self::is_compact_task_expired(compact_task, &versioning.branched_ssts);
                 if is_expired {
-                    compact_task.set_task_status(TaskStatus::InvalidGroupCanceled);
+                    compact_task.set_task_status(TaskStatus::InputOutdatedCanceled);
                     false
                 } else {
                     true


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
add new task status `TaskStatus::InputOutdatedCanceled` to replace some usage of original `TaskStatus::InvalidGroupCanceled`

## Checklist For Contributors

- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
