### PR TITLE
test: add debezium-postgres demo in integration tests

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -345,6 +345,7 @@ services:
       - "29092:29092"
       - "9092:9092"
       - "9644:9644"
+      - "8081:8081"
     depends_on: []
     volumes:
       - "message_queue:/var/lib/redpanda/data"

--- a/integration_tests/debezium-postgres/create_mv.sql
+++ b/integration_tests/debezium-postgres/create_mv.sql
@@ -1,0 +1,8 @@
+CREATE MATERIALIZED VIEW product_count AS
+SELECT
+    product_id,
+    COUNT(*) as product_count
+FROM
+    orders
+GROUP BY
+    product_id;

--- a/integration_tests/debezium-postgres/create_source.sql
+++ b/integration_tests/debezium-postgres/create_source.sql
@@ -1,0 +1,6 @@
+CREATE TABLE orders (order_id INT PRIMARY KEY) with (
+    connector = 'kafka',
+    kafka.topic = 'postgres.public.orders',
+    kafka.brokers = 'message_queue:29092',
+    kafka.scan.startup.mode = 'earliest'
+) ROW FORMAT DEBEZIUM_AVRO ROW SCHEMA LOCATION CONFLUENT SCHEMA REGISTRY 'http://message_queue:8081';

--- a/integration_tests/debezium-postgres/data_check
+++ b/integration_tests/debezium-postgres/data_check
@@ -1,0 +1,1 @@
+orders,product_count

--- a/integration_tests/debezium-postgres/docker-compose.yml
+++ b/integration_tests/debezium-postgres/docker-compose.yml
@@ -1,0 +1,101 @@
+---
+version: "3"
+services:
+  risingwave:
+    image: ghcr.io/risingwavelabs/risingwave:latest
+    ports:
+      - 4566:4566
+      - 5691:5691
+    command:
+      - playground
+    container_name: risingwave
+
+  postgres:
+    image: debezium/postgres:13
+    ports:
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgrespw
+      POSTGRES_USER: postgresuser
+      POSTGRES_DB: mydb
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -h 127.0.0.1 -U postgresuser -d mydb"
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    container_name: postgres
+    volumes:
+      - ./postgres/postgres_bootstrap.sql:/docker-entrypoint-initdb.d/postgres_bootstrap.sql
+
+  message_queue:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: message_queue
+
+  debezium:
+    image: debezium/connect:1.9
+    environment:
+      BOOTSTRAP_SERVERS: message_queue:29092
+      GROUP_ID: 1
+      CONFIG_STORAGE_TOPIC: connect_configs
+      OFFSET_STORAGE_TOPIC: connect_offsets
+      KEY_CONVERTER: io.confluent.connect.avro.AvroConverter
+      VALUE_CONVERTER: io.confluent.connect.avro.AvroConverter
+      CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL: http://message_queue:8081
+      CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL: http://message_queue:8081
+    ports:
+      - 8083:8083
+    healthcheck:
+      test: curl -f localhost:8083
+      interval: 1s
+      start_period: 120s
+    depends_on:
+      message_queue: { condition: service_healthy }
+      postgres: { condition: service_healthy }
+    container_name: debezium
+
+  debezium_deploy:
+    image: debezium/connect:1.9
+    depends_on:
+      debezium:
+        condition: service_healthy
+    volumes:
+      - ./postgres/postgres_dbz.sh:/postgres_dbz.sh
+    entrypoint: [ bash, -c, /postgres_dbz.sh ]
+    container_name: debezium_deploy
+    restart: on-failure
+
+  datagen:
+    image: postgres
+    depends_on:
+      postgres: { condition: service_healthy }
+    command:
+      - /bin/sh
+      - -c 
+      - psql "postgresql://postgresuser:postgrespw@postgres:5432/mydb" -f ./postgres_prepare.sql
+    volumes:
+      - "./postgres_prepare.sql:/postgres_prepare.sql"
+    container_name: datagen
+    restart: on-failure
+
+  # Check out the connectors via 127.0.0.1:8000
+  kafka-connect-ui:
+    image: landoop/kafka-connect-ui
+    ports:
+      - 8000:8000
+    environment:
+      CONNECT_URL: http://debezium:8083
+    container_name: kafka-connect-ui
+    depends_on: 
+      message_queue: { condition: service_healthy }
+
+volumes:
+  message_queue:
+    external: false
+
+name: risingwave-compose
+ 

--- a/integration_tests/debezium-postgres/postgres/postgres_bootstrap.sql
+++ b/integration_tests/debezium-postgres/postgres/postgres_bootstrap.sql
@@ -1,0 +1,4 @@
+-- https://www.postgresql.org/docs/current/logical-replication.html
+ALTER SYSTEM SET wal_level = logical;
+
+ALTER ROLE postgresuser WITH REPLICATION;

--- a/integration_tests/debezium-postgres/postgres/postgres_dbz.sh
+++ b/integration_tests/debezium-postgres/postgres/postgres_dbz.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+echo "Deploying Debezium Postgres connector"
+
+curl -s -X PUT -H "Content-Type: application/json" http://debezium:8083/connectors/register-postgres/config \
+  -d '{
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.hostname": "postgres",
+    "database.port": 5432,
+    "database.user": "postgresuser",
+    "database.password": "postgrespw",
+    "database.dbname": "mydb",
+    "database.server.name": "postgres",
+    "database.schema": "public",
+    "database.history.kafka.bootstrap.servers": "message_queue:29092",
+    "database.history.kafka.topic": "postgres-history",
+    "time.precision.mode": "connect",
+    "include.schema.changes": false
+}'

--- a/integration_tests/debezium-postgres/postgres_prepare.sql
+++ b/integration_tests/debezium-postgres/postgres_prepare.sql
@@ -1,0 +1,32 @@
+-- Create the orders table
+CREATE TABLE orders (
+  order_id SERIAL PRIMARY KEY,
+  order_date BIGINT,
+  customer_name VARCHAR(200),
+  price DECIMAL,
+  product_id INT,
+  order_status SMALLINT
+);
+
+-- FULL - Emitted events for UPDATE and DELETE operations contain the previous values of all columns in the table.
+-- Refer to https://debezium.io/documentation/reference/stable/connectors/postgresql.html#postgresql-replica-identity
+ALTER TABLE
+  orders REPLICA IDENTITY FULL;
+
+-- -- https://www.postgresql.org/docs/15/logical-replication-publication.html
+-- CREATE PUBLICATION mz_source FOR TABLE orders;
+
+-- Insert data into the orders table
+INSERT INTO
+  orders (
+    order_id,
+    order_date,
+    customer_name,
+    price,
+    product_id,
+    order_status
+  )
+VALUES
+  (1, 1558430840000, 'Bob', 10.50, 1, 1),
+  (2, 1558430840001, 'Alice', 20.50, 2, 1),
+  (3, 1558430840002, 'Alice', 18.50, 2, 1);

--- a/integration_tests/debezium-postgres/query.sql
+++ b/integration_tests/debezium-postgres/query.sql
@@ -1,0 +1,6 @@
+SELECT
+    *
+FROM
+    orders
+LIMIT
+    10;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The entire docker compose workflow for debezium + postgres cdc has been runnable, but not fully functional due to the bug in our debezium source: https://github.com/risingwavelabs/risingwave/issues/9673 I will enable this workflow once we resolve this issue.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

