### PR TITLE
feat: separate handling for `sum` aggregation function of `Int256`.

### DIFF
--- a/e2e_test/batch/types/int256.slt.part
+++ b/e2e_test/batch/types/int256.slt.part
@@ -167,12 +167,12 @@ select distinct v::rw_int256 from generate_series(1, 1, 1) as t(v);
 ----
 1
 
-query T
+query I
 select max(v) from t;
 ----
 100000000000000000000000000000000
 
-query T
+query I
 select min(v) from t;
 ----
 -100000000000000000000000000000000
@@ -181,6 +181,29 @@ query I
 select count(v) from t;
 ----
 13
+
+statement ok
+insert into t values (1);
+
+query I
+select sum(v) from t;
+----
+1
+
+query I
+select count(v) from t;
+----
+14
+
+query I
+select count(distinct v) from t;
+----
+13
+
+query I
+select sum(distinct v) from t;
+----
+0
 
 statement ok
 drop table t;

--- a/src/expr/src/sig/agg.rs
+++ b/src/expr/src/sig/agg.rs
@@ -137,6 +137,7 @@ pub fn infer_return_type(agg_kind: &AggKind, inputs: &[DataType]) -> Option<Data
             DataType::Int16 => DataType::Int64,
             DataType::Int32 => DataType::Int64,
             DataType::Int64 => DataType::Decimal,
+            DataType::Int256 => DataType::Int256,
             DataType::Decimal => DataType::Decimal,
             DataType::Float32 => DataType::Float32,
             DataType::Float64 => DataType::Float64,

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -29,7 +29,7 @@ use crate::vector_op::agg::filter::*;
 use crate::vector_op::agg::functions::*;
 use crate::vector_op::agg::general_agg::*;
 use crate::vector_op::agg::general_distinct_agg::*;
-use crate::vector_op::agg::non_primitive::NonPrimitiveSum;
+use crate::vector_op::agg::non_primitive::Int256Sum;
 use crate::vector_op::agg::string_agg::create_string_agg_state;
 use crate::Result;
 
