### PR TITLE
refactor(common): disallow `ToPrimitive`/`NumCast` in favor of `From`/`TryFrom`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -7,6 +7,8 @@ disallowed-methods = [
 disallowed-types = [
     { path = "num_traits::AsPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
     { path = "num_traits::FromPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
+    { path = "num_traits::ToPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
+    { path = "num_traits::NumCast", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },
 ]
 doc-valid-idents = [
     "RisingWave",

--- a/src/common/src/field_generator/numeric.rs
+++ b/src/common/src/field_generator/numeric.rs
@@ -33,7 +33,8 @@ where
         + PartialOrd
         + num_traits::Num
         + num_traits::NumAssignOps
-        + num_traits::NumCast
+        + From<i16>
+        + TryFrom<u64>
         + serde::Serialize
         + SampleUniform,
 {
@@ -72,7 +73,7 @@ where
         Self: Sized,
     {
         let mut min = T::zero();
-        let mut max = T::from(i16::MAX).unwrap();
+        let mut max = T::from(i16::MAX);
 
         if let Some(min_option) = min_option {
             min = min_option.parse::<T>()?;
@@ -101,6 +102,7 @@ impl<T> NumericFieldSequenceGenerator for NumericFieldSequenceConcrete<T>
 where
     T: NumericType + Scalar,
     <T as FromStr>::Err: std::error::Error + Send + Sync + 'static,
+    <T as TryFrom<u64>>::Error: Debug,
 {
     fn new(
         star_option: Option<String>,
@@ -113,7 +115,7 @@ where
         Self: Sized,
     {
         let mut start = T::zero();
-        let mut end = T::from(i16::MAX).unwrap();
+        let mut end = T::from(i16::MAX);
 
         if let Some(star_optiont) = star_option {
             start = star_optiont.parse::<T>()?;
@@ -128,15 +130,16 @@ where
             end,
             offset,
             step,
-            cur: T::from(event_offset).ok_or_else(|| {
+            cur: T::try_from(event_offset).map_err(|_| {
                 anyhow::anyhow!("event offset is too big, offset: {}", event_offset,)
             })?,
         })
     }
 
     fn generate(&mut self) -> serde_json::Value {
-        let partition_result =
-            self.start + T::from(self.offset).unwrap() + T::from(self.step).unwrap() * self.cur;
+        let partition_result = self.start
+            + T::try_from(self.offset).unwrap()
+            + T::try_from(self.step).unwrap() * self.cur;
         let partition_result = if partition_result > self.end {
             None
         } else {
@@ -147,8 +150,9 @@ where
     }
 
     fn generate_datum(&mut self) -> Datum {
-        let partition_result =
-            self.start + T::from(self.offset).unwrap() + T::from(self.step).unwrap() * self.cur;
+        let partition_result = self.start
+            + T::try_from(self.offset).unwrap()
+            + T::try_from(self.step).unwrap() * self.cur;
         self.cur += T::one();
         if partition_result > self.end {
             None

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -17,7 +17,6 @@ use std::hash::Hash;
 use std::sync::Arc;
 
 use bytes::{Buf, BufMut, Bytes};
-use num_traits::Float;
 use parse_display::{Display, FromStr};
 use postgres_types::FromSql;
 use risingwave_common_proc_macro::EstimateSize;
@@ -58,7 +57,7 @@ pub use decimal::Decimal;
 pub use interval::*;
 use itertools::Itertools;
 pub use ops::{CheckedAdd, IsNegative};
-pub use ordered_float::IntoOrdered;
+pub use ordered_float::{FloatExt, IntoOrdered};
 use paste::paste;
 use postgres_types::{IsNull, ToSql, Type};
 use strum_macros::EnumDiscriminants;

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -997,10 +997,12 @@ mod impl_from {
     impl_from_lossless!(i16, f32);
     impl_from_approx!(i32, f32);
     impl_from_approx!(i64, f32);
+    impl_from_approx!(u64, f32);
 
     impl_from_lossless!(i16, f64);
     impl_from_lossless!(i32, f64);
     impl_from_approx!(i64, f64);
+    impl_from_approx!(u64, f64);
 
     impl TryFrom<OrderedFloat<f64>> for OrderedFloat<f32> {
         type Error = &'static str;

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -52,8 +52,8 @@ use core::str::FromStr;
 
 pub use num_traits::Float;
 use num_traits::{
-    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, NumCast,
-    One, Pow, Signed, ToPrimitive, Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, One, Pow,
+    Signed, Zero,
 };
 
 // masks for the parts of the IEEE 754 float
@@ -565,64 +565,12 @@ impl<T: One> One for OrderedFloat<T> {
     }
 }
 
-impl<T: NumCast> NumCast for OrderedFloat<T> {
-    #[inline]
-    fn from<F: ToPrimitive>(n: F) -> Option<Self> {
-        T::from(n).map(OrderedFloat)
-    }
-}
-
-impl<T: ToPrimitive> ToPrimitive for OrderedFloat<T> {
-    fn to_i64(&self) -> Option<i64> {
-        self.0.to_i64()
-    }
-
-    fn to_u64(&self) -> Option<u64> {
-        self.0.to_u64()
-    }
-
-    fn to_isize(&self) -> Option<isize> {
-        self.0.to_isize()
-    }
-
-    fn to_i8(&self) -> Option<i8> {
-        self.0.to_i8()
-    }
-
-    fn to_i16(&self) -> Option<i16> {
-        self.0.to_i16()
-    }
-
-    fn to_i32(&self) -> Option<i32> {
-        self.0.to_i32()
-    }
-
-    fn to_usize(&self) -> Option<usize> {
-        self.0.to_usize()
-    }
-
-    fn to_u8(&self) -> Option<u8> {
-        self.0.to_u8()
-    }
-
-    fn to_u16(&self) -> Option<u16> {
-        self.0.to_u16()
-    }
-
-    fn to_u32(&self) -> Option<u32> {
-        self.0.to_u32()
-    }
-
-    fn to_f32(&self) -> Option<f32> {
-        self.0.to_f32()
-    }
-
-    fn to_f64(&self) -> Option<f64> {
-        self.0.to_f64()
-    }
-}
-
-impl<T: Float> Float for OrderedFloat<T> {
+/// Similar to [`num_traits::Float`], but without requiring `NumCast` and `ToPrimitive`.
+#[easy_ext::ext(FloatExt)]
+pub impl<T: Float> OrderedFloat<T>
+where
+    Self: Sized + Copy,
+{
     fn nan() -> Self {
         OrderedFloat(T::nan())
     }

--- a/src/common/src/util/memcmp_encoding.rs
+++ b/src/common/src/util/memcmp_encoding.rs
@@ -259,7 +259,7 @@ mod tests {
     use super::*;
     use crate::array::{DataChunk, ListValue, StructValue};
     use crate::row::{OwnedRow, RowExt};
-    use crate::types::{DataType, ScalarImpl, F32};
+    use crate::types::{DataType, FloatExt, ScalarImpl, F32};
     use crate::util::sort_util::{ColumnOrder, OrderType};
 
     #[test]

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -16,8 +16,10 @@ use std::convert::TryInto;
 use std::fmt::Debug;
 
 use chrono::{Duration, NaiveDateTime};
-use num_traits::{CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Float, Signed, Zero};
-use risingwave_common::types::{CheckedAdd, Date, Decimal, Interval, Time, Timestamp, F64};
+use num_traits::{CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Signed, Zero};
+use risingwave_common::types::{
+    CheckedAdd, Date, Decimal, FloatExt, Interval, Time, Timestamp, F64,
+};
 use risingwave_expr_macro::function;
 use rust_decimal::MathematicalOps;
 
@@ -407,6 +409,7 @@ pub fn sqrt_decimal(expr: Decimal) -> Result<Decimal> {
 mod tests {
     use std::str::FromStr;
 
+    use num_traits::Float;
     use risingwave_common::types::num256::{Int256, Int256Ref};
     use risingwave_common::types::test_utils::IntervalTestExt;
     use risingwave_common::types::{Date, Decimal, Interval, Scalar, Timestamp, F32, F64};

--- a/src/expr/src/vector_op/exp.rs
+++ b/src/expr/src/vector_op/exp.rs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::{Float, Zero};
-use risingwave_common::types::F64;
+use num_traits::Zero;
+use risingwave_common::types::{FloatExt, F64};
 use risingwave_expr_macro::function;
 
 use crate::{ExprError, Result};

--- a/src/expr/src/vector_op/trigonometric.rs
+++ b/src/expr/src/vector_op/trigonometric.rs
@@ -284,8 +284,7 @@ pub fn radians_f64(input: F64) -> F64 {
 mod tests {
     use std::f64::consts::PI;
 
-    use num_traits::Float;
-    use risingwave_common::types::F64;
+    use risingwave_common::types::{FloatExt, F64};
 
     use crate::vector_op::trigonometric::*;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #9411 #9439 for more context.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
