### PR TITLE
chore(type): change `DataType::List` to tuple struct style

### DIFF
--- a/src/batch/src/executor/filter.rs
+++ b/src/batch/src/executor/filter.rs
@@ -140,12 +140,7 @@ mod tests {
         use risingwave_common::array::{ArrayBuilder, ListArrayBuilder, ListRef, ListValue};
         use risingwave_common::types::Scalar;
 
-        let mut builder = ListArrayBuilder::with_type(
-            4,
-            DataType::List {
-                datatype: Box::new(DataType::Int32),
-            },
-        );
+        let mut builder = ListArrayBuilder::with_type(4, DataType::List(Box::new(DataType::Int32)));
 
         // Add 4 ListValues to ArrayBuilder
         (1..=4).for_each(|i| {
@@ -159,9 +154,7 @@ mod tests {
 
         // Initialize mock executor
         let mut mock_executor = MockExecutor::new(Schema {
-            fields: vec![Field::unnamed(DataType::List {
-                datatype: Box::new(DataType::Int32),
-            })],
+            fields: vec![Field::unnamed(DataType::List(Box::new(DataType::Int32)))],
         });
         mock_executor.add(chunk);
 
@@ -175,10 +168,9 @@ mod tests {
 
         let fields = &filter_executor.schema().fields;
 
-        assert!(fields.iter().all(|f| f.data_type
-            == DataType::List {
-                datatype: Box::new(DataType::Int32)
-            }));
+        assert!(fields
+            .iter()
+            .all(|f| f.data_type == DataType::List(Box::new(DataType::Int32))));
 
         let mut stream = filter_executor.execute();
 

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -534,9 +534,7 @@ mod tests {
                     vec![DataType::Varchar, DataType::Float32],
                     vec![],
                 )),
-                Field::unnamed(DataType::List {
-                    datatype: Box::new(DataType::Int64),
-                }),
+                Field::unnamed(DataType::List(Box::new(DataType::Int64))),
             ],
         };
         let mut struct_builder = StructArrayBuilder::with_type(
@@ -546,12 +544,8 @@ mod tests {
                 DataType::Float32,
             ]))),
         );
-        let mut list_builder = ListArrayBuilder::with_type(
-            0,
-            DataType::List {
-                datatype: Box::new(DataType::Int64),
-            },
-        );
+        let mut list_builder =
+            ListArrayBuilder::with_type(0, DataType::List(Box::new(DataType::Int64)));
         // {abcd, -1.2}   .
         // {c, 0}         [1, ., 3]
         // {c, .}         .
@@ -612,12 +606,8 @@ mod tests {
                 DataType::Float32,
             ]))),
         );
-        let mut list_builder = ListArrayBuilder::with_type(
-            0,
-            DataType::List {
-                datatype: Box::new(DataType::Int64),
-            },
-        );
+        let mut list_builder =
+            ListArrayBuilder::with_type(0, DataType::List(Box::new(DataType::Int64)));
         // {abcd, -1.2}   .
         // {c, 0}         [2]
         // {c, 0}         [1, ., 3]

--- a/src/common/benches/bench_encoding.rs
+++ b/src/common/benches/bench_encoding.rs
@@ -129,9 +129,7 @@ fn bench_encoding(c: &mut Criterion) {
         ),
         Case::new(
             "List of Bool (len = 100)",
-            DataType::List {
-                datatype: Box::new(DataType::Boolean),
-            },
+            DataType::List(Box::new(DataType::Boolean)),
             ScalarImpl::List(ListValue::new(vec![Some(ScalarImpl::Bool(true)); 100])),
         ),
     ];

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -127,9 +127,7 @@ impl From<&arrow_schema::DataType> for DataType {
                 fields: field.iter().map(|f| f.data_type().into()).collect(),
                 field_names: field.iter().map(|f| f.name().clone()).collect(),
             })),
-            List(field) => Self::List {
-                datatype: Box::new(field.data_type().into()),
-            },
+            List(field) => Self::List(Box::new(field.data_type().into())),
             Decimal128(_, _) => Self::Decimal,
             Decimal256(_, _) => Self::Int256,
             _ => todo!("Unsupported arrow data type: {value:?}"),
@@ -164,7 +162,7 @@ impl From<&DataType> for arrow_schema::DataType {
             DataType::Struct(struct_type) => {
                 Self::Struct(get_field_vector_from_struct_type(struct_type))
             }
-            DataType::List { datatype } => {
+            DataType::List(datatype) => {
                 Self::List(Box::new(Field::new("item", datatype.as_ref().into(), true)))
             }
             _ => todo!("Unsupported arrow data type: {value:?}"),

--- a/src/common/src/test_utils/rand_chunk.rs
+++ b/src/common/src/test_utils/rand_chunk.rs
@@ -44,7 +44,7 @@ pub fn gen_chunk(data_types: &[DataType], size: usize, seed: u64, null_ratio: f6
             DataType::Struct(_) | DataType::Bytea | DataType::Jsonb => {
                 todo!()
             }
-            DataType::List { datatype: _ } => {
+            DataType::List(_) => {
                 todo!()
             }
         }));

--- a/src/common/src/types/postgres_type.rs
+++ b/src/common/src/types/postgres_type.rs
@@ -62,51 +62,21 @@ impl DataType {
             1184 => Ok(DataType::Timestamptz),
             1186 => Ok(DataType::Interval),
             3802 => Ok(DataType::Jsonb),
-            1000 => Ok(DataType::List {
-                datatype: Box::new(DataType::Boolean),
-            }),
-            1005 => Ok(DataType::List {
-                datatype: Box::new(DataType::Int16),
-            }),
-            1007 => Ok(DataType::List {
-                datatype: Box::new(DataType::Int32),
-            }),
-            1016 => Ok(DataType::List {
-                datatype: Box::new(DataType::Int64),
-            }),
-            1021 => Ok(DataType::List {
-                datatype: Box::new(DataType::Float32),
-            }),
-            1022 => Ok(DataType::List {
-                datatype: Box::new(DataType::Float64),
-            }),
-            1231 => Ok(DataType::List {
-                datatype: Box::new(DataType::Decimal),
-            }),
-            1182 => Ok(DataType::List {
-                datatype: Box::new(DataType::Date),
-            }),
-            1015 => Ok(DataType::List {
-                datatype: Box::new(DataType::Varchar),
-            }),
-            1266 => Ok(DataType::List {
-                datatype: Box::new(DataType::Time),
-            }),
-            1115 => Ok(DataType::List {
-                datatype: Box::new(DataType::Timestamp),
-            }),
-            1185 => Ok(DataType::List {
-                datatype: Box::new(DataType::Timestamptz),
-            }),
-            1001 => Ok(DataType::List {
-                datatype: Box::new(DataType::Bytea),
-            }),
-            1187 => Ok(DataType::List {
-                datatype: Box::new(DataType::Interval),
-            }),
-            3807 => Ok(DataType::List {
-                datatype: Box::new(DataType::Jsonb),
-            }),
+            1000 => Ok(DataType::List(Box::new(DataType::Boolean))),
+            1005 => Ok(DataType::List(Box::new(DataType::Int16))),
+            1007 => Ok(DataType::List(Box::new(DataType::Int32))),
+            1016 => Ok(DataType::List(Box::new(DataType::Int64))),
+            1021 => Ok(DataType::List(Box::new(DataType::Float32))),
+            1022 => Ok(DataType::List(Box::new(DataType::Float64))),
+            1231 => Ok(DataType::List(Box::new(DataType::Decimal))),
+            1182 => Ok(DataType::List(Box::new(DataType::Date))),
+            1015 => Ok(DataType::List(Box::new(DataType::Varchar))),
+            1266 => Ok(DataType::List(Box::new(DataType::Time))),
+            1115 => Ok(DataType::List(Box::new(DataType::Timestamp))),
+            1185 => Ok(DataType::List(Box::new(DataType::Timestamptz))),
+            1001 => Ok(DataType::List(Box::new(DataType::Bytea))),
+            1187 => Ok(DataType::List(Box::new(DataType::Interval))),
+            3807 => Ok(DataType::List(Box::new(DataType::Jsonb))),
             _ => Err(ErrorCode::InternalError(format!("Unsupported oid {}", oid)).into()),
         }
     }
