### PR TITLE
feat(frontend,meta): support rw_catalog.rw_relation_info

### DIFF
--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -208,4 +208,5 @@ prepare_sys_catalog! {
     { INFORMATION_SCHEMA, TABLES, vec![], read_tables_info },
     { RW_CATALOG, RW_META_SNAPSHOT, vec![], read_meta_snapshot await },
     { RW_CATALOG, RW_DDL_PROGRESS, vec![], read_ddl_progress await },
+    { RW_CATALOG, RW_RELATION_INFO, vec![], read_relation_info await },
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -644,4 +644,117 @@ impl SysCatalogReaderImpl {
     pub(super) fn read_stat_activity(&self) -> Result<Vec<OwnedRow>> {
         Ok(vec![])
     }
+
+    pub(super) async fn read_relation_info(&self) -> Result<Vec<OwnedRow>> {
+        let mut table_ids = Vec::new();
+        {
+            let reader = self.catalog_reader.read_guard();
+            let schemas = reader.get_all_schema_names(&self.auth_context.database)?;
+            for schema in &schemas {
+                let schema_catalog =
+                    reader.get_schema_by_name(&self.auth_context.database, schema)?;
+
+                schema_catalog.iter_mv().for_each(|t| {
+                    table_ids.push(t.id.table_id);
+                });
+
+                schema_catalog.iter_table().for_each(|t| {
+                    table_ids.push(t.id.table_id);
+                });
+
+                schema_catalog.iter_sink().for_each(|t| {
+                    table_ids.push(t.id.sink_id);
+                });
+
+                schema_catalog.iter_index().for_each(|t| {
+                    table_ids.push(t.index_table.id.table_id);
+                });
+            }
+        }
+
+        let table_fragments = self.meta_client.list_table_fragments(&table_ids).await?;
+        let mut rows = Vec::new();
+        let reader = self.catalog_reader.read_guard();
+        let schemas = reader.get_all_schema_names(&self.auth_context.database)?;
+        for schema in &schemas {
+            let schema_catalog = reader.get_schema_by_name(&self.auth_context.database, schema)?;
+            schema_catalog.iter_mv().for_each(|t| {
+                if let Some(fragments) = table_fragments.get(&t.id.table_id) {
+                    rows.push(OwnedRow::new(vec![
+                        Some(ScalarImpl::Utf8(schema.clone().into())),
+                        Some(ScalarImpl::Utf8(t.name.clone().into())),
+                        Some(ScalarImpl::Int32(t.owner as i32)),
+                        Some(ScalarImpl::Utf8(t.definition.clone().into())),
+                        Some(ScalarImpl::Utf8("MATERIALIZED VIEW".into())),
+                        Some(ScalarImpl::Int32(t.id.table_id as i32)),
+                        Some(ScalarImpl::Utf8(
+                            fragments.get_env().unwrap().get_timezone().clone().into(),
+                        )),
+                        Some(ScalarImpl::Utf8(
+                            json!(fragments.get_fragments()).to_string().into(),
+                        )),
+                    ]));
+                }
+            });
+
+            schema_catalog.iter_table().for_each(|t| {
+                if let Some(fragments) = table_fragments.get(&t.id.table_id) {
+                    rows.push(OwnedRow::new(vec![
+                        Some(ScalarImpl::Utf8(schema.clone().into())),
+                        Some(ScalarImpl::Utf8(t.name.clone().into())),
+                        Some(ScalarImpl::Int32(t.owner as i32)),
+                        Some(ScalarImpl::Utf8(t.definition.clone().into())),
+                        Some(ScalarImpl::Utf8("TABLE".into())),
+                        Some(ScalarImpl::Int32(t.id.table_id as i32)),
+                        Some(ScalarImpl::Utf8(
+                            fragments.get_env().unwrap().get_timezone().clone().into(),
+                        )),
+                        Some(ScalarImpl::Utf8(
+                            json!(fragments.get_fragments()).to_string().into(),
+                        )),
+                    ]));
+                }
+            });
+
+            schema_catalog.iter_sink().for_each(|t| {
+                if let Some(fragments) = table_fragments.get(&t.id.sink_id) {
+                    rows.push(OwnedRow::new(vec![
+                        Some(ScalarImpl::Utf8(schema.clone().into())),
+                        Some(ScalarImpl::Utf8(t.name.clone().into())),
+                        Some(ScalarImpl::Int32(t.owner.user_id as i32)),
+                        Some(ScalarImpl::Utf8(t.definition.clone().into())),
+                        Some(ScalarImpl::Utf8("SINK".into())),
+                        Some(ScalarImpl::Int32(t.id.sink_id as i32)),
+                        Some(ScalarImpl::Utf8(
+                            fragments.get_env().unwrap().get_timezone().clone().into(),
+                        )),
+                        Some(ScalarImpl::Utf8(
+                            json!(fragments.get_fragments()).to_string().into(),
+                        )),
+                    ]));
+                }
+            });
+
+            schema_catalog.iter_index().for_each(|t| {
+                if let Some(fragments) = table_fragments.get(&t.index_table.id.table_id) {
+                    rows.push(OwnedRow::new(vec![
+                        Some(ScalarImpl::Utf8(schema.clone().into())),
+                        Some(ScalarImpl::Utf8(t.name.clone().into())),
+                        Some(ScalarImpl::Int32(t.index_table.owner as i32)),
+                        Some(ScalarImpl::Utf8(t.index_table.definition.clone().into())),
+                        Some(ScalarImpl::Utf8("INDEX".into())),
+                        Some(ScalarImpl::Int32(t.index_table.id.table_id as i32)),
+                        Some(ScalarImpl::Utf8(
+                            fragments.get_env().unwrap().get_timezone().clone().into(),
+                        )),
+                        Some(ScalarImpl::Utf8(
+                            json!(fragments.get_fragments()).to_string().into(),
+                        )),
+                    ]));
+                }
+            });
+        }
+
+        Ok(rows)
+    }
 }

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -753,6 +753,20 @@ impl SysCatalogReaderImpl {
                     ]));
                 }
             });
