### PR TITLE
fix(backup): restore cluster id

### DIFF
--- a/src/meta/src/backup_restore/meta_snapshot_builder.rs
+++ b/src/meta/src/backup_restore/meta_snapshot_builder.rs
@@ -229,7 +229,7 @@ mod tests {
         assert_eq!("cluster id not found in meta store", err.to_error_str());
 
         ClusterId::new()
-            .put_at_meta_store(&meta_store)
+            .put_at_meta_store(meta_store.deref())
             .await
             .unwrap();
 

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -177,7 +177,7 @@ where
         let notification_manager = Arc::new(NotificationManager::new(meta_store.clone()).await);
         let idle_manager = Arc::new(IdleManager::new(opts.max_idle_ms));
         let (cluster_id, cluster_first_launch) =
-            if let Some(id) = ClusterId::from_meta_store(&meta_store).await? {
+            if let Some(id) = ClusterId::from_meta_store(meta_store.deref()).await? {
                 (id, false)
             } else {
                 (ClusterId::new(), true)

--- a/src/meta/src/model/cluster.rs
+++ b/src/meta/src/model/cluster.rs
@@ -14,7 +14,6 @@
 
 use std::cmp;
 use std::ops::{Add, Deref};
-use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
 use risingwave_hummock_sdk::HummockSstableObjectId;
@@ -137,7 +136,7 @@ impl ClusterId {
     }
 
     pub(crate) async fn from_meta_store<S: MetaStore>(
-        meta_store: &Arc<S>,
+        meta_store: &S,
     ) -> MetadataModelResult<Option<Self>> {
         Self::from_snapshot::<S>(&meta_store.snapshot().await).await
     }
@@ -154,9 +153,9 @@ impl ClusterId {
         }
     }
 
-    pub(crate) async fn put_at_meta_store(
+    pub(crate) async fn put_at_meta_store<S: MetaStore>(
         &self,
-        meta_store: &Arc<impl MetaStore>,
+        meta_store: &S,
     ) -> MetadataModelResult<()> {
         Ok(meta_store
             .put_cf(

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::net::SocketAddr;
+use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -633,7 +634,9 @@ pub async fn start_service_as_election_leader<S: MetaStore>(
     // Persist params before starting services so that invalid params that cause meta node
     // to crash will not be persisted.
     system_params_manager.flush_params().await?;
-    env.cluster_id().put_at_meta_store(&meta_store).await?;
+    env.cluster_id()
+        .put_at_meta_store(meta_store.deref())
+        .await?;
 
     tracing::info!("Assigned cluster id {:?}", *env.cluster_id());
     tracing::info!("Starting meta services");

--- a/src/meta/src/rpc/service/telemetry_service.rs
+++ b/src/meta/src/rpc/service/telemetry_service.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ops::Deref;
 use std::sync::Arc;
 
 use risingwave_pb::meta::telemetry_info_service_server::TelemetryInfoService;
@@ -31,7 +32,7 @@ impl<S: MetaStore> TelemetryInfoServiceImpl<S> {
     }
 
     async fn get_tracking_id(&self) -> Option<ClusterId> {
-        ClusterId::from_meta_store(&self.meta_store)
+        ClusterId::from_meta_store(self.meta_store.deref())
             .await
             .ok()
             .flatten()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Cluster id should be restored when restoring meta node from backup. Otherwise it will fail with "data directory is already used by another cluster with id", because the restored meta node is treated as a newly created one unexpectedly.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
