### PR TITLE
feat(over window): generate EOWC stream plan from `LogicalOverAgg`

### DIFF
--- a/e2e_test/streaming/eowc/eowc_over_window.slt
+++ b/e2e_test/streaming/eowc/eowc_over_window.slt
@@ -1,0 +1,58 @@
+statement ok
+set RW_IMPLICIT_FLUSH to true;
+
+statement ok
+set streaming_parallelism = 1;
+
+statement ok
+create table t (
+    tm timestamp,
+    foo int,
+    bar int,
+    watermark for tm as tm - interval '5 minutes'
+) append only;
+
+statement ok
+set streaming_parallelism = 0;
+
+statement ok
+create materialized view mv
+emit on window close
+as
+select
+    tm, foo, bar,
+    lag(foo, 2) over (partition by bar order by tm),
+    max(foo) over (partition by bar order by tm rows between 1 preceding and 1 following)
+from t;
+
+statement ok
+insert into t values
+('2023-05-06 16:51:00', 1, 100),
+('2023-05-06 16:56:00', 8, 100),
+('2023-05-06 17:30:00', 3, 200),
+('2023-05-06 17:59:00', 4, 100),
+('2023-05-06 18:01:00', 6, 200);
+
+# Note that the row where foo = 8 is not emitted because it's window is not closed by watermark.
+query TI
+select * from mv order by tm;
+----
+2023-05-06 16:51:00  1  100  NULL  8
+
+statement ok
+insert into t values
+('2023-05-06 18:10:00', 7, 100),
+('2023-05-06 18:11:00', 9, 200);
+
+query TI
+select * from mv order by tm;
+----
+2023-05-06 16:51:00  1  100  NULL  8
+2023-05-06 16:56:00  8  100  NULL  8
+2023-05-06 17:30:00  3  200  NULL  6
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t;

--- a/src/frontend/planner_test/tests/testdata/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/emit_on_window_close.yaml
@@ -122,9 +122,49 @@
 - sql: |
     create source t (a int, b int, tm timestamp, watermark for tm as tm - interval '5 minutes') with (connector = 'kinesis') ROW FORMAT JSON;
     select lag(a, 2) over (partition by b order by tm) from t;
