### PR TITLE
feat: better memory estimation for `SharedBufferBatch::measure_batch_size`

### DIFF
--- a/src/common/src/jemalloc.rs
+++ b/src/common/src/jemalloc.rs
@@ -31,3 +31,67 @@ macro_rules! enable_task_local_jemalloc_on_unix {
             task_stats_alloc::TaskLocalAlloc(tikv_jemallocator::Jemalloc);
     };
 }
+
+/// Estimate the aligned size for a struct allocated by jemalloc.
+///
+/// The estimated result is expected to be equal with `tikv_jemallocator::usable_size`. It's
+/// designed as a substitute of `tikv_jemallocator::usable_size` because the latter one would panic
+/// if the passed pointer is not in heap.
+///
+/// This estimation assumes 4 KB page size, 16-byte quantum in 64-bit system, which is the most
+/// common cases in 64-bit Linux.
+///
+/// See also: https://jemalloc.net/jemalloc.3.html#size_classes
+pub fn aligned_size(size: usize) -> usize {
+    sz_s2u_compute(size)
+}
+
+// Below are copied from Jemalloc source code: jemalloc/include/jemalloc/internal/sz.h
+//
+// See also:
+// https://github.com/jemalloc/jemalloc/blob/521970fb2e5278b7b92061933cbacdbb9478998a/include/jemalloc/internal/sz.h#L261
+
+fn pow2_ceil_u64(x: u64) -> u64 {
+    if x <= 1 {
+        return x;
+    }
+    let msb_on_index = fls_u64(x - 1);
+    // Range-check; it's on the callers to ensure that the result of this
+    // call won't overflow.
+    assert!(msb_on_index < 63);
+    return 1u64 << (msb_on_index + 1);
+}
+
+fn fls_u64(x: u64) -> usize {
+    assert!(x != 0);
+    return (8 * 8 - 1) ^ x.leading_zeros() as usize;
+}
+
+fn lg_floor(x: u64) -> usize {
+    assert!(x != 0);
+    return fls_u64(x);
+}
+
+fn sz_s2u_compute(mut size: usize) -> usize {
+    if size == 0 {
+        size = 1;
+    }
+
+    if size <= (1 << 3) {
+        let lg_tmin = 3 - 1 + 1;
+        let lg_ceil = lg_floor(pow2_ceil_u64(size as u64));
+        return if lg_ceil < lg_tmin {
+            1 << lg_tmin
+        } else {
+            1 << lg_ceil
+        };
+    } else {
+        let x = lg_floor(((size << 1 as i64) - 1) as u64);
+        let lg_delta = if x < 2 + 4 + 1 { 4 } else { x - 2 - 1 };
+        let delta = 1 << lg_delta;
+        let delta_mask = delta - 1;
+        return (size + delta_mask) & !delta_mask;
+    }
+}
+
+// TODO: add tests to compare between jemalloc and this

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -383,12 +383,10 @@ impl SharedBufferBatch {
                 jemalloc::aligned_size(std::mem::size_of::<Bytes>())
                     + jemalloc::aligned_size(k.len())
                     + jemalloc::aligned_size(std::mem::size_of::<HummockValue<Bytes>>())
-                    + jemalloc::aligned_size(match v {
-                        HummockValue::Put(val) => unsafe {
-                            tikv_jemallocator::usable_size(val.as_ptr())
-                        },
+                    + match v {
+                        HummockValue::Put(val) => jemalloc::aligned_size(val.len()),
                         HummockValue::Delete => 0,
-                    })
+                    }
             })
             .sum()
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

A more accurate estimation for `SharedBufferBatch` items, including the memory usage of struct `Bytes` and the memory overhead of jemalloc allocation. 

_Update at Jun 15_: It has not been merged yet because it was not the cause of any previous OOM problem, but I don't think it will have any negative impact either.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
