### PR TITLE
fix(frontend): support `drop function` without arguments

### DIFF
--- a/e2e_test/udf/python.slt
+++ b/e2e_test/udf/python.slt
@@ -165,20 +165,18 @@ drop materialized view mv;
 statement ok
 drop table t;
 
-# TODO: drop function without arguments
-
-# # Drop a function but ambiguous.
-# statement error is not unique
-# drop function gcd;
-
 # Drop a function
 statement ok
 drop function int_42();
 
-# Drop a function
+# Drop a function without arguments, but the function name is not unique.
+statement error is not unique
+drop function gcd;
+
+# Drop a function with arguments.
 statement ok
 drop function gcd(int, int);
 
-# Drop a function
+# Drop a function without arguments. Now the function name is unique.
 statement ok
-drop function gcd(int, int, int);
+drop function gcd;

--- a/e2e_test/udf/python.slt
+++ b/e2e_test/udf/python.slt
@@ -177,6 +177,10 @@ drop function gcd;
 statement ok
 drop function gcd(int, int);
 
+# foo() is different from foo.
+statement error function not found
+drop function gcd();
+
 # Drop a function without arguments. Now the function name is unique.
 statement ok
 drop function gcd;

--- a/src/frontend/src/catalog/root_catalog.rs
+++ b/src/frontend/src/catalog/root_catalog.rs
@@ -571,6 +571,22 @@ impl Catalog {
             .ok_or_else(|| CatalogError::NotFound("function", function_name.to_string()))
     }
 
+    /// Gets all functions with the given name.
+    pub fn get_functions_by_name<'a>(
+        &self,
+        db_name: &str,
+        schema_path: SchemaPath<'a>,
+        function_name: &str,
+    ) -> CatalogResult<(Vec<&Arc<FunctionCatalog>>, &'a str)> {
+        schema_path
+            .try_find(|schema_name| {
+                Ok(self
+                    .get_schema_by_name(db_name, schema_name)?
+                    .get_functions_by_name(function_name))
+            })?
+            .ok_or_else(|| CatalogError::NotFound("function", function_name.to_string()))
+    }
+
     /// Check if the name duplicates with existing table, materialized view or source.
     pub fn check_relation_name_duplicated(
         &self,

--- a/src/frontend/src/catalog/root_catalog.rs
+++ b/src/frontend/src/catalog/root_catalog.rs
@@ -568,7 +568,16 @@ impl Catalog {
                     .get_schema_by_name(db_name, schema_name)?
                     .get_function_by_name_args(function_name, args))
             })?
-            .ok_or_else(|| CatalogError::NotFound("function", function_name.to_string()))
+            .ok_or_else(|| {
+                CatalogError::NotFound(
+                    "function",
+                    format!(
+                        "{}({})",
+                        function_name,
+                        args.iter().map(|a| a.to_string()).join(", ")
+                    ),
+                )
+            })
     }
 
     /// Gets all functions with the given name.

--- a/src/frontend/src/catalog/schema_catalog.rs
+++ b/src/frontend/src/catalog/schema_catalog.rs
@@ -483,6 +483,14 @@ impl SchemaCatalog {
         self.function_by_name.get(name)?.get(args)
     }
 
+    pub fn get_functions_by_name(&self, name: &str) -> Option<Vec<&Arc<FunctionCatalog>>> {
+        let functions = self.function_by_name.get(name)?;
+        if functions.is_empty() {
+            return None;
+        }
+        Some(functions.values().collect())
+    }
+
     pub fn get_connection_by_name(&self, connection_name: &str) -> Option<&Arc<ConnectionCatalog>> {
         self.connection_by_name.get(connection_name)
     }

--- a/src/frontend/src/handler/drop_function.rs
+++ b/src/frontend/src/handler/drop_function.rs
@@ -43,15 +43,38 @@ pub async fn handle_drop_function(
     let user_name = &session.auth_context().user_name;
     let schema_path = SchemaPath::new(schema_name.as_deref(), &search_path, user_name);
 
-    // TODO: argument is not specified, drop the only function with the name
-    let mut arg_types = vec![];
-    for arg in func_desc.args.unwrap_or_default() {
-        arg_types.push(bind_data_type(&arg.data_type)?);
-    }
+    let arg_types = match func_desc.args {
+        Some(args) => {
+            let mut arg_types = vec![];
+            for arg in args {
+                arg_types.push(bind_data_type(&arg.data_type)?);
+            }
+            Some(arg_types)
+        }
+        None => None,
+    };
 
     let function_id = {
         let reader = session.env().catalog_reader().read_guard();
-        match reader.get_function_by_name_args(db_name, schema_path, &function_name, &arg_types) {
+        let res = match arg_types {
+            Some(arg_types) => {
+                reader.get_function_by_name_args(db_name, schema_path, &function_name, &arg_types)
+            }
+            // check if there is only one function if arguments are not specified
+            None => match reader.get_functions_by_name(db_name, schema_path, &function_name) {
+                Ok((functions, schema_name)) => {
+                    if functions.len() > 1 {
+                        return Err(ErrorCode::CatalogError(format!("function name {function_name:?} is not unique\nHINT: Specify the argument list to select the function unambiguously.").into()).into());
+                    }
+                    Ok((
+                        functions.into_iter().next().expect("no functions"),
+                        schema_name,
+                    ))
+                }
+                Err(e) => Err(e),
+            },
+        };
+        match res {
             Ok((function, schema_name)) => {
                 session.check_privilege_for_drop_alter(schema_name, &**function)?;
                 function.id

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2108,7 +2108,7 @@ impl Parser {
 
         let args = if self.consume_token(&Token::LParen) {
             if self.consume_token(&Token::RParen) {
-                None
+                Some(vec![])
             } else {
                 let args = self.parse_comma_separated(Parser::parse_function_arg)?;
                 self.expect_token(&Token::RParen)?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. `drop function foo;` will succeed only when there's exactly one function named `foo`.

Here are some examples:
```sql
dev=> create function foo() ...;
dev=> create function foo(int) ...;

dev=> drop function foo;
ERROR:  QueryError: Catalog error: function name "foo" is not unique
HINT: Specify the argument list to select the function unambiguously.

dev=> drop function foo();
DROP_FUNCTION

# now there's only one function `foo(int)`. this command will succeed to drop it.
dev=> drop function foo;
DROP_FUNCTION
```

This PR also improved the error message when function is not found.

```diff
 dev=> drop function gcd(int);
-ERROR:  QueryError: Catalog error: function not found: gcd
+ERROR:  QueryError: Catalog error: function not found: gcd(integer)
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

> Borrowed from Postgres [documents](https://www.postgresql.org/docs/current/sql-dropfunction.html):

If the function name is unique in its schema, it can be referred to without an argument list:
```sql
DROP FUNCTION foo;
```
Note that this is different from
```sql
DROP FUNCTION foo();
```
which refers to a function with zero arguments, whereas the first variant can refer to a function with any number of arguments, including zero, as long as the name is unique.

</details>
