### PR TITLE
refactor(optimizer): customize default behavior of plan visitor

### DIFF
--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![expect(incomplete_features)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![feature(map_try_insert)]
@@ -32,6 +33,8 @@
 #![feature(min_specialization)]
 #![feature(is_some_and)]
 #![feature(extend_one)]
+#![feature(type_alias_impl_trait)]
+#![feature(return_position_impl_trait_in_trait)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![expect(incomplete_features)]
 #![allow(clippy::derive_partial_eq_without_eq)]
 #![allow(rustdoc::private_intra_doc_links)]
 #![feature(map_try_insert)]
@@ -34,7 +33,6 @@
 #![feature(is_some_and)]
 #![feature(extend_one)]
 #![feature(type_alias_impl_trait)]
-#![feature(return_position_impl_trait_in_trait)]
 #![recursion_limit = "256"]
 
 #[macro_use]

--- a/src/frontend/src/optimizer/plan_rewriter/mod.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/mod.rs
@@ -54,9 +54,6 @@ macro_rules! def_rewriter {
 
         /// it's kind of like a [`PlanVisitor<PlanRef>`](super::plan_visitor::PlanVisitor), but with default behaviour of each rewrite method
         pub trait PlanRewriter {
-            fn check_convention(&self, _convention: Convention) -> bool {
-                return true;
-            }
             paste! {
                 fn rewrite(&mut self, plan: PlanRef) -> PlanRef{
                     match plan.node_type() {

--- a/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
@@ -20,6 +20,7 @@ use crate::catalog::SourceId;
 use crate::optimizer::plan_node::{
     LogicalShare, LogicalSource, PlanNodeId, PlanTreeNode, StreamShare,
 };
+use crate::optimizer::plan_visitor::{DefaultBehavior, DefaultValue};
 use crate::optimizer::{PlanRewriter, PlanVisitor};
 use crate::PlanRef;
 
@@ -109,7 +110,9 @@ impl PlanRewriter for ShareSourceRewriter {
 }
 
 impl PlanVisitor<()> for SourceCounter {
-    fn merge(_: (), _: ()) {}
+    fn default_behavior() -> impl DefaultBehavior<()> {
+        DefaultValue
+    }
 
     fn visit_logical_source(&mut self, source: &LogicalSource) {
         if let Some(source) = &source.core.catalog {

--- a/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
@@ -20,7 +20,7 @@ use crate::catalog::SourceId;
 use crate::optimizer::plan_node::{
     LogicalShare, LogicalSource, PlanNodeId, PlanTreeNode, StreamShare,
 };
-use crate::optimizer::plan_visitor::{DefaultBehavior, DefaultValue};
+use crate::optimizer::plan_visitor::{DefaultBehavior, Merge};
 use crate::optimizer::{PlanRewriter, PlanVisitor};
 use crate::PlanRef;
 
@@ -111,7 +111,7 @@ impl PlanRewriter for ShareSourceRewriter {
 
 impl PlanVisitor<()> for SourceCounter {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        DefaultValue
+        Merge(|_, _| ())
     }
 
     fn visit_logical_source(&mut self, source: &LogicalSource) {

--- a/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
@@ -20,7 +20,7 @@ use crate::catalog::SourceId;
 use crate::optimizer::plan_node::{
     LogicalShare, LogicalSource, PlanNodeId, PlanTreeNode, StreamShare,
 };
-use crate::optimizer::plan_visitor::{DefaultBehavior, Merge};
+use crate::optimizer::plan_visitor::{DefaultBehavior, DefaultValue};
 use crate::optimizer::{PlanRewriter, PlanVisitor};
 use crate::PlanRef;
 
@@ -111,7 +111,7 @@ impl PlanRewriter for ShareSourceRewriter {
 
 impl PlanVisitor<()> for SourceCounter {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        Merge(|_, _| ())
+        DefaultValue
     }
 
     fn visit_logical_source(&mut self, source: &LogicalSource) {

--- a/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
+++ b/src/frontend/src/optimizer/plan_rewriter/share_source_rewriter.rs
@@ -110,7 +110,9 @@ impl PlanRewriter for ShareSourceRewriter {
 }
 
 impl PlanVisitor<()> for SourceCounter {
-    fn default_behavior() -> impl DefaultBehavior<()> {
+    type DefaultBehavior = impl DefaultBehavior<()>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         DefaultValue
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
+++ b/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
@@ -29,7 +29,9 @@ impl ExecutionModeDecider {
 }
 
 impl PlanVisitor<bool> for ExecutionModeDecider {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a & b)
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
+++ b/src/frontend/src/optimizer/plan_visitor/execution_mode_decider.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::{DefaultBehavior, Merge};
 use crate::optimizer::plan_node::{BatchLimit, BatchSeqScan, BatchValues, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
@@ -28,8 +29,8 @@ impl ExecutionModeDecider {
 }
 
 impl PlanVisitor<bool> for ExecutionModeDecider {
-    fn merge(a: bool, b: bool) -> bool {
-        a & b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a & b)
     }
 
     /// Point select, index lookup and two side bound range scan.

--- a/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
@@ -125,7 +125,9 @@ impl PlanVisitor<Option<String>> for InputRefValidator {
 
     // TODO: add more checks
 
-    fn default_behavior() -> impl DefaultBehavior<Option<String>> {
+    type DefaultBehavior = impl DefaultBehavior<Option<String>>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a: Option<String>, b| a.or(b))
     }
 }

--- a/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
@@ -102,9 +102,15 @@ macro_rules! visit_project {
 }
 
 impl PlanVisitor<Option<String>> for InputRefValidator {
+    type DefaultBehavior = impl DefaultBehavior<Option<String>>;
+
     visit_filter!(logical, batch, stream);
 
     visit_project!(logical, batch, stream);
+
+    fn default_behavior() -> Self::DefaultBehavior {
+        Merge(|a: Option<String>, b| a.or(b))
+    }
 
     fn visit_logical_scan(
         &mut self,
@@ -124,10 +130,4 @@ impl PlanVisitor<Option<String>> for InputRefValidator {
     }
 
     // TODO: add more checks
-
-    type DefaultBehavior = impl DefaultBehavior<Option<String>>;
-
-    fn default_behavior() -> Self::DefaultBehavior {
-        Merge(|a: Option<String>, b| a.or(b))
-    }
 }

--- a/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/input_ref_validator.rs
@@ -15,6 +15,7 @@
 use paste::paste;
 use risingwave_common::catalog::{Field, Schema};
 
+use super::{DefaultBehavior, Merge};
 use crate::expr::ExprVisitor;
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{Explain, PlanRef, PlanTreeNodeUnary};
@@ -124,7 +125,7 @@ impl PlanVisitor<Option<String>> for InputRefValidator {
 
     // TODO: add more checks
 
-    fn merge(a: Option<String>, b: Option<String>) -> Option<String> {
-        a.or(b)
+    fn default_behavior() -> impl DefaultBehavior<Option<String>> {
+        Merge(|a: Option<String>, b| a.or(b))
     }
 }

--- a/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
@@ -28,7 +28,9 @@ pub struct MaxOneRowVisitor;
 
 /// Return true if we can determine at most one row returns by the plan, otherwise false.
 impl PlanVisitor<bool> for MaxOneRowVisitor {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a & b)
     }
 
@@ -109,7 +111,9 @@ impl PlanVisitor<bool> for MaxOneRowVisitor {
 pub struct HasMaxOneRowApply();
 
 impl PlanVisitor<bool> for HasMaxOneRowApply {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a | b)
     }
 
@@ -121,7 +125,9 @@ impl PlanVisitor<bool> for HasMaxOneRowApply {
 pub struct CountRows;
 
 impl PlanVisitor<Option<usize>> for CountRows {
-    fn default_behavior() -> impl DefaultBehavior<Option<usize>> {
+    type DefaultBehavior = impl DefaultBehavior<Option<usize>>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         DefaultValue
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/max_one_row_visitor.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashSet;
 
+use super::{DefaultBehavior, DefaultValue, Merge};
 use crate::catalog::system_catalog::pg_catalog::PG_NAMESPACE_TABLE_NAME;
 use crate::optimizer::plan_node::{
     LogicalAgg, LogicalApply, LogicalExpand, LogicalFilter, LogicalHopWindow, LogicalLimit,
@@ -27,8 +28,8 @@ pub struct MaxOneRowVisitor;
 
 /// Return true if we can determine at most one row returns by the plan, otherwise false.
 impl PlanVisitor<bool> for MaxOneRowVisitor {
-    fn merge(a: bool, b: bool) -> bool {
-        a & b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a & b)
     }
 
     fn visit_logical_values(&mut self, plan: &LogicalValues) -> bool {
@@ -108,8 +109,8 @@ impl PlanVisitor<bool> for MaxOneRowVisitor {
 pub struct HasMaxOneRowApply();
 
 impl PlanVisitor<bool> for HasMaxOneRowApply {
-    fn merge(a: bool, b: bool) -> bool {
-        a | b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a | b)
     }
 
     fn visit_logical_apply(&mut self, plan: &LogicalApply) -> bool {
@@ -120,9 +121,8 @@ impl PlanVisitor<bool> for HasMaxOneRowApply {
 pub struct CountRows;
 
 impl PlanVisitor<Option<usize>> for CountRows {
-    fn merge(_a: Option<usize>, _b: Option<usize>) -> Option<usize> {
-        // Impossible to determine count e.g. after a join
-        None
+    fn default_behavior() -> impl DefaultBehavior<Option<usize>> {
+        DefaultValue
     }
 
     fn visit_logical_agg(&mut self, plan: &LogicalAgg) -> Option<usize> {

--- a/src/frontend/src/optimizer/plan_visitor/mod.rs
+++ b/src/frontend/src/optimizer/plan_visitor/mod.rs
@@ -79,8 +79,10 @@ macro_rules! def_visitor {
         /// The visitor for plan nodes. visit all inputs and return the ret value of the left most input,
         /// and leaf node returns `R::default()`
         pub trait PlanVisitor<R: Default> {
+            type DefaultBehavior: DefaultBehavior<R>;
+
             /// The behavior for the default implementations of `visit_xxx`.
-            fn default_behavior() -> impl DefaultBehavior<R>;
+            fn default_behavior() -> Self::DefaultBehavior;
 
             paste! {
                 fn visit(&mut self, plan: PlanRef) -> R{
@@ -121,7 +123,9 @@ macro_rules! impl_has_variant {
                     where
                         P: FnMut(&$variant) -> bool,
                     {
-                        fn default_behavior() -> impl DefaultBehavior<bool> {
+                        type DefaultBehavior = impl DefaultBehavior<bool>;
+
+                        fn default_behavior() -> Self::DefaultBehavior {
                             Merge(|a, b| a | b)
                         }
 

--- a/src/frontend/src/optimizer/plan_visitor/mod.rs
+++ b/src/frontend/src/optimizer/plan_visitor/mod.rs
@@ -48,7 +48,7 @@ pub trait DefaultBehavior<R> {
 /// Merge the `visit` result of all input nodes with a function.
 /// - If there's no input node, return the default value of the result type.
 /// - If there's only a single input node, directly return its result.
-pub struct Merge<F>(pub F);
+pub struct Merge<F>(F);
 
 impl<F, R> DefaultBehavior<R> for Merge<F>
 where
@@ -64,7 +64,7 @@ where
     }
 }
 
-/// Returns the default value of the result type, **without** calling `visit` on input nodes.
+/// Returns the default value of the result type.
 pub struct DefaultValue;
 
 impl<R> DefaultBehavior<R> for DefaultValue

--- a/src/frontend/src/optimizer/plan_visitor/mod.rs
+++ b/src/frontend/src/optimizer/plan_visitor/mod.rs
@@ -48,7 +48,7 @@ pub trait DefaultBehavior<R> {
 /// Merge the `visit` result of all input nodes with a function.
 /// - If there's no input node, return the default value of the result type.
 /// - If there's only a single input node, directly return its result.
-pub struct Merge<F>(F);
+pub struct Merge<F>(pub F);
 
 impl<F, R> DefaultBehavior<R> for Merge<F>
 where
@@ -64,7 +64,7 @@ where
     }
 }
 
-/// Returns the default value of the result type.
+/// Returns the default value of the result type, **without** calling `visit` on input nodes.
 pub struct DefaultValue;
 
 impl<R> DefaultBehavior<R> for DefaultValue

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -43,7 +43,9 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter`,
     /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
 
-    fn default_behavior() -> impl DefaultBehavior<()> {
+    type DefaultBehavior = impl DefaultBehavior<()>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         DefaultValue
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, DefaultValue};
 use crate::expr::{CorrelatedId, CorrelatedInputRef, ExprVisitor};
 use crate::optimizer::plan_node::{
     LogicalAgg, LogicalFilter, LogicalJoin, LogicalProject, PlanTreeNode,
@@ -44,7 +44,7 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
 
     fn default_behavior() -> impl DefaultBehavior<()> {
-        Merge(|_, _| ())
+        DefaultValue
     }
 
     fn visit_logical_join(&mut self, plan: &LogicalJoin) {

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashSet;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{DefaultBehavior, Merge};
 use crate::expr::{CorrelatedId, CorrelatedInputRef, ExprVisitor};
 use crate::optimizer::plan_node::{
     LogicalAgg, LogicalFilter, LogicalJoin, LogicalProject, PlanTreeNode,
@@ -44,7 +44,7 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
 
     fn default_behavior() -> impl DefaultBehavior<()> {
-        DefaultValue
+        Merge(|_, _| ())
     }
 
     fn visit_logical_join(&mut self, plan: &LogicalJoin) {

--- a/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
+++ b/src/frontend/src/optimizer/plan_visitor/plan_correlated_id_finder.rs
@@ -14,6 +14,7 @@
 
 use std::collections::HashSet;
 
+use super::{DefaultBehavior, DefaultValue};
 use crate::expr::{CorrelatedId, CorrelatedInputRef, ExprVisitor};
 use crate::optimizer::plan_node::{
     LogicalAgg, LogicalFilter, LogicalJoin, LogicalProject, PlanTreeNode,
@@ -42,7 +43,9 @@ impl PlanVisitor<()> for PlanCorrelatedIdFinder {
     /// `correlated_input_ref` can only appear in `LogicalProject`, `LogicalFilter`,
     /// `LogicalJoin` or the `filter` clause of `PlanAggCall` of `LogicalAgg` now.
 
-    fn merge(_: (), _: ()) {}
+    fn default_behavior() -> impl DefaultBehavior<()> {
+        DefaultValue
+    }
 
     fn visit_logical_join(&mut self, plan: &LogicalJoin) {
         let mut finder = ExprCorrelatedIdFinder::default();

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use risingwave_common::catalog::TableId;
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, DefaultValue};
 use crate::optimizer::plan_node::{BatchSource, LogicalScan, StreamSource, StreamTableScan};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
@@ -44,7 +44,7 @@ impl RelationCollectorVisitor {
 
 impl PlanVisitor<()> for RelationCollectorVisitor {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        Merge(|_, _| ())
+        DefaultValue
     }
 
     fn visit_batch_seq_scan(&mut self, plan: &crate::optimizer::plan_node::BatchSeqScan) {

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -16,7 +16,7 @@ use std::collections::HashSet;
 
 use risingwave_common::catalog::TableId;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{DefaultBehavior, Merge};
 use crate::optimizer::plan_node::{BatchSource, LogicalScan, StreamSource, StreamTableScan};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
@@ -44,7 +44,7 @@ impl RelationCollectorVisitor {
 
 impl PlanVisitor<()> for RelationCollectorVisitor {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        DefaultValue
+        Merge(|_, _| ())
     }
 
     fn visit_batch_seq_scan(&mut self, plan: &crate::optimizer::plan_node::BatchSeqScan) {

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -43,7 +43,9 @@ impl RelationCollectorVisitor {
 }
 
 impl PlanVisitor<()> for RelationCollectorVisitor {
-    fn default_behavior() -> impl DefaultBehavior<()> {
+    type DefaultBehavior = impl DefaultBehavior<()>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         DefaultValue
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -20,6 +20,8 @@ use crate::optimizer::plan_node::{BatchSource, LogicalScan, StreamSource, Stream
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
 
+use super::{DefaultBehavior, DefaultValue};
+
 #[derive(Debug, Clone, Default)]
 pub struct RelationCollectorVisitor {
     relations: HashSet<TableId>,
@@ -42,7 +44,9 @@ impl RelationCollectorVisitor {
 }
 
 impl PlanVisitor<()> for RelationCollectorVisitor {
-    fn merge(_: (), _: ()) {}
+    fn default_behavior() -> impl DefaultBehavior<()> {
+        DefaultValue
+    }
 
     fn visit_batch_seq_scan(&mut self, plan: &crate::optimizer::plan_node::BatchSeqScan) {
         if !plan.logical().is_sys_table() {

--- a/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/relation_collector_visitor.rs
@@ -16,11 +16,10 @@ use std::collections::HashSet;
 
 use risingwave_common::catalog::TableId;
 
+use super::{DefaultBehavior, DefaultValue};
 use crate::optimizer::plan_node::{BatchSource, LogicalScan, StreamSource, StreamTableScan};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
-
-use super::{DefaultBehavior, DefaultValue};
 
 #[derive(Debug, Clone, Default)]
 pub struct RelationCollectorVisitor {

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -14,10 +14,9 @@
 
 use std::collections::HashMap;
 
+use super::{DefaultBehavior, DefaultValue};
 use crate::optimizer::plan_node::{LogicalShare, PlanNodeId, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
-
-use super::{DefaultBehavior, DefaultValue};
 
 #[derive(Debug, Clone, Default)]
 pub struct ShareParentCounter {

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -17,6 +17,8 @@ use std::collections::HashMap;
 use crate::optimizer::plan_node::{LogicalShare, PlanNodeId, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
 
+use super::{DefaultBehavior, DefaultValue};
+
 #[derive(Debug, Clone, Default)]
 pub struct ShareParentCounter {
     /// Plan node id to parent number mapping.
@@ -33,7 +35,9 @@ impl ShareParentCounter {
 }
 
 impl PlanVisitor<()> for ShareParentCounter {
-    fn merge(_: (), _: ()) {}
+    fn default_behavior() -> impl DefaultBehavior<()> {
+        DefaultValue
+    }
 
     fn visit_logical_share(&mut self, share: &LogicalShare) {
         let v = self

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -34,7 +34,9 @@ impl ShareParentCounter {
 }
 
 impl PlanVisitor<()> for ShareParentCounter {
-    fn default_behavior() -> impl DefaultBehavior<()> {
+    type DefaultBehavior = impl DefaultBehavior<()>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         DefaultValue
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use super::{DefaultBehavior, DefaultValue};
+use super::{DefaultBehavior, Merge};
 use crate::optimizer::plan_node::{LogicalShare, PlanNodeId, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
 
@@ -35,7 +35,7 @@ impl ShareParentCounter {
 
 impl PlanVisitor<()> for ShareParentCounter {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        DefaultValue
+        Merge(|_, _| ())
     }
 
     fn visit_logical_share(&mut self, share: &LogicalShare) {

--- a/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
+++ b/src/frontend/src/optimizer/plan_visitor/share_parent_counter.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 
-use super::{DefaultBehavior, Merge};
+use super::{DefaultBehavior, DefaultValue};
 use crate::optimizer::plan_node::{LogicalShare, PlanNodeId, PlanTreeNodeUnary};
 use crate::optimizer::plan_visitor::PlanVisitor;
 
@@ -35,7 +35,7 @@ impl ShareParentCounter {
 
 impl PlanVisitor<()> for ShareParentCounter {
     fn default_behavior() -> impl DefaultBehavior<()> {
-        Merge(|_, _| ())
+        DefaultValue
     }
 
     fn visit_logical_share(&mut self, share: &LogicalShare) {

--- a/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::{PlanVisitor, DefaultBehavior, Merge};
+use super::{DefaultBehavior, Merge, PlanVisitor};
 use crate::optimizer::plan_node;
 
 /// Recursively visit the **logical** plan and decide whether it has side effect and cannot be

--- a/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use super::PlanVisitor;
+use super::{PlanVisitor, DefaultBehavior, Merge};
 use crate::optimizer::plan_node;
 
 /// Recursively visit the **logical** plan and decide whether it has side effect and cannot be
@@ -20,8 +20,8 @@ use crate::optimizer::plan_node;
 pub struct SideEffectVisitor;
 
 impl PlanVisitor<bool> for SideEffectVisitor {
-    fn merge(a: bool, b: bool) -> bool {
-        a || b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a | b)
     }
 
     fn visit_logical_insert(&mut self, _plan: &plan_node::LogicalInsert) -> bool {

--- a/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/side_effect_visitor.rs
@@ -20,7 +20,9 @@ use crate::optimizer::plan_node;
 pub struct SideEffectVisitor;
 
 impl PlanVisitor<bool> for SideEffectVisitor {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a | b)
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
@@ -16,6 +16,8 @@ use crate::optimizer::plan_node::{BatchSeqScan, LogicalScan, StreamTableScan};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
 
+use super::{Merge, DefaultBehavior};
+
 #[derive(Debug, Clone, Default)]
 pub struct SysTableVisitor {}
 
@@ -27,8 +29,8 @@ impl SysTableVisitor {
 }
 
 impl PlanVisitor<bool> for SysTableVisitor {
-    fn merge(a: bool, b: bool) -> bool {
-        a | b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a | b)
     }
 
     fn visit_batch_seq_scan(&mut self, batch_seq_scan: &BatchSeqScan) -> bool {

--- a/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::{DefaultBehavior, Merge};
 use crate::optimizer::plan_node::{BatchSeqScan, LogicalScan, StreamTableScan};
 use crate::optimizer::plan_visitor::PlanVisitor;
 use crate::PlanRef;
-
-use super::{Merge, DefaultBehavior};
 
 #[derive(Debug, Clone, Default)]
 pub struct SysTableVisitor {}

--- a/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/sys_table_visitor.rs
@@ -28,7 +28,9 @@ impl SysTableVisitor {
 }
 
 impl PlanVisitor<bool> for SysTableVisitor {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a | b)
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
@@ -30,7 +30,9 @@ impl TemporalJoinValidator {
 }
 
 impl PlanVisitor<bool> for TemporalJoinValidator {
-    fn default_behavior() -> impl DefaultBehavior<bool> {
+    type DefaultBehavior = impl DefaultBehavior<bool>;
+
+    fn default_behavior() -> Self::DefaultBehavior {
         Merge(|a, b| a | b)
     }
 

--- a/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
+++ b/src/frontend/src/optimizer/plan_visitor/temporal_join_validator.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use super::{DefaultBehavior, Merge};
 use crate::optimizer::plan_node::{
     BatchSeqScan, LogicalScan, PlanTreeNodeBinary, StreamTableScan, StreamTemporalJoin,
 };
@@ -29,8 +30,8 @@ impl TemporalJoinValidator {
 }
 
 impl PlanVisitor<bool> for TemporalJoinValidator {
-    fn merge(a: bool, b: bool) -> bool {
-        a | b
+    fn default_behavior() -> impl DefaultBehavior<bool> {
+        Merge(|a, b| a | b)
     }
 
     fn visit_stream_table_scan(&mut self, stream_table_scan: &StreamTableScan) -> bool {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Allow customizing the default behavior of the plan visitor:
- `Merge`: The original behavior. Inherits the result if there's only single input, or `reduce` them with the `merge` function.
- `DefaultValue`: Always return the default return value if `visit_xxx` is not implemented.

Defaulting to `Merge` can be dangerous. Takes `MaxOneRow` as an example: if we introduce a new operator that behaves like a set-returning function while forgetting to add it to the visitor, then the `MaxOneRow` property of the input will automatically be inherited, which is wrong. We should use `DefaultValue` for those not implemented, which is always safe.

This PR is in favor of #9237, which will replace `MaxOneRow` and `CountRows`. So we don't fix the above issue.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
