### PR TITLE
fix(memory-manager): should not use prev_memory_stats.streaming_memory_usage

### DIFF
--- a/risedev.yml
+++ b/risedev.yml
@@ -778,13 +778,6 @@ template:
     # Total available memory for the compute node in bytes
     total-memory-bytes: 8589934592
 
-    # The policy for compute node memory control.
-    memory-control-policy: streaming-only
-
-    #  The proportion of streaming memory to all available memory for computing. Only works when
-    # `memory_control_policy` is set to "streaming-batch".
-    streaming-memory-proportion: 0.7
-
     # Parallelism of tasks per compute node
     parallelism: 4
 

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -84,22 +84,6 @@ pub struct ComputeNodeOpts {
     #[clap(long, env = "RW_PARALLELISM", default_value_t = default_parallelism())]
     pub parallelism: usize,
 
-    /// The policy for compute node memory control. Valid values:
-    /// - streaming-only
-    /// - streaming-batch
-    #[clap(
-        long,
-        env = "RW_MEMORY_CONTROL_POLICY",
-        default_value = "streaming-only"
-    )]
-    pub memory_control_policy: String,
-
-    /// The proportion of streaming memory to all available memory for computing. Only works when
-    /// `memory_control_policy` is set to "streaming-batch". Ignored otherwise. See
-    /// [`FixedProportionPolicy`] for more details.
-    #[clap(long, env = "RW_STREAMING_MEMORY_PROPORTION", default_value_t = 0.7)]
-    pub streaming_memory_proportion: f64,
-
     #[clap(flatten)]
     override_config: OverrideConfigOpts,
 }

--- a/src/compute/src/memory_management/memory_manager.rs
+++ b/src/compute/src/memory_management/memory_manager.rs
@@ -21,7 +21,7 @@ use risingwave_common::util::epoch::Epoch;
 use risingwave_stream::executor::monitor::StreamingMetrics;
 use risingwave_stream::task::LocalStreamManager;
 
-use super::MemoryControlPolicy;
+use super::MemoryControlRef;
 use crate::memory_management::MemoryControlStats;
 
 /// Compute node uses [`GlobalMemoryManager`] to limit the memory usage.
@@ -35,7 +35,7 @@ pub struct GlobalMemoryManager {
     barrier_interval_ms: u32,
     metrics: Arc<StreamingMetrics>,
     /// The memory control policy for computing tasks.
-    memory_control_policy: MemoryControlPolicy,
+    memory_control_policy: MemoryControlRef,
 }
 
 pub type GlobalMemoryManagerRef = Arc<GlobalMemoryManager>;
