### PR TITLE
fix(udf): eval_row panic due to misuse of input row as arg row

### DIFF
--- a/e2e_test/udf/python.slt
+++ b/e2e_test/udf/python.slt
@@ -123,6 +123,34 @@ select (extract_tcp_info(E'\\x45000034a8a8400040065b8ac0a8000ec0a80001035d20b6d9
 ----
 192.168.0.14 192.168.0.1 861 8374
 
+# error handling
+
+statement error
+select hex_to_dec('1z');
+
+statement ok
+create table t (dummy date, v varchar);
+
+statement ok
+create materialized view mv as select dummy, hex_to_dec(v) from t;
+
+statement ok
+insert into t values ('2023-01-01', '1z');
+
+statement ok
+flush;
+
+query TI
+select * from mv;
+----
+2023-01-01 NULL
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;
+
 # TODO: drop function without arguments
 
 # # Drop a function but ambiguous.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #9066
```
    async fn eval_row(&self, input: &OwnedRow) -> Result<Datum> {
        let chunk = DataChunk::from_rows(std::slice::from_ref(input), &self.arg_types);
        let output_array = self.eval(&chunk).await?;
```
In this previous implementation, it converts an input row to an input chunk and reuses `eval`. However, the data types of columns are not `arg_types`. We have to evaluate children expressions to get arrays / datums of `arg_types`.

This always fails, but the `eval_row` code path executes rarely, mostly only during stream error tolerating (and frontend constant folding). Similar issues: https://github.com/risingwavelabs/risingwave/pull/8115#pullrequestreview-1308619049 #7777

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
