### PR TITLE
refactor(streaming): retrieve epoch from task local storage

### DIFF
--- a/src/common/src/util/epoch.rs
+++ b/src/common/src/util/epoch.rs
@@ -128,7 +128,6 @@ impl EpochPair {
 /// Task-local storage for the epoch pair.
 pub mod task_local {
     use futures::Future;
-    use tokio::task::futures::TaskLocalFuture;
     use tokio::task_local;
 
     use super::{Epoch, EpochPair};
@@ -162,11 +161,11 @@ pub mod task_local {
     }
 
     /// Provides the given epoch pair in the task local storage for the scope of the given future.
-    pub fn scope<F>(epoch: EpochPair, f: F) -> TaskLocalFuture<EpochPair, F>
+    pub async fn scope<F>(epoch: EpochPair, f: F) -> F::Output
     where
         F: Future,
     {
-        TASK_LOCAL_EPOCH_PAIR.scope(epoch, f)
+        TASK_LOCAL_EPOCH_PAIR.scope(epoch, f).await
     }
 }
 

--- a/src/expr/src/expr/expr_proctime.rs
+++ b/src/expr/src/expr/expr_proctime.rs
@@ -15,10 +15,11 @@
 use risingwave_common::array::DataChunk;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
+use risingwave_common::util::epoch;
 use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
 
-use super::{Expression, ValueImpl, CONTEXT};
+use super::{Expression, ValueImpl};
 use crate::{bail, ensure, ExprError, Result};
 
 #[derive(Debug)]
@@ -45,6 +46,15 @@ impl<'a> TryFrom<&'a ExprNode> for ProcTimeExpression {
     }
 }
 
