### PR TITLE
refactor(frontend): refine query log

### DIFF
--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -19,6 +19,7 @@ use std::pin::Pin;
 use std::str;
 use std::str::Utf8Error;
 use std::sync::Arc;
+use std::time::Instant;
 
 use bytes::{Bytes, BytesMut};
 use futures::stream::StreamExt;
@@ -333,12 +334,33 @@ where
 
     async fn process_query_msg(&mut self, query_string: io::Result<&str>) -> PsqlResult<()> {
         let sql = query_string.map_err(|err| PsqlError::QueryError(Box::new(err)))?;
-        tracing::trace!(
-            target: "pgwire_query_log",
-            "(simple query)receive query: {}", sql);
-
+        let start = Instant::now();
         let session = self.session.clone().unwrap();
+        let session_id = session.id().0;
+        let res = self.inner_process_query_msg(sql, session).await;
+        // Record query run successfully
+        let mills = start.elapsed().as_millis();
+        match res {
+            Ok(x) => {
+                tracing::trace!(
+                    target: "pgwire_query_log",
+                    "(simple query) session: {}, status: ok, time: {}ms,  sql: {}", session_id, mills, sql);
+                Ok(x)
+            }
+            Err(err) => {
+                tracing::trace!(
+                    target: "pgwire_query_log",
+                    "(simple query) session: {}, status: err, time: {}ms,  sql: {}", session_id, mills, sql);
+                Err(err)
+            }
+        }
+    }
 
