### PR TITLE
test(dbz_mongo): add tests

### DIFF
--- a/e2e_test/source/basic/ddl.slt
+++ b/e2e_test/source/basic/ddl.slt
@@ -97,7 +97,7 @@ create source s with (
   connection.name = 'nonexist',
 ) row format json;
 
-
+# `DEBEZIUM_MONGO_JSON` requires the source table have `_id` and `payload` columns.
 statement error
 create source s (
   a int,
@@ -109,6 +109,7 @@ create source s (
   connection.name = 'nonexist',
 ) row format DEBEZIUM_MONGO_JSON;
 
+# `DEBEZIUM_MONGO_JSON` requires the `_id` column is primary key.
 statement error
 create source s (
   _id jsonb,
@@ -120,9 +121,10 @@ create source s (
   connection.name = 'nonexist',
 ) row format DEBEZIUM_MONGO_JSON;
 
+# `DEBEZIUM_MONGO_JSON` requires the `payload` column is jsonb type.
 statement error
 create source s (
-  _id varchar,
+  _id varchar primary key,
   payload int
 ) with (
   connector = 'kafka',

--- a/e2e_test/source/basic/ddl.slt
+++ b/e2e_test/source/basic/ddl.slt
@@ -97,6 +97,40 @@ create source s with (
   connection.name = 'nonexist',
 ) row format json;
 
+
+statement error
+create source s (
+  a int,
+  b int
+) with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = '127.0.0.1:29092',
+  connection.name = 'nonexist',
+) row format DEBEZIUM_MONGO_JSON;
+
+statement error
+create source s (
+  _id jsonb,
+  payload jsonb
+) with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = '127.0.0.1:29092',
+  connection.name = 'nonexist',
+) row format DEBEZIUM_MONGO_JSON;
+
+statement error
+create source s (
+  _id varchar,
+  payload int
+) with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = '127.0.0.1:29092',
+  connection.name = 'nonexist',
+) row format DEBEZIUM_MONGO_JSON;
+
 statement ok
 create source s with (
   connector = 'kafka',


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add some e2e test cases for dbz mongo source.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.



