### PR TITLE
refactor(end key): use bound to represent end key (close #9348)

### DIFF
--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -35,8 +35,8 @@ use crate::hummock::store::memtable::ImmId;
 use crate::hummock::utils::{range_overlap, MemoryTracker};
 use crate::hummock::value::HummockValue;
 use crate::hummock::{
-    create_monotonic_events, create_tombstones_to_represent_monotonic_deletes,
-    DeleteRangeTombstone, HummockEpoch, HummockResult, MonotonicDeleteEvent,
+    create_tombstones_to_represent_monotonic_deletes, DeleteRangeTombstone, HummockEpoch,
+    HummockResult, MonotonicDeleteEvent,
 };
 use crate::storage_value::StorageValue;
 use crate::store::ReadOptions;
@@ -159,7 +159,7 @@ impl SharedBufferBatchInner {
         largest_table_key: Bound<Bytes>,
         num_items: usize,
         imm_ids: Vec<ImmId>,
-        range_tombstone_list: Vec<DeleteRangeTombstone>,
+        monotonic_tombstone_events: Vec<MonotonicDeleteEvent>,
         size: usize,
         tracker: Option<MemoryTracker>,
     ) -> Self {
@@ -169,7 +169,6 @@ impl SharedBufferBatchInner {
 
         let max_imm_id = *imm_ids.iter().max().unwrap();
 
-        let monotonic_tombstone_events = create_monotonic_events(&range_tombstone_list);
         Self {
             payload,
             epochs,

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -357,7 +357,7 @@ impl SharedBufferBatch {
             && range_overlap(
                 &(left, right),
                 &self.start_table_key(),
-                &self.end_table_key().as_ref(),
+                self.end_table_key().as_ref(),
             )
     }
 

--- a/src/storage/src/hummock/sstable/delete_range_aggregator.rs
+++ b/src/storage/src/hummock/sstable/delete_range_aggregator.rs
@@ -66,7 +66,7 @@ pub(crate) struct TombstoneEnterExitEvent {
     tombstone_epoch: HummockEpoch,
 }
 
-type CompactionDeleteRangeEvent = (
+pub(crate) type CompactionDeleteRangeEvent = (
     // event key
     UserKey<Vec<u8>>,
     // Old tombstones which exits at the event key
@@ -223,8 +223,8 @@ impl CompactionDeleteRanges {
         create_monotonic_events(&tombstones)
     }
 
-    pub(crate) fn into_tombstones(self) -> Vec<DeleteRangeTombstone> {
-        self.delete_tombstones
+    pub(crate) fn into_events(self) -> Vec<CompactionDeleteRangeEvent> {
+        self.events
     }
 }
 

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -169,7 +169,7 @@ impl StagingVersion {
                     && range_overlap(
                         &(left, right),
                         &imm.start_table_key(),
-                        &imm.end_table_key().as_ref(),
+                        imm.end_table_key().as_ref(),
                     )
             });
 

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -166,7 +166,11 @@ impl StagingVersion {
                 imm.min_epoch() <= max_epoch_inclusive
                     && imm.table_id == table_id
                     && imm.min_epoch() > min_epoch_exclusive
-                    && range_overlap(&(left, right), &imm.start_table_key(), &imm.end_table_key())
+                    && range_overlap(
+                        &(left, right),
+                        &imm.start_table_key(),
+                        &imm.end_table_key().as_ref(),
+                    )
             });
 
         // TODO: Remove duplicate sst based on sst id

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -38,7 +38,7 @@ use crate::store::{ReadOptions, StateStoreRead};
 pub fn range_overlap<R, B>(
     search_key_range: &R,
     inclusive_start_key: &B,
-    end_key: &Bound<&B>,
+    end_key: Bound<&B>,
 ) -> bool
 where
     R: RangeBounds<B>,
@@ -108,7 +108,7 @@ where
     range_overlap(
         &(left, right),
         &table_start,
-        &if table_range.right_exclusive {
+        if table_range.right_exclusive {
             Bound::Excluded(&table_end)
         } else {
             Bound::Included(&table_end)

--- a/src/storage/src/hummock/utils.rs
+++ b/src/storage/src/hummock/utils.rs
@@ -38,7 +38,7 @@ use crate::store::{ReadOptions, StateStoreRead};
 pub fn range_overlap<R, B>(
     search_key_range: &R,
     inclusive_start_key: &B,
-    inclusive_end_key: &B,
+    end_key: &Bound<&B>,
 ) -> bool
 where
     R: RangeBounds<B>,
@@ -48,10 +48,12 @@ where
 
     //        RANGE
     // TABLE
-    let too_left = match start_bound {
-        Included(range_start) => range_start > inclusive_end_key,
-        Excluded(range_start) => range_start >= inclusive_end_key,
-        Unbounded => false,
+    let too_left = match (start_bound, end_key) {
+        (Included(range_start), Included(inclusive_end_key)) => range_start > inclusive_end_key,
+        (Included(range_start), Excluded(end_key))
+        | (Excluded(range_start), Included(end_key))
+        | (Excluded(range_start), Excluded(end_key)) => range_start >= end_key,
+        (Unbounded, _) | (_, Unbounded) => false,
     };
     // RANGE
     //        TABLE
@@ -103,11 +105,18 @@ where
     let (left, right) = bound_table_key_range(table_id, table_key_range);
     let left: Bound<UserKey<&[u8]>> = left.as_ref().map(|key| key.as_ref());
     let right: Bound<UserKey<&[u8]>> = right.as_ref().map(|key| key.as_ref());
-    range_overlap(&(left, right), &table_start, &table_end)
-        && info
-            .get_table_ids()
-            .binary_search(&table_id.table_id())
-            .is_ok()
+    range_overlap(
+        &(left, right),
+        &table_start,
+        &if table_range.right_exclusive {
+            Bound::Excluded(&table_end)
+        } else {
+            Bound::Included(&table_end)
+        },
+    ) && info
+        .get_table_ids()
+        .binary_search(&table_id.table_id())
+        .is_ok()
 }
 
 /// Search the SST containing the specified key within a level, using binary search.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
As described in #9348 ,`filter_single_sst` does not take `right_exclusive` property of SST Key Range into consideration, so this PR fixes it by let `filter_single_sst` receive `std::ops::Bound` as end_key.
In addition, immutable memtables should also use `std::ops::Bound` as end_key because there will be indefinite range delete in the future.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
