### PR TITLE
fix(storage): fix some bugs in retention second in read option

### DIFF
--- a/src/meta/src/hummock/compaction/picker/ttl_reclaim_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/ttl_reclaim_compaction_picker.rs
@@ -97,7 +97,7 @@ impl TtlReclaimCompactionPicker {
                     // default to zero.
                     let ttl_mill = *ttl_second_u32 as u64 * 1000;
                     let min_epoch = expire_epoch.subtract_ms(ttl_mill);
-                    if Epoch(sst.min_epoch) <= min_epoch {
+                    if Epoch(sst.min_epoch) < min_epoch {
                         return false;
                     }
                 }

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -960,7 +960,7 @@ pub(crate) mod tests {
                 .meta
                 .key_count;
         }
-        let expect_count = kv_count as u32 - retention_seconds_expire_second;
+        let expect_count = kv_count as u32 - retention_seconds_expire_second + 1;
         assert_eq!(expect_count, key_count); // retention_seconds will clean the key (which epoch < epoch - retention_seconds)
 
         // 5. get compact task and there should be none

--- a/src/storage/hummock_test/src/hummock_storage_tests.rs
+++ b/src/storage/hummock_test/src/hummock_storage_tests.rs
@@ -1025,7 +1025,7 @@ async fn test_iter_with_min_epoch() {
                     ReadOptions {
                         ignore_range_tombstone: false,
                         table_id: TEST_TABLE_ID,
-                        retention_seconds: Some(1),
+                        retention_seconds: Some(0),
                         prefix_hint: None,
                         read_version_from_backup: false,
                         prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
@@ -1118,7 +1118,7 @@ async fn test_iter_with_min_epoch() {
                     ReadOptions {
                         ignore_range_tombstone: false,
                         table_id: TEST_TABLE_ID,
-                        retention_seconds: Some(1),
+                        retention_seconds: Some(0),
                         prefix_hint: None,
                         read_version_from_backup: false,
                         prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
@@ -1304,7 +1304,7 @@ async fn test_hummock_version_reader() {
                         ReadOptions {
                             ignore_range_tombstone: false,
                             table_id: TEST_TABLE_ID,
-                            retention_seconds: Some(1),
+                            retention_seconds: Some(0),
                             prefix_hint: None,
                             read_version_from_backup: false,
                             prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
@@ -1457,7 +1457,7 @@ async fn test_hummock_version_reader() {
                         ReadOptions {
                             ignore_range_tombstone: false,
                             table_id: TEST_TABLE_ID,
-                            retention_seconds: Some(1),
+                            retention_seconds: Some(0),
                             prefix_hint: None,
                             read_version_from_backup: false,
                             prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
@@ -1748,7 +1748,7 @@ async fn test_get_with_min_epoch() {
                     ReadOptions {
                         ignore_range_tombstone: false,
                         table_id: TEST_TABLE_ID,
-                        retention_seconds: Some(1),
+                        retention_seconds: Some(0),
                         prefix_hint: Some(Bytes::from(prefix_hint.clone())),
                         read_version_from_backup: false,
                         prefetch_options: Default::default(),
@@ -1863,7 +1863,7 @@ async fn test_get_with_min_epoch() {
                 ReadOptions {
                     ignore_range_tombstone: false,
                     table_id: TEST_TABLE_ID,
-                    retention_seconds: Some(1),
+                    retention_seconds: Some(0),
 
                     prefix_hint: Some(Bytes::from(prefix_hint.clone())),
                     read_version_from_backup: false,

--- a/src/storage/src/hummock/compactor/compaction_filter.rs
+++ b/src/storage/src/hummock/compactor/compaction_filter.rs
@@ -75,7 +75,7 @@ impl CompactionFilter for TtlCompactionFilter {
         if let Some((last_table_id, ttl_mill)) = self.last_table_and_ttl.as_ref() {
             if *last_table_id == table_id {
                 let min_epoch = Epoch(self.expire_epoch).subtract_ms(*ttl_mill);
-                return Epoch(epoch) <= min_epoch;
+                return Epoch(epoch) < min_epoch;
             }
         }
         match self.table_id_to_ttl.get(&table_id) {
@@ -85,7 +85,7 @@ impl CompactionFilter for TtlCompactionFilter {
                 let ttl_mill = *ttl_second_u32 as u64 * 1000;
                 let min_epoch = Epoch(self.expire_epoch).subtract_ms(ttl_mill);
                 self.last_table_and_ttl = Some((table_id, ttl_mill));
-                Epoch(epoch) <= min_epoch
+                Epoch(epoch) < min_epoch
             }
             None => false,
         }

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -93,7 +93,7 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
             let epoch = full_key.epoch;
 
             // handle multi-version
-            if epoch <= self.min_epoch || epoch > self.read_epoch {
+            if epoch < self.min_epoch || epoch > self.read_epoch {
                 self.iterator.next().await?;
                 continue;
             }

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -891,13 +891,13 @@ mod tests {
         while ui.is_valid() {
             let key = ui.key();
             let key_epoch = key.epoch;
-            assert!(key_epoch > min_epoch);
+            assert!(key_epoch >= min_epoch);
 
             i += 1;
             ui.next().await.unwrap();
         }
 
-        let expect_count = TEST_KEYS_COUNT - min_epoch as usize;
+        let expect_count = TEST_KEYS_COUNT - min_epoch as usize + 1;
         assert_eq!(i, expect_count);
     }
 

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -384,8 +384,10 @@ pub async fn get_from_sstable_info(
     // Iterator has sought passed the borders.
     if !iter.is_valid() {
         if !read_options.ignore_range_tombstone {
-            let delete_epoch =
-                get_min_delete_range_epoch_from_sstable(iter.sst().value().as_ref(), full_key.user_key);
+            let delete_epoch = get_min_delete_range_epoch_from_sstable(
+                iter.sst().value().as_ref(),
+                full_key.user_key,
+            );
             if delete_epoch <= full_key.epoch {
                 return Ok(Some((HummockValue::Delete, delete_epoch)));
             }

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -90,7 +90,7 @@ use crate::hummock::store::memtable::ImmutableMemtable;
 use crate::hummock::store::version::HummockVersionReader;
 use crate::hummock::write_limiter::{WriteLimiter, WriteLimiterRef};
 use crate::monitor::{CompactorMetrics, StoreLocalStatistic};
-use crate::store::{gen_min_epoch, NewLocalOptions, ReadOptions};
+use crate::store::{NewLocalOptions, ReadOptions};
 
 struct HummockStorageShutdownGuard {
     shutdown_sender: UnboundedSender<HummockEvent>,
@@ -357,15 +357,17 @@ pub async fn get_from_sstable_info(
     read_options: &ReadOptions,
     dist_key_hash: Option<u64>,
     local_stats: &mut StoreLocalStatistic,
-) -> HummockResult<Option<HummockValue<Bytes>>> {
+) -> HummockResult<Option<(HummockValue<Bytes>, HummockEpoch)>> {
     let sstable = sstable_store_ref.sstable(sstable_info, local_stats).await?;
-    let min_epoch = gen_min_epoch(full_key.epoch, read_options.retention_seconds.as_ref());
 
     // Bloom filter key is the distribution key, which is no need to be the prefix of pk, and do not
     // contain `TablePrefix` and `VnodePrefix`.
     if let Some(hash) = dist_key_hash && !hit_sstable_bloom_filter(sstable.value(), hash, local_stats) {
-        if !read_options.ignore_range_tombstone && get_min_delete_range_epoch_from_sstable(sstable.value().as_ref(), full_key.user_key) <= full_key.epoch {
-            return Ok(Some(HummockValue::Delete));
+        if !read_options.ignore_range_tombstone {
+            let delete_epoch = get_min_delete_range_epoch_from_sstable(sstable.value().as_ref(), full_key.user_key);
+            if delete_epoch <= full_key.epoch {
+                return Ok(Some((HummockValue::Delete, delete_epoch)));
+            }
         }
 
         return Ok(None);
@@ -381,30 +383,29 @@ pub async fn get_from_sstable_info(
     iter.seek(full_key).await?;
     // Iterator has sought passed the borders.
     if !iter.is_valid() {
-        if !read_options.ignore_range_tombstone
-            && get_min_delete_range_epoch_from_sstable(
-                iter.sst().value().as_ref(),
-                full_key.user_key,
-            ) <= full_key.epoch
-        {
-            return Ok(Some(HummockValue::Delete));
+        if !read_options.ignore_range_tombstone {
+            let delete_epoch =
+                get_min_delete_range_epoch_from_sstable(iter.sst().value().as_ref(), full_key.user_key);
+            if delete_epoch <= full_key.epoch {
+                return Ok(Some((HummockValue::Delete, delete_epoch)));
+            }
         }
+
         return Ok(None);
     }
 
     // Iterator gets us the key, we tell if it's the key we want
     // or key next to it.
     let value = if iter.key().user_key == full_key.user_key {
-        if iter.key().epoch <= min_epoch {
-            None
+        Some((iter.value().to_bytes(), iter.key().epoch))
+    } else if !read_options.ignore_range_tombstone {
+        let delete_epoch =
+            get_min_delete_range_epoch_from_sstable(iter.sst().value().as_ref(), full_key.user_key);
+        if delete_epoch <= full_key.epoch {
+            Some((HummockValue::Delete, delete_epoch))
         } else {
-            Some(iter.value().to_bytes())
+            None
         }
-    } else if !read_options.ignore_range_tombstone
-        && get_min_delete_range_epoch_from_sstable(iter.sst().value().as_ref(), full_key.user_key)
-            <= full_key.epoch
-    {
-        Some(HummockValue::Delete)
     } else {
         None
     };
@@ -434,7 +435,7 @@ pub fn get_from_batch(
     read_epoch: HummockEpoch,
     read_options: &ReadOptions,
     local_stats: &mut StoreLocalStatistic,
-) -> Option<HummockValue<Bytes>> {
+) -> Option<(HummockValue<Bytes>, HummockEpoch)> {
     imm.get(table_key, read_epoch, read_options).map(|v| {
         local_stats.get_shared_buffer_hit_counts += 1;
         v

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -241,7 +241,7 @@ impl SharedBufferBatchInner {
         table_key: TableKey<&[u8]>,
         read_epoch: HummockEpoch,
         read_options: &ReadOptions,
-    ) -> Option<HummockValue<Bytes>> {
+    ) -> Option<(HummockValue<Bytes>, HummockEpoch)> {
         // Perform binary search on table key to find the corresponding entry
         if let Ok(i) = self.payload.binary_search_by(|m| (m.0[..]).cmp(*table_key)) {
             let item = &self.payload[i];
@@ -252,15 +252,18 @@ impl SharedBufferBatchInner {
                 if read_epoch < *e {
                     continue;
                 }
-                return Some(v.clone());
+                return Some((v.clone(), *e));
             }
             // cannot find a visible version
         }
 
-        if !read_options.ignore_range_tombstone
-            && self.get_min_delete_range_epoch(UserKey::new(table_id, table_key)) <= read_epoch
-        {
-            Some(HummockValue::Delete)
+        if !read_options.ignore_range_tombstone {
+            let delete_epoch = self.get_min_delete_range_epoch(UserKey::new(table_id, table_key));
+            if delete_epoch <= read_epoch {
+                Some((HummockValue::Delete, delete_epoch))
+            } else {
+                None
+            }
         } else {
             None
         }
@@ -393,7 +396,7 @@ impl SharedBufferBatch {
         table_key: TableKey<&[u8]>,
         read_epoch: HummockEpoch,
         read_options: &ReadOptions,
-    ) -> Option<HummockValue<Bytes>> {
+    ) -> Option<(HummockValue<Bytes>, HummockEpoch)> {
         self.inner
             .get_value(self.table_id, table_key, read_epoch, read_options)
     }
@@ -852,8 +855,11 @@ mod tests {
         // Point lookup
         for (k, v) in &shared_buffer_items {
             assert_eq!(
-                shared_buffer_batch.get(TableKey(k.as_slice()), epoch, &ReadOptions::default()),
-                Some(v.clone())
+                shared_buffer_batch
+                    .get(TableKey(k.as_slice()), epoch, &ReadOptions::default())
+                    .unwrap()
+                    .0,
+                v.clone()
             );
         }
         assert_eq!(
@@ -1234,12 +1240,15 @@ mod tests {
         for (i, items) in batch_items.iter().enumerate() {
             for (key, value) in items {
                 assert_eq!(
-                    merged_imm.get(
-                        TableKey(key.as_slice()),
-                        i as u64 + 1,
-                        &ReadOptions::default()
-                    ),
-                    Some(value.clone()),
+                    merged_imm
+                        .get(
+                            TableKey(key.as_slice()),
+                            i as u64 + 1,
+                            &ReadOptions::default()
+                        )
+                        .unwrap()
+                        .0,
+                    value.clone(),
                     "epoch: {}, key: {:?}",
                     i + 1,
                     String::from_utf8(key.clone())
@@ -1410,37 +1419,55 @@ mod tests {
         );
 
         assert_eq!(
-            Some(HummockValue::put(Bytes::from("value12"))),
-            merged_imm.get(TableKey(b"111"), 2, &ReadOptions::default())
+            HummockValue::put(Bytes::from("value12")),
+            merged_imm
+                .get(TableKey(b"111"), 2, &ReadOptions::default())
+                .unwrap()
+                .0
         );
 
         // 555 is deleted in epoch=1
         assert_eq!(
-            Some(HummockValue::Delete),
-            merged_imm.get(TableKey(b"555"), 1, &ReadOptions::default())
+            HummockValue::Delete,
+            merged_imm
+                .get(TableKey(b"555"), 1, &ReadOptions::default())
+                .unwrap()
+                .0
         );
 
         // 555 is inserted again in epoch=2
         assert_eq!(
-            Some(HummockValue::put(Bytes::from("value52"))),
-            merged_imm.get(TableKey(b"555"), 2, &ReadOptions::default())
+            HummockValue::put(Bytes::from("value52")),
+            merged_imm
+                .get(TableKey(b"555"), 2, &ReadOptions::default())
+                .unwrap()
+                .0
         );
 
         // "666" is deleted in epoch=1 and isn't inserted in later epochs
         assert_eq!(
-            Some(HummockValue::Delete),
-            merged_imm.get(TableKey(b"666"), 2, &ReadOptions::default())
+            HummockValue::Delete,
+            merged_imm
+                .get(TableKey(b"666"), 2, &ReadOptions::default())
+                .unwrap()
+                .0
         );
         // "888" is deleted in epoch=2
         assert_eq!(
-            Some(HummockValue::Delete),
-            merged_imm.get(TableKey(b"888"), 2, &ReadOptions::default())
+            HummockValue::Delete,
+            merged_imm
+                .get(TableKey(b"888"), 2, &ReadOptions::default())
+                .unwrap()
+                .0
         );
 
         // 888 exists in the snapshot of epoch=1
         assert_eq!(
-            Some(HummockValue::put(Bytes::from("value8"))),
-            merged_imm.get(TableKey(b"888"), 1, &ReadOptions::default())
+            HummockValue::put(Bytes::from("value8")),
+            merged_imm
+                .get(TableKey(b"888"), 1, &ReadOptions::default())
+                .unwrap()
+                .0
         );
     }
 }

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -234,7 +234,8 @@ impl SharedBufferBatchInner {
         }
     }
 
-    // If the key is deleted by a epoch greater than the read epoch, return None
+    /// Return `None` if cannot find a visible version
+    /// Return `HummockValue::Delete` if the key has been deleted by some epoch <= `read_epoch`
     fn get_value(
         &self,
         table_id: TableId,
@@ -389,8 +390,6 @@ impl SharedBufferBatch {
         self.inner.kv_count
     }
 
-    /// Return `None` if the key doesn't exist
-    /// Return `HummockValue::Delete` if the key has been deleted by some epoch >= `read_epoch`
     pub fn get(
         &self,
         table_key: TableKey<&[u8]>,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
As title.
Currently there are 2 bugs on `retention_second`:
* `Epoch` consists of `time || seq`, and both part need to be considered in filter.
* Read result of merged imm is not checked when `retention_second` is set.

## Checklist For Contributors

- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
