### PR TITLE
fix(ci): connector integration test trigger condition

### DIFF
--- a/.github/workflows/connector-node-integration.yml
+++ b/.github/workflows/connector-node-integration.yml
@@ -3,10 +3,8 @@ name: Connector Node Integration Tests
 on:
   push:
     branches: [main]
-    paths: [java/**, proto/**]
   pull_request:
     branches: [main]
-    paths: [java/**, proto/**]
 
 jobs:
   build:
@@ -17,13 +15,23 @@ jobs:
     name: Java ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v3
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            java:
+              - 'java/**'
+            proto:
+              - 'proto/**'
       - name: Set up JDK ${{ matrix.java }}
+        if: steps.filter.outputs.java == 'true' || steps.filter.outputs.proto == 'true'
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
           cache: 'maven'
       - name: run integration tests
+        if: steps.filter.outputs.java == 'true' || steps.filter.outputs.proto == 'true'
         run: |
           set -ex
           


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- previously, the connector node integration workflow is triggered if the files in `java/**` or `proto/**` have been modified
- if the files in `java/**` or `proto/**`  are not modified, the workflow will be skipped. however, if we change the workflow to be `required`, merging pr's will blocked if the workflow was skipped (since no status was reported)
- therefore, the workflow was modified such that:
  - the workflow is run no matter the files in `java/**` or `proto/**` are modified or not
  - the integration test will only run if the files in `java/**` or `proto/**` are modified
  - if the integration test is skipped, the workflow will still succeed

References:
- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks
- https://github.com/dorny/paths-filter

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

