### PR TITLE
fix(docker): add data-directory config in docker compose meta node

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -209,6 +209,8 @@ services:
       - "connector-node:50051"
       - "--state-store"
       - "hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001"
+      - "--data-directory"
+      - "hummock_001"
       - "--config-path"
       - /risingwave.toml
     expose:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Because of this #9170 we must add --data-directory when starting the meta node

This is why the integration test failed yesterday

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.


