### PR TITLE
feat(watermark): handle watermark on desc column (close #9730)

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -33,7 +33,7 @@ use risingwave_common::util::row_serde::OrderedRowSerde;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_common::util::value_encoding::{BasicSerde, ValueRowSerde};
 use risingwave_hummock_sdk::key::{
-    end_bound_of_prefix, prefixed_range, range_of_prefix, start_bound_of_excluded_prefix,
+    end_bound_of_prefix, next_key, prefixed_range, range_of_prefix, start_bound_of_excluded_prefix,
 };
 use risingwave_pb::catalog::Table;
 use risingwave_storage::error::StorageError;
@@ -825,26 +825,41 @@ where
                 prefix_serializer.as_ref().unwrap(),
             )
         });
-        if let Some(watermark_suffix) = watermark_suffix {
-            // We either serialize null into `0u8`, data into `(1u8 || scalar)`, or serialize null
-            // into `1u8`, data into `(0u8 || scalar)`. We do not want to delete null
-            // here, so `range_begin_suffix` cannot be `vec![]` when null is represented as `0u8`.
-            let range_begin_suffix = watermark_suffix
-                .first()
-                .map(|bit| vec![*bit])
-                .unwrap_or_default();
+        if let Some(watermark_suffix) = watermark_suffix && let Some(first_byte) = watermark_suffix.first() {
             trace!(table_id = %self.table_id, watermark = ?watermark_suffix, vnodes = ?{
                 self.vnodes.iter_vnodes().collect_vec()
             }, "delete range");
-            for vnode in self.vnodes.iter_vnodes() {
-                let mut range_begin = vnode.to_be_bytes().to_vec();
-                let mut range_end = range_begin.clone();
-                range_begin.extend(&range_begin_suffix);
-                range_end.extend(&watermark_suffix);
-                delete_ranges.push((
-                    Bound::Included(Bytes::from(range_begin)),
-                    Bound::Excluded(Bytes::from(range_end)),
-                ));
+            if prefix_serializer.as_ref().unwrap().get_order_types().first().unwrap().is_ascending() {
+                // We either serialize null into `0u8`, data into `(1u8 || scalar)`, or serialize null
+                // into `1u8`, data into `(0u8 || scalar)`. We do not want to delete null
+                // here, so `range_begin_suffix` cannot be `vec![]` when null is represented as `0u8`.
+                let range_begin_suffix = vec![*first_byte];
+                for vnode in self.vnodes.iter_vnodes() {
+                    let mut range_begin = vnode.to_be_bytes().to_vec();
+                    let mut range_end = range_begin.clone();
+                    range_begin.extend(&range_begin_suffix);
+                    range_end.extend(&watermark_suffix);
+                    delete_ranges.push((
+                        Bound::Included(Bytes::from(range_begin)),
+                        Bound::Excluded(Bytes::from(range_end)),
+                    ));
+                }
+            } else {
+                assert_ne!(*first_byte, u8::MAX);
+                let following_bytes = next_key(&watermark_suffix[1..]);
+                if !following_bytes.is_empty() {
+                    for vnode in self.vnodes.iter_vnodes() {
+                        let mut range_begin = vnode.to_be_bytes().to_vec();
+                        let mut range_end = range_begin.clone();
+                        range_begin.push(*first_byte);
+                        range_begin.extend(&following_bytes);
+                        range_end.push(first_byte + 1);
+                        delete_ranges.push((
+                            Bound::Included(Bytes::from(range_begin)),
+                            Bound::Excluded(Bytes::from(range_end)),
+                        ));
+                    }
+                }
             }
         }
         self.local_store.flush(delete_ranges).await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->
In `state_table.rs`, we didn't handle watermark on descending columns correctly in state cleaning.

## Checklist For Contributors

- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
