### PR TITLE
feat(frontend): postgres' behavior of misaligned insert

### DIFF
--- a/e2e_test/batch/basic/insert_unaligned.slt.part
+++ b/e2e_test/batch/basic/insert_unaligned.slt.part
@@ -1,0 +1,97 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table t (v1 int);
+
+statement ok
+insert into t values (10), (20), (30);
+
+statement ok
+create table t1 (v1 int, v2 int);
+
+statement ok
+insert into t1 (v1) values (1), (2);
+
+query I rowsort
+select * from t1;
+----
+1 NULL
+2 NULL
+
+statement ok
+insert into t1 (v2) values (1), (2);
+
+query I rowsort
+select * from t1;
+----
+1 NULL
+2 NULL
+NULL 1
+NULL 2
+
+statement ok
+insert into t1 select * from t;
+
+query I rowsort
+select * from t1;
+----
+1 NULL
+10 NULL
+2 NULL
+20 NULL
+30 NULL
+NULL 1
+NULL 2
+
+statement ok
+insert into t1 (v2) select * from t;
+
+query I rowsort
+select * from t1;
+----
+1 NULL
+10 NULL
+2 NULL
+20 NULL
+30 NULL
+NULL 1
+NULL 10
+NULL 2
+NULL 20
+NULL 30
+
+statement error
+insert into t1 (v1, v2) select * from t;
+
+statement error
+insert into t1 (v1, v2) values (1);
+
+statement error
+insert into t1 (v1, v2) values (1, 2, 3);
+
+statement ok
+delete from t1;
+
+statement ok
+insert into t1 (v2, v1) values (2, 1);
+
+query I rowsort
+select * from t1;
+----
+1 2
+
+statement ok
+insert into t1 (v2, v1) select * from t1;
+
+query I rowsort
+select * from t1;
+----
+1 2
+2 1
+
+statement ok
+drop table t1;
+
+statement ok
+drop table t;

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -83,6 +83,10 @@ message InsertNode {
   // An optional field and will be `None` for tables without user-defined pk.
   // The `BatchInsertExecutor` should add a column with NULL value which will
   // be filled in streaming.
+  message DefaultColumnIndices {
+    repeated uint32 default_column_indices = 1;
+  }
+  optional DefaultColumnIndices default_column_indices = 6;
   optional uint32 row_id_index = 3;
   bool returning = 4;
 }

--- a/proto/batch_plan.proto
+++ b/proto/batch_plan.proto
@@ -83,10 +83,14 @@ message InsertNode {
   // An optional field and will be `None` for tables without user-defined pk.
   // The `BatchInsertExecutor` should add a column with NULL value which will
   // be filled in streaming.
-  message DefaultColumnIndices {
-    repeated uint32 default_column_indices = 1;
+  message DefaultColumns {
+    message IndexAndExpr {
+      uint32 index = 1;
+      expr.ExprNode expr = 2;
+    }
+    repeated IndexAndExpr default_column = 1;
   }
-  optional DefaultColumnIndices default_column_indices = 6;
+  optional DefaultColumns default_columns = 6;
   optional uint32 row_id_index = 3;
   bool returning = 4;
 }

--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -210,7 +210,8 @@ impl BoxedExecutorBuilder for InsertExecutor {
                 .map(|IndexAndExpr { index: i, expr: e }| {
                     (
                         i as usize,
-                        build_from_prost(&(e.expect("expr should be Some"))).expect("expr corrputed"),
+                        build_from_prost(&(e.expect("expr should be Some")))
+                            .expect("expr corrputed"),
                     )
                 })
                 .collect_vec();

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -231,6 +231,7 @@ async fn test_table_materialize() -> StreamResult<()> {
         1024,
         "InsertExecutor".to_string(),
         vec![], // ignore insertion order
+        vec![], 
         Some(row_id_index),
         false,
     ));

--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -231,7 +231,7 @@ async fn test_table_materialize() -> StreamResult<()> {
         1024,
         "InsertExecutor".to_string(),
         vec![], // ignore insertion order
-        vec![], 
+        vec![],
         Some(row_id_index),
         false,
     ));

--- a/src/frontend/planner_test/tests/testdata/insert.yaml
+++ b/src/frontend/planner_test/tests/testdata/insert.yaml
@@ -27,7 +27,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[1:Float32, 2:Int32, null:Varchar]] }
+      └─BatchValues { rows: [[1:Float32, 2:Int32]] }
 - name: insert values with implicit null (multiple rows)
   sql: |
     create table t (v1 real, v2 int, v3 varchar);