@@ -132,7 +102,7 @@ impl DataType {
             DataType::Struct(_) => 1043,
             DataType::Jsonb => 3802,
             DataType::Bytea => 17,
-            DataType::List { datatype } => match unnested_list_type(datatype.as_ref().clone()) {
+            DataType::List(datatype) => match unnested_list_type(datatype.as_ref().clone()) {
                 DataType::Boolean => 1000,
                 DataType::Int16 => 1005,
                 DataType::Int32 => 1007,

--- a/src/common/src/util/sort_util.rs
+++ b/src/common/src/util/sort_util.rs
@@ -558,9 +558,7 @@ mod tests {
                 DataType::Timestamp,
                 DataType::Time,
                 DataType::new_struct(vec![DataType::Int32, DataType::Float32], vec![]),
-                DataType::List {
-                    datatype: Box::new(DataType::Int32),
-                },
+                DataType::List(Box::new(DataType::Int32)),
             ],
         );
         assert_eq!(

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -369,9 +369,7 @@ fn deserialize_value(ty: &DataType, data: &mut impl Buf) -> Result<ScalarImpl> {
         ),
         DataType::Struct(struct_def) => deserialize_struct(struct_def, data)?,
         DataType::Bytea => ScalarImpl::Bytea(deserialize_bytea(data).into()),
-        DataType::List {
-            datatype: item_type,
-        } => deserialize_list(item_type, data)?,
+        DataType::List(item_type) => deserialize_list(item_type, data)?,
     })
 }
 

