### PR TITLE
feat(compaction): do not split compaction output by size in L0 and Lbase

### DIFF
--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -266,6 +266,8 @@ message CompactTask {
   // compaction output will be added to [`target_level`] of LSM after compaction
   uint32 target_level = 6;
   bool gc_delete_keys = 7;
+  // Lbase in LSM
+  uint32 base_level = 8;
   TaskStatus task_status = 9;
   // compaction group the task belongs to
   uint64 compaction_group_id = 12;

--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -100,6 +100,7 @@ impl CompactionInput {
 
 pub struct CompactionTask {
     pub input: CompactionInput,
+    pub base_level: usize,
     pub compression_algorithm: String,
     pub target_file_size: u64,
     pub compaction_task_type: compact_task::TaskType,
@@ -163,6 +164,7 @@ impl CompactStatus {
             // only gc delete keys in last level because there may be older version in more bottom
             // level.
             gc_delete_keys: target_level_id == self.level_handlers.len() - 1,
+            base_level: ret.base_level as u32,
             task_status: TaskStatus::Pending as i32,
             compaction_group_id: group.group_id,
             existing_table_ids: vec![],
@@ -379,6 +381,7 @@ pub fn create_compaction_task(
             base_level,
             input.target_level,
         ),
+        base_level,
         input,
         target_file_size,
         compaction_task_type,

--- a/src/meta/src/hummock/compaction_schedule_policy.rs
+++ b/src/meta/src/hummock/compaction_schedule_policy.rs
@@ -495,6 +495,7 @@ mod tests {
             task_id,
             target_level: 0,
             gc_delete_keys: false,
+            base_level: 0,
             task_status: TaskStatus::Pending as i32,
             compaction_group_id: StaticCompactionGroupId::StateDefault.into(),
             existing_table_ids: vec![],

--- a/src/storage/benches/bench_compactor.rs
+++ b/src/storage/benches/bench_compactor.rs
@@ -185,6 +185,7 @@ async fn compact<I: HummockIterator<Direction = Forward>>(iter: I, sstable_store
         watermark: 0,
         stats_target_table_ids: None,
         task_type: compact_task::TaskType::Dynamic,
+        is_target_l0_or_lbase: false,
         split_by_table: false,
     };
     Compactor::compact_and_build_sst(

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -124,6 +124,7 @@ pub struct TaskConfig {
     /// doesn't belong to this divided SST. See `Compactor::compact_and_build_sst`.
     pub stats_target_table_ids: Option<HashSet<u32>>,
     pub task_type: compact_task::TaskType,
+    pub is_target_l0_or_lbase: bool,
     pub split_by_table: bool,
 }
 

--- a/src/storage/src/hummock/compactor/compactor_runner.rs
+++ b/src/storage/src/hummock/compactor/compactor_runner.rs
@@ -70,6 +70,8 @@ impl CompactorRunner {
                 watermark: task.watermark,
                 stats_target_table_ids: Some(HashSet::from_iter(task.existing_table_ids.clone())),
                 task_type: task.task_type(),
+                is_target_l0_or_lbase: task.target_level == 0
+                    || task.target_level == task.base_level,
                 split_by_table: task.split_by_state_table,
             },
         );

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -893,6 +893,7 @@ impl Compactor {
             task_progress,
             del_agg,
             self.task_config.key_range.clone(),
+            self.task_config.is_target_l0_or_lbase,
             self.task_config.split_by_table,
         );
         let compaction_statistics = Compactor::compact_and_build_sst(

--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -431,6 +431,7 @@ impl SharedBufferCompactRunner {
                 watermark: GC_WATERMARK_FOR_FLUSH,
                 stats_target_table_ids: None,
                 task_type: compact_task::TaskType::SharedBuffer,
+                is_target_l0_or_lbase: true,
                 split_by_table: false,
             },
         );

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -71,6 +71,7 @@ where
     pub del_agg: Arc<CompactionDeleteRanges>,
     key_range: KeyRange,
     last_table_id: u32,
+    is_target_level_l0_or_lbase: bool,
     split_by_table: bool,
 }
 
@@ -85,6 +86,7 @@ where
         task_progress: Option<Arc<TaskProgress>>,
         del_agg: Arc<CompactionDeleteRanges>,
         key_range: KeyRange,
+        is_target_level_l0_or_lbase: bool,
         split_by_table: bool,
     ) -> Self {
         let start_key = if key_range.left.is_empty() {
@@ -103,6 +105,7 @@ where
             last_sealed_key: start_key,
             key_range,
             last_table_id: 0,
+            is_target_level_l0_or_lbase,
             split_by_table,
         }
     }
@@ -118,6 +121,7 @@ where
             del_agg: Arc::new(CompactionDeleteRanges::for_test()),
             key_range: KeyRange::inf(),
             last_table_id: 0,
+            is_target_level_l0_or_lbase: false,
             split_by_table: false,
         }
     }
@@ -160,7 +164,11 @@ where
             switch_builder = true;
         }
         if let Some(builder) = self.current_builder.as_ref() {
-            if is_new_user_key && (switch_builder || builder.reach_capacity()) {
+            if is_new_user_key
+                && (switch_builder
+                    || (!(self.is_target_level_l0_or_lbase && self.split_by_table)
+                        && builder.reach_capacity()))
+            {
                 let monotonic_deletes = self
                     .del_agg
                     .get_tombstone_between(self.last_sealed_key.as_ref(), full_key.user_key);
@@ -440,6 +448,7 @@ mod tests {
             builder.build_for_compaction(false),
             KeyRange::inf(),
             false,
+            false,
         );
         builder
             .add_full_key_for_test(
@@ -490,6 +499,7 @@ mod tests {
             None,
             builder.build_for_compaction(false),
             KeyRange::inf(),
+            false,
             false,
         );
         let results = builder.finish().await.unwrap();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
Do not split compaction output by size when the output is already split by state table in L0 and Lbase to make code more clear.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
