### PR TITLE
perf(delete range): monotonic event is all you need

### DIFF
--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -222,13 +222,12 @@ pub async fn sst_dump_via_sstable_store(
     println!("Key Count: {}", sstable_meta.key_count);
     println!("Version: {}", sstable_meta.version);
     println!(
-        "Range Tomestone Count: {}",
-        sstable_meta.range_tombstone_list.len()
+        "Monotonoic Deletes Count: {}",
+        sstable_meta.monotonic_tombstone_events.len()
     );
-    for range_tomstone in &sstable_meta.range_tombstone_list {
-        println!("\tstart: {:?}", range_tomstone.start_user_key);
-        println!("\tend: {:?}", range_tomstone.end_user_key);
-        println!("\tepoch: {:?}", range_tomstone.sequence);
+    for monotonic_delete in &sstable_meta.monotonic_tombstone_events {
+        println!("\tevent key: {:?}", monotonic_delete.event_key);
+        println!("\tnew epoch: {:?}", monotonic_delete.new_epoch);
     }
 
     println!("Block Count: {}", sstable.block_count());

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -223,11 +223,12 @@ pub async fn sst_dump_via_sstable_store(
     println!("Version: {}", sstable_meta.version);
     println!(
         "Monotonoic Deletes Count: {}",
-        sstable_meta.monotonic_tombstone_events.len()
+        sstable_meta.monotonic_tombstones.len()
     );
-    for monotonic_delete in &sstable_meta.monotonic_tombstone_events {
-        println!("\tevent key: {:?}", monotonic_delete.event_key);
-        println!("\tnew epoch: {:?}", monotonic_delete.new_epoch);
+    for monotonic_tombstone in &sstable_meta.monotonic_tombstones {
+        println!("\tstart user key: {:?}", monotonic_tombstone.start_user_key);
+        println!("\tend user key: {:?}", monotonic_tombstone.end_user_key);
+        println!("\tsequence: {:?}", monotonic_tombstone.sequence);
     }
 
     println!("Block Count: {}", sstable.block_count());

--- a/src/ctl/src/cmd_impl/hummock/sst_dump.rs
+++ b/src/ctl/src/cmd_impl/hummock/sst_dump.rs
@@ -223,12 +223,11 @@ pub async fn sst_dump_via_sstable_store(
     println!("Version: {}", sstable_meta.version);
     println!(
         "Monotonoic Deletes Count: {}",
-        sstable_meta.monotonic_tombstones.len()
+        sstable_meta.monotonic_tombstone_events.len()
     );
-    for monotonic_tombstone in &sstable_meta.monotonic_tombstones {
-        println!("\tstart user key: {:?}", monotonic_tombstone.start_user_key);
-        println!("\tend user key: {:?}", monotonic_tombstone.end_user_key);
-        println!("\tsequence: {:?}", monotonic_tombstone.sequence);
+    for monotonic_delete in &sstable_meta.monotonic_tombstone_events {
+        println!("\tevent key: {:?}", monotonic_delete.event_key);
+        println!("\tnew epoch: {:?}", monotonic_delete.new_epoch);
     }
 
     println!("Block Count: {}", sstable.block_count());

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -30,8 +30,8 @@ use crate::hummock::compactor::{CompactOutput, CompactionFilter, Compactor, Comp
 use crate::hummock::iterator::{Forward, HummockIterator, UnorderedMergeIteratorInner};
 use crate::hummock::sstable::CompactionDeleteRangesBuilder;
 use crate::hummock::{
-    CachePolicy, CompactionDeleteRanges, CompressionAlgorithm, HummockResult,
-    SstableBuilderOptions, SstableStoreRef,
+    create_tombstones_to_represent_monotonic_deletes, CachePolicy, CompactionDeleteRanges,
+    CompressionAlgorithm, HummockResult, SstableBuilderOptions, SstableStoreRef,
 };
 use crate::monitor::StoreLocalStatistic;
 
@@ -128,24 +128,19 @@ impl CompactorRunner {
 
             for table_info in &level.table_infos {
                 let table = sstable_store.sstable(table_info, &mut local_stats).await?;
-                let range_tombstone_list = table
-                    .value()
-                    .meta
-                    .range_tombstone_list
-                    .iter()
-                    .filter(|tombstone| {
-                        !filter.should_delete(FullKey::from_user_key(
-                            tombstone.start_user_key.as_ref(),
-                            tombstone.sequence,
-                        ))
-                    })
-                    .cloned()
-                    .collect_vec();
+                let mut range_tombstone_list = create_tombstones_to_represent_monotonic_deletes(
+                    &table.value().meta.monotonic_tombstone_events,
+                );
+                range_tombstone_list.retain(|tombstone| {
+                    !filter.should_delete(FullKey::from_user_key(
+                        tombstone.start_user_key.as_ref(),
+                        tombstone.sequence,
+                    ))
+                });
                 builder.add_tombstone(range_tombstone_list);
             }
         }
-        let aggregator =
-            builder.build_for_compaction(compact_task.watermark, compact_task.gc_delete_keys);
+        let aggregator = builder.build_for_compaction(compact_task.gc_delete_keys);
         Ok(aggregator)
     }
 
@@ -208,7 +203,7 @@ mod tests {
     use crate::hummock::test_utils::{
         default_builder_opt_for_test, gen_test_sstable_with_range_tombstone,
     };
-    use crate::hummock::DeleteRangeTombstone;
+    use crate::hummock::{create_monotonic_events, DeleteRangeTombstone};
 
     #[tokio::test]
     async fn test_delete_range_aggregator_with_filter() {
@@ -250,7 +245,9 @@ mod tests {
             &UserKey::<Bytes>::default().as_ref(),
             &UserKey::<Bytes>::default().as_ref(),
         );
-        assert_eq!(ret.len(), 1);
-        assert_eq!(ret[0], range_tombstones[1]);
+        assert_eq!(
+            ret,
+            create_monotonic_events(&vec![range_tombstones[1].clone()])
+        );
     }
 }

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -30,8 +30,8 @@ use crate::hummock::compactor::{CompactOutput, CompactionFilter, Compactor, Comp
 use crate::hummock::iterator::{Forward, HummockIterator, UnorderedMergeIteratorInner};
 use crate::hummock::sstable::CompactionDeleteRangesBuilder;
 use crate::hummock::{
-    CachePolicy, CompactionDeleteRanges, CompressionAlgorithm, HummockResult,
-    SstableBuilderOptions, SstableStoreRef,
+    create_tombstones_to_represent_monotonic_deletes, CachePolicy, CompactionDeleteRanges,
+    CompressionAlgorithm, HummockResult, SstableBuilderOptions, SstableStoreRef,
 };
 use crate::monitor::StoreLocalStatistic;
 
@@ -128,19 +128,15 @@ impl CompactorRunner {
 
             for table_info in &level.table_infos {
                 let table = sstable_store.sstable(table_info, &mut local_stats).await?;
-                let range_tombstone_list = table
-                    .value()
-                    .meta
-                    .monotonic_tombstones
-                    .iter()
-                    .filter(|tombstone| {
-                        !filter.should_delete(FullKey::from_user_key(
-                            tombstone.start_user_key.as_ref(),
-                            tombstone.sequence,
-                        ))
-                    })
-                    .cloned()
-                    .collect_vec();
+                let mut range_tombstone_list = create_tombstones_to_represent_monotonic_deletes(
+                    &table.value().meta.monotonic_tombstone_events,
+                );
+                range_tombstone_list.retain(|tombstone| {
+                    !filter.should_delete(FullKey::from_user_key(
+                        tombstone.start_user_key.as_ref(),
+                        tombstone.sequence,
+                    ))
+                });
                 builder.add_tombstone(range_tombstone_list);
             }
         }
@@ -207,7 +203,7 @@ mod tests {
     use crate::hummock::test_utils::{
         default_builder_opt_for_test, gen_test_sstable_with_range_tombstone,
     };
-    use crate::hummock::DeleteRangeTombstone;
+    use crate::hummock::{create_monotonic_events, DeleteRangeTombstone};
 
     #[tokio::test]
     async fn test_delete_range_aggregator_with_filter() {
@@ -249,6 +245,9 @@ mod tests {
             &UserKey::<Bytes>::default().as_ref(),
             &UserKey::<Bytes>::default().as_ref(),
         );
-        assert_eq!(ret, vec![range_tombstones[1].clone()]);
+        assert_eq!(
+            ret,
+            create_monotonic_events(&vec![range_tombstones[1].clone()])
+        );
     }
 }

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -191,7 +191,7 @@ async fn compact_shared_buffer(
     let mut output_ssts = Vec::with_capacity(parallelism);
     let mut compaction_futures = vec![];
 
-    let agg = builder.build_for_compaction(GC_WATERMARK_FOR_FLUSH, GC_DELETE_KEYS_FOR_FLUSH);
+    let agg = builder.build_for_compaction(GC_DELETE_KEYS_FOR_FLUSH);
     for (split_index, key_range) in splits.into_iter().enumerate() {
         let compactor = SharedBufferCompactRunner::new(
             split_index,
@@ -309,8 +309,7 @@ pub async fn merge_imms_in_memory(
     }
     let mut builder = CompactionDeleteRangesBuilder::default();
     builder.add_tombstone(range_tombstone_list.clone());
-    let compaction_delete_ranges =
-        builder.build_for_compaction(GC_WATERMARK_FOR_FLUSH, GC_DELETE_KEYS_FOR_FLUSH);
+    let compaction_delete_ranges = builder.build_for_compaction(GC_DELETE_KEYS_FOR_FLUSH);
     let mut del_iter = compaction_delete_ranges.iter();
     del_iter.rewind();
     epochs.sort();

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -34,10 +34,7 @@ use crate::hummock::iterator::{
 use crate::hummock::store::memtable::ImmId;
 use crate::hummock::utils::{range_overlap, MemoryTracker};
 use crate::hummock::value::HummockValue;
-use crate::hummock::{
-    create_monotonic_events, create_tombstones_to_represent_monotonic_deletes,
-    DeleteRangeTombstone, HummockEpoch, HummockResult, MonotonicDeleteEvent,
-};
+use crate::hummock::{create_monotonic_deletes, DeleteRangeTombstone, HummockEpoch, HummockResult};
 use crate::storage_value::StorageValue;
 use crate::store::ReadOptions;
 
@@ -58,7 +55,7 @@ pub(crate) struct SharedBufferBatchInner {
     imm_ids: Vec<ImmId>,
     /// The epochs of the data in batch, sorted in ascending order (old to new)
     epochs: Vec<HummockEpoch>,
-    monotonic_tombstone_events: Vec<MonotonicDeleteEvent>,
+    monotonic_deletes: Vec<DeleteRangeTombstone>,
     largest_table_key: Vec<u8>,
     smallest_table_key: Vec<u8>,
     kv_count: usize,
@@ -99,16 +96,17 @@ impl SharedBufferBatchInner {
             .map(|(k, v)| (k, vec![(epoch, v)]))
             .collect_vec();
 
-        let mut monotonic_tombstone_events = Vec::with_capacity(range_tombstones.len() * 2);
-        for range_tombstone in &range_tombstones {
-            monotonic_tombstone_events.push(MonotonicDeleteEvent {
-                event_key: range_tombstone.start_user_key.clone(),
-                new_epoch: range_tombstone.sequence,
-            });
-            monotonic_tombstone_events.push(MonotonicDeleteEvent {
-                event_key: range_tombstone.end_user_key.clone(),
-                new_epoch: HummockEpoch::MAX,
-            });
+        let mut monotonic_deletes = Vec::with_capacity(range_tombstones.len() * 2);
+        let range_tombstones_len = range_tombstones.len();
+        for i in 0..range_tombstones_len {
+            monotonic_deletes.push(range_tombstones[i].clone());
+            if i + 1 < range_tombstones_len {
+                monotonic_deletes.push(DeleteRangeTombstone {
+                    start_user_key: range_tombstones[i].end_user_key.clone(),
+                    end_user_key: range_tombstones[i + 1].start_user_key.clone(),
+                    sequence: HummockEpoch::MAX,
+                });
+            }
         }
 
         let batch_id = SHARED_BUFFER_BATCH_ID_GENERATOR.fetch_add(1, Relaxed);
@@ -116,7 +114,7 @@ impl SharedBufferBatchInner {
             payload: items,
             imm_ids: vec![batch_id],
             epochs: vec![epoch],
-            monotonic_tombstone_events,
+            monotonic_deletes,
             kv_count,
             size,
             largest_table_key,
@@ -144,12 +142,12 @@ impl SharedBufferBatchInner {
 
         let max_imm_id = *imm_ids.iter().max().unwrap();
 
-        let monotonic_tombstone_events = create_monotonic_events(&range_tombstone_list);
+        let monotonic_deletes = create_monotonic_deletes(&range_tombstone_list);
         Self {
             payload,
             epochs,
             imm_ids,
-            monotonic_tombstone_events,
+            monotonic_deletes,
             largest_table_key,
             smallest_table_key,
             kv_count: num_items,
@@ -237,13 +235,21 @@ impl SharedBufferBatchInner {
     }
 
     fn get_min_delete_range_epoch(&self, query_user_key: &UserKey<&[u8]>) -> HummockEpoch {
-        let idx = self.monotonic_tombstone_events.partition_point(
-            |MonotonicDeleteEvent { event_key, .. }| event_key.as_ref().le(query_user_key),
+        let idx = self.monotonic_deletes.partition_point(
+            |DeleteRangeTombstone { start_user_key, .. }| {
+                start_user_key.as_ref().le(query_user_key)
+            },
         );
-        if idx == 0 {
+        if idx == 0
+            || (idx == self.monotonic_deletes.len()
+                && self.monotonic_deletes[idx - 1]
+                    .end_user_key
+                    .as_ref()
+                    .le(query_user_key))
+        {
             HummockEpoch::MAX
         } else {
-            self.monotonic_tombstone_events[idx - 1].new_epoch
+            self.monotonic_deletes[idx - 1].sequence
         }
     }
 }
@@ -446,7 +452,7 @@ impl SharedBufferBatch {
 
     #[inline(always)]
     pub fn has_range_tombstone(&self) -> bool {
-        !self.inner.monotonic_tombstone_events.is_empty()
+        !self.inner.monotonic_deletes.is_empty()
     }
 
     /// return inclusive right endpoint, which means that all data in this batch should be smaller
@@ -515,7 +521,7 @@ impl SharedBufferBatch {
     }
 
     pub fn get_delete_range_tombstones(&self) -> Vec<DeleteRangeTombstone> {
-        create_tombstones_to_represent_monotonic_deletes(&self.inner.monotonic_tombstone_events)
+        self.inner.monotonic_deletes.clone()
     }
 
     #[cfg(test)]
@@ -742,14 +748,18 @@ impl SharedBufferDeleteRangeIterator {
 
 impl DeleteRangeIterator for SharedBufferDeleteRangeIterator {
     fn next_user_key(&self) -> UserKey<&[u8]> {
-        self.inner.monotonic_tombstone_events[self.next_idx]
-            .event_key
-            .as_ref()
+        if self.next_idx > 0 {
+            self.inner.monotonic_deletes[self.next_idx - 1]
+                .end_user_key
+                .as_ref()
+        } else {
+            self.inner.monotonic_deletes[0].start_user_key.as_ref()
+        }
     }
 
     fn current_epoch(&self) -> HummockEpoch {
         if self.next_idx > 0 {
-            self.inner.monotonic_tombstone_events[self.next_idx - 1].new_epoch
+            self.inner.monotonic_deletes[self.next_idx - 1].sequence
         } else {
             HummockEpoch::MAX
         }
@@ -764,13 +774,28 @@ impl DeleteRangeIterator for SharedBufferDeleteRangeIterator {
     }
 
     fn seek<'a>(&'a mut self, target_user_key: UserKey<&'a [u8]>) {
-        self.next_idx = self.inner.monotonic_tombstone_events.partition_point(
-            |MonotonicDeleteEvent { event_key, .. }| event_key.as_ref().le(&target_user_key),
-        );
+        let monotonic_deletes = &self.inner.monotonic_deletes;
+        if !monotonic_deletes.is_empty() {
+            self.next_idx = monotonic_deletes.partition_point(
+                |DeleteRangeTombstone { start_user_key, .. }| {
+                    start_user_key.as_ref().le(&target_user_key)
+                },
+            );
+            if self.next_idx == monotonic_deletes.len() {
+                if monotonic_deletes[self.next_idx - 1]
+                    .end_user_key
+                    .as_ref()
+                    .le(&target_user_key)
+                {
+                    self.next_idx += 1;
+                }
+            }
+        }
     }
 
     fn is_valid(&self) -> bool {
-        self.next_idx < self.inner.monotonic_tombstone_events.len()
+        let len = self.inner.monotonic_deletes.len();
+        len > 0 && self.next_idx <= len
     }
 }
 

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -35,8 +35,8 @@ use crate::hummock::store::memtable::ImmId;
 use crate::hummock::utils::{range_overlap, MemoryTracker};
 use crate::hummock::value::HummockValue;
 use crate::hummock::{
-    create_monotonic_events, DeleteRangeTombstone, HummockEpoch, HummockResult,
-    MonotonicDeleteEvent,
+    create_monotonic_events, create_tombstones_to_represent_monotonic_deletes,
+    DeleteRangeTombstone, HummockEpoch, HummockResult, MonotonicDeleteEvent,
 };
 use crate::storage_value::StorageValue;
 use crate::store::ReadOptions;
@@ -58,7 +58,6 @@ pub(crate) struct SharedBufferBatchInner {
     imm_ids: Vec<ImmId>,
     /// The epochs of the data in batch, sorted in ascending order (old to new)
     epochs: Vec<HummockEpoch>,
-    range_tombstone_list: Vec<DeleteRangeTombstone>,
     monotonic_tombstone_events: Vec<MonotonicDeleteEvent>,
     largest_table_key: Vec<u8>,
     smallest_table_key: Vec<u8>,
@@ -117,7 +116,6 @@ impl SharedBufferBatchInner {
             payload: items,
             imm_ids: vec![batch_id],
             epochs: vec![epoch],
-            range_tombstone_list: range_tombstones,
             monotonic_tombstone_events,
             kv_count,
             size,
@@ -151,7 +149,6 @@ impl SharedBufferBatchInner {
             payload,
             epochs,
             imm_ids,
-            range_tombstone_list,
             monotonic_tombstone_events,
             largest_table_key,
             smallest_table_key,
@@ -449,7 +446,7 @@ impl SharedBufferBatch {
 
     #[inline(always)]
     pub fn has_range_tombstone(&self) -> bool {
-        !self.inner.range_tombstone_list.is_empty()
+        !self.inner.monotonic_tombstone_events.is_empty()
     }
 
     /// return inclusive right endpoint, which means that all data in this batch should be smaller
@@ -518,7 +515,7 @@ impl SharedBufferBatch {
     }
 
     pub fn get_delete_range_tombstones(&self) -> Vec<DeleteRangeTombstone> {
-        self.inner.range_tombstone_list.clone()
+        create_tombstones_to_represent_monotonic_deletes(&self.inner.monotonic_tombstone_events)
     }
 
     #[cfg(test)]

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -25,13 +25,13 @@ use risingwave_pb::hummock::SstableInfo;
 
 use super::utils::CompressionAlgorithm;
 use super::{
-    BlockBuilder, BlockBuilderOptions, BlockMeta, SstableMeta, SstableWriter, DEFAULT_BLOCK_SIZE,
-    DEFAULT_ENTRY_SIZE, DEFAULT_RESTART_INTERVAL, VERSION,
+    BlockBuilder, BlockBuilderOptions, BlockMeta, MonotonicDeleteEvent, SstableMeta, SstableWriter,
+    DEFAULT_BLOCK_SIZE, DEFAULT_ENTRY_SIZE, DEFAULT_RESTART_INTERVAL, VERSION,
 };
 use crate::filter_key_extractor::{FilterKeyExtractorImpl, FullKeyFilterKeyExtractor};
-use crate::hummock::sstable::{create_monotonic_events, FilterBuilder, XorFilterBuilder};
+use crate::hummock::sstable::{FilterBuilder, XorFilterBuilder};
 use crate::hummock::value::HummockValue;
-use crate::hummock::{DeleteRangeTombstone, HummockResult};
+use crate::hummock::HummockResult;
 use crate::opts::StorageOpts;
 
 pub const DEFAULT_SSTABLE_SIZE: usize = 4 * 1024 * 1024;
@@ -94,8 +94,20 @@ pub struct SstableBuilder<W: SstableWriter, F: FilterBuilder> {
     filter_key_extractor: Arc<FilterKeyExtractorImpl>,
     /// Block metadata vec.
     block_metas: Vec<BlockMeta>,
-    /// store operation of delete-range
-    range_tombstones: Vec<DeleteRangeTombstone>,
+    /// Assume that watermark1 is 5, watermark2 is 7, watermark3 is 11, delete ranges
+    /// `{ [0, wmk1) in epoch1, [wmk1, wmk2) in epoch2, [wmk2, wmk3) in epoch3 }`
+    /// can be transformed into events below:
+    /// `{ <0, +epoch1> <wmk1, -epoch1> <wmk1, +epoch2> <wmk2, -epoch2> <wmk2, +epoch3> <wmk3,
+    /// -epoch3> }`
+    /// Then we can get monotonic events (they are in order by user key) as below:
+    /// `{ <0, epoch1>, <wmk1, epoch2>, <wmk2, epoch3>, <wmk3, +inf> }`
+    /// which means that delete range of [0, wmk1) is epoch1, delete range of [wmk1, wmk2) if
+    /// epoch2, etc. In this example, at the event key wmk1 (5), delete range changes from
+    /// epoch1 to epoch2, thus the `new epoch` is epoch2. epoch2 will be used from the event
+    /// key wmk1 (5) and till the next event key wmk2 (7) (not inclusive).
+    /// If there is no range deletes between current event key and next event key, `new_epoch` will
+    /// be `HummockEpoch::MAX`.
+    monotonic_deletes: Vec<MonotonicDeleteEvent>,
     /// `table_id` of added keys.
     table_ids: BTreeSet<u32>,
     last_full_key: Vec<u8>,
@@ -159,7 +171,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             raw_value: BytesMut::new(),
             last_full_key: vec![],
             last_extract_key: vec![],
-            range_tombstones: vec![],
+            monotonic_deletes: vec![],
             sstable_id,
             filter_key_extractor,
             stale_key_count: 0,
@@ -171,16 +183,19 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
     }
 
     /// Add kv pair to sstable.
-    pub fn add_delete_range(&mut self, range_tombstones: Vec<DeleteRangeTombstone>) {
+    pub fn add_monotonic_deletes(&mut self, monotonic_deletes: Vec<MonotonicDeleteEvent>) {
         let mut last_table_id = TableId::default();
-        for tombstone in &range_tombstones {
-            if last_table_id != tombstone.start_user_key.table_id {
-                last_table_id = tombstone.start_user_key.table_id;
+        for monotonic_delete in monotonic_deletes
+            .iter()
+            .filter(|monotonic_delete| monotonic_delete.new_epoch != HummockEpoch::MAX)
+        {
+            if last_table_id != monotonic_delete.event_key.table_id {
+                last_table_id = monotonic_delete.event_key.table_id;
                 self.table_ids
-                    .insert(tombstone.start_user_key.table_id.table_id);
+                    .insert(monotonic_delete.event_key.table_id.table_id());
             }
         }
-        self.range_tombstones.extend(range_tombstones);
+        self.monotonic_deletes.extend(monotonic_deletes);
     }
 
     /// Add kv pair to sstable.
@@ -302,34 +317,38 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         self.build_block().await?;
         let mut right_exclusive = false;
         let meta_offset = self.writer.data_len() as u64;
-        for tombstone in &self.range_tombstones {
-            assert!(!tombstone.end_user_key.is_empty());
+        if let Some(monotonic_delete) = self.monotonic_deletes.last() {
+            debug_assert_eq!(monotonic_delete.new_epoch, HummockEpoch::MAX);
             if largest_key.is_empty()
                 || KeyComparator::encoded_less_than_unencoded(
                     user_key(&largest_key),
-                    &tombstone.end_user_key,
+                    &monotonic_delete.event_key,
                 )
             {
-                // use MAX as epoch because `end_user_key` of the range-tombstone is exclusive, so
-                // we can not include any version of this key.
+                // use MAX as epoch because the last monotonic delete must be `HummockEpoch::MAX`,
+                // so we can not include any version of this key.
                 largest_key =
-                    FullKey::from_user_key(tombstone.end_user_key.clone(), HummockEpoch::MAX)
+                    FullKey::from_user_key(monotonic_delete.event_key.clone(), HummockEpoch::MAX)
                         .encode();
                 right_exclusive = true;
             }
+        }
+        if let Some(monotonic_delete) = self.monotonic_deletes.first() {
             if smallest_key.is_empty()
                 || KeyComparator::encoded_greater_than_unencoded(
                     user_key(&smallest_key),
-                    &tombstone.start_user_key,
+                    &monotonic_delete.event_key,
                 )
             {
-                smallest_key =
-                    FullKey::from_user_key(tombstone.start_user_key.clone(), tombstone.sequence)
-                        .encode();
+                smallest_key = FullKey::from_user_key(
+                    monotonic_delete.event_key.clone(),
+                    monotonic_delete.new_epoch,
+                )
+                .encode();
             }
         }
-        self.total_key_count += self.range_tombstones.len() as u64;
-        self.stale_key_count += self.range_tombstones.len() as u64;
+        self.total_key_count += self.monotonic_deletes.len() as u64;
+        self.stale_key_count += self.monotonic_deletes.len() as u64;
         let bloom_filter = if self.options.bloom_false_positive > 0.0 {
             self.filter_builder.finish()
         } else {
@@ -342,8 +361,6 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             .map(|block_meta| block_meta.uncompressed_size as u64)
             .sum::<u64>();
 
-        let monotonic_tombstone_events = create_monotonic_events(&self.range_tombstones);
-
         let mut meta = SstableMeta {
             block_metas: self.block_metas,
             bloom_filter,
@@ -353,8 +370,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             largest_key,
             version: VERSION,
             meta_offset,
-            range_tombstone_list: self.range_tombstones,
-            monotonic_tombstone_events,
+            monotonic_tombstone_events: self.monotonic_deletes,
         };
         meta.estimated_size = meta.encoded_size() as u32 + meta_offset as u32;
 
@@ -363,9 +379,11 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             let mut tombstone_min_epoch = u64::MAX;
             let mut tombstone_max_epoch = u64::MIN;
 
-            for tombstone in &meta.range_tombstone_list {
-                tombstone_min_epoch = cmp::min(tombstone_min_epoch, tombstone.sequence);
-                tombstone_max_epoch = cmp::max(tombstone_max_epoch, tombstone.sequence);
+            for monotonic_delete in &meta.monotonic_tombstone_events {
+                if monotonic_delete.new_epoch != HummockEpoch::MAX {
+                    tombstone_min_epoch = cmp::min(tombstone_min_epoch, monotonic_delete.new_epoch);
+                    tombstone_max_epoch = cmp::max(tombstone_max_epoch, monotonic_delete.new_epoch);
+                }
             }
 
             (tombstone_min_epoch, tombstone_max_epoch)
@@ -538,12 +556,10 @@ pub(super) mod tests {
         };
         let table_id = TableId::default();
         let mut b = SstableBuilder::for_test(0, mock_sst_writer(&opt), opt);
-        b.add_delete_range(vec![DeleteRangeTombstone::new(
-            table_id,
-            b"abcd".to_vec(),
-            b"eeee".to_vec(),
-            0,
-        )]);
+        b.add_monotonic_deletes(vec![
+            MonotonicDeleteEvent::new(table_id, b"abcd".to_vec(), 0),
+            MonotonicDeleteEvent::new(table_id, b"eeee".to_vec(), HummockEpoch::MAX),
+        ]);
         let s = b.finish().await.unwrap().sst_info;
         let key_range = s.sst_info.key_range.unwrap();
         assert_eq!(

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -25,7 +25,7 @@ use risingwave_pb::hummock::SstableInfo;
 
 use super::utils::CompressionAlgorithm;
 use super::{
-    BlockBuilder, BlockBuilderOptions, BlockMeta, DeleteRangeTombstone, SstableMeta, SstableWriter,
+    BlockBuilder, BlockBuilderOptions, BlockMeta, MonotonicDeleteEvent, SstableMeta, SstableWriter,
     DEFAULT_BLOCK_SIZE, DEFAULT_ENTRY_SIZE, DEFAULT_RESTART_INTERVAL, VERSION,
 };
 use crate::filter_key_extractor::{FilterKeyExtractorImpl, FullKeyFilterKeyExtractor};
@@ -107,7 +107,7 @@ pub struct SstableBuilder<W: SstableWriter, F: FilterBuilder> {
     /// key wmk1 (5) and till the next event key wmk2 (7) (not inclusive).
     /// If there is no range deletes between current event key and next event key, `new_epoch` will
     /// be `HummockEpoch::MAX`.
-    monotonic_deletes: Vec<DeleteRangeTombstone>,
+    monotonic_deletes: Vec<MonotonicDeleteEvent>,
     /// `table_id` of added keys.
     table_ids: BTreeSet<u32>,
     last_full_key: Vec<u8>,
@@ -183,13 +183,16 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
     }
 
     /// Add kv pair to sstable.
-    pub fn add_monotonic_deletes(&mut self, monotonic_deletes: Vec<DeleteRangeTombstone>) {
+    pub fn add_monotonic_deletes(&mut self, monotonic_deletes: Vec<MonotonicDeleteEvent>) {
         let mut last_table_id = TableId::default();
-        for monotonic_delete in &monotonic_deletes {
-            if last_table_id != monotonic_delete.start_user_key.table_id {
-                last_table_id = monotonic_delete.start_user_key.table_id;
+        for monotonic_delete in monotonic_deletes
+            .iter()
+            .filter(|monotonic_delete| monotonic_delete.new_epoch != HummockEpoch::MAX)
+        {
+            if last_table_id != monotonic_delete.event_key.table_id {
+                last_table_id = monotonic_delete.event_key.table_id;
                 self.table_ids
-                    .insert(monotonic_delete.start_user_key.table_id.table_id());
+                    .insert(monotonic_delete.event_key.table_id.table_id());
             }
         }
         self.monotonic_deletes.extend(monotonic_deletes);
@@ -315,19 +318,18 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let mut right_exclusive = false;
         let meta_offset = self.writer.data_len() as u64;
         if let Some(monotonic_delete) = self.monotonic_deletes.last() {
+            debug_assert_eq!(monotonic_delete.new_epoch, HummockEpoch::MAX);
             if largest_key.is_empty()
                 || KeyComparator::encoded_less_than_unencoded(
                     user_key(&largest_key),
-                    &monotonic_delete.end_user_key,
+                    &monotonic_delete.event_key,
                 )
             {
-                // use MAX as epoch because `end_user_key` of the range-tombstone is exclusive, so
-                // we can not include any version of this key.
-                largest_key = FullKey::from_user_key(
-                    monotonic_delete.end_user_key.clone(),
-                    HummockEpoch::MAX,
-                )
-                .encode();
+                // use MAX as epoch because the last monotonic delete must be `HummockEpoch::MAX`,
+                // so we can not include any version of this key.
+                largest_key =
+                    FullKey::from_user_key(monotonic_delete.event_key.clone(), HummockEpoch::MAX)
+                        .encode();
                 right_exclusive = true;
             }
         }
@@ -335,12 +337,12 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             if smallest_key.is_empty()
                 || KeyComparator::encoded_greater_than_unencoded(
                     user_key(&smallest_key),
-                    &monotonic_delete.start_user_key,
+                    &monotonic_delete.event_key,
                 )
             {
                 smallest_key = FullKey::from_user_key(
-                    monotonic_delete.start_user_key.clone(),
-                    monotonic_delete.sequence,
+                    monotonic_delete.event_key.clone(),
+                    monotonic_delete.new_epoch,
                 )
                 .encode();
             }
@@ -368,7 +370,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             largest_key,
             version: VERSION,
             meta_offset,
-            monotonic_tombstones: self.monotonic_deletes,
+            monotonic_tombstone_events: self.monotonic_deletes,
         };
         meta.estimated_size = meta.encoded_size() as u32 + meta_offset as u32;
 
@@ -377,9 +379,11 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             let mut tombstone_min_epoch = u64::MAX;
             let mut tombstone_max_epoch = u64::MIN;
 
-            for monotonic_delete in &meta.monotonic_tombstones {
-                tombstone_min_epoch = cmp::min(tombstone_min_epoch, monotonic_delete.sequence);
-                tombstone_max_epoch = cmp::max(tombstone_max_epoch, monotonic_delete.sequence);
+            for monotonic_delete in &meta.monotonic_tombstone_events {
+                if monotonic_delete.new_epoch != HummockEpoch::MAX {
+                    tombstone_min_epoch = cmp::min(tombstone_min_epoch, monotonic_delete.new_epoch);
+                    tombstone_max_epoch = cmp::max(tombstone_max_epoch, monotonic_delete.new_epoch);
+                }
             }
 
             (tombstone_min_epoch, tombstone_max_epoch)
@@ -552,12 +556,10 @@ pub(super) mod tests {
         };
         let table_id = TableId::default();
         let mut b = SstableBuilder::for_test(0, mock_sst_writer(&opt), opt);
-        b.add_monotonic_deletes(vec![DeleteRangeTombstone::new(
-            table_id,
-            b"abcd".to_vec(),
-            b"eeee".to_vec(),
-            0,
-        )]);
+        b.add_monotonic_deletes(vec![
+            MonotonicDeleteEvent::new(table_id, b"abcd".to_vec(), 0),
+            MonotonicDeleteEvent::new(table_id, b"eeee".to_vec(), HummockEpoch::MAX),
+        ]);
         let s = b.finish().await.unwrap().sst_info;
         let key_range = s.sst_info.key_range.unwrap();
         assert_eq!(

--- a/src/storage/src/hummock/sstable/delete_range_aggregator.rs
+++ b/src/storage/src/hummock/sstable/delete_range_aggregator.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use risingwave_hummock_sdk::key::UserKey;
 use risingwave_hummock_sdk::HummockEpoch;
 
-use super::{create_monotonic_events, DeleteRangeTombstone, MonotonicDeleteEvent};
+use super::{create_monotonic_deletes, DeleteRangeTombstone};
 use crate::hummock::iterator::DeleteRangeIterator;
 use crate::hummock::sstable_store::TableHolder;
 use crate::hummock::Sstable;
@@ -198,7 +198,7 @@ impl CompactionDeleteRanges {
         &self,
         smallest_user_key: &UserKey<&[u8]>,
         largest_user_key: &UserKey<&[u8]>,
-    ) -> Vec<MonotonicDeleteEvent> {
+    ) -> Vec<DeleteRangeTombstone> {
         if self.gc_delete_keys {
             return vec![];
         }
@@ -220,7 +220,7 @@ impl CompactionDeleteRanges {
             }
         }
 
-        create_monotonic_events(&tombstones)
+        create_monotonic_deletes(&tombstones)
     }
 }
 
@@ -288,14 +288,20 @@ impl SstableDeleteRangeIterator {
 
 impl DeleteRangeIterator for SstableDeleteRangeIterator {
     fn next_user_key(&self) -> UserKey<&[u8]> {
-        self.table.value().meta.monotonic_tombstone_events[self.next_idx]
-            .event_key
-            .as_ref()
+        if self.next_idx > 0 {
+            self.table.value().meta.monotonic_tombstones[self.next_idx - 1]
+                .end_user_key
+                .as_ref()
+        } else {
+            self.table.value().meta.monotonic_tombstones[0]
+                .start_user_key
+                .as_ref()
+        }
     }
 
     fn current_epoch(&self) -> HummockEpoch {
         if self.next_idx > 0 {
-            self.table.value().meta.monotonic_tombstone_events[self.next_idx - 1].new_epoch
+            self.table.value().meta.monotonic_tombstones[self.next_idx - 1].sequence
         } else {
             HummockEpoch::MAX
         }
@@ -310,18 +316,28 @@ impl DeleteRangeIterator for SstableDeleteRangeIterator {
     }
 
     fn seek<'a>(&'a mut self, target_user_key: UserKey<&'a [u8]>) {
-        self.next_idx = self
-            .table
-            .value()
-            .meta
-            .monotonic_tombstone_events
-            .partition_point(|MonotonicDeleteEvent { event_key, .. }| {
-                event_key.as_ref().le(&target_user_key)
-            });
+        let monotonic_deletes = &self.table.value().meta.monotonic_tombstones;
+        if !monotonic_deletes.is_empty() {
+            self.next_idx = monotonic_deletes.partition_point(
+                |DeleteRangeTombstone { start_user_key, .. }| {
+                    start_user_key.as_ref().le(&target_user_key)
+                },
+            );
+            if self.next_idx == monotonic_deletes.len() {
+                if monotonic_deletes[self.next_idx - 1]
+                    .end_user_key
+                    .as_ref()
+                    .le(&target_user_key)
+                {
+                    self.next_idx += 1;
+                }
+            }
+        }
     }
 
     fn is_valid(&self) -> bool {
-        self.next_idx < self.table.value().meta.monotonic_tombstone_events.len()
+        let len = self.table.value().meta.monotonic_tombstones.len();
+        len > 0 && self.next_idx <= len
     }
 }
 
@@ -329,13 +345,19 @@ pub fn get_min_delete_range_epoch_from_sstable(
     table: &Sstable,
     query_user_key: &UserKey<&[u8]>,
 ) -> HummockEpoch {
-    let idx = table.meta.monotonic_tombstone_events.partition_point(
-        |MonotonicDeleteEvent { event_key, .. }| event_key.as_ref().le(query_user_key),
+    let idx = table.meta.monotonic_tombstones.partition_point(
+        |DeleteRangeTombstone { start_user_key, .. }| start_user_key.as_ref().le(query_user_key),
     );
-    if idx == 0 {
+    if idx == 0
+        || (idx == table.meta.monotonic_tombstones.len()
+            && table.meta.monotonic_tombstones[idx - 1]
+                .end_user_key
+                .as_ref()
+                .le(query_user_key))
+    {
         HummockEpoch::MAX
     } else {
-        table.meta.monotonic_tombstone_events[idx - 1].new_epoch
+        table.meta.monotonic_tombstones[idx - 1].sequence
     }
 }
 
@@ -429,11 +451,11 @@ mod tests {
             &test_user_key(b"bbbb").as_ref(),
             &test_user_key(b"eeeeee").as_ref(),
         );
-        assert_eq!(4, split_ranges.len());
-        assert_eq!(test_user_key(b"bbbb"), split_ranges[0].event_key);
-        assert_eq!(test_user_key(b"cccc"), split_ranges[1].event_key);
-        assert_eq!(test_user_key(b"dddd"), split_ranges[2].event_key);
-        assert_eq!(test_user_key(b"eeeeee"), split_ranges[3].event_key);
+        assert_eq!(3, split_ranges.len());
+        assert_eq!(test_user_key(b"bbbb"), split_ranges[0].start_user_key);
+        assert_eq!(test_user_key(b"cccc"), split_ranges[1].start_user_key);
+        assert_eq!(test_user_key(b"dddd"), split_ranges[2].start_user_key);
+        assert_eq!(test_user_key(b"eeeeee"), split_ranges[2].end_user_key);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/delete_range_aggregator.rs
+++ b/src/storage/src/hummock/sstable/delete_range_aggregator.rs
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 use std::cmp::Ordering;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeSet;
 use std::sync::Arc;
 
 use itertools::Itertools;
 use risingwave_hummock_sdk::key::UserKey;
 use risingwave_hummock_sdk::HummockEpoch;
 
-use super::{DeleteRangeTombstone, MonotonicDeleteEvent};
+use super::{create_monotonic_events, DeleteRangeTombstone, MonotonicDeleteEvent};
 use crate::hummock::iterator::DeleteRangeIterator;
 use crate::hummock::sstable_store::TableHolder;
 use crate::hummock::Sstable;
@@ -63,7 +63,6 @@ pub struct CompactionDeleteRangesBuilder {
 
 #[derive(Clone)]
 pub(crate) struct TombstoneEnterExitEvent {
-    original_position_in_delete_tombstones: usize,
     tombstone_epoch: HummockEpoch,
 }
 
@@ -104,16 +103,10 @@ type CompactionDeleteRangeEvent = (
 pub(crate) fn apply_event(epochs: &mut BTreeSet<HummockEpoch>, event: &CompactionDeleteRangeEvent) {
     let (_, exit, enter) = event;
     // Correct because ranges in an epoch won't intersect.
-    for TombstoneEnterExitEvent {
-        tombstone_epoch, ..
-    } in exit
-    {
+    for TombstoneEnterExitEvent { tombstone_epoch } in exit {
         epochs.remove(tombstone_epoch);
     }
-    for TombstoneEnterExitEvent {
-        tombstone_epoch, ..
-    } in enter
-    {
+    for TombstoneEnterExitEvent { tombstone_epoch } in enter {
         epochs.insert(*tombstone_epoch);
     }
 }
@@ -122,7 +115,6 @@ pub(crate) fn apply_event(epochs: &mut BTreeSet<HummockEpoch>, event: &Compactio
 pub struct CompactionDeleteRanges {
     delete_tombstones: Vec<DeleteRangeTombstone>,
     events: Vec<CompactionDeleteRangeEvent>,
-    watermark: HummockEpoch,
     gc_delete_keys: bool,
 }
 
@@ -141,33 +133,28 @@ impl CompactionDeleteRangesBuilder {
     ) -> Vec<CompactionDeleteRangeEvent> {
         let tombstone_len = delete_tombstones.len();
         let mut events = Vec::with_capacity(tombstone_len * 2);
-        for (
-            index,
-            DeleteRangeTombstone {
-                start_user_key,
-                end_user_key,
-                ..
-            },
-        ) in delete_tombstones.iter().enumerate()
+        for DeleteRangeTombstone {
+            start_user_key,
+            end_user_key,
+            sequence,
+        } in delete_tombstones
         {
-            events.push((start_user_key, 1, index));
-            events.push((end_user_key, 0, index));
+            events.push((start_user_key, 1, *sequence));
+            events.push((end_user_key, 0, *sequence));
         }
         events.sort();
 
         let mut result = Vec::with_capacity(events.len());
         for (user_key, group) in &events.into_iter().group_by(|(user_key, _, _)| *user_key) {
             let (mut exit, mut enter) = (vec![], vec![]);
-            for (_, op, index) in group {
+            for (_, op, sequence) in group {
                 match op {
                     0 => exit.push(TombstoneEnterExitEvent {
-                        original_position_in_delete_tombstones: index,
-                        tombstone_epoch: delete_tombstones[index].sequence,
+                        tombstone_epoch: sequence,
                     }),
                     1 => {
                         enter.push(TombstoneEnterExitEvent {
-                            original_position_in_delete_tombstones: index,
-                            tombstone_epoch: delete_tombstones[index].sequence,
+                            tombstone_epoch: sequence,
                         });
                     }
                     _ => unreachable!(),
@@ -179,17 +166,12 @@ impl CompactionDeleteRangesBuilder {
         result
     }
 
-    pub(crate) fn build_for_compaction(
-        self,
-        watermark: HummockEpoch,
-        gc_delete_keys: bool,
-    ) -> Arc<CompactionDeleteRanges> {
+    pub(crate) fn build_for_compaction(self, gc_delete_keys: bool) -> Arc<CompactionDeleteRanges> {
         let result = Self::build_events(&self.delete_tombstones);
 
         Arc::new(CompactionDeleteRanges {
             delete_tombstones: self.delete_tombstones,
             events: result,
-            watermark,
             gc_delete_keys,
         })
     }
@@ -201,7 +183,6 @@ impl CompactionDeleteRanges {
             delete_tombstones: vec![],
             events: vec![],
             gc_delete_keys: false,
-            watermark: 0,
         }
     }
 
@@ -217,8 +198,12 @@ impl CompactionDeleteRanges {
         &self,
         smallest_user_key: &UserKey<&[u8]>,
         largest_user_key: &UserKey<&[u8]>,
-    ) -> Vec<DeleteRangeTombstone> {
-        let (mut tombstones_above_watermark, mut tombstones_within_watermark) = (vec![], vec![]);
+    ) -> Vec<MonotonicDeleteEvent> {
+        if self.gc_delete_keys {
+            return vec![];
+        }
+
+        let mut tombstones = Vec::with_capacity(self.delete_tombstones.len());
         for tombstone in &self.delete_tombstones {
             let mut candidate = tombstone.clone();
             if !smallest_user_key.is_empty()
@@ -231,50 +216,11 @@ impl CompactionDeleteRanges {
                 candidate.end_user_key = largest_user_key.to_vec();
             }
             if candidate.start_user_key < candidate.end_user_key {
-                if candidate.sequence > self.watermark {
-                    tombstones_above_watermark.push(candidate);
-                } else {
-                    tombstones_within_watermark.push(candidate);
-                }
+                tombstones.push(candidate);
             }
         }
 
-        let mut ret = tombstones_above_watermark;
-        if self.gc_delete_keys {
-            return ret;
-        }
-
-        let events = CompactionDeleteRangesBuilder::build_events(&tombstones_within_watermark);
-        let mut epoch2index = BTreeMap::new();
-        let mut is_useful = vec![false; tombstones_within_watermark.len()];
-        for (_, exit, enter) in events {
-            // Correct because ranges in an epoch won't intersect.
-            for TombstoneEnterExitEvent {
-                tombstone_epoch, ..
-            } in exit
-            {
-                epoch2index.remove(&tombstone_epoch);
-            }
-            for TombstoneEnterExitEvent {
-                original_position_in_delete_tombstones,
-                tombstone_epoch,
-            } in enter
-            {
-                epoch2index.insert(tombstone_epoch, original_position_in_delete_tombstones);
-            }
-            if let Some((_, index)) = epoch2index.last_key_value() {
-                is_useful[*index] = true;
-            }
-        }
-
-        ret.extend(
-            tombstones_within_watermark
-                .into_iter()
-                .enumerate()
-                .filter(|(index, _tombstone)| is_useful[*index])
-                .map(|(_index, tombstone)| tombstone),
-        );
-        ret
+        create_monotonic_events(&tombstones)
     }
 }
 
@@ -416,7 +362,7 @@ mod tests {
             DeleteRangeTombstone::new(table_id, b"bbbfff".to_vec(), b"ffffff".to_vec(), 9),
             DeleteRangeTombstone::new(table_id, b"gggggg".to_vec(), b"hhhhhh".to_vec(), 9),
         ]);
-        let compaction_delete_ranges = builder.build_for_compaction(10, false);
+        let compaction_delete_ranges = builder.build_for_compaction(false);
         let mut iter = compaction_delete_ranges.iter();
 
         assert_eq!(
@@ -478,16 +424,16 @@ mod tests {
             DeleteRangeTombstone::new(table_id, b"cccc".to_vec(), b"eeee".to_vec(), 12),
             DeleteRangeTombstone::new(table_id, b"eeee".to_vec(), b"ffff".to_vec(), 12),
         ]);
-        let compaction_delete_range = builder.build_for_compaction(10, true);
+        let compaction_delete_range = builder.build_for_compaction(false);
         let split_ranges = compaction_delete_range.get_tombstone_between(
             &test_user_key(b"bbbb").as_ref(),
             &test_user_key(b"eeeeee").as_ref(),
         );
-        assert_eq!(3, split_ranges.len());
-        assert_eq!(test_user_key(b"bbbb"), split_ranges[0].start_user_key);
-        assert_eq!(test_user_key(b"cccc"), split_ranges[0].end_user_key);
-        assert_eq!(test_user_key(b"cccc"), split_ranges[1].start_user_key);
-        assert_eq!(test_user_key(b"eeee"), split_ranges[1].end_user_key);
+        assert_eq!(4, split_ranges.len());
+        assert_eq!(test_user_key(b"bbbb"), split_ranges[0].event_key);
+        assert_eq!(test_user_key(b"cccc"), split_ranges[1].event_key);
+        assert_eq!(test_user_key(b"dddd"), split_ranges[2].event_key);
+        assert_eq!(test_user_key(b"eeeeee"), split_ranges[3].event_key);
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -169,41 +169,31 @@ impl MonotonicDeleteEvent {
     }
 }
 
-pub(crate) fn create_monotonic_events(
+pub(crate) fn create_monotonic_deletes(
     delete_range_tombstones: &Vec<DeleteRangeTombstone>,
-) -> Vec<MonotonicDeleteEvent> {
+) -> Vec<DeleteRangeTombstone> {
     let events = CompactionDeleteRangesBuilder::build_events(delete_range_tombstones);
     let mut epochs = BTreeSet::new();
-    let mut monotonic_tombstone_events = Vec::with_capacity(events.len());
+    let mut monotonic_deletes = Vec::with_capacity(events.len());
+    let mut half_tombstone: Option<DeleteRangeTombstone> = None;
     for event in events {
         apply_event(&mut epochs, &event);
-        monotonic_tombstone_events.push(MonotonicDeleteEvent {
-            event_key: event.0,
-            new_epoch: epochs.first().map_or(HummockEpoch::MAX, |epoch| *epoch),
+        let new_epoch = epochs.first().map_or(HummockEpoch::MAX, |epoch| *epoch);
+        if let Some(last_tombstone) = half_tombstone.as_mut() {
+            if new_epoch == last_tombstone.sequence {
+                continue;
+            }
+            last_tombstone.end_user_key = event.0.clone();
+            monotonic_deletes.push(half_tombstone.take().unwrap());
+        }
+        half_tombstone = Some(DeleteRangeTombstone {
+            start_user_key: event.0,
+            end_user_key: UserKey::default(),
+            sequence: new_epoch,
         });
     }
-    monotonic_tombstone_events.dedup_by_key(|MonotonicDeleteEvent { new_epoch, .. }| *new_epoch);
 
-    monotonic_tombstone_events
-}
-
-pub(crate) fn create_tombstones_to_represent_monotonic_deletes(
-    monotonic_deletes: &Vec<MonotonicDeleteEvent>,
-) -> Vec<DeleteRangeTombstone> {
-    let mut ret = vec![];
-    let len = monotonic_deletes.len();
-    if len > 1 {
-        for i in 0..(len - 1) {
-            if monotonic_deletes[i].new_epoch != HummockEpoch::MAX {
-                ret.push(DeleteRangeTombstone {
-                    start_user_key: monotonic_deletes[i].event_key.clone(),
-                    end_user_key: monotonic_deletes[i + 1].event_key.clone(),
-                    sequence: monotonic_deletes[i].new_epoch,
-                });
-            }
-        }
-    }
-    ret
+    monotonic_deletes
 }
 
 /// [`Sstable`] is a handle for accessing SST.
@@ -366,7 +356,7 @@ pub struct SstableMeta {
     /// key wmk1 (5) and till the next event key wmk2 (7) (not inclusive).
     /// If there is no range deletes between current event key and next event key, `new_epoch` will
     /// be `HummockEpoch::MAX`.
-    pub monotonic_tombstone_events: Vec<MonotonicDeleteEvent>,
+    pub monotonic_tombstones: Vec<DeleteRangeTombstone>,
     /// Format version, for further compatibility.
     pub version: u32,
 }
@@ -381,8 +371,8 @@ impl SstableMeta {
     /// | estimated size (4B) | key count (4B) |
     /// | smallest key len (4B) | smallest key |
     /// | largest key len (4B) | largest key |
-    /// | K (4B) |
-    /// | tombstone-event 0 | ... | tombstone-event K-1 |
+    /// | M (4B) |
+    /// | monotonic-tombstone 0 | ... | monotonic-tombstone M-1 |
     /// | file offset of this meta block (8B) |
     /// | checksum (8B) | version (4B) | magic (4B) |
     /// ```
@@ -403,9 +393,9 @@ impl SstableMeta {
         buf.put_u32_le(self.key_count);
         put_length_prefixed_slice(buf, &self.smallest_key);
         put_length_prefixed_slice(buf, &self.largest_key);
-        buf.put_u32_le(self.monotonic_tombstone_events.len() as u32);
-        for monotonic_tombstone_event in &self.monotonic_tombstone_events {
-            monotonic_tombstone_event.encode(buf);
+        buf.put_u32_le(self.monotonic_tombstones.len() as u32);
+        for monotonic_tombstone in &self.monotonic_tombstones {
+            monotonic_tombstone.encode(buf);
         }
         buf.put_u64_le(self.meta_offset);
         let checksum = xxhash64_checksum(&buf[start_offset..]);
@@ -444,11 +434,11 @@ impl SstableMeta {
         let key_count = buf.get_u32_le();
         let smallest_key = get_length_prefixed_slice(buf);
         let largest_key = get_length_prefixed_slice(buf);
-        let tomb_event_count = buf.get_u32_le() as usize;
-        let mut monotonic_tombstone_events = Vec::with_capacity(tomb_event_count);
-        for _ in 0..tomb_event_count {
-            let monotonic_tombstone_event = MonotonicDeleteEvent::decode(buf);
-            monotonic_tombstone_events.push(monotonic_tombstone_event);
+        let monotonic_tomb_count = buf.get_u32_le() as usize;
+        let mut monotonic_tombstones = Vec::with_capacity(monotonic_tomb_count);
+        for _ in 0..monotonic_tomb_count {
+            let monotonic_tombstone = DeleteRangeTombstone::decode(buf);
+            monotonic_tombstones.push(monotonic_tombstone);
         }
         let meta_offset = buf.get_u64_le();
 
@@ -460,7 +450,7 @@ impl SstableMeta {
             smallest_key,
             largest_key,
             meta_offset,
-            monotonic_tombstone_events,
+            monotonic_tombstones,
             version,
         })
     }
@@ -473,11 +463,11 @@ impl SstableMeta {
             .iter()
             .map(|block_meta| block_meta.encoded_size())
             .sum::<usize>()
-            + 4 // monotonic tombstone events len
+            + 4 // monotonic tombstones len
             + self
-            .monotonic_tombstone_events
+            .monotonic_tombstones
             .iter()
-            .map(|event| 8 + 4 + event.event_key.encoded_len())
+            .map(|tombstone| 8 + 4 + tombstone.start_user_key.encoded_len() + 4 + tombstone.end_user_key.encoded_len())
             .sum::<usize>()
             + 4 // bloom filter len
             + self.bloom_filter.len()
@@ -536,7 +526,7 @@ mod tests {
             smallest_key: b"0-smallest-key".to_vec(),
             largest_key: b"9-largest-key".to_vec(),
             meta_offset: 123,
-            monotonic_tombstone_events: vec![],
+            monotonic_tombstones: vec![],
             version: VERSION,
         };
         let sz = meta.encoded_size();

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -21,7 +21,7 @@ use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use tokio::task::JoinHandle;
 
-use super::{CompactionDeleteRanges, DeleteRangeTombstone};
+use super::{CompactionDeleteRanges, MonotonicDeleteEvent};
 use crate::hummock::compactor::task_progress::TaskProgress;
 use crate::hummock::sstable::filter::FilterBuilder;
 use crate::hummock::sstable_store::SstableStoreRef;
@@ -184,7 +184,7 @@ where
     /// will be no-op.
     pub async fn seal_current(
         &mut self,
-        monotonic_deletes: Vec<DeleteRangeTombstone>,
+        monotonic_deletes: Vec<MonotonicDeleteEvent>,
     ) -> HummockResult<()> {
         if let Some(mut builder) = self.current_builder.take() {
             builder.add_monotonic_deletes(monotonic_deletes);

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -21,7 +21,7 @@ use risingwave_hummock_sdk::key_range::KeyRange;
 use risingwave_hummock_sdk::LocalSstableInfo;
 use tokio::task::JoinHandle;
 
-use super::{CompactionDeleteRanges, MonotonicDeleteEvent};
+use super::{CompactionDeleteRanges, DeleteRangeTombstone};
 use crate::hummock::compactor::task_progress::TaskProgress;
 use crate::hummock::sstable::filter::FilterBuilder;
 use crate::hummock::sstable_store::SstableStoreRef;
@@ -184,7 +184,7 @@ where
     /// will be no-op.
     pub async fn seal_current(
         &mut self,
-        monotonic_deletes: Vec<MonotonicDeleteEvent>,
+        monotonic_deletes: Vec<DeleteRangeTombstone>,
     ) -> HummockResult<()> {
         if let Some(mut builder) = self.current_builder.take() {
             builder.add_monotonic_deletes(monotonic_deletes);

--- a/src/storage/src/hummock/sstable/writer.rs
+++ b/src/storage/src/hummock/sstable/writer.rs
@@ -106,7 +106,6 @@ mod tests {
             smallest_key: Vec::new(),
             largest_key: Vec::new(),
             meta_offset: data.len() as u64,
-            range_tombstone_list: vec![],
             monotonic_tombstone_events: vec![],
             version: VERSION,
         };

--- a/src/storage/src/hummock/sstable/writer.rs
+++ b/src/storage/src/hummock/sstable/writer.rs
@@ -106,7 +106,7 @@ mod tests {
             smallest_key: Vec::new(),
             largest_key: Vec::new(),
             meta_offset: data.len() as u64,
-            monotonic_tombstones: vec![],
+            monotonic_tombstone_events: vec![],
             version: VERSION,
         };
 

--- a/src/storage/src/hummock/sstable/writer.rs
+++ b/src/storage/src/hummock/sstable/writer.rs
@@ -106,7 +106,7 @@ mod tests {
             smallest_key: Vec::new(),
             largest_key: Vec::new(),
             meta_offset: data.len() as u64,
-            monotonic_tombstone_events: vec![],
+            monotonic_tombstones: vec![],
             version: VERSION,
         };
 

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -672,11 +672,7 @@ impl HummockVersionReader {
                 .in_span(Span::enter_with_local_parent("get_sstable"))
                 .await?;
 
-            if !table_holder
-                .value()
-                .meta
-                .monotonic_tombstone_events
-                .is_empty()
+            if !table_holder.value().meta.monotonic_tombstones.is_empty()
                 && !read_options.ignore_range_tombstone
             {
                 delete_range_iter
@@ -796,7 +792,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
+                    if !sstable.value().meta.monotonic_tombstones.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter
@@ -822,7 +818,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
+                    if !sstable.value().meta.monotonic_tombstones.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -672,7 +672,11 @@ impl HummockVersionReader {
                 .in_span(Span::enter_with_local_parent("get_sstable"))
                 .await?;
 
-            if !table_holder.value().meta.range_tombstone_list.is_empty()
+            if !table_holder
+                .value()
+                .meta
+                .monotonic_tombstone_events
+                .is_empty()
                 && !read_options.ignore_range_tombstone
             {
                 delete_range_iter
@@ -792,7 +796,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.range_tombstone_list.is_empty()
+                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter
@@ -818,7 +822,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.range_tombstone_list.is_empty()
+                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -672,7 +672,11 @@ impl HummockVersionReader {
                 .in_span(Span::enter_with_local_parent("get_sstable"))
                 .await?;
 
-            if !table_holder.value().meta.monotonic_tombstones.is_empty()
+            if !table_holder
+                .value()
+                .meta
+                .monotonic_tombstone_events
+                .is_empty()
                 && !read_options.ignore_range_tombstone
             {
                 delete_range_iter
@@ -792,7 +796,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.monotonic_tombstones.is_empty()
+                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter
@@ -818,7 +822,7 @@ impl HummockVersionReader {
                         flatten_resps.pop().unwrap().unwrap();
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     local_stats.apply_meta_fetch(local_cache_meta_block_miss);
-                    if !sstable.value().meta.monotonic_tombstones.is_empty()
+                    if !sstable.value().meta.monotonic_tombstone_events.is_empty()
                         && !read_options.ignore_range_tombstone
                     {
                         delete_range_iter

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -24,7 +24,7 @@ use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 use super::iterator::test_utils::iterator_test_table_key_of;
 use super::{
-    create_monotonic_events, CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta,
+    create_monotonic_deletes, CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta,
     SstableWriterOptions, DEFAULT_RESTART_INTERVAL,
 };
 use crate::error::StorageResult;
@@ -263,7 +263,7 @@ pub async fn gen_test_sstable_inner<B: AsRef<[u8]> + Clone + Default + Eq>(
             .await
             .unwrap();
     }
-    b.add_monotonic_deletes(create_monotonic_events(&range_tombstones));
+    b.add_monotonic_deletes(create_monotonic_deletes(&range_tombstones));
     let output = b.finish().await.unwrap();
     output.writer_output.await.unwrap().unwrap();
     let table = sstable_store

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -24,7 +24,7 @@ use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 use super::iterator::test_utils::iterator_test_table_key_of;
 use super::{
-    create_monotonic_deletes, CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta,
+    create_monotonic_events, CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta,
     SstableWriterOptions, DEFAULT_RESTART_INTERVAL,
 };
 use crate::error::StorageResult;
@@ -263,7 +263,7 @@ pub async fn gen_test_sstable_inner<B: AsRef<[u8]> + Clone + Default + Eq>(
             .await
             .unwrap();
     }
-    b.add_monotonic_deletes(create_monotonic_deletes(&range_tombstones));
+    b.add_monotonic_deletes(create_monotonic_events(&range_tombstones));
     let output = b.finish().await.unwrap();
     output.writer_output.await.unwrap().unwrap();
     let table = sstable_store

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -24,8 +24,8 @@ use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
 use super::iterator::test_utils::iterator_test_table_key_of;
 use super::{
-    CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta, SstableWriterOptions,
-    DEFAULT_RESTART_INTERVAL,
+    create_monotonic_events, CompressionAlgorithm, HummockResult, InMemWriter, SstableMeta,
+    SstableWriterOptions, DEFAULT_RESTART_INTERVAL,
 };
 use crate::error::StorageResult;
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferBatch;
@@ -263,7 +263,7 @@ pub async fn gen_test_sstable_inner<B: AsRef<[u8]> + Clone + Default + Eq>(
             .await
             .unwrap();
     }
-    b.add_delete_range(range_tombstones);
+    b.add_monotonic_deletes(create_monotonic_events(&range_tombstones));
     let output = b.finish().await.unwrap();
     output.writer_output.await.unwrap().unwrap();
     let table = sstable_store


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Monotonic event is all you need.

In #8927, we replaced delete ranges with monotonic delete events in hummock read interface.
However, we did still save original delete ranges for compaction use.
In this PR, to further reduce cost, we do not save the original delete ranges and directly use the collection of monotonic delete events of input SSTs in compaction.
The proof of correctness in this PR is the same as that in #8927 :
> we only need to keep the smallest epoch of the overlapping range tomstone intervals since the key covered by the range tombstone in lower level must have smaller epoches

Implementation: trivially replacing usage of delete ranges with monotonic delete events.
Two consecutive events in monotonic delete events can serve as a delete range.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
