### PR TITLE
feat(concat delete iterator): prefetch for concat delete range iterator

### DIFF
--- a/src/storage/src/hummock/iterator/delete_range_iterator.rs
+++ b/src/storage/src/hummock/iterator/delete_range_iterator.rs
@@ -14,6 +14,7 @@
 
 use std::collections::{BTreeSet, BinaryHeap};
 use std::future::Future;
+use std::sync::Arc;
 
 use risingwave_hummock_sdk::key::{PointRange, UserKey};
 use risingwave_hummock_sdk::HummockEpoch;
@@ -21,6 +22,7 @@ use risingwave_pb::hummock::SstableInfo;
 
 use crate::hummock::iterator::concat_delete_range_iterator::ConcatDeleteRangeIterator;
 use crate::hummock::shared_buffer::shared_buffer_batch::SharedBufferDeleteRangeIterator;
+use crate::hummock::sstable::SstableIteratorReadOptions;
 use crate::hummock::sstable_store::SstableStoreRef;
 use crate::hummock::{HummockResult, SstableDeleteRangeIterator};
 
@@ -249,11 +251,17 @@ impl ForwardMergeRangeIterator {
         self.unused_iters.push(RangeIteratorTyped::Sst(iter));
     }
 
-    pub fn add_concat_iter(&mut self, sstables: Vec<SstableInfo>, sstable_store: SstableStoreRef) {
+    pub fn add_concat_iter(
+        &mut self,
+        sstables: Vec<SstableInfo>,
+        sstable_store: SstableStoreRef,
+        options: Arc<SstableIteratorReadOptions>,
+    ) {
         self.unused_iters
             .push(RangeIteratorTyped::Concat(ConcatDeleteRangeIterator::new(
                 sstables,
                 sstable_store,
+                options,
             )))
     }
 }

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -761,7 +761,15 @@ impl HummockVersionReader {
                     continue;
                 }
                 if sstables.len() > 1 {
-                    delete_range_iter.add_concat_iter(sstables.clone(), self.sstable_store.clone());
+                    delete_range_iter.add_concat_iter(
+                        sstables
+                            .iter()
+                            .filter(|sst| sst.get_range_tombstone_count() > 0)
+                            .cloned()
+                            .collect_vec(),
+                        self.sstable_store.clone(),
+                        sst_read_options.clone(),
+                    );
                     non_overlapping_iters.push(ConcatIterator::new(
                         sstables,
                         self.sstable_store.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
background: https://github.com/risingwavelabs/risingwave/pull/9517#discussion_r1186666172
However, when `read_options.ignore_range_tombstone == false`, concat delete range iterator will usually request for `SstableMeta` of an SST earlier than `SstableMeta` of the same SST is requested for by concat iterator.
Therefore, in such situation, prefetching in `ConcatDeleteRangeIterator` is meaningful and prefetching in `ConcatIterator` is meaningless.

This PR makes `ConcatDeleteRangeIterator` prefetch one extra `SSTableMeta` every time it requests for an `SSTableMeta`.

This PR maintains a prefetch queue (`prefetched_metas: VecDeque`) for `SSTableMeta`s that have already been prefetched.

## Checklist For Contributors

- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
