### PR TITLE
refactor(meta): always persist compaction config.

### DIFF
--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -539,18 +539,12 @@ impl<S: MetaStore> HummockManager<S> {
                     .id_gen_manager()
                     .generate::<{ IdCategory::CompactionGroup }>()
                     .await?;
+                // The new config will be persisted later.
                 let mut config = self
                     .compaction_group_manager
-                    .write()
+                    .read()
                     .await
-                    .get_or_insert_compaction_group_config(
-                        new_compaction_group_id,
-                        self.env.meta_store(),
-                    )
-                    .await?
-                    .compaction_config
-                    .as_ref()
-                    .clone();
+                    .default_compaction_config();
                 config.split_by_state_table = allow_split_by_table;
 
                 new_version_delta.group_deltas.insert(

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -708,10 +708,7 @@ impl CompactionGroupManager {
         compaction_groups.commit();
         let r = compaction_group_ids
             .iter()
-            .map(|id| {
-                let group = self.compaction_groups.get(id).cloned().unwrap();
-                (*id, group)
-            })
+            .map(|id| (*id, self.compaction_groups[id].clone()))
             .collect();
         Ok(r)
     }

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -767,6 +767,9 @@ where
             .generate::<{ IdCategory::HummockCompactionTask }>()
             .await?;
 
+        // When the last table of a compaction group is deleted, the compaction group (and its
+        // config) is destroyed as well. Then a compaction task for this group may come later and
+        // cannot find its config.
         let group_config = match self
             .compaction_group_manager
             .read()

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -2024,8 +2024,8 @@ where
         let compaction = read_lock!(self, compaction).await;
         for (group_id, status) in &compaction.compaction_statuses {
             if let Some(levels) = version.levels.get(group_id) {
-                let cg = configs.get(group_id).unwrap();
-                let info = status.get_compaction_info(levels, cg.compaction_config());
+                let info =
+                    status.get_compaction_info(levels, configs[group_id].compaction_config());
                 global_info.add(&info);
                 tracing::debug!("cg {} info {:?}", group_id, info);
             }
@@ -2080,8 +2080,7 @@ where
                     let compaction_group_ids_from_version =
                         get_compaction_group_ids(&current_version);
                     for compaction_group_id in &compaction_group_ids_from_version {
-                        let compaction_group_config =
-                            id_to_config.get(compaction_group_id).cloned().unwrap();
+                        let compaction_group_config = &id_to_config[compaction_group_id];
                         trigger_lsm_stat(
                             &hummock_manager.metrics,
                             compaction_group_config.compaction_config(),
@@ -2130,7 +2129,7 @@ where
         let mut slowdown_groups: HashMap<u64, u64> = HashMap::default();
         {
             for (group_id, l0_file_size) in groups {
-                let group = configs.get(&group_id).unwrap();
+                let group = &configs[&group_id];
                 if l0_file_size
                     > MAX_COMPACTION_L0_MULTIPLIER
                         * group.compaction_config.max_bytes_for_level_base

--- a/src/meta/src/hummock/manager/versioning.rs
+++ b/src/meta/src/hummock/manager/versioning.rs
@@ -29,12 +29,11 @@ use risingwave_hummock_sdk::{
 use risingwave_pb::common::WorkerNode;
 use risingwave_pb::hummock::write_limits::WriteLimit;
 use risingwave_pb::hummock::{
-    HummockPinnedSnapshot, HummockPinnedVersion, HummockVersion, HummockVersionCheckpoint,
-    HummockVersionDelta, HummockVersionStats,
+    CompactionConfig, HummockPinnedSnapshot, HummockPinnedVersion, HummockVersion,
+    HummockVersionCheckpoint, HummockVersionDelta, HummockVersionStats,
 };
 use risingwave_pb::meta::subscribe_response::{Info, Operation};
 
-use crate::hummock::compaction::compaction_config::CompactionConfigBuilder;
 use crate::hummock::manager::worker::{HummockManagerEvent, HummockManagerEventSender};
 use crate::hummock::manager::{read_lock, write_lock};
 use crate::hummock::metrics_utils::trigger_safepoint_stat;
@@ -309,15 +308,13 @@ pub(super) fn calc_new_write_limits(
     new_write_limits
 }
 
-pub(super) fn create_init_version() -> HummockVersion {
+pub(super) fn create_init_version(default_compaction_config: CompactionConfig) -> HummockVersion {
     let mut init_version = HummockVersion {
         id: FIRST_VERSION_ID,
         levels: Default::default(),
         max_committed_epoch: INVALID_EPOCH,
         safe_epoch: INVALID_EPOCH,
     };
-    // Initialize independent levels via corresponding compaction groups' config.
-    let default_compaction_config = CompactionConfigBuilder::new().build();
     for group_id in [
         StaticCompactionGroupId::StateDefault as CompactionGroupId,
         StaticCompactionGroupId::MaterializedView as CompactionGroupId,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously, when accessing a compaction group's compaction config:
1. If it has been set explicitly (and persisted) before, it's used.
2. otherwise, a hard-coding `default config` is used.

The problem with this approach is, if the `default config` is changed later (e.g. hard-coding default value is changed), case 2 may start to use a different compaction config unconsciously. This can be risky especially for configs expected to be immutable for a group, e.g. `split_by_state_table`.

With this PR, whenever a new compaction group is created, it's guaranteed its compaction config is persisted as well. So that only case 1 is allowed.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
