### PR TITLE
feat(frontend): refine prepare statement query log

### DIFF
--- a/src/frontend/src/binder/bind_param.rs
+++ b/src/frontend/src/binder/bind_param.rs
@@ -15,7 +15,7 @@
 use bytes::Bytes;
 use pgwire::types::{Format, FormatIterator};
 use risingwave_common::error::{ErrorCode, Result, RwError};
-use risingwave_common::types::ScalarImpl;
+use risingwave_common::types::{Datum, ScalarImpl};
 
 use super::statement::RewriteExprsRecursive;
 use super::BoundStatement;
@@ -24,8 +24,20 @@ use crate::expr::{Expr, ExprImpl, ExprRewriter, Literal};
 /// Rewrites parameter expressions to literals.
 pub(crate) struct ParamRewriter {
     pub(crate) params: Vec<Bytes>,
+    pub(crate) parsed_params: Vec<Datum>,
     pub(crate) param_formats: Vec<Format>,
     pub(crate) error: Option<RwError>,
+}
+
+impl ParamRewriter {
+    pub(crate) fn new(param_formats: Vec<Format>, params: Vec<Bytes>) -> Self {
+        Self {
+            parsed_params: vec![None; params.len()],
+            params,
+            param_formats,
+            error: None,
+        }
+    }
 }
 
 impl ExprRewriter for ParamRewriter {
@@ -75,6 +87,7 @@ impl ExprRewriter for ParamRewriter {
                 }
             }
         };
+        self.parsed_params[parameter_index] = Some(scalar.clone());
         Literal::new(Some(scalar), data_type).into()
     }
 }
@@ -84,14 +97,13 @@ impl BoundStatement {
         mut self,
         params: Vec<Bytes>,
         param_formats: Vec<Format>,
-    ) -> Result<BoundStatement> {
-        let mut rewriter = ParamRewriter {
-            param_formats: FormatIterator::new(&param_formats, params.len())
+    ) -> Result<(BoundStatement, Vec<Datum>)> {
+        let mut rewriter = ParamRewriter::new(
+            FormatIterator::new(&param_formats, params.len())
                 .map_err(ErrorCode::BindError)?
                 .collect(),
             params,
-            error: None,
-        };
+        );
 
         self.rewrite_exprs_recursive(&mut rewriter);
 
@@ -99,7 +111,7 @@ impl BoundStatement {
             return Err(err);
         }
 
-        Ok(self)
+        Ok((self, rewriter.parsed_params))
     }
 }
 
@@ -128,7 +140,7 @@ mod test {
         let mut binder = mock_binder_with_param_types(param_types);
         let stmt = parse_sql_statements(sql).unwrap().remove(0);
         let bound = binder.bind(stmt).unwrap();
-        bound.bind_parameter(params, param_formats).unwrap()
+        bound.bind_parameter(params, param_formats).unwrap().0
     }
 
     fn expect_actual_eq(expect: BoundStatement, actual: BoundStatement) {

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -25,7 +25,7 @@ use postgres_types::FromSql;
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::session_config::QueryMode;
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, Datum};
 use risingwave_sqlparser::ast::{SetExpr, Statement};
 
 use super::extended_handle::{PortalResult, PrepareStatement, PreparedResult};
@@ -115,6 +115,7 @@ pub struct BoundResult {
     pub(crate) must_dist: bool,
     pub(crate) bound: BoundStatement,
     pub(crate) param_types: Vec<DataType>,
+    pub(crate) parsed_params: Option<Vec<Datum>>,
     pub(crate) dependent_relations: HashSet<TableId>,
 }
 
