### PR TITLE
feat(test_utils): use seed in rand_bitmap

### DIFF
--- a/src/common/src/test_utils/rand_bitmap.rs
+++ b/src/common/src/test_utils/rand_bitmap.rs
@@ -14,13 +14,14 @@
 
 use itertools::Itertools;
 use rand::seq::SliceRandom;
+use rand::SeedableRng;
 
 use crate::buffer::{Bitmap, BitmapBuilder};
 
-pub fn gen_rand_bitmap(num_bits: usize, count_ones: usize) -> Bitmap {
+pub fn gen_rand_bitmap(num_bits: usize, count_ones: usize, seed: u64) -> Bitmap {
     let mut builder = BitmapBuilder::zeroed(num_bits);
     let mut range = (0..num_bits).collect_vec();
-    range.shuffle(&mut rand::thread_rng());
+    range.shuffle(&mut rand::rngs::StdRng::seed_from_u64(seed));
     let shuffled = range.into_iter().collect_vec();
     for item in shuffled.iter().take(count_ones) {
         builder.set(*item, true);

--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -673,6 +673,7 @@ mod tests {
             Some(rand_bitmap::gen_rand_bitmap(
                 chunk_size,
                 (chunk_size as f64 * vis_rate) as usize,
+                666,
             ))
         } else {
             None


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
