### PR TITLE
perf(over-window): store `agg_call` instead of `agg_state_prototype` in `AggregateState` to reduce memory consumption

### DIFF
--- a/src/stream/src/executor/over_window/state/aggregate.rs
+++ b/src/stream/src/executor/over_window/state/aggregate.rs
@@ -19,7 +19,7 @@ use risingwave_common::array::{DataChunk, Vis};
 use risingwave_common::types::{DataType, Datum};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::{bail, must_match};
-use risingwave_expr::agg::{build as builg_agg, AggArgs, AggCall, BoxedAggState};
+use risingwave_expr::agg::{build as builg_agg, AggArgs, AggCall};
 use risingwave_expr::function::window::{WindowFuncCall, WindowFuncKind};
 use smallvec::SmallVec;
 
@@ -28,7 +28,7 @@ use super::{StateEvictHint, StateKey, StateOutput, StatePos, WindowState};
 use crate::executor::StreamExecutorResult;
 
 pub(super) struct AggregateState {
-    factory: BoxedAggState,
+    agg_call: AggCall,
     arg_data_types: Vec<DataType>,
     buffer: StreamWindowBuffer<StateKey, SmallVec<[Datum; 2]>>,
 }
@@ -56,7 +56,7 @@ impl AggregateState {
             distinct: false,
         };
         Ok(Self {
-            factory: builg_agg(agg_call)?,
+            agg_call,
             arg_data_types,
             buffer: StreamWindowBuffer::new(call.frame.clone()),
         })
@@ -79,7 +79,7 @@ impl WindowState for AggregateState {
     fn output(&mut self) -> StreamExecutorResult<StateOutput> {
         assert!(self.curr_window().is_ready);
         let wrapper = BatchAggregatorWrapper {
-            factory: &self.factory,
+            agg_call: &self.agg_call,
             arg_data_types: &self.arg_data_types,
         };
         let return_value =
@@ -102,7 +102,7 @@ impl WindowState for AggregateState {
 }
 
 struct BatchAggregatorWrapper<'a> {
-    factory: &'a BoxedAggState,
+    agg_call: &'a AggCall,
     arg_data_types: &'a [DataType],
 }
 
@@ -131,7 +131,7 @@ impl BatchAggregatorWrapper<'_> {
             .collect::<Vec<_>>();
         let chunk = DataChunk::new(columns, Vis::Compact(n_values));
 
-        let mut aggregator = self.factory.clone();
+        let mut aggregator = builg_agg(self.agg_call.clone())?;
         aggregator
             .update_multi(&chunk, 0, n_values)
             .now_or_never()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

At title.

## Checklist For Contributors

- ~[ ] I have written necessary rustdoc comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