--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -86,9 +86,7 @@ fn avro_type_mapping(schema: &Schema) -> Result<DataType> {
         }
         Schema::Array(item_schema) => {
             let item_type = avro_type_mapping(item_schema.as_ref())?;
-            DataType::List {
-                datatype: Box::new(item_type),
-            }
+            DataType::List(Box::new(item_type))
         }
         Schema::Union(union_schema) => {
             let nested_schema = union_schema

--- a/src/connector/src/parser/common.rs
+++ b/src/connector/src/parser/common.rs
@@ -138,9 +138,7 @@ fn do_parse_simd_json_value(
                 .collect::<Result<Vec<Datum>>>()?;
             ScalarImpl::Struct(StructValue::new(fields))
         }
-        DataType::List {
-            datatype: item_type,
-        } => {
+        DataType::List(item_type) => {
             if let BorrowedValue::Array(values) = v {
                 let values = values
                     .iter()

--- a/src/connector/src/parser/protobuf/parser.rs
+++ b/src/connector/src/parser/protobuf/parser.rs
@@ -316,9 +316,7 @@ fn protobuf_type_mapping(field_descriptor: &FieldDescriptor) -> Result<DataType>
         }
     };
     if field_descriptor.cardinality() == Cardinality::Repeated {
-        t = DataType::List {
-            datatype: Box::new(t),
-        }
+        t = DataType::List(Box::new(t))
     }
     Ok(t)
 }

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -327,7 +327,7 @@ fn datum_to_json_object(field: &Field, datum: DatumRef<'_>) -> ArrayResult<Value
         (DataType::Interval, ScalarRefImpl::Interval(v)) => {
             json!(v.as_iso_8601())
         }
-        (DataType::List { datatype }, ScalarRefImpl::List(list_ref)) => {
+        (DataType::List(datatype), ScalarRefImpl::List(list_ref)) => {
             let elems = list_ref.iter_elems_ref();
             let mut vec = Vec::with_capacity(elems.len());
             let inner_field = Field::unnamed(Box::<DataType>::into_inner(datatype));

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -265,7 +265,7 @@ fn generator_from_data_type(
                     .collect::<Result<_>>()?;
             FieldGeneratorImpl::with_struct_fields(struct_fields)
         }
-        DataType::List { datatype } => {
+        DataType::List(datatype) => {
             let length_key = format!("fields.{}.length", name);
             let length_value = fields_option_map.get(&length_key).map(|s| s.to_string());
             let generator = generator_from_data_type(

--- a/src/expr/src/agg/array_agg.rs
+++ b/src/expr/src/agg/array_agg.rs
@@ -41,9 +41,7 @@ mod tests {
              456
              789",
         );
-        let return_type = DataType::List {
-            datatype: Box::new(DataType::Int32),
-        };
+        let return_type = DataType::List(Box::new(DataType::Int32));
         let mut agg = crate::agg::build(AggCall {
             kind: AggKind::ArrayAgg,
             args: AggArgs::Unary(DataType::Int32, 0),
@@ -74,9 +72,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_array_agg_empty() -> Result<()> {
-        let return_type = DataType::List {
-            datatype: Box::new(DataType::Int32),
-        };
+        let return_type = DataType::List(Box::new(DataType::Int32));
         let mut agg = crate::agg::build(AggCall {
             kind: AggKind::ArrayAgg,
             args: AggArgs::Unary(DataType::Int32, 0),
@@ -123,9 +119,7 @@ mod tests {
              789  2
              321  9",
         );
-        let return_type = DataType::List {
-            datatype: Box::new(DataType::Int32),
-        };
+        let return_type = DataType::List(Box::new(DataType::Int32));
         let mut agg = crate::agg::build(AggCall {
             kind: AggKind::ArrayAgg,
             args: AggArgs::Unary(DataType::Int32, 0),

--- a/src/expr/src/agg/general.rs
+++ b/src/expr/src/agg/general.rs
@@ -236,12 +236,8 @@ mod tests {
             DataType::Int32,
         );
         let agg_type = AggKind::Min;
-        let input_type = DataType::List {
-            datatype: Box::new(DataType::Int32),
-        };
-        let return_type = DataType::List {
-            datatype: Box::new(DataType::Int32),
-        };
+        let input_type = DataType::List(Box::new(DataType::Int32));
+        let return_type = DataType::List(Box::new(DataType::Int32));
         let actual = eval_agg(
             input_type,
             Arc::new(input.into()),
@@ -249,9 +245,7 @@ mod tests {
             return_type,
             ArrayBuilderImpl::List(ListArrayBuilder::with_type(
                 0,
-                DataType::List {
-                    datatype: Box::new(DataType::Int32),
-                },
+                DataType::List(Box::new(DataType::Int32)),
             )),
         )
         .await?;

--- a/src/expr/src/expr/expr_array_concat.rs
+++ b/src/expr/src/expr/expr_array_concat.rs
@@ -400,12 +400,7 @@ mod tests {
     fn make_i64_array_expr_node(values: Vec<i64>) -> ExprNode {
         ExprNode {
             expr_type: PbType::Array as i32,
-            return_type: Some(
-                DataType::List {
-                    datatype: Box::new(DataType::Int64),
-                }
-                .to_protobuf(),
-            ),
+            return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
                 children: values.into_iter().map(make_i64_expr_node).collect(),
             })),
@@ -416,12 +411,7 @@ mod tests {
         ExprNode {
             expr_type: PbType::Array as i32,
             return_type: Some(
-                DataType::List {
-                    datatype: Box::new(DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }),
-                }
-                .to_protobuf(),
+                DataType::List(Box::new(DataType::List(Box::new(DataType::Int64)))).to_protobuf(),
             ),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
                 children: values.into_iter().map(make_i64_array_expr_node).collect(),
@@ -436,12 +426,7 @@ mod tests {
             let right = make_i64_array_expr_node(vec![43]);
             let expr = ExprNode {
                 expr_type: PbType::ArrayCat as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -454,12 +439,7 @@ mod tests {
             let right = make_i64_array_array_expr_node(vec![vec![43]]);
             let expr = ExprNode {
                 expr_type: PbType::ArrayCat as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -472,12 +452,7 @@ mod tests {
             let right = make_i64_expr_node(43);
             let expr = ExprNode {
                 expr_type: PbType::ArrayAppend as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -490,12 +465,7 @@ mod tests {
             let right = make_i64_array_expr_node(vec![43]);
             let expr = ExprNode {
                 expr_type: PbType::ArrayAppend as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -508,12 +478,7 @@ mod tests {
             let right = make_i64_array_expr_node(vec![42]);
             let expr = ExprNode {
                 expr_type: PbType::ArrayPrepend as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -526,12 +491,7 @@ mod tests {
             let right = make_i64_array_array_expr_node(vec![vec![42]]);
             let expr = ExprNode {
                 expr_type: PbType::ArrayPrepend as i32,
-                return_type: Some(
-                    DataType::List {
-                        datatype: Box::new(DataType::Int64),
-                    }
-                    .to_protobuf(),
-                ),
+                return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
                 })),
@@ -542,9 +502,7 @@ mod tests {
 
     fn make_i64_array_expr(values: Vec<i64>) -> BoxedExpression {
         LiteralExpression::new(
-            DataType::List {
-                datatype: Box::new(DataType::Int64),
-            },
+            DataType::List(Box::new(DataType::Int64)),
             Some(ListValue::new(values.into_iter().map(|x| Some(x.into())).collect()).into()),
         )
         .boxed()
@@ -555,9 +513,7 @@ mod tests {
         let left = make_i64_array_expr(vec![42]);
         let right = make_i64_array_expr(vec![43, 44]);
         let expr = ArrayConcatExpression::new(
-            DataType::List {
-                datatype: Box::new(DataType::Int64),
-            },
+            DataType::List(Box::new(DataType::Int64)),
             left,
             right,
             Operation::ConcatArray,

--- a/src/expr/src/expr/expr_array_to_string.rs
+++ b/src/expr/src/expr/expr_array_to_string.rs
@@ -32,7 +32,7 @@ fn build_array_to_string(
     let list = iter.next().unwrap();
     let delimiter = iter.next().unwrap();
     let elem_type = match list.return_type() {
-        DataType::List { datatype } => *datatype,
+        DataType::List(datatype) => *datatype,
         _ => panic!("expected list type"),
     };
     let expr = BinaryBytesExpression::<ListArray, Utf8Array, _>::new(
@@ -122,7 +122,7 @@ fn build_array_to_string_with_null(
     let delimiter = iter.next().unwrap();
     let null_string = iter.next().unwrap();
     let elem_type = match list.return_type() {
-        DataType::List { datatype } => *datatype,
+        DataType::List(datatype) => *datatype,
         _ => panic!("expected list type"),
     };
     let expr = TernaryBytesExpression::<ListArray, Utf8Array, Utf8Array, _>::new(

--- a/src/expr/src/expr/expr_nested_construct.rs
+++ b/src/expr/src/expr/expr_nested_construct.rs
@@ -77,7 +77,7 @@ impl Expression for NestedConstructExpression {
         }
         if let DataType::Struct { .. } = &self.data_type {
             Ok(Some(StructValue::new(datums).to_scalar_value()))
-        } else if let DataType::List { datatype: _ } = &self.data_type {
+        } else if let DataType::List(_) = &self.data_type {
             Ok(Some(ListValue::new(datums).to_scalar_value()))
         } else {
             Err(ExprError::UnsupportedFunction(
@@ -127,9 +127,7 @@ mod tests {
     #[tokio::test]
     async fn test_eval_array_expr() {
         let expr = NestedConstructExpression {
-            data_type: DataType::List {
-                datatype: DataType::Int32.into(),
-            },
+            data_type: DataType::List(DataType::Int32.into()),
             elements: vec![i32_expr(1.into()), i32_expr(2.into())],
         };
 
@@ -140,9 +138,7 @@ mod tests {
     #[tokio::test]
     async fn test_eval_row_array_expr() {
         let expr = NestedConstructExpression {
-            data_type: DataType::List {
-                datatype: DataType::Int32.into(),
-            },
+            data_type: DataType::List(DataType::Int32.into()),
             elements: vec![i32_expr(1.into()), i32_expr(2.into())],
         };
 

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -191,9 +191,7 @@ impl RegexpMatchExpression {
 #[async_trait::async_trait]
 impl Expression for RegexpMatchExpression {
     fn return_type(&self) -> DataType {
-        DataType::List {
-            datatype: Box::new(DataType::Varchar),
-        }
+        DataType::List(Box::new(DataType::Varchar))
     }
 
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
@@ -201,9 +199,7 @@ impl Expression for RegexpMatchExpression {
         let text_arr: &Utf8Array = text_arr.as_ref().into();
         let mut output = ListArrayBuilder::with_type(
             input.capacity(),
-            DataType::List {
-                datatype: Box::new(DataType::Varchar),
-            },
+            DataType::List(Box::new(DataType::Varchar)),
         );
 
         for (text, vis) in text_arr.iter().zip_eq_fast(input.vis().iter()) {

--- a/src/expr/src/expr/expr_some_all.rs
+++ b/src/expr/src/expr/expr_some_all.rs
@@ -88,7 +88,7 @@ impl Expression for SomeAllExpression {
         let mut num_array = Vec::with_capacity(data_chunk.capacity());
 
         let arr_right_inner = arr_right.as_list();
-        let DataType::List { datatype } = arr_right_inner.data_type() else { unreachable!() };
+        let DataType::List(datatype) = arr_right_inner.data_type() else { unreachable!() };
         let capacity = arr_right_inner
             .iter()
             .flatten()
@@ -217,9 +217,7 @@ impl<'a> TryFrom<&'a ExprNode> for SomeAllExpression {
         let left_expr = build_from_prost(&inner_children[0])?;
         let right_expr = build_from_prost(&inner_children[1])?;
 
-        let DataType::List {
-            datatype: right_expr_return_type,
-        } = right_expr.return_type() else {
+        let DataType::List(right_expr_return_type) = right_expr.return_type() else {
             bail!("Expect Array Type");
         };
 

--- a/src/expr/src/table_function/regexp_matches.rs
+++ b/src/expr/src/table_function/regexp_matches.rs
@@ -61,9 +61,7 @@ impl RegexpMatches {
 #[async_trait::async_trait]
 impl TableFunction for RegexpMatches {
     fn return_type(&self) -> DataType {
-        DataType::List {
-            datatype: Box::new(DataType::Varchar),
-        }
+        DataType::List(Box::new(DataType::Varchar))
     }
 
     async fn eval(&self, input: &DataChunk) -> Result<Vec<ArrayRef>> {
@@ -106,15 +104,7 @@ pub fn new_regexp_matches(
     prost: &TableFunctionPb,
     chunk_size: usize,
 ) -> Result<BoxedTableFunction> {
-    ensure!(
-        prost.return_type
-            == Some(
-                DataType::List {
-                    datatype: Box::new(DataType::Varchar),
-                }
-                .to_protobuf()
-            )
-    );
+    ensure!(prost.return_type == Some(DataType::List(Box::new(DataType::Varchar)).to_protobuf()));
     let mut args = prost.args.iter();
     let Some(text_node) = args.next() else {
         bail!("Expected argument text");

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -510,7 +510,7 @@ fn build_cast_str_to_list(
     children: Vec<BoxedExpression>,
 ) -> Result<BoxedExpression> {
     let elem_type = match &return_type {
-        DataType::List { datatype } => (**datatype).clone(),
+        DataType::List(datatype) => (**datatype).clone(),
         _ => panic!("expected list type"),
     };
     let child = children.into_iter().next().unwrap();
@@ -546,11 +546,11 @@ fn build_cast_list_to_list(
 ) -> Result<BoxedExpression> {
     let child = children.into_iter().next().unwrap();
     let source_elem_type = match child.return_type() {
-        DataType::List { datatype } => (*datatype).clone(),
+        DataType::List(datatype) => (*datatype).clone(),
         _ => panic!("expected list type"),
     };
     let target_elem_type = match &return_type {
-        DataType::List { datatype } => (**datatype).clone(),
+        DataType::List(datatype) => (**datatype).clone(),
         _ => panic!("expected list type"),
     };
     Ok(Box::new(UnaryExpression::<ListArray, ListArray, _>::new(
@@ -792,13 +792,7 @@ mod tests {
         // Nested List
         let nested_list123 = ListValue::new(vec![Some(ScalarImpl::List(list123))]);
         assert_eq!(
-            str_to_list(
-                "{{1, 2, 3}}",
-                &DataType::List {
-                    datatype: Box::new(DataType::Int32)
-                }
-            )
-            .unwrap(),
+            str_to_list("{{1, 2, 3}}", &DataType::List(Box::new(DataType::Int32))).unwrap(),
             nested_list123
         );
 
@@ -817,11 +811,7 @@ mod tests {
         assert_eq!(
             str_to_list(
                 "{{{1, 2, 3}}, {{44, 55, 66}}}",
-                &DataType::List {
-                    datatype: Box::new(DataType::List {
-                        datatype: Box::new(DataType::Int32)
-                    })
-                }
+                &DataType::List(Box::new(DataType::List(Box::new(DataType::Int32))))
             )
             .unwrap(),
             double_nested_list123_445566
@@ -834,12 +824,8 @@ mod tests {
                     ListRef::ValueRef {
                         val: &nested_list123,
                     },
-                    &DataType::List {
-                        datatype: Box::new(DataType::Int32),
-                    },
-                    &DataType::List {
-                        datatype: Box::new(DataType::Varchar),
-                    },
+                    &DataType::List(Box::new(DataType::Int32)),
+                    &DataType::List(Box::new(DataType::Varchar)),
                 )
                 .unwrap(),
             )),
@@ -848,12 +834,8 @@ mod tests {
                     ListRef::ValueRef {
                         val: &nested_list445566,
                     },
-                    &DataType::List {
-                        datatype: Box::new(DataType::Int32),
-                    },
-                    &DataType::List {
-                        datatype: Box::new(DataType::Varchar),
-                    },
+                    &DataType::List(Box::new(DataType::Int32)),
+                    &DataType::List(Box::new(DataType::Varchar)),
                 )
                 .unwrap(),
             )),
@@ -863,11 +845,7 @@ mod tests {
         assert_eq!(
             str_to_list(
                 "{{{1, 2, 3}}, {{44, 55, 66}}}",
-                &DataType::List {
-                    datatype: Box::new(DataType::List {
-                        datatype: Box::new(DataType::Varchar)
-                    })
-                }
+                &DataType::List(Box::new(DataType::List(Box::new(DataType::Varchar))))
             )
             .unwrap(),
             double_nested_varchar_list123_445566

--- a/src/frontend/planner_test/tests/testdata/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/array.yaml
@@ -2,15 +2,15 @@
 - sql: |
     values (ARRAY['foo', 'bar']);
   logical_plan: |
-    LogicalValues { rows: [[Array('foo':Varchar, 'bar':Varchar)]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Varchar }] } }
+    LogicalValues { rows: [[Array('foo':Varchar, 'bar':Varchar)]], schema: Schema { fields: [*VALUES*_0.column_0:List(Varchar)] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[foo, bar]:List { datatype: Varchar }]] }
+    BatchValues { rows: [[ARRAY[foo, bar]:List(Varchar)]] }
 - sql: |
     values (ARRAY[1, 2+3, 4*5+1]);
   logical_plan: |
-    LogicalValues { rows: [[Array(1:Int32, (2:Int32 + 3:Int32), ((4:Int32 * 5:Int32) + 1:Int32))]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Int32 }] } }
+    LogicalValues { rows: [[Array(1:Int32, (2:Int32 + 3:Int32), ((4:Int32 * 5:Int32) + 1:Int32))]], schema: Schema { fields: [*VALUES*_0.column_0:List(Int32)] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[1, 5, 21]:List { datatype: Int32 }]] }
+    BatchValues { rows: [[ARRAY[1, 5, 21]:List(Int32)]] }
 - sql: |
     create table t (v1 int);
     select (ARRAY[1, v1]) from t;
@@ -37,12 +37,12 @@
 - sql: |
     select ARRAY[]::int[];
   logical_plan: |
-    LogicalProject { exprs: [Array::List { datatype: Int32 } as $expr1] }
+    LogicalProject { exprs: [Array::List(Int32) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int[][];
   logical_plan: |
-    LogicalProject { exprs: [Array::List { datatype: List { datatype: Int32 } } as $expr1] }
+    LogicalProject { exprs: [Array::List(List(Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int;
@@ -58,21 +58,21 @@
     LogicalProject { exprs: [ArrayCat(Array(66:Int32), Array(123:Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[66, 123]:List { datatype: Int32 }]] }
+    BatchValues { rows: [[ARRAY[66, 123]:List(Int32)]] }
 - sql: |
     select array_cat(array[array[66]], array[233]);
   logical_plan: |
     LogicalProject { exprs: [ArrayCat(Array(Array(66:Int32)), Array(233:Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[{66}, {233}]:List { datatype: List { datatype: Int32 } }]] }
+    BatchValues { rows: [[ARRAY[{66}, {233}]:List(List(Int32))]] }
 - sql: |
     select array_cat(array[233], array[array[66]]);
   logical_plan: |
     LogicalProject { exprs: [ArrayCat(Array(233:Int32), Array(Array(66:Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[{233}, {66}]:List { datatype: List { datatype: Int32 } }]] }
+    BatchValues { rows: [[ARRAY[{233}, {66}]:List(List(Int32))]] }
 - sql: |
     select array_cat(array[233], array[array[array[66]]]);
   binder_error: |-
@@ -100,7 +100,7 @@
     LogicalProject { exprs: [ArrayAppend(Array(66:Int32), 123:Int32) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[66, 123]:List { datatype: Int32 }]] }
+    BatchValues { rows: [[ARRAY[66, 123]:List(Int32)]] }
 - sql: |
     select array_append(123, 234);
   binder_error: |-
@@ -120,7 +120,7 @@
     LogicalProject { exprs: [ArrayPrepend(123:Int32, Array(66:Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchValues { rows: [[ARRAY[123, 66]:List { datatype: Int32 }]] }
+    BatchValues { rows: [[ARRAY[123, 66]:List(Int32)]] }
 - sql: |
     select array_prepend(123, 234);
   binder_error: |-
@@ -136,7 +136,7 @@
 - name: string from/to varchar[] in implicit context
   sql: |
     values (array['a', 'b']), ('{c,' || 'd}');
-  binder_error: 'Bind error: types List { datatype: Varchar } and Varchar cannot be matched'
+  binder_error: 'Bind error: types List(Varchar) and Varchar cannot be matched'
 - name: string to varchar[] in assign context
   sql: |
     create table t (v1 varchar[]);
@@ -146,25 +146,25 @@
   sql: |
     select ('{c,' || 'd}')::varchar[];
   logical_plan: |
-    LogicalProject { exprs: [ConcatOp('{c,':Varchar, 'd}':Varchar)::List { datatype: Varchar } as $expr1] }
+    LogicalProject { exprs: [ConcatOp('{c,':Varchar, 'd}':Varchar)::List(Varchar) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - name: unknown to varchar[] in implicit context
   sql: |
     values (array['a', 'b']), ('{c,d}');
   logical_plan: |
-    LogicalValues { rows: [[Array('a':Varchar, 'b':Varchar)], ['{c,d}':Varchar::List { datatype: Varchar }]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Varchar }] } }
+    LogicalValues { rows: [[Array('a':Varchar, 'b':Varchar)], ['{c,d}':Varchar::List(Varchar)]], schema: Schema { fields: [*VALUES*_0.column_0:List(Varchar)] } }
 - name: unknown to varchar[] in assign context
   sql: |
     create table t (v1 varchar[]);
     insert into t values ('{c,d}');
   logical_plan: |
     LogicalInsert { table: t, mapping: [0:0] }
-    └─LogicalValues { rows: [['{c,d}':Varchar::List { datatype: Varchar }]], schema: Schema { fields: [*VALUES*_0.column_0:List { datatype: Varchar }] } }
+    └─LogicalValues { rows: [['{c,d}':Varchar::List(Varchar)]], schema: Schema { fields: [*VALUES*_0.column_0:List(Varchar)] } }
 - name: unknown to varchar[] in explicit context
   sql: |
     select ('{c,d}')::varchar[];
   logical_plan: |
-    LogicalProject { exprs: ['{c,d}':Varchar::List { datatype: Varchar } as $expr1] }
+    LogicalProject { exprs: ['{c,d}':Varchar::List(Varchar) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - name: varchar[] to string in assign context
   sql: |
@@ -195,13 +195,13 @@
   sql: |
     select null = array[1];
   logical_plan: |
-    LogicalProject { exprs: [(null:List { datatype: Int32 } = Array(1:Int32)) as $expr1] }
+    LogicalProject { exprs: [(null:List(Int32) = Array(1:Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - name: compare with literal
   sql: |
     select array[1] = '{1}';
   logical_plan: |
-    LogicalProject { exprs: [(Array(1:Int32) = '{1}':Varchar::List { datatype: Int32 }) as $expr1] }
+    LogicalProject { exprs: [(Array(1:Int32) = '{1}':Varchar::List(Int32)) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - name: compare with different type
   sql: |

--- a/src/frontend/planner_test/tests/testdata/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/basic_query.yaml
@@ -132,11 +132,11 @@
 - sql: |
     select * from unnest(Array[1,2,3]);
   batch_plan: |
-    BatchTableFunction { Unnest(ARRAY[1, 2, 3]:List { datatype: Int32 }) }
+    BatchTableFunction { Unnest(ARRAY[1, 2, 3]:List(Int32)) }
 - sql: |
     select * from unnest(Array[Array[1,2,3], Array[4,5,6]]);
   batch_plan: |
-    BatchTableFunction { Unnest(ARRAY[{1,2,3}, {4,5,6}]:List { datatype: List { datatype: Int32 } }) }
+    BatchTableFunction { Unnest(ARRAY[{1,2,3}, {4,5,6}]:List(List(Int32))) }
 - sql: |
     create table t1 (x int);
     select * from t1 where EXISTS(select * where t1.x=1);

--- a/src/frontend/planner_test/tests/testdata/cast.yaml
+++ b/src/frontend/planner_test/tests/testdata/cast.yaml
@@ -36,7 +36,7 @@
   sql: |
     select current_schemas(NULL);
   batch_plan: |
-    BatchValues { rows: [[null:List { datatype: Varchar }]] }
+    BatchValues { rows: [[null:List(Varchar)]] }
 - name: FILTER (FILTER NULL)
   sql: |
     create table t(v1 int);
@@ -76,7 +76,7 @@
   sql: |
     select current_schemas('y');
   batch_plan: |
-    BatchValues { rows: [[ARRAY[pg_catalog, public]:List { datatype: Varchar }]] }
+    BatchValues { rows: [[ARRAY[pg_catalog, public]:List(Varchar)]] }
 - name: FILTER (FILTER with literal 'y' of unknown type)
   sql: |
     create table t(v1 int);

--- a/src/frontend/planner_test/tests/testdata/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/expr.yaml
@@ -401,27 +401,27 @@
 - sql: |
     select 1 < SOME(null);
   logical_plan: |
-    LogicalProject { exprs: [Some((1:Int32 < null:List { datatype: Int32 })) as $expr1] }
+    LogicalProject { exprs: [Some((1:Int32 < null:List(Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select 1 < ANY(null);
   logical_plan: |
-    LogicalProject { exprs: [Some((1:Int32 < null:List { datatype: Int32 })) as $expr1] }
+    LogicalProject { exprs: [Some((1:Int32 < null:List(Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select 1 < ALL(null);
   logical_plan: |
-    LogicalProject { exprs: [All((1:Int32 < null:List { datatype: Int32 })) as $expr1] }
+    LogicalProject { exprs: [All((1:Int32 < null:List(Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select 1 < ALL('{2,3}');
   logical_plan: |
-    LogicalProject { exprs: [All((1:Int32 < '{2,3}':Varchar::List { datatype: Int32 })) as $expr1] }
+    LogicalProject { exprs: [All((1:Int32 < '{2,3}':Varchar::List(Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select 1 < SOME(null::integer[]);
   logical_plan: |
-    LogicalProject { exprs: [Some((1:Int32 < null:List { datatype: Int32 })) as $expr1] }
+    LogicalProject { exprs: [Some((1:Int32 < null:List(Int32))) as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select 1 < SOME(null::varchar[]);
@@ -473,10 +473,10 @@
       └─LogicalProject { exprs: [Array(1:Int32) as $expr1] }
         └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchProject { exprs: [Some((1:Int32 < ArrayCat($expr10037, ARRAY[2]:List { datatype: Int32 }))) as $expr1] }
+    BatchProject { exprs: [Some((1:Int32 < ArrayCat($expr10037, ARRAY[2]:List(Int32)))) as $expr1] }
     └─BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
       ├─BatchValues { rows: [[]] }
-      └─BatchValues { rows: [[ARRAY[1]:List { datatype: Int32 }]] }
+      └─BatchValues { rows: [[ARRAY[1]:List(Int32)]] }
 - sql: |
     select 1 < ALL(array[null]::integer[]);
   logical_plan: |
@@ -496,10 +496,10 @@
       └─LogicalProject { exprs: [Array(1:Int32) as $expr1] }
         └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
   batch_plan: |
-    BatchProject { exprs: [All((1:Int32 < ArrayCat($expr10037, ARRAY[2]:List { datatype: Int32 }))) as $expr1] }
+    BatchProject { exprs: [All((1:Int32 < ArrayCat($expr10037, ARRAY[2]:List(Int32)))) as $expr1] }
     └─BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
       ├─BatchValues { rows: [[]] }
-      └─BatchValues { rows: [[ARRAY[1]:List { datatype: Int32 }]] }
+      └─BatchValues { rows: [[ARRAY[1]:List(Int32)]] }
 - name: now expression
   sql: |
     create table t (v1 timestamp with time zone);

--- a/src/frontend/planner_test/tests/testdata/project_set.yaml
+++ b/src/frontend/planner_test/tests/testdata/project_set.yaml
@@ -8,14 +8,14 @@
 - sql: |
     select unnest(Array[1,2,3]);
   batch_plan: |
-    BatchProject { exprs: [Unnest(ARRAY[1, 2, 3]:List { datatype: Int32 })] }
-    └─BatchProjectSet { select_list: [Unnest(ARRAY[1, 2, 3]:List { datatype: Int32 })] }
+    BatchProject { exprs: [Unnest(ARRAY[1, 2, 3]:List(Int32))] }
+    └─BatchProjectSet { select_list: [Unnest(ARRAY[1, 2, 3]:List(Int32))] }
       └─BatchValues { rows: [[]] }
 - sql: |
     select unnest(Array[Array[1,2,3], Array[4,5,6]]);
   batch_plan: |
-    BatchProject { exprs: [Unnest(ARRAY[{1,2,3}, {4,5,6}]:List { datatype: List { datatype: Int32 } })] }
-    └─BatchProjectSet { select_list: [Unnest(ARRAY[{1,2,3}, {4,5,6}]:List { datatype: List { datatype: Int32 } })] }
+    BatchProject { exprs: [Unnest(ARRAY[{1,2,3}, {4,5,6}]:List(List(Int32)))] }
+    └─BatchProjectSet { select_list: [Unnest(ARRAY[{1,2,3}, {4,5,6}]:List(List(Int32)))] }
       └─BatchValues { rows: [[]] }
 - sql: |
     create table t(x int[]);
@@ -43,9 +43,9 @@
     create table t(x int[]);
     select unnest(x), unnest(Array[1,2]) from t;
   batch_plan: |
-    BatchProject { exprs: [Unnest($0), Unnest(ARRAY[1, 2]:List { datatype: Int32 })] }
+    BatchProject { exprs: [Unnest($0), Unnest(ARRAY[1, 2]:List(Int32))] }
     └─BatchExchange { order: [], dist: Single }
-      └─BatchProjectSet { select_list: [Unnest($0), Unnest(ARRAY[1, 2]:List { datatype: Int32 })] }
+      └─BatchProjectSet { select_list: [Unnest($0), Unnest(ARRAY[1, 2]:List(Int32))] }
         └─BatchScan { table: t, columns: [t.x], distribution: SomeShard }
 - name: table functions as parameters of usual functions
   sql: |

--- a/src/frontend/planner_test/tests/testdata/sysinfo_funcs.yaml
+++ b/src/frontend/planner_test/tests/testdata/sysinfo_funcs.yaml
@@ -14,15 +14,15 @@
 - sql: |
     select current_schemas(true);
   batch_plan: |
-    BatchValues { rows: [[ARRAY[pg_catalog, public]:List { datatype: Varchar }]] }
+    BatchValues { rows: [[ARRAY[pg_catalog, public]:List(Varchar)]] }
 - sql: |
     select current_schemas(false);
   batch_plan: |
-    BatchValues { rows: [[ARRAY[public]:List { datatype: Varchar }]] }
+    BatchValues { rows: [[ARRAY[public]:List(Varchar)]] }
 - sql: |
     select current_schemas(null);
   batch_plan: |
-    BatchValues { rows: [[null:List { datatype: Varchar }]] }
+    BatchValues { rows: [[null:List(Varchar)]] }
 - sql: |
     select current_schemas(true and false);
   binder_error: |-

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -533,9 +533,7 @@ impl Binder {
                     };
 
                     let Some(bool) = literal.get_data().as_ref().map(|bool| bool.clone().into_bool()) else {
-                        return Ok(ExprImpl::literal_null(DataType::List {
-                            datatype: Box::new(DataType::Varchar),
-                        }));
+                        return Ok(ExprImpl::literal_null(DataType::List(Box::new(DataType::Varchar))));
                     };
 
                     let paths = if bool {

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -554,9 +554,7 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
         AstDataType::Timestamp(false) => DataType::Timestamp,
         AstDataType::Timestamp(true) => DataType::Timestamptz,
         AstDataType::Interval => DataType::Interval,
-        AstDataType::Array(datatype) => DataType::List {
-            datatype: Box::new(bind_data_type(datatype)?),
-        },
+        AstDataType::Array(datatype) => DataType::List(Box::new(bind_data_type(datatype)?)),
         AstDataType::Char(..) => {
             return Err(ErrorCode::NotImplemented(
                 "CHAR is not supported, please use VARCHAR instead\n".to_string(),

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_index.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_index.rs
@@ -26,12 +26,7 @@ pub static PG_INDEX_COLUMNS: LazyLock<Vec<SystemCatalogColumnsDef<'_>>> = LazyLo
         (DataType::Int32, "indexrelid"),
         (DataType::Int32, "indrelid"),
         (DataType::Int16, "indnatts"),
-        (
-            DataType::List {
-                datatype: Box::new(DataType::Int16),
-            },
-            "indkey",
-        ),
+        (DataType::List(Box::new(DataType::Int16)), "indkey"),
         // None. We don't have `pg_node_tree` type yet, so we use `text` instead.
         (DataType::Varchar, "indexprs"),
         // None. We don't have `pg_node_tree` type yet, so we use `text` instead.

--- a/src/frontend/src/expr/agg_call.rs
+++ b/src/frontend/src/expr/agg_call.rs
@@ -69,9 +69,7 @@ impl AggCall {
 
             // may return list or struct type
             (AggKind::Min | AggKind::Max | AggKind::FirstValue, [input]) => input.clone(),
-            (AggKind::ArrayAgg, [input]) => List {
-                datatype: Box::new(input.clone()),
-            },
+            (AggKind::ArrayAgg, [input]) => List(Box::new(input.clone())),
             // functions that are rewritten in the frontend and don't exist in the expr crate
             (AggKind::Avg, [input]) => match input {
                 Int16 | Int32 | Int64 | Decimal => Decimal,

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -174,9 +174,7 @@ mod tests {
         if let RexNode::Constant(prost) = node {
             let data2 = deserialize_datum(
                 prost.get_body().as_slice(),
-                &DataType::List {
-                    datatype: Box::new(DataType::Varchar),
-                },
+                &DataType::List(Box::new(DataType::Varchar)),
             )
             .unwrap()
             .unwrap();

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -142,9 +142,7 @@ impl ExprImpl {
     pub fn literal_list(v: ListValue, element_type: DataType) -> Self {
         Literal::new(
             Some(v.to_scalar_value()),
-            DataType::List {
-                datatype: Box::new(element_type),
-            },
+            DataType::List(Box::new(element_type)),
         )
         .into()
     }

--- a/src/frontend/src/expr/table_function.rs
+++ b/src/frontend/src/expr/table_function.rs
@@ -143,7 +143,7 @@ impl TableFunction {
                 }
 
                 let expr = args.into_iter().next().unwrap();
-                if matches!(expr.return_type(), DataType::List { datatype: _ }) {
+                if matches!(expr.return_type(), DataType::List(_)) {
                     let data_type = unnested_list_type(expr.return_type());
 
                     Ok(TableFunction {
@@ -206,9 +206,7 @@ impl TableFunction {
                 }
                 Ok(TableFunction {
                     args,
-                    return_type: DataType::List {
-                        datatype: Box::new(DataType::Varchar),
-                    },
+                    return_type: DataType::List(Box::new(DataType::Varchar)),
                     function_type: TableFunctionType::RegexpMatches,
                     udtf_catalog: None,
                 })

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -68,7 +68,7 @@ pub fn infer_some_all(
 ) -> Result<DataType> {
     let element_type = if inputs[1].is_unknown() {
         None
-    } else if let DataType::List { datatype } = inputs[1].return_type() {
+    } else if let DataType::List(datatype) = inputs[1].return_type() {
         Some(DataTypeName::from(*datatype))
     } else {
         return Err(ErrorCode::BindError(
@@ -104,9 +104,9 @@ pub fn infer_some_all(
                 ErrorCode::BindError("array/struct on left are not supported yet".into()).into(),
             );
         }
-        inputs[1] = inputs[1].clone().cast_implicit(DataType::List {
-            datatype: Box::new(sig.inputs_type[1].into()),
-        })?;
+        inputs[1] = inputs[1]
+            .clone()
+            .cast_implicit(DataType::List(Box::new(sig.inputs_type[1].into())))?;
     }
 
     let inputs_owned = std::mem::take(inputs);
@@ -473,23 +473,14 @@ fn infer_type_for_special(
                     }
                 }
             }
-            Ok(Some(DataType::List {
-                datatype: Box::new(DataType::Varchar),
-            }))
+            Ok(Some(DataType::List(Box::new(DataType::Varchar))))
         }
         ExprType::ArrayCat => {
             ensure_arity!("array_cat", | inputs | == 2);
             let left_type = inputs[0].return_type();
             let right_type = inputs[1].return_type();
             let return_type = match (&left_type, &right_type) {
-                (
-                    DataType::List {
-                        datatype: left_elem_type,
-                    },
-                    DataType::List {
-                        datatype: right_elem_type,
-                    },
-                ) => {
+                (DataType::List(left_elem_type), DataType::List(right_elem_type)) => {
                     if let Ok(res) = align_types(inputs.iter_mut()) {
                         Some(res)
                     } else if **left_elem_type == right_type {
@@ -557,9 +548,7 @@ fn infer_type_for_special(
             ensure_arity!("array_positions", | inputs | == 2);
             let common_type = align_array_and_element(0, 1, inputs);
             match common_type {
-                Ok(_) => Ok(Some(DataType::List {
-                    datatype: Box::new(DataType::Int32),
-                })),
+                Ok(_) => Ok(Some(DataType::List(Box::new(DataType::Int32)))),
                 Err(_) => Err(ErrorCode::BindError(format!(
                     "Cannot get position of {} in {}",
                     inputs[1].return_type(),
@@ -579,11 +568,7 @@ fn infer_type_for_special(
                 .into());
             }
             match ret_type {
-                DataType::List {
-                    datatype: list_elem_type,
-                } => Ok(Some(DataType::List {
-                    datatype: list_elem_type,
-                })),
+                DataType::List(list_elem_type) => Ok(Some(DataType::List(list_elem_type))),
                 _ => Ok(None),
             }
         }
@@ -599,15 +584,11 @@ fn infer_type_for_special(
             }
 
             match return_type {
-                DataType::List {
-                    datatype: _list_elem_type,
-                } => Ok(Some(DataType::Int64)),
+                DataType::List(_list_elem_type) => Ok(Some(DataType::Int64)),
                 _ => Ok(None),
             }
         }
-        ExprType::StringToArray => Ok(Some(DataType::List {
-            datatype: Box::new(DataType::Varchar),
-        })),
+        ExprType::StringToArray => Ok(Some(DataType::List(Box::new(DataType::Varchar)))),
         ExprType::Cardinality => {
             ensure_arity!("cardinality", | inputs | == 1);
             let return_type = inputs[0].return_type();
@@ -620,9 +601,7 @@ fn infer_type_for_special(
             }
 
             match return_type {
-                DataType::List {
-                    datatype: _list_elem_type,
-                } => Ok(Some(DataType::Int64)),
+                DataType::List(_list_elem_type) => Ok(Some(DataType::Int64)),
                 _ => Ok(None),
             }
         }
@@ -633,7 +612,7 @@ fn infer_type_for_special(
             inputs[1] = owned.cast_implicit(DataType::Int32)?;
 
             match inputs[0].return_type() {
-                DataType::List { datatype: typ } => Ok(Some(DataType::List { datatype: typ })),
+                DataType::List(typ) => Ok(Some(DataType::List(typ))),
                 _ => Ok(None),
             }
         }

--- a/src/frontend/src/optimizer/plan_node/generic/agg.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/agg.rs
@@ -361,9 +361,7 @@ impl<PlanRef: stream::StreamPlanRef> Agg<PlanRef> {
                 AggKind::ApproxCountDistinct => {
                     // Add register column.
                     internal_table_catalog_builder.add_column(&Field {
-                        data_type: DataType::List {
-                            datatype: Box::new(DataType::Int64),
-                        },
+                        data_type: DataType::List(Box::new(DataType::Int64)),
                         name: String::from("registers"),
                         sub_fields: vec![],
                         type_name: String::default(),

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -168,9 +168,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     }
 
     fn gen_list_data_type(&mut self, depth: usize) -> DataType {
-        DataType::List {
-            datatype: Box::new(self.gen_data_type_inner(depth)),
-        }
+        DataType::List(Box::new(self.gen_data_type_inner(depth)))
     }
 
     fn gen_struct_data_type(&mut self, depth: usize) -> DataType {

--- a/src/tests/sqlsmith/src/sql_gen/scalar.rs
+++ b/src/tests/sqlsmith/src/sql_gen/scalar.rs
@@ -88,7 +88,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
                 data_type: AstDataType::Interval,
                 value: self.gen_temporal_scalar(typ),
             })),
-            T::List { datatype: ref ty } => {
+            T::List(ref ty) => {
                 let n = self.rng.gen_range(1..=4);
                 Expr::Array(Array {
                     elem: self.gen_simple_scalar_list(ty, n),

--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -57,9 +57,7 @@ pub(super) fn data_type_to_ast_data_type(data_type: &DataType) -> AstDataType {
                 })
                 .collect(),
         ),
-        DataType::List { datatype: ref typ } => {
-            AstDataType::Array(Box::new(data_type_to_ast_data_type(typ)))
-        }
+        DataType::List(ref typ) => AstDataType::Array(Box::new(data_type_to_ast_data_type(typ))),
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR changes all `DataType::List { datatype: ... }` to `DataType::List(...)`. 💦
This makes the code more compact and easier to write.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
