### PR TITLE
fix(ci): fix source e2e test main ci failure

### DIFF
--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -90,6 +90,10 @@ sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check.slt'
 # kill cluster
 cargo make kill
 echo "cluster killed "
+echo "insert new rows into mysql & postgres"
+mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc_insert.sql
+psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.sql
+sleep 5
 
 echo "start cluster again"
 # start cluster w/o clean-data
@@ -98,10 +102,6 @@ cargo make dev ci-1cn-1fe-with-recovery
 echo "wait for recovery finish"
 sleep 15
 
-echo "insert new rows into mysql & postgres"
-mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc_insert.sql
-psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.sql
-sleep 5
 echo "check mviews after cluster recovery"
 # check results
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -89,15 +89,19 @@ sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check.slt'
 
 # kill cluster
 cargo make kill
-# insert new rows
-mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc_insert.sql
-psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.sql
+echo "cluster killed "
 
+echo "start cluster again"
 # start cluster w/o clean-data
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 cargo make dev ci-1cn-1fe-with-recovery
 echo "wait for recovery finish"
-sleep 20
+sleep 15
+
+echo "insert new rows into mysql & postgres"
+mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc_insert.sql
+psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.sql
+sleep 5
 echo "check mviews after cluster recovery"
 # check results
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -39,7 +39,6 @@ cp src/connector/src/test_data/complex-schema.avsc ./avro-complex-schema.avsc
 cp src/connector/src/test_data/complex-schema ./proto-complex-schema
 
 
-
 echo "--- e2e, ci-1cn-1fe, mysql & postgres cdc"
 
 # import data to mysql
@@ -53,29 +52,33 @@ psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc.sql
 node_port=50051
 node_timeout=10
 
+wait_for_connector_node_start() {
+  start_time=$(date +%s)
+  while :
+  do
+      if nc -z localhost $node_port; then
+          echo "Port $node_port is listened! Connector Node is up!"
+          break
+      fi
+
+      current_time=$(date +%s)
+      elapsed_time=$((current_time - start_time))
+      if [ $elapsed_time -ge $node_timeout ]; then
+          echo "Timeout waiting for port $node_port to be listened!"
+          exit 1
+      fi
+      sleep 0.1
+  done
+  sleep 2
+}
+
 echo "--- starting risingwave cluster with connector node"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 cargo make ci-start ci-1cn-1fe-with-recovery
 ./connector-node/start-service.sh -p $node_port > .risingwave/log/connector-node.log 2>&1 &
 
 echo "waiting for connector node to start"
-start_time=$(date +%s)
-while :
-do
-    if nc -z localhost $node_port; then
-        echo "Port $node_port is listened! Connector Node is up!"
-        break
-    fi
-
-    current_time=$(date +%s)
-    elapsed_time=$((current_time - start_time))
-    if [ $elapsed_time -ge $node_timeout ]; then
-        echo "Timeout waiting for port $node_port to be listened!"
-        exit 1
-    fi
-    sleep 0.1
-done
-sleep 2
+wait_for_connector_node_start
 
 echo "--- mysql & postgres cdc validate test"
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.validate.mysql.slt'
@@ -87,21 +90,26 @@ sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.load.slt'
 sleep 10
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check.slt'
 
-# kill cluster
+# kill cluster and the connector node
 cargo make kill
+pkill -f connector-node
 echo "cluster killed "
-echo "insert new rows into mysql & postgres"
+
+# insert new rows
 mysql --host=mysql --port=3306 -u root -p123456 < ./e2e_test/source/cdc/mysql_cdc_insert.sql
 psql -h db -U postgres -d cdc_test < ./e2e_test/source/cdc/postgres_cdc_insert.sql
-sleep 5
+echo "inserted new rows into mysql and postgres"
 
-echo "start cluster again"
 # start cluster w/o clean-data
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
-cargo make dev ci-1cn-1fe-with-recovery
-echo "wait for recovery finish"
-sleep 15
+touch .risingwave/log/connector-node.log
+./connector-node/start-service.sh -p $node_port >> .risingwave/log/connector-node.log 2>&1 &
+echo "(recovery) waiting for connector node to start"
+wait_for_connector_node_start
 
+cargo make dev ci-1cn-1fe-with-recovery
+echo "wait for cluster recovery finish"
+sleep 20
 echo "check mviews after cluster recovery"
 # check results
 sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

We also needs to kill the connector node when we kill the cluster before recovery. Otherwise, we may encounter the following issue in the recovery scenario：
```
metrics.Metrics:92 - Unable to register metrics as an old set with the same name exists, retrying in PT5S
```

Fix #9312 

## Checklist For Contributors

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
