### PR TITLE
refactor: removed unused num-traits in hummock_sdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4089,17 +4089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "num-format"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6275,8 +6264,6 @@ dependencies = [
  "hex",
  "itertools",
  "madsim-tokio",
- "num-derive",
- "num-traits",
  "parking_lot 0.12.1",
  "parse-display",
  "risingwave_common",

--- a/src/storage/hummock_sdk/Cargo.toml
+++ b/src/storage/hummock_sdk/Cargo.toml
@@ -17,8 +17,6 @@ normal = ["workspace-hack"]
 bytes = "1"
 hex = "0.4"
 itertools = "0.10"
-num-derive = "0.3"
-num-traits = "0.2"
 parking_lot = "0.12"
 parse-display = "0.6"
 risingwave_common = { path = "../../common" }

--- a/src/storage/hummock_sdk/src/compaction_group/mod.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/mod.rs
@@ -22,7 +22,7 @@ pub type StateTableId = u32;
 
 /// A compaction task's `StaticCompactionGroupId` indicates the compaction group that all its input
 /// SSTs belong to.
-#[derive(FromPrimitive, Display)]
+#[derive(Display)]
 pub enum StaticCompactionGroupId {
     /// Create a new compaction group.
     NewCompactionGroup = 0,

--- a/src/storage/hummock_sdk/src/lib.rs
+++ b/src/storage/hummock_sdk/src/lib.rs
@@ -21,9 +21,6 @@
 
 mod key_cmp;
 
-#[macro_use]
-extern crate num_derive;
-
 use std::cmp::Ordering;
 
 pub use key_cmp::*;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

So that we can enable some lints about correct usage of `AsPrimitive` vs `FromPrimitive` vs `ToPrimitive` later. It seems this should not be relevant to hummuck.

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
