### PR TITLE
refactor(common): memcomparable encoding of i256

### DIFF
--- a/src/common/src/util/memcmp_encoding.rs
+++ b/src/common/src/util/memcmp_encoding.rs
@@ -20,6 +20,7 @@ use super::iter_util::{ZipEqDebug, ZipEqFast};
 use crate::array::serial_array::Serial;
 use crate::array::{ArrayImpl, DataChunk};
 use crate::row::Row;
+use crate::types::num256::Int256;
 use crate::types::{DataType, Date, Datum, ScalarImpl, Time, Timestamp, ToDatumRef, F32, F64};
 use crate::util::sort_util::{ColumnOrder, OrderType};
 
@@ -165,7 +166,7 @@ fn calculate_encoded_size_inner(
             DataType::Jsonb => deserializer.skip_bytes()?,
             DataType::Varchar => deserializer.skip_bytes()?,
             DataType::Bytea => deserializer.skip_bytes()?,
-            DataType::Int256 => deserializer.skip_bytes()?,
+            DataType::Int256 => Int256::MEMCMP_ENCODED_SIZE,
         };
 
         // consume offset of fixed_type


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The previous encoding is treating 32-byte big endian as variable length byte slice, so the serializer inserts extra marker bytes. This PR uses exactly 32 bytes representing the number in big endian, making it compact, easier to understand and debug.

This is a backward incompatible change, in the sense that data encoded by old version cannot be decoded by this new version. But this is within the same release as previous PR, and would only impact nightly.

related: #9158

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
