### PR TITLE
feat(stream): evict cache more frequently

### DIFF
--- a/src/stream/src/cache/managed_lru.rs
+++ b/src/stream/src/cache/managed_lru.rs
@@ -26,10 +26,10 @@ use risingwave_common::estimate_size::EstimateSize;
 /// The managed cache is a lru cache that bounds the memory usage by epoch.
 /// Should be used with `GlobalMemoryManager`.
 pub struct ManagedLruCache<K, V, S = DefaultHasher, A: Clone + Allocator = Global> {
-    pub(super) inner: EstimatedLruCache<K, V, S, A>,
+    inner: EstimatedLruCache<K, V, S, A>,
     /// The entry with epoch less than water should be evicted.
     /// Should only be updated by the `GlobalMemoryManager`.
-    pub watermark_epoch: Arc<AtomicU64>,
+    watermark_epoch: Arc<AtomicU64>,
 }
 
 impl<K: Hash + Eq + EstimateSize, V: EstimateSize, S: BuildHasher, A: Clone + Allocator>

--- a/src/stream/src/cache/managed_lru.rs
+++ b/src/stream/src/cache/managed_lru.rs
@@ -29,7 +29,7 @@ pub struct ManagedLruCache<K, V, S = DefaultHasher, A: Clone + Allocator = Globa
     pub(super) inner: EstimatedLruCache<K, V, S, A>,
     /// The entry with epoch less than water should be evicted.
     /// Should only be updated by the `GlobalMemoryManager`.
-    pub(super) watermark_epoch: Arc<AtomicU64>,
+    pub watermark_epoch: Arc<AtomicU64>,
 }
 
 impl<K: Hash + Eq + EstimateSize, V: EstimateSize, S: BuildHasher, A: Clone + Allocator>

--- a/src/stream/src/executor/aggregation/distinct.rs
+++ b/src/stream/src/executor/aggregation/distinct.rs
@@ -159,6 +159,10 @@ impl<S: StateStore> ColumnDeduplicater<S> {
             }
         }
 
+        // if we determine to flush to the table when processing every chunk instead of barrier
+        // coming, we can evict all including current epoch data.
+        self.cache.evict_except_cur_epoch();
+
         Ok(())
     }
 

--- a/src/stream/src/executor/aggregation/distinct.rs
+++ b/src/stream/src/executor/aggregation/distinct.rs
@@ -161,7 +161,7 @@ impl<S: StateStore> ColumnDeduplicater<S> {
 
         // if we determine to flush to the table when processing every chunk instead of barrier
         // coming, we can evict all including current epoch data.
-        self.cache.evict_except_cur_epoch();
+        self.cache.evict();
 
         Ok(())
     }
@@ -169,6 +169,8 @@ impl<S: StateStore> ColumnDeduplicater<S> {
     /// Flush the deduplication table.
     fn flush(&mut self, _dedup_table: &mut StateTable<S>) {
         // TODO(rc): now we flush the table in `dedup` method.
+        // WARN: if you want to change to batching the write to table. please remember to change
+        // `self.cache.evict()` too.
         self.cache.evict();
     }
 }

--- a/src/stream/src/executor/dedup/append_only_dedup.rs
+++ b/src/stream/src/executor/dedup/append_only_dedup.rs
@@ -79,6 +79,8 @@ impl<S: StateStore> AppendOnlyDedupExecutor<S> {
 
         #[for_await]
         for msg in input {
+            self.cache.evict();
+
             match msg? {
                 Message::Chunk(chunk) => {
                     // Append-only dedup executor only receives INSERT messages.
@@ -146,8 +148,6 @@ impl<S: StateStore> AppendOnlyDedupExecutor<S> {
                             self.cache.clear();
                         }
                     }
-
-                    self.cache.evict();
 
                     yield Message::Barrier(barrier);
                 }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -566,6 +566,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         #[for_await]
         for msg in input {
             let msg = msg?;
+            vars.agg_group_cache.evict_except_cur_epoch();
             match msg {
                 Message::Watermark(watermark) => {
                     let group_key_seq = group_key_invert_idx[watermark.col_idx];

--- a/src/stream/src/executor/lookup/cache.rs
+++ b/src/stream/src/executor/lookup/cache.rs
@@ -54,9 +54,8 @@ impl LookupCache {
         }
     }
 
-    /// Flush the cache and evict the items.
-    pub fn flush(&mut self) {
-        self.data.evict();
+    pub fn evict(&mut self) {
+        self.data.evict()
     }
 
     /// Update the current epoch.

--- a/src/stream/src/executor/lookup/impl_.rs
+++ b/src/stream/src/executor/lookup/impl_.rs
@@ -270,14 +270,9 @@ impl<S: StateStore> LookupExecutor<S> {
         #[for_await]
         for msg in input {
             let msg = msg?;
+            self.lookup_cache.evict();
             match msg {
                 ArrangeMessage::Barrier(barrier) => {
-                    if self.arrangement.use_current_epoch {
-                        // If we are using current epoch, stream barrier should always come after
-                        // arrange barrier. So we flush now.
-                        self.lookup_cache.flush();
-                    }
-
                     self.process_barrier(&barrier);
 
                     if self.arrangement.use_current_epoch {
@@ -297,10 +292,6 @@ impl<S: StateStore> LookupExecutor<S> {
                     }
 
                     if !self.arrangement.use_current_epoch {
-                        // If we are using previous epoch, arrange barrier should always come after
-                        // stream barrier. So we flush now.
-                        self.lookup_cache.flush();
-
                         // When look prev epoch, arrange ready will always come after stream
                         // barrier. So we yield barrier now.
                         yield Message::Barrier(barrier);

--- a/src/stream/src/executor/mview/materialize.rs
+++ b/src/stream/src/executor/mview/materialize.rs
@@ -128,6 +128,8 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
         #[for_await]
         for msg in input {
             let msg = msg?;
+            self.materialize_cache.evict();
+
             yield match msg {
                 Message::Watermark(w) => Message::Watermark(w),
                 Message::Chunk(chunk) => {
@@ -184,7 +186,6 @@ impl<S: StateStore, SD: ValueRowSerde> MaterializeExecutor<S, SD> {
                             self.materialize_cache.data.clear();
                         }
                     }
-                    self.materialize_cache.evict();
                     Message::Barrier(b)
                 }
             }

--- a/src/stream/src/executor/top_n/utils.rs
+++ b/src/stream/src/executor/top_n/utils.rs
@@ -123,6 +123,7 @@ where
 
         #[for_await]
         for msg in input {
+            self.inner.evict();
             let msg = msg?;
             match msg {
                 Message::Watermark(watermark) => {
@@ -138,7 +139,6 @@ where
                     if let Some(vnode_bitmap) = barrier.as_update_vnode_bitmap(self.ctx.id) {
                         self.inner.update_vnode_bitmap(vnode_bitmap);
                     }
-                    self.inner.evict();
                     yield Message::Barrier(barrier)
                 }
             };


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Every streaming executor which uses the LRUCache will call the `evict` at least for every chunk, which will make state eviction more timely
This PR is just a quick fix and we need some refactoring later.
<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
