### PR TITLE
perf(array): optimize array compact with Bitmap::iter_ones()

### DIFF
--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -226,7 +226,7 @@ impl DataChunk {
         match &self.vis2 {
             Vis::Compact(_) => self,
             Vis::Bitmap(visibility) => {
-                let cardinality = visibility.iter().filter(|&vis| vis).count();
+                let cardinality = visibility.count_ones();
                 let columns = self
                     .columns
                     .into_iter()

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -320,9 +320,10 @@ trait CompactableArray: Array {
 impl<A: Array> CompactableArray for A {
     fn compact(&self, visibility: &Bitmap, cardinality: usize) -> Self {
         let mut builder = A::Builder::with_meta(cardinality, self.array_meta());
-        for (elem, visible) in self.iter().zip_eq_fast(visibility.iter()) {
-            if visible {
-                builder.append(elem);
+        for idx in visibility.iter_ones() {
+            // SAFETY(value_at_unchecked): the idx is always in bound.
+            unsafe {
+                builder.append(self.value_at_unchecked(idx));
             }
         }
         builder.finish()

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -72,6 +72,7 @@ pub use crate::array::num256_array::{Int256Array, Int256ArrayBuilder};
 use crate::buffer::Bitmap;
 use crate::estimate_size::EstimateSize;
 use crate::types::*;
+use crate::util::iter_util::ZipEqFast;
 pub type ArrayResult<T> = Result<T, ArrayError>;
 
 pub type I64Array = PrimitiveArray<i64>;

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -72,7 +72,6 @@ pub use crate::array::num256_array::{Int256Array, Int256ArrayBuilder};
 use crate::buffer::Bitmap;
 use crate::estimate_size::EstimateSize;
 use crate::types::*;
-use crate::util::iter_util::ZipEqFast;
 pub type ArrayResult<T> = Result<T, ArrayError>;
 
 pub type I64Array = PrimitiveArray<i64>;

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -72,7 +72,6 @@ pub use crate::array::num256_array::{Int256Array, Int256ArrayBuilder};
 use crate::buffer::Bitmap;
 use crate::estimate_size::EstimateSize;
 use crate::types::*;
-use crate::util::iter_util::ZipEqFast;
 pub type ArrayResult<T> = Result<T, ArrayError>;
 
 pub type I64Array = PrimitiveArray<i64>;
@@ -748,6 +747,7 @@ impl PartialEq for ArrayImpl {
 mod tests {
 
     use super::*;
+    use crate::util::iter_util::ZipEqFast;
 
     fn filter<'a, A, F>(data: &'a A, pred: F) -> ArrayResult<A>
     where

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -172,10 +172,8 @@ impl StreamChunk {
             })
             .collect();
         let mut new_ops = Vec::with_capacity(cardinality);
-        for (op, visible) in ops.into_iter().zip_eq_fast(visibility.iter()) {
-            if visible {
-                new_ops.push(op);
-            }
+        for idx in visibility.iter_ones() {
+            new_ops.push(ops[idx]);
         }
         StreamChunk::new(new_ops, columns, None)
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

optimize Array::compact() and StreamChunk::compact()

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

benchmark

```
data chunk compact: 1 column, 128 rows, vis rate 0.05
                        time:   [176.25 ns 176.27 ns 176.29 ns]
                        change: [-59.548% -59.454% -59.396%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 1024 rows, vis rate 0.05
                        time:   [483.28 ns 483.69 ns 484.09 ns]
                        change: [-82.976% -82.946% -82.891%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 128 rows, vis rate 0.25
                        time:   [351.29 ns 351.41 ns 351.54 ns]
                        change: [-37.091% -36.825% -36.588%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 1024 rows, vis rate 0.25
                        time:   [2.0218 µs 2.0224 µs 2.0229 µs]
                        change: [-51.069% -50.999% -50.883%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 128 rows, vis rate 0.5
                        time:   [552.99 ns 553.10 ns 553.21 ns]
                        change: [-23.444% -23.187% -22.929%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 1024 rows, vis rate 0.5
                        time:   [3.7376 µs 3.7390 µs 3.7403 µs]
                        change: [-40.243% -40.089% -39.983%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 128 rows, vis rate 0.75
                        time:   [771.89 ns 772.10 ns 772.31 ns]
                        change: [-24.186% -24.000% -23.774%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 1024 rows, vis rate 0.75
                        time:   [5.4473 µs 5.4480 µs 5.4487 µs]
                        change: [-29.820% -28.956% -28.483%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 128 rows, vis rate 0.95
                        time:   [923.22 ns 923.28 ns 923.35 ns]
                        change: [-13.917% -13.793% -13.571%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 1 column, 1024 rows, vis rate 0.95
                        time:   [6.8156 µs 6.8166 µs 6.8178 µs]
                        change: [-18.312% -18.034% -17.878%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 128 rows, vis rate 0.05
                        time:   [266.29 ns 266.30 ns 266.32 ns]
                        change: [-65.897% -65.875% -65.851%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 1024 rows, vis rate 0.05
                        time:   [925.73 ns 926.32 ns 926.93 ns]
                        change: [-82.251% -82.202% -82.172%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 128 rows, vis rate 0.25
                        time:   [665.06 ns 665.28 ns 665.48 ns]
                        change: [-35.138% -35.113% -35.088%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 1024 rows, vis rate 0.25
                        time:   [4.0100 µs 4.0112 µs 4.0124 µs]
                        change: [-48.318% -48.151% -48.002%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 128 rows, vis rate 0.5
                        time:   [1.0752 µs 1.0757 µs 1.0762 µs]
                        change: [-20.470% -20.251% -20.123%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 1024 rows, vis rate 0.5
                        time:   [7.4400 µs 7.4441 µs 7.4486 µs]
                        change: [-37.990% -37.793% -37.589%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 128 rows, vis rate 0.75
                        time:   [1.4981 µs 1.4986 µs 1.4991 µs]
                        change: [-23.293% -23.060% -22.880%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 1024 rows, vis rate 0.75
                        time:   [10.899 µs 10.900 µs 10.901 µs]
                        change: [-26.264% -26.041% -25.801%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 128 rows, vis rate 0.95
                        time:   [1.7933 µs 1.7935 µs 1.7938 µs]
                        change: [-13.224% -12.916% -12.616%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 2 columns, 1024 rows, vis rate 0.95
                        time:   [13.621 µs 13.626 µs 13.634 µs]
                        change: [-15.703% -15.385% -15.094%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 128 rows, vis rate 0.05
                        time:   [751.45 ns 751.53 ns 751.65 ns]
                        change: [-60.845% -60.712% -60.561%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 1024 rows, vis rate 0.05
                        time:   [2.2557 µs 2.2572 µs 2.2587 µs]
                        change: [-81.767% -81.713% -81.676%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 128 rows, vis rate 0.25
                        time:   [1.6063 µs 1.6072 µs 1.6084 µs]
                        change: [-33.759% -33.661% -33.505%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 1024 rows, vis rate 0.25
                        time:   [9.9906 µs 10.076 µs 10.189 µs]
                        change: [-46.636% -46.141% -45.419%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 128 rows, vis rate 0.5
                        time:   [2.7994 µs 2.7997 µs 2.8001 µs]
                        change: [-19.496% -19.273% -19.147%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 1024 rows, vis rate 0.5
                        time:   [18.380 µs 18.382 µs 18.384 µs]
                        change: [-37.700% -37.555% -37.448%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 128 rows, vis rate 0.75
                        time:   [3.6954 µs 3.6965 µs 3.6976 µs]
                        change: [-21.933% -21.856% -21.767%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 1024 rows, vis rate 0.75
                        time:   [27.090 µs 27.093 µs 27.097 µs]
                        change: [-25.289% -25.131% -25.044%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 128 rows, vis rate 0.95
                        time:   [4.4485 µs 4.4489 µs 4.4492 µs]
                        change: [-11.691% -11.491% -11.385%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 5 columns, 1024 rows, vis rate 0.95
                        time:   [34.150 µs 34.152 µs 34.154 µs]
                        change: [-14.468% -14.285% -14.183%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 128 rows, vis rate 0.05
                        time:   [1.5684 µs 1.5696 µs 1.5718 µs]
                        change: [-60.584% -60.477% -60.383%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 1024 rows, vis rate 0.05
                        time:   [4.8721 µs 4.8763 µs 4.8805 µs]
                        change: [-80.293% -80.230% -80.175%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 128 rows, vis rate 0.25
                        time:   [3.4429 µs 3.4436 µs 3.4442 µs]
                        change: [-32.065% -31.902% -31.810%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 1024 rows, vis rate 0.25
                        time:   [20.496 µs 20.504 µs 20.512 µs]
                        change: [-45.333% -45.266% -45.216%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 128 rows, vis rate 0.5
                        time:   [5.8570 µs 5.8581 µs 5.8593 µs]
                        change: [-18.947% -18.916% -18.889%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 1024 rows, vis rate 0.5
                        time:   [37.543 µs 37.547 µs 37.553 µs]
                        change: [-35.999% -35.934% -35.855%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 128 rows, vis rate 0.75
                        time:   [7.6996 µs 7.7016 µs 7.7041 µs]
                        change: [-22.193% -22.066% -21.847%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 1024 rows, vis rate 0.75
                        time:   [54.645 µs 54.648 µs 54.652 µs]
                        change: [-24.670% -24.437% -24.196%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 128 rows, vis rate 0.95
                        time:   [9.1714 µs 9.1748 µs 9.1780 µs]
                        change: [-11.740% -11.694% -11.651%] (p = 0.00 < 0.05)
                        Performance has improved.

data chunk compact: 10 columns, 1024 rows, vis rate 0.95
                        time:   [68.431 µs 68.446 µs 68.460 µs]
                        change: [-14.215% -13.950% -13.672%] (p = 0.00 < 0.05)
                        Performance has improved.
```