### PR TITLE
perf(data_chunk): add benchmark for `DataChunk::compact()`

### DIFF
--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -127,6 +127,10 @@ harness = false
 name = "bench_data_chunk_encoding"
 harness = false
 
+[[bench]]
+name = "bench_data_chunk_compact"
+harness = false
+
 [[bin]]
 name = "example-config"
 path = "src/bin/default_config.rs"

--- a/src/common/benches/bench_data_chunk_compact.rs
+++ b/src/common/benches/bench_data_chunk_compact.rs
@@ -1,0 +1,72 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use risingwave_common::test_utils::{rand_bitmap, rand_chunk};
+use risingwave_common::types::DataType;
+
+static SEED: u64 = 998244353u64;
+static CHUNK_SIZES: &[usize] = &[128, 1024];
+static VIS_RATE: &[f64] = &[0.05, 0.25, 0.5, 0.75, 0.95];
+
+struct DataChunkBenchCase {
+    pub name: String,
+    pub data_types: Vec<DataType>,
+}
+
+impl DataChunkBenchCase {
+    pub fn new(name: &str, data_types: Vec<DataType>) -> Self {
+        Self {
+            name: name.to_string(),
+            data_types,
+        }
+    }
+}
+
+fn bench_data_chunk_compact(c: &mut Criterion) {
+    let test_cases = vec![
+        DataChunkBenchCase::new("1 column", vec![DataType::Int16]),
+        DataChunkBenchCase::new("2 columns", vec![DataType::Int16, DataType::Int16]),
+        DataChunkBenchCase::new("5 columns", vec![DataType::Int16; 5]),
+        DataChunkBenchCase::new("10 columns", vec![DataType::Int16; 10]),
+    ];
+    for case in test_cases {
+        for vis_rate in VIS_RATE {
+            for chunk_size in CHUNK_SIZES {
+                let mut chunk = rand_chunk::gen_chunk(&case.data_types, *chunk_size, SEED, 1.0);
+                if vis_rate < &1.0 {
+                    chunk.set_visibility(rand_bitmap::gen_rand_bitmap(
+                        *chunk_size,
+                        (*chunk_size as f64 * vis_rate) as usize,
+                        SEED,
+                    ));
+                }
+                c.bench_function(
+                    &format!(
+                        "data chunk compact: {}, {} rows, vis rate {}",
+                        case.name, chunk_size, vis_rate
+                    ),
+                    |b| {
+                        b.iter(|| {
+                            let _ = chunk.clone().compact();
+                        })
+                    },
+                );
+            }
+        }
+    }
+}
+
+criterion_group!(benches, bench_data_chunk_compact);
+criterion_main!(benches);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

