### PR TITLE
fix(expr): float should round ties to even

### DIFF
--- a/e2e_test/batch/functions/round.slt.part
+++ b/e2e_test/batch/functions/round.slt.part
@@ -14,7 +14,7 @@ SELECT ceil(4.7)
 5
 
 query I
-SELECT floor(4.7::double)
+SELECT floor(4.7::double precision)
 ----
 4
 
@@ -26,9 +26,38 @@ SELECT round(4)
 query I
 SELECT round(4.5::float)
 ----
-5
+4
 
 query R
 SELECT round('4.5')
 ----
-5
+4
+
+query RIIRRRRRR
+with t(v) as (
+	select v / 4.0 from generate_series(-6, 6, 1) as t(v)
+) select
+	v::real,
+	v::decimal::int AS ties_away,
+	v::float8::int AS ties_even,
+	round(v::decimal),
+	round(v::float8),
+	floor(v::decimal),
+	floor(v::float8),
+	ceil(v::decimal),
+	ceil(v::float8)
+from t;
+----
+ -1.5 -2 -2 -2 -2 -2 -2 -1 -1
+-1.25 -1 -1 -1 -1 -2 -2 -1 -1
+   -1 -1 -1 -1 -1 -1 -1 -1 -1
+-0.75 -1 -1 -1 -1 -1 -1  0 -0
+ -0.5 -1  0 -1 -0 -1 -1  0 -0
+-0.25  0  0  0 -0 -1 -1  0 -0
+    0  0  0  0  0  0  0  0  0
+ 0.25  0  0  0  0  0  0  1  1
+  0.5  1  0  1  0  0  0  1  1
+ 0.75  1  1  1  1  0  0  1  1
+    1  1  1  1  1  1  1  1  1
+ 1.25  1  1  1  1  1  1  2  2
+  1.5  2  2  2  2  1  1  2  2

--- a/e2e_test/batch/types/decimal.slt.part
+++ b/e2e_test/batch/types/decimal.slt.part
@@ -87,28 +87,3 @@ query R
 select 79228162514264337593543950335::decimal::float8;
 ----
 7.922816251426434e+28
-
-query RIRRR
-with t(v) as (
-	select (v / 4.0)::decimal from generate_series(-6, 6, 1) as t(v)
-) select
-	v::real,
-	v::int,
-	round(v),
-	floor(v),
-	ceil(v)
-from t;
-----
- -1.5 -2 -2 -2 -1
--1.25 -1 -1 -2 -1
-   -1 -1 -1 -1 -1
--0.75 -1 -1 -1  0
- -0.5 -1 -1 -1  0
--0.25  0  0 -1  0
-    0  0  0  0  0
- 0.25  0  0  0  1
-  0.5  1  1  0  1
- 0.75  1  1  0  1
-    1  1  1  1  1
- 1.25  1  1  1  2
-  1.5  2  2  1  2

--- a/e2e_test/batch/types/interval.slt.part
+++ b/e2e_test/batch/types/interval.slt.part
@@ -152,9 +152,38 @@ statement error
 select '-2562047788:00:54.775809'::interval;
 
 query T
+values
+	('12:34:56.1234564'::interval),
+	('12:34:56.1234566'::interval),
+	('12:34:56.1234565'::interval),
+	('12:34:56.1234555'::interval);
+----
+12:34:56.123456
+12:34:56.123457
+12:34:56.123456
+12:34:56.123456
+
+query T
 select interval '3 mons -3 days' / 2;
 ----
 1 mon 14 days -12:00:00
+
+query T
+with t(v, d) as (values
+	('00:00:00.000003'::interval, 2),
+	('00:00:00.000005', 2),
+	('1 day', 16384),
+	('3 day', 16384),
+	('1 month', 32768),
+	('3 month', 32768))
+select v / d from t;
+----
+00:00:00.000002
+00:00:00.000002
+00:00:05.273438
+00:00:15.820312
+00:01:19.101562
+00:03:57.304688
 
 # The following is an overflow bug present in PostgreSQL 15.2
 # Their `days` overflows to a negative value, leading to the latter smaller

