### PR TITLE
fix(expr): support multibyte Unicode for `overlay` and `ascii`

### DIFF
--- a/src/expr/src/vector_op/ascii.rs
+++ b/src/expr/src/vector_op/ascii.rs
@@ -16,7 +16,7 @@ use risingwave_expr_macro::function;
 
 #[function("ascii(varchar) -> int32")]
 pub fn ascii(s: &str) -> i32 {
-    s.as_bytes().first().map(|x| *x as i32).unwrap_or(0)
+    s.chars().next().map(|x| x as i32).unwrap_or(0)
 }
 
 #[cfg(test)]
@@ -25,7 +25,7 @@ mod tests {
 
     #[test]
     fn test_ascii() {
-        let cases = [("hello", 104), ("你好", 228), ("", 0)];
+        let cases = [("hello", 104), ("你好", 20320), ("", 0)];
         for (s, expected) in cases {
             assert_eq!(ascii(s), expected)
         }

--- a/src/expr/src/vector_op/overlay.rs
+++ b/src/expr/src/vector_op/overlay.rs
@@ -18,12 +18,70 @@ use risingwave_expr_macro::function;
 
 use crate::{ExprError, Result};
 
+/// Replaces a substring of the given string with a new substring.
+///
+/// ```slt
+/// query T
+/// select overlay('αβγδεζ' placing '💯' from 3);
+/// ----
+/// αβ💯δεζ
+/// ```
 #[function("overlay(varchar, varchar, int32) -> varchar")]
 pub fn overlay(s: &str, new_sub_str: &str, start: i32, writer: &mut dyn Write) -> Result<()> {
-    // If count is omitted, it defaults to the length of new_sub_str.
-    overlay_for(s, new_sub_str, start, new_sub_str.len() as i32, writer)
+    let sub_len = new_sub_str
+        .chars()
+        .count()
+        .try_into()
+        .map_err(|_| ExprError::NumericOutOfRange)?;
+    overlay_for(s, new_sub_str, start, sub_len, writer)
 }
 
+/// Replaces a substring of the given string with a new substring.
+///
+/// ```slt
+/// statement error not positive
+/// select overlay('αβγδεζ' placing '①②③' from 0);
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 10);
+/// ----
+/// αβγδεζ①②③
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 4 for 2);
+/// ----
+/// αβγ①②③ζ
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 4);
+/// ----
+/// αβγ①②③
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 2 for 4);
+/// ----
+/// α①②③ζ
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 2 for 7);
+/// ----
+/// α①②③
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 4 for 0);
+/// ----
+/// αβγ①②③δεζ
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 4 for -2);
+/// ----
+/// αβγ①②③βγδεζ
+///
+/// query T
+/// select overlay('αβγδεζ' placing '①②③' from 4 for -1000);
+/// ----
+/// αβγ①②③αβγδεζ
+/// ```
 #[function("overlay(varchar, varchar, int32, int32) -> varchar")]
 pub fn overlay_for(
     s: &str,
@@ -32,23 +90,30 @@ pub fn overlay_for(
     count: i32,
     writer: &mut dyn Write,
 ) -> Result<()> {
-    let count = count.max(0) as usize;
+    if start <= 0 {
+        return Err(ExprError::InvalidParam {
+            name: "start",
+            reason: format!("{start} is not positive"),
+        });
+    }
 
-    // If start is out of range, attach it to the end.
-    // Note that indices are 1-based.
-    let start = (start
-        .checked_sub(1)
-        .ok_or(ExprError::NumericOutOfRange)?
-        .max(0) as usize)
-        .min(s.len());
+    let mut chars = s.chars();
+    for _ in 1..start {
+        if let Some(c) = chars.next() {
+            writer.write_char(c).unwrap();
+        }
+    }
 
-    let remaining = start + count;
-
-    writer.write_str(&s[..start]).unwrap();
     writer.write_str(new_sub_str).unwrap();
 
-    if remaining < s.len() {
-        writer.write_str(&s[remaining..]).unwrap();
+    let Ok(count) = count.try_into() else {
+        // For negative `count`, which is rare in practice, we hand over to `substr`
+        let start_right = start.checked_add(count).ok_or(ExprError::NumericOutOfRange)?;
+        return super::substr::substr_start(s, start_right, writer);
+    };
+
+    for c in chars.skip(count) {
+        writer.write_char(c).unwrap();
     }
 
     Ok(())
@@ -71,11 +136,10 @@ mod tests {
             ("aaaaaa", "XYZ", 4, Some(0), "aaaXYZaaa"),
             // Replace longer string.
             ("aaa___aaa", "X", 4, Some(3), "aaaXaaa"),
-            // start too small or large.
-            ("aaa", "XY", -123, None, "XYa"),
+            // start too large.
             ("aaa", "XY", 123, None, "aaaXY"),
             // count too small or large.
-            ("aaa", "X", 4, Some(-123), "aaaX"),
+            ("aaa", "X", 4, Some(-123), "aaaXaaa"),
             ("aaa_", "X", 4, Some(123), "aaaX"),
         ];
 

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -67,6 +67,11 @@ fn is_neg_substr_error(db_error: &str) -> bool {
     db_error.contains("negative substring length not allowed")
 }
 
+/// Zero or negative overlay start error
+fn is_overlay_start_error(db_error: &str) -> bool {
+    db_error.contains("Invalid parameter start") && db_error.contains("is not positive")
+}
+
 /// Certain errors are permitted to occur. This is because:
 /// 1. It is more complex to generate queries without these errors.
 /// 2. These errors seldom occur, skipping them won't affect overall effectiveness of sqlsmith.
@@ -80,4 +85,5 @@ pub fn is_permissible_error(db_error: &str) -> bool {
         || is_subquery_unnesting_error(db_error)
         || is_numeric_overflow_error(db_error)
         || is_neg_substr_error(db_error)
+        || is_overlay_start_error(db_error)
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #9118

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support multibyte Unicode for `overlay` and `ascii`.