### PR TITLE
fix(udf): fix bad data sent to UDF server

### DIFF
--- a/src/udf/src/lib.rs
+++ b/src/udf/src/lib.rs
@@ -95,14 +95,17 @@ impl ArrowFlightUdfClient {
         inputs: impl Stream<Item = RecordBatch> + Send + 'static,
     ) -> Result<impl Stream<Item = Result<RecordBatch>> + Send + 'static> {
         let descriptor = FlightDescriptor::new_path(vec![id.into()]);
-        let flight_data_stream =
-            FlightDataEncoderBuilder::new()
-                .build(inputs.map(Ok))
-                .map(move |res| FlightData {
-                    // TODO: fill descriptor only for the first message
-                    flight_descriptor: Some(descriptor.clone()),
-                    ..res.unwrap()
-                });
+        let flight_data_stream = FlightDataEncoderBuilder::new()
+            // XXX(wrj): unlimit the size of flight data to avoid splitting batch
+            //           there's a bug in arrow-flight when splitting batch with list type array
+            // FIXME: remove this when the bug is fixed in arrow-flight
+            .with_max_flight_data_size(usize::MAX)
+            .build(inputs.map(Ok))
+            .map(move |res| FlightData {
+                // TODO: fill descriptor only for the first message
+                flight_descriptor: Some(descriptor.clone()),
+                ..res.unwrap()
+            });
 
         // call `do_exchange` on Flight server
         let response = self.client.clone().do_exchange(flight_data_stream).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR fixes the bug that caused inconsistent result between select item and having clause.

```sql
SELECT some_udf(array_agg(traces::varchar))
FROM ...
GROUP BY ...
HAVING some_udf(array_agg(traces::varchar))
--- expect: t,t,t,t,t...
--- actual: t,t,f,t,f...
```

It turned out to be a bug in arrow-flight v36.0. When encoding a chunk before sending to UDF server, the encoder will split it into multiple chunks smaller than 2MB. However, the subsequent chunks are repeating the first one if there's a column of `VARCHAR[]`.

A minimal reproducible example is:
```python
@udf(input_types=['VARCHAR[]'], result_type="INT")
def strlen(s: list[str]) -> int:
    return len(s[0])
```
```sql
create function strlen(varchar[]) returns int
language python as strlen using link 'http://localhost:8815';

-- construct an array of varchar[] whose size is large enough
SELECT strlen(array[rpad('', i, 'x')]) FROM generate_series(100000, 100100, 1) AS t(i);
-- expect: 100000...100100
-- actual: 100000...100019,100000...100019,100000...100019,...
```

I have not found the source of this bug in arrow-flight yet. So this PR simply disables the size limit to avoid chunk splitting. We'll report this issue to arrow-rs and submit a patch later if possible.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