--- a/e2e_test/batch/types/timestamptz_utc.slt.part
+++ b/e2e_test/batch/types/timestamptz_utc.slt.part
@@ -107,7 +107,12 @@ select to_timestamp(extract(epoch from '2010-01-01 12:34:56.789012Z'::timestamp 
 2010-01-01 12:34:56.789012+00:00
 
 query R
-select extract(epoch from to_timestamp(1262349296.7890123));
+select extract(epoch from to_timestamp(1262349296.7890125));
+----
+1262349296.789012
+
+query R
+select extract(epoch from to_timestamp(1262349296.7890115));
 ----
 1262349296.789012
 

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -254,12 +254,12 @@ impl Interval {
     fn from_floats(months: f64, days: f64, usecs: f64) -> Option<Self> {
         // TSROUND in include/datatype/timestamp.h
         // round eagerly at usecs precision because floats are imprecise
-        // should round to even #5576
-        let months_round_usecs =
-            |months: f64| (months * (USECS_PER_MONTH as f64)).round() / (USECS_PER_MONTH as f64);
+        let months_round_usecs = |months: f64| {
+            (months * (USECS_PER_MONTH as f64)).round_ties_even() / (USECS_PER_MONTH as f64)
+        };
 
         let days_round_usecs =
-            |days: f64| (days * (USECS_PER_DAY as f64)).round() / (USECS_PER_DAY as f64);
+            |days: f64| (days * (USECS_PER_DAY as f64)).round_ties_even() / (USECS_PER_DAY as f64);
 
         let trunc_fract = |num: f64| (num.trunc(), num.fract());
 
@@ -293,7 +293,7 @@ impl Interval {
 
         // Handle usecs
         let result_usecs = usecs + leftover_usecs;
-        let usecs = result_usecs.round();
+        let usecs = result_usecs.round_ties_even();
         if usecs.is_nan() || usecs < (i64::MIN as f64) || usecs > (i64::MAX as f64) {
             return None;
         }
@@ -1362,7 +1362,7 @@ impl Interval {
                     result = match interval_unit {
                         Second => {
                             // If unsatisfied precision is passed as input, we should not return None (Error).
-                            let usecs = (second.into_inner() * (USECS_PER_SEC as f64)).round() as i64;
+                            let usecs = (second.into_inner() * (USECS_PER_SEC as f64)).round_ties_even() as i64;
                             Some(Interval::from_month_day_usec(0, 0, usecs))
                         }
                         _ => None,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -21,6 +21,7 @@
 #![feature(exclusive_range_pattern)]
 #![feature(lazy_cell)]
 #![feature(try_blocks)]
+#![feature(round_ties_even)]
 
 mod error;
 pub mod expr;

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -49,7 +49,7 @@ pub fn floor_decimal(input: Decimal) -> Decimal {
 // Ties are broken by rounding away from zero
 #[function("round(float64) -> float64")]
 pub fn round_f64(input: F64) -> F64 {
-    f64::round(input.0).into()
+    f64::round_ties_even(input.0).into()
 }
 
 // Ties are broken by rounding away from zero

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -94,8 +94,10 @@ mod tests {
         assert_eq!(floor_f64(F64::from(-42.8)), F64::from(-43.0));
 
         assert_eq!(round_f64(F64::from(42.4)), F64::from(42.0));
-        assert_eq!(round_f64(F64::from(42.5)), F64::from(43.0));
-        assert_eq!(round_f64(F64::from(-6.5)), F64::from(-7.0));
+        assert_eq!(round_f64(F64::from(42.5)), F64::from(42.0));
+        assert_eq!(round_f64(F64::from(-6.5)), F64::from(-6.0));
+        assert_eq!(round_f64(F64::from(43.5)), F64::from(44.0));
+        assert_eq!(round_f64(F64::from(-7.5)), F64::from(-8.0));
     }
 
     #[test]

--- a/src/tests/regress/data/sql/float4.sql
+++ b/src/tests/regress/data/sql/float4.sql
@@ -96,9 +96,9 @@ SELECT * FROM FLOAT4_TBL;
 
 -- test edge-case coercions to integer
 SELECT '32767.4'::float4::int2 AS int2;
---@ SELECT '32767.6'::float4::int2;
+SELECT '32767.6'::float4::int2;
 SELECT '-32768.4'::float4::int2 AS int2;
---@ SELECT '-32768.6'::float4::int2;
+SELECT '-32768.6'::float4::int2;
 SELECT '2147483520'::float4::int4 AS int4;
 SELECT '2147483647'::float4::int4;
 SELECT '-2147483648.5'::float4::int4 AS int4;

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -248,13 +248,13 @@ SELECT * FROM FLOAT8_TBL;
 
 -- test edge-case coercions to integer
 SELECT '32767.4'::float8::int2 AS int2;
---@ SELECT '32767.6'::float8::int2;
+SELECT '32767.6'::float8::int2;
 SELECT '-32768.4'::float8::int2 AS int2;
---@ SELECT '-32768.6'::float8::int2;
+SELECT '-32768.6'::float8::int2;
 SELECT '2147483647.4'::float8::int4 AS int4;
---@ SELECT '2147483647.6'::float8::int4;
+SELECT '2147483647.6'::float8::int4;
 SELECT '-2147483648.4'::float8::int4 AS int4;
---@ SELECT '-2147483648.6'::float8::int4;
+SELECT '-2147483648.6'::float8::int4;
 SELECT '9223372036854773760'::float8::int8 AS int8;
 SELECT '9223372036854775807'::float8::int8;
 SELECT '-9223372036854775808.5'::float8::int8 AS int8;

--- a/src/tests/regress/data/sql/int2.sql
+++ b/src/tests/regress/data/sql/int2.sql
@@ -94,14 +94,14 @@ SELECT (-32768)::int2 / (-1)::int2;
 --@ SELECT (-32768)::int2 % (-1)::int2;
 
 -- check rounding when casting from float
---@ SELECT x, x::int2 AS int2_value
---@ FROM (VALUES (-2.5::float8),
---@              (-1.5::float8),
---@              (-0.5::float8),
---@              (0.0::float8),
---@              (0.5::float8),
---@              (1.5::float8),
---@              (2.5::float8)) t(x);
+SELECT x, x::int2 AS int2_value
+FROM (VALUES (-2.5::float8),
+             (-1.5::float8),
+             (-0.5::float8),
+             (0.0::float8),
+             (0.5::float8),
+             (1.5::float8),
+             (2.5::float8)) t(x);
 
 -- check rounding when casting from numeric
 SELECT x, x::int2 AS int2_value

--- a/src/tests/regress/data/sql/int4.sql
+++ b/src/tests/regress/data/sql/int4.sql
@@ -133,14 +133,14 @@ SELECT (-2147483648)::int4 / (-1)::int2;
 --@ SELECT (-2147483648)::int4 % (-1)::int2;
 
 -- check rounding when casting from float
---@ SELECT x, x::int4 AS int4_value
---@ FROM (VALUES (-2.5::float8),
---@              (-1.5::float8),
---@              (-0.5::float8),
---@              (0.0::float8),
---@              (0.5::float8),
---@              (1.5::float8),
---@              (2.5::float8)) t(x);
+SELECT x, x::int4 AS int4_value
+FROM (VALUES (-2.5::float8),
+             (-1.5::float8),
+             (-0.5::float8),
+             (0.0::float8),
+             (0.5::float8),
+             (1.5::float8),
+             (2.5::float8)) t(x);
 
 -- check rounding when casting from numeric
 SELECT x, x::int4 AS int4_value

--- a/src/tests/regress/data/sql/int8.sql
+++ b/src/tests/regress/data/sql/int8.sql
@@ -207,14 +207,14 @@ SELECT (-9223372036854775808)::int8 / (-1)::int2;
 --@ SELECT (-9223372036854775808)::int8 % (-1)::int2;
 
 -- check rounding when casting from float
---@ SELECT x, x::int8 AS int8_value
---@ FROM (VALUES (-2.5::float8),
---@              (-1.5::float8),
---@              (-0.5::float8),
---@              (0.0::float8),
---@              (0.5::float8),
---@              (1.5::float8),
---@              (2.5::float8)) t(x);
+SELECT x, x::int8 AS int8_value
+FROM (VALUES (-2.5::float8),
+             (-1.5::float8),
+             (-0.5::float8),
+             (0.0::float8),
+             (0.5::float8),
+             (1.5::float8),
+             (2.5::float8)) t(x);
 
 -- check rounding when casting from numeric
 SELECT x, x::int8 AS int8_value


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #5576

For context, there are 5 rounding modes in IEEE 754:
* towards `-Infinity` aka `floor`
* towards `+infinity` aka `ceil`
* towards zero aka `trunc`
  * rust builtin float `as` int
* to nearest, ties to even
  * PostgreSQL float to int cast, and float round
  * native to x86 / arm
  * rust builtin int `as` float and f32 `as` f64
* to nearest, ties away from zero
  * PostgreSQL decimal to int cast, and decimal round
  * rust builtin round

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