@@ -35,7 +35,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[1:Float32, 2:Int32, null:Varchar], [3:Float32, 4:Int32, null:Varchar]] }
+      └─BatchValues { rows: [[1:Float32, 2:Int32], [3:Float32, 4:Int32]] }
 - name: implicit null user defined columns 1
   sql: |
     create table t (v1 int, v2 int);
@@ -43,7 +43,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[5:Int32, null:Int32]] }
+      └─BatchValues { rows: [[5:Int32]] }
 - name: implicit null user defined columns 2
   sql: |
     create table t (v1 int, v2 int);
@@ -51,7 +51,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[6:Int32, null:Int32]] }
+      └─BatchValues { rows: [[6:Int32]] }
 - name: implicit null user defined columns 3
   sql: |
     create table t (v1 int, v2 int, v3 int);
@@ -59,7 +59,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[6:Int32, null:Int32, null:Int32]] }
+      └─BatchValues { rows: [[6:Int32]] }
 - name: implicit null user defined columns 4
   sql: |
     create table t (v1 int, v2 int, v3 int);
@@ -67,7 +67,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[6:Int32, null:Int32, null:Int32]] }
+      └─BatchValues { rows: [[6:Int32]] }
 - name: implicit null user defined columns 5
   sql: |
     create table t (v1 int, v2 int, v3 int);
@@ -75,7 +75,7 @@
   batch_plan: |
     BatchExchange { order: [], dist: Single }
     └─BatchInsert { table: t }
-      └─BatchValues { rows: [[6:Int32, null:Int32, null:Int32]] }
+      └─BatchValues { rows: [[6:Int32]] }
 - name: insert values on non-assign-castable types
   sql: |
     create table t (v1 real, v2 int);
@@ -234,3 +234,86 @@
     create table t (a int, b int);
     insert into t values (0,1), (1,2) returning sum(a);
   binder_error: 'Bind error: should not have agg/window in the `RETURNING` list'
+- name: insert and specify all columns with values
+  sql: |
+    create table t (a int, b int);
+    insert into t (b, a) values (1, 2);
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalValues { rows: [[1:Int32, 2:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32, *VALUES*_0.column_1:Int32] } }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[1:Int32, 2:Int32]] }
+- name: insert and specify all columns with query
+  sql: |
+    create table t (a int, b int);
+    insert into t (b, a) select * from t;
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalProject { exprs: [t.a, t.b] }
+      └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.a, t.b], distribution: SomeShard }
+- name: insert and specify some columns with values
+  sql: |
+    create table t (a int, b int);
+    insert into t (a) values (1), (2);
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalValues { rows: [[1:Int32], [2:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[1:Int32], [2:Int32]] }
+- name: insert and specify some columns with query
+  sql: |
+    create table t (a int, b int);
+    insert into t (a) select b from t;
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalProject { exprs: [t.b] }
+      └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.b], distribution: SomeShard }
+- name: insert with less source columns from values
+  sql: |
+    create table t (a int, b int);
+    insert into t values (1);
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalValues { rows: [[1:Int32]], schema: Schema { fields: [*VALUES*_0.column_0:Int32] } }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchValues { rows: [[1:Int32]] }
+- name: insert with less source columns from query
+  sql: |
+    create table t (a int, b int);
+    insert into t select a from t;
+  logical_plan: |
+    LogicalInsert { table: t }
+    └─LogicalProject { exprs: [t.a] }
+      └─LogicalProject { exprs: [t.a] }
+        └─LogicalScan { table: t, columns: [t.a, t.b, t._row_id] }
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchInsert { table: t }
+      └─BatchExchange { order: [], dist: Single }
+        └─BatchScan { table: t, columns: [t.a], distribution: SomeShard }
+- name: insert with more source columns, reject
+  sql: |
+    create table t (a int, b int);
+    insert into t values (1, 2, 3);
+  binder_error: 'Bind error: INSERT has more expressions than target columns'
+- name: insert with more source columns than target, reject
+  sql: |
+    create table t (a int, b int);
+    insert into t (a) select * from t;
+  binder_error: 'Bind error: INSERT has more expressions than target columns'

