### PR TITLE
fix(meta): correctly specify mv_table for compaction group manager

### DIFF
--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -91,7 +91,8 @@ impl<S: MetaStore> HummockManager<S> {
     /// Registers `table_fragments` to compaction groups.
     pub async fn register_table_fragments(
         &self,
-        table_fragments: &TableFragments,
+        mv_table: Option<u32>,
+        mut internal_tables: Vec<u32>,
         table_properties: &HashMap<String, String>,
     ) -> Result<Vec<StateTableId>> {
         let is_independent_compaction_group = table_properties
@@ -99,18 +100,22 @@ impl<S: MetaStore> HummockManager<S> {
             .map(|s| s == "1")
             == Some(true);
         let mut pairs = vec![];
-        // materialized_view
-        pairs.push((
-            table_fragments.table_id().table_id,
-            if is_independent_compaction_group {
-                CompactionGroupId::from(StaticCompactionGroupId::NewCompactionGroup)
-            } else {
-                CompactionGroupId::from(StaticCompactionGroupId::MaterializedView)
-            },
-        ));
+        if let Some(mv_table) = mv_table {
+            if internal_tables.drain_filter(|t| *t == mv_table).count() > 0 {
+                tracing::warn!("`mv_table` {} found in `internal_tables`", mv_table);
+            }
+            // materialized_view
+            pairs.push((
+                mv_table,
+                if is_independent_compaction_group {
+                    CompactionGroupId::from(StaticCompactionGroupId::NewCompactionGroup)
+                } else {
+                    CompactionGroupId::from(StaticCompactionGroupId::MaterializedView)
+                },
+            ));
+        }
         // internal states
-        for table_id in table_fragments.internal_table_ids() {
-            assert_ne!(table_id, table_fragments.table_id().table_id);
+        for table_id in internal_tables {
             pairs.push((
                 table_id,
                 if is_independent_compaction_group {
@@ -920,12 +925,20 @@ mod tests {
         )]);
 
         compaction_group_manager
-            .register_table_fragments(&table_fragment_1, &table_properties)
+            .register_table_fragments(
+                Some(table_fragment_1.table_id().table_id),
+                table_fragment_1.internal_table_ids(),
+                &table_properties,
+            )
             .await
             .unwrap();
         assert_eq!(registered_number().await, 4);
         compaction_group_manager
-            .register_table_fragments(&table_fragment_2, &table_properties)
+            .register_table_fragments(
+                Some(table_fragment_2.table_id().table_id),
+                table_fragment_2.internal_table_ids(),
+                &table_properties,
+            )
             .await
             .unwrap();
         assert_eq!(registered_number().await, 8);
@@ -953,7 +966,11 @@ mod tests {
             String::from("1"),
         );
         compaction_group_manager
-            .register_table_fragments(&table_fragment_1, &table_properties)
+            .register_table_fragments(
+                Some(table_fragment_1.table_id().table_id),
+                table_fragment_1.internal_table_ids(),
+                &table_properties,
+            )
             .await
             .unwrap();
         assert_eq!(registered_number().await, 4);

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -62,6 +62,15 @@ impl StreamingJob {
         }
     }
 
+    pub fn mv_table(&self) -> Option<u32> {
+        match self {
+            Self::MaterializedView(table) => Some(table.id),
+            Self::Sink(_sink) => None,
+            Self::Table(_, table) => Some(table.id),
+            Self::Index(_, table) => Some(table.id),
+        }
+    }
+
     /// Returns the reference to the [`Table`] of the job if it exists.
     pub fn table(&self) -> Option<&Table> {
         match self {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -404,6 +404,7 @@ where
             existing_locations,
             table_properties: stream_job.properties(),
             definition: stream_job.mview_definition(),
+            mv_table_id: stream_job.mv_table(),
         };
 
         // 4. Mark creating tables, including internal tables and the table of the stream job.

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -65,6 +65,8 @@ pub struct CreateStreamingJobContext {
 
     /// DDL definition.
     pub definition: String,
+
+    pub mv_table_id: Option<u32>,
 }
 
 impl CreateStreamingJobContext {
@@ -388,17 +390,23 @@ where
             building_locations,
             existing_locations,
             definition,
+            mv_table_id,
+            internal_tables,
             ..
         }: CreateStreamingJobContext,
     ) -> MetaResult<()> {
         // Register to compaction group beforehand.
         let hummock_manager_ref = self.hummock_manager.clone();
         let registered_table_ids = hummock_manager_ref
-            .register_table_fragments(&table_fragments, &table_properties)
+            .register_table_fragments(
+                mv_table_id,
+                internal_tables.keys().copied().collect(),
+                &table_properties,
+            )
             .await?;
         debug_assert_eq!(
             registered_table_ids.len(),
-            table_fragments.all_table_ids().count()
+            table_fragments.internal_table_ids().len() + mv_table_id.map_or(0, |_| 1)
         );
         revert_funcs.push(Box::pin(async move {
             if let Err(e) = hummock_manager_ref.unregister_table_ids(&registered_table_ids).await {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously `CompactionGroupManager` infers mv table id from `TableFragments::table_id`, aka `StreamingJob::id`. It's incorrect because: 
- Sink doesn't get a mv table, but its `TableFragments::table_id` is set as well. We shouldn't register it to `CompactionGroupManager`.
- Index's `TableFragments::table_id` is actually `Index::id`. We just get lucky so far cause it's equal to `Table::id`.

This PR adds a `StreamingJob::mv_table` to make it explicit for `CompactionGroupManager`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
