### PR TITLE
feat(batch): optimize batch limit and topn

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -1022,7 +1022,7 @@
         └─LogicalScan { table: t, columns: [t.v1, t.v2, t._row_id] }
   optimized_logical_plan_for_batch: |
     LogicalAgg { aggs: [max(idx.v2)] }
-    └─LogicalLimit { limit: 1, offset: 0 }
+    └─LogicalTopN { order: "[idx.v2 DESC]", limit: 1, offset: 0 }
       └─LogicalFilter { predicate: IsNotNull(idx.v2) }
         └─LogicalScan { table: idx, columns: [idx.v2] }
 - name: min/max on index with group by, shall NOT optimize
@@ -1050,7 +1050,7 @@
         └─LogicalScan { table: t, columns: [t.v1] }
   optimized_logical_plan_for_batch: |
     LogicalAgg { aggs: [min(t.v1)] }
-    └─LogicalLimit { limit: 1, offset: 0 }
+    └─LogicalTopN { order: "[t.v1 ASC]", limit: 1, offset: 0 }
       └─LogicalFilter { predicate: IsNotNull(t.v1) }
         └─LogicalScan { table: t, columns: [t.v1] }
 - name: stddev_samp

--- a/src/frontend/planner_test/tests/testdata/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/index_selection.yaml
@@ -584,8 +584,8 @@
     create index idx1 on t1(a);
     select * from t1 order by a limit 1
   batch_plan: |
-    BatchLimit { limit: 1, offset: 0 }
-    └─BatchExchange { order: [idx1.a ASC], dist: Single }
+    BatchTopN { order: "[idx1.a ASC]", limit: 1, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], distribution: UpstreamHashShard(idx1.a) }
 - name: topn on primary key
@@ -594,8 +594,8 @@
     create index idx1 on t1(a);
     select * from t1 order by a limit 1
   batch_plan: |
-    BatchLimit { limit: 1, offset: 0 }
-    └─BatchExchange { order: [t1.a ASC], dist: Single }
+    BatchTopN { order: "[t1.a ASC]", limit: 1, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: t1, columns: [t1.a, t1.b], distribution: UpstreamHashShard(t1.a) }
 - name: topn on index with descending ordering
@@ -604,8 +604,8 @@
     create index idx1 on t1(a desc);
     select * from t1 order by a desc limit 1
   batch_plan: |
-    BatchLimit { limit: 1, offset: 0 }
-    └─BatchExchange { order: [idx1.a DESC], dist: Single }
+    BatchTopN { order: "[idx1.a DESC]", limit: 1, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: idx1, columns: [idx1.a, idx1.b], distribution: UpstreamHashShard(idx1.a) }
 - name: topn on pk streaming case, should NOT optimized

--- a/src/frontend/planner_test/tests/testdata/limit.yaml
+++ b/src/frontend/planner_test/tests/testdata/limit.yaml
@@ -112,3 +112,11 @@
       └─BatchExchange { order: [], dist: Single }
         └─BatchSimpleAgg { aggs: [count] }
           └─BatchScan { table: t, columns: [], distribution: SomeShard }
+- sql: |
+    create table t (a int primary key);
+    select * from t limit 1;
+  batch_plan: |
+    BatchLimit { limit: 1, offset: 0 }
+    └─BatchExchange { order: [], dist: Single }
+      └─BatchLimit { limit: 1, offset: 0 }
+        └─BatchScan { table: t, columns: [t.a], distribution: UpstreamHashShard(t.a) }

