### PR TITLE
feat(streaming): add bit_xor aggregation

### DIFF
--- a/e2e_test/streaming/bit_agg.slt
+++ b/e2e_test/streaming/bit_agg.slt
@@ -1,0 +1,37 @@
+statement ok
+create table t1 (v1 smallint, v2 int, v3 bigint);
+
+statement ok
+create materialized view agg_mv as select
+bit_xor(v1) as a1,
+bit_xor(v2) as a2,
+bit_xor(v3) as a3
+from t1;
+
+statement ok
+insert into t1 values (1, 1, 1), (10, 10, 10), (38, 38, 38), (41, 41, 41);
+
+statement ok
+flush;
+
+query III
+select * from agg_mv;
+----
+4 4 4
+
+statement ok
+delete from t1 where v1 = 1;
+
+statement ok
+flush;
+
+query III
+select * from agg_mv;
+----
+5 5 5
+
+statement ok
+drop materialized view agg_mv;
+
+statement ok
+drop table t1;

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -423,7 +423,8 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
                         AggCallState::ResultValue
                     }
                 }
-                AggKind::Sum
+                AggKind::BitXor
+                | AggKind::Sum
                 | AggKind::Sum0
                 | AggKind::Count
                 | AggKind::Avg
@@ -441,7 +442,8 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
                         AggCallState::Table(Box::new(state))
                     }
                 }
-                AggKind::BitAnd | AggKind::BitOr | AggKind::BitXor => {
+                // TODO: is its state a Table?
+                AggKind::BitAnd | AggKind::BitOr => {
                     unimplemented!()
                 }
             })

--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -15,6 +15,7 @@
 //! Implementation of `StreamingFoldAgg`, which includes sum and count.
 
 use std::marker::PhantomData;
+use std::ops::BitXor;
 
 use risingwave_common::array::stream_chunk::Ops;
 use risingwave_common::array::*;
@@ -191,6 +192,46 @@ where
 
     fn initial() -> Option<i64> {
         Some(0)
+    }
+}
+
+/// `BitXorable` returns the result of bit_xor all the values.
+/// It produces the same type of output as input `S`.
+#[derive(Debug)]
+pub struct BitXorable<S>
+where
+    S: Scalar + BitXor<Output = S>,
+{
+    _phantom: PhantomData<S>,
+}
+
+impl<S> StreamingFoldable<S, S> for BitXorable<S>
+where
+    S: Scalar + BitXor<Output = S>,
+{
+    fn accumulate(
+        result: Option<&S>,
+        input: Option<S::ScalarRefType<'_>>,
+    ) -> StreamExecutorResult<Option<S>> {
+        Ok(match (result, input) {
+            (Some(x), Some(y)) => Some(x.clone().bitxor(y.to_owned_scalar())),
+            (None, Some(y)) => Some(y.to_owned_scalar()),
+            (Some(x), None) => Some(x.clone()),
+            (None, None) => None,
+        })
+    }
+
+    /// `fn accumulate` and `fn retract` share the same implementation.
+    fn retract(
+        result: Option<&S>,
+        input: Option<S::ScalarRefType<'_>>,
+    ) -> StreamExecutorResult<Option<S>> {
+        Ok(match (result, input) {
+            (Some(x), Some(y)) => Some(x.clone().bitxor(y.to_owned_scalar())),
+            (None, Some(y)) => Some(y.to_owned_scalar()),
+            (Some(x), None) => Some(x.clone()),
+            (None, None) => None,
+        })
     }
 }
 
@@ -450,6 +491,8 @@ mod tests {
 
     type TestStreamingMaxAgg<R> = StreamingFoldAgg<R, R, Maximizable<<R as Array>::OwnedItem>>;
 
+    type TestStreamingBitXorAgg<R> = StreamingFoldAgg<R, R, BitXorable<<R as Array>::OwnedItem>>;
+
     #[test]
     /// This test uses `Box<dyn StreamingAggImpl>` to test an aggregator.
     fn test_primitive_sum_boxed() {
@@ -649,6 +692,27 @@ mod tests {
 
         agg.apply_batch(
             &[Op::Insert, Op::Insert, Op::Insert, Op::Insert],
+            None,
+            &[&array!(I64Array, [Some(1), Some(10), Some(100), Some(5)]).into()],
+        )
+        .unwrap();
+        assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &100);
+    }
+
+    #[test]
+    fn test_bit_xor() {
+        let mut agg = TestStreamingBitXorAgg::<I64Array>::default();
+        agg.apply_batch(
+            &[Op::Insert, Op::Insert, Op::Insert, Op::Insert],
+            None,
+            &[&array!(I64Array, [Some(10), Some(1), None, Some(5)]).into()],
+        )
+        .unwrap();
+
+        assert_eq!(agg.get_output().unwrap().unwrap().as_int64(), &14);
+
+        agg.apply_batch(
+            &[Op::Delete, Op::Delete, Op::Delete, Op::Delete],
             None,
             &[&array!(I64Array, [Some(1), Some(10), Some(100), Some(5)]).into()],
         )

--- a/src/stream/src/executor/aggregation/agg_impl/foldable.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/foldable.rs
@@ -195,7 +195,7 @@ where
     }
 }
 
-/// `BitXorable` returns the result of bit_xor all the values.
+/// `BitXorable` returns the result of `bit_xor` all the values.
 /// It produces the same type of output as input `S`.
 #[derive(Debug)]
 pub struct BitXorable<S>

--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -98,6 +98,9 @@ type StreamingMinAgg<S> = StreamingFoldAgg<S, S, Minimizable<<S as Array>::Owned
 /// `StreamingMaxAgg` get maximum data of the same type.
 type StreamingMaxAgg<S> = StreamingFoldAgg<S, S, Maximizable<<S as Array>::OwnedItem>>;
 
+/// `StreamingBitXor`
+type StreamingBitXorAgg<S> = StreamingFoldAgg<S, S, BitXorable<<S as Array>::OwnedItem>>;
+
 /// [postgresql specification of aggregate functions](https://www.postgresql.org/docs/13/functions-aggregate.html)
 /// Most of the general-purpose aggregate functions have one input except for:
 /// 1. `count(*) -> bigint`. The input type of count(*)
@@ -226,6 +229,10 @@ pub fn create_streaming_agg_impl(
                     (Max, timestamptz, timestamptz, StreamingMaxAgg::<I64Array>),
                     (Max, varchar, varchar, StreamingMaxAgg::<Utf8Array>),
                     (Max, bytea, bytea, StreamingMaxAgg::<BytesArray>),
+                    // BitXor
+                    (BitXor, int16, int16, StreamingBitXorAgg::<I16Array>),
+                    (BitXor, int32, int32, StreamingBitXorAgg::<I32Array>),
+                    (BitXor, int64, int64, StreamingBitXorAgg::<I64Array>),
                 ]
             )
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#9281 
We only add a `bit_xor` in streaming aggregation because it is trivial.
`bit_and` and `bit_or` are left undone.

`BitXorable`.... is this name even legal?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

~- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

Refer to https://learn.microsoft.com/en-us/azure/databricks/sql/language-manual/functions/bit_xor,
this one is for streaming. We have implemented batch ones in #9324 

</details>
