### PR TITLE
fix(sqlsmith): avoid generating `count(distinct *)`

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -412,7 +412,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             .map(|t| self.gen_expr(t, context))
             .collect();
 
-        let distinct = self.flip_coin() && self.is_distinct_allowed;
+        let distinct = self.flip_coin() && self.is_distinct_allowed && !exprs.is_empty();
         let filter = if self.flip_coin() {
             let context = SqlGeneratorContext::new_with_can_agg(false);
             // ENABLE: https://github.com/risingwavelabs/risingwave/issues/4762


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See the following link for a failing occurrence:
https://buildkite.com/risingwavelabs/pull-request/builds/23391#01880b50-0166-4067-8c63-72c0f69ab0d2

The failing query at bottom contains `HAVING (count(DISTINCT ) >= (SMALLINT '478'))`, despite the surfaced error at the beginning was:
```
---- run_sqlsmith_on_frontend_434 ----
Error Reason:
internal error: Scalar subquery might produce more than one row.
```
I have tried the create table + create materialized view statements before the last batch query and they all succeeded without the subquery error.

Btw, sqlsmith was only able to generate unary aggregates until #9432, since when it gained the ability to generate all signatures including `count(*)`.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
