### PR TITLE
feat(storage): adjust pick_overlapping_level strategy

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -545,6 +545,7 @@ message RiseCtlUpdateCompactionConfigRequest {
       uint32 compaction_filter_mask = 8;
       uint32 max_sub_compaction = 9;
       uint64 level0_stop_write_threshold_sub_level_number = 10;
+      uint32 level0_sub_level_compact_level_count = 11;
     }
   }
   repeated uint64 compaction_group_ids = 1;
@@ -632,6 +633,7 @@ message CompactionConfig {
   // soft limit for max number of sub level number
   uint64 level0_stop_write_threshold_sub_level_number = 15;
   uint64 level0_max_compact_file_number = 16;
+  uint32 level0_sub_level_compact_level_count = 17;
 }
 
 message TableStats {

--- a/src/ctl/src/cmd_impl/hummock/compaction_group.rs
+++ b/src/ctl/src/cmd_impl/hummock/compaction_group.rs
@@ -52,6 +52,7 @@ pub fn build_compaction_config_vec(
     compaction_filter_mask: Option<u32>,
     max_sub_compaction: Option<u32>,
     level0_stop_write_threshold_sub_level_number: Option<u64>,
+    level0_sub_level_compact_level_count: Option<u32>,
 ) -> Vec<MutableConfig> {
     let mut configs = vec![];
     if let Some(c) = max_bytes_for_level_base {
@@ -80,6 +81,9 @@ pub fn build_compaction_config_vec(
     }
     if let Some(c) = level0_stop_write_threshold_sub_level_number {
         configs.push(MutableConfig::Level0StopWriteThresholdSubLevelNumber(c));
+    }
+    if let Some(c) = level0_sub_level_compact_level_count {
+        configs.push(MutableConfig::Level0SubLevelCompactLevelCount(c));
     }
     configs
 }

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -145,6 +145,8 @@ enum HummockCommands {
         max_sub_compaction: Option<u32>,
         #[clap(long)]
         level0_stop_write_threshold_sub_level_number: Option<u64>,
+        #[clap(long)]
+        level0_sub_level_compact_level_count: Option<u32>,
     },
     /// Split given compaction group into two. Moves the given tables to the new group.
     SplitCompactionGroup {
@@ -287,6 +289,7 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             compaction_filter_mask,
             max_sub_compaction,
             level0_stop_write_threshold_sub_level_number,
+            level0_sub_level_compact_level_count,
         }) => {
             cmd_impl::hummock::update_compaction_config(
                 context,
@@ -301,6 +304,7 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                     compaction_filter_mask,
                     max_sub_compaction,
                     level0_stop_write_threshold_sub_level_number,
+                    level0_sub_level_compact_level_count,
                 ),
             )
             .await?

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -136,4 +136,5 @@ builder_field! {
     max_space_reclaim_bytes: u64,
     level0_stop_write_threshold_sub_level_number: u64,
     level0_max_compact_file_number: u64,
+    level0_sub_level_compact_level_count: u32,
 }

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -29,6 +29,7 @@ const DEFAULT_LEVEL_MULTIPLIER: u64 = 5;
 const DEFAULT_MAX_SPACE_RECLAIM_BYTES: u64 = 512 * 1024 * 1024; // 512MB;
 const DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER: u64 = u32::MAX as u64;
 const DEFAULT_MAX_COMPACTION_FILE_COUNT: u64 = 96;
+const DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 3;
 
 pub struct CompactionConfigBuilder {
     config: CompactionConfig,
@@ -71,6 +72,7 @@ impl CompactionConfigBuilder {
                 //    level0_max_compact_file_number * target_file_size_base >
                 // max_bytes_for_level_base
                 level0_max_compact_file_number: DEFAULT_MAX_COMPACTION_FILE_COUNT,
+                level0_sub_level_compact_level_count: DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT,
             },
         }
     }

--- a/src/meta/src/hummock/compaction/picker/tier_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/tier_compaction_picker.rs
@@ -308,7 +308,8 @@ impl TierCompactionPicker {
             // so the design here wants to merge multiple overlapping-levels in one compaction
             let max_compaction_bytes = std::cmp::min(
                 self.config.max_compaction_bytes,
-                self.config.sub_level_max_compaction_bytes * 4,
+                self.config.sub_level_max_compaction_bytes
+                    * self.config.level0_sub_level_compact_level_count as u64,
             );
 
             let mut compaction_bytes = level.total_file_size;
@@ -435,6 +436,7 @@ pub mod tests {
             CompactionConfigBuilder::new()
                 .level0_tier_compact_file_number(2)
                 .target_file_size_base(30)
+                .level0_sub_level_compact_level_count(2)
                 .build(),
         );
         let mut picker =
@@ -519,6 +521,7 @@ pub mod tests {
         let config = Arc::new(
             CompactionConfigBuilder::new()
                 .level0_tier_compact_file_number(2)
+                .level0_sub_level_compact_level_count(2)
                 .build(),
         );
         let mut picker =
@@ -568,6 +571,7 @@ pub mod tests {
                 .level0_tier_compact_file_number(2)
                 .sub_level_max_compaction_bytes(100)
                 .max_compaction_bytes(500000)
+                .level0_sub_level_compact_level_count(2)
                 .build(),
         );
 

--- a/src/meta/src/hummock/compaction_schedule_policy.rs
+++ b/src/meta/src/hummock/compaction_schedule_policy.rs
@@ -561,6 +561,7 @@ mod tests {
         let config = CompactionConfigBuilder::new()
             .level0_tier_compact_file_number(1)
             .max_bytes_for_level_base(1)
+            .level0_sub_level_compact_level_count(1)
             .build();
         let (_, hummock_manager, _, worker_node) = setup_compute_env_with_config(80, config).await;
         let context_id = worker_node.id;

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -799,6 +799,9 @@ fn update_compaction_config(target: &mut CompactionConfig, items: &[MutableConfi
             MutableConfig::Level0StopWriteThresholdSubLevelNumber(c) => {
                 target.level0_stop_write_threshold_sub_level_number = *c;
             }
+            MutableConfig::Level0SubLevelCompactLevelCount(c) => {
+                target.level0_sub_level_compact_level_count = *c;
+            }
         }
     }
 }

--- a/src/meta/src/hummock/test_utils.rs
+++ b/src/meta/src/hummock/test_utils.rs
@@ -312,6 +312,7 @@ pub async fn setup_compute_env(
     let config = CompactionConfigBuilder::new()
         .level0_tier_compact_file_number(1)
         .level0_max_compact_file_number(130)
+        .level0_sub_level_compact_level_count(1)
         .build();
     setup_compute_env_with_config(port, config).await
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

1. level0_sub_level_compact_level_count for limiting the count of compaction level
2. increase the compaction size for overlapping level compact task
3. support update level0_sub_level_compact_level_count config 

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
