### PR TITLE
refactor(common): use `From`/`TryFrom` rather than `ToPrimitive`/`FromPrimitive` for floats

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -4,6 +4,9 @@ disallowed-methods = [
     { path = "futures::stream::select_all", reason = "Please use `risingwave_common::util::select_all` instead." },
     { path = "risingwave_common::array::JsonbVal::from_serde", reason = "Please add dedicated methods as part of `JsonbRef`/`JsonbVal`, rather than take inner `serde_json::Value` out, process, and put back." },
 ]
+disallowed-types = [
+    { path = "num_traits::AsPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
+]
 doc-valid-idents = [
     "RisingWave",
     "MinIO",

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,6 +6,7 @@ disallowed-methods = [
 ]
 disallowed-types = [
     { path = "num_traits::AsPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
+    { path = "num_traits::FromPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
 ]
 doc-valid-idents = [
     "RisingWave",

--- a/e2e_test/batch/types/jsonb.slt.part
+++ b/e2e_test/batch/types/jsonb.slt.part
@@ -68,12 +68,13 @@ select '2.5'::jsonb::double precision;
 ----
 2.5
 
-# This would fail after #5576 fixed
-# Because PG rounds differently for `decimal -> int` and `float8 -> int`
+# We represent numbers in jsonb as float8, while PostgreSQL uses decimal.
+# PG rounds differently for `decimal -> int` and `float8 -> int`
+# So this is different from PostgreSQL.
 query II
 select '2.5'::jsonb::smallint, '3.5'::jsonb::smallint;
 ----
-2 3
+2 4
 
 statement error cannot cast jsonb null to type boolean
 select 'null'::jsonb::bool;

--- a/src/common/src/array/mod.rs
+++ b/src/common/src/array/mod.rs
@@ -740,7 +740,6 @@ mod tests {
         assert_eq!(array.iter().collect::<Vec<Option<i32>>>(), vec![Some(60)]);
     }
 
-    use num_traits::cast::AsPrimitive;
     use num_traits::ops::checked::CheckedAdd;
 
     fn vec_add<T1, T2, T3>(
@@ -748,14 +747,14 @@ mod tests {
         b: &PrimitiveArray<T2>,
     ) -> ArrayResult<PrimitiveArray<T3>>
     where
-        T1: PrimitiveArrayItemType + AsPrimitive<T3>,
-        T2: PrimitiveArrayItemType + AsPrimitive<T3>,
-        T3: PrimitiveArrayItemType + CheckedAdd,
+        T1: PrimitiveArrayItemType,
+        T2: PrimitiveArrayItemType,
+        T3: PrimitiveArrayItemType + CheckedAdd + From<T1> + From<T2>,
     {
         let mut builder = PrimitiveArrayBuilder::<T3>::new(a.len());
         for (a, b) in a.iter().zip_eq_fast(b.iter()) {
             let item = match (a, b) {
-                (Some(a), Some(b)) => Some(a.as_() + b.as_()),
+                (Some(a), Some(b)) => Some(T3::from(a) + T3::from(b)),
                 _ => None,
             };
             builder.append(item);

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -34,6 +34,7 @@
 #![allow(incomplete_features)]
 #![feature(const_option_ext)]
 #![feature(iterator_try_collect)]
+#![feature(round_ties_even)]
 
 #[macro_use]
 pub mod jemalloc;

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -1013,50 +1013,6 @@ mod impl_rand {
     impl_uniform_sampler! { f64 }
 }
 
-mod impl_as_primitive {
-    use num_traits::AsPrimitive;
-
-    use super::*;
-
-    impl<T, F> AsPrimitive<T> for OrderedFloat<F>
-    where
-        F: 'static + Float + AsPrimitive<T>,
-        T: 'static + Copy,
-    {
-        fn as_(self) -> T {
-            AsPrimitive::as_(self.0)
-        }
-    }
-
-    macro_rules! impl_as_primitive_for {
-        ($ty:ty) => {
-            impl<F> AsPrimitive<OrderedFloat<F>> for $ty
-            where
-                F: 'static + Float,
-                $ty: AsPrimitive<F>,
-            {
-                fn as_(self) -> OrderedFloat<F> {
-                    let inner: F = AsPrimitive::as_(self);
-                    inner.into()
-                }
-            }
-        };
-    }
-
-    impl_as_primitive_for!(i8);
-    impl_as_primitive_for!(i16);
-    impl_as_primitive_for!(i32);
-    impl_as_primitive_for!(i64);
-
-    impl_as_primitive_for!(u8);
-    impl_as_primitive_for!(u16);
-    impl_as_primitive_for!(u32);
-    impl_as_primitive_for!(u64);
-
-    impl_as_primitive_for!(f32);
-    impl_as_primitive_for!(f64);
-}
-
 mod impl_from {
     use super::*;
 

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -52,8 +52,8 @@ use core::str::FromStr;
 
 pub use num_traits::Float;
 use num_traits::{
-    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, FromPrimitive,
-    Num, NumCast, One, Pow, Signed, ToPrimitive, Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, NumCast,
+    One, Pow, Signed, ToPrimitive, Zero,
 };
 
 // masks for the parts of the IEEE 754 float
@@ -569,56 +569,6 @@ impl<T: NumCast> NumCast for OrderedFloat<T> {
     #[inline]
     fn from<F: ToPrimitive>(n: F) -> Option<Self> {
         T::from(n).map(OrderedFloat)
-    }
-}
-
-impl<T: FromPrimitive> FromPrimitive for OrderedFloat<T> {
-    fn from_i64(n: i64) -> Option<Self> {
-        T::from_i64(n).map(OrderedFloat)
-    }
-
-    fn from_u64(n: u64) -> Option<Self> {
-        T::from_u64(n).map(OrderedFloat)
-    }
-
-    fn from_isize(n: isize) -> Option<Self> {
-        T::from_isize(n).map(OrderedFloat)
-    }
-
-    fn from_i8(n: i8) -> Option<Self> {
-        T::from_i8(n).map(OrderedFloat)
-    }
-
-    fn from_i16(n: i16) -> Option<Self> {
-        T::from_i16(n).map(OrderedFloat)
-    }
-
-    fn from_i32(n: i32) -> Option<Self> {
-        T::from_i32(n).map(OrderedFloat)
-    }
-
-    fn from_usize(n: usize) -> Option<Self> {
-        T::from_usize(n).map(OrderedFloat)
-    }
-
-    fn from_u8(n: u8) -> Option<Self> {
-        T::from_u8(n).map(OrderedFloat)
-    }
-
-    fn from_u16(n: u16) -> Option<Self> {
-        T::from_u16(n).map(OrderedFloat)
-    }
-
-    fn from_u32(n: u32) -> Option<Self> {
-        T::from_u32(n).map(OrderedFloat)
-    }
-
-    fn from_f32(n: f32) -> Option<Self> {
-        T::from_f32(n).map(OrderedFloat)
-    }
-
-    fn from_f64(n: f64) -> Option<Self> {
-        T::from_f64(n).map(OrderedFloat)
     }
 }
 

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -1003,14 +1003,14 @@ mod impl_from {
     impl_from_approx!(i64, f64);
 
     impl TryFrom<OrderedFloat<f64>> for OrderedFloat<f32> {
-        type Error = u8;
+        type Error = &'static str;
 
         fn try_from(s: OrderedFloat<f64>) -> Result<Self, Self::Error> {
             let inner = s.0 as f32;
             if inner.is_infinite() && s.0.is_finite() {
-                Err(1)
+                Err("double precision to real out of range: overflow")
             } else if inner == 0.0 && s.0 != 0.0 {
-                Err(2)
+                Err("double precision to real out of range: underflow")
             } else {
                 Ok(Self(inner))
             }
@@ -1020,14 +1020,14 @@ mod impl_from {
     macro_rules! impl_try_from_even {
         ($f:ty, $ty:ty) => {
             impl TryFrom<OrderedFloat<$f>> for $ty {
-                type Error = ();
+                type Error = &'static str;
 
                 fn try_from(n: OrderedFloat<$f>) -> Result<Self, Self::Error> {
                     let n = n.0.round_ties_even();
                     // `-MIN` can be represented exactly but `MAX` cannot.
                     // So we test `>= -MIN` rather than `> MAX`.
                     if n.is_nan() || n < (<$ty>::MIN as $f) || n >= -(<$ty>::MIN as $f) {
-                        Err(())
+                        Err("float to integral out of range")
                     } else {
                         Ok(n as _)
                     }

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -1060,30 +1060,6 @@ mod impl_as_primitive {
 mod impl_from {
     use super::*;
 
-    macro_rules! impl_from_for {
-        ($ty:ty) => {
-            impl<F> From<OrderedFloat<F>> for $ty
-            where
-                F: 'static + Float,
-                Self: From<F>,
-            {
-                fn from(value: OrderedFloat<F>) -> Self {
-                    From::from(value.0)
-                }
-            }
-        };
-    }
-
-    impl_from_for!(i8);
-    impl_from_for!(i16);
-    impl_from_for!(i32);
-    impl_from_for!(i64);
-
-    impl_from_for!(u8);
-    impl_from_for!(u16);
-    impl_from_for!(u32);
-    impl_from_for!(u64);
-
     impl From<OrderedFloat<f32>> for OrderedFloat<f64> {
         fn from(s: OrderedFloat<f32>) -> Self {
             Self(s.0.into())
@@ -1101,18 +1077,10 @@ mod impl_from {
         };
     }
 
-    impl_from!(i8, f32);
     impl_from!(i16, f32);
-    impl_from!(u8, f32);
-    impl_from!(u16, f32);
 
-    impl_from!(i8, f64);
     impl_from!(i16, f64);
     impl_from!(i32, f64);
-    impl_from!(u8, f64);
-    impl_from!(u16, f64);
-    impl_from!(u32, f64);
-    impl_from!(f32, f64);
 }
 
 impl From<i64> for OrderedFloat<f64> {

--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -324,8 +324,6 @@ pub(crate) fn from_avro_value(value: Value, value_schema: &Schema) -> Result<Dat
 
 #[cfg(test)]
 mod tests {
-    use num_traits::FromPrimitive;
-
     use super::*;
     #[test]
     fn test_convert_decimal() {
@@ -333,13 +331,13 @@ mod tests {
         let v = vec![1, 24];
         let avro_decimal = AvroDecimal::from(v);
         let rust_decimal = avro_decimal_to_rust_decimal(avro_decimal, 28, 0).unwrap();
-        assert_eq!(rust_decimal, rust_decimal::Decimal::from_i32(280).unwrap());
+        assert_eq!(rust_decimal, rust_decimal::Decimal::from(280));
 
         // 28.1
         let v = vec![1, 25];
         let avro_decimal = AvroDecimal::from(v);
         let rust_decimal = avro_decimal_to_rust_decimal(avro_decimal, 28, 1).unwrap();
-        assert_eq!(rust_decimal, rust_decimal::Decimal::from_f32(28.1).unwrap());
+        assert_eq!(rust_decimal, rust_decimal::Decimal::try_from(28.1).unwrap());
     }
 
     #[test]

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -13,13 +13,12 @@
 // limitations under the License.
 
 use std::any::type_name;
-use std::fmt::{Debug, Write};
+use std::fmt::Write;
 use std::str::FromStr;
 
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use futures_util::FutureExt;
 use itertools::Itertools;
-use num_traits::ToPrimitive;
 use risingwave_common::array::{
     JsonbRef, ListArray, ListRef, ListValue, StructArray, StructRef, StructValue, Utf8Array,
 };
@@ -28,7 +27,7 @@ use risingwave_common::types::num256::Int256;
 use risingwave_common::types::struct_type::StructType;
 use risingwave_common::types::to_text::ToText;
 use risingwave_common::types::{
-    DataType, Date, Decimal, Interval, ScalarImpl, Time, Timestamp, F32, F64,
+    DataType, Date, Decimal, Interval, IntoOrdered, ScalarImpl, Time, Timestamp, F32, F64,
 };
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr_macro::{build_function, function};
@@ -274,43 +273,6 @@ where
         .map_err(|_| ExprError::Parse(type_name::<T>().into()))
 }
 
-// Define the cast function to primitive types.
-//
-// Due to the orphan rule, some data can't implement `TryFrom` trait for basic type.
-// We can only use [`ToPrimitive`] trait.
-//
-// Note: this might be lossy according to the docs from [`ToPrimitive`]:
-// > On the other hand, conversions with possible precision loss or truncation
-// are admitted, like an `f32` with a decimal part to an integer type, or
-// even a large `f64` saturating to `f32` infinity.
-
-#[function("cast(float32) -> int16")]
-#[function("cast(float64) -> int16")]
-pub fn to_i16<T: ToPrimitive + Debug>(elem: T) -> Result<i16> {
-    elem.to_i16().ok_or(ExprError::CastOutOfRange("i16"))
-}
-
-#[function("cast(float32) -> int32")]
-#[function("cast(float64) -> int32")]
-pub fn to_i32<T: ToPrimitive + Debug>(elem: T) -> Result<i32> {
-    elem.to_i32().ok_or(ExprError::CastOutOfRange("i32"))
-}
-
-#[function("cast(float32) -> int64")]
-#[function("cast(float64) -> int64")]
-pub fn to_i64<T: ToPrimitive + Debug>(elem: T) -> Result<i64> {
-    elem.to_i64().ok_or(ExprError::CastOutOfRange("i64"))
-}
-
-#[function("cast(int32) -> float32")]
-#[function("cast(int64) -> float32")]
-#[function("cast(float64) -> float32")]
-pub fn to_f32<T: ToPrimitive + Debug>(elem: T) -> Result<F32> {
-    elem.to_f32()
-        .map(Into::into)
-        .ok_or(ExprError::CastOutOfRange("f32"))
-}
-
 #[function("cast(int16) -> int256")]
 #[function("cast(int32) -> int256")]
 #[function("cast(int64) -> int256")]
@@ -319,49 +281,26 @@ pub fn to_int256<T: TryInto<Int256>>(elem: T) -> Result<Int256> {
         .map_err(|_| ExprError::CastOutOfRange("int256"))
 }
 
-pub fn to_f64<T: ToPrimitive + Debug>(elem: T) -> Result<F64> {
-    elem.to_f64()
-        .map(Into::into)
-        .ok_or(ExprError::CastOutOfRange("f64"))
-}
-
 #[function("cast(jsonb) -> boolean")]
 pub fn jsonb_to_bool(v: JsonbRef<'_>) -> Result<bool> {
     v.as_bool().map_err(|e| ExprError::Parse(e.into()))
 }
 
+/// Note that PostgreSQL casts JSON numbers from arbitrary precision `numeric` but we use `f64`.
+/// This is less powerful but still meets RFC 8259 interoperability.
+#[function("cast(jsonb) -> int16")]
+#[function("cast(jsonb) -> int32")]
+#[function("cast(jsonb) -> int64")]
 #[function("cast(jsonb) -> decimal")]
-pub fn jsonb_to_dec(v: JsonbRef<'_>) -> Result<Decimal> {
+#[function("cast(jsonb) -> float32")]
+#[function("cast(jsonb) -> float64")]
+pub fn jsonb_to_number<T: TryFrom<F64>>(v: JsonbRef<'_>) -> Result<T> {
     v.as_number()
         .map_err(|e| ExprError::Parse(e.into()))?
+        .into_ordered()
         .try_into()
         .map_err(|_| ExprError::NumericOutOfRange)
 }
-
-/// Similar to and an result of [`define_cast_to_primitive`] macro above.
-/// If that was implemented as a trait to cast from `f64`, this could also call them via trait
-/// rather than macro.
-///
-/// Note that PostgreSQL casts JSON numbers from arbitrary precision `numeric` but we use `f64`.
-/// This is less powerful but still meets RFC 8259 interoperability.
-macro_rules! define_jsonb_to_number {
-    ($ty:ty, $sig:literal) => {
-        define_jsonb_to_number! { $ty, $ty, $sig }
-    };
-    ($ty:ty, $wrapper_ty:ty, $sig:literal) => {
-        paste::paste! {
-            #[function($sig)]
-            pub fn [<jsonb_to_ $ty>](v: JsonbRef<'_>) -> Result<$wrapper_ty> {
-                v.as_number().map_err(|e| ExprError::Parse(e.into())).and_then([<to_ $ty>])
-            }
-        }
-    };
-}
-define_jsonb_to_number! { i16, "cast(jsonb) -> int16" }
-define_jsonb_to_number! { i32, "cast(jsonb) -> int32" }
-define_jsonb_to_number! { i64, "cast(jsonb) -> int64" }
-define_jsonb_to_number! { f32, F32, "cast(jsonb) -> float32" }
-define_jsonb_to_number! { f64, F64, "cast(jsonb) -> float64" }
 
 /// In `PostgreSQL`, casting from timestamp to date discards the time part.
 #[function("cast(timestamp) -> date")]
@@ -384,11 +323,16 @@ pub fn interval_to_time(elem: Interval) -> Time {
     Time::from_num_seconds_from_midnight_uncheck(secs, nano)
 }
 
-#[function("cast(boolean) -> int32")]
 #[function("cast(int32) -> int16")]
 #[function("cast(int64) -> int16")]
 #[function("cast(int64) -> int32")]
-#[function("cast(int64) -> float64")]
+#[function("cast(float32) -> int16")]
+#[function("cast(float64) -> int16")]
+#[function("cast(float32) -> int32")]
+#[function("cast(float64) -> int32")]
+#[function("cast(float32) -> int64")]
+#[function("cast(float64) -> int64")]
+#[function("cast(float64) -> float32")]
 #[function("cast(decimal) -> int16")]
 #[function("cast(decimal) -> int32")]
 #[function("cast(decimal) -> int64")]
@@ -399,20 +343,23 @@ pub fn interval_to_time(elem: Interval) -> Time {
 pub fn try_cast<T1, T2>(elem: T1) -> Result<T2>
 where
     T1: TryInto<T2> + std::fmt::Debug + Copy,
-    <T1 as TryInto<T2>>::Error: std::fmt::Display,
 {
     elem.try_into()
         .map_err(|_| ExprError::CastOutOfRange(std::any::type_name::<T2>()))
 }
 
+#[function("cast(boolean) -> int32")]
 #[function("cast(int16) -> int32")]
 #[function("cast(int16) -> int64")]
 #[function("cast(int16) -> float32")]
 #[function("cast(int16) -> float64")]
 #[function("cast(int16) -> decimal")]
 #[function("cast(int32) -> int64")]
+#[function("cast(int32) -> float32")]
 #[function("cast(int32) -> float64")]
 #[function("cast(int32) -> decimal")]
+#[function("cast(int64) -> float32")]
+#[function("cast(int64) -> float64")]
 #[function("cast(int64) -> decimal")]
 #[function("cast(float32) -> float64")]
 #[function("cast(date) -> timestamp")]

--- a/src/expr/src/vector_op/timestamptz.rs
+++ b/src/expr/src/vector_op/timestamptz.rs
@@ -16,8 +16,7 @@ use std::fmt::Write;
 
 use chrono::{TimeZone, Utc};
 use chrono_tz::Tz;
-use num_traits::ToPrimitive;
-use risingwave_common::types::{Timestamp, F64};
+use risingwave_common::types::{IntoOrdered, Timestamp, F64};
 use risingwave_expr_macro::function;
 
 use crate::vector_op::cast::{str_to_timestamp, str_with_time_zone_to_timestamptz};
@@ -36,9 +35,9 @@ fn lookup_time_zone(time_zone: &str) -> Result<Tz> {
 pub fn f64_sec_to_timestamptz(elem: F64) -> Result<i64> {
     // TODO(#4515): handle +/- infinity
     (elem.0 * 1e6)
-        .round() // TODO(#5576): should round to even
-        .to_i64()
-        .ok_or(ExprError::NumericOutOfRange)
+        .into_ordered()
+        .try_into()
+        .map_err(|_| ExprError::NumericOutOfRange)
 }
 
 #[function("at_time_zone(timestamp, varchar) -> timestamptz")]

--- a/src/tests/e2e_extended_mode/src/test.rs
+++ b/src/tests/e2e_extended_mode/src/test.rs
@@ -15,7 +15,6 @@
 use anyhow::anyhow;
 use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
 use pg_interval::Interval;
-use rust_decimal::prelude::FromPrimitive;
 use rust_decimal::Decimal;
 use tokio::select;
 use tokio_postgres::types::Type;
@@ -118,11 +117,14 @@ impl TestSuite {
         }
 
         for row in client
-            .query("select $1::DECIMAL;", &[&Decimal::from_f32(2.33454_f32)])
+            .query(
+                "select $1::DECIMAL;",
+                &[&Decimal::try_from(2.33454_f32).ok()],
+            )
             .await?
         {
             let data: Decimal = row.try_get(0)?;
-            test_eq!(data, Decimal::from_f32(2.33454_f32).unwrap());
+            test_eq!(data, Decimal::try_from(2.33454_f32).unwrap());
         }
 
         for row in client.query("select $1::BOOL;", &[&true]).await? {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Similar to #9411

|| into F32 | into F64 | from F32 | from F64 |
|-|-|-|-|-|
|i16|lossless|lossless|TryFrom|TryFrom|
|i32|approx|lossless|TryFrom|TryFrom|
|i64|approx|approx|TryFrom|TryFrom|
|f32|ordered|NA|inner|NA|
|f64|NA|ordered|NA|inner|
|F32|noop (A)|lossless (B)| dup with (A) | dup with (C) |
|F64|TryFrom (C)|noop (D)| dup with (B) | dup with (D) |

* The lossless ones are implemented via rust builtin `From`.
* The approx ones are implemented via rust [`as` operator](https://doc.rust-lang.org/reference/expressions/operator-expr.html#numeric-cast).
* The `TryFrom` ones are implemented via preprocessing + `as`.
* Conversion between builtin `f32` and custom `F64`, or between `f64` and `F32`, are not provided.
* ordered / inner / noop are trivial cases not changed by this PR

`ToPrimitive` / `NumCast` are not disallowed by clippy yet because they are required by `Float` and that makes the refactor larger. It would be a separate PR later.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