benchmark
```
data chunk compact: 1 column, 128 rows, vis rate 0.05
                        time:   [434.29 ns 434.44 ns 434.58 ns]

data chunk compact: 1 column, 1024 rows, vis rate 0.05
                        time:   [2.8380 µs 2.8391 µs 2.8402 µs]

data chunk compact: 1 column, 128 rows, vis rate 0.25
                        time:   [555.29 ns 555.84 ns 556.41 ns]

data chunk compact: 1 column, 1024 rows, vis rate 0.25
                        time:   [4.1308 µs 4.1315 µs 4.1323 µs]

data chunk compact: 1 column, 128 rows, vis rate 0.5
                        time:   [719.37 ns 720.03 ns 720.71 ns]

data chunk compact: 1 column, 1024 rows, vis rate 0.5
                        time:   [6.2182 µs 6.2233 µs 6.2293 µs]

data chunk compact: 1 column, 128 rows, vis rate 0.75
                        time:   [1.0150 µs 1.0165 µs 1.0193 µs]

data chunk compact: 1 column, 1024 rows, vis rate 0.75
                        time:   [7.6183 µs 7.6200 µs 7.6217 µs]

data chunk compact: 1 column, 128 rows, vis rate 0.95
                        time:   [1.0722 µs 1.0726 µs 1.0729 µs]

data chunk compact: 1 column, 1024 rows, vis rate 0.95
                        time:   [8.2990 µs 8.3006 µs 8.3022 µs]

data chunk compact: 2 columns, 128 rows, vis rate 0.05
                        time:   [780.05 ns 780.51 ns 780.97 ns]

data chunk compact: 2 columns, 1024 rows, vis rate 0.05
                        time:   [5.1969 µs 5.1989 µs 5.2008 µs]

data chunk compact: 2 columns, 128 rows, vis rate 0.25
                        time:   [1.0250 µs 1.0251 µs 1.0253 µs]

data chunk compact: 2 columns, 1024 rows, vis rate 0.25
                        time:   [7.7372 µs 7.7388 µs 7.7404 µs]

data chunk compact: 2 columns, 128 rows, vis rate 0.5
                        time:   [1.3470 µs 1.3476 µs 1.3482 µs]

data chunk compact: 2 columns, 1024 rows, vis rate 0.5
                        time:   [11.962 µs 11.967 µs 11.972 µs]

data chunk compact: 2 columns, 128 rows, vis rate 0.75
                        time:   [1.9494 µs 1.9502 µs 1.9510 µs]

data chunk compact: 2 columns, 1024 rows, vis rate 0.75
                        time:   [14.739 µs 14.741 µs 14.743 µs]

data chunk compact: 2 columns, 128 rows, vis rate 0.95
                        time:   [2.0598 µs 2.0600 µs 2.0602 µs]

data chunk compact: 2 columns, 1024 rows, vis rate 0.95
                        time:   [16.088 µs 16.101 µs 16.119 µs]

data chunk compact: 5 columns, 128 rows, vis rate 0.05
                        time:   [1.9114 µs 1.9119 µs 1.9124 µs]

data chunk compact: 5 columns, 1024 rows, vis rate 0.05
                        time:   [12.304 µs 12.314 µs 12.330 µs]

data chunk compact: 5 columns, 128 rows, vis rate 0.25
                        time:   [2.4252 µs 2.4255 µs 2.4258 µs]

data chunk compact: 5 columns, 1024 rows, vis rate 0.25
                        time:   [18.782 µs 18.787 µs 18.792 µs]

data chunk compact: 5 columns, 128 rows, vis rate 0.5
                        time:   [3.4625 µs 3.4636 µs 3.4654 µs]

data chunk compact: 5 columns, 1024 rows, vis rate 0.5
                        time:   [29.474 µs 29.509 µs 29.540 µs]

data chunk compact: 5 columns, 128 rows, vis rate 0.75
                        time:   [4.7316 µs 4.7339 µs 4.7363 µs]

data chunk compact: 5 columns, 1024 rows, vis rate 0.75
                        time:   [36.169 µs 36.173 µs 36.177 µs]

data chunk compact: 5 columns, 128 rows, vis rate 0.95
                        time:   [5.0214 µs 5.0219 µs 5.0224 µs]

data chunk compact: 5 columns, 1024 rows, vis rate 0.95
                        time:   [39.814 µs 39.821 µs 39.829 µs]

data chunk compact: 10 columns, 128 rows, vis rate 0.05
                        time:   [3.9687 µs 3.9698 µs 3.9710 µs]

data chunk compact: 10 columns, 1024 rows, vis rate 0.05
                        time:   [24.649 µs 24.656 µs 24.663 µs]

data chunk compact: 10 columns, 128 rows, vis rate 0.25
                        time:   [5.0504 µs 5.0515 µs 5.0528 µs]

data chunk compact: 10 columns, 1024 rows, vis rate 0.25
                        time:   [37.439 µs 37.451 µs 37.463 µs]

data chunk compact: 10 columns, 128 rows, vis rate 0.5
                        time:   [7.2225 µs 7.2230 µs 7.2236 µs]

data chunk compact: 10 columns, 1024 rows, vis rate 0.5
                        time:   [58.566 µs 58.600 µs 58.637 µs]

data chunk compact: 10 columns, 128 rows, vis rate 0.75
                        time:   [9.8946 µs 9.8973 µs 9.9003 µs]

data chunk compact: 10 columns, 1024 rows, vis rate 0.75
                        time:   [72.240 µs 72.288 µs 72.375 µs]

data chunk compact: 10 columns, 128 rows, vis rate 0.95
                        time:   [10.385 µs 10.390 µs 10.395 µs]

data chunk compact: 10 columns, 1024 rows, vis rate 0.95
                        time:   [79.535 µs 79.543 µs 79.551 µs]
```