+
+            // Sources have no fragments.
+            schema_catalog.iter_source().for_each(|t| {
+                rows.push(OwnedRow::new(vec![
+                    Some(ScalarImpl::Utf8(schema.clone().into())),
+                    Some(ScalarImpl::Utf8(t.name.clone().into())),
+                    Some(ScalarImpl::Int32(t.owner as i32)),
+                    Some(ScalarImpl::Utf8(t.definition.clone().into())),
+                    Some(ScalarImpl::Utf8("SOURCE".into())),
+                    Some(ScalarImpl::Int32(t.id as i32)),
+                    Some(ScalarImpl::Utf8("".into())),
+                    None,
+                ]));
+            });
         }
 
         Ok(rows)

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/mod.rs
@@ -14,6 +14,8 @@
 
 mod rw_ddl_progress;
 mod rw_meta_snapshot;
+mod rw_relation_info;
 
 pub use rw_ddl_progress::*;
 pub use rw_meta_snapshot::*;
+pub use rw_relation_info::*;

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -1,0 +1,31 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::DataType;
+
+use crate::catalog::system_catalog::SystemCatalogColumnsDef;
+
+pub const RW_RELATION_INFO_TABLE_NAME: &str = "rw_relation_info";
+
+pub const RW_RELATION_INFO_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
+    (DataType::Varchar, "schemaname"),
+    (DataType::Varchar, "relationname"),
+    (DataType::Int32, "relationowner"),
+    (DataType::Varchar, "definition"),
+    (DataType::Varchar, "relationtype"),
+    (DataType::Int32, "relationid"),
+    (DataType::Varchar, "relationtimezone"), /* The timezone used to interpret ambiguous
+                                              * dates/timestamps as tstz */
+    (DataType::Varchar, "fragments"), // graph is json encoded fragment infos.
+];

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -27,5 +27,5 @@ pub const RW_RELATION_INFO_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "relationid"),
     (DataType::Varchar, "relationtimezone"), /* The timezone used to interpret ambiguous
                                               * dates/timestamps as tstz */
-    (DataType::Varchar, "fragments"), // graph is json encoded fragment infos.
+    (DataType::Varchar, "fragments"), // fragments is json encoded fragment infos.
 ];


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Support `rw_catalog.rw_relation_info`. Resolve https://github.com/risingwavelabs/risingwave/issues/8264.

Example
```sql
dev=> select  schemaname, relationname, relationowner, definition, relationtype, relationid, relationtimezone from rw_catalog.rw_relation_info;
 schemaname | relationname | relationowner |                                             definition                                             |   relationtype    | relationid | relationtimezone
------------+--------------+---------------+----------------------------------------------------------------------------------------------------+-------------------+------------+------------------
 public     | cnt          |             1 | CREATE MATERIALIZED VIEW cnt AS SELECT count(*) FROM sbtest1                                       | MATERIALIZED VIEW |       1004 | UTC
 public     | sbtest1      |             1 | CREATE TABLE sbtest1 (id INT, k INT, c CHARACTER VARYING, pad CHARACTER VARYING, PRIMARY KEY (id)) | TABLE             |       1001 |
 public     | s5           |             1 | CREATE SINK s5 AS SELECT * FROM sbtest1 WITH (connector = 'blackhole')                             | SINK              |       1006 |
 public     | k_1          |             1 | CREATE INDEX k_1 ON sbtest1(k)                                                                     | INDEX             |       1002 |
 public     | ck_1         |             1 | CREATE INDEX ck_1 ON sbtest1(k) INCLUDE(id,c,pad)                                                  | INDEX             |       1003 |
(5 rows)
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Other (please specify in the release note below)

### Release note

- Support `rw_catalog.rw_relation_info` to display fragments for each relation.


</details>
