### PR TITLE
refactor: improve error message when read barrier fails

### DIFF
--- a/src/storage/src/hummock/error.rs
+++ b/src/storage/src/hummock/error.rs
@@ -45,8 +45,8 @@ enum HummockErrorInner {
     SharedBufferError(String),
     #[error("Wait epoch error {0}.")]
     WaitEpoch(String),
-    #[error("ReadCurrentEpoch error {0}.")]
-    ReadCurrentEpoch(String),
+    #[error("Barrier read is unavailable for now. Likely the cluster is recovering.")]
+    ReadCurrentEpoch,
     #[error("Expired Epoch: watermark {safe_epoch}, epoch {epoch}.")]
     ExpiredEpoch { safe_epoch: u64, epoch: u64 },
     #[error("CompactionExecutor error {0}.")]
@@ -118,8 +118,8 @@ impl HummockError {
         HummockErrorInner::WaitEpoch(error.to_string()).into()
     }
 
-    pub fn read_current_epoch(error: impl ToString) -> HummockError {
-        HummockErrorInner::ReadCurrentEpoch(error.to_string()).into()
+    pub fn read_current_epoch() -> HummockError {
+        HummockErrorInner::ReadCurrentEpoch.into()
     }
 
     pub fn expired_epoch(safe_epoch: u64, epoch: u64) -> HummockError {

--- a/src/storage/src/hummock/state_store.rs
+++ b/src/storage/src/hummock/state_store.rs
@@ -293,20 +293,22 @@ impl StateStore for HummockStorage {
             );
             let sealed_epoch = self.seal_epoch.load(MemOrdering::SeqCst);
             if read_current_epoch > sealed_epoch {
-                return Err(HummockError::read_current_epoch(format!(
-                    "Cannot read when cluster is under recovery. read {} > max seal epoch {}",
-                    read_current_epoch, sealed_epoch
-                ))
-                .into());
+                tracing::warn!(
+                    "invalid barrier read {} > max seal epoch {}",
+                    read_current_epoch,
+                    sealed_epoch
+                );
+                return Err(HummockError::read_current_epoch().into());
             }
 
             let min_current_epoch = self.min_current_epoch.load(MemOrdering::SeqCst);
             if read_current_epoch < min_current_epoch {
-                return Err(HummockError::read_current_epoch(format!(
-                    "Cannot read when cluster is under recovery. read {} < min current epoch {}",
-                    read_current_epoch, min_current_epoch
-                ))
-                .into());
+                tracing::warn!(
+                    "invalid barrier read {} < min current epoch {}",
+                    read_current_epoch,
+                    min_current_epoch
+                );
+                return Err(HummockError::read_current_epoch().into());
             }
         }
         Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #8561.
Now when query fails due to cluster being recovering,
- psql will see `Storage error: Hummock error: Barrier read is unavailable for now. Likely the cluster is recovering.`.
- compute node log will show failure reason: `invalid barrier read {} > max seal epoch {}` or `invalid barrier read {} < min current epoch {}`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
