### PR TITLE
chore(storage): support update split_by_state_table with risectl

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -545,6 +545,7 @@ message RiseCtlUpdateCompactionConfigRequest {
       uint32 compaction_filter_mask = 8;
       uint32 max_sub_compaction = 9;
       uint64 level0_stop_write_threshold_sub_level_number = 10;
+      bool split_by_state_table = 11;
     }
   }
   repeated uint64 compaction_group_ids = 1;

--- a/src/ctl/src/cmd_impl/hummock/compaction_group.rs
+++ b/src/ctl/src/cmd_impl/hummock/compaction_group.rs
@@ -52,6 +52,7 @@ pub fn build_compaction_config_vec(
     compaction_filter_mask: Option<u32>,
     max_sub_compaction: Option<u32>,
     level0_stop_write_threshold_sub_level_number: Option<u64>,
+    split_by_state_table: Option<bool>,
 ) -> Vec<MutableConfig> {
     let mut configs = vec![];
     if let Some(c) = max_bytes_for_level_base {
@@ -81,6 +82,10 @@ pub fn build_compaction_config_vec(
     if let Some(c) = level0_stop_write_threshold_sub_level_number {
         configs.push(MutableConfig::Level0StopWriteThresholdSubLevelNumber(c));
     }
+    if let Some(c) = split_by_state_table {
+        configs.push(MutableConfig::SplitByStateTable(c));
+    }
+
     configs
 }
 

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -145,6 +145,8 @@ enum HummockCommands {
         max_sub_compaction: Option<u32>,
         #[clap(long)]
         level0_stop_write_threshold_sub_level_number: Option<u64>,
+        #[clap(long)]
+        split_by_state_table: Option<bool>,
     },
     /// Split given compaction group into two. Moves the given tables to the new group.
     SplitCompactionGroup {
@@ -287,6 +289,7 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             compaction_filter_mask,
             max_sub_compaction,
             level0_stop_write_threshold_sub_level_number,
+            split_by_state_table,
         }) => {
             cmd_impl::hummock::update_compaction_config(
                 context,
@@ -301,6 +304,7 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                     compaction_filter_mask,
                     max_sub_compaction,
                     level0_stop_write_threshold_sub_level_number,
+                    split_by_state_table,
                 ),
             )
             .await?

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -799,6 +799,9 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             MutableConfig::Level0StopWriteThresholdSubLevelNumber(c) => {
                 target.level0_stop_write_threshold_sub_level_number = *c;
             }
+            MutableConfig::SplitByStateTable(c) => {
+                target.split_by_state_table = *c;
+            }
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In the risectl tool, turn on the `split_by_state_table` configuration for the specified cg for the purpose of splitting the sst.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- ~[ ] I have written necessary rustdoc comments~
- ~[ ] I have added necessary unit tests and integration tests~
- ~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- ~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- ~[ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
