### PR TITLE
feat(delete range): open interval range delete

### DIFF
--- a/src/storage/hummock_sdk/src/key.rs
+++ b/src/storage/hummock_sdk/src/key.rs
@@ -719,6 +719,47 @@ impl<T: AsRef<[u8]> + Ord + Eq> PartialOrd for FullKey<T> {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct PointRange<T: AsRef<[u8]>> {
+    // When comparing `PointRange`, we first compare `left_user_key`, then
+    // `is_exclude_left_key`. Therefore the order of declaration matters.
+    pub left_user_key: UserKey<T>,
+    /// `PointRange` represents the left user key itself if `is_exclude_left_key==false`
+    /// while represents the right δ Neighborhood of the left user key if
+    /// `is_exclude_left_key==true`.
+    pub is_exclude_left_key: bool,
+}
+
+impl<T: AsRef<[u8]>> PointRange<T> {
+    pub fn from_user_key(left_user_key: UserKey<T>, is_exclude_left_key: bool) -> Self {
+        Self {
+            left_user_key,
+            is_exclude_left_key,
+        }
+    }
+
+    pub fn as_ref(&self) -> PointRange<&[u8]> {
+        PointRange::from_user_key(self.left_user_key.as_ref(), self.is_exclude_left_key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.left_user_key.is_empty()
+    }
+}
+
+impl<'a> PointRange<&'a [u8]> {
+    pub fn to_vec(&self) -> PointRange<Vec<u8>> {
+        self.copy_into()
+    }
+
+    pub fn copy_into<T: CopyFromSlice + AsRef<[u8]>>(&self) -> PointRange<T> {
+        PointRange {
+            left_user_key: self.left_user_key.copy_into(),
+            is_exclude_left_key: self.is_exclude_left_key,
+        }
+    }
+}
+
 pub trait EmptySliceRef {
     fn empty_slice_ref<'a>() -> &'a Self;
 }

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -121,7 +121,7 @@ impl CompactorRunner {
                     table.value().meta.monotonic_tombstone_events.clone();
                 range_tombstone_list.iter_mut().for_each(|tombstone| {
                     if filter.should_delete(FullKey::from_user_key(
-                        tombstone.event_key.as_ref(),
+                        tombstone.event_key.left_user_key.as_ref(),
                         tombstone.new_epoch,
                     )) {
                         tombstone.new_epoch = HummockEpoch::MAX;
@@ -200,8 +200,18 @@ mod tests {
         let sstable_store = mock_sstable_store();
         let kv_pairs = vec![];
         let range_tombstones = vec![
-            DeleteRangeTombstone::new(TableId::new(1), b"abc".to_vec(), b"cde".to_vec(), 1),
-            DeleteRangeTombstone::new(TableId::new(2), b"abc".to_vec(), b"def".to_vec(), 1),
+            DeleteRangeTombstone::new_for_test(
+                TableId::new(1),
+                b"abc".to_vec(),
+                b"cde".to_vec(),
+                1,
+            ),
+            DeleteRangeTombstone::new_for_test(
+                TableId::new(2),
+                b"abc".to_vec(),
+                b"def".to_vec(),
+                1,
+            ),
         ];
         let sstable_info = gen_test_sstable_with_range_tombstone(
             default_builder_opt_for_test(),

--- a/src/storage/src/hummock/iterator/delete_range_iterator.rs
+++ b/src/storage/src/hummock/iterator/delete_range_iterator.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{BTreeSet, BinaryHeap};
 
-use risingwave_hummock_sdk::key::UserKey;
+use risingwave_hummock_sdk::key::{PointRange, UserKey};
 use risingwave_hummock_sdk::HummockEpoch;
 
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferDeleteRangeIterator;
@@ -27,7 +27,7 @@ use crate::hummock::SstableDeleteRangeIterator;
 /// - if you want to iterate from the beginning, you need to then call its `rewind` method.
 /// - if you want to iterate from some specific position, you need to then call its `seek` method.
 pub trait DeleteRangeIterator {
-    /// Retrieves the next user key that changes current epoch.
+    /// Retrieves the next extended user key that changes current epoch.
     ///
     /// Note:
     /// - Before calling this function, makes sure the iterator `is_valid`.
@@ -35,7 +35,7 @@ pub trait DeleteRangeIterator {
     ///
     /// # Panics
     /// This function will panic if the iterator is invalid.
-    fn next_user_key(&self) -> UserKey<&[u8]>;
+    fn next_extended_user_key(&self) -> PointRange<&[u8]>;
 
     /// Retrieves the epoch of the current range delete.
     /// It returns the epoch between the previous `next_user_key` (inclusive) and the current
@@ -95,10 +95,10 @@ pub enum RangeIteratorTyped {
 }
 
 impl DeleteRangeIterator for RangeIteratorTyped {
-    fn next_user_key(&self) -> UserKey<&[u8]> {
+    fn next_extended_user_key(&self) -> PointRange<&[u8]> {
         match self {
-            RangeIteratorTyped::Sst(sst) => sst.next_user_key(),
-            RangeIteratorTyped::Batch(batch) => batch.next_user_key(),
+            RangeIteratorTyped::Sst(sst) => sst.next_extended_user_key(),
+            RangeIteratorTyped::Batch(batch) => batch.next_extended_user_key(),
         }
     }
 
@@ -148,7 +148,8 @@ impl DeleteRangeIterator for RangeIteratorTyped {
 
 impl PartialEq<Self> for RangeIteratorTyped {
     fn eq(&self, other: &Self) -> bool {
-        self.next_user_key().eq(&other.next_user_key())
+        self.next_extended_user_key()
+            .eq(&other.next_extended_user_key())
     }
 }
 
@@ -162,7 +163,9 @@ impl Eq for RangeIteratorTyped {}
 
 impl Ord for RangeIteratorTyped {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        other.next_user_key().cmp(&self.next_user_key())
+        other
+            .next_extended_user_key()
+            .cmp(&self.next_extended_user_key())
     }
 }
 
@@ -227,15 +230,16 @@ impl ForwardMergeRangeIterator {
 
 impl ForwardMergeRangeIterator {
     pub(super) fn next_until(&mut self, target_user_key: UserKey<&[u8]>) {
-        while self.is_valid() && self.next_user_key().le(&target_user_key) {
+        let target_extended_user_key = PointRange::from_user_key(target_user_key, false);
+        while self.is_valid() && self.next_extended_user_key().le(&target_extended_user_key) {
             self.next();
         }
     }
 }
 
 impl DeleteRangeIterator for ForwardMergeRangeIterator {
-    fn next_user_key(&self) -> UserKey<&[u8]> {
-        self.heap.peek().unwrap().next_user_key()
+    fn next_extended_user_key(&self) -> PointRange<&[u8]> {
+        self.heap.peek().unwrap().next_extended_user_key()
     }
 
     fn current_epoch(&self) -> HummockEpoch {
@@ -248,7 +252,7 @@ impl DeleteRangeIterator for ForwardMergeRangeIterator {
     fn next(&mut self) {
         self.tmp_buffer
             .push(self.heap.pop().expect("no inner iter"));
-        while let Some(node) = self.heap.peek() && node.is_valid() && node.next_user_key() == self.tmp_buffer[0].next_user_key() {
+        while let Some(node) = self.heap.peek() && node.is_valid() && node.next_extended_user_key() == self.tmp_buffer[0].next_extended_user_key() {
             self.tmp_buffer.push(self.heap.pop().unwrap());
         }
         for node in &self.tmp_buffer {

--- a/src/storage/src/hummock/iterator/test_utils.rs
+++ b/src/storage/src/hummock/iterator/test_utils.rs
@@ -183,7 +183,9 @@ pub async fn gen_iterator_test_sstable_with_range_tombstones(
             DeleteRangeTombstone::new(
                 TableId::default(),
                 iterator_test_table_key_of(start),
+                false,
                 iterator_test_table_key_of(end),
+                false,
                 epoch,
             )
         })

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -189,10 +189,10 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
             .iter()
             .filter(|monotonic_delete| monotonic_delete.new_epoch != HummockEpoch::MAX)
         {
-            if last_table_id != monotonic_delete.event_key.table_id {
-                last_table_id = monotonic_delete.event_key.table_id;
+            if last_table_id != monotonic_delete.event_key.left_user_key.table_id {
+                last_table_id = monotonic_delete.event_key.left_user_key.table_id;
                 self.table_ids
-                    .insert(monotonic_delete.event_key.table_id.table_id());
+                    .insert(monotonic_delete.event_key.left_user_key.table_id.table_id());
             }
         }
         self.monotonic_deletes.extend(monotonic_deletes);
@@ -319,30 +319,46 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         let meta_offset = self.writer.data_len() as u64;
         if let Some(monotonic_delete) = self.monotonic_deletes.last() {
             debug_assert_eq!(monotonic_delete.new_epoch, HummockEpoch::MAX);
-            if largest_key.is_empty()
+            if monotonic_delete.event_key.is_exclude_left_key {
+                if largest_key.is_empty()
+                    || !KeyComparator::encoded_greater_than_unencoded(
+                        user_key(&largest_key),
+                        &monotonic_delete.event_key.left_user_key,
+                    )
+                {
+                    largest_key = FullKey::from_user_key(
+                        monotonic_delete.event_key.left_user_key.clone(),
+                        HummockEpoch::MIN,
+                    )
+                    .encode();
+                }
+            } else if largest_key.is_empty()
                 || KeyComparator::encoded_less_than_unencoded(
                     user_key(&largest_key),
-                    &monotonic_delete.event_key,
+                    &monotonic_delete.event_key.left_user_key,
                 )
             {
-                // use MAX as epoch because the last monotonic delete must be `HummockEpoch::MAX`,
-                // so we can not include any version of this key.
-                largest_key =
-                    FullKey::from_user_key(monotonic_delete.event_key.clone(), HummockEpoch::MAX)
-                        .encode();
+                // use MAX as epoch because the last monotonic delete must be
+                // `HummockEpoch::MAX`, so we can not include any version of
+                // this key.
+                largest_key = FullKey::from_user_key(
+                    monotonic_delete.event_key.left_user_key.clone(),
+                    HummockEpoch::MAX,
+                )
+                .encode();
                 right_exclusive = true;
             }
         }
         if let Some(monotonic_delete) = self.monotonic_deletes.first() {
             if smallest_key.is_empty()
-                || KeyComparator::encoded_greater_than_unencoded(
+                || !KeyComparator::encoded_less_than_unencoded(
                     user_key(&smallest_key),
-                    &monotonic_delete.event_key,
+                    &monotonic_delete.event_key.left_user_key,
                 )
             {
                 smallest_key = FullKey::from_user_key(
-                    monotonic_delete.event_key.clone(),
-                    monotonic_delete.new_epoch,
+                    monotonic_delete.event_key.left_user_key.clone(),
+                    HummockEpoch::MAX,
                 )
                 .encode();
             }

--- a/src/storage/src/hummock/sstable/delete_range_aggregator.rs
+++ b/src/storage/src/hummock/sstable/delete_range_aggregator.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use itertools::Itertools;
-use risingwave_hummock_sdk::key::UserKey;
+use risingwave_hummock_sdk::key::{PointRange, UserKey};
 use risingwave_hummock_sdk::HummockEpoch;
 
 use super::{DeleteRangeTombstone, MonotonicDeleteEvent};
@@ -68,7 +68,7 @@ pub(crate) struct TombstoneEnterExitEvent {
 
 pub(crate) type CompactionDeleteRangeEvent = (
     // event key
-    UserKey<Vec<u8>>,
+    PointRange<Vec<u8>>,
     // Old tombstones which exits at the event key
     Vec<TombstoneEnterExitEvent>,
     // New tombstones which enters at the event key
@@ -167,7 +167,7 @@ impl CompactionDeleteRangesBuilder {
 
     pub(crate) fn build_for_compaction(self, gc_delete_keys: bool) -> Arc<CompactionDeleteRanges> {
         let mut ret = BTreeMap::<
-            UserKey<Vec<u8>>,
+            PointRange<Vec<u8>>,
             (Vec<TombstoneEnterExitEvent>, Vec<TombstoneEnterExitEvent>),
         >::default();
         for monotonic_deletes in self.events {
@@ -226,16 +226,18 @@ impl CompactionDeleteRanges {
             return vec![];
         }
 
+        let extended_smallest_user_key = PointRange::from_user_key(smallest_user_key, false);
+        let extended_largest_user_key = PointRange::from_user_key(largest_user_key, false);
+
         let mut monotonic_events = Vec::with_capacity(self.events.len());
         let mut epochs = BTreeSet::new();
         let mut idx = 0;
         while idx < self.events.len() {
-            if self.events[idx].0.as_ref().gt(&smallest_user_key) {
+            if self.events[idx].0.as_ref().gt(&extended_smallest_user_key) {
                 if let Some(epoch) = epochs.first() {
                     monotonic_events.push(MonotonicDeleteEvent {
-                        event_key: smallest_user_key.to_vec(),
+                        event_key: extended_smallest_user_key.to_vec(),
                         new_epoch: *epoch,
-                        is_exclusive: false,
                     });
                 }
                 break;
@@ -245,12 +247,13 @@ impl CompactionDeleteRanges {
         }
         while idx < self.events.len() {
             // TODO: replace it with Bound
-            if !largest_user_key.is_empty() && self.events[idx].0.as_ref().ge(&largest_user_key) {
+            if !extended_largest_user_key.is_empty()
+                && self.events[idx].0.as_ref().ge(&extended_largest_user_key)
+            {
                 if !monotonic_events.is_empty() {
                     monotonic_events.push(MonotonicDeleteEvent {
-                        event_key: largest_user_key.to_vec(),
+                        event_key: extended_largest_user_key.to_vec(),
                         new_epoch: HummockEpoch::MAX,
-                        is_exclusive: false,
                     });
                 }
                 break;
@@ -258,13 +261,13 @@ impl CompactionDeleteRanges {
             apply_event(&mut epochs, &self.events[idx]);
             monotonic_events.push(MonotonicDeleteEvent {
                 event_key: self.events[idx].0.clone(),
-                is_exclusive: false,
                 new_epoch: epochs.first().map_or(HummockEpoch::MAX, |epoch| *epoch),
             });
             idx += 1;
         }
         monotonic_events.dedup_by(|a, b| {
-            a.event_key.table_id == b.event_key.table_id && a.new_epoch == b.new_epoch
+            a.event_key.left_user_key.table_id == b.event_key.left_user_key.table_id
+                && a.new_epoch == b.new_epoch
         });
         if !monotonic_events.is_empty() {
             assert_ne!(
@@ -304,7 +307,8 @@ impl CompactionDeleteRangeIterator {
         target_user_key: UserKey<&[u8]>,
         epoch: HummockEpoch,
     ) -> HummockEpoch {
-        while let Some((user_key, ..)) = self.events.events.get(self.seek_idx) && user_key.as_ref().le(&target_user_key) {
+        let target_extended_user_key = PointRange::from_user_key(target_user_key, false);
+        while let Some((extended_user_key, ..)) = self.events.events.get(self.seek_idx) && extended_user_key.as_ref().le(&target_extended_user_key) {
             self.apply(self.seek_idx);
             self.seek_idx += 1;
         }
@@ -319,10 +323,13 @@ impl CompactionDeleteRangeIterator {
     }
 
     pub(crate) fn seek<'a>(&'a mut self, target_user_key: UserKey<&'a [u8]>) {
+        let target_extended_user_key = PointRange::from_user_key(target_user_key, false);
         self.seek_idx = self
             .events
             .events
-            .partition_point(|(user_key, ..)| user_key.as_ref().le(&target_user_key));
+            .partition_point(|(extended_user_key, ..)| {
+                extended_user_key.as_ref().le(&target_extended_user_key)
+            });
         self.epochs.clear();
         for idx in 0..self.seek_idx {
             self.apply(idx);
@@ -347,7 +354,7 @@ impl SstableDeleteRangeIterator {
 }
 
 impl DeleteRangeIterator for SstableDeleteRangeIterator {
-    fn next_user_key(&self) -> UserKey<&[u8]> {
+    fn next_extended_user_key(&self) -> PointRange<&[u8]> {
         self.table.value().meta.monotonic_tombstone_events[self.next_idx]
             .event_key
             .as_ref()
@@ -370,13 +377,14 @@ impl DeleteRangeIterator for SstableDeleteRangeIterator {
     }
 
     fn seek<'a>(&'a mut self, target_user_key: UserKey<&'a [u8]>) {
+        let target_extended_user_key = PointRange::from_user_key(target_user_key, false);
         self.next_idx = self
             .table
             .value()
             .meta
             .monotonic_tombstone_events
             .partition_point(|MonotonicDeleteEvent { event_key, .. }| {
-                event_key.as_ref().le(&target_user_key)
+                event_key.as_ref().le(&target_extended_user_key)
             });
     }
 
@@ -389,8 +397,9 @@ pub fn get_min_delete_range_epoch_from_sstable(
     table: &Sstable,
     query_user_key: UserKey<&[u8]>,
 ) -> HummockEpoch {
+    let query_extended_user_key = PointRange::from_user_key(query_user_key, false);
     let idx = table.meta.monotonic_tombstone_events.partition_point(
-        |MonotonicDeleteEvent { event_key, .. }| event_key.as_ref().le(&query_user_key),
+        |MonotonicDeleteEvent { event_key, .. }| event_key.as_ref().le(&query_extended_user_key),
     );
     if idx == 0 {
         HummockEpoch::MAX
@@ -416,12 +425,22 @@ mod tests {
         let mut builder = CompactionDeleteRangesBuilder::default();
         let table_id = TableId::default();
         let data = vec![
-            DeleteRangeTombstone::new(table_id, b"aaaaaa".to_vec(), b"bbbccc".to_vec(), 12),
-            DeleteRangeTombstone::new(table_id, b"aaaaaa".to_vec(), b"bbbddd".to_vec(), 9),
-            DeleteRangeTombstone::new(table_id, b"bbbfff".to_vec(), b"ffffff".to_vec(), 9),
-            DeleteRangeTombstone::new(table_id, b"gggggg".to_vec(), b"hhhhhh".to_vec(), 9),
-            DeleteRangeTombstone::new(table_id, b"bbbeee".to_vec(), b"eeeeee".to_vec(), 8),
-            DeleteRangeTombstone::new(table_id, b"bbbaab".to_vec(), b"bbbdddf".to_vec(), 6),
+            DeleteRangeTombstone::new_for_test(
+                table_id,
+                b"aaaaaa".to_vec(),
+                b"bbbccc".to_vec(),
+                12,
+            ),
+            DeleteRangeTombstone::new_for_test(table_id, b"aaaaaa".to_vec(), b"bbbddd".to_vec(), 9),
+            DeleteRangeTombstone::new_for_test(table_id, b"bbbfff".to_vec(), b"ffffff".to_vec(), 9),
+            DeleteRangeTombstone::new_for_test(table_id, b"gggggg".to_vec(), b"hhhhhh".to_vec(), 9),
+            DeleteRangeTombstone::new_for_test(table_id, b"bbbeee".to_vec(), b"eeeeee".to_vec(), 8),
+            DeleteRangeTombstone::new_for_test(
+                table_id,
+                b"bbbaab".to_vec(),
+                b"bbbdddf".to_vec(),
+                6,
+            ),
         ];
         for range in data {
             builder.add_delete_events(create_monotonic_events(vec![range]));
@@ -482,10 +501,10 @@ mod tests {
         let table_id = TableId::default();
         let mut builder = CompactionDeleteRangesBuilder::default();
         let data = vec![
-            DeleteRangeTombstone::new(table_id, b"aaaa".to_vec(), b"cccc".to_vec(), 12),
-            DeleteRangeTombstone::new(table_id, b"cccc".to_vec(), b"dddd".to_vec(), 10),
-            DeleteRangeTombstone::new(table_id, b"cccc".to_vec(), b"eeee".to_vec(), 12),
-            DeleteRangeTombstone::new(table_id, b"eeee".to_vec(), b"ffff".to_vec(), 12),
+            DeleteRangeTombstone::new_for_test(table_id, b"aaaa".to_vec(), b"cccc".to_vec(), 12),
+            DeleteRangeTombstone::new_for_test(table_id, b"cccc".to_vec(), b"dddd".to_vec(), 10),
+            DeleteRangeTombstone::new_for_test(table_id, b"cccc".to_vec(), b"eeee".to_vec(), 12),
+            DeleteRangeTombstone::new_for_test(table_id, b"eeee".to_vec(), b"ffff".to_vec(), 12),
         ];
         for range in data {
             builder.add_delete_events(create_monotonic_events(vec![range]));
@@ -496,10 +515,22 @@ mod tests {
             test_user_key(b"eeeeee").as_ref(),
         );
         assert_eq!(4, split_ranges.len());
-        assert_eq!(test_user_key(b"bbbb"), split_ranges[0].event_key);
-        assert_eq!(test_user_key(b"cccc"), split_ranges[1].event_key);
-        assert_eq!(test_user_key(b"dddd"), split_ranges[2].event_key);
-        assert_eq!(test_user_key(b"eeeeee"), split_ranges[3].event_key);
+        assert_eq!(
+            PointRange::from_user_key(test_user_key(b"bbbb"), false),
+            split_ranges[0].event_key
+        );
+        assert_eq!(
+            PointRange::from_user_key(test_user_key(b"cccc"), false),
+            split_ranges[1].event_key
+        );
+        assert_eq!(
+            PointRange::from_user_key(test_user_key(b"dddd"), false),
+            split_ranges[2].event_key
+        );
+        assert_eq!(
+            PointRange::from_user_key(test_user_key(b"eeeeee"), false),
+            split_ranges[3].event_key
+        );
     }
 
     #[tokio::test]

--- a/src/storage/src/hummock/sstable/mod.rs
+++ b/src/storage/src/hummock/sstable/mod.rs
@@ -41,7 +41,7 @@ use bytes::{Buf, BufMut};
 pub use forward_sstable_iterator::*;
 mod backward_sstable_iterator;
 pub use backward_sstable_iterator::*;
-use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, TableKey, UserKey};
+use risingwave_hummock_sdk::key::{FullKey, KeyPayloadType, PointRange, TableKey, UserKey};
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 #[cfg(test)]
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
@@ -74,8 +74,8 @@ const VERSION: u32 = 1;
 #[derive(Clone, PartialEq, Eq, Debug)]
 // delete keys located in [start_user_key, end_user_key)
 pub struct DeleteRangeTombstone {
-    pub start_user_key: UserKey<Vec<u8>>,
-    pub end_user_key: UserKey<Vec<u8>>,
+    pub start_user_key: PointRange<Vec<u8>>,
+    pub end_user_key: PointRange<Vec<u8>>,
     pub sequence: HummockEpoch,
 }
 
@@ -98,14 +98,39 @@ impl DeleteRangeTombstone {
     pub fn new(
         table_id: TableId,
         start_table_key: Vec<u8>,
+        is_left_open: bool,
         end_table_key: Vec<u8>,
+        is_right_close: bool,
         sequence: HummockEpoch,
     ) -> Self {
         Self {
-            start_user_key: UserKey::new(table_id, TableKey(start_table_key)),
-            end_user_key: UserKey::new(table_id, TableKey(end_table_key)),
+            start_user_key: PointRange::from_user_key(
+                UserKey::new(table_id, TableKey(start_table_key)),
+                is_left_open,
+            ),
+            end_user_key: PointRange::from_user_key(
+                UserKey::new(table_id, TableKey(end_table_key)),
+                is_right_close,
+            ),
             sequence,
         }
+    }
+
+    #[cfg(test)]
+    pub fn new_for_test(
+        table_id: TableId,
+        start_table_key: Vec<u8>,
+        end_table_key: Vec<u8>,
+        sequence: HummockEpoch,
+    ) -> Self {
+        Self::new(
+            table_id,
+            start_table_key,
+            false,
+            end_table_key,
+            false,
+            sequence,
+        )
     }
 }
 
@@ -124,8 +149,7 @@ impl DeleteRangeTombstone {
 /// `HummockEpoch::MAX`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MonotonicDeleteEvent {
-    pub event_key: UserKey<Vec<u8>>,
-    pub is_exclusive: bool,
+    pub event_key: PointRange<Vec<u8>>,
     pub new_epoch: HummockEpoch,
 }
 
@@ -133,37 +157,42 @@ impl MonotonicDeleteEvent {
     #[cfg(test)]
     pub fn new(table_id: TableId, event_key: Vec<u8>, new_epoch: HummockEpoch) -> Self {
         Self {
-            event_key: UserKey::new(table_id, TableKey(event_key)),
-            is_exclusive: false,
+            event_key: PointRange::from_user_key(
+                UserKey::new(table_id, TableKey(event_key)),
+                false,
+            ),
             new_epoch,
         }
     }
 
     pub fn encode(&self, buf: &mut Vec<u8>) {
-        self.event_key.encode_length_prefixed(buf);
-        buf.put_u8(if self.is_exclusive { 1 } else { 0 });
+        self.event_key.left_user_key.encode_length_prefixed(buf);
+        buf.put_u8(if self.event_key.is_exclude_left_key {
+            1
+        } else {
+            0
+        });
         buf.put_u64_le(self.new_epoch);
     }
 
     pub fn decode(buf: &mut &[u8]) -> Self {
-        let event_key = UserKey::decode_length_prefixed(buf);
-        let exclusive_flag = buf.get_u8();
-        let is_exclusive = match exclusive_flag {
+        let user_key = UserKey::decode_length_prefixed(buf);
+        let exclude_left_key_flag = buf.get_u8();
+        let is_exclude_left_key = match exclude_left_key_flag {
             0 => false,
             1 => true,
             _ => panic!("exclusive flag should be either 0 or 1"),
         };
         let new_epoch = buf.get_u64_le();
         Self {
-            event_key,
-            is_exclusive,
+            event_key: PointRange::from_user_key(user_key, is_exclude_left_key),
             new_epoch,
         }
     }
 
     #[inline]
     pub fn encoded_size(&self) -> usize {
-        4 + self.event_key.encoded_len() + 1 + 8
+        4 + self.event_key.left_user_key.encoded_len() + 1 + 8
     }
 }
 
@@ -176,12 +205,12 @@ pub(crate) fn create_monotonic_events_from_compaction_delete_events(
         apply_event(&mut epochs, &event);
         monotonic_tombstone_events.push(MonotonicDeleteEvent {
             event_key: event.0,
-            is_exclusive: false,
             new_epoch: epochs.first().map_or(HummockEpoch::MAX, |epoch| *epoch),
         });
     }
     monotonic_tombstone_events.dedup_by(|a, b| {
-        a.event_key.table_id == b.event_key.table_id && a.new_epoch == b.new_epoch
+        a.event_key.left_user_key.table_id == b.event_key.left_user_key.table_id
+            && a.new_epoch == b.new_epoch
     });
     monotonic_tombstone_events
 }

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -481,8 +481,8 @@ mod tests {
         let table_id = TableId::new(1);
         let mut builder = CompactionDeleteRangesBuilder::default();
         builder.add_delete_events(create_monotonic_events(vec![
-            DeleteRangeTombstone::new_for_test(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
-            DeleteRangeTombstone::new_for_test(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
+            DeleteRangeTombstone::new(table_id, b"k".to_vec(), false, b"kkk".to_vec(), true, 100),
+            DeleteRangeTombstone::new(table_id, b"aaa".to_vec(), true, b"ddd".to_vec(), true, 200),
         ]));
         let builder = CapacitySplitTableBuilder::new(
             LocalTableBuilderFactory::new(1001, mock_sstable_store(), opts),

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -429,8 +429,8 @@ mod tests {
         let table_id = TableId::default();
         let mut builder = CompactionDeleteRangesBuilder::default();
         let events = create_monotonic_events(vec![
-            DeleteRangeTombstone::new(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
-            DeleteRangeTombstone::new(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
+            DeleteRangeTombstone::new_for_test(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
+            DeleteRangeTombstone::new_for_test(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
         ]);
         builder.add_delete_events(events);
         let mut builder = CapacitySplitTableBuilder::new(
@@ -459,7 +459,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             key_range.left,
-            FullKey::for_test(table_id, b"aaa", 200).encode()
+            FullKey::for_test(table_id, b"aaa", u64::MAX).encode()
         );
         assert_eq!(
             key_range.right,
@@ -481,8 +481,8 @@ mod tests {
         let table_id = TableId::new(1);
         let mut builder = CompactionDeleteRangesBuilder::default();
         builder.add_delete_events(create_monotonic_events(vec![
-            DeleteRangeTombstone::new(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
-            DeleteRangeTombstone::new(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
+            DeleteRangeTombstone::new_for_test(table_id, b"k".to_vec(), b"kkk".to_vec(), 100),
+            DeleteRangeTombstone::new_for_test(table_id, b"aaa".to_vec(), b"ddd".to_vec(), 200),
         ]));
         let builder = CapacitySplitTableBuilder::new(
             LocalTableBuilderFactory::new(1001, mock_sstable_store(), opts),

--- a/src/storage/src/hummock/test_utils.rs
+++ b/src/storage/src/hummock/test_utils.rs
@@ -20,7 +20,7 @@ use futures::{Stream, TryStreamExt};
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
 use risingwave_common::must_match;
-use risingwave_hummock_sdk::key::{FullKey, UserKey};
+use risingwave_hummock_sdk::key::{FullKey, PointRange, UserKey};
 use risingwave_hummock_sdk::{HummockEpoch, HummockSstableObjectId};
 use risingwave_pb::hummock::{KeyRange, SstableInfo};
 
@@ -235,15 +235,13 @@ pub async fn gen_test_sstable_inner<B: AsRef<[u8]> + Clone + Default + Eq>(
         }
 
         let mut earliest_delete_epoch = HummockEpoch::MAX;
+        let extended_user_key = PointRange::from_user_key(key.user_key.as_ref(), false);
         for range_tombstone in &range_tombstones {
             if range_tombstone
                 .start_user_key
                 .as_ref()
-                .le(&key.user_key.as_ref())
-                && range_tombstone
-                    .end_user_key
-                    .as_ref()
-                    .gt(&key.user_key.as_ref())
+                .le(&extended_user_key)
+                && range_tombstone.end_user_key.as_ref().gt(&extended_user_key)
                 && range_tombstone.sequence >= key.epoch
                 && range_tombstone.sequence < earliest_delete_epoch
             {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
We will need to support delete range type other than the typical left-closed-right-open range due to watermark on desc columns.

We introduce `ExtendedUserKey` in our `MonotonicDelete` design. We treat the right neighbourhood space of a user key as a new user key, and both type of user key are called `ExtendedUserKey`.
`ExtendedUserKey` represents the user key itself if `is_right_neighbourhood_of_key==false`
while represents the right δ Neighborhood of the user key if `is_right_neighbourhood_of_key==true`.

Simply replacing `UserKey` with `ExtendedUserKey` helps us resolve queries and compaction on the new type of delete range.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
