### PR TITLE
refactor(pgwire): refine the interface of notice

### DIFF
--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -143,9 +143,8 @@ pub async fn handle_create_mv(
     let has_order_by = !query.order_by.is_empty();
 
     session.check_relation_name_duplicated(name.clone())?;
-    let mut notice = String::new();
 
-    let (table, graph) = {
+    let (table, graph, mut notices) = {
         let context = OptimizerContext::from_handler_args(handler_args);
         let (plan, table) = gen_create_mv_plan(&session, context.into(), query, name, columns)?;
         let context = plan.plan_base().ctx.clone();
@@ -157,9 +156,10 @@ pub async fn handle_create_mv(
         // Set the timezone for the stream environment
         let env = graph.env.as_mut().unwrap();
         env.timezone = context.get_session_timezone();
-        context.append_notice(&mut notice);
 
-        (table, graph)
+        let notices = context.take_warnings();
+
+        (table, graph, notices)
     };
 
     let _job_guard =
@@ -179,13 +179,13 @@ pub async fn handle_create_mv(
         .await?;
 
     if has_order_by {
-        notice.push_str(r#"
-The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
-It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view."#);
+        notices.push(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
+It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
+"#.to_string());
     }
-    Ok(PgResponse::empty_result_with_notice(
+    Ok(PgResponse::empty_result_with_notices(
         StatementType::CREATE_MATERIALIZED_VIEW,
-        notice.to_string(),
+        notices,
     ))
 }
 
@@ -317,18 +317,17 @@ pub mod tests {
         let sql = "create materialized view mv1 as select * from t";
         let response = frontend.run_sql(sql).await.unwrap();
         assert_eq!(response.get_stmt_type(), CREATE_MATERIALIZED_VIEW);
-        assert_eq!(response.get_notice(), None);
+        assert!(response.get_notices().is_empty());
 
         // With order by
         let sql = "create materialized view mv2 as select * from t order by x";
         let response = frontend.run_sql(sql).await.unwrap();
         assert_eq!(response.get_stmt_type(), CREATE_MATERIALIZED_VIEW);
         assert_eq!(
-            response.get_notice().unwrap(),
-r#"
-The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
-It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view."#
-                .to_string()
+            response.get_notices()[1],
+            r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
+It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
+"#
         );
     }
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -324,7 +324,7 @@ pub mod tests {
         let response = frontend.run_sql(sql).await.unwrap();
         assert_eq!(response.get_stmt_type(), CREATE_MATERIALIZED_VIEW);
         assert_eq!(
-            response.get_notices()[1],
+            response.get_notices()[0],
             r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
 It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
 "#

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -257,7 +257,7 @@ struct BatchPlanFragmenterResult {
     pub(crate) schema: Schema,
     pub(crate) stmt_type: StatementType,
     pub(crate) _dependent_relations: Vec<TableId>,
-    pub(crate) notice: String,
+    pub(crate) warnings: Vec<String>,
 }
 
 fn gen_batch_plan_fragmenter(
@@ -288,8 +288,7 @@ fn gen_batch_plan_fragmenter(
         session.config().get_batch_parallelism(),
         plan,
     )?;
-    let mut notice = String::new();
-    context.append_notice(&mut notice);
+    let warnings = context.take_warnings();
 
     Ok(BatchPlanFragmenterResult {
         plan_fragmenter,
@@ -297,7 +296,7 @@ fn gen_batch_plan_fragmenter(
         schema,
         stmt_type,
         _dependent_relations: dependent_relations,
-        notice,
+        warnings,
     })
 }
 
@@ -311,7 +310,7 @@ async fn execute(
         query_mode,
         schema,
         stmt_type,
-        notice,
+        warnings,
         ..
     } = plan_fragmenter_result;
 
@@ -447,7 +446,7 @@ async fn execute(
     };
 
     Ok(PgResponse::new_for_stream_extra(
-        stmt_type, rows_count, row_stream, pg_descs, notice, callback,
+        stmt_type, rows_count, row_stream, pg_descs, warnings, callback,
     ))
 }
 

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -18,6 +18,7 @@ use std::cell::{RefCell, RefMut};
 use std::rc::Rc;
 use std::sync::Arc;
 
+use itertools::Itertools;
 use risingwave_sqlparser::ast::{ExplainOptions, ExplainType};
 
 use crate::expr::{CorrelatedId, SessionTimezone};
@@ -50,6 +51,8 @@ pub struct OptimizerContext {
     session_timezone: RefCell<SessionTimezone>,
     /// Store expr display id.
     next_expr_display_id: RefCell<usize>,
+    /// warning messages
+    warning_messages: RefCell<Vec<String>>,
 }
 
 pub type OptimizerContextRef = Rc<OptimizerContext>;
@@ -78,6 +81,7 @@ impl OptimizerContext {
             with_options: handler_args.with_options,
             session_timezone,
             next_expr_display_id: RefCell::new(RESERVED_ID_NUM.into()),
+            warning_messages: RefCell::new(vec![]),
         }
     }
 
@@ -97,6 +101,7 @@ impl OptimizerContext {
             with_options: Default::default(),
             session_timezone: RefCell::new(SessionTimezone::new("UTC".into())),
             next_expr_display_id: RefCell::new(0),
+            warning_messages: RefCell::new(vec![]),
         }
         .into()
     }
@@ -160,6 +165,17 @@ impl OptimizerContext {
         optimizer_trace.push("\n".to_string());
     }
 
+    pub fn warn(&self, str: impl Into<String>) {
+        // If explain type is logical, do not store the trace for any optimizations beyond logical.
+        if self.is_explain_logical() && self.logical_explain.borrow().is_some() {
+            return;
+        }
+        let mut warnings = self.warning_messages.borrow_mut();
+        let string = str.into();
+        tracing::trace!("{}", string);
+        warnings.push(string);
+    }
+
     pub fn store_logical(&self, str: impl Into<String>) {
         *self.logical_explain.borrow_mut() = Some(str.into())
     }
@@ -170,6 +186,14 @@ impl OptimizerContext {
 
     pub fn take_trace(&self) -> Vec<String> {
         self.optimizer_trace.borrow_mut().drain(..).collect()
+    }
+
+    pub fn take_warnings(&self) -> Vec<String> {
+        let mut warnings = self.warning_messages.borrow_mut().drain(..).collect_vec();
+        if let Some(warning) = self.session_timezone.borrow().warning() {
+            warnings.push(warning);
+        };
+        warnings
     }
 
     pub fn with_options(&self) -> &WithOptions {
@@ -192,13 +216,6 @@ impl OptimizerContext {
 
     pub fn session_timezone(&self) -> RefMut<'_, SessionTimezone> {
         self.session_timezone.borrow_mut()
-    }
-
-    /// Appends any information that the optimizer needs to alert the user about to the PG NOTICE
-    pub fn append_notice(&self, notice: &mut String) {
-        if let Some(warning) = self.session_timezone.borrow().warning() {
-            notice.push_str(&warning);
-        }
     }
 
     pub fn get_session_timezone(&self) -> String {

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -166,13 +166,9 @@ impl OptimizerContext {
     }
 
     pub fn warn(&self, str: impl Into<String>) {
-        // If explain type is logical, do not store the trace for any optimizations beyond logical.
-        if self.is_explain_logical() && self.logical_explain.borrow().is_some() {
-            return;
-        }
         let mut warnings = self.warning_messages.borrow_mut();
         let string = str.into();
-        tracing::trace!("{}", string);
+        tracing::trace!("warn to user:{}", string);
         warnings.push(string);
     }
 

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -49,10 +49,9 @@ where
         row_limit: usize,
         msg_stream: &mut Conn<S>,
     ) -> PsqlResult<bool> {
-        if let Some(notice) = self.result.get_notice() {
-            msg_stream.write_no_flush(&BeMessage::NoticeResponse(&notice))?;
+        for notice in self.result.get_notices() {
+            msg_stream.write_no_flush(&BeMessage::NoticeResponse(notice))?;
         }
-
         if self.result.is_empty() {
             // Run the callback before sending the response.
             self.result.run_callback().await?;

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -354,9 +354,9 @@ where
                 .await
                 .map_err(|err| PsqlError::QueryError(err))?;
 
-            if let Some(notice) = res.get_notice() {
+            for notice in res.get_notices() {
                 self.stream
-                    .write_no_flush(&BeMessage::NoticeResponse(&notice))?;
+                    .write_no_flush(&BeMessage::NoticeResponse(notice))?;
             }
 
             if res.is_query() {

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -106,7 +106,7 @@ pub struct PgResponse<VS> {
     // row count of effected row. Used for INSERT, UPDATE, DELETE, COPY, and other statements that
     // don't return rows.
     row_cnt: Option<i32>,
-    notice: Option<String>,
+    notices: Vec<String>,
     values_stream: Option<VS>,
     callback: Option<BoxedCallback>,
     row_desc: Vec<PgFieldDescriptor>,
@@ -120,7 +120,7 @@ where
         f.debug_struct("PgResponse")
             .field("stmt_type", &self.stmt_type)
             .field("row_cnt", &self.row_cnt)
-            .field("notice", &self.notice)
+            .field("notices", &self.notices)
             .field("row_desc", &self.row_desc)
             .finish()
     }
@@ -268,7 +268,7 @@ where
             row_cnt,
             values_stream: None,
             row_desc: vec![],
-            notice: None,
+            notices: vec![],
             callback: None,
         }
     }
@@ -280,11 +280,19 @@ where
             row_cnt,
             values_stream: None,
             row_desc: vec![],
-            notice: if !notice.is_empty() {
-                Some(notice)
-            } else {
-                None
-            },
+            notices: vec![notice],
+            callback: None,
+        }
+    }
+
+    pub fn empty_result_with_notices(stmt_type: StatementType, notices: Vec<String>) -> Self {
+        let row_cnt = if stmt_type.is_query() { None } else { Some(0) };
+        Self {
+            stmt_type,
+            row_cnt,
+            values_stream: None,
+            row_desc: vec![],
+            notices,
             callback: None,
         }
     }
@@ -295,7 +303,7 @@ where
         values_stream: VS,
         row_desc: Vec<PgFieldDescriptor>,
     ) -> Self {
-        Self::new_for_stream_inner(stmt_type, row_cnt, values_stream, row_desc, None, None)
+        Self::new_for_stream_inner(stmt_type, row_cnt, values_stream, row_desc, vec![], None)
     }
 
     pub fn new_for_stream_extra(
@@ -303,7 +311,7 @@ where
         row_cnt: Option<i32>,
         values_stream: VS,
         row_desc: Vec<PgFieldDescriptor>,
-        notice: String,
+        notices: Vec<String>,
         callback: impl Callback + 'static,
     ) -> Self {
         Self::new_for_stream_inner(
@@ -311,11 +319,7 @@ where
             row_cnt,
             values_stream,
             row_desc,
-            if !notice.is_empty() {
-                Some(notice)
-            } else {
-                None
-            },
+            notices,
             Some(callback.boxed()),
         )
     }
@@ -325,7 +329,7 @@ where
         row_cnt: Option<i32>,
         values_stream: VS,
         row_desc: Vec<PgFieldDescriptor>,
-        notice: Option<String>,
+        notices: Vec<String>,
         callback: Option<BoxedCallback>,
     ) -> Self {
         assert!(
@@ -337,7 +341,7 @@ where
             row_cnt,
             values_stream: Some(values_stream),
             row_desc,
-            notice,
+            notices,
             callback,
         }
     }
@@ -346,8 +350,8 @@ where
         self.stmt_type
     }
 
-    pub fn get_notice(&self) -> Option<String> {
-        self.notice.clone()
+    pub fn get_notices(&self) -> &[String] {
+        &self.notices
     }
 
     pub fn get_effected_rows_cnt(&self) -> Option<i32> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- support notice multiple times for a query
```
dev=> create materialized view mv as select * from t where y > now() order by x;
NOTICE:  Your session timezone is UTC. It was used in the interpretation of timestamps and dates in your query. If this is unintended, change your timezone to match that of your data's with `set timezone = [timezone]` or rewrite your query with an explicit timezone conversion, e.g. with `AT TIME ZONE`.

NOTICE:  The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.

CREATE_MATERIALIZED_VIEW
```
- add interface to warning to user in optimizer

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
