### PR TITLE
chore(optimizer): refine collect input ref logic

### DIFF
--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::iter::once;
+
 use enum_as_inner::EnumAsInner;
 use fixedbitset::FixedBitSet;
 use futures::FutureExt;
@@ -166,9 +168,7 @@ impl ExprImpl {
     /// # Panics
     /// Panics if `input_ref >= input_col_num`.
     pub fn collect_input_refs(&self, input_col_num: usize) -> FixedBitSet {
-        let mut visitor = CollectInputRef::with_capacity(input_col_num);
-        visitor.visit_expr(self);
-        visitor.into()
+        collect_input_refs(input_col_num, once(self))
     }
 
     /// Check if the expression has no side effects and output is deterministic

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -395,7 +395,7 @@ impl Extend<usize> for CollectInputRef {
 /// Panics if `input_ref >= input_col_num`.
 pub fn collect_input_refs<'a>(
     input_col_num: usize,
-    exprs: impl Iterator<Item = &'a ExprImpl>,
+    exprs: impl IntoIterator<Item = &'a ExprImpl>,
 ) -> FixedBitSet {
     let mut input_ref_collector = CollectInputRef::with_capacity(input_col_num);
     for expr in exprs {

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -389,6 +389,21 @@ impl Extend<usize> for CollectInputRef {
     }
 }
 
+/// Collect all `InputRef`s' indexes in the expressions.
+///
+/// # Panics
+/// Panics if `input_ref >= input_col_num`.
+pub fn collect_input_ref<'a>(
+    input_col_num: usize,
+    exprs: impl Iterator<Item = &'a ExprImpl>,
+) -> FixedBitSet {
+    let mut input_ref_collector = CollectInputRef::with_capacity(input_col_num);
+    for expr in exprs {
+        input_ref_collector.visit_expr(expr);
+    }
+    input_ref_collector.into()
+}
+
 /// Count `Now`s in the expression.
 #[derive(Clone, Default)]
 pub struct CountNow {}

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -393,7 +393,7 @@ impl Extend<usize> for CollectInputRef {
 ///
 /// # Panics
 /// Panics if `input_ref >= input_col_num`.
-pub fn collect_input_ref<'a>(
+pub fn collect_input_refs<'a>(
     input_col_num: usize,
     exprs: impl Iterator<Item = &'a ExprImpl>,
 ) -> FixedBitSet {

--- a/src/frontend/src/optimizer/plan_node/col_pruning.rs
+++ b/src/frontend/src/optimizer/plan_node/col_pruning.rs
@@ -17,7 +17,6 @@ use std::collections::{HashMap, HashSet};
 use paste::paste;
 
 use super::*;
-pub use crate::expr::CollectInputRef;
 use crate::optimizer::plan_visitor::ShareParentCounter;
 use crate::optimizer::PlanVisitor;
 use crate::{for_batch_plan_nodes, for_stream_plan_nodes};

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -24,10 +24,10 @@ use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::ChainType;
 
 use super::{
-    generic, ColPrunable, CollectInputRef, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary,
-    PredicatePushdown, StreamHashJoin, StreamProject, ToBatch, ToStream,
+    generic, ColPrunable, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, PredicatePushdown,
+    StreamHashJoin, StreamProject, ToBatch, ToStream,
 };
-use crate::expr::{Expr, ExprImpl, ExprRewriter, ExprType, InputRef};
+use crate::expr::{CollectInputRef, Expr, ExprImpl, ExprRewriter, ExprType, InputRef};
 use crate::optimizer::plan_node::generic::{
     push_down_into_join, push_down_join_condition, GenericPlanRef,
 };

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -22,7 +22,7 @@ use super::{
     gen_filter_and_pushdown, generic, BatchProject, ColPrunable, ExprRewritable, PlanBase, PlanRef,
     PlanTreeNodeUnary, PredicatePushdown, StreamProject, ToBatch, ToStream,
 };
-use crate::expr::{collect_input_ref, ExprImpl, ExprRewriter, InputRef};
+use crate::expr::{collect_input_refs, ExprImpl, ExprRewriter, InputRef};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
     ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
@@ -149,7 +149,7 @@ impl ColPrunable for LogicalProject {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
         let input_col_num: usize = self.input().schema().len();
         let input_required_cols = {
-            collect_input_ref(
+            collect_input_refs(
                 input_col_num,
                 required_cols.iter().map(|i| &self.exprs()[*i]),
             )

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -22,11 +22,10 @@ use super::{
     gen_filter_and_pushdown, generic, BatchProject, ColPrunable, ExprRewritable, PlanBase, PlanRef,
     PlanTreeNodeUnary, PredicatePushdown, StreamProject, ToBatch, ToStream,
 };
-use crate::expr::{ExprImpl, ExprRewriter, ExprVisitor, InputRef};
+use crate::expr::{collect_input_ref, ExprImpl, ExprRewriter, InputRef};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
-    CollectInputRef, ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext,
-    ToStreamContext,
+    ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
 use crate::utils::{ColIndexMapping, ColIndexMappingRewriteExt, Condition, Substitute};
@@ -148,26 +147,15 @@ impl fmt::Display for LogicalProject {
 
 impl ColPrunable for LogicalProject {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
-        let input_col_num = self.input().schema().len();
-        let mut input_required_appeared = FixedBitSet::with_capacity(input_col_num);
-
-        // Record each InputRef's index.
-        let mut input_ref_collector = CollectInputRef::with_capacity(input_col_num);
-        required_cols.iter().for_each(|i| {
-            if let ExprImpl::InputRef(ref input_ref) = self.exprs()[*i] {
-                let input_idx = input_ref.index;
-                input_required_appeared.put(input_idx);
-            } else {
-                input_ref_collector.visit_expr(&self.exprs()[*i]);
-            }
-        });
+        let input_col_num: usize = self.input().schema().len();
         let input_required_cols = {
-            let mut tmp = FixedBitSet::from(input_ref_collector);
-            tmp.union_with(&input_required_appeared);
-            tmp
+            collect_input_ref(
+                input_col_num,
+                required_cols.iter().map(|i| &self.exprs()[*i]),
+            )
+            .ones()
+            .collect_vec()
         };
-
-        let input_required_cols = input_required_cols.ones().collect_vec();
         let new_input = self.input().prune_col(&input_required_cols, ctx);
         let mut mapping = ColIndexMapping::with_remaining_columns(
             &input_required_cols,

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -148,14 +148,12 @@ impl fmt::Display for LogicalProject {
 impl ColPrunable for LogicalProject {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
         let input_col_num: usize = self.input().schema().len();
-        let input_required_cols = {
-            collect_input_refs(
-                input_col_num,
-                required_cols.iter().map(|i| &self.exprs()[*i]),
-            )
-            .ones()
-            .collect_vec()
-        };
+        let input_required_cols = collect_input_refs(
+            input_col_num,
+            required_cols.iter().map(|i| &self.exprs()[*i]),
+        )
+        .ones()
+        .collect_vec();
         let new_input = self.input().prune_col(&input_required_cols, ctx);
         let mut mapping = ColIndexMapping::with_remaining_columns(
             &input_required_cols,

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -24,7 +24,7 @@ use super::{
     PlanBase, PlanRef, PlanTreeNodeUnary, PredicatePushdown, StreamProjectSet, ToBatch, ToStream,
 };
 use crate::expr::{
-    collect_input_ref, Expr, ExprImpl, ExprRewriter, FunctionCall, InputRef, TableFunction,
+    collect_input_refs, Expr, ExprImpl, ExprRewriter, FunctionCall, InputRef, TableFunction,
 };
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
@@ -227,7 +227,7 @@ impl ColPrunable for LogicalProjectSet {
         let input_col_num = self.input().schema().len();
 
         let input_required_cols = {
-            collect_input_ref(
+            collect_input_refs(
                 input_col_num,
                 required_cols
                     .iter()

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -226,17 +226,15 @@ impl ColPrunable for LogicalProjectSet {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
         let input_col_num = self.input().schema().len();
 
-        let input_required_cols = {
-            collect_input_refs(
-                input_col_num,
-                required_cols
-                    .iter()
-                    .filter(|&&i| i > 0)
-                    .map(|i| &self.select_list()[*i - 1]),
-            )
-            .ones()
-            .collect_vec()
-        };
+        let input_required_cols = collect_input_refs(
+            input_col_num,
+            required_cols
+                .iter()
+                .filter(|&&i| i > 0)
+                .map(|i| &self.select_list()[*i - 1]),
+        )
+        .ones()
+        .collect_vec();
         let new_input = self.input().prune_col(&input_required_cols, ctx);
         let mut mapping = ColIndexMapping::with_remaining_columns(
             &input_required_cols,

--- a/src/frontend/src/optimizer/plan_node/logical_project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project_set.rs
@@ -24,12 +24,11 @@ use super::{
     PlanBase, PlanRef, PlanTreeNodeUnary, PredicatePushdown, StreamProjectSet, ToBatch, ToStream,
 };
 use crate::expr::{
-    Expr, ExprImpl, ExprRewriter, ExprVisitor, FunctionCall, InputRef, TableFunction,
+    collect_input_ref, Expr, ExprImpl, ExprRewriter, FunctionCall, InputRef, TableFunction,
 };
 use crate::optimizer::plan_node::generic::GenericPlanRef;
 use crate::optimizer::plan_node::{
-    CollectInputRef, ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext,
-    ToStreamContext,
+    ColumnPruningContext, PredicatePushdownContext, RewriteStreamContext, ToStreamContext,
 };
 use crate::utils::{ColIndexMapping, Condition, Substitute};
 
@@ -226,24 +225,18 @@ impl fmt::Display for LogicalProjectSet {
 impl ColPrunable for LogicalProjectSet {
     fn prune_col(&self, required_cols: &[usize], ctx: &mut ColumnPruningContext) -> PlanRef {
         let input_col_num = self.input().schema().len();
-        let mut input_required_appeared = FixedBitSet::with_capacity(input_col_num);
 
-        // Record each InputRef's index.
-        let mut input_ref_collector = CollectInputRef::with_capacity(input_col_num);
-        required_cols.iter().filter(|&&i| i > 0).for_each(|&i| {
-            if let ExprImpl::InputRef(ref input_ref) = self.select_list()[i - 1] {
-                let input_idx = input_ref.index;
-                input_required_appeared.put(input_idx);
-            } else {
-                input_ref_collector.visit_expr(&self.select_list()[i - 1]);
-            }
-        });
         let input_required_cols = {
-            let mut tmp = FixedBitSet::from(input_ref_collector);
-            tmp.union_with(&input_required_appeared);
-            tmp
+            collect_input_ref(
+                input_col_num,
+                required_cols
+                    .iter()
+                    .filter(|&&i| i > 0)
+                    .map(|i| &self.select_list()[*i - 1]),
+            )
+            .ones()
+            .collect_vec()
         };
-        let input_required_cols = input_required_cols.ones().collect_vec();
         let new_input = self.input().prune_col(&input_required_cols, ctx);
         let mut mapping = ColIndexMapping::with_remaining_columns(
             &input_required_cols,

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -29,8 +29,7 @@ use super::{
 };
 use crate::catalog::{ColumnId, IndexCatalog};
 use crate::expr::{
-    CollectInputRef, CorrelatedInputRef, Expr, ExprImpl, ExprRewriter, ExprVisitor, FunctionCall,
-    InputRef,
+    CorrelatedInputRef, Expr, ExprImpl, ExprRewriter, ExprVisitor, FunctionCall, InputRef,
 };
 use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::{
@@ -70,10 +69,7 @@ impl LogicalScan {
         // required columns, i.e., the mapping from operator_idx to table_idx.
 
         let mut required_col_idx = output_col_idx.clone();
-        let mut visitor =
-            CollectInputRef::new(FixedBitSet::with_capacity(table_desc.columns.len()));
-        predicate.visit_expr(&mut visitor);
-        let predicate_col_idx: FixedBitSet = visitor.into();
+        let predicate_col_idx = predicate.collect_input_refs(table_desc.columns.len());
         predicate_col_idx.ones().for_each(|idx| {
             if !required_col_idx.contains(&idx) {
                 required_col_idx.push(idx);

--- a/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
+++ b/src/frontend/src/optimizer/rule/distinct_agg_rule.rs
@@ -21,11 +21,9 @@ use risingwave_common::types::DataType;
 use risingwave_expr::agg::AggKind;
 
 use super::{BoxedRule, Rule};
-use crate::expr::{ExprType, FunctionCall, InputRef, Literal};
+use crate::expr::{CollectInputRef, ExprType, FunctionCall, InputRef, Literal};
 use crate::optimizer::plan_node::generic::Agg;
-use crate::optimizer::plan_node::{
-    CollectInputRef, LogicalAgg, LogicalExpand, LogicalProject, PlanAggCall,
-};
+use crate::optimizer::plan_node::{LogicalAgg, LogicalExpand, LogicalProject, PlanAggCall};
 use crate::optimizer::PlanRef;
 use crate::utils::{ColIndexMapping, Condition};
 

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -149,7 +149,7 @@ impl Condition {
     /// # Panics
     /// Panics if `input_ref >= input_col_num`.
     pub fn collect_input_refs(&self, input_col_num: usize) -> FixedBitSet {
-        collect_input_refs(input_col_num, self.conjunctions.iter())
+        collect_input_refs(input_col_num, &self.conjunctions)
     }
 
     /// Split the condition expressions into (N choose 2) + 1 groups: those containing two columns

--- a/src/frontend/src/utils/condition.rs
+++ b/src/frontend/src/utils/condition.rs
@@ -26,7 +26,7 @@ use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::scan_range::{is_full_range, ScanRange};
 
 use crate::expr::{
-    factorization_expr, fold_boolean_constant, push_down_not, to_conjunctions,
+    collect_input_refs, factorization_expr, fold_boolean_constant, push_down_not, to_conjunctions,
     try_get_bool_constant, ExprDisplay, ExprImpl, ExprMutator, ExprRewriter, ExprType, ExprVisitor,
     FunctionCall, InequalityInputPair, InputRef,
 };
@@ -144,12 +144,12 @@ impl Condition {
         .unwrap()
     }
 
+    /// Collect all `InputRef`s' indexes in the expressions.
+    ///
+    /// # Panics
+    /// Panics if `input_ref >= input_col_num`.
     pub fn collect_input_refs(&self, input_col_num: usize) -> FixedBitSet {
-        let mut input_bits = FixedBitSet::with_capacity(input_col_num);
-        for expr in &self.conjunctions {
-            input_bits.union_with(&expr.collect_input_refs(input_col_num));
-        }
-        input_bits
+        collect_input_refs(input_col_num, self.conjunctions.iter())
     }
 
     /// Split the condition expressions into (N choose 2) + 1 groups: those containing two columns


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- refine the `col_prune` for Project and ProjectSet
- use `Conditon::collect_input_refs` instead of use `CollectInputRef` visitor diectly

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
