### PR TITLE
chore: Fix invalid URL that was being parsed as a relative path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Learn more at [Introduction to RisingWave](https://www.risingwave.dev/docs/curre
 
 ## RisingWave Cloud
 
-RisingWave Cloud is the fully managed service of RisingWave Database. It is now in Beta. Feel free to try out at: [risingwave.com/cloud](risingwave.com/cloud).
+RisingWave Cloud is the fully managed service of RisingWave Database. It is now in Beta. Feel free to try out at: [risingwave.com/cloud](https://risingwave.com/cloud).
 
 ## Notes on telemetry
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This pull request fixes an issue in README.md where the RisingWave Cloud URL was being incorrectly parsed as a relative path instead of a full URL. As a result, the link was not working properly. This commit updates the URL to "https://risingwave.com/cloud", ensuring that the correct absolute URL is being used. 

As an example:
-RisingWave Cloud is the fully managed service of RisingWave Database. It is now in Beta. Feel free to try out at: [risingwave.com/cloud](risingwave.com/cloud).
+RisingWave Cloud is the fully managed service of RisingWave Database. It is now in Beta. Feel free to try out at: [risingwave.com/cloud](https://risingwave.com/cloud).

This is a minor change, so please don't mind its small scope 😂.