+    async fn inner_process_query_msg(
+        &mut self,
+        sql: &str,
+        session: Arc<SM::Session>,
+    ) -> PsqlResult<()> {
         // Parse sql.
         let stmts = Parser::parse_sql(sql)
             .inspect_err(|e| tracing::error!("failed to parse sql:\n{}:\n{}", sql, e))
@@ -347,7 +369,6 @@ where
         // Execute multiple statements in simple query. KISS later.
         for stmt in stmts {
             let session = session.clone();
-
             // execute query
             let res = session.clone().run_one_query(stmt, Format::Text).await;
             for notice in session.take_notices() {
@@ -410,9 +431,12 @@ where
 
     fn process_parse_msg(&mut self, msg: FeParseMessage) -> PsqlResult<()> {
         let sql = cstr_to_str(&msg.sql_bytes).unwrap();
+        let session = self.session.clone().unwrap();
+        let session_id = session.id().0;
         let statement_name = cstr_to_str(&msg.statement_name).unwrap().to_string();
         tracing::trace!(
-            "(extended query)parse query: {}, statement name: {}",
+            "(extended query) session: {}, parse query: {}, statement name: {}",
+            session_id,
             sql,
             statement_name
         );
@@ -449,7 +473,6 @@ where
             .try_collect()
             .map_err(|err| PsqlError::ParseError(err.into()))?;
 
-        let session = self.session.clone().unwrap();
         let prepare_statement = session
             .parse(stmt, param_types)
             .map_err(PsqlError::ParseError)?;
@@ -473,11 +496,12 @@ where
     fn process_bind_msg(&mut self, msg: FeBindMessage) -> PsqlResult<()> {
         let statement_name = cstr_to_str(&msg.statement_name).unwrap().to_string();
         let portal_name = cstr_to_str(&msg.portal_name).unwrap().to_string();
-
+        let session = self.session.clone().unwrap();
+        let session_id = session.id().0;
         trace!(
             target: "pgwire_query_log",
-            "(extended query)bind: statement name: {}, portal name: {}",
-            &statement_name,&portal_name
+            "(extended query) session: {}, bind: statement name: {}, portal name: {}",
+            session_id, &statement_name, &portal_name
         );
 
         if self.portal_store.contains_key(&portal_name) {
@@ -497,10 +521,7 @@ where
             .map(|&format_code| Format::from_i16(format_code))
             .try_collect()?;
 
-        let portal = self
-            .session
-            .clone()
-            .unwrap()
+        let portal = session
             .bind(prepare_statement, msg.params, param_formats, result_formats)
             .map_err(PsqlError::Internal)?;
 
@@ -527,7 +548,9 @@ where
     async fn process_execute_msg(&mut self, msg: FeExecuteMessage) -> PsqlResult<()> {
         let portal_name = cstr_to_str(&msg.portal_name).unwrap().to_string();
         let row_max = msg.max_rows as usize;
-        tracing::trace!(target: "pgwire_query_log", "(extended query)execute portal name: {}",portal_name);
+        let session = self.session.clone().unwrap();
+        let session_id = session.id().0;
+        tracing::trace!(target: "pgwire_query_log", "(extended query) session: {}, execute portal name: {}", session_id, portal_name);
 
         if let Some(mut result_cache) = self.result_cache.remove(&portal_name) {
             assert!(self.portal_store.contains_key(&portal_name));
@@ -540,10 +563,7 @@ where
         } else {
             let portal = self.get_portal(&portal_name)?;
 
-            let pg_response = self
-                .session
-                .clone()
-                .unwrap()
+            let pg_response = session
                 .execute(portal)
                 .await
                 .map_err(PsqlError::ExecuteError)?;

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -206,6 +206,9 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
             .with_level(false)
             .with_file(false)
             .with_target(false)
+            .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+            .with_thread_names(true)
+            .with_thread_ids(true)
             .with_writer(std::sync::Mutex::new(file))
             .with_filter(filter::Targets::new().with_target("pgwire_query_log", Level::TRACE));
         layers.push(layer.boxed());
@@ -238,6 +241,9 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
         .with_level(false)
         .with_file(false)
         .with_target(false)
+        .with_timer(tracing_subscriber::fmt::time::UtcTime::rfc_3339())
+        .with_thread_names(true)
+        .with_thread_ids(true)
         .with_writer(std::sync::Mutex::new(file))
         .with_filter(
             filter::Targets::new().with_target("risingwave_frontend_slow_query_log", Level::TRACE),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Refine the query log format.

### Example:

`query.log:`
```
2023-05-12T06:40:19.157835Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 52ms,  sql: create table t1 (v1 int, v2 int, v3 int);
2023-05-12T06:40:19.190056Z risingwave-main ThreadId(03) (simple query) session: 0, status: ok, time: 31ms,  sql: create table t2 (v1 int, v2 int, v3 int);
2023-05-12T06:40:19.221089Z risingwave-main ThreadId(03) (simple query) session: 0, status: ok, time: 30ms,  sql: create table t3 (v1 int, v2 int, v3 int);
2023-05-12T06:40:19.256399Z risingwave-main ThreadId(07) (simple query) session: 0, status: ok, time: 35ms,  sql: create table t4 (v1 real, v2 int, v3 real);
2023-05-12T06:40:19.287931Z risingwave-main ThreadId(06) (simple query) session: 0, status: ok, time: 31ms,  sql: create table t5 (d decimal);
2023-05-12T06:40:19.298414Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 8ms,  sql: insert into t1 values (1,4,2), (2,3,3);
2023-05-12T06:40:19.300791Z risingwave-main ThreadId(12) (simple query) session: 0, status: ok, time: 2ms,  sql: insert into t3 values (1,3,5), (2,4,6);
2023-05-12T06:40:19.306667Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 5ms,  sql: insert into t4 values (1,1,4), (5,1,4), (1,9,1), (9,8,1), (0,2,3);
2023-05-12T06:40:19.31095Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 3ms,  sql: insert into t5 values ('NaN'::decimal);
2023-05-12T06:40:19.31304Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 1ms,  sql: insert into t5 values ('+inf');
2023-05-12T06:40:19.314839Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 1ms,  sql: insert into t5 values ('-inf');
2023-05-12T06:40:21.37404Z risingwave-main ThreadId(07) (simple query) session: 0, status: ok, time: 2058ms,  sql: create materialized view mv1 as select * from t1;
2023-05-12T06:40:23.448871Z risingwave-main ThreadId(11) (simple query) session: 0, status: ok, time: 2074ms,  sql: create materialized view mv2 as select round(avg(v1), 1) as avg_v1, sum(v2) as sum_v2, count(v3) as count_v3 from t1;
2023-05-12T06:40:25.556656Z risingwave-main ThreadId(11) (simple query) session: 0, status: ok, time: 2107ms,  sql: create materialized view mv3 as select v3, sum(v1) as sum_v1, min(v1) as min_v1, max(v1) as max_v1 from t4 group by v3;
2023-05-12T06:40:27.646866Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 2089ms,  sql: create materialized view mv4 as select count(*) as count, d from t5 group by d;
2023-05-12T06:40:27.661576Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 14ms,  sql: select v1, v2, v3 from mv1;
2023-05-12T06:40:27.667496Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 3ms,  sql: select avg_v1, sum_v2, count_v3 from mv2;
2023-05-12T06:40:27.67057Z risingwave-main ThreadId(11) (simple query) session: 0, status: ok, time: 2ms,  sql: insert into t1 values (3,4,4), (4,3,5);
2023-05-12T06:40:27.69062Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 19ms,  sql: flush;
2023-05-12T06:40:27.696762Z risingwave-main ThreadId(07) (simple query) session: 0, status: ok, time: 5ms,  sql: select v1, v2, v3 from mv1;
2023-05-12T06:40:27.699847Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 2ms,  sql: select avg_v1, sum_v2, count_v3 from mv2;
2023-05-12T06:40:27.710599Z risingwave-main ThreadId(03) (simple query) session: 0, status: ok, time: 10ms,  sql: select sum_v1, min_v1, max_v1, v3 from mv3 order by sum_v1;
2023-05-12T06:40:27.716668Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 5ms,  sql: select * from mv4
2023-05-12T06:40:27.74002Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 23ms,  sql: drop materialized view mv1
2023-05-12T06:40:27.762834Z risingwave-main ThreadId(08) (simple query) session: 0, status: ok, time: 22ms,  sql: drop materialized view mv2
2023-05-12T06:40:27.788102Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 24ms,  sql: drop materialized view mv3
2023-05-12T06:40:27.811609Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 21ms,  sql: drop materialized view mv4
2023-05-12T06:40:27.83044Z risingwave-main ThreadId(05) (simple query) session: 0, status: ok, time: 18ms,  sql: drop table t1
2023-05-12T06:40:27.845621Z risingwave-main ThreadId(04) (simple query) session: 0, status: ok, time: 14ms,  sql: drop table t2
2023-05-12T06:40:27.859503Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 13ms,  sql: drop table t3
2023-05-12T06:40:27.873778Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 13ms,  sql: drop table t4
2023-05-12T06:40:27.883918Z risingwave-main ThreadId(11) (simple query) session: 0, status: ok, time: 9ms,  sql: drop table t5
2023-05-12T06:40:27.915256Z risingwave-main ThreadId(12) (simple query) session: 0, status: ok, time: 30ms,  sql: create table t (v1 int, v2 int);
2023-05-12T06:40:28.467516Z risingwave-main ThreadId(09) (simple query) session: 0, status: err, time: 551ms,  sql: create materialized view mv(a) as select * from t;
2023-05-12T06:40:28.986121Z risingwave-main ThreadId(06) (simple query) session: 0, status: err, time: 516ms,  sql: create materialized view mv(a,b,c) as select * from t;
2023-05-12T06:40:29.016052Z risingwave-main ThreadId(12) (simple query) session: 0, status: ok, time: 29ms,  sql: create materialized view mv(a,b) as select * from t;
2023-05-12T06:40:29.025867Z risingwave-main ThreadId(11) (simple query) session: 0, status: ok, time: 9ms,  sql: drop materialized view mv 
2023-05-12T06:40:29.034516Z risingwave-main ThreadId(09) (simple query) session: 0, status: ok, time: 8ms,  sql: drop table t 

```


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
