### PR TITLE
feat(expr): support US/MS in to_timestamp/to_char

### DIFF
--- a/e2e_test/batch/functions/to_char.slt.part
+++ b/e2e_test/batch/functions/to_char.slt.part
@@ -12,3 +12,28 @@ query T
 SELECT to_char(timestamp '2006-01-02 15:04:05', 'yyyy-mm-dd hh24:mi:ss');
 ----
 2006-01-02 15:04:05
+
+query T
+SELECT to_char(timestamp '2006-01-02 15:04:05.003', 'yyyy-mm-dd hh24:mi:ss.ms');
+----
+2006-01-02 15:04:05.003
+
+query T
+SELECT to_char(timestamp '2006-01-02 15:04:05.113223', 'yyyy-mm-dd hh24:mi:ss.us');
+----
+2006-01-02 15:04:05.113223
+
+query T
+SELECT to_char(timestamp '2006-01-02 15:04:05.113223', 'yyyy-mm-dd hh24:mi:ss.ms');
+----
+2006-01-02 15:04:05.113
+
+query T
+SELECT to_char(timestamp '2006-01-02 15:04:05.3', 'yyyy-mm-dd hh24:mi:ss.ms');
+----
+2006-01-02 15:04:05.300
+
+query T
+SELECT to_char(timestamp '2006-01-02 15:04:05.3', 'yyyy-mm-dd hh24:mi:ss.us');
+----
+2006-01-02 15:04:05.300000

--- a/e2e_test/batch/functions/to_timestamp.slt.part
+++ b/e2e_test/batch/functions/to_timestamp.slt.part
@@ -22,3 +22,31 @@ query T
 select to_timestamp('2022/12/25 15', 'YYYY/MM/DD HH24');
 ----
 2022-12-25 15:00:00
+
+query T
+select to_timestamp('2001-04-17 00:00:00.900006', 'YYYY-MM-DD HH24:MI:SS.US');
+----
+2001-04-17 00:00:00.900006
+
+query T
+select to_timestamp('2001-04-17 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US');
+----
+2001-04-17 00:00:00
+
+query T
+select to_timestamp('2001-04-17 00:00:00.906', 'YYYY-MM-DD HH24:MI:SS.MS');
+----
+2001-04-17 00:00:00.906
+
+query T
+select to_timestamp('2001-04-17 00:00:00.000', 'YYYY-MM-DD HH24:MI:SS.MS');
+----
+2001-04-17 00:00:00
+
+# FIXME: false positive cases, but hard to handle in chrono.
+
+statement error
+select to_timestamp('2001-04-17 00:00:00.9', 'YYYY-MM-DD HH24:MI:SS.MS');
+
+statement error
+select to_timestamp('2001-04-17 00:00:00.9999', 'YYYY-MM-DD HH24:MI:SS.US');

--- a/src/expr/src/vector_op/to_char.rs
+++ b/src/expr/src/vector_op/to_char.rs
@@ -42,12 +42,13 @@ pub fn compile_pattern_to_chrono(tmpl: &str) -> ChronoPattern {
     // https://www.postgresql.org/docs/current/functions-formatting.html
     static PG_PATTERNS: &[&str] = &[
         "HH24", "hh24", "HH12", "hh12", "HH", "hh", "MI", "mi", "SS", "ss", "YYYY", "yyyy", "YY",
-        "yy", "IYYY", "iyyy", "IY", "iy", "MM", "mm", "Month", "Mon", "DD", "dd",
+        "yy", "IYYY", "iyyy", "IY", "iy", "MM", "mm", "Month", "Mon", "DD", "dd", "US", "us", "MS",
+        "ms",
     ];
     // https://docs.rs/chrono/latest/chrono/format/strftime/index.html
     static CHRONO_PATTERNS: &[&str] = &[
         "%H", "%H", "%I", "%I", "%I", "%I", "%M", "%M", "%S", "%S", "%Y", "%Y", "%y", "%y", "%G",
-        "%G", "%g", "%g", "%m", "%m", "%B", "%b", "%d", "%d",
+        "%G", "%g", "%g", "%m", "%m", "%B", "%b", "%d", "%d", "%6f", "%6f", "%3f", "%3f",
     ];
     static AC: LazyLock<AhoCorasick> = LazyLock::new(|| {
         AhoCorasickBuilder::new()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See title and SLT changes.

Fixes #7737 
Fixes #9244 
Related #112 

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

support US/MS in to_timestamp/to_char

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
