### PR TITLE
perf(agg): use `Bitmap::iter_ones()` in `StreamingRowCountAgg::apply_batch()`

### DIFF
--- a/src/stream/src/executor/aggregation/agg_impl/row_count.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/row_count.rs
@@ -18,7 +18,6 @@ use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::*;
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
-use risingwave_common::util::iter_util::ZipEqFast;
 
 use super::StreamingAggImpl;
 use crate::executor::error::StreamExecutorResult;
@@ -79,12 +78,10 @@ impl StreamingAggImpl for StreamingRowCountAgg {
                 }
             }
             Some(visibility) => {
-                for (op, visible) in ops.iter().zip_eq_fast(visibility.iter()) {
-                    if visible {
-                        match op {
-                            Op::Insert | Op::UpdateInsert => self.row_cnt += 1,
-                            Op::Delete | Op::UpdateDelete => self.row_cnt -= 1,
-                        }
+                for idx in visibility.iter_ones() {
+                    match ops[idx] {
+                        Op::Insert | Op::UpdateInsert => self.row_cnt += 1,
+                        Op::Delete | Op::UpdateDelete => self.row_cnt -= 1,
                     }
                 }
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

After #9278 , using `Bitmap::iter_ones()` has achieved significant performance advantages over iterating the entire Bitmap.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
