### PR TITLE
refactor(sqlsmith): cleanup agg repeated code

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -445,50 +445,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     ) -> Option<Expr> {
         use AggKind as A;
         match func {
-            A::BitAnd => Some(Expr::Function(make_agg_func(
-                "bit_and", exprs, distinct, filter, order_by,
-            ))),
-            A::BitOr => Some(Expr::Function(make_agg_func(
-                "bit_or", exprs, distinct, filter, order_by,
-            ))),
-            A::BitXor => Some(Expr::Function(make_agg_func(
-                "bit_xor", exprs, distinct, filter, order_by,
-            ))),
-            A::Sum | A::Sum0 => Some(Expr::Function(make_agg_func(
-                "sum", exprs, distinct, filter, order_by,
-            ))),
-            A::Min => Some(Expr::Function(make_agg_func(
-                "min", exprs, distinct, filter, order_by,
-            ))),
-            A::Max => Some(Expr::Function(make_agg_func(
-                "max", exprs, distinct, filter, order_by,
-            ))),
-            A::Count => Some(Expr::Function(make_agg_func(
-                "count", exprs, distinct, filter, order_by,
-            ))),
-            A::Avg => Some(Expr::Function(make_agg_func(
-                "avg", exprs, distinct, filter, order_by,
-            ))),
-            A::VarSamp => Some(Expr::Function(make_agg_func(
-                "var_samp", exprs, distinct, filter, order_by,
-            ))),
-            A::VarPop => Some(Expr::Function(make_agg_func(
-                "var_pop", exprs, distinct, filter, order_by,
-            ))),
-            A::StddevSamp => Some(Expr::Function(make_agg_func(
-                "stddev_samp",
-                exprs,
-                distinct,
-                filter,
-                order_by,
-            ))),
-            A::StddevPop => Some(Expr::Function(make_agg_func(
-                "stddev_pop",
-                exprs,
-                distinct,
-                filter,
-                order_by,
-            ))),
             A::StringAgg => {
                 // distinct and non_distinct_string_agg are incompatible according to
                 // https://github.com/risingwavelabs/risingwave/blob/a703dc7d725aa995fecbaedc4e9569bc9f6ca5ba/src/frontend/src/optimizer/plan_node/logical_agg.rs#L394
@@ -520,8 +476,8 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                     )))
                 }
             }
-            A::ArrayAgg => Some(Expr::Function(make_agg_func(
-                "array_agg",
+            other => Some(Expr::Function(make_agg_func(
+                &other.to_string(),
                 exprs,
                 distinct,
                 filter,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as per title.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