@@ -138,6 +139,7 @@ fn gen_bound(
         must_dist,
         bound,
         param_types: binder.export_param_types()?,
+        parsed_params: None,
         dependent_relations: binder.included_relations(),
     })
 }

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -655,11 +655,12 @@ impl SessionImpl {
             if cfg!(debug_assertions) {
                 // Report the SQL in the log periodically if the query is slow.
                 const SLOW_QUERY_LOG_PERIOD: Duration = Duration::from_secs(60);
+                const SLOW_QUERY_LOG: &str = "risingwave_frontend_slow_query_log";
                 loop {
                     match tokio::time::timeout(SLOW_QUERY_LOG_PERIOD, &mut handle_fut).await {
                         Ok(result) => break result,
                         Err(_) => tracing::warn!(
-                            target: "risingwave_frontend_slow_query_log",
+                            target: SLOW_QUERY_LOG,
                             sql,
                             "slow query has been running for another {SLOW_QUERY_LOG_PERIOD:?}"
                         ),

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -76,6 +76,8 @@ where
     tls_context: Option<SslContext>,
 }
 
+const PGWIRE_QUERY_LOG: &str = "pgwire_query_log";
+
 /// Configures TLS encryption for connections.
 #[derive(Debug, Clone)]
 pub struct TlsConfig {
@@ -340,8 +342,14 @@ where
 
         let mills = start.elapsed().as_millis();
         let truncated_sql = &sql[..std::cmp::min(sql.len(), 1024)];
-        tracing::trace!(target: "pgwire_query_log",
-            "(simple query) session: {}, status: {}, time: {}ms, sql: {}", session_id, if result.is_ok() {"ok"} else {"err"}, mills, truncated_sql);
+        tracing::trace!(
+            target: PGWIRE_QUERY_LOG,
+            "(simple query) session: {}, status: {}, time: {}ms, sql: {}",
+            session_id,
+            if result.is_ok() { "ok" } else { "err" },
+            mills,
+            truncated_sql
+        );
 
         result
     }
@@ -430,8 +438,14 @@ where
 
         let mills = start.elapsed().as_millis();
         let truncated_sql = &sql[..std::cmp::min(sql.len(), 1024)];
-        tracing::trace!(target: "pgwire_query_log",
-            "(extended query parse) session: {}, status: {}, time: {}ms, sql: {}", session_id, if result.is_ok() {"ok"} else {"err"}, mills, truncated_sql);
+        tracing::trace!(
+            target: PGWIRE_QUERY_LOG,
+            "(extended query parse) session: {}, status: {}, time: {}ms, sql: {}",
+            session_id,
+            if result.is_ok() { "ok" } else { "err" },
+            mills,
+            truncated_sql
+        );
 
         result
     }
@@ -563,7 +577,14 @@ where
             let result = session.execute(portal).await;
 
             let mills = start.elapsed().as_millis();
-            tracing::trace!(target: "pgwire_query_log", "(extended query execute) session: {}, status: {}, time: {}ms, sql: {}", session_id, if result.is_ok() {"ok"} else {"err"}, mills, truncated_sql);
+            tracing::trace!(
+                target: PGWIRE_QUERY_LOG,
+                "(extended query execute) session: {}, status: {}, time: {}ms, sql: {}",
+                session_id,
+                if result.is_ok() { "ok" } else { "err" },
+                mills,
+                truncated_sql
+            );
 
             let pg_response = match result {
                 Ok(pg_response) => pg_response,

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -38,7 +38,7 @@ pub trait SessionManager<VS, PS, PO>: Send + Sync + 'static
 where
     VS: Stream<Item = RowSetResult> + Unpin + Send,
     PS: Send + Clone + 'static,
-    PO: Send + Clone + 'static,
+    PO: Send + Clone + std::fmt::Display + 'static,
 {
     type Session: Session<VS, PS, PO>;
 
@@ -58,7 +58,7 @@ pub trait Session<VS, PS, PO>: Send + Sync
 where
     VS: Stream<Item = RowSetResult> + Unpin + Send,
     PS: Send + Clone + 'static,
-    PO: Send + Clone + 'static,
+    PO: Send + Clone + std::fmt::Display + 'static,
 {
     /// The str sql can not use the unparse from AST: There is some problem when dealing with create
     /// view, see  https://github.com/risingwavelabs/risingwave/issues/6801.
@@ -134,7 +134,7 @@ pub async fn pg_serve<VS, PS, PO>(
 where
     VS: Stream<Item = RowSetResult> + Unpin + Send + 'static,
     PS: Send + Clone + 'static,
-    PO: Send + Clone + 'static,
+    PO: Send + Clone + std::fmt::Display + 'static,
 {
     let listener = TcpListener::bind(addr).await.unwrap();
     // accept connections and process them, spawning a new thread for each one
@@ -169,7 +169,7 @@ where
     SM: SessionManager<VS, PS, PO>,
     VS: Stream<Item = RowSetResult> + Unpin + Send + 'static,
     PS: Send + Clone + 'static,
-    PO: Send + Clone + 'static,
+    PO: Send + Clone + std::fmt::Display + 'static,
 {
     let mut pg_proto = PgProtocol::new(stream, session_mgr, tls_config);
     async {

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -42,6 +42,10 @@ const ENABLE_QUERY_LOG_FILE: bool = false;
 /// Includes line numbers for each log.
 const ENABLE_PRETTY_LOG: bool = false;
 
+const PGWIRE_QUERY_LOG: &str = "pgwire_query_log";
+
+const SLOW_QUERY_LOG: &str = "risingwave_frontend_slow_query_log";
+
 /// Configure log targets for all `RisingWave` crates. When new crates are added and TRACE level
 /// logs are needed, add them here.
 fn configure_risingwave_targets_fmt(targets: filter::Targets) -> filter::Targets {
@@ -210,7 +214,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
             .with_thread_names(true)
             .with_thread_ids(true)
             .with_writer(std::sync::Mutex::new(file))
-            .with_filter(filter::Targets::new().with_target("pgwire_query_log", Level::TRACE));
+            .with_filter(filter::Targets::new().with_target(PGWIRE_QUERY_LOG, Level::TRACE));
         layers.push(layer.boxed());
     }
 
@@ -245,9 +249,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings) {
         .with_thread_names(true)
         .with_thread_ids(true)
         .with_writer(std::sync::Mutex::new(file))
-        .with_filter(
-            filter::Targets::new().with_target("risingwave_frontend_slow_query_log", Level::TRACE),
-        );
+        .with_filter(filter::Targets::new().with_target(SLOW_QUERY_LOG, Level::TRACE));
     layers.push(layer.boxed());
 
     if settings.enable_tokio_console {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Only print logs when handling `parse` and `execute` messages for prepare statements. Related issue https://github.com/risingwavelabs/risingwave/issues/9710.

## Example:
```
2023-05-15T04:44:32.59611Z risingwave-main ThreadId(11) (extended query parse) session: 17, status: ok, time: 6ms, sql: SELECT c FROM sbtest1 WHERE id=$1
2023-05-15T04:44:32.603533Z risingwave-main ThreadId(11) (extended query execute) session: 17, status: ok, time: 6ms, sql: SELECT c FROM sbtest1 WHERE id = $1, params = Some([Some(Int64(4992))])
2023-05-15T04:44:32.616455Z risingwave-main ThreadId(05) (extended query execute) session: 17, status: ok, time: 2ms, sql: SELECT c FROM sbtest1 WHERE id = $1, params = Some([Some(Int64(4374))])
2023-05-15T04:44:32.622121Z risingwave-main ThreadId(06) (extended query execute) session: 17, status: ok, time: 2ms, sql: SELECT c FROM sbtest1 WHERE id = $1, params = Some([Some(Int64(3137))])
2023-05-15T04:44:32.62675Z risingwave-main ThreadId(06) (extended query execute) session: 17, status: ok, time: 1ms, sql: SELECT c FROM sbtest1 WHERE id = $1, params = Some([Some(Int64(2489))])
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
