### PR TITLE
feat: support show functions

### DIFF
--- a/e2e_test/udf/python.slt
+++ b/e2e_test/udf/python.slt
@@ -49,6 +49,20 @@ create function jsonb_access(jsonb, int) returns jsonb language python as jsonb_
 statement ok
 create function jsonb_concat(jsonb[]) returns jsonb language python as jsonb_concat using link 'http://localhost:8815';
 
+query TTTTT rowsort
+show functions
+----
+array_access varchar[], integer varchar python http://localhost:8815
+extract_tcp_info bytea struct<src_ip varchar,dst_ip varchar,src_port smallint,dst_port smallint> python http://localhost:8815
+gcd integer, integer integer python http://localhost:8815
+gcd integer, integer, integer integer python http://localhost:8815
+hex_to_dec varchar numeric python http://localhost:8815
+int_42 (empty) integer python http://localhost:8815
+jsonb_access jsonb, integer jsonb python http://localhost:8815
+jsonb_concat jsonb[] jsonb python http://localhost:8815
+series integer integer python http://localhost:8815
+series2 integer struct<x integer,y varchar> python http://localhost:8815
+
 query I
 select int_42();
 ----

--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -410,6 +410,10 @@ impl SchemaCatalog {
         self.view_by_name.values()
     }
 
+    pub fn iter_function(&self) -> impl Iterator<Item = &Arc<FunctionCatalog>> {
+        self.function_by_name.values().flat_map(|v| v.values())
+    }
+
     pub fn iter_connections(&self) -> impl Iterator<Item = &Arc<ConnectionCatalog>> {
         self.connection_by_name.values()
     }

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -187,6 +187,53 @@ pub fn handle_show_object(handler_args: HandlerArgs, command: ShowObject) -> Res
                 ],
             ));
         }
+        ShowObject::Function { schema } => {
+            let rows = catalog_reader
+                .get_schema_by_name(session.database(), &schema_or_default(&schema))?
+                .iter_function()
+                .map(|t| {
+                    Row::new(vec![
+                        Some(t.name.clone().into()),
+                        Some(t.arg_types.iter().map(|t| t.to_string()).join(", ").into()),
+                        Some(t.return_type.to_string().into()),
+                        Some(t.language.clone().into()),
+                        Some(t.link.clone().into()),
+                    ])
+                })
+                .collect_vec();
+            return Ok(PgResponse::new_for_stream(
+                StatementType::SHOW_COMMAND,
+                None,
+                rows.into(),
+                vec![
+                    PgFieldDescriptor::new(
+                        "Name".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Arguments".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Return Type".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Language".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Link".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                ],
+            ));
+        }
     };
 
     let rows = names

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -778,6 +778,7 @@ pub enum ShowObject {
     Sink { schema: Option<Ident> },
     Columns { table: ObjectName },
     Connection { schema: Option<Ident> },
+    Function { schema: Option<Ident> },
 }
 
 impl fmt::Display for ShowObject {
@@ -809,6 +810,7 @@ impl fmt::Display for ShowObject {
             ShowObject::Sink { schema } => write!(f, "SINKS{}", fmt_schema(schema)),
             ShowObject::Columns { table } => write!(f, "COLUMNS FROM {}", table),
             ShowObject::Connection { schema } => write!(f, "CONNECTIONS{}", fmt_schema(schema)),
+            ShowObject::Function { schema } => write!(f, "FUNCTIONS{}", fmt_schema(schema)),
         }
     }
 }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -234,6 +234,7 @@ define_keywords!(
     FROM,
     FULL,
     FUNCTION,
+    FUNCTIONS,
     FUSION,
     GET,
     GLOBAL,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3676,6 +3676,11 @@ impl Parser {
                         schema: self.parse_from_and_identifier()?,
                     }));
                 }
+                Keyword::FUNCTIONS => {
+                    return Ok(Statement::ShowObjects(ShowObject::Function {
+                        schema: self.parse_from_and_identifier()?,
+                    }));
+                }
                 _ => {}
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Support new sql commands `show functions`, i.e:
```sql
dev=> show functions;
       Name       |         Arguments         |                                Return Type                                | Language |         Link
------------------+---------------------------+---------------------------------------------------------------------------+----------+-----------------------
 jsonb_concat     | jsonb[]                   | jsonb                                                                     | python   | http://localhost:8815
 array_access     | varchar[], integer        | varchar                                                                   | python   | http://localhost:8815
 hex_to_dec       | varchar                   | numeric                                                                   | python   | http://localhost:8815
 gcd              | integer, integer, integer | integer                                                                   | python   | http://localhost:8815
 gcd              | integer, integer          | integer                                                                   | python   | http://localhost:8815
 extract_tcp_info | bytea                     | struct<src_ip varchar,dst_ip varchar,src_port smallint,dst_port smallint> | python   | http://localhost:8815
 int_42           |                           | integer                                                                   | python   | http://localhost:8815
 series2          | integer                   | struct<x integer,y varchar>                                               | python   | http://localhost:8815
 series           | integer                   | integer                                                                   | python   | http://localhost:8815
 jsonb_access     | jsonb, integer            | jsonb                                                                     | python   | http://localhost:8815
(10 rows)
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

Support syntax `SHOW FUNCTIONS`, it will return five fields of each function: `Name`, `Arguments`, `Return Type`, `Language` and `Link`.
