### PR TITLE
feat(storage): support identifying "object not found" error kind

### DIFF
--- a/src/object_store/src/object/disk.rs
+++ b/src/object_store/src/object/disk.rs
@@ -411,6 +411,11 @@ mod tests {
             .upload("test.obj", Bytes::from(payload.clone()))
             .await
             .unwrap();
+        assert!(store
+            .metadata("not_exist.obj")
+            .await
+            .unwrap_err()
+            .is_object_not_found_error());
         let metadata = store.metadata("test.obj").await.unwrap();
         assert_eq!(payload.len(), metadata.total_size);
 
@@ -584,8 +589,8 @@ mod tests {
         let test_dir = TempDir::new().unwrap();
         let test_root_path = test_dir.path().to_str().unwrap();
         let store = DiskObjectStore::new(test_root_path);
-
-        assert!(store.read("non-exist.obj", None).await.is_err());
+        let err = store.read("non-exist.obj", None).await.unwrap_err();
+        assert!(err.is_object_not_found_error());
     }
 
     #[tokio::test]

--- a/src/object_store/src/object/error.rs
+++ b/src/object_store/src/object/error.rs
@@ -16,24 +16,27 @@ use std::backtrace::Backtrace;
 use std::io;
 use std::marker::{Send, Sync};
 
+use aws_sdk_s3::error::{GetObjectError, GetObjectErrorKind, HeadObjectError, HeadObjectErrorKind};
 use risingwave_common::error::BoxedError;
 use thiserror::Error;
 use tokio::sync::oneshot::error::RecvError;
+
+use crate::object::Error;
 
 #[derive(Error, Debug)]
 enum ObjectErrorInner {
     #[error(transparent)]
     S3(BoxedError),
-
     #[error("disk error: {msg}")]
     Disk {
         msg: String,
         #[source]
         inner: io::Error,
     },
-
     #[error(transparent)]
     Opendal(BoxedError),
+    #[error(transparent)]
+    Mem(BoxedError),
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -71,12 +74,37 @@ impl ObjectError {
         ObjectErrorInner::Disk { msg, inner: err }.into()
     }
 
-    pub fn opendal(err: impl Into<BoxedError>) -> Self {
-        ObjectErrorInner::Opendal(err.into()).into()
-    }
-
-    pub fn s3(err: impl Into<BoxedError>) -> Self {
-        ObjectErrorInner::S3(err.into()).into()
+    /// Tells whether the error indicates the target object is not found.
+    pub fn is_object_not_found_error(&self) -> bool {
+        match &self.inner {
+            ObjectErrorInner::S3(e) => {
+                if let Some(aws_smithy_http::result::SdkError::ServiceError { err, .. }) =
+                    e.downcast_ref::<aws_smithy_http::result::SdkError<GetObjectError>>()
+                {
+                    return matches!(err.kind, GetObjectErrorKind::NoSuchKey(_));
+                }
+                if let Some(aws_smithy_http::result::SdkError::ServiceError { err, .. }) =
+                    e.downcast_ref::<aws_smithy_http::result::SdkError<HeadObjectError>>()
+                {
+                    return matches!(err.kind, HeadObjectErrorKind::NotFound(_));
+                }
+            }
+            ObjectErrorInner::Opendal(e) => {
+                if let Some(e) = e.downcast_ref::<opendal::Error>() {
+                    return matches!(e.kind(), opendal::ErrorKind::NotFound);
+                }
+            }
+            ObjectErrorInner::Disk { msg: _msg, inner } => {
+                return matches!(inner.kind(), io::ErrorKind::NotFound);
+            }
+            ObjectErrorInner::Mem(e) => {
+                if let Some(e) = e.downcast_ref::<crate::object::mem::Error>() {
+                    return matches!(e, crate::object::mem::Error::NotFound(_));
+                }
+            }
+            _ => {}
+        };
+        false
     }
 }
 
@@ -109,6 +137,12 @@ impl From<io::Error> for ObjectError {
 impl From<RecvError> for ObjectError {
     fn from(e: RecvError) -> Self {
         ObjectErrorInner::Internal(e.to_string()).into()
+    }
+}
+
+impl From<crate::object::mem::Error> for ObjectError {
+    fn from(e: Error) -> Self {
+        ObjectErrorInner::Mem(e.into()).into()
     }
 }
 

--- a/src/object_store/src/object/error.rs
+++ b/src/object_store/src/object/error.rs
@@ -34,7 +34,7 @@ enum ObjectErrorInner {
         inner: io::Error,
     },
     #[error(transparent)]
-    Opendal(BoxedError),
+    Opendal(opendal::Error),
     #[error(transparent)]
     Mem(crate::object::mem::Error),
     #[error("Internal error: {0}")]
@@ -90,9 +90,7 @@ impl ObjectError {
                 }
             }
             ObjectErrorInner::Opendal(e) => {
-                if let Some(e) = e.downcast_ref::<opendal::Error>() {
-                    return matches!(e.kind(), opendal::ErrorKind::NotFound);
-                }
+                return matches!(e.kind(), opendal::ErrorKind::NotFound);
             }
             ObjectErrorInner::Disk { msg: _msg, inner } => {
                 return matches!(inner.kind(), io::ErrorKind::NotFound);
@@ -122,13 +120,7 @@ impl From<aws_smithy_http::byte_stream::Error> for ObjectError {
 }
 impl From<opendal::Error> for ObjectError {
     fn from(e: opendal::Error) -> Self {
-        ObjectErrorInner::Opendal(e.into()).into()
-    }
-}
-
-impl From<io::Error> for ObjectError {
-    fn from(e: io::Error) -> Self {
-        ObjectErrorInner::Opendal(e.into()).into()
+        ObjectErrorInner::Opendal(e).into()
     }
 }
 

--- a/src/object_store/src/object/error.rs
+++ b/src/object_store/src/object/error.rs
@@ -36,7 +36,7 @@ enum ObjectErrorInner {
     #[error(transparent)]
     Opendal(BoxedError),
     #[error(transparent)]
-    Mem(BoxedError),
+    Mem(crate::object::mem::Error),
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -98,9 +98,7 @@ impl ObjectError {
                 return matches!(inner.kind(), io::ErrorKind::NotFound);
             }
             ObjectErrorInner::Mem(e) => {
-                if let Some(e) = e.downcast_ref::<crate::object::mem::Error>() {
-                    return matches!(e, crate::object::mem::Error::NotFound(_));
-                }
+                return e.is_object_not_found_error();
             }
             _ => {}
         };
@@ -142,7 +140,7 @@ impl From<RecvError> for ObjectError {
 
 impl From<crate::object::mem::Error> for ObjectError {
     fn from(e: Error) -> Self {
-        ObjectErrorInner::Mem(e.into()).into()
+        ObjectErrorInner::Mem(e).into()
     }
 }
 

--- a/src/object_store/src/object/mem.rs
+++ b/src/object_store/src/object/mem.rs
@@ -39,6 +39,12 @@ pub enum Error {
 }
 
 impl Error {
+    pub fn is_object_not_found_error(&self) -> bool {
+        matches!(self, Error::NotFound(_))
+    }
+}
+
+impl Error {
     fn not_found(msg: impl ToString) -> Self {
         Error::NotFound(msg.to_string())
     }

--- a/src/object_store/src/object/opendal_engine/opendal_object_store.rs
+++ b/src/object_store/src/object/opendal_engine/opendal_object_store.rs
@@ -285,6 +285,8 @@ mod tests {
         let obj_store = OpendalObjectStore::new_memory_engine().unwrap();
         obj_store.upload("/abc", block).await.unwrap();
 
+        let err = obj_store.metadata("/not_exist").await.unwrap_err();
+        assert!(err.is_object_not_found_error());
         let metadata = obj_store.metadata("/abc").await.unwrap();
         assert_eq!(metadata.total_size, 6);
         obj_store.delete(&path).await.unwrap();

--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -166,7 +166,7 @@ impl S3StreamingUploader {
                 .content_length(len as i64)
                 .send()
                 .await
-                .map_err(ObjectError::s3);
+                .map_err(Into::into);
             try_update_failure_metric(&metrics, &upload_output_res, operation_type);
             Ok((part_id, upload_output_res?))
         }));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously when ObjectStore::read returns a error, we cannot tell whether it's "object does not exist" or any other error kinds (maybe transient/recoverable ones). We encounter several cases to distinguish them.

This PR add `is_object_not_found_error` method for `ObjectError`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
