### PR TITLE
fix(common): panic during large f64 to decimal conversion

### DIFF
--- a/e2e_test/batch/types/interoperate_decimal_float.slt.part
+++ b/e2e_test/batch/types/interoperate_decimal_float.slt.part
@@ -1,0 +1,77 @@
+query TT
+select v::varchar, pg_typeof(v) from (select '1.0'::decimal + '-1'::float4) as t(v);
+----
+0 double precision
+
+query TT
+select v::varchar, pg_typeof(v) from (select '1.0'::decimal - '1'::float4) as t(v);
+----
+0 double precision
+
+query TT
+select v::varchar, pg_typeof(v) from (select '0.0'::decimal * '1'::float4) as t(v);
+----
+0 double precision
+
+query TT
+select v::varchar, pg_typeof(v) from (select '0.0'::decimal / '1'::float4) as t(v);
+----
+0 double precision
+
+statement error
+select '0.0'::decimal % '1'::float4;
+
+query TTT
+select a < b, a::float8, b::float8 from (select '1.1'::decimal, '1.1'::float4) as t(a, b);
+----
+t 1.1 1.100000023841858
+
+query T
+select '1.0'::decimal = '1.0'::float4;
+----
+t
+
+query T
+select '1.0'::decimal <> '1.0'::float4;
+----
+f
+
+query T
+select '1.0'::decimal > '2.0'::float4;
+----
+f
+
+query T
+select '1.0'::decimal <= '2.1'::float4;
+----
+t
+
+query T
+select '1.0'::decimal >= '2.1'::float4;
+----
+f
+
+query T
+select '1.0'::decimal < '2.1'::float4;
+----
+t
+
+query T
+select '1.0'::decimal is distinct from '2.0'::float4;
+----
+t
+
+query T
+select '1.0'::decimal is distinct from null::float4;
+----
+t
+
+query T
+select '1.0'::decimal is distinct from '1.0'::float4;
+----
+f
+
+query T
+select null::decimal is distinct from null::float4;
+----
+f

