### PR TITLE
fix(test): fix panic on scaling test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "madsim"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0296e75e03fc45c2e0bd30a11eb023a6b5698c781355ae526a01478bb09dd83"
+checksum = "3d3f6f28042419b0a63a7db6a8b4f74db021453d567f76cdbfd81494eeec0b22"
 dependencies = [
  "ahash 0.7.6",
  "async-channel",
@@ -3702,9 +3702,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-tonic"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189f256e4ce279a6635b323d2b9652f0cd530c89916ac9b1c08228141104cddd"
+checksum = "fe20f1ea4dcec4518527299b2313c680d7f064140e026c0fa4c2857649d982f4"
 dependencies = [
  "async-stream",
  "chrono",

--- a/src/prost/Cargo.toml
+++ b/src/prost/Cargo.toml
@@ -13,7 +13,7 @@ pbjson = "0.5"
 prost = "0.11"
 prost-helpers = { path = "helpers" }
 serde = { version = "1", features = ["derive"] }
-tonic = { version = "0.2.20", package = "madsim-tonic" }
+tonic = { version = "0.2.21", package = "madsim-tonic" }
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -21,7 +21,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"
 lru = { git = "https://github.com/risingwavelabs/lru-rs.git", branch = "evict_by_timestamp" }
-madsim = "0.2.20"
+madsim = "0.2.21"
 paste = "1"
 pin-project = "1.0"
 pretty_assertions = "1"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR updates madsim again to fix the [panic](https://buildkite.com/risingwavelabs/main/builds/3808#01877eb4-587e-4403-bcdb-826ffd1f1113/180-1425) in scaling recovery test since #9168.

Also added `madsim::time::advance` API to simulate spin loop in #9135. 

Related PR: https://github.com/madsim-rs/madsim/pull/140

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