--- a/src/frontend/src/binder/insert.rs
+++ b/src/frontend/src/binder/insert.rs
@@ -265,7 +265,7 @@ impl Binder {
         println!(
             "col_indices_to_insert: {:?}, default_column_indices: {:?}",
             col_indices_to_insert.clone(),
-            default_column_indices.clone().unwrap_or_default()
+            default_columns.clone().unwrap_or_default()
         );
 
         let insert = BoundInsert {

--- a/src/frontend/src/binder/values.rs
+++ b/src/frontend/src/binder/values.rs
@@ -102,21 +102,11 @@ impl Binder {
 
         // Adding Null values in case user did not specify all columns. E.g.
         // create table t1 (v1 int, v2 int); insert into t1 (v2) values (5);
-        let mut num_columns = bound[0].len();
+        let num_columns = bound[0].len();
         if bound.iter().any(|row| row.len() != num_columns) {
             return Err(
                 ErrorCode::BindError("VALUES lists must all be the same length".into()).into(),
             );
-        }
-        if let Some(expected_types) = &expected_types && expected_types.len() > num_columns {
-            let nulls_to_insert = expected_types.len() - num_columns;
-            for row in &mut bound {
-                for i in 0..nulls_to_insert {
-                    let t = expected_types[num_columns + i].clone();
-                    row.push(ExprImpl::literal_null(t));
-                }
-            }
-            num_columns = expected_types.len();
         }
 
         // Calculate column types.
@@ -138,7 +128,7 @@ impl Binder {
         let schema = Schema::new(
             types
                 .into_iter()
-                .zip_eq_fast(0..num_columns)
+                .zip(0..num_columns)
                 .map(|(ty, col_id)| Field::with_name(ty, values_column_name(values_id, col_id)))
                 .collect(),
         );

--- a/src/frontend/src/binder/values.rs
+++ b/src/frontend/src/binder/values.rs
@@ -16,7 +16,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
-use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_sqlparser::ast::Values;
 
 use super::bind_context::Clause;
@@ -125,6 +124,7 @@ impl Binder {
         };
 
         let values_id = self.next_values_id();
+        #[expect(clippy::disallowed_methods)]
         let schema = Schema::new(
             types
                 .into_iter()
@@ -158,7 +158,7 @@ impl Binder {
 
 #[cfg(test)]
 mod tests {
-    use risingwave_common::util::iter_util::zip_eq_fast;
+    use risingwave_common::util::iter_util::{zip_eq_fast, ZipEqFast};
     use risingwave_sqlparser::ast::{Expr, Value};
 
     use super::*;

--- a/src/frontend/src/optimizer/plan_node/batch_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_insert.rs
@@ -83,19 +83,18 @@ impl ToBatchPb for BatchInsert {
             .iter()
             .map(|&i| i as u32)
             .collect();
-        let default_columns = if let Some(default_columns) = self.logical.default_columns() {
-            Some(DefaultColumns {
-                default_column: default_columns
-                    .iter()
-                    .map(|(i, expr)| IndexAndExpr {
-                        index: *i as u32,
-                        expr: Some(expr.to_expr_proto()),
-                    })
-                    .collect_vec(),
-            })
-        } else {
-            None
-        };
+        let default_columns =
+            self.logical
+                .default_columns()
+                .map(|default_columns| DefaultColumns {
+                    default_column: default_columns
+                        .iter()
+                        .map(|(i, expr)| IndexAndExpr {
+                            index: *i as u32,
+                            expr: Some(expr.to_expr_proto()),
+                        })
+                        .collect_vec(),
+                });
         NodeBody::Insert(InsertNode {
             table_id: self.logical.table_id().table_id(),
             table_version_id: self.logical.table_version_id(),

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -23,6 +23,7 @@ use super::{
     PlanTreeNodeUnary, PredicatePushdown, ToBatch, ToStream,
 };
 use crate::catalog::TableId;
+use crate::expr::ExprImpl;
 use crate::optimizer::plan_node::{
     ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
@@ -41,7 +42,7 @@ pub struct LogicalInsert {
     table_version_id: TableVersionId,
     input: PlanRef,
     column_indices: Vec<usize>, // columns in which to insert
-    default_column_indices: Option<Vec<usize>>, // columns to be set to default
+    default_columns: Option<Vec<(usize, ExprImpl)>>, // columns to be set to default
     row_id_index: Option<usize>,
     returning: bool,
 }
@@ -54,7 +55,7 @@ impl LogicalInsert {
         table_id: TableId,
         table_version_id: TableVersionId,
         column_indices: Vec<usize>,
-        default_column_indices: Option<Vec<usize>>,
+        default_columns: Option<Vec<(usize, ExprImpl)>>,
         row_id_index: Option<usize>,
         returning: bool,
     ) -> Self {
@@ -73,7 +74,7 @@ impl LogicalInsert {
             table_version_id,
             input,
             column_indices,
-            default_column_indices,
+            default_columns,
             row_id_index,
             returning,
         }
@@ -86,7 +87,7 @@ impl LogicalInsert {
         table_id: TableId,
         table_version_id: TableVersionId,
         column_indices: Vec<usize>,
-        default_column_indices: Option<Vec<usize>>,
+        default_columns: Option<Vec<(usize, ExprImpl)>>,
         row_id_index: Option<usize>,
         returning: bool,
     ) -> Result<Self> {
@@ -96,7 +97,7 @@ impl LogicalInsert {
             table_id,
             table_version_id,
             column_indices,
-            default_column_indices,
+            default_columns,
             row_id_index,
             returning,
         ))
@@ -123,8 +124,8 @@ impl LogicalInsert {
     }
 
     #[must_use]
-    pub fn default_column_indices(&self) -> Option<Vec<usize>> {
-        self.default_column_indices.clone()
+    pub fn default_columns(&self) -> Option<Vec<(usize, ExprImpl)>> {
+        self.default_columns.clone()
     }
 
     #[must_use]
@@ -158,7 +159,7 @@ impl PlanTreeNodeUnary for LogicalInsert {
             self.table_id,
             self.table_version_id,
             self.column_indices.clone(),
-            self.default_column_indices.clone(),
+            self.default_columns.clone(),
             self.row_id_index,
             self.returning,
         )

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -41,6 +41,7 @@ pub struct LogicalInsert {
     table_version_id: TableVersionId,
     input: PlanRef,
     column_indices: Vec<usize>, // columns in which to insert
+    default_column_indices: Option<Vec<usize>>, // columns to be set to default
     row_id_index: Option<usize>,
     returning: bool,
 }
@@ -53,6 +54,7 @@ impl LogicalInsert {
         table_id: TableId,
         table_version_id: TableVersionId,
         column_indices: Vec<usize>,
+        default_column_indices: Option<Vec<usize>>,
         row_id_index: Option<usize>,
         returning: bool,
     ) -> Self {
@@ -71,6 +73,7 @@ impl LogicalInsert {
             table_version_id,
             input,
             column_indices,
+            default_column_indices,
             row_id_index,
             returning,
         }
@@ -83,6 +86,7 @@ impl LogicalInsert {
         table_id: TableId,
         table_version_id: TableVersionId,
         column_indices: Vec<usize>,
+        default_column_indices: Option<Vec<usize>>,
         row_id_index: Option<usize>,
         returning: bool,
     ) -> Result<Self> {
@@ -92,6 +96,7 @@ impl LogicalInsert {
             table_id,
             table_version_id,
             column_indices,
+            default_column_indices,
             row_id_index,
             returning,
         ))
@@ -115,6 +120,11 @@ impl LogicalInsert {
     #[must_use]
     pub fn column_indices(&self) -> Vec<usize> {
         self.column_indices.clone()
+    }
+
+    #[must_use]
+    pub fn default_column_indices(&self) -> Option<Vec<usize>> {
+        self.default_column_indices.clone()
     }
 
     #[must_use]
@@ -148,6 +158,7 @@ impl PlanTreeNodeUnary for LogicalInsert {
             self.table_id,
             self.table_version_id,
             self.column_indices.clone(),
+            self.default_column_indices.clone(),
             self.row_id_index,
             self.returning,
         )

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -49,6 +49,7 @@ pub struct LogicalInsert {
 
 impl LogicalInsert {
     /// Create a [`LogicalInsert`] node. Used internally by optimizer.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         input: PlanRef,
         table_name: String,
@@ -81,6 +82,7 @@ impl LogicalInsert {
     }
 
     /// Create a [`LogicalInsert`] node. Used by planner.
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         input: PlanRef,
         table_name: String,

--- a/src/frontend/src/planner/insert.rs
+++ b/src/frontend/src/planner/insert.rs
@@ -34,6 +34,7 @@ impl Planner {
             insert.table_id,
             insert.table_version_id,
             insert.column_indices,
+            insert.default_column_indices,
             insert.row_id_index,
             returning,
         )?

--- a/src/frontend/src/planner/insert.rs
+++ b/src/frontend/src/planner/insert.rs
@@ -34,7 +34,7 @@ impl Planner {
             insert.table_id,
             insert.table_version_id,
             insert.column_indices,
-            insert.default_column_indices,
+            insert.default_columns,
             insert.row_id_index,
             returning,
         )?


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
`insert` follows postgres' behavior.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
postpone padding nulls to insert executor, and arbitrarily bind to first a few columns when source's schema is less.
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)
#9036 

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

~~- [ ] My PR **DOES NOT** contain user-facing changes.~~

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
`insert` follows postgres' behavior.