--- a/e2e_test/batch/types/interoperate_decimal_float.slt.part
+++ b/e2e_test/batch/types/interoperate_decimal_float.slt.part
@@ -21,6 +21,20 @@ select v::varchar, pg_typeof(v) from (select '0.0'::decimal / '1'::float4) as t(
 statement error
 select '0.0'::decimal % '1'::float4;
 
+# Although arithmetic (and comparison) between decimal and float4 is handled by float8,
+# their union is still float4
+
+query T
+with t(v) as (values (1::real), (1::decimal)) select pg_typeof(v) from t;
+----
+real
+real
+
+query T
+select pg_typeof(array[1::real, 1::decimal]);
+----
+real[]
+
 query TTT
 select a < b, a::float8, b::float8 from (select '1.1'::decimal, '1.1'::float4) as t(a, b);
 ----

--- a/e2e_test/batch/types/interoperate_decimal_float.slt.part
+++ b/e2e_test/batch/types/interoperate_decimal_float.slt.part
@@ -1,3 +1,5 @@
+# Arithmetic
+
 query TT
 select v::varchar, pg_typeof(v) from (select '1.0'::decimal + '-1'::float4) as t(v);
 ----
@@ -34,6 +36,8 @@ query T
 select pg_typeof(array[1::real, 1::decimal]);
 ----
 real[]
+
+# Comparison
 
 query TTT
 select a < b, a::float8, b::float8 from (select '1.1'::decimal, '1.1'::float4) as t(a, b);
@@ -89,3 +93,13 @@ query T
 select null::decimal is distinct from null::float4;
 ----
 f
+
+# Out of range
+statement error
+select '1e29'::float4::decimal;
+
+statement error
+select '1e29'::jsonb::decimal;
+
+statement error
+select '1e309'::decimal > '1'::float4;

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -191,14 +191,14 @@ macro_rules! impl_try_from_float {
             type Error = Error;
 
             fn try_from(value: $from_ty) -> Result<Self, Self::Error> {
-                $convert(value).ok_or_else(|| Error::ConversionTo("".into()))
+                $convert(value).ok_or_else(|| Error::ConversionTo("decimal".into()))
             }
         }
         impl core::convert::TryFrom<OrderedFloat<$from_ty>> for $to_ty {
             type Error = Error;
 
             fn try_from(value: OrderedFloat<$from_ty>) -> Result<Self, Self::Error> {
-                $convert(value.0).ok_or_else(|| Error::ConversionTo("".into()))
+                $convert(value.0).ok_or_else(|| Error::ConversionTo("decimal".into()))
             }
         }
     };

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -220,6 +220,12 @@ impl_try_from_decimal!(Decimal, f64, Decimal::to_f64, "Failed to convert to f64"
 impl_try_from_float!(f32, Decimal, Decimal::from_f32);
 impl_try_from_float!(f64, Decimal, Decimal::from_f64);
 
+impl From<crate::types::Decimal> for OrderedFloat<f64> {
+    fn from(n: crate::types::Decimal) -> Self {
+        n.to_f64().map_or(Self(f64::NAN), Self)
+    }
+}
+
 impl FromPrimitive for Decimal {
     impl_from_integer!([
         (u8, from_u8),

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -187,14 +187,18 @@ macro_rules! impl_try_from_decimal {
 
 macro_rules! impl_try_from_float {
     ($from_ty:ty, $to_ty:ty, $convert:path) => {
-        impl core::convert::From<$from_ty> for $to_ty {
-            fn from(value: $from_ty) -> Self {
-                $convert(value).expect("f32/f64 to decimal should not fail")
+        impl core::convert::TryFrom<$from_ty> for $to_ty {
+            type Error = Error;
+
+            fn try_from(value: $from_ty) -> Result<Self, Self::Error> {
+                $convert(value).ok_or_else(|| Error::ConversionTo("".into()))
             }
         }
-        impl core::convert::From<OrderedFloat<$from_ty>> for $to_ty {
-            fn from(value: OrderedFloat<$from_ty>) -> Self {
-                $convert(value.0).expect("f32/f64 to decimal should not fail")
+        impl core::convert::TryFrom<OrderedFloat<$from_ty>> for $to_ty {
+            type Error = Error;
+
+            fn try_from(value: OrderedFloat<$from_ty>) -> Result<Self, Self::Error> {
+                $convert(value.0).ok_or_else(|| Error::ConversionTo("".into()))
             }
         }
     };

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -1049,8 +1049,6 @@ mod impl_as_primitive {
 
     impl_as_primitive_for!(f32);
     impl_as_primitive_for!(f64);
-
-    impl_as_primitive_for!(crate::types::Decimal);
 }
 
 mod impl_from {
@@ -1114,12 +1112,6 @@ mod impl_from {
 impl From<i64> for OrderedFloat<f64> {
     fn from(n: i64) -> Self {
         AsPrimitive::<OrderedFloat<f64>>::as_(n)
-    }
-}
-
-impl From<crate::types::Decimal> for OrderedFloat<f64> {
-    fn from(n: crate::types::Decimal) -> Self {
-        n.to_f64().map_or(Self(f64::NAN), Self)
     }
 }
 

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -95,7 +95,6 @@ where
 
 #[function("modulus(*int, *int) -> auto")]
 #[function("modulus(*numeric, *numeric) -> auto")]
-#[function("modulus(*float, *float) -> auto")]
 #[function("modulus(int256, int256) -> int256")]
 pub fn general_mod<T1, T2, T3>(l: T1, r: T2) -> Result<T3>
 where
@@ -452,22 +451,6 @@ mod tests {
         assert_eq!(general_mod::<i16, i32, i32>(1i16, 1i32).unwrap(), 0i32);
         assert_eq!(general_neg::<i16>(1i16).unwrap(), -1i16);
 
-        assert_eq!(
-            general_add::<Decimal, F32, F64>(dec("1.0"), (-1f32).into()).unwrap(),
-            0.0f64
-        );
-        assert_eq!(
-            general_sub::<Decimal, F32, F64>(dec("1.0"), 1f32.into()).unwrap(),
-            0.0f64
-        );
-        assert_eq!(
-            general_div::<Decimal, F32, F64>(dec("0.0"), 1f32.into()).unwrap(),
-            0.0f64
-        );
-        assert_eq!(
-            general_mul::<Decimal, F32, F64>(dec("0.0"), 1f32.into()).unwrap(),
-            0.0f64
-        );
         assert!(general_add::<i32, F32, F64>(-1i32, 1f32.into())
             .unwrap()
             .is_zero());

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -453,24 +453,20 @@ mod tests {
         assert_eq!(general_neg::<i16>(1i16).unwrap(), -1i16);
 
         assert_eq!(
-            general_add::<Decimal, f32, Decimal>(dec("1.0"), -1f32).unwrap(),
-            dec("0.0")
+            general_add::<Decimal, F32, F64>(dec("1.0"), (-1f32).into()).unwrap(),
+            0.0f64
         );
         assert_eq!(
-            general_sub::<Decimal, f32, Decimal>(dec("1.0"), 1f32).unwrap(),
-            dec("0.0")
+            general_sub::<Decimal, F32, F64>(dec("1.0"), 1f32.into()).unwrap(),
+            0.0f64
         );
         assert_eq!(
-            general_div::<Decimal, f32, Decimal>(dec("0.0"), 1f32).unwrap(),
-            dec("0.0")
+            general_div::<Decimal, F32, F64>(dec("0.0"), 1f32.into()).unwrap(),
+            0.0f64
         );
         assert_eq!(
-            general_mul::<Decimal, f32, Decimal>(dec("0.0"), 1f32).unwrap(),
-            dec("0.0")
-        );
-        assert_eq!(
-            general_mod::<Decimal, f32, Decimal>(dec("0.0"), 1f32).unwrap(),
-            dec("0.0")
+            general_mul::<Decimal, F32, F64>(dec("0.0"), 1f32.into()).unwrap(),
+            0.0f64
         );
         assert!(general_add::<i32, F32, F64>(-1i32, 1f32.into())
             .unwrap()

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -352,8 +352,9 @@ pub fn jsonb_to_bool(v: JsonbRef<'_>) -> Result<bool> {
 #[function("cast(jsonb) -> decimal")]
 pub fn jsonb_to_dec(v: JsonbRef<'_>) -> Result<Decimal> {
     v.as_number()
-        .map_err(|e| ExprError::Parse(e.into()))
-        .map(Into::into)
+        .map_err(|e| ExprError::Parse(e.into()))?
+        .try_into()
+        .map_err(|_| ExprError::NumericOutOfRange)
 }
 
 /// Similar to and an result of [`define_cast_to_primitive`] macro above.
@@ -407,6 +408,8 @@ pub fn interval_to_time(elem: Interval) -> Time {
 #[function("cast(int64) -> int16")]
 #[function("cast(int64) -> int32")]
 #[function("cast(int64) -> float64")]
+#[function("cast(float32) -> decimal")]
+#[function("cast(float64) -> decimal")]
 pub fn try_cast<T1, T2>(elem: T1) -> Result<T2>
 where
     T1: TryInto<T2> + std::fmt::Debug + Copy,
@@ -426,8 +429,6 @@ where
 #[function("cast(int32) -> decimal")]
 #[function("cast(int64) -> decimal")]
 #[function("cast(float32) -> float64")]
-#[function("cast(float32) -> decimal")]
-#[function("cast(float64) -> decimal")]
 #[function("cast(date) -> timestamp")]
 #[function("cast(time) -> interval")]
 #[function("cast(varchar) -> varchar")]

--- a/src/expr/src/vector_op/cmp.rs
+++ b/src/expr/src/vector_op/cmp.rs
@@ -377,35 +377,36 @@ mod tests {
 
     #[test]
     fn test_deci_f() {
-        assert!(general_eq::<_, _, Decimal>(
+        // A subtle case that 1.1f32 -> f64 is larger than 1.1f64
+        assert!(general_lt::<Decimal, F32, F64>(
             Decimal::from_str("1.1").unwrap(),
-            1.1f32
+            1.1f32.into(),
         ))
     }
 
     #[test]
     fn test_comparison() {
         assert!(general_eq::<Decimal, i32, Decimal>(dec("1.0"), 1));
-        assert!(general_eq::<Decimal, f32, Decimal>(dec("1.0"), 1.0));
+        assert!(general_eq::<Decimal, F32, F64>(dec("1.0"), 1.0.into()));
         assert!(!general_ne::<Decimal, i32, Decimal>(dec("1.0"), 1));
-        assert!(!general_ne::<Decimal, f32, Decimal>(dec("1.0"), 1.0));
+        assert!(!general_ne::<Decimal, F32, F64>(dec("1.0"), 1.0.into()));
         assert!(!general_gt::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(!general_gt::<Decimal, f32, Decimal>(dec("1.0"), 2.0));
+        assert!(!general_gt::<Decimal, F32, F64>(dec("1.0"), 2.0.into()));
         assert!(general_le::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(general_le::<Decimal, f32, Decimal>(dec("1.0"), 2.1));
+        assert!(general_le::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(!general_ge::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(!general_ge::<Decimal, f32, Decimal>(dec("1.0"), 2.1));
+        assert!(!general_ge::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(general_lt::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(general_lt::<Decimal, f32, Decimal>(dec("1.0"), 2.1));
+        assert!(general_lt::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(general_is_distinct_from::<Decimal, i32, Decimal>(
             Some(dec("1.0")),
             Some(2)
         ));
-        assert!(general_is_distinct_from::<Decimal, f32, Decimal>(
+        assert!(general_is_distinct_from::<Decimal, F32, F64>(
             Some(dec("1.0")),
-            Some(2.0)
+            Some(2.0.into())
         ));
-        assert!(general_is_distinct_from::<Decimal, f32, Decimal>(
+        assert!(general_is_distinct_from::<Decimal, F32, F64>(
             Some(dec("1.0")),
             None
         ));
@@ -417,13 +418,11 @@ mod tests {
             Some(dec("1.0")),
             Some(1)
         ));
-        assert!(!general_is_distinct_from::<Decimal, f32, Decimal>(
+        assert!(!general_is_distinct_from::<Decimal, F32, F64>(
             Some(dec("1.0")),
-            Some(1.0)
+            Some(1.0.into())
         ));
-        assert!(!general_is_distinct_from::<Decimal, f32, Decimal>(
-            None, None
-        ));
+        assert!(!general_is_distinct_from::<Decimal, F32, F64>(None, None));
         assert!(general_eq::<F32, i32, F64>(1.0.into(), 1));
         assert!(!general_ne::<F32, i32, F64>(1.0.into(), 1));
         assert!(!general_lt::<F32, i32, F64>(1.0.into(), 1));

--- a/src/expr/src/vector_op/cmp.rs
+++ b/src/expr/src/vector_op/cmp.rs
@@ -376,39 +376,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_deci_f() {
-        // A subtle case that 1.1f32 -> f64 is larger than 1.1f64
-        assert!(general_lt::<Decimal, F32, F64>(
-            Decimal::from_str("1.1").unwrap(),
-            1.1f32.into(),
-        ))
-    }
-
-    #[test]
     fn test_comparison() {
         assert!(general_eq::<Decimal, i32, Decimal>(dec("1.0"), 1));
-        assert!(general_eq::<Decimal, F32, F64>(dec("1.0"), 1.0.into()));
         assert!(!general_ne::<Decimal, i32, Decimal>(dec("1.0"), 1));
-        assert!(!general_ne::<Decimal, F32, F64>(dec("1.0"), 1.0.into()));
         assert!(!general_gt::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(!general_gt::<Decimal, F32, F64>(dec("1.0"), 2.0.into()));
         assert!(general_le::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(general_le::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(!general_ge::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(!general_ge::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(general_lt::<Decimal, i32, Decimal>(dec("1.0"), 2));
-        assert!(general_lt::<Decimal, F32, F64>(dec("1.0"), 2.1.into()));
         assert!(general_is_distinct_from::<Decimal, i32, Decimal>(
             Some(dec("1.0")),
             Some(2)
-        ));
-        assert!(general_is_distinct_from::<Decimal, F32, F64>(
-            Some(dec("1.0")),
-            Some(2.0.into())
-        ));
-        assert!(general_is_distinct_from::<Decimal, F32, F64>(
-            Some(dec("1.0")),
-            None
         ));
         assert!(general_is_distinct_from::<Decimal, i32, Decimal>(
             None,
@@ -418,11 +395,6 @@ mod tests {
             Some(dec("1.0")),
             Some(1)
         ));
-        assert!(!general_is_distinct_from::<Decimal, F32, F64>(
-            Some(dec("1.0")),
-            Some(1.0.into())
-        ));
-        assert!(!general_is_distinct_from::<Decimal, F32, F64>(None, None));
         assert!(general_eq::<F32, i32, F64>(1.0.into(), 1));
         assert!(!general_ne::<F32, i32, F64>(1.0.into(), 1));
         assert!(!general_lt::<F32, i32, F64>(1.0.into(), 1));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #9214. Replace `From<F64> for Decimal` with `TryFrom<F64> for Decimal`.

This PR also moves unit tests of arithmetic and comparison between decimal and float4 to e2e tests. In reality, they are not compared directly using the `T1: Into<T3>` and `T2: Into<T3>`, but by implicit cast expressions inserted by frontend. It also benefits the separation of fallible and infallible expression, so that comparison remain infallible while casts can fail.

This PR focuses on fixing this specific float to decimal issue. There will be more refactor PRs to follow, to clarify when frontend implicit casts (decimal < float4) or backend interoperation (float8 < float4) is actually effective, and to deprecate `AsPrimitive`/`FromPrimitive`/`ToPrimitive`/`NumCast` from `num-traits` (because it always returns `Option` and thus encouraging unthoughtful `unwrap`) in factor of fine granular `From` / `TryFrom`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