@@ -104,7 +104,7 @@ impl AggStateFactory {
             (AggKind::Sum, [arg])
                 if matches!(DataType::from(arg.get_type()?), DataType::Int256) =>
             {
-                Box::new(NonPrimitiveSum::new(return_type.clone()))
+                Box::new(Int256Sum::new(arg.get_index() as usize))
             }
             (AggKind::ArrayAgg, [arg]) => {
                 let agg_col_idx = arg.get_index() as usize;

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -111,7 +111,7 @@ impl AggStateFactory {
                 // here. It is important to note that this is a temporary and rough imitation of the
                 // `GeneralAgg` solution and will need to be considered and fixed
                 // when refactoring the code related to aggregation in the future.
-                Box::new(Int256Sum::new(arg.get_index() as usize))
+                Box::new(Int256Sum::new(arg.get_index() as usize, distinct))
             }
             (AggKind::ArrayAgg, [arg]) => {
                 let agg_col_idx = arg.get_index() as usize;

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -29,7 +29,7 @@ use crate::vector_op::agg::filter::*;
 use crate::vector_op::agg::functions::*;
 use crate::vector_op::agg::general_agg::*;
 use crate::vector_op::agg::general_distinct_agg::*;
-use crate::vector_op::agg::non_primitive::Int256Sum;
+use crate::vector_op::agg::non_primitive_sum::Int256Sum;
 use crate::vector_op::agg::string_agg::create_string_agg_state;
 use crate::Result;
 
@@ -104,6 +104,13 @@ impl AggStateFactory {
             (AggKind::Sum, [arg])
                 if matches!(DataType::from(arg.get_type()?), DataType::Int256) =>
             {
+                // Special handling of the `sum` function for `Int256`, when the
+                // `GeneralAgg` is applied to `sum`, it needs `sum` to return a temporary
+                // `ScalarRef` for intermediate variable. However, this is not feasible
+                // for non-primitive `Int256` types. Therefore, we have added a separate handling
+                // here. It is important to note that this is a temporary and rough imitation of the
+                // `GeneralAgg` solution and will need to be considered and fixed
+                // when refactoring the code related to aggregation in the future.
                 Box::new(Int256Sum::new(arg.get_index() as usize))
             }
             (AggKind::ArrayAgg, [arg]) => {

--- a/src/expr/src/vector_op/agg/aggregator.rs
+++ b/src/expr/src/vector_op/agg/aggregator.rs
@@ -29,6 +29,7 @@ use crate::vector_op::agg::filter::*;
 use crate::vector_op::agg::functions::*;
 use crate::vector_op::agg::general_agg::*;
 use crate::vector_op::agg::general_distinct_agg::*;
+use crate::vector_op::agg::non_primitive::NonPrimitiveSum;
 use crate::vector_op::agg::string_agg::create_string_agg_state;
 use crate::Result;
 
@@ -99,6 +100,11 @@ impl AggStateFactory {
                 let agg_col_idx = agg_arg.get_index() as usize;
                 let delim_col_idx = delim_arg.get_index() as usize;
                 create_string_agg_state(agg_col_idx, delim_col_idx, column_orders)?
+            }
+            (AggKind::Sum, [arg])
+                if matches!(DataType::from(arg.get_type()?), DataType::Int256) =>
+            {
+                Box::new(NonPrimitiveSum::new(return_type.clone()))
             }
             (AggKind::ArrayAgg, [arg]) => {
                 let agg_col_idx = arg.get_index() as usize;

--- a/src/expr/src/vector_op/agg/mod.rs
+++ b/src/expr/src/vector_op/agg/mod.rs
@@ -22,6 +22,7 @@ mod general_agg;
 mod general_distinct_agg;
 mod general_sorted_grouper;
 mod string_agg;
+mod non_primitive;
 
 pub use aggregator::{create_agg_state_unary, AggStateFactory, BoxedAggState};
 pub use general_sorted_grouper::{create_sorted_grouper, BoxedSortedGrouper, EqGroups};

--- a/src/expr/src/vector_op/agg/mod.rs
+++ b/src/expr/src/vector_op/agg/mod.rs
@@ -21,8 +21,8 @@ mod functions;
 mod general_agg;
 mod general_distinct_agg;
 mod general_sorted_grouper;
+mod non_primitive_sum;
 mod string_agg;
-mod non_primitive;
 
 pub use aggregator::{create_agg_state_unary, AggStateFactory, BoxedAggState};
 pub use general_sorted_grouper::{create_sorted_grouper, BoxedSortedGrouper, EqGroups};

--- a/src/expr/src/vector_op/agg/non_primitive.rs
+++ b/src/expr/src/vector_op/agg/non_primitive.rs
@@ -1,0 +1,97 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::array::{ArrayBuilderImpl, DataChunk};
+use risingwave_common::types::num256::Int256;
+use risingwave_common::types::DataType;
+
+use crate::vector_op::agg::aggregator::Aggregator;
+
+#[derive(Clone)]
+pub struct NonPrimitiveSum {
+    return_type: DataType,
+    result: Int256,
+}
+
+impl NonPrimitiveSum {
+    pub fn new(return_type: DataType) -> Self {
+        Self {
+            return_type,
+            result: Int256::default(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Aggregator for NonPrimitiveSum {
+    fn return_type(&self) -> DataType {
+        todo!()
+    }
+
+    async fn update_single(&mut self, input: &DataChunk, row_id: usize) -> crate::Result<()> {
+        todo!()
+    }
+
+    async fn update_multi(
+        &mut self,
+        input: &DataChunk,
+        start_row_id: usize,
+        end_row_id: usize,
+    ) -> crate::Result<()> {
+        todo!()
+    }
+
+    fn output(&mut self, builder: &mut ArrayBuilderImpl) -> crate::Result<()> {
+        todo!()
+    }
+    // fn return_type(&self) -> DataType {
+    //     self.return_type.clone()
+    // }
+    //
+    // async fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
+    //     if let (_, true) = input.row_at(row_id) {
+    //         self.result += 1;
+    //     }
+    //     Ok(())
+    // }
+    //
+    // async fn update_multi(
+    //     &mut self,
+    //     input: &DataChunk,
+    //     start_row_id: usize,
+    //     end_row_id: usize,
+    // ) -> Result<()> {
+    //     if let Some(visibility) = input.visibility() {
+    //         for row_id in start_row_id..end_row_id {
+    //             if visibility.is_set(row_id) {
+    //                 self.result += 1;
+    //             }
+    //         }
+    //     } else {
+    //         self.result += end_row_id - start_row_id;
+    //     }
+    //     Ok(())
+    // }
+    //
+    // fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
+    //     let res = std::mem::replace(&mut self.result, 0) as i64;
+    //     match builder {
+    //         ArrayBuilderImpl::Int64(b) => {
+    //             b.append(Some(res));
+    //             Ok(())
+    //         }
+    //         _ => bail!("Unexpected builder for count(*)."),
+    //     }
+    // }
+}

--- a/src/expr/src/vector_op/agg/non_primitive.rs
+++ b/src/expr/src/vector_op/agg/non_primitive.rs
@@ -12,35 +12,57 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::array::{ArrayBuilderImpl, DataChunk};
-use risingwave_common::types::num256::Int256;
-use risingwave_common::types::DataType;
+use anyhow::anyhow;
+use num_traits::Zero;
+use risingwave_common::array::{
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk,
+};
+use risingwave_common::bail;
+use risingwave_common::types::num256::{Int256, Int256Ref};
+use risingwave_common::types::{CheckedAdd, DataType, Scalar, ScalarRef};
 
 use crate::vector_op::agg::aggregator::Aggregator;
 
 #[derive(Clone)]
-pub struct NonPrimitiveSum {
-    return_type: DataType,
+pub struct Int256Sum {
+    input_col_idx: usize,
     result: Int256,
 }
 
-impl NonPrimitiveSum {
-    pub fn new(return_type: DataType) -> Self {
+impl Int256Sum {
+    pub fn new(input_col_idx: usize) -> Self {
         Self {
-            return_type,
-            result: Int256::default(),
+            input_col_idx,
+            result: Int256::zero(),
         }
+    }
+
+    fn add(&mut self, scalar_ref: Option<Int256Ref<'_>>) -> crate::Result<()> {
+        self.result = self.result
+            .checked_add(scalar_ref.to_owned_scalar())
+            .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+        Ok(())
     }
 }
 
 #[async_trait::async_trait]
-impl Aggregator for NonPrimitiveSum {
+impl Aggregator for Int256Sum {
     fn return_type(&self) -> DataType {
-        todo!()
+        DataType::Int256
     }
 
     async fn update_single(&mut self, input: &DataChunk, row_id: usize) -> crate::Result<()> {
-        todo!()
+        if let ArrayImpl::Int256(array) = input.column_at(self.input_col_idx).array_ref() {
+            self.result = array
+                .value_at(row_id)
+                .and_then(|scalar_ref| {
+                    self.result
+                        .clone()
+                        .checked_add(scalar_ref.to_owned_scalar())
+                })
+                .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+        }
+        Ok(())
     }
 
     async fn update_multi(
@@ -49,49 +71,29 @@ impl Aggregator for NonPrimitiveSum {
         start_row_id: usize,
         end_row_id: usize,
     ) -> crate::Result<()> {
-        todo!()
+        if let ArrayImpl::Int256(array) = input.column_at(self.input_col_idx).array_ref() {
+            let mut cur = self.result.clone();
+            for row_id in start_row_id..end_row_id {
+                cur = array
+                    .value_at(row_id)
+                    .and_then(|scalar_ref| cur.checked_add(scalar_ref.to_owned_scalar()))
+                    .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+            }
+            self.result = cur;
+            Ok(())
+        } else {
+            bail!("Unexpected array type for sum(int256).")
+        }
     }
 
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> crate::Result<()> {
-        todo!()
+        let res = std::mem::take(&mut self.result);
+        match builder {
+            ArrayBuilderImpl::Int256(b) => {
+                b.append(Some(res.as_scalar_ref()));
+                Ok(())
+            }
+            _ => bail!("Unexpected builder for sum(int256)."),
+        }
     }
-    // fn return_type(&self) -> DataType {
-    //     self.return_type.clone()
-    // }
-    //
-    // async fn update_single(&mut self, input: &DataChunk, row_id: usize) -> Result<()> {
-    //     if let (_, true) = input.row_at(row_id) {
-    //         self.result += 1;
-    //     }
-    //     Ok(())
-    // }
-    //
-    // async fn update_multi(
-    //     &mut self,
-    //     input: &DataChunk,
-    //     start_row_id: usize,
-    //     end_row_id: usize,
-    // ) -> Result<()> {
-    //     if let Some(visibility) = input.visibility() {
-    //         for row_id in start_row_id..end_row_id {
-    //             if visibility.is_set(row_id) {
-    //                 self.result += 1;
-    //             }
-    //         }
-    //     } else {
-    //         self.result += end_row_id - start_row_id;
-    //     }
-    //     Ok(())
-    // }
-    //
-    // fn output(&mut self, builder: &mut ArrayBuilderImpl) -> Result<()> {
-    //     let res = std::mem::replace(&mut self.result, 0) as i64;
-    //     match builder {
-    //         ArrayBuilderImpl::Int64(b) => {
-    //             b.append(Some(res));
-    //             Ok(())
-    //         }
-    //         _ => bail!("Unexpected builder for count(*)."),
-    //     }
-    // }
 }

--- a/src/expr/src/vector_op/agg/non_primitive_sum.rs
+++ b/src/expr/src/vector_op/agg/non_primitive_sum.rs
@@ -14,11 +14,9 @@
 
 use anyhow::anyhow;
 use num_traits::Zero;
-use risingwave_common::array::{
-    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk,
-};
+use risingwave_common::array::{Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk};
 use risingwave_common::bail;
-use risingwave_common::types::num256::{Int256, Int256Ref};
+use risingwave_common::types::num256::Int256;
 use risingwave_common::types::{CheckedAdd, DataType, Scalar, ScalarRef};
 
 use crate::vector_op::agg::aggregator::Aggregator;
@@ -35,13 +33,6 @@ impl Int256Sum {
             input_col_idx,
             result: Int256::zero(),
         }
-    }
-
-    fn add(&mut self, scalar_ref: Option<Int256Ref<'_>>) -> crate::Result<()> {
-        self.result = self.result
-            .checked_add(scalar_ref.to_owned_scalar())
-            .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
-        Ok(())
     }
 }
 
@@ -87,10 +78,9 @@ impl Aggregator for Int256Sum {
     }
 
     fn output(&mut self, builder: &mut ArrayBuilderImpl) -> crate::Result<()> {
-        let res = std::mem::take(&mut self.result);
         match builder {
             ArrayBuilderImpl::Int256(b) => {
-                b.append(Some(res.as_scalar_ref()));
+                b.append(Some(self.result.as_scalar_ref()));
                 Ok(())
             }
             _ => bail!("Unexpected builder for sum(int256)."),

--- a/src/expr/src/vector_op/agg/non_primitive_sum.rs
+++ b/src/expr/src/vector_op/agg/non_primitive_sum.rs
@@ -12,12 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::HashSet;
+
 use anyhow::anyhow;
-use num_traits::Zero;
-use risingwave_common::array::{Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk};
+use num_traits::{CheckedAdd, Zero};
+use risingwave_common::array::{
+    Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, DataChunk, Int256Array,
+};
 use risingwave_common::bail;
 use risingwave_common::types::num256::Int256;
-use risingwave_common::types::{CheckedAdd, DataType, Scalar, ScalarRef};
+use risingwave_common::types::{DataType, Scalar, ScalarRef};
 
 use crate::vector_op::agg::aggregator::Aggregator;
 
@@ -25,14 +29,35 @@ use crate::vector_op::agg::aggregator::Aggregator;
 pub struct Int256Sum {
     input_col_idx: usize,
     result: Int256,
+    distinct: bool,
+    exists: HashSet<Option<Int256>>,
 }
 
 impl Int256Sum {
-    pub fn new(input_col_idx: usize) -> Self {
+    pub fn new(input_col_idx: usize, distinct: bool) -> Self {
         Self {
             input_col_idx,
+            distinct,
             result: Int256::zero(),
+            exists: HashSet::new(),
         }
+    }
+
+    fn accumulate_value_at(&mut self, array: &Int256Array, row_id: usize) -> crate::Result<()> {
+        let value = array
+            .value_at(row_id)
+            .map(|scalar_ref| scalar_ref.to_owned_scalar());
+
+        if !self.distinct || self.exists.insert(value.clone()) {
+            if let Some(scalar) = value {
+                self.result = self
+                    .result
+                    .checked_add(&scalar)
+                    .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -44,14 +69,7 @@ impl Aggregator for Int256Sum {
 
     async fn update_single(&mut self, input: &DataChunk, row_id: usize) -> crate::Result<()> {
         if let ArrayImpl::Int256(array) = input.column_at(self.input_col_idx).array_ref() {
-            self.result = array
-                .value_at(row_id)
-                .and_then(|scalar_ref| {
-                    self.result
-                        .clone()
-                        .checked_add(scalar_ref.to_owned_scalar())
-                })
-                .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+            self.accumulate_value_at(array, row_id)?;
         }
         Ok(())
     }
@@ -63,14 +81,9 @@ impl Aggregator for Int256Sum {
         end_row_id: usize,
     ) -> crate::Result<()> {
         if let ArrayImpl::Int256(array) = input.column_at(self.input_col_idx).array_ref() {
-            let mut cur = self.result.clone();
             for row_id in start_row_id..end_row_id {
-                cur = array
-                    .value_at(row_id)
-                    .and_then(|scalar_ref| cur.checked_add(scalar_ref.to_owned_scalar()))
-                    .ok_or_else(|| anyhow!("Overflow when summing up Int256 values."))?;
+                self.accumulate_value_at(array, row_id)?;
             }
-            self.result = cur;
             Ok(())
         } else {
             bail!("Unexpected array type for sum(int256).")


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR implements a separate, rough `sum` function for non-primitive types such as `Int256`. This should be considered and removed during future refactoring of the aggregation functions.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
