### PR TITLE
refactor: make docslt faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2627,15 +2627,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getopts"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5240,7 +5231,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d9cc634bc78768157b5cbfe988ffcd1dcba95cd2b2f03a88316c08c6d00ed63"
 dependencies = [
  "bitflags 1.3.2",
- "getopts",
  "memchr",
  "unicase",
 ]
@@ -5662,13 +5652,13 @@ dependencies = [
  "dialoguer",
  "enum-iterator",
  "fs-err",
+ "glob",
  "google-cloud-pubsub",
  "indicatif",
  "isahc",
  "itertools",
  "kafka",
  "madsim-tokio",
- "pulldown-cmark",
  "redis",
  "regex",
  "serde",
@@ -5676,6 +5666,8 @@ dependencies = [
  "serde_with 2.3.1",
  "serde_yaml",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
  "workspace-hack",
  "yaml-rust",
 ]

--- a/src/risedevtool/Cargo.toml
+++ b/src/risedevtool/Cargo.toml
@@ -21,12 +21,12 @@ console = "0.15"
 dialoguer = "0.10"
 enum-iterator = "1"
 fs-err = "2.9.0"
+glob = "0.3"
 google-cloud-pubsub = "0.7.0"
 indicatif = "0.17"
 isahc = { version = "1", default-features = false, features = ["text-decoding"] }
 itertools = "0.10"
 kafka = { version = "0.9", default-features = false }
-pulldown-cmark = "0.9"
 redis = "0.22"
 regex = "1"
 serde = { version = "1", features = ["derive"] }
@@ -43,5 +43,7 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
     "signal",
     "fs"
 ] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
 workspace-hack = { path = "../workspace-hack" }
 yaml-rust = "0.4"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

risedev-docslt is a handy tool to extract slt blocks from Rust docs. However, it runs very slow since it has to wait for rustdoc to build the whole project. This process takes over 2 mins in my env, which significantly blocks the dev workflow.

This PR refactors the extraction with plain text processing. It no longer depends on rustdoc, therefore can complete immediately.

I also removed support for setup and teardown, since it's not used and I don't think it will be in the future. 🤔

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
