### PR TITLE
feat(ci): Support adhoc flamegraph generation + Support `main-cron` flamegraph generation for all queries

### DIFF
--- a/ci/scripts/flamegraph-env-build.sh
+++ b/ci/scripts/flamegraph-env-build.sh
@@ -7,6 +7,7 @@ source ci/scripts/common.sh
 
 ############# INSTALL NEXMARK BENCH
 
+echo "--- Installing nexmark-bench"
 echo "CUR_DIR: $PWD"
 pushd ..
 git clone https://"$GITHUB_TOKEN"@github.com/risingwavelabs/nexmark-bench.git

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -227,10 +227,6 @@ setup() {
 
 # Run benchmark for a query
 run() {
-
-  echo "--- Machine Debug Info Before running $QUERY"
-  print_machine_debug_info
-
   echo "--- Running benchmark for $QUERY"
   echo "--- Setting variables"
   QUERY_LABEL="$1"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -166,10 +166,7 @@ start_kafka() {
   ./kafka_2.13-3.4.0/bin/kafka-server-start.sh ./kafka_2.13-3.4.0/config/server.properties --override num.partitions=8 > kafka.log 2>&1 &
   sleep 10
   echo "Should have zookeeper and kafka running"
-  echo "zookeeper PID: "
-  pgrep zookeeper
-  echo "kafka PID: "
-  pgrep kafka
+  ps
   # TODO(kwannoel): `trap ERR` and upload these logs.
   # buildkite-agent artifact upload ./zookeeper.log
   # buildkite-agent artifact upload ./kafka.log

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -164,12 +164,12 @@ start_nperf() {
 start_kafka() {
   ./kafka_2.13-3.4.0/bin/zookeeper-server-start.sh ./kafka_2.13-3.4.0/config/zookeeper.properties > zookeeper.log 2>&1 &
   ./kafka_2.13-3.4.0/bin/kafka-server-start.sh ./kafka_2.13-3.4.0/config/server.properties --override num.partitions=8 > kafka.log 2>&1 &
+  sleep 10
   echo "Should have zookeeper and kafka running"
   echo "zookeeper PID: "
   pgrep zookeeper
   echo "kafka PID: "
   pgrep kafka
-  sleep 10
   # TODO(kwannoel): `trap ERR` and upload these logs.
   # buildkite-agent artifact upload ./zookeeper.log
   # buildkite-agent artifact upload ./kafka.log

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -13,6 +13,7 @@ pushd ..
 
 # Buildkite does not support labels at the moment. Have to get via github api.
 get_nexmark_queries_to_run() {
+  set +u
   if [[ -z "$NEXMARK_QUERIES" ]]; then
     # every PR is an issue, we can use github api to pull it.
     echo "PULL_REQUEST: $PULL_REQUEST"
@@ -27,6 +28,7 @@ get_nexmark_queries_to_run() {
   else
     echo "NEXMARK_QUERIES already set."
   fi
+  set -u
   echo "Nexmark queries to run: $NEXMARK_QUERIES"
 }
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -13,14 +13,20 @@ pushd ..
 
 # Buildkite does not support labels at the moment. Have to get via github api.
 get_nexmark_queries_to_run() {
-  # every PR is an issue, we can use github api to pull it.
-  echo "PULL_REQUEST: $PULL_REQUEST"
-  export NEXMARK_QUERIES=$(curl -L \
-    -H "Accept: application/vnd.github+json" \
-    -H "Authorization: Bearer $GITHUB_TOKEN"\
-    -H "X-GitHub-Api-Version: 2022-11-28" \
-    https://api.github.com/repos/risingwavelabs/risingwave/issues/"$PULL_REQUEST"/labels \
-  | parse_labels)
+  if [[ -z "$NEXMARK_QUERIES" ]]; then
+    # every PR is an issue, we can use github api to pull it.
+    echo "PULL_REQUEST: $PULL_REQUEST"
+    export NEXMARK_QUERIES=$(curl -L \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer $GITHUB_TOKEN"\
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      https://api.github.com/repos/risingwavelabs/risingwave/issues/"$PULL_REQUEST"/labels \
+    | parse_labels)
+  elif [[ "$NEXMARK_QUERIES" == "all" ]]; then
+    export NEXMARK_QUERIES="$(ls $QUERY_DIR | sed -n 's/^q\([0-9]*\)\.sql/\1/p' | sort -n | sed 's/\(.*\)/nexmark-q\1/')"
+  else
+    echo "NEXMARK_QUERIES already set."
+  fi
   echo "Nexmark queries to run: $NEXMARK_QUERIES"
 }
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -211,6 +211,7 @@ stop_processes() {
   # stop rw
   pushd risingwave
   ./risedev k
+  ./risedev clean-data
   popd
 }
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -225,6 +225,10 @@ setup() {
 
 # Run benchmark for a query
 run() {
+
+  echo "--- Machine Debug Info Before running $QUERY"
+  print_machine_debug_info
+
   echo "--- Running benchmark for $QUERY"
   echo "--- Setting variables"
   QUERY_LABEL="$1"
@@ -270,6 +274,10 @@ run() {
 
   echo "--- Uploading flamegraph"
   buildkite-agent artifact upload "./$FLAMEGRAPH_PATH"
+
+  echo "--- Machine Debug Info After running $QUERY"
+  print_machine_debug_info
+
 }
 
 ############## MAIN

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -165,8 +165,6 @@ start_kafka() {
   ./kafka_2.13-3.4.0/bin/zookeeper-server-start.sh ./kafka_2.13-3.4.0/config/zookeeper.properties > zookeeper.log 2>&1 &
   ./kafka_2.13-3.4.0/bin/kafka-server-start.sh ./kafka_2.13-3.4.0/config/server.properties --override num.partitions=8 > kafka.log 2>&1 &
   sleep 10
-  echo "Should have zookeeper and kafka running"
-  ps
   # TODO(kwannoel): `trap ERR` and upload these logs.
   # buildkite-agent artifact upload ./zookeeper.log
   # buildkite-agent artifact upload ./kafka.log

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -45,7 +45,7 @@ steps:
     timeout_in_minutes: 20
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
-  - label: Generate CPU flamegraph"
+  - label: "Generate CPU flamegraph"
     command: "NEXMARK_QUERIES=$NEXMARK_QUERIES ci/scripts/gen-flamegraph.sh"
     depends_on: "cpu-flamegraph-env-build"
 

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -1,0 +1,69 @@
+cargo-cache: &cargo-cache
+  id: cache
+  key: "v1-cache-{{ id }}-{{ runner.os }}-{{ checksum 'Cargo.lock' }}"
+  restore-keys:
+    - "v1-cache-{{ id }}-{{ runner.os }}-"
+    - "v1-cache-{{ id }}-"
+  backend: s3
+  s3:
+    bucket: ci-cache-bucket
+    args: '--no-progress'
+  paths:
+    - ".cargo/registry/index"
+    - ".cargo/registry/cache"
+    - ".cargo/git/db"
+    - ".cargo/advisory-db"
+
+steps:
+  - label: "check ci image rebuild"
+    plugins:
+      - chronotc/monorepo-diff#v2.3.0:
+          diff: "git diff --name-only origin/main"
+          watch:
+            - path: "ci/build-ci-image.sh"
+              config:
+                command: "ci/build-ci-image.sh"
+                label: "ci build images"
+  - wait
+  -
+  # Generates cpu flamegraph env
+  - label: "cpu-flamegraph-env-build"
+    key: "cpu-flamegraph-env-build"
+    command: "ci/scripts/flamegraph-env-build.sh"
+    if: build.pull_request.labels includes "cpu_flamegraph"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GITHUB_TOKEN: github-token
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v4.9.0:
+          run: rw-build-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_TOKEN
+    timeout_in_minutes: 20
+
+  # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
+  - label: Generate CPU flamegraph"
+    command: "NEXMARK_QUERIES=$NEXMARK_QUERIES ci/scripts/gen-flamegraph.sh"
+    depends_on: "cpu-flamegraph-env-build"
+
+    if: build.pull_request.labels includes "cpu_flamegraph"
+
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GITHUB_TOKEN: github-token
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v4.9.0:
+          run: ci-flamegraph-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_TOKEN
+    # TODO(kwannoel): Here are the areas that can be further optimized:
+    # - Nexmark event generation: ~3min for 100mil records.
+    # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
+    # - Building RW artifacts: ~8min
+    timeout_in_minutes: 60 # ~3-4 queries can run

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -62,4 +62,4 @@ steps:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
     # - Building RW artifacts: ~8min
-    timeout_in_minutes: 120
+    timeout_in_minutes: 360

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -44,7 +44,7 @@ steps:
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
   - label: "Generate CPU flamegraph"
-    command: "NEXMARK_QUERIES=$NEXMARK_QUERIES ci/scripts/gen-flamegraph.sh"
+    command: "ci/scripts/gen-flamegraph.sh"
     depends_on: "cpu-flamegraph-env-build"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -57,6 +57,7 @@ steps:
           mount-buildkite-agent: true
           environment:
             - GITHUB_TOKEN
+            - NEXMARK_QUERIES
     # TODO(kwannoel): Here are the areas that can be further optimized:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -25,12 +25,10 @@ steps:
                 command: "ci/build-ci-image.sh"
                 label: "ci build images"
   - wait
-  -
   # Generates cpu flamegraph env
   - label: "cpu-flamegraph-env-build"
     key: "cpu-flamegraph-env-build"
     command: "ci/scripts/flamegraph-env-build.sh"
-    if: build.pull_request.labels includes "cpu_flamegraph"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -48,9 +46,6 @@ steps:
   - label: "Generate CPU flamegraph"
     command: "NEXMARK_QUERIES=$NEXMARK_QUERIES ci/scripts/gen-flamegraph.sh"
     depends_on: "cpu-flamegraph-env-build"
-
-    if: build.pull_request.labels includes "cpu_flamegraph"
-
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -62,4 +62,4 @@ steps:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
     # - Building RW artifacts: ~8min
-    timeout_in_minutes: 60 # ~3-4 queries can run
+    timeout_in_minutes: 120

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -308,4 +308,4 @@ steps:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
     # - Building RW artifacts: ~8min
-    timeout_in_minutes: 50
+    timeout_in_minutes: 120

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -307,4 +307,4 @@ steps:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
     # - Building RW artifacts: ~8min
-    timeout_in_minutes: 120
+    timeout_in_minutes: 360

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -290,7 +290,7 @@ steps:
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
   - label: "Generate CPU flamegraph"
-    command: "ci/scripts/gen-flamegraph.sh"
+    command: "NEXMARK_QUERIES=all ci/scripts/gen-flamegraph.sh"
     depends_on: "cpu-flamegraph-env-build"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -303,7 +303,6 @@ steps:
           mount-buildkite-agent: true
           environment:
             - GITHUB_TOKEN
-            - NEXMARK_QUERIES: "all"
     # TODO(kwannoel): Here are the areas that can be further optimized:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -303,6 +303,7 @@ steps:
           mount-buildkite-agent: true
           environment:
             - GITHUB_TOKEN
+            - NEXMARK_QUERIES: "all"
     # TODO(kwannoel): Here are the areas that can be further optimized:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Workflow to trigger adhoc flamegraph generation on arbitrary branch and commit.
You can trigger it via buildkite api, or via buildkite gui after this PR.

---

After #9421 

This will be very useful for https://github.com/risingwavelabs/risingwave/issues/9285.

1. We can `curl` to trigger a build: https://buildkite.com/docs/apis/rest-api/builds#create-a-build.
2. Upload throughput as meta data https://buildkite.com/docs/apis/rest-api/builds#get-a-build.
3. Use that to determine whether tps regressed.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