+/// Get the processing time in microseconds from the task-local epoch.
+fn proc_time_us_from_epoch() -> Result<ScalarImpl> {
+    let us = epoch::task_local::curr_epoch()
+        .ok_or(ExprError::Context)?
+        .as_unix_millis()
+        * 1000;
+    Ok(ScalarImpl::Int64(us as i64))
+}
+
 #[async_trait::async_trait]
 impl Expression for ProcTimeExpression {
     fn return_type(&self) -> DataType {
@@ -52,24 +62,14 @@ impl Expression for ProcTimeExpression {
     }
 
     async fn eval_v2(&self, input: &DataChunk) -> Result<ValueImpl> {
-        let proctime = CONTEXT
-            .try_with(|context| context.get_proctime())
-            .map_err(|_| ExprError::Context)?;
-        let datum = Some(ScalarImpl::Int64(proctime as i64));
-
-        Ok(ValueImpl::Scalar {
-            value: datum,
+        proc_time_us_from_epoch().map(|s| ValueImpl::Scalar {
+            value: Some(s),
             capacity: input.capacity(),
         })
     }
 
     async fn eval_row(&self, _input: &OwnedRow) -> Result<Datum> {
-        let proctime = CONTEXT
-            .try_with(|context| context.get_proctime())
-            .map_err(|_| ExprError::Context)?;
-        let datum = Some(ScalarImpl::Int64(proctime as i64));
-
-        Ok(datum)
+        proc_time_us_from_epoch().map(Some)
     }
 }
 
@@ -77,25 +77,26 @@ impl Expression for ProcTimeExpression {
 mod tests {
     use risingwave_common::array::DataChunk;
     use risingwave_common::types::ScalarRefImpl;
-    use risingwave_common::util::epoch::Epoch;
+    use risingwave_common::util::epoch::{Epoch, EpochPair};
 
     use super::*;
-    use crate::expr::{ExprContext, CONTEXT};
 
     #[tokio::test]
     async fn test_expr_proctime() {
         let proctime_expr = ProcTimeExpression::new();
-        let epoch = Epoch::now();
-        let time_us = epoch.as_unix_millis() * 1000;
-        let time_datum = Some(ScalarRefImpl::Int64(time_us as i64));
-        let context = ExprContext::new(epoch);
+        let curr_epoch = Epoch::now();
+        let epoch = EpochPair {
+            curr: curr_epoch.0,
+            prev: 0,
+        };
         let chunk = DataChunk::new_dummy(3);
 
-        let array = CONTEXT
-            .scope(context, proctime_expr.eval(&chunk))
+        let array = epoch::task_local::scope(epoch, proctime_expr.eval(&chunk))
             .await
             .unwrap();
 
+        let time_us = curr_epoch.as_unix_millis() * 1000;
+        let time_datum = Some(ScalarRefImpl::Int64(time_us as i64));
         for datum_ref in array.iter() {
             assert_eq!(datum_ref, time_datum)
         }

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -75,7 +75,6 @@ use futures_util::TryFutureExt;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::{OwnedRow, Row};
 use risingwave_common::types::{DataType, Datum};
-use risingwave_common::util::epoch::Epoch;
 use static_assertions::const_assert;
 
 pub use self::build::*;
@@ -193,24 +192,3 @@ pub type ExpressionRef = Arc<dyn Expression>;
 /// See also <https://github.com/risingwavelabs/risingwave/issues/4625>.
 #[allow(dead_code)]
 const STRICT_MODE: bool = false;
-
-/// The context used by expressions.
-#[derive(Clone)]
-pub struct ExprContext {
-    /// The epoch that an executor currently in.
-    curr_epoch: Epoch,
-}
-
-impl ExprContext {
-    pub fn new(curr_epoch: Epoch) -> Self {
-        Self { curr_epoch }
-    }
-
-    pub fn get_proctime(&self) -> u64 {
-        self.curr_epoch.as_unix_millis() * 1000
-    }
-}
-
-tokio::task_local! {
-    pub static CONTEXT: ExprContext;
-}

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -143,7 +143,7 @@ pub use top_n::{
 pub use union::UnionExecutor;
 pub use values::ValuesExecutor;
 pub use watermark_filter::WatermarkFilterExecutor;
-pub use wrapper::WrapperExecutor;
+pub use wrapper::{curr_epoch, epoch, prev_epoch, WrapperExecutor};
 
 use self::barrier_align::AlignedMessageStream;
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -143,13 +143,15 @@ pub use top_n::{
 pub use union::UnionExecutor;
 pub use values::ValuesExecutor;
 pub use watermark_filter::WatermarkFilterExecutor;
-pub use wrapper::{curr_epoch, epoch, prev_epoch, WrapperExecutor};
+pub use wrapper::WrapperExecutor;
 
 use self::barrier_align::AlignedMessageStream;
 
 pub type BoxedExecutor = Box<dyn Executor>;
 pub type MessageStreamItem = StreamExecutorResult<Message>;
 pub type BoxedMessageStream = BoxStream<'static, MessageStreamItem>;
+
+pub use risingwave_common::util::epoch::task_local::{curr_epoch, epoch, prev_epoch};
 
 pub trait MessageStream = futures::Stream<Item = MessageStreamItem> + Send;
 

--- a/src/stream/src/executor/wrapper.rs
+++ b/src/stream/src/executor/wrapper.rs
@@ -29,8 +29,6 @@ mod schema_check;
 mod trace;
 mod update_check;
 
-pub use epoch_provide::{curr_epoch, epoch, prev_epoch};
-
 struct ExtraInfo {
     /// Index of input to this operator.
     input_pos: usize,

--- a/src/stream/src/executor/wrapper/epoch_provide.rs
+++ b/src/stream/src/executor/wrapper/epoch_provide.rs
@@ -1,0 +1,68 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use futures::{pin_mut, TryStreamExt};
+use futures_async_stream::try_stream;
+use risingwave_common::util::epoch::EpochPair;
+
+use crate::executor::error::StreamExecutorError;
+use crate::executor::{Message, MessageStream};
+
+tokio::task_local! {
+    static EPOCH: EpochPair;
+}
+
+/// Retrieve the current epoch from the task local storage.
+///
+/// This value is updated after every yield of the barrier message. **Panics** if the first barrier
+/// message is not yielded.
+pub fn curr_epoch() -> u64 {
+    EPOCH.with(|e| e.curr)
+}
+
+/// Retrieve the previous epoch from the task local storage.
+///
+/// This value is updated after every yield of the barrier message. **Panics** if the first barrier
+/// message is not yielded.
+pub fn prev_epoch() -> u64 {
+    EPOCH.with(|e| e.prev)
+}
+
+/// Retrieve the epoch pair from the task local storage.
+///
+/// This value is updated after every yield of the barrier message. **Panics** if the first barrier
+/// message is not yielded.
+pub fn epoch() -> EpochPair {
+    EPOCH.get()
+}
+
+/// Streams wrapped by `epoch_provide` is able to retrieve the current epoch from the `xxx`
+/// function.
+#[try_stream(ok = Message, error = StreamExecutorError)]
+pub async fn epoch_provide(input: impl MessageStream) {
+    pin_mut!(input);
+
+    let mut epoch = None;
+
+    while let Some(message) = if let Some(epoch) = epoch {
+        EPOCH.scope(epoch, input.try_next()).await?
+    } else {
+        input.try_next().await?
+    } {
+        if let Message::Barrier(b) = &message {
+            epoch = Some(b.epoch);
+        }
+        yield message;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Epoch changes periodically in streaming executors, while providing a correct value is crucial to several components like `LruCache`, `StateTable`, `PROCTIME()`. For the simplicity of the interface design, we do not pass the value everywhere. Instead, we make these components to hold other copies of the value and let the executor call `update_epoch` when it needs to be updated.

This could be really error-prone if we accidentally forget to call that! For example, in #9459 we find that a lot of executors forget to update the epoch for the LRU cache, so the eviction will be problematic implicitly.

**In this PR** we attempt to provide the epoch in the task-local storage. Components can directly call `curr_epoch` to get the current epoch without any context, as long as it's in the scope of a running executor. We've also refactored the `PROCTIME` (#9088) to retrieve the epoch from this value.

This could be further used by `LruCache` and `StateTable` in the future.

NOTE: Per offline discussions, we agree that we should be really cautious and think twice before introducing such "global variables". Abusing it will hurt the maintainability of our system.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
