### PR TITLE
feat(frontend): print partial explain traces if there's error

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -477,7 +477,7 @@ alias = "dev"
 [tasks.dev]
 category = "RiseDev - Start"
 dependencies = ["pre-start-dev"]
-script = "RUST_BACKTRACE=full target/${BUILD_MODE_DIR}/risedev-dev ${@}"
+script = "RUST_BACKTRACE=1 target/${BUILD_MODE_DIR}/risedev-dev ${@}"
 description = "Start a full RisingWave dev cluster using risedev-dev"
 
 [tasks.kafka]

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -230,9 +230,9 @@ pub async fn handle_explain(
         if options.trace {
             // If `trace` is on, we include the error in the output with partial traces.
             blocks.push(if options.verbose {
-                format!("{:?}", e)
+                format!("ERROR: {:?}", e)
             } else {
-                format!("{}", e)
+                format!("ERROR: {}", e)
             });
         } else {
             // Else, directly return the error.

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use futures::StreamExt;
+use itertools::Itertools;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
-use pgwire::pg_response::{PgResponse, StatementType};
+use pgwire::pg_response::{PgResponse, RowSetResult, StatementType};
 use pgwire::types::Row;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
@@ -34,23 +36,57 @@ use crate::optimizer::OptimizerContext;
 use crate::scheduler::BatchPlanFragmenter;
 use crate::stream_fragmenter::build_graph;
 use crate::utils::explain_stream_graph;
+use crate::{OptimizerContextRef, PgResponseStream};
 
-pub async fn handle_explain(
-    handler_args: HandlerArgs,
+// Statement::CreateTable {
+//     name,
+//     columns,
+//     constraints,
+//     source_schema,
+//     source_watermarks,
+//     append_only,
+//     ..
+// } => match check_create_table_with_source(&handler_args.with_options, source_schema)?
+// {     Some(s) => {
+//         gen_create_table_plan_with_source(
+//             context,
+//             name,
+//             columns,
+//             constraints,
+//             s,
+//             source_watermarks,
+//             ColumnIdGenerator::new_initial(),
+//             append_only,
+//         )
+//         .await?
+//         .0
+//     }
+//     None => {
+//         gen_create_table_plan(
+//             context,
+//             name,
+//             columns,
+//             constraints,
+//             ColumnIdGenerator::new_initial(),
+//             source_watermarks,
+//             append_only,
+//         )?
+//         .0
+//     }
+// },
+
+async fn do_handle_explain(
+    context: OptimizerContext,
     stmt: Statement,
-    options: ExplainOptions,
-    analyze: bool,
-) -> Result<RwPgResponse> {
-    let context = OptimizerContext::new(handler_args.clone(), options.clone());
-
-    if analyze {
-        return Err(ErrorCode::NotImplemented("explain analyze".to_string(), 4856.into()).into());
-    }
-
-    let session = context.session_ctx().clone();
-
+    blocks: &mut Vec<String>,
+) -> Result<()> {
+    // Hack to avoid `Rc` across `await` point.
     let mut plan_fragmenter = None;
-    let mut rows = {
+
+    {
+        let context: OptimizerContextRef = context.into();
+        let session = context.session_ctx().clone();
+
         let plan = match stmt {
             Statement::CreateView {
                 or_replace: false,
@@ -59,46 +95,11 @@ pub async fn handle_explain(
                 name,
                 columns,
                 ..
-            } => gen_create_mv_plan(&session, context.into(), *query, name, columns)?.0,
+            } => gen_create_mv_plan(&session, context.clone(), *query, name, columns).map(|x| x.0),
 
-            Statement::CreateSink { stmt } => gen_sink_plan(&session, context.into(), stmt)?.0,
-
-            Statement::CreateTable {
-                name,
-                columns,
-                constraints,
-                source_schema,
-                source_watermarks,
-                append_only,
-                ..
-            } => match check_create_table_with_source(&handler_args.with_options, source_schema)? {
-                Some(s) => {
-                    gen_create_table_plan_with_source(
-                        context,
-                        name,
-                        columns,
-                        constraints,
-                        s,
-                        source_watermarks,
-                        ColumnIdGenerator::new_initial(),
-                        append_only,
-                    )
-                    .await?
-                    .0
-                }
-                None => {
-                    gen_create_table_plan(
-                        context,
-                        name,
-                        columns,
-                        constraints,
-                        ColumnIdGenerator::new_initial(),
-                        source_watermarks,
-                        append_only,
-                    )?
-                    .0
-                }
-            },
+            Statement::CreateSink { stmt } => {
+                gen_sink_plan(&session, context.clone(), stmt).map(|x| x.0)
+            }
 
             Statement::CreateIndex {
                 name,
@@ -107,38 +108,46 @@ pub async fn handle_explain(
                 include,
                 distributed_by,
                 ..
-            } => {
-                gen_create_index_plan(
-                    &session,
-                    context.into(),
-                    name,
-                    table_name,
-                    columns,
-                    include,
-                    distributed_by,
-                )?
-                .0
+            } => gen_create_index_plan(
+                &session,
+                context.clone(),
+                name,
+                table_name,
+                columns,
+                include,
+                distributed_by,
+            )
+            .map(|x| x.0),
+
+            Statement::Insert { .. }
+            | Statement::Delete { .. }
+            | Statement::Update { .. }
+            | Statement::Query { .. } => {
+                gen_batch_plan_by_statement(&session, context.clone(), stmt).map(|x| x.plan)
             }
 
-            stmt => gen_batch_plan_by_statement(&session, context.into(), stmt)?.plan,
+            _ => {
+                return Err(ErrorCode::NotImplemented(
+                    format!("unsupported statement {:?}", stmt),
+                    None.into(),
+                )
+                .into())
+            }
         };
 
-        let ctx = plan.plan_base().ctx.clone();
-        let explain_trace = ctx.is_explain_trace();
-        let explain_verbose = ctx.is_explain_verbose();
+        let explain_trace = context.is_explain_trace();
+        let explain_verbose = context.is_explain_verbose();
+        let explain_type = context.explain_type();
 
-        let mut rows = if explain_trace {
-            let trace = ctx.take_trace();
-            trace
-                .iter()
-                .flat_map(|s| s.lines())
-                .map(|s| Row::new(vec![Some(s.to_string().into())]))
-                .collect::<Vec<_>>()
-        } else {
-            vec![]
-        };
+        if explain_trace {
+            let trace = context.take_trace();
+            blocks.extend(trace);
+        }
 
-        match options.explain_type {
+        // Throw the error.
+        let plan = plan?;
+
+        match explain_type {
             ExplainType::DistSql => match plan.convention() {
                 Convention::Logical => unreachable!(),
                 Convention::Batch => {
@@ -151,56 +160,71 @@ pub async fn handle_explain(
                 }
                 Convention::Stream => {
                     let graph = build_graph(plan);
-                    rows.extend(
-                        explain_stream_graph(&graph, explain_verbose)
-                            .lines()
-                            .map(|s| Row::new(vec![Some(s.to_string().into())])),
-                    );
+                    blocks.push(explain_stream_graph(&graph, explain_verbose));
                 }
             },
             ExplainType::Physical => {
                 // if explain trace is open, the plan has been in the rows
                 if !explain_trace {
                     let output = plan.explain_to_string()?;
-                    rows.extend(
-                        output
-                            .lines()
-                            .map(|s| Row::new(vec![Some(s.to_string().into())])),
-                    );
+                    blocks.push(output);
                 }
             }
             ExplainType::Logical => {
                 // if explain trace is open, the plan has been in the rows
                 if !explain_trace {
-                    let output = plan.ctx().take_logical().ok_or_else(|| {
+                    let output = context.take_logical().ok_or_else(|| {
                         ErrorCode::InternalError("Logical plan not found for query".into())
                     })?;
-                    rows.extend(
-                        output
-                            .lines()
-                            .map(|s| Row::new(vec![Some(s.to_string().into())])),
-                    );
+                    blocks.push(output);
                 }
             }
         }
-        rows
-    };
+    }
 
     if let Some(plan_fragmenter) = plan_fragmenter {
         let query = plan_fragmenter.generate_complete_query().await?;
         let stage_graph_json = serde_json::to_string_pretty(&query.stage_graph).unwrap();
-        rows.extend(
-            vec![stage_graph_json]
-                .iter()
-                .flat_map(|s| s.lines())
-                .map(|s| Row::new(vec![Some(s.to_string().into())])),
-        );
+        blocks.push(stage_graph_json);
     }
+
+    Ok(())
+}
+
+pub async fn handle_explain(
+    handler_args: HandlerArgs,
+    stmt: Statement,
+    options: ExplainOptions,
+    analyze: bool,
+) -> Result<RwPgResponse> {
+    if analyze {
+        return Err(ErrorCode::NotImplemented("explain analyze".to_string(), 4856.into()).into());
+    }
+
+    let context = OptimizerContext::new(handler_args.clone(), options.clone()).into();
+    let mut blocks = Vec::new();
+
+    let result = do_handle_explain(context, stmt, &mut blocks).await;
+
+    let mut row_sets = Vec::<RowSetResult>::new();
+    for block in blocks {
+        let row_set = block
+            .lines()
+            .map(|l| Row::new(vec![Some(l.to_owned().into())]))
+            .collect_vec();
+        row_sets.push(Ok(row_set));
+    }
+
+    if let Err(e) = result {
+        row_sets.push(Err(e.into()));
+    }
+
+    let stream = PgResponseStream::Rows(futures::stream::iter(row_sets).boxed());
 
     Ok(PgResponse::new_for_stream(
         StatementType::EXPLAIN,
         None,
-        rows.into(),
+        stream,
         vec![PgFieldDescriptor::new(
             "QUERY PLAN".to_owned(),
             DataType::Varchar.to_oid(),

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -140,8 +140,12 @@ impl OptimizerContext {
         self.explain_options.trace
     }
 
+    pub fn explain_type(&self) -> ExplainType {
+        self.explain_options.explain_type
+    }
+
     pub fn is_explain_logical(&self) -> bool {
-        self.explain_options.explain_type == ExplainType::Logical
+        self.explain_type() == ExplainType::Logical
     }
 
     pub fn trace(&self, str: impl Into<String>) {

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -141,7 +141,7 @@ impl OptimizerContext {
     }
 
     pub fn explain_type(&self) -> ExplainType {
-        self.explain_options.explain_type
+        self.explain_options.explain_type.clone()
     }
 
     pub fn is_explain_logical(&self) -> bool {


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR makes it possible to peek at the partial outputs of `EXPLAIN` if there's an error during plan generation and optimization. This may be helpful for us to develop a new feature or optimizer rule.

```
dev=> create table t (v int);
CREATE_TABLE
dev=> explain(trace) select (select v from t), 1 from t;
                                    QUERY PLAN                                     
-----------------------------------------------------------------------------------
 Begin:
 
 LogicalProject { exprs: [t.v, 1:Int32] }
 └─LogicalApply { type: LeftOuter, on: true, correlated_id: 1, max_one_row: true }
   ├─LogicalScan { table: t, columns: [v, _row_id] }
   └─LogicalProject { exprs: [t.v] }
     └─LogicalScan { table: t, columns: [v, _row_id] }
 
 ERROR: internal error: Scalar subquery might produce more than one row.
(9 rows)
```

For example, if we're working on a logical plan node and are sure that its `to_stream` won't work for now, we can now use `explain(logical)` to get the logical plan. Previously, this can only be achieved with the planner test.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
