### PR TITLE
perf(minor): change `stream_extreme_cache_size` from 1024 to 10

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -788,7 +788,7 @@ mod default {
         }
 
         pub fn unsafe_stream_extreme_cache_size() -> usize {
-            1 << 10
+            10
         }
 
         pub fn stream_chunk_size() -> usize {

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -23,7 +23,10 @@ node_num_monitor_interval_sec = 10
 backend = "Mem"
 periodic_space_reclaim_compaction_interval_sec = 3600
 periodic_ttl_reclaim_compaction_interval_sec = 1800
+periodic_split_compact_group_interval_sec = 180
 max_compactor_task_multiplier = 2
+move_table_size_limit = 5368709120
+split_group_size_limit = 21474836480
 
 [batch.developer]
 batch_connector_message_buffer_size = 16
@@ -39,7 +42,7 @@ unique_user_stream_errors = 10
 [streaming.developer]
 stream_enable_executor_row_count = false
 stream_connector_message_buffer_size = 16
-stream_unsafe_extreme_cache_size = 1024
+stream_unsafe_extreme_cache_size = 10
 stream_chunk_size = 1024
 stream_exchange_initial_permits = 8192
 stream_exchange_batched_permits = 1024


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As @fuyufjh suggested, 1024 seems too large for extreme agg cache size.

## Checklist For Contributors

- ~~[ ] I have written necessary rustdoc comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
