### PR TITLE
fix(frontend): fix incorrect number of arguments for `now()`

### DIFF
--- a/e2e_test/batch/functions/now.slt.part
+++ b/e2e_test/batch/functions/now.slt.part
@@ -21,3 +21,6 @@ drop table tz
 
 statement ok
 drop table t
+
+statement error Function `now` takes 0 argument (1 given)
+select now(1);

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -621,7 +621,7 @@ fn infer_type_for_special(
             Ok(Some(DataType::Int16))
         }
         ExprType::Now => {
-            if inputs.len() != 1 {
+            if inputs.len() > 1 {
                 return Err(ErrorCode::BindError(format!(
                     "Function `now` takes 0 argument ({} given)",
                     inputs.len() - 1,

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -621,7 +621,13 @@ fn infer_type_for_special(
             Ok(Some(DataType::Int16))
         }
         ExprType::Now => {
-            ensure_arity!("now", | inputs | <= 1);
+            if inputs.len() != 1 {
+                return Err(ErrorCode::BindError(format!(
+                    "Function `now` takes 0 argument ({} given)",
+                    inputs.len() - 1,
+                ))
+                .into());
+            }
             Ok(Some(DataType::Timestamptz))
         }
         ExprType::Proctime => {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #9605.

Function `now()` takes no argument. But internally we give it an implicit argument. This PR makes a special treatment to avoid this inconsistency.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
