### PR TITLE
test: add negative tests for source and sink

### DIFF
--- a/e2e_test/sink/append_only_sink.slt
+++ b/e2e_test/sink/append_only_sink.slt
@@ -16,6 +16,15 @@ create sink s3 from t with (connector = 'blackhole', type = 'append-only', force
 statement error Cannot force the sink to be append-only
 create sink s4 from t with (connector = 'blackhole', type = 'upsert', force_append_only = 'true');
 
+statement error
+create sink invalid_sink_type from t with (connector = 'blackhole', type = 'invalid');
+
+statement error `force_append_only` must be true or false
+create sink invalid_force_append_only from t with (connector = 'blackhole', force_append_only = 'invalid');
+
+statement error invalid connector type: invalid
+create sink invalid_connector from t with (connector = 'invalid');
+
 statement ok
 drop sink s1
 

--- a/e2e_test/sink/create_sink_as.slt
+++ b/e2e_test/sink/create_sink_as.slt
@@ -4,6 +4,10 @@ CREATE TABLE t4 (v1 int primary key, v2 int);
 statement ok
 CREATE MATERIALIZED VIEW mv4 AS SELECT * FROM t4;
 
+# The configs are valid but the query is not.
+statement error
+CREATE SINK invalid_sink_query AS select * from t4 where v1 = invalid WITH (connector = 'blackhole');
+
 statement ok
 CREATE SINK s4 AS select mv4.v1 as v1, mv4.v2 as v2 from mv4 WITH (
     connector = 'jdbc',

--- a/e2e_test/sink/kafka/create_sink.slt
+++ b/e2e_test/sink/kafka/create_sink.slt
@@ -97,6 +97,35 @@ create sink si_kafka_debezium from t_kafka with (
     primary_key = 'id',
 );
 
+statement error primary key not defined for debezium kafka sink
+create sink debezium_without_pk from t_kafka with (
+    connector = 'kafka',
+    properties.bootstrap.server = '127.0.0.1:29092',
+    topic = 'test-rw-sink-debezium',
+    type = 'debezium',
+);
+
+statement ok
+create sink multiple_pk from t_kafka with (
+    connector = 'kafka',
+    properties.bootstrap.server = '127.0.0.1:29092',
+    topic = 'test-rw-sink-debezium',
+    type = 'debezium',
+    primary_key = 'id,v_varchar'
+);
+
+statement ok
+drop sink multiple_pk;
+
+statement error Sink primary key column not found: invalid.
+create sink invalid_pk_column from t_kafka with (
+    connector = 'kafka',
+    properties.bootstrap.server = '127.0.0.1:29092',
+    topic = 'test-rw-sink-debezium',
+    type = 'debezium',
+    primary_key = 'id,invalid'
+);
+
 statement ok
 insert into t_kafka values
     (1, '8DfUFencLe', 31031, 1872, 1872, 26261.416, 23956.39329760601, '2023-04-14 06:27:14.104742'),

--- a/e2e_test/source/basic/ddl.slt
+++ b/e2e_test/source/basic/ddl.slt
@@ -1,3 +1,46 @@
+statement error topic invalid_topic not found
+create source s with (
+  connector = 'kafka',
+  topic = 'invalid_topic',
+  properties.bootstrap.server = '127.0.0.1:29092'
+) row format json;
+
+statement error properties `scan_startup_mode` only support earliest and latest or leave it empty
+create source invalid_startup_mode with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  scan.startup.mode = 'invalid',
+  properties.bootstrap.server = '127.0.0.1:29092'
+) row format json;
+
+# TODO: Better to refine the error message.
+statement error internal error: invalid digit found in string
+create source invalid_startup_timestamp with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  scan.startup.timestamp_millis	= 'abc',
+  properties.bootstrap.server = '127.0.0.1:29092'
+) row format json;
+
+statement ok
+create source upsert_source with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  upsert = 'true',
+  properties.bootstrap.server = '127.0.0.1:29092'
+) row format json;
+
+statement ok
+drop source upsert_source;
+
+# Will fail at the parser phase.
+statement error
+create source invalid_format with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = '127.0.0.1:29092'
+) row format abc;
+
 statement ok
 create table s with (
   connector = 'kafka',

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -169,7 +169,8 @@ impl<const APPEND_ONLY: bool> KafkaSink<APPEND_ONLY> {
         // For upsert Kafka sink, the primary key must be defined.
         if !APPEND_ONLY && pk_indices.is_empty() {
             return Err(SinkError::Config(anyhow!(
-                "primary key not defined for upsert kafka sink (please define in `primary_key` field)"
+                "primary key not defined for {} kafka sink (please define in `primary_key` field)",
+                config.r#type
             )));
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

Some negative tests that are intended to check if RisingWave can handle the unwanted user input and the behavior is as expected. 

Bugs that were found throughout the process:
- https://github.com/risingwavelabs/risingwave/issues/9470
- https://github.com/risingwavelabs/risingwave/issues/9450
- https://github.com/risingwavelabs/risingwave/issues/9443
- https://github.com/risingwavelabs/risingwave/issues/9440

## Checklist For Contributors

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Connector (sources & sinks)