--- a/src/frontend/src/optimizer/plan_node/batch_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_limit.rs
@@ -55,11 +55,7 @@ impl BatchLimit {
         let ensure_single_dist = if !batch_partial_limit.distribution().satisfies(&single_dist) {
             single_dist.enforce_if_not_satisfies(
                 batch_partial_limit.into(),
-                if self.order().column_orders.is_empty() {
-                    &any_order
-                } else {
-                    self.order()
-                },
+                    &any_order,
             )?
         } else {
             // The input's distribution is singleton, so use one phase limit is enough.

--- a/src/frontend/src/optimizer/plan_node/batch_limit.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_limit.rs
@@ -53,10 +53,7 @@ impl BatchLimit {
 
         let single_dist = RequiredDist::single();
         let ensure_single_dist = if !batch_partial_limit.distribution().satisfies(&single_dist) {
-            single_dist.enforce_if_not_satisfies(
-                batch_partial_limit.into(),
-                    &any_order,
-            )?
+            single_dist.enforce_if_not_satisfies(batch_partial_limit.into(), &any_order)?
         } else {
             // The input's distribution is singleton, so use one phase limit is enough.
             return Ok(batch_partial_limit.into());

--- a/src/frontend/src/optimizer/plan_node/batch_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_topn.rs
@@ -68,10 +68,10 @@ impl BatchTopN {
 
         let single_dist = RequiredDist::single();
         let ensure_single_dist = if !partial_input.distribution().satisfies(&single_dist) {
-            single_dist.enforce_if_not_satisfies(partial_input.into(), &Order::any())?
+            single_dist.enforce_if_not_satisfies(partial_input, &Order::any())?
         } else {
             // The input's distribution is singleton, so use one phase topn is enough.
-            return Ok(partial_input.into());
+            return Ok(partial_input);
         };
 
         let batch_global_topn = self.clone_with_input(ensure_single_dist);

--- a/src/frontend/src/optimizer/plan_node/batch_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_topn.rs
@@ -17,12 +17,12 @@ use std::fmt;
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::TopNNode;
-use crate::optimizer::plan_node::batch::BatchPlanRef;
 
 use super::generic::Limit;
 use super::{
     generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch,
 };
+use crate::optimizer::plan_node::batch::BatchPlanRef;
 use crate::optimizer::plan_node::{BatchLimit, LogicalLimit, ToLocalBatch};
 use crate::optimizer::property::{Order, RequiredDist};
 
@@ -56,8 +56,12 @@ impl BatchTopN {
             let batch_partial_limit = BatchLimit::new(logical_partial_limit);
             batch_partial_limit.into()
         } else {
-            let logical_partial_topn =
-                generic::TopN::without_group(input, new_limit, new_offset, self.logical.order.clone());
+            let logical_partial_topn = generic::TopN::without_group(
+                input,
+                new_limit,
+                new_offset,
+                self.logical.order.clone(),
+            );
             let batch_partial_topn = Self::new(logical_partial_topn);
             batch_partial_topn.into()
         };

--- a/src/frontend/src/optimizer/rule/min_max_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/min_max_on_index_rule.rs
@@ -29,7 +29,7 @@ use super::{BoxedRule, Rule};
 use crate::expr::{ExprImpl, ExprType, FunctionCall, InputRef};
 use crate::optimizer::plan_node::generic::Agg;
 use crate::optimizer::plan_node::{
-    LogicalAgg, LogicalFilter, LogicalLimit, LogicalScan, PlanAggCall, PlanTreeNodeUnary,
+    LogicalAgg, LogicalFilter, LogicalScan, LogicalTopN, PlanAggCall, PlanTreeNodeUnary,
 };
 use crate::optimizer::property::Order;
 use crate::optimizer::PlanRef;
@@ -107,7 +107,7 @@ impl MinMaxOnIndexRule {
                     .into(),
                 );
 
-                let limit = LogicalLimit::create(non_null_filter, 1, 0);
+                let topn = LogicalTopN::new(non_null_filter, 1, 0, false, required_order.clone());
 
                 let formatting_agg = Agg::new(
                     vec![PlanAggCall {
@@ -124,7 +124,7 @@ impl MinMaxOnIndexRule {
                         },
                     }],
                     FixedBitSet::new(),
-                    limit,
+                    topn.into(),
                 );
 
                 return Some(formatting_agg.into());
@@ -176,7 +176,7 @@ impl MinMaxOnIndexRule {
                 .into(),
             );
 
-            let limit = LogicalLimit::create(non_null_filter, 1, 0);
+            let topn = LogicalTopN::new(non_null_filter, 1, 0, false, order.clone());
 
             let formatting_agg = Agg::new(
                 vec![PlanAggCall {
@@ -193,7 +193,7 @@ impl MinMaxOnIndexRule {
                     },
                 }],
                 FixedBitSet::new(),
-                limit,
+                topn.into(),
             );
 
             Some(formatting_agg.into())

--- a/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
+++ b/src/frontend/src/optimizer/rule/top_n_on_index_rule.rs
@@ -22,7 +22,7 @@ use std::collections::BTreeMap;
 use risingwave_common::util::sort_util::ColumnOrder;
 
 use super::{BoxedRule, Rule};
-use crate::optimizer::plan_node::{LogicalLimit, LogicalScan, LogicalTopN, PlanTreeNodeUnary};
+use crate::optimizer::plan_node::{LogicalScan, LogicalTopN, PlanTreeNodeUnary};
 use crate::optimizer::property::Order;
 use crate::optimizer::PlanRef;
 
@@ -66,13 +66,7 @@ impl TopNOnIndexRule {
                         .min(logical_top_n.limit_attr().limit() + logical_top_n.offset()))
                         as u32,
                 );
-
-                let logical_limit = LogicalLimit::create(
-                    index_scan.into(),
-                    logical_top_n.limit_attr().limit(),
-                    logical_top_n.offset(),
-                );
-                return Some(logical_limit);
+                return Some(logical_top_n.clone_with_input(index_scan.into()).into());
             }
         }
 
@@ -112,12 +106,7 @@ impl TopNOnIndexRule {
                 ((u32::MAX as u64).min(logical_top_n.limit_attr().limit() + logical_top_n.offset()))
                     as u32,
             );
-            let logical_limit = LogicalLimit::create(
-                logical_scan.into(),
-                logical_top_n.limit_attr().limit(),
-                logical_top_n.offset(),
-            );
-            Some(logical_limit)
+            Some(logical_top_n.clone_with_input(logical_scan.into()).into())
         } else {
             None
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Two-phase limit shouldn't require input to satisfy an order, because it would result in `MergeSortExchange`. SQL `select * from t limit 1` doesn't need `MergeSortExchange` at all.
- `TopNOnIndexRule` and `MinMaxOnIndexRule` should use `LogicalTopN` instead of `LogicalLimit`, since `LogicalLimit` has no order guarantee.
- Two-phase topn can utilize partial limit if its input's order satisfy the order of the topn

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
