### PR TITLE
feat(fe): refine notice framework

### DIFF
--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -101,7 +101,7 @@ pub fn gen_create_mv_plan(
 
     let emit_on_window_close = emit_mode == Some(EmitMode::OnWindowClose);
     if emit_on_window_close {
-        context.warn("EMIT ON WINDOW CLOSE is currently an experimental feature. Please use it with caution.");
+        context.warn_to_user("EMIT ON WINDOW CLOSE is currently an experimental feature. Please use it with caution.");
     }
 
     let mut plan_root = Planner::new(context).plan_query(bound)?;
@@ -155,7 +155,7 @@ pub async fn handle_create_mv(
 
         let has_order_by = !query.order_by.is_empty();
         if has_order_by {
-            context.warn(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
+            context.warn_to_user(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
 It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
 "#.to_string());
         }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -330,11 +330,5 @@ pub mod tests {
         let sql = "create materialized view mv2 as select * from t order by x";
         let response = frontend.run_sql(sql).await.unwrap();
         assert_eq!(response.get_stmt_type(), CREATE_MATERIALIZED_VIEW);
-        assert_eq!(
-            response.get_notices()[0],
-            r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
-It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
-"#
-        );
     }
 }

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -148,12 +148,18 @@ pub async fn handle_create_mv(
 ) -> Result<RwPgResponse> {
     let session = handler_args.session.clone();
 
-    let has_order_by = !query.order_by.is_empty();
-
     session.check_relation_name_duplicated(name.clone())?;
 
-    let (table, graph, mut notices) = {
+    let (table, graph) = {
         let context = OptimizerContext::from_handler_args(handler_args);
+
+        let has_order_by = !query.order_by.is_empty();
+        if has_order_by {
+            context.warn(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
+It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
+"#.to_string());
+        }
+
         let (plan, table) =
             gen_create_mv_plan(&session, context.into(), query, name, columns, emit_mode)?;
         let context = plan.plan_base().ctx.clone();
@@ -166,9 +172,7 @@ pub async fn handle_create_mv(
         let env = graph.env.as_mut().unwrap();
         env.timezone = context.get_session_timezone();
 
-        let notices = context.take_warnings();
-
-        (table, graph, notices)
+        (table, graph)
     };
 
     let _job_guard =
@@ -187,15 +191,8 @@ pub async fn handle_create_mv(
         .create_materialized_view(table, graph)
         .await?;
 
-    if has_order_by {
-        notices.push(r#"The ORDER BY clause in the CREATE MATERIALIZED VIEW statement does not guarantee that the rows selected out of this materialized view is returned in this order.
-It only indicates the physical clustering of the data, which may improve the performance of queries issued against this materialized view.
-"#.to_string());
-    }
-
-    Ok(PgResponse::empty_result_with_notices(
+    Ok(PgResponse::empty_result(
         StatementType::CREATE_MATERIALIZED_VIEW,
-        notices,
     ))
 }
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -651,7 +651,7 @@ pub async fn handle_create_table(
         }
     }
 
-    let (graph, source, table, notices) = {
+    let (graph, source, table) = {
         let context = OptimizerContext::from_handler_args(handler_args);
         let source_schema = check_create_table_with_source(context.with_options(), source_schema)?;
         let col_id_gen = ColumnIdGenerator::new_initial();
@@ -681,15 +681,12 @@ pub async fn handle_create_table(
             )?,
         };
 
-        let context = plan.plan_base().ctx.clone();
-        let notices = context.take_warnings();
-
         let mut graph = build_graph(plan);
         graph.parallelism = session
             .config()
             .get_streaming_parallelism()
             .map(|parallelism| Parallelism { parallelism });
-        (graph, source, table, notices)
+        (graph, source, table)
     };
 
     tracing::trace!(
@@ -701,10 +698,7 @@ pub async fn handle_create_table(
     let catalog_writer = session.env().catalog_writer();
     catalog_writer.create_table(source, table, graph).await?;
 
-    Ok(PgResponse::empty_result_with_notices(
-        StatementType::CREATE_TABLE,
-        notices,
-    ))
+    Ok(PgResponse::empty_result(StatementType::CREATE_TABLE))
 }
 
 pub fn check_create_table_with_source(

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -257,7 +257,6 @@ struct BatchPlanFragmenterResult {
     pub(crate) schema: Schema,
     pub(crate) stmt_type: StatementType,
     pub(crate) _dependent_relations: Vec<TableId>,
-    pub(crate) warnings: Vec<String>,
 }
 
 fn gen_batch_plan_fragmenter(
@@ -272,7 +271,6 @@ fn gen_batch_plan_fragmenter(
         dependent_relations,
     } = plan_result;
 
-    let context = plan.plan_base().ctx.clone();
     tracing::trace!(
         "Generated query plan: {:?}, query_mode:{:?}",
         plan.explain_to_string()?,
@@ -288,7 +286,6 @@ fn gen_batch_plan_fragmenter(
         session.config().get_batch_parallelism(),
         plan,
     )?;
-    let warnings = context.take_warnings();
 
     Ok(BatchPlanFragmenterResult {
         plan_fragmenter,
@@ -296,7 +293,6 @@ fn gen_batch_plan_fragmenter(
         schema,
         stmt_type,
         _dependent_relations: dependent_relations,
-        warnings,
     })
 }
 
@@ -310,7 +306,6 @@ async fn execute(
         query_mode,
         schema,
         stmt_type,
-        warnings,
         ..
     } = plan_fragmenter_result;
 
@@ -446,7 +441,12 @@ async fn execute(
     };
 
     Ok(PgResponse::new_for_stream_extra(
-        stmt_type, rows_count, row_stream, pg_descs, warnings, callback,
+        stmt_type,
+        rows_count,
+        row_stream,
+        pg_descs,
+        vec![],
+        callback,
     ))
 }
 

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -87,7 +87,6 @@ impl OptimizerContext {
             with_options: handler_args.with_options,
             session_timezone,
             next_expr_display_id: RefCell::new(RESERVED_ID_NUM.into()),
-            warning_messages: RefCell::new(vec![]),
         }
     }
 
@@ -107,7 +106,6 @@ impl OptimizerContext {
             with_options: Default::default(),
             session_timezone: RefCell::new(SessionTimezone::new("UTC".into())),
             next_expr_display_id: RefCell::new(0),
-            warning_messages: RefCell::new(vec![]),
         }
         .into()
     }

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -56,7 +56,7 @@ pub struct OptimizerContext {
 impl Drop for OptimizerContext {
     fn drop(&mut self) {
         if let Some(warning) = self.session_timezone.borrow().warning() {
-            self.warn(warning);
+            self.warn_to_user(warning);
         };
     }
 }
@@ -169,7 +169,7 @@ impl OptimizerContext {
         optimizer_trace.push("\n".to_string());
     }
 
-    pub fn warn(&self, str: impl Into<String>) {
+    pub fn warn_to_user(&self, str: impl Into<String>) {
         self.session_ctx().notice_to_user(str);
     }
 

--- a/src/frontend/src/optimizer/optimizer_context.rs
+++ b/src/frontend/src/optimizer/optimizer_context.rs
@@ -18,7 +18,6 @@ use std::cell::{RefCell, RefMut};
 use std::rc::Rc;
 use std::sync::Arc;
 
-use itertools::Itertools;
 use risingwave_sqlparser::ast::{ExplainOptions, ExplainType};
 
 use crate::expr::{CorrelatedId, SessionTimezone};
@@ -51,8 +50,6 @@ pub struct OptimizerContext {
     session_timezone: RefCell<SessionTimezone>,
     /// Store expr display id.
     next_expr_display_id: RefCell<usize>,
-    /// warning messages
-    warning_messages: RefCell<Vec<String>>,
 }
 
 // Still not sure if we need to introduce "on_optimization_finish" or other common callback methods,

--- a/src/frontend/src/optimizer/plan_node/convert.rs
+++ b/src/frontend/src/optimizer/plan_node/convert.rs
@@ -75,7 +75,7 @@ pub fn stream_enforce_eowc_requirement(
             .into())
         } else {
             if n_watermark_cols > 1 {
-                ctx.warn("There are multiple watermark columns in the query, currently only the first one will be used.");
+                ctx.warn_to_user("There are multiple watermark columns in the query, currently only the first one will be used.");
             }
             let watermark_col_idx = watermark_cols.ones().next().unwrap();
             Ok(StreamSort::new(plan, watermark_col_idx).into())

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -418,6 +418,8 @@ pub struct SessionImpl {
     user_authenticator: UserAuthenticator,
     /// Stores the value of configurations.
     config_map: RwLock<ConfigMap>,
+    /// buffer the Notices to users,
+    notices: RwLock<Vec<String>>,
 
     /// Identified by process_id, secret_key. Corresponds to SessionManager.
     id: (i32, i32),
@@ -442,6 +444,7 @@ impl SessionImpl {
             config_map: Default::default(),
             id,
             current_query_cancel_flag: Mutex::new(None),
+            notices: Default::default(),
         }
     }
 
@@ -459,6 +462,7 @@ impl SessionImpl {
             // Mock session use non-sense id.
             id: (0, 0),
             current_query_cancel_flag: Mutex::new(None),
+            notices: Default::default(),
         }
     }
 
@@ -601,6 +605,10 @@ impl SessionImpl {
         tripwire
     }
 
+    fn clear_notices(&self) {
+        *self.notices.write() = vec![];
+    }
+
     pub fn cancel_current_query(&self) {
         let mut flag_guard = self.current_query_cancel_flag.lock().unwrap();
         if let Some(trigger) = flag_guard.take() {
@@ -612,10 +620,12 @@ impl SessionImpl {
             info!("Trying to cancel query in distributed mode.");
             self.env.query_manager().cancel_queries_in_session(self.id)
         }
+        self.clear_notices()
     }
 
     pub fn cancel_current_creating_job(&self) {
         self.env.creating_streaming_job_tracker.abort_jobs(self.id);
+        self.clear_notices()
     }
 
     /// This function only used for test now.
@@ -661,6 +671,12 @@ impl SessionImpl {
         }
         .inspect_err(|e| tracing::error!("failed to handle sql:\n{}:\n{}", sql, e))?;
         Ok(rsp)
+    }
+
+    pub fn notice_to_user(&self, str: impl Into<String>) {
+        let notice = str.into();
+        tracing::trace!("notice to user:{}", notice);
+        self.notices.write().push(notice);
     }
 }
 
@@ -921,6 +937,11 @@ impl Session<PgResponseStream, PrepareStatement, Portal> for SessionImpl {
             Portal::Portal(portal) => Ok(infer(Some(portal.bound_result.bound), portal.statement)?),
             Portal::PureStatement(statement) => Ok(infer(None, statement)?),
         }
+    }
+
+    fn take_notices(self: Arc<Self>) -> Vec<String> {
+        let inner = &mut (*self.notices.write());
+        std::mem::take(inner)
     }
 }
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -350,6 +350,7 @@ where
 
             // execute query
             let mut res = session
+                .clone()
                 .run_one_query(stmt, Format::Text)
                 .await
                 .map_err(|err| PsqlError::QueryError(err))?;
@@ -357,6 +358,11 @@ where
             for notice in res.get_notices() {
                 self.stream
                     .write_no_flush(&BeMessage::NoticeResponse(notice))?;
+            }
+
+            for notice in session.take_notices() {
+                self.stream
+                    .write_no_flush(&BeMessage::NoticeResponse(&notice))?;
             }
 
             if res.is_query() {

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -349,20 +349,16 @@ where
             let session = session.clone();
 
             // execute query
-            let mut res = session
-                .clone()
-                .run_one_query(stmt, Format::Text)
-                .await
-                .map_err(|err| PsqlError::QueryError(err))?;
+            let res = session.clone().run_one_query(stmt, Format::Text).await;
+            for notice in session.take_notices() {
+                self.stream
+                    .write_no_flush(&BeMessage::NoticeResponse(&notice))?;
+            }
+            let mut res = res.map_err(|err| PsqlError::QueryError(err))?;
 
             for notice in res.get_notices() {
                 self.stream
                     .write_no_flush(&BeMessage::NoticeResponse(notice))?;
-            }
-
-            for notice in session.take_notices() {
-                self.stream
-                    .write_no_flush(&BeMessage::NoticeResponse(&notice))?;
             }
 
             if res.is_query() {

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -74,6 +74,10 @@ where
         params_types: Vec<DataType>,
     ) -> Result<PS, BoxedError>;
 
+    // TODO: maybe this function should be async and return the notice more timely
+    /// try to take the current notices from the session
+    fn take_notices(self: Arc<Self>) -> Vec<String>;
+
     fn bind(
         self: Arc<Self>,
         prepare_statement: PS,
@@ -303,6 +307,10 @@ mod tests {
 
         fn id(&self) -> SessionId {
             (0, 0)
+        }
+
+        fn take_notices(self: Arc<Self>) -> Vec<String> {
+            vec![]
         }
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In the previous notice implementation https://github.com/risingwavelabs/risingwave/pull/9577, we can not notice user when the optimizer throws an error. 
- add the warning messages in the `SessionImpl` and add a interface on the `trait pgwire::Session`
- rename the `warn` to `warn_to_user`

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
