### PR TITLE
fix: directly get the sign of `Int256` in `hex_to_int256`

### DIFF
--- a/e2e_test/batch/types/int256.slt.part
+++ b/e2e_test/batch/types/int256.slt.part
@@ -77,7 +77,7 @@ select hex_to_int256('0x11');
 17
 
 query I
-select hex_to_int256('-0x11');
+select hex_to_int256('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffef');
 ----
 -17
 
@@ -86,6 +86,10 @@ select hex_to_int256('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ----
 7237005577332262213973186563042994240829374041602535252466099000494570602495
 
+query I
+select hex_to_int256('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01');
+----
+-255
 
 statement ok
 create table t (v rw_int256)

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -770,8 +770,8 @@ mod tests {
                     * Int256::from(i64::MAX)
                     * Int256::from(i64::MAX),
             ),
-            Some(Int256::min()),
-            Some(Int256::max()),
+            Some(Int256::min_value()),
+            Some(Int256::max_value()),
         ];
 
         let array =

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -405,7 +405,7 @@ impl DataType {
             DataType::Int16 => ScalarImpl::Int16(i16::MIN),
             DataType::Int32 => ScalarImpl::Int32(i32::MIN),
             DataType::Int64 => ScalarImpl::Int64(i64::MIN),
-            DataType::Int256 => ScalarImpl::Int256(Int256::min()),
+            DataType::Int256 => ScalarImpl::Int256(Int256::min_value()),
             DataType::Serial => ScalarImpl::Serial(Serial::from(i64::MIN)),
             DataType::Float32 => ScalarImpl::Float32(F32::neg_infinity()),
             DataType::Float64 => ScalarImpl::Float64(F64::neg_infinity()),

--- a/src/common/src/types/num256.rs
+++ b/src/common/src/types/num256.rs
@@ -21,7 +21,7 @@ use std::ops::{Add, Div, Mul, Neg, Rem, Sub};
 use std::str::FromStr;
 
 use bytes::{BufMut, Bytes};
-use ethnum::{i256, AsI256};
+use ethnum::{i256, u256, AsI256};
 use num_traits::{
     CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, One, Signed, Zero,
 };
@@ -197,9 +197,12 @@ impl Int256 {
 
     // `from_str_hex` function only accepts string inputs that start with "0x".
     pub fn from_str_hex(src: &str) -> Result<Self, ParseIntError> {
-        i256::from_str_hex(src)
-            .or_else(|_| i256::from_str_hex(&src.to_lowercase()))
-            .map(Into::into)
+        u256::from_str_hex(src)
+            .or_else(|_| u256::from_str_hex(&src.to_lowercase()))
+            .map(|u| {
+                println!("u is {}", u);
+                u.as_i256().into()
+            })
     }
 }
 

--- a/src/common/src/types/num256.rs
+++ b/src/common/src/types/num256.rs
@@ -79,12 +79,12 @@ macro_rules! impl_common_for_num256 {
 
         impl $scalar {
             #[inline]
-            pub fn min() -> Self {
+            pub fn min_value() -> Self {
                 Self::from(<$inner>::MIN)
             }
 
             #[inline]
-            pub fn max() -> Self {
+            pub fn max_value() -> Self {
                 Self::from(<$inner>::MAX)
             }
 
@@ -190,19 +190,16 @@ impl Int256 {
     // `from_str_prefixed` function accepts string inputs that start with "0x". If the parsing
     // fails, it will attempt to parse the input as a decimal value.
     pub fn from_str_prefixed(src: &str) -> Result<Self, ParseIntError> {
-        i256::from_str_prefixed(src)
-            .or_else(|_| i256::from_str_prefixed(&src.to_lowercase()))
-            .map(Into::into)
+        u256::from_str_prefixed(src)
+            .or_else(|_| u256::from_str_prefixed(&src.to_lowercase()))
+            .map(|u| u.as_i256().into())
     }
 
     // `from_str_hex` function only accepts string inputs that start with "0x".
     pub fn from_str_hex(src: &str) -> Result<Self, ParseIntError> {
         u256::from_str_hex(src)
             .or_else(|_| u256::from_str_hex(&src.to_lowercase()))
-            .map(|u| {
-                println!("u is {}", u);
-                u.as_i256().into()
-            })
+            .map(|u| u.as_i256().into())
     }
 }
 
@@ -481,11 +478,25 @@ mod tests {
     fn hex_to_int256() {
         assert_eq!(Int256::from_str_hex("0x0").unwrap(), Int256::from(0));
         assert_eq!(Int256::from_str_hex("0x1").unwrap(), Int256::from(1));
-        assert_eq!(Int256::from_str_hex("-0x1").unwrap(), Int256::from(-1));
+        assert_eq!(
+            Int256::from_str_hex(
+                "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+            )
+            .unwrap(),
+            Int256::from(-1)
+        );
         assert_eq!(Int256::from_str_hex("0xa").unwrap(), Int256::from(10));
         assert_eq!(Int256::from_str_hex("0xA").unwrap(), Int256::from(10));
-        assert_eq!(Int256::from_str_hex("-0Xff").unwrap(), Int256::from(-255));
         assert_eq!(Int256::from_str_hex("0Xff").unwrap(), Int256::from(255));
+
+        assert_eq!(
+            Int256::from_str_hex(
+                "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01"
+            )
+            .unwrap(),
+            Int256::from(-255)
+        );
+
         assert_eq!(
             Int256::from_str_hex("0xf").unwrap(),
             Int256::from_str("15").unwrap()
@@ -568,16 +579,16 @@ mod tests {
                 "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
             )
             .unwrap(),
-            Int256::max(),
+            Int256::max_value(),
         );
 
         // int256 min
         assert_eq!(
             Int256::from_str_hex(
-                "-0x8000000000000000000000000000000000000000000000000000000000000000"
+                "0x8000000000000000000000000000000000000000000000000000000000000000"
             )
             .unwrap(),
-            Int256::min(),
+            Int256::min_value(),
         );
     }
 }

--- a/src/expr/src/vector_op/int256.rs
+++ b/src/expr/src/vector_op/int256.rs
@@ -44,23 +44,33 @@ mod tests {
         assert_eq!(hex_to_int256("0x0").unwrap(), Int256::from(0));
         assert_eq!(hex_to_int256("0x0000").unwrap(), Int256::from(0));
         assert_eq!(hex_to_int256("0x1").unwrap(), Int256::from(1));
-        assert_eq!(hex_to_int256("-0x1").unwrap(), Int256::from(-1));
+
         assert_eq!(hex_to_int256("0xf").unwrap(), Int256::from(15));
         assert_eq!(hex_to_int256("0xff").unwrap(), Int256::from(255));
-        assert_eq!(hex_to_int256("-0xff").unwrap(), Int256::from(-255));
+
+        assert_eq!(
+            hex_to_int256("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+                .unwrap(),
+            Int256::from(-1)
+        );
+        assert_eq!(
+            hex_to_int256("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff01")
+                .unwrap(),
+            Int256::from(-255)
+        );
 
         // int256 max
         assert_eq!(
             hex_to_int256("0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
                 .unwrap(),
-            Int256::max(),
+            Int256::max_value(),
         );
 
         // int256 min
         assert_eq!(
-            hex_to_int256("-0x8000000000000000000000000000000000000000000000000000000000000000")
+            hex_to_int256("0x8000000000000000000000000000000000000000000000000000000000000000")
                 .unwrap(),
-            Int256::min(),
+            Int256::min_value(),
         );
     }
 }


### PR DESCRIPTION
Signed-off-by: Shanicky Chen <peng@risingwave-labs.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This is a simple fix to directly get the sign of `Int256` from the highest bit in the hex value. As a result, we no longer support the `-0xff` representation.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
