### PR TITLE
fix(meta): expect data dir is empty when creating cluster

### DIFF
--- a/src/common/src/system_param/mod.rs
+++ b/src/common/src/system_param/mod.rs
@@ -98,22 +98,31 @@ macro_rules! def_default {
 
 for_all_undeprecated_params!(def_default);
 
+macro_rules! impl_check_missing_fields {
+    ($({ $field:ident, $type:ty, $default:expr },)*) => {
+        /// Check if any undeprecated fields are missing.
+        pub fn check_missing_params(params: &SystemParams) -> Result<()> {
+            $(
+                if params.$field.is_none() {
+                    return Err(format!("missing system param {:?}", key_of!($field)));
+                }
+            )*
+            Ok(())
+        }
+    };
+}
+
 /// Derive serialization to kv pairs.
 macro_rules! impl_system_params_to_kv {
     ($({ $field:ident, $type:ty, $default:expr },)*) => {
         /// The returned map only contains undeprecated fields.
         /// Return error if there are missing fields.
         pub fn system_params_to_kv(params: &SystemParams) -> Result<Vec<(String, String)>> {
-            let mut ret = Vec::with_capacity(9);
+            check_missing_params(params)?;
+            let mut ret = Vec::new();
             $(ret.push((
                 key_of!($field).to_string(),
-                params
-                    .$field.as_ref()
-                    .ok_or_else(||format!(
-                        "missing system param {:?}",
-                        key_of!($field)
-                    ))?
-                    .to_string(),
+                params.$field.as_ref().unwrap().to_string(),
             ));)*
             Ok(ret)
         }
@@ -278,6 +287,7 @@ macro_rules! impl_system_params_for_test {
 
 for_all_undeprecated_params!(impl_derive_missing_fields);
 for_all_params!(impl_system_params_from_kv);
+for_all_undeprecated_params!(impl_check_missing_fields);
 for_all_undeprecated_params!(impl_system_params_to_kv);
 for_all_undeprecated_params!(impl_set_system_param);
 for_all_undeprecated_params!(impl_default_validation_on_set);

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -296,7 +296,9 @@ where
             .await,
         );
         // If the cluster is being created, the object store should be empty.
-        if sys_params_manager.cluster_first_launch() && object_store.list("").await?.len() > 0 {
+        if sys_params_manager.cluster_first_launch()
+            && !object_store.list(state_store_dir).await?.is_empty()
+        {
             return Err(ObjectError::internal(
                 "object store is not empty on cluster creation, existing data might be overwritten",
             )

--- a/src/meta/src/manager/system_param/mod.rs
+++ b/src/meta/src/manager/system_param/mod.rs
@@ -27,6 +27,7 @@ use risingwave_pb::meta::SystemParams;
 use tokio::sync::oneshot::Sender;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
+use tracing::info;
 
 use self::model::SystemParamsModel;
 use super::NotificationManagerRef;
@@ -61,6 +62,7 @@ impl<S: MetaStore> SystemParamsManager<S> {
             (init_params, true)
         };
 
+        info!("system parameters: {:?}", params);
         check_missing_params(&params).map_err(|e| anyhow!(e))?;
 
         Ok(Self {

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -638,6 +638,10 @@ pub async fn start_service_as_election_leader<S: MetaStore>(
         }
     };
 
+    // Persist params before starting services so that invalid params that cause meta node
+    // to crash will not be persisted.
+    system_params_manager.flush_params().await?;
+
     tracing::info!("Starting meta services");
 
     tonic::transport::Server::builder()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. Defer system parameter persistence to before starting RPC services, so that if invalid parameters prevent the meta node from starting, they will not be persisted.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment

### Release note

The object store URL identified by `state_store` and `data_directory` must be empty when creating the cluster, or the meta node will refuse to start.
