### PR TITLE
fix(frontend): reject `ALTER SOURCE` on table with connector

### DIFF
--- a/e2e_test/ddl/alter_rename_relation.slt
+++ b/e2e_test/ddl/alter_rename_relation.slt
@@ -184,6 +184,10 @@ SHOW CREATE TABLE msrc1;
 ----
 public.msrc1 CREATE TABLE msrc1 (v INT) WITH (connector = 'datagen', fields.v.kind = 'sequence', fields.v.start = '1', fields.v.end = '10', datagen.rows.per.second = '15', datagen.split.num = '1') ROW FORMAT JSON
 
+# the underlying source cannot have the same name with other sources
+statement error source .+ exists
+ALTER TABLE msrc1 RENAME TO src1;
+
 statement ok
 DROP SINK sink1;
 

--- a/e2e_test/ddl/alter_rename_relation.slt
+++ b/e2e_test/ddl/alter_rename_relation.slt
@@ -26,6 +26,16 @@ CREATE SOURCE src (v INT) WITH (
 ) ROW FORMAT JSON;
 
 statement ok
+CREATE TABLE msrc (v INT) WITH (
+    connector = 'datagen',
+    fields.v.kind = 'sequence',
+    fields.v.start = '1',
+    fields.v.end  = '10',
+    datagen.rows.per.second='15',
+    datagen.split.num = '1'
+) ROW FORMAT JSON;
+
+statement ok
 CREATE VIEW v1 AS ( SELECT * FROM t_as WHERE id = 1);
 
 statement ok
@@ -162,6 +172,18 @@ SHOW CREATE MATERIALIZED VIEW mv4;
 ----
 public.mv4 CREATE MATERIALIZED VIEW mv4 AS SELECT * FROM src1 AS src
 
+# should use `ALTER TABLE` to alter a table with connector
+statement error ALTER TABLE
+ALTER SOURCE msrc RENAME TO msrc1;
+
+statement ok
+ALTER TABLE msrc RENAME TO msrc1;
+
+query TT
+SHOW CREATE TABLE msrc1;
+----
+public.msrc1 CREATE TABLE msrc1 (v INT) WITH (connector = 'datagen', fields.v.kind = 'sequence', fields.v.start = '1', fields.v.end = '10', datagen.rows.per.second = '15', datagen.split.num = '1') ROW FORMAT JSON
+
 statement ok
 DROP SINK sink1;
 
@@ -185,6 +207,9 @@ DROP VIEW v2;
 
 statement ok
 DROP MATERIALIZED VIEW mv4;
+
+statement ok
+DROP TABLE msrc1;
 
 statement ok
 DROP SOURCE src1;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As explained in https://github.com/risingwavelabs/risingwave/issues/9540#issuecomment-1534155805. Close #9540.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
