### PR TITLE
feat(source): experimental support for split reduction.

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -917,7 +917,7 @@ where
                 let actor_ids = actors_after_reschedule.keys().cloned().collect_vec();
                 let actor_splits = self
                     .source_manager
-                    .reallocate_splits(&prev_actor_ids,  &actor_ids)
+                    .reallocate_splits(&prev_actor_ids, &actor_ids)
                     .await?;
 
                 fragment_stream_source_actor_splits.insert(*fragment_id, actor_splits);

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -906,10 +906,10 @@ where
                 fragment_actors_after_reschedule.get(fragment_id).unwrap();
 
             if ctx.stream_source_fragment_ids.contains(fragment_id) {
-                let actor_ids = actors_after_reschedule.keys().cloned();
+                let actor_ids = actors_after_reschedule.keys().cloned().collect_vec();
                 let actor_splits = self
                     .source_manager
-                    .reallocate_splits(fragment_id, actor_ids)
+                    .reallocate_splits(fragment_id, &actor_ids)
                     .await?;
 
                 fragment_stream_source_actor_splits.insert(*fragment_id, actor_splits);

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -906,10 +906,18 @@ where
                 fragment_actors_after_reschedule.get(fragment_id).unwrap();
 
             if ctx.stream_source_fragment_ids.contains(fragment_id) {
+                let fragment = ctx.fragment_map.get(fragment_id).unwrap();
+
+                let prev_actor_ids = fragment
+                    .actors
+                    .iter()
+                    .map(|actor| actor.actor_id)
+                    .collect_vec();
+
                 let actor_ids = actors_after_reschedule.keys().cloned().collect_vec();
                 let actor_splits = self
                     .source_manager
-                    .reallocate_splits(fragment_id, &actor_ids)
+                    .reallocate_splits(&prev_actor_ids,  &actor_ids)
                     .await?;
 
                 fragment_stream_source_actor_splits.insert(*fragment_id, actor_splits);

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -914,10 +914,11 @@ where
                     .map(|actor| actor.actor_id)
                     .collect_vec();
 
-                let actor_ids = actors_after_reschedule.keys().cloned().collect_vec();
+                let curr_actor_ids = actors_after_reschedule.keys().cloned().collect_vec();
+
                 let actor_splits = self
                     .source_manager
-                    .reallocate_splits(&prev_actor_ids, &actor_ids)
+                    .reallocate_splits(&prev_actor_ids, &curr_actor_ids)
                     .await?;
 
                 fragment_stream_source_actor_splits.insert(*fragment_id, actor_splits);

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -575,56 +575,41 @@ where
         core.apply_source_change(source_fragments, split_assignment, dropped_actors);
     }
 
+    // After introducing the remove function for split, there may be a very occasional split removal
+    // during scaling, in which case we need to use the old splits for reallocation instead of the
+    // latest splits (which may be missing), so that we can resolve the split removal in the next
+    // command.
     pub async fn reallocate_splits(
         &self,
-        fragment_id: &FragmentId,
+        prev_actor_ids: &[ActorId],
         actor_ids: &[ActorId],
     ) -> MetaResult<HashMap<ActorId, Vec<SplitImpl>>> {
         let core = self.core.lock().await;
-        todo!("old actor ids ");
 
-        // for actor_id in actor_ids {
-        //     let split = core.actor_splits.get(actor_id).unwrap();
-        // }
-
-        let prev_splits = actor_ids
+        let prev_splits = prev_actor_ids
             .iter()
-            .flat_map(|actor_id| core.actor_splits.get(actor_id))
-            .flatten()
+            .flat_map(|actor_id| core.actor_splits.get(actor_id).unwrap())
             .cloned()
-            .map(|split| (split.id(), split))
-            .collect();
-
-        // let source_id = core.fragment_sources.get(fragment_id).unwrap();
-        // let handle = core.managed_sources.get(source_id).unwrap();
-        //
-        // if handle.splits.lock().await.splits.is_none() {
-        //     // force refresh source
-        //     let (tx, rx) = oneshot::channel();
-        //     handle
-        //         .sync_call_tx
-        //         .send(tx)
-        //         .map_err(|e| anyhow!(e.to_string()))?;
-        //     rx.await.map_err(|e| anyhow!(e.to_string()))??;
-        // }
-        //
-        // let splits = handle.discovered_splits().await.unwrap();
-        // if splits.is_empty() {
-        //     tracing::warn!("no splits detected for source {}", source_id);
-        //     return Ok(Default::default());
-        // }
+            .collect_vec();
 
         let empty_actor_splits = actor_ids
             .iter()
             .map(|actor_id| (*actor_id, vec![]))
             .collect();
 
-        Ok(diff_splits(
+        let prev_splits = prev_splits
+            .into_iter()
+            .map(|split| (split.id(), split))
+            .collect();
+
+        let diff = diff_splits(
             empty_actor_splits,
             &prev_splits,
             SplitDiffOptions::default(),
         )
-        .unwrap_or_default())
+        .unwrap_or_default();
+
+        Ok(diff)
     }
 
     pub async fn pre_allocate_splits(&self, table_id: &TableId) -> MetaResult<SplitAssignment> {

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -582,7 +582,7 @@ where
     pub async fn reallocate_splits(
         &self,
         prev_actor_ids: &[ActorId],
-        actor_ids: &[ActorId],
+        curr_actor_ids: &[ActorId],
     ) -> MetaResult<HashMap<ActorId, Vec<SplitImpl>>> {
         let core = self.core.lock().await;
 
@@ -592,7 +592,7 @@ where
             .cloned()
             .collect_vec();
 
-        let empty_actor_splits = actor_ids
+        let empty_actor_splits = curr_actor_ids
             .iter()
             .map(|actor_id| (*actor_id, vec![]))
             .collect();

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -401,19 +401,15 @@ impl<S: StateStore> SourceExecutor<S> {
                             match mutation {
                                 Mutation::Pause => stream.pause_stream(),
                                 Mutation::Resume => stream.resume_stream(),
-                                Mutation::SourceChangeSplit(split_assignment) => {
+                                Mutation::SourceChangeSplit(actor_splits) => {
                                     // In the context of split changes, we do not allow split
                                     // migration because it can lead to inconsistent states.
                                     // Therefore, all split migration must be done via update
                                     // mutation and pause/resume
-                                    assert!(!self.check_split_is_migration(split_assignment));
+                                    assert!(!self.check_split_is_migration(actor_splits));
 
                                     target_state = self
-                                        .apply_split_change(
-                                            &source_desc,
-                                            &mut stream,
-                                            split_assignment,
-                                        )
+                                        .apply_split_change(&source_desc, &mut stream, actor_splits)
                                         .await?;
                                     should_trim_state = true;
                                 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -109,57 +109,81 @@ impl<S: StateStore> SourceExecutor<S> {
         &mut self,
         source_desc: &SourceDesc,
         stream: &mut StreamReaderWithPause<BIASED>,
-        mapping: &HashMap<ActorId, Vec<SplitImpl>>,
-    ) -> StreamExecutorResult<()> {
-        if let Some(target_splits) = mapping.get(&self.ctx.id).cloned() {
-            if let Some(target_state) = self.get_diff(Some(target_splits)).await? {
+        split_assignment: &HashMap<ActorId, Vec<SplitImpl>>,
+    ) -> StreamExecutorResult<Option<Vec<SplitImpl>>> {
+        if let Some(target_splits) = split_assignment.get(&self.ctx.id).cloned() {
+            if let Some(target_state) = self.update_state_if_changed(Some(target_splits)).await? {
                 tracing::info!(
                     actor_id = self.ctx.id,
                     state = ?target_state,
                     "apply split change"
                 );
 
-                self.replace_stream_reader_with_target_state(source_desc, stream, target_state)
-                    .await?;
+                self.replace_stream_reader_with_target_state(
+                    source_desc,
+                    stream,
+                    target_state.clone(),
+                )
+                .await?;
+
+                return Ok(Some(target_state));
             }
         }
 
-        Ok(())
+        Ok(None)
     }
 
-    // Note: `get_diff` will modify `state_cache`
-    // `rhs` can not be None because we do not support split number reduction
-    async fn get_diff(&mut self, rhs: ConnectorState) -> StreamExecutorResult<ConnectorState> {
+    // Note: `update_state_if_changed` will modify `state_cache`
+    async fn update_state_if_changed(
+        &mut self,
+        state: ConnectorState,
+    ) -> StreamExecutorResult<ConnectorState> {
         let core = self.stream_source_core.as_mut().unwrap();
 
-        let split_change = rhs.unwrap();
-        let mut target_state: Vec<SplitImpl> = Vec::with_capacity(split_change.len());
-        let mut no_change_flag = true;
-        for sc in &split_change {
-            if let Some(s) = core.state_cache.get(&sc.id()) {
+        let target_splits: HashMap<_, _> = state
+            .unwrap()
+            .into_iter()
+            .map(|split| (split.id(), split))
+            .collect();
+
+        let mut target_state: Vec<SplitImpl> = Vec::with_capacity(target_splits.len());
+
+        let mut split_changed = false;
+
+        for (split_id, split) in &target_splits {
+            if let Some(s) = core.state_cache.get(split_id) {
+                // existing split, no change, clone from cache
                 target_state.push(s.clone())
             } else {
-                no_change_flag = false;
+                split_changed = true;
                 // write new assigned split to state cache. snapshot is base on cache.
 
-                let state = if let Some(recover_state) = core
+                let initial_state = if let Some(recover_state) = core
                     .split_state_store
-                    .try_recover_from_state_store(sc)
+                    .try_recover_from_state_store(split)
                     .await?
                 {
                     recover_state
                 } else {
-                    sc.clone()
+                    split.clone()
                 };
 
                 core.state_cache
-                    .entry(sc.id())
-                    .or_insert_with(|| state.clone());
-                target_state.push(state);
+                    .entry(split.id())
+                    .or_insert_with(|| initial_state.clone());
+
+                target_state.push(initial_state);
             }
         }
 
-        Ok((!no_change_flag).then_some(target_state))
+        // todo(peng): check if we support split number reduction in cn
+        for existing_split_id in core.state_cache.keys() {
+            if !target_splits.contains_key(existing_split_id) {
+                split_changed = true;
+            }
+        }
+
+        Ok(split_changed.then_some(target_state))
     }
 
     async fn replace_stream_reader_with_target_state<const BIASED: bool>(
@@ -194,14 +218,28 @@ impl<S: StateStore> SourceExecutor<S> {
     async fn take_snapshot_and_clear_cache(
         &mut self,
         epoch: EpochPair,
+        target_state: Option<Vec<SplitImpl>>,
     ) -> StreamExecutorResult<()> {
         let core = self.stream_source_core.as_mut().unwrap();
 
-        let cache = core
+        let mut cache = core
             .state_cache
             .values()
             .map(|split_impl| split_impl.to_owned())
             .collect_vec();
+
+        if let Some(target_splits) = target_state {
+            let target_split_ids: HashSet<_> =
+                target_splits.iter().map(|split| split.id()).collect();
+
+            let dropped_splits = cache
+                .drain_filter(|split| target_split_ids.contains(&split.id()))
+                .collect_vec();
+
+            if !dropped_splits.is_empty() {
+                core.split_state_store.trim_state(dropped_splits);
+            }
+        }
 
         if !cache.is_empty() {
             tracing::debug!(actor_id = self.ctx.id, state = ?cache, "take snapshot");
@@ -314,33 +352,34 @@ impl<S: StateStore> SourceExecutor<S> {
                 Either::Left(msg) => match &msg {
                     Message::Barrier(barrier) => {
                         last_barrier_time = Instant::now();
+
                         if self_paused {
                             stream.resume_stream();
                             self_paused = false;
                         }
+
                         let epoch = barrier.epoch;
+
+                        let mut target_state = None;
 
                         if let Some(ref mutation) = barrier.mutation.as_deref() {
                             match mutation {
-                                Mutation::SourceChangeSplit(actor_splits) => {
-                                    self.apply_split_change(&source_desc, &mut stream, actor_splits)
-                                        .await?
-                                }
                                 Mutation::Pause => stream.pause_stream(),
                                 Mutation::Resume => stream.resume_stream(),
-                                Mutation::Update { actor_splits, .. } => {
-                                    self.apply_split_change(
-                                        &source_desc,
-                                        &mut stream,
-                                        actor_splits,
-                                    )
-                                    .await?;
+                                Mutation::SourceChangeSplit(actor_splits)
+                                | Mutation::Update { actor_splits, .. } => {
+                                    let target_splits = self
+                                        .apply_split_change(&source_desc, &mut stream, actor_splits)
+                                        .await?;
+
+                                    target_state = target_splits;
                                 }
                                 _ => {}
                             }
                         }
 
-                        self.take_snapshot_and_clear_cache(epoch).await?;
+                        self.take_snapshot_and_clear_cache(epoch, target_state)
+                            .await?;
 
                         self.metrics
                             .source_row_per_barrier

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -233,7 +233,7 @@ impl<S: StateStore> SourceExecutor<S> {
                 target_splits.iter().map(|split| split.id()).collect();
 
             let dropped_splits = cache
-                .drain_filter(|split| target_split_ids.contains(&split.id()))
+                .drain_filter(|split| !target_split_ids.contains(&split.id()))
                 .collect_vec();
 
             if !dropped_splits.is_empty() {

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -159,6 +159,11 @@ impl<S: StateStore> SourceStateTableHandler<S> {
         Ok(())
     }
 
+    fn delete(&mut self, key: SplitId) {
+        self.state_store
+            .delete(row::once(Some(Self::string_to_scalar(key.deref()))));
+    }
+
     /// This function provides the ability to persist the source state
     /// and needs to be invoked by the ``SourceReader`` to call it,
     /// and will return the error when the dependent ``StateStore`` handles the error.
@@ -177,6 +182,15 @@ impl<S: StateStore> SourceStateTableHandler<S> {
             }
         }
         Ok(())
+    }
+
+    pub fn trim_state<SS>(&mut self, to_trim: Vec<SS>)
+    where
+        SS: SplitMetaData,
+    {
+        for split in to_trim {
+            self.delete(split.id());
+        }
     }
 
     ///

--- a/src/stream/src/executor/source/state_table_handler.rs
+++ b/src/stream/src/executor/source/state_table_handler.rs
@@ -184,7 +184,7 @@ impl<S: StateStore> SourceStateTableHandler<S> {
         Ok(())
     }
 
-    pub fn trim_state<SS>(&mut self, to_trim: Vec<SS>)
+    pub fn trim_state<SS>(&mut self, to_trim: &[SS])
     where
         SS: SplitMetaData,
     {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR experimentally supports split reduction.

When the source in the source manager enables the split scale-in function, the source manager will treat the split reduction as a change instead of ignoring it during the tick, leading to an in-place removal and pushing the assignment downstream. Upon receiving this, the source executor will consider the split reduction as a state change and delete the removed split's state during the commit phase.

Please note that the changes in this PR will need complex testing. cc @tabVersion 

#### generated by gpt

# Experimental Support for Split Reduction

This Pull Request introduces several key changes across the `scale.rs`, `source_manager.rs`, `source_executor.rs`, and `state_table_handler.rs` files.

## Main Changes

1. Refactoring of the `reallocate_splits` function and its usage&#8203;`oaicite:{"index":10,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
2. Addition of split removal handling and reallocation&#8203;`oaicite:{"index":11,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
3. Improvement of source state persistence and trim capability&#8203;`oaicite:{"index":12,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
4. Fix for the `drain_filter` method for cache&#8203;`oaicite:{"index":13,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
5. Improved split migration handling and memory efficiency&#8203;`oaicite:{"index":14,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
6. Asynchronous delete & `trim_state`, log trimming&#8203;`oaicite:{"index":15,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
7. Refactoring of `SourceExecutor`'s split tracking and migration check&#8203;`oaicite:{"index":16,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.
8. Modification of `SourceExecutor` match expression to add a new `Mutation::Source`&#8203;`oaicite:{"index":17,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"ac725ec Refactor reallocate_splits function & usage. shanicky May 9, 2023   4db8ea0 Add split removal handling & reallocation shanicky May 9, 2023   bd69c6f Improve source state persistence and trim ability shanicky May 9, 2023   a72bc0b Fix `drain_filter` method for cache. shanicky May 9, 2023   1d6b0a0 Improved split migration handling and memory efficiency shanicky May 10, 2023   674c9ff Async delete & trim_state, log trimming shanicky May 10, 2023   0444abd Refactor SourceExecutor's split tracking and migration check shanicky May 10, 2023   eefd899 Modify `SourceExecutor` match expression to add new `Mutation::Source… shanicky May 10, 2023","pub_date":null}}`&#8203;.

## File Changes

- `scale.rs`: 12 changes (10 additions, 2 deletions)&#8203;`oaicite:{"index":18,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"12 changes: 10 additions & 2 deletions  12  src/meta/src/stream/scale.rs","pub_date":null}}`&#8203;.
- `source_manager.rs`: 47 changes (24 additions, 23 deletions)&#8203;`oaicite:{"index":19,"metadata":{"title":"","url":"https://github.com/risingwavelabs/risingwave/pull/9714/files","text":"47 changes: 24 additions & 23 deletions  47  src/meta/src/stream/source_manager.rs","pub_date":null}}`&#8203;.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
