### PR TITLE
feat(ci): Add adhoc heap flamegraph generation

### DIFF
--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -69,7 +69,7 @@ install_all() {
 
   # flamegraph.pl used to generate heap flamegraph
   echo ">>> Installing flamegraph.pl"
-  wget https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl
+  wget https://raw.githubusercontent.com/brendangregg/FlameGraph/master/flamegraph.pl
   chmod +x ./flamegraph.pl
 
   # faster addr2line to speed up heap flamegraph analysis by jeprof
@@ -217,9 +217,10 @@ gen_heap_flamegraph() {
   FIRST_HEAP_PROFILE=$(ls -c | grep "\.heap" | head -1)
   LATEST_HEAP_PROFILE=$(ls -c | grep "\.heap" | tail -1)
   JEPROF=$(find . -name 'jeprof' | head -1)
+  chmod +x "$JEPROF"
   COMPUTE_NODE=".risingwave/bin/risingwave/compute-node"
   $JEPROF --collapsed $COMPUTE_NODE $LATEST_HEAP_PROFILE > heap.collapsed
-  ./flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
+  ../flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
   popd
 }
 
@@ -277,7 +278,7 @@ run_heap_flamegraph() {
 
   echo "--- Running Benchmarks"
   # TODO(kwannoel): Allow users to configure which query they want to run.
-  psql -h localhost -p 4566 -d dev -U root -f $QUERY_PATH
+  psql -h localhost -p 4566 -d dev -U root -f "$QUERY_PATH"
 
   # NOTE(kwannoel): Can stub first if promql gives us issues.
   # Most nexmark queries (q4-q20) will have a runtime of 10+ min.
@@ -327,7 +328,7 @@ run_cpu_flamegraph() {
 
   echo "--- Running Benchmarks"
   # TODO(kwannoel): Allow users to configure which query they want to run.
-  psql -h localhost -p 4566 -d dev -U root -f $QUERY_PATH
+  psql -h localhost -p 4566 -d dev -U root -f "$QUERY_PATH"
 
   echo "--- Start Profiling"
   start_nperf

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -296,8 +296,8 @@ run_heap_flamegraph() {
   echo "--- Benchmark finished, stopping processes"
   stop_processes
 
+  echo "--- Generate flamegraph"
   if gen_heap_flamegraph; then
-    echo "--- Generate flamegraph"
     mv perf.svg "$FLAMEGRAPH_PATH"
 
     echo "--- Uploading flamegraph"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -294,7 +294,7 @@ run_heap_flamegraph() {
   echo "--- Benchmark finished, stopping processes"
   stop_processes
 
-  if [[ $(gen_heap_flamegraph) ]]; then
+  if gen_heap_flamegraph; then
     echo "--- Generate flamegraph"
     mv perf.svg "$FLAMEGRAPH_PATH"
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -10,6 +10,7 @@ QUERY_DIR="/risingwave/ci/scripts/sql/nexmark"
 # Perhaps we should have a new docker container just for benchmarking?
 pushd ..
 
+############## JOB METADATA
 
 # Buildkite does not support labels at the moment. Have to get via github api.
 get_nexmark_queries_to_run() {
@@ -40,12 +41,6 @@ parse_labels() {
   | xargs echo -n
 }
 
-install_aws_cli() {
-  echo ">>> Install aws cli"
-  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-  unzip -q awscliv2.zip && ./aws/install && mv /usr/local/bin/aws /bin/aws
-}
-
 ############## DEBUG INFO
 
 print_machine_debug_info() {
@@ -56,6 +51,13 @@ print_machine_debug_info() {
 }
 
 ############## INSTALL
+
+# NOTE(kwannoel): Unused for now, maybe used if we use s3 as storage backend.
+install_aws_cli() {
+  echo ">>> Install aws cli"
+  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+  unzip -q awscliv2.zip && ./aws/install && mv /usr/local/bin/aws /bin/aws
+}
 
 # NOTE(kwannoel) we can mirror the artifacts here in an s3 bucket if there are errors with access.
 install_all() {

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -349,6 +349,12 @@ run_cpu_flamegraph() {
   echo "--- Uploading flamegraph"
   buildkite-agent artifact upload "./$FLAMEGRAPH_PATH"
 
+  echo "--- Cleaning up heap artifacts"
+  pushd risingwave
+  rm *.heap
+  rm heap.collapsed
+  popd
+
   echo "--- Machine Debug Info After running $QUERY"
   print_machine_debug_info
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -214,14 +214,19 @@ gen_heap_flamegraph() {
   pushd risingwave
   echo ">>> Heap files"
   ls -lac | grep "\.heap"
-  FIRST_HEAP_PROFILE=$(ls -c | grep "\.heap" | head -1)
-  LATEST_HEAP_PROFILE=$(ls -c | grep "\.heap" | tail -1)
-  JEPROF=$(find . -name 'jeprof' | head -1)
-  chmod +x "$JEPROF"
-  COMPUTE_NODE=".risingwave/bin/risingwave/compute-node"
-  $JEPROF --collapsed $COMPUTE_NODE $LATEST_HEAP_PROFILE > heap.collapsed
-  ../flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
-  mv perf.svg ..
+  set +e
+  LATEST_HEAP_PROFILE="$(ls -c | grep "\.heap" | tail -1)"
+  if [[ -z "$LATEST_HEAP_PROFILE" ]]; then
+    echo "No heap profile generated. Less than 4GB allocated."
+  else
+    JEPROF=$(find . -name 'jeprof' | head -1)
+    chmod +x "$JEPROF"
+    COMPUTE_NODE=".risingwave/bin/risingwave/compute-node"
+    $JEPROF --collapsed $COMPUTE_NODE $LATEST_HEAP_PROFILE > heap.collapsed
+    ../flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
+    mv perf.svg ..
+  fi
+  set -e
   popd
 }
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -232,9 +232,6 @@ monitor() {
 }
 
 stop_processes() {
-  # stop profiler
-  pkill nperf
-
   # stop rw
   pushd risingwave
   ./risedev k
@@ -341,6 +338,8 @@ run_cpu_flamegraph() {
   monitor
 
   echo "--- Benchmark finished, stopping processes"
+  # stop profiler
+  pkill nperf
   stop_processes
 
   echo "--- Generate flamegraph"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -400,4 +400,4 @@ main() {
   #  popd
 }
 
-main
+main "$@"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -295,6 +295,12 @@ run_heap_flamegraph() {
   echo "--- Uploading flamegraph"
   buildkite-agent artifact upload "./$FLAMEGRAPH_PATH"
 
+  echo "--- Cleaning up heap artifacts"
+  pushd risingwave
+  rm *.heap
+  rm heap.collapsed
+  popd
+
   echo "--- Machine Debug Info After running $QUERY"
   print_machine_debug_info
 
@@ -344,17 +350,11 @@ run_cpu_flamegraph() {
   stop_processes
 
   echo "--- Generate flamegraph"
-  gen_heap_flamegraph
+  gen_cpu_flamegraph
   mv perf.svg $FLAMEGRAPH_PATH
 
   echo "--- Uploading flamegraph"
   buildkite-agent artifact upload "./$FLAMEGRAPH_PATH"
-
-  echo "--- Cleaning up heap artifacts"
-  pushd risingwave
-  rm *.heap
-  rm heap.collapsed
-  popd
 
   echo "--- Machine Debug Info After running $QUERY"
   print_machine_debug_info

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -75,7 +75,7 @@ install_all() {
   git clone https://github.com/gimli-rs/addr2line
   pushd addr2line
   cargo b --examples -r
-  cp ./target/release/examples/addr2line $(whereis addr2line)
+  mv ./target/release/examples/addr2line $(which addr2line)
   popd
   rm -rf addr2line
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -68,10 +68,12 @@ install_all() {
   mv jq-linux64 /usr/local/bin/jq
 
   # flamegraph.pl used to generate heap flamegraph
+  echo ">>> Installing flamegraph.pl"
   wget https://github.com/brendangregg/FlameGraph/blob/master/flamegraph.pl
   chmod +x ./flamegraph.pl
 
-  # faster addr2line to speed up flamegraph analysis by jeprof
+  # faster addr2line to speed up heap flamegraph analysis by jeprof
+  echo ">>> Installing addr2line"
   git clone https://github.com/gimli-rs/addr2line
   pushd addr2line
   cargo b --examples -r

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -218,6 +218,8 @@ gen_heap_flamegraph() {
   LATEST_HEAP_PROFILE="$(ls -c | grep "\.heap" | tail -1)"
   if [[ -z "$LATEST_HEAP_PROFILE" ]]; then
     echo "No heap profile generated. Less than 4GB allocated."
+    popd
+    set -e
     return 1
   else
     JEPROF=$(find . -name 'jeprof' | head -1)
@@ -226,10 +228,10 @@ gen_heap_flamegraph() {
     $JEPROF --collapsed $COMPUTE_NODE $LATEST_HEAP_PROFILE > heap.collapsed
     ../flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
     mv perf.svg ..
+    popd
+    set -e
     return 0
   fi
-  set -e
-  popd
 }
 
 ############## MONITORING

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -221,6 +221,7 @@ gen_heap_flamegraph() {
   COMPUTE_NODE=".risingwave/bin/risingwave/compute-node"
   $JEPROF --collapsed $COMPUTE_NODE $LATEST_HEAP_PROFILE > heap.collapsed
   ../flamegraph.pl --color=mem --countname=bytes heap.collapsed > perf.svg
+  mv perf.svg ..
   popd
 }
 

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -212,9 +212,9 @@ gen_cpu_flamegraph() {
 
 gen_heap_flamegraph() {
   pushd risingwave
+  set +e
   echo ">>> Heap files"
   ls -lac | grep "\.heap"
-  set +e
   LATEST_HEAP_PROFILE="$(ls -c | grep "\.heap" | tail -1)"
   if [[ -z "$LATEST_HEAP_PROFILE" ]]; then
     echo "No heap profile generated. Less than 4GB allocated."

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -280,7 +280,6 @@ run_heap_flamegraph() {
   psql -h localhost -p 4566 -d dev -U root -f risingwave/ci/scripts/sql/nexmark/ddl.sql
 
   echo "--- Running Benchmarks"
-  # TODO(kwannoel): Allow users to configure which query they want to run.
   psql -h localhost -p 4566 -d dev -U root -f "$QUERY_PATH"
 
   # NOTE(kwannoel): Can stub first if promql gives us issues.
@@ -336,7 +335,6 @@ run_cpu_flamegraph() {
   psql -h localhost -p 4566 -d dev -U root -f risingwave/ci/scripts/sql/nexmark/ddl.sql
 
   echo "--- Running Benchmarks"
-  # TODO(kwannoel): Allow users to configure which query they want to run.
   psql -h localhost -p 4566 -d dev -U root -f "$QUERY_PATH"
 
   echo "--- Start Profiling"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -288,7 +288,7 @@ run_heap_flamegraph() {
   stop_processes
 
   echo "--- Generate flamegraph"
-  gen_cpu_flamegraph
+  gen_heap_flamegraph
   mv perf.svg $FLAMEGRAPH_PATH
 
   echo "--- Uploading flamegraph"

--- a/ci/scripts/gen-flamegraph.sh
+++ b/ci/scripts/gen-flamegraph.sh
@@ -281,6 +281,10 @@ main() {
   echo "--- Machine Debug Info before Setup"
   print_machine_debug_info
 
+  echo "--- Getting Flamegraph Type (HEAP | CPU)"
+  FL_TYPE="$1"
+  echo "Flamegraph type: $FL_TYPE"
+
   echo "--- Running setup"
   setup
 

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -46,7 +46,8 @@ steps:
 
   # Generates cpu flamegraph if label `CPU_FLAMEGRAPH=true` is added to env var.
   - label: "Generate CPU flamegraph"
-    command: "ci/scripts/gen-flamegraph.sh cpu"
+    command: |
+      NEXMARK_QUERIES="$NEXMARK_QUERIES" ci/scripts/gen-flamegraph.sh cpu
     depends_on: "cpu-flamegraph-env-build"
     if: build.env("CPU_FLAMEGRAPH") == "true"
     plugins:
@@ -60,7 +61,6 @@ steps:
           mount-buildkite-agent: true
           environment:
             - GITHUB_TOKEN
-            - NEXMARK_QUERIES
     # TODO(kwannoel): Here are the areas that can be further optimized:
     # - Nexmark event generation: ~3min for 100mil records.
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
@@ -69,7 +69,8 @@ steps:
 
   # Generates Heap flamegraph if label `HEAP_FLAMEGRAPH=true` is added to env var.
   - label: "Generate Heap flamegraph"
-    command: "ci/scripts/gen-flamegraph.sh heap"
+    command: |
+      NEXMARK_QUERIES="$NEXMARK_QUERIES" ci/scripts/gen-flamegraph.sh heap
     depends_on: "cpu-flamegraph-env-build"
     if: build.env("HEAP_FLAMEGRAPH") == "true"
     plugins:
@@ -83,5 +84,4 @@ steps:
           mount-buildkite-agent: true
           environment:
             - GITHUB_TOKEN
-            - NEXMARK_QUERIES
     timeout_in_minutes: 360

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -44,7 +44,7 @@ steps:
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
   - label: "Generate CPU flamegraph"
-    command: "ci/scripts/gen-flamegraph.sh"
+    command: "ci/scripts/gen-flamegraph.sh cpu"
     depends_on: "cpu-flamegraph-env-build"
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -63,3 +63,21 @@ steps:
     # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
     # - Building RW artifacts: ~8min
     timeout_in_minutes: 360
+
+  # Generates Heap flamegraph if label `heap_flamegraph` is added to PR.
+  - label: "Generate Heap flamegraph"
+    command: "ci/scripts/gen-flamegraph.sh heap"
+    depends_on: "cpu-flamegraph-env-build"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GITHUB_TOKEN: github-token
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v4.9.0:
+          run: ci-flamegraph-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_TOKEN
+            - NEXMARK_QUERIES
+    timeout_in_minutes: 360

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -42,10 +42,11 @@ steps:
             - GITHUB_TOKEN
     timeout_in_minutes: 20
 
-  # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
+  # Generates cpu flamegraph if label `CPU_FLAMEGRAPH=true` is added to env var.
   - label: "Generate CPU flamegraph"
     command: "ci/scripts/gen-flamegraph.sh cpu"
     depends_on: "cpu-flamegraph-env-build"
+    if: build.env("CPU_FLAMEGRAPH") == "true"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -64,10 +65,11 @@ steps:
     # - Building RW artifacts: ~8min
     timeout_in_minutes: 360
 
-  # Generates Heap flamegraph if label `heap_flamegraph` is added to PR.
+  # Generates Heap flamegraph if label `heap_flamegraph=true` is added to env var.
   - label: "Generate Heap flamegraph"
     command: "ci/scripts/gen-flamegraph.sh heap"
     depends_on: "cpu-flamegraph-env-build"
+    if: build.env("HEAP_FLAMEGRAPH") == "true"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:

--- a/ci/workflows/gen-flamegraph.yml
+++ b/ci/workflows/gen-flamegraph.yml
@@ -16,6 +16,7 @@ cargo-cache: &cargo-cache
 
 steps:
   - label: "check ci image rebuild"
+    if: build.env("CPU_FLAMEGRAPH") == "true" || build.env("HEAP_FLAMEGRAPH") == "true"
     plugins:
       - chronotc/monorepo-diff#v2.3.0:
           diff: "git diff --name-only origin/main"
@@ -25,10 +26,11 @@ steps:
                 command: "ci/build-ci-image.sh"
                 label: "ci build images"
   - wait
-  # Generates cpu flamegraph env
+  # Builds cpu flamegraph env
   - label: "cpu-flamegraph-env-build"
     key: "cpu-flamegraph-env-build"
     command: "ci/scripts/flamegraph-env-build.sh"
+    if: build.env("CPU_FLAMEGRAPH") == "true" || build.env("HEAP_FLAMEGRAPH") == "true"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:
@@ -65,7 +67,7 @@ steps:
     # - Building RW artifacts: ~8min
     timeout_in_minutes: 360
 
-  # Generates Heap flamegraph if label `heap_flamegraph=true` is added to env var.
+  # Generates Heap flamegraph if label `HEAP_FLAMEGRAPH=true` is added to env var.
   - label: "Generate Heap flamegraph"
     command: "ci/scripts/gen-flamegraph.sh heap"
     depends_on: "cpu-flamegraph-env-build"

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -290,7 +290,7 @@ steps:
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
   - label: "Generate CPU flamegraph"
-    command: "NEXMARK_QUERIES=all ci/scripts/gen-flamegraph.sh"
+    command: "NEXMARK_QUERIES=all ci/scripts/gen-flamegraph.sh cpu"
     depends_on: "cpu-flamegraph-env-build"
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -313,8 +313,8 @@ steps:
     timeout_in_minutes: 5
 
   # Generates cpu flamegraph env
-  - label: "cpu-flamegraph-env-build"
-    key: "cpu-flamegraph-env-build"
+  - label: "flamegraph-env-build"
+    key: "flamegraph-env-build"
     command: "ci/scripts/flamegraph-env-build.sh"
     if: build.pull_request.labels includes "cpu_flamegraph"
     plugins:
@@ -331,11 +331,35 @@ steps:
     timeout_in_minutes: 20
 
   # Generates cpu flamegraph if label `cpu_flamegraph` is added to PR.
-  - label: Generate CPU flamegraph"
-    command: "PULL_REQUEST=$BUILDKITE_PULL_REQUEST ci/scripts/gen-flamegraph.sh"
-    depends_on: "cpu-flamegraph-env-build"
+  - label: "Generate CPU flamegraph"
+    command: "PULL_REQUEST=$BUILDKITE_PULL_REQUEST ci/scripts/gen-flamegraph.sh cpu"
+    depends_on: "flamegraph-env-build"
 
     if: build.pull_request.labels includes "cpu_flamegraph"
+
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GITHUB_TOKEN: github-token
+      - gencer/cache#v2.4.10: *cargo-cache
+      - docker-compose#v4.9.0:
+          run: ci-flamegraph-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_TOKEN
+    # TODO(kwannoel): Here are the areas that can be further optimized:
+    # - Nexmark event generation: ~3min for 100mil records.
+    # - Generate Flamegraph: ~15min (see https://github.com/koute/not-perf/issues/30 on optimizing)
+    # - Building RW artifacts: ~8min
+    timeout_in_minutes: 60 # ~3-4 queries can run
+
+  # Generates heap flamegraph if label `heap_flamegraph` is added to PR.
+  - label: "Generate Heap flamegraph"
+    command: "PULL_REQUEST=$BUILDKITE_PULL_REQUEST ci/scripts/gen-flamegraph.sh heap"
+    depends_on: "flamegraph-env-build"
+
+    if: build.pull_request.labels includes "heap_flamegraph"
 
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -316,7 +316,7 @@ steps:
   - label: "flamegraph-env-build"
     key: "flamegraph-env-build"
     command: "ci/scripts/flamegraph-env-build.sh"
-    if: build.pull_request.labels includes "cpu_flamegraph"
+    if: build.pull_request.labels includes "cpu_flamegraph" || build.pull_request.labels includes "heap_flamegraph"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
           env:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Add heap profiling to ci. I don't know how essential this is to run regularly, so just adding it to pull request and manual workflows.
We can run it on `main-cron` if needed.

---

### Future work

Future improvements tracked here: https://github.com/risingwavelabs/risingwave/issues/9426.
1. Increase nexmark events so we have more allocations.
2. Get multiple snapshots of the heap flamegraph and render them.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