@@ -45,7 +45,7 @@ impl GlobalMemoryManager {
         total_compute_memory_bytes: usize,
         barrier_interval_ms: u32,
         metrics: Arc<StreamingMetrics>,
-        memory_control_policy: MemoryControlPolicy,
+        memory_control_policy: MemoryControlRef,
     ) -> Arc<Self> {
         // Arbitrarily set a minimal barrier interval in case it is too small,
         // especially when it's 0.
@@ -81,8 +81,6 @@ impl GlobalMemoryManager {
             tokio::time::interval(Duration::from_millis(self.barrier_interval_ms as u64));
 
         let mut memory_control_stats = MemoryControlStats {
-            batch_memory_usage: 0,
-            streaming_memory_usage: 0,
             jemalloc_allocated_mib: 0,
             lru_watermark_step: 0,
             lru_watermark_time_ms: Epoch::physical_now(),

--- a/src/compute/src/memory_management/mod.rs
+++ b/src/compute/src/memory_management/mod.rs
@@ -62,7 +62,7 @@ pub trait MemoryControl: Send + Sync {
     fn apply(
         &self,
         total_compute_memory_bytes: usize,
-        barrier_interval_ms: u32,
+        interval_ms: u32,
         prev_memory_stats: MemoryControlStats,
         batch_manager: Arc<BatchManager>,
         stream_manager: Arc<LocalStreamManager>,
@@ -107,7 +107,7 @@ impl MemoryControl for DummyPolicy {
     fn apply(
         &self,
         _total_compute_memory_bytes: usize,
-        _barrier_interval_ms: u32,
+        _interval_ms: u32,
         _prev_memory_stats: MemoryControlStats,
         _batch_manager: Arc<BatchManager>,
         _stream_manager: Arc<LocalStreamManager>,

--- a/src/compute/src/memory_management/mod.rs
+++ b/src/compute/src/memory_management/mod.rs
@@ -47,12 +47,9 @@ pub const STORAGE_SHARED_BUFFER_MEMORY_PROPORTION: f64 = 0.5;
 pub const STORAGE_FILE_CACHE_MEMORY_PROPORTION: f64 = 0.1;
 pub const STORAGE_DEFAULT_HIGH_PRIORITY_BLOCK_CACHE_RATIO: usize = 70;
 
-/// `MemoryControlStats` contains the necessary information for memory control, including both batch
-/// and streaming.
+/// `MemoryControlStats` contains the necessary information for memory control
 #[derive(Default)]
 pub struct MemoryControlStats {
-    pub batch_memory_usage: usize,
-    pub streaming_memory_usage: usize,
     pub jemalloc_allocated_mib: usize,
     pub lru_watermark_step: u64,
     pub lru_watermark_time_ms: u64,

--- a/src/compute/src/memory_management/policy.rs
+++ b/src/compute/src/memory_management/policy.rs
@@ -24,115 +24,18 @@ use risingwave_stream::task::LocalStreamManager;
 
 use super::{MemoryControl, MemoryControlStats};
 
-/// `FixedProportionPolicy` performs memory control by limiting the memory usage of both batch and
-/// streaming to a fixed proportion.
-pub struct FixedProportionPolicy {
-    /// The proportion of streaming memory to all available memory for computing. This should
-    /// always fall in (0, 1). The proportion of batch memory will be 1
-    /// -`streaming_memory_proportion`.
-    streaming_memory_proportion: f64,
-}
+/// `JemallocMemoryControl` is a memory control policy that uses jemalloc statistics to control. It
+/// assumes that most memory is used by streaming engine and does memory control over LRU watermark
+/// based on jemalloc statistics.
+pub struct JemallocMemoryControl;
 
-impl FixedProportionPolicy {
-    const BATCH_KILL_QUERY_THRESHOLD: f64 = 0.8;
-    pub const CONFIG_STR: &str = "streaming-batch";
-    const STREAM_EVICTION_THRESHOLD_AGGRESSIVE: f64 = 0.9;
-    const STREAM_EVICTION_THRESHOLD_GRACEFUL: f64 = 0.7;
-
-    pub fn new(streaming_memory_proportion: f64) -> Result<Self> {
-        if streaming_memory_proportion <= 0.0 || streaming_memory_proportion >= 1.0 {
-            return Err(anyhow!("streaming memory proportion should fall in (0, 1)").into());
-        }
-        Ok(Self {
-            streaming_memory_proportion,
-        })
-    }
-}
-
-impl MemoryControl for FixedProportionPolicy {
-    fn apply(
-        &self,
-        total_compute_memory_bytes: usize,
-        barrier_interval_ms: u32,
-        prev_memory_stats: MemoryControlStats,
-        batch_manager: Arc<BatchManager>,
-        stream_manager: Arc<LocalStreamManager>,
-        watermark_epoch: Arc<AtomicU64>,
-    ) -> MemoryControlStats {
-        let batch_memory_proportion = 1.0 - self.streaming_memory_proportion;
-        let total_batch_memory_bytes = total_compute_memory_bytes as f64 * batch_memory_proportion;
-        let batch_memory_threshold =
-            (total_batch_memory_bytes * Self::BATCH_KILL_QUERY_THRESHOLD) as usize;
-        let total_stream_memory_bytes =
-            total_compute_memory_bytes as f64 * self.streaming_memory_proportion;
-        let stream_memory_threshold_graceful =
-            (total_stream_memory_bytes * Self::STREAM_EVICTION_THRESHOLD_GRACEFUL) as usize;
-        let stream_memory_threshold_aggressive =
-            (total_stream_memory_bytes * Self::STREAM_EVICTION_THRESHOLD_AGGRESSIVE) as usize;
-
-        let jemalloc_allocated_mib =
-            advance_jemalloc_epoch(prev_memory_stats.jemalloc_allocated_mib);
-
-        // Batch memory control
-        //
-        // When the batch memory usage exceeds the threshold, we choose the query that uses the
-        // most memory and kill it.
-
-        let batch_used_memory_bytes = batch_manager.total_mem_usage();
-        if batch_used_memory_bytes > batch_memory_threshold {
-            batch_manager.kill_queries("excessive batch memory usage".to_string());
-        }
-
-        // Streaming memory control
-        //
-        // We calculate the watermark of the LRU cache, which provides hints for streaming executors
-        // on cache eviction.
-
-        let stream_used_memory_bytes = stream_manager.total_mem_usage();
-        let (lru_watermark_step, lru_watermark_time_ms, lru_physical_now) = calculate_lru_watermark(
-            stream_used_memory_bytes,
-            stream_memory_threshold_graceful,
-            stream_memory_threshold_aggressive,
-            barrier_interval_ms,
-            prev_memory_stats,
-        );
-        set_lru_watermark_time_ms(watermark_epoch, lru_watermark_time_ms);
-
-        MemoryControlStats {
-            batch_memory_usage: batch_used_memory_bytes,
-            streaming_memory_usage: stream_used_memory_bytes,
-            jemalloc_allocated_mib,
-            lru_watermark_step,
-            lru_watermark_time_ms,
-            lru_physical_now_ms: lru_physical_now,
-        }
-    }
-
-    fn describe(&self, total_compute_memory_bytes: usize) -> String {
-        let total_stream_memory_bytes =
-            total_compute_memory_bytes as f64 * self.streaming_memory_proportion;
-        let total_batch_memory_bytes =
-            total_compute_memory_bytes as f64 * (1.0 - self.streaming_memory_proportion);
-        format!(
-            "FixedProportionPolicy: total available streaming memory is {}, total available batch memory is {}",
-            convert(total_stream_memory_bytes),
-            convert(total_batch_memory_bytes)
-        )
-    }
-}
-/// `StreamingOnlyPolicy` only performs memory control on streaming tasks. It differs from
-/// `FixedProportionPolicy` in that it calculates the memory usage based on jemalloc statistics,
-/// which actually contains system usage other than computing tasks. This is the default memory
-/// control policy.
-pub struct StreamingOnlyPolicy;
-
-impl StreamingOnlyPolicy {
+impl JemallocMemoryControl {
     pub const CONFIG_STR: &str = "streaming-only";
     const STREAM_EVICTION_THRESHOLD_AGGRESSIVE: f64 = 0.9;
     const STREAM_EVICTION_THRESHOLD_GRACEFUL: f64 = 0.7;
 }
 
-impl MemoryControl for StreamingOnlyPolicy {
+impl MemoryControl for JemallocMemoryControl {
     fn apply(
         &self,
         total_compute_memory_bytes: usize,
@@ -176,7 +79,7 @@ impl MemoryControl for StreamingOnlyPolicy {
 
     fn describe(&self, total_compute_memory_bytes: usize) -> String {
         format!(
-            "StreamingOnlyPolicy: total available streaming memory is {}",
+            "JemallocMemoryControl: total available streaming memory is {}",
             convert(total_compute_memory_bytes as f64)
         )
     }

--- a/src/compute/src/memory_management/policy.rs
+++ b/src/compute/src/memory_management/policy.rs
@@ -38,7 +38,7 @@ impl MemoryControl for JemallocMemoryControl {
         total_compute_memory_bytes: usize,
         barrier_interval_ms: u32,
         prev_memory_stats: MemoryControlStats,
-        batch_manager: Arc<BatchManager>,
+        _batch_manager: Arc<BatchManager>,
         _stream_manager: Arc<LocalStreamManager>,
         watermark_epoch: Arc<AtomicU64>,
     ) -> MemoryControlStats {

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -62,8 +62,7 @@ use tokio::task::JoinHandle;
 
 use crate::memory_management::memory_manager::GlobalMemoryManager;
 use crate::memory_management::{
-    memory_control_policy_from_config, reserve_memory_bytes, storage_memory_config,
-    MIN_COMPUTE_MEMORY_MB,
+    build_memory_control_policy, reserve_memory_bytes, storage_memory_config, MIN_COMPUTE_MEMORY_MB,
 };
 use crate::observer::observer_manager::ComputeObserverNode;
 use crate::rpc::service::config_service::ConfigServiceImpl;
@@ -134,7 +133,15 @@ pub async fn compute_node_serve(
         reserved_memory_bytes,
     );
 
-    let memory_control_policy = memory_control_policy_from_config(&opts).unwrap();
+    // NOTE: Due to some limits, we use `compute_memory_bytes + storage_memory_bytes` as
+    // `total_compute_memory_bytes` for memory control. This is just a workaround for some
+    // memory control issues and should be modified as soon as we figure out a better solution.
+    //
+    // Related issues:
+    // - https://github.com/risingwavelabs/risingwave/issues/8696
+    // - https://github.com/risingwavelabs/risingwave/issues/8822
+    let total_memory_bytes = compute_memory_bytes + storage_memory_bytes;
+    let memory_control_policy = build_memory_control_policy(total_memory_bytes).unwrap();
 
     let storage_opts = Arc::new(StorageOpts::from((
         &config,
@@ -276,15 +283,7 @@ pub async fn compute_node_serve(
     let batch_mgr_clone = batch_mgr.clone();
     let stream_mgr_clone = stream_mgr.clone();
 
-    // NOTE: Due to some limits, we use `compute_memory_bytes + storage_memory_bytes` as
-    // `total_compute_memory_bytes` for memory control. This is just a workaround for some
-    // memory control issues and should be modified as soon as we figure out a better solution.
-    //
-    // Related issues:
-    // - https://github.com/risingwavelabs/risingwave/issues/8696
-    // - https://github.com/risingwavelabs/risingwave/issues/8822
     let memory_mgr = GlobalMemoryManager::new(
-        compute_memory_bytes + storage_memory_bytes,
         system_params.barrier_interval_ms(),
         streaming_metrics.clone(),
         memory_control_policy,

--- a/src/risedevtool/src/service_config.rs
+++ b/src/risedevtool/src/service_config.rs
@@ -40,8 +40,6 @@ pub struct ComputeNodeConfig {
     pub connector_rpc_endpoint: String,
 
     pub total_memory_bytes: usize,
-    pub memory_control_policy: String,
-    pub streaming_memory_proportion: f64,
     pub parallelism: usize,
 }
 

--- a/src/risedevtool/src/task/compute_node_service.rs
+++ b/src/risedevtool/src/task/compute_node_service.rs
@@ -61,11 +61,7 @@ impl ComputeNodeService {
             .arg("--parallelism")
             .arg(&config.parallelism.to_string())
             .arg("--total-memory-bytes")
-            .arg(&config.total_memory_bytes.to_string())
-            .arg("--memory-control-policy")
-            .arg(&config.memory_control_policy)
-            .arg("--streaming-memory-proportion")
-            .arg(&config.streaming_memory_proportion.to_string());
+            .arg(&config.total_memory_bytes.to_string());
 
         let provide_jaeger = config.provide_jaeger.as_ref().unwrap();
         match provide_jaeger.len() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #9383.

This PR also reverts #8253 and #8475 but keeps the `trait MemoryControlPolicy` (renamed to "MemoryControl") for possible future usage.

The reason of that is, we are not actually ready for such "MemoryControlPolicy" right now. Back to that point when we wrote #8253 and #8475, we didn't realize that these policy cannot work at all without a better memory estimation.

After that, when #8827 merged, things become worse. Code of #8827 mixed up 2 things: 
- the **machanism of measuring** current memory usage 
- and the **policy** about how the memory should be used

... which made that part of code become quite error-prone. I think #9383 is one of its result.

(As you may see, I renamed `StreamingOnlyPolicy` to `JemallocMemoryControl` to emphasize it is a **machanism of measuring** rather than **policy**)

In my mind, This is a typical case of over-design or premature design. Thus, I strongly tend to remove these unused code and keep it simple and clear. We can add them back when memory estimation is ready, at which time we should get rid of `JemallocMemoryControl` and add back "StreamingOnlyPolicy" and "StreamingBatchPolicy".

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation
 My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