+  eowc_stream_plan: |
+    StreamMaterialize { columns: [lag, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck" }
+    └─StreamExchange { dist: HashShard(_row_id) }
+      └─StreamProject { exprs: [lag, _row_id] }
+        └─StreamEowcOverWindow { window_functions: [lag(a) OVER(PARTITION BY b ORDER BY tm ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)] }
+          └─StreamSort { sort_column_index: 2 }
+            └─StreamExchange { dist: HashShard(b) }
+              └─StreamProject { exprs: [a, b, tm, _row_id], output_watermarks: [tm] }
+                └─StreamRowIdGen { row_id_index: 3 }
+                  └─StreamWatermarkFilter { watermark_descs: [idx: 2, expr: (tm - '00:05:00':Interval)] }
+                    └─StreamSource { source: "t", columns: ["a", "b", "tm", "_row_id"] }
+  eowc_stream_dist_plan: |+
+    Fragment 0
+    StreamMaterialize { columns: [lag, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck" }
+    ├── materialized table: 4294967294
+    └──  StreamExchange Hash([1]) from 1
+
+    Fragment 1
+    StreamProject { exprs: [lag, _row_id] }
+    └── StreamEowcOverWindow { window_functions: [lag(a) OVER(PARTITION BY b ORDER BY tm ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)] }
+        └── StreamSort { sort_column_index: 2 }
+            └──  StreamExchange Hash([1]) from 2
+
+    Fragment 2
+    StreamProject { exprs: [a, b, tm, _row_id], output_watermarks: [tm] }
+    └── StreamRowIdGen { row_id_index: 3 }
+        └── StreamWatermarkFilter { watermark_descs: [idx: 2, expr: (tm - '00:05:00':Interval)] }
+            └──  StreamSource { source: "t", columns: ["a", "b", "tm", "_row_id"] } { source state table: 3 }
+
+    Table 3
+    ├── columns: [ partition_id, offset_info ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: []
+    └── read pk prefix len hint: 1
+
+    Table 4294967294
+    ├── columns: [ lag, _row_id ]
+    ├── primary key: [ $1 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: [ 1 ]
+    └── read pk prefix len hint: 1
+
   stream_error: |-
-    Feature is not yet implemented: OverAgg to stream
-    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
-  eowc_stream_error: |-
     Feature is not yet implemented: OverAgg to stream
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124

--- a/src/frontend/planner_test/tests/testdata/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/over_window_function.yaml
@@ -4,7 +4,7 @@
     select lag(x) over() from t;
   logical_plan: |
     LogicalProject { exprs: [lag] }
-    └─LogicalOverAgg { window_functions: [lag() OVER(ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+    └─LogicalOverAgg { window_functions: [lag(t.x) OVER(ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)] }
       └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: OverAgg to batch
@@ -25,7 +25,7 @@
     select lead(x, 2) over() from t;
   logical_plan: |
     LogicalProject { exprs: [lead] }
-    └─LogicalOverAgg { window_functions: [lead() OVER(ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)] }
+    └─LogicalOverAgg { window_functions: [lead(t.x) OVER(ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)] }
       └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: OverAgg to batch
@@ -53,7 +53,7 @@
     select sum(x) over() from t;
   logical_plan: |
     LogicalProject { exprs: [sum] }
-    └─LogicalOverAgg { window_functions: [sum() OVER(ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
+    └─LogicalOverAgg { window_functions: [sum(t.x) OVER(ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
       └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: OverAgg to batch
@@ -66,14 +66,14 @@
     select x, y, min(x) over(PARTITION BY y ROWS 10 PRECEDING) from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y, min] }
-    └─LogicalOverAgg { window_functions: [min() OVER(PARTITION BY t.y ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
+    └─LogicalOverAgg { window_functions: [min(t.x) OVER(PARTITION BY t.y ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)] }
       └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
 - sql: |
     create table t(x int, y int);
     select x, y, min(x) over(PARTITION BY y ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING) from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y, min] }
-    └─LogicalOverAgg { window_functions: [min() OVER(PARTITION BY t.y ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)] }
+    └─LogicalOverAgg { window_functions: [min(t.x) OVER(PARTITION BY t.y ROWS BETWEEN 1 PRECEDING AND 2 FOLLOWING)] }
       └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: OverAgg to batch
@@ -94,7 +94,7 @@
     select x, y, lag(x) over(PARTITION BY y ORDER BY x) from t;
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y, lag] }
-    └─LogicalOverAgg { window_functions: [lag() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)] }
+    └─LogicalOverAgg { window_functions: [lag(t.x) OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN 1 PRECEDING AND CURRENT ROW)] }
       └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: OverAgg to batch

--- a/src/frontend/src/optimizer/plan_node/generic/over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/over_window.rs
@@ -146,6 +146,10 @@ impl<PlanRef: GenericPlanRef> OverWindow<PlanRef> {
         }
     }
 
+    pub fn input_len(&self) -> usize {
+        self.input.schema().len()
+    }
+
     pub fn output_len(&self) -> usize {
         self.input.schema().len() + self.window_functions.len()
     }

--- a/src/frontend/src/optimizer/plan_node/generic/over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/over_window.rs
@@ -51,13 +51,27 @@ impl<'a> std::fmt::Debug for PlanWindowFunctionDisplay<'a> {
             f.debug_struct("WindowFunction")
                 .field("kind", &window_function.kind)
                 .field("return_type", &window_function.return_type)
+                .field("args", &window_function.args)
                 .field("partition_by", &window_function.partition_by)
                 .field("order_by", &window_function.order_by)
                 .field("frame", &window_function.frame)
                 .finish()
         } else {
-            write!(f, "{}() OVER(", window_function.kind)?;
-
+            write!(f, "{}(", window_function.kind)?;
+            let mut delim = "";
+            for arg in &window_function.args {
+                write!(f, "{}", delim)?;
+                delim = ", ";
+                write!(
+                    f,
+                    "{}",
+                    InputRefDisplay {
+                        input_ref: arg,
+                        input_schema: self.input_schema
+                    }
+                )?;
+            }
+            write!(f, ") OVER(")?;
             let mut delim = "";
             if !window_function.partition_by.is_empty() {
                 delim = " ";

--- a/src/frontend/src/optimizer/plan_node/logical_over_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_agg.rs
@@ -18,18 +18,19 @@ use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
-use risingwave_common::util::sort_util::ColumnOrder;
+use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_expr::function::window::{Frame, FrameBound, WindowFuncKind};
 
 use super::generic::{OverWindow, PlanWindowFunction};
 use super::{
     gen_filter_and_pushdown, ColPrunable, ExprRewritable, LogicalProject, PlanBase, PlanRef,
-    PlanTreeNodeUnary, PredicatePushdown, ToBatch, ToStream,
+    PlanTreeNodeUnary, PredicatePushdown, StreamEowcOverWindow, StreamSort, ToBatch, ToStream,
 };
 use crate::expr::{Expr, ExprImpl, InputRef, WindowFunction};
 use crate::optimizer::plan_node::{
     ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
+use crate::optimizer::property::{Order, RequiredDist};
 use crate::utils::{ColIndexMapping, Condition};
 
 /// `LogicalOverAgg` performs `OVER` window aggregates ([`WindowFunction`]) to its input.
@@ -357,7 +358,56 @@ impl ToBatch for LogicalOverAgg {
 }
 
 impl ToStream for LogicalOverAgg {
-    fn to_stream(&self, _ctx: &mut ToStreamContext) -> Result<PlanRef> {
+    fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<PlanRef> {
+        let stream_input = self.core.input.to_stream(ctx)?;
+        stream_input.watermark_columns();
+
+        if ctx.emit_on_window_close() {
+            if !self.core.funcs_have_same_partition_and_order() {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "All window functions must have the same PARTITION BY and ORDER BY".to_string(),
+                )
+                .into());
+            }
+
+            let order_by = &self.window_functions()[0].order_by;
+            if order_by.len() != 1
+                || !stream_input
+                    .watermark_columns()
+                    .contains(order_by[0].column_index)
+                || order_by[0].order_type != OrderType::ascending()
+            {
+                return Err(ErrorCode::InvalidInputSyntax(
+                    "Only support window functions order by single watermark column in ascending order"
+                        .to_string(),
+                )
+                .into());
+            }
+            let order_key_index = order_by[0].column_index;
+
+            let partition_key_indices = self.window_functions()[0]
+                .partition_by
+                .iter()
+                .map(|e| e.index())
+                .collect_vec();
+            if partition_key_indices.is_empty() {
+                return Err(ErrorCode::NotImplemented(
+                    "Window function with empty PARTITION BY is not supported yet".to_string(),
+                    None.into(),
+                )
+                .into());
+            }
+
+            let sort_input =
+                RequiredDist::shard_by_key(stream_input.schema().len(), &partition_key_indices)
+                    .enforce_if_not_satisfies(stream_input, &Order::any())?;
+            let sort = StreamSort::new(sort_input, order_key_index);
+
+            let mut logical = self.core.clone();
+            logical.input = sort.into();
+            return Ok(StreamEowcOverWindow::new(logical).into());
+        }
+
         Err(ErrorCode::NotImplemented("OverAgg to stream".to_string(), 9124.into()).into())
     }
 

--- a/src/frontend/src/optimizer/plan_node/stream_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sort.rs
@@ -80,6 +80,15 @@ impl StreamSort {
         let mut order_cols = HashSet::new();
         tbl_builder.add_order_column(self.sort_column_index, OrderType::ascending());
         order_cols.insert(self.sort_column_index);
+
+        let dist_key = self.base.dist.dist_column_indices().to_vec();
+        for idx in &dist_key {
+            if !order_cols.contains(idx) {
+                tbl_builder.add_order_column(*idx, OrderType::ascending());
+                order_cols.insert(*idx);
+            }
+        }
+
         for idx in self.input.logical_pk() {
             if !order_cols.contains(idx) {
                 tbl_builder.add_order_column(*idx, OrderType::ascending());
@@ -87,9 +96,8 @@ impl StreamSort {
             }
         }
 
-        let in_dist_key = self.input.distribution().dist_column_indices();
         let read_prefix_len_hint = 0;
-        tbl_builder.build(in_dist_key.to_vec(), read_prefix_len_hint)
+        tbl_builder.build(dist_key, read_prefix_len_hint)
     }
 }
 

--- a/src/stream/src/from_proto/eowc_over_window.rs
+++ b/src/stream/src/from_proto/eowc_over_window.rs
@@ -56,7 +56,8 @@ impl ExecutorBuilder for EowcOverWindowExecutorBuilder {
                 .expect("vnodes not set for EOWC over window"),
         ));
         let state_table =
-            StateTable::from_table_catalog(node.get_state_table()?, store, vnodes).await;
+            StateTable::from_table_catalog_inconsistent_op(node.get_state_table()?, store, vnodes)
+                .await;
         Ok(EowcOverWindowExecutor::new(EowcOverWindowExecutorArgs {
             input,
             actor_ctx: params.actor_context,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR enables [Over Window](https://github.com/risingwavelabs/rfcs/pull/8) feature with `EMIT ON WINDOW CLOSE`. Tracked in #9124.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support Over Window (a.k.a Over Aggregation or Window Function) with `EMIT ON WINDOW CLOSE`. Currently only support windows partitioned by at least one column and ordered by only single watermark column.

Example:

```sql
CREATE SOURCE t (a TIMESTAMP, b INT, WATERMARK FOR a AS a - INTERVAL '5 minutes') WITH ...;
CREATE MATERIALIZED VIEW mv EMIT ON WINDOW CLOSE AS
SELECT
    window_start,
    lag(b) OVER (PARTITION BY window_start ORDER BY a),
    max(b) OVER (PARTITION BY window_start ORDER BY a ROWS BETWEEN 10 PRECEDING AND CURRENT ROW)
FROM tumble(t, a, INTERVAL '1 hour');
```

Window functions supported by far:

- `lag` and `lead` with constant offset
- aggregate functions

Window frame types supported by far:

- `ROWS` without exclusion clause