### PR TITLE
fix(optimizer): use correct schema for always-false condition on table scan

### DIFF
--- a/src/frontend/planner_test/tests/testdata/range_scan.yaml
+++ b/src/frontend/planner_test/tests/testdata/range_scan.yaml
@@ -475,3 +475,12 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchSimpleAgg { aggs: [count(sbtest1.k)] }
         └─BatchScan { table: sbtest1, columns: [sbtest1.k], scan_ranges: [sbtest1.id = Int32(0) , sbtest1.id = Int32(1) , sbtest1.id = Int32(2) , sbtest1.id = Int32(3) , sbtest1.id = Int32(4) , sbtest1.id = Int32(5)], distribution: SomeShard }
+- sql: |
+    create table t (k int primary key, v int);
+    select v from t where k = 2147483648; -- out of range of int32
+  logical_plan: |
+    LogicalProject { exprs: [t.v] }
+    └─LogicalFilter { predicate: (t.k = 2147483648:Int64) }
+      └─LogicalScan { table: t, columns: [t.k, t.v] }
+  batch_plan: |
+    BatchValues { rows: [] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After `predicate_pull_up`, the new `Scan` may have a different schema from the original one. Previously we ignore this if we find an always-false condition, which lead to a mismatched schema.

Actually, there's no need to check this **after** `pull_up` since `always_false` property does not change if only column mapping changes. So this PR makes it a separate code path.

Close #9677.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
