### PR TITLE
feat(storage): support flush as non-overlapping-level

### DIFF
--- a/src/storage/src/hummock/compactor/shared_buffer_compact.rs
+++ b/src/storage/src/hummock/compactor/shared_buffer_compact.rs
@@ -22,6 +22,7 @@ use futures::{stream, StreamExt, TryFutureExt};
 use itertools::Itertools;
 use risingwave_common::cache::CachePriority;
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::compaction_group::StaticCompactionGroupId;
 use risingwave_hummock_sdk::key::{FullKey, TableKey, UserKey};
 use risingwave_hummock_sdk::key_range::KeyRange;
@@ -165,27 +166,52 @@ async fn compact_shared_buffer(
         compact_data_size
     };
     // mul 1.2 for other extra memory usage.
-    let sub_compaction_sstable_size = std::cmp::min(sstable_size, sub_compaction_data_size * 6 / 5);
-    if parallelism > 1 && compact_data_size > sstable_size {
-        let mut last_buffer_size = 0;
-        let mut last_user_key = UserKey::default();
-        for (data_size, user_key) in size_and_start_user_keys {
-            if last_buffer_size >= sub_compaction_data_size && last_user_key.as_ref() != user_key {
-                last_user_key.set(user_key);
-                key_split_append(
-                    &FullKey {
-                        user_key,
-                        epoch: HummockEpoch::MAX,
-                    }
-                    .encode()
-                    .into(),
-                );
-                last_buffer_size = data_size;
-            } else {
-                last_user_key.set(user_key);
-                last_buffer_size += data_size;
+    let mut sub_compaction_sstable_size =
+        std::cmp::min(sstable_size, sub_compaction_data_size * 6 / 5);
+    let mut split_weight_by_vnode = 0;
+    if existing_table_ids.len() > 1 {
+        if parallelism > 1 && compact_data_size > sstable_size {
+            let mut last_buffer_size = 0;
+            let mut last_user_key = UserKey::default();
+            for (data_size, user_key) in size_and_start_user_keys {
+                if last_buffer_size >= sub_compaction_data_size
+                    && last_user_key.as_ref() != user_key
+                {
+                    last_user_key.set(user_key);
+                    key_split_append(
+                        &FullKey {
+                            user_key,
+                            epoch: HummockEpoch::MAX,
+                        }
+                        .encode()
+                        .into(),
+                    );
+                    last_buffer_size = data_size;
+                } else {
+                    last_user_key.set(user_key);
+                    last_buffer_size += data_size;
+                }
             }
         }
+    } else {
+        let mut vnodes = vec![];
+        for imm in &payload {
+            vnodes.extend(imm.collect_vnodes());
+        }
+        vnodes.sort();
+        vnodes.dedup();
+        const MIN_SSTABLE_SIZE: u64 = 1024 * 1024;
+        let mut avg_vnode_size = compact_data_size / (vnodes.len() as u64);
+        if avg_vnode_size >= MIN_SSTABLE_SIZE {
+            split_weight_by_vnode = VirtualNode::COUNT;
+        } else if vnodes.len() >= VirtualNode::COUNT / 2 {
+            split_weight_by_vnode = VirtualNode::COUNT;
+            while avg_vnode_size < MIN_SSTABLE_SIZE && split_weight_by_vnode > 0 {
+                split_weight_by_vnode /= 2;
+                avg_vnode_size *= 2;
+            }
+        }
+        sub_compaction_sstable_size = compact_data_size;
     }
 
     let parallelism = splits.len();
@@ -200,6 +226,7 @@ async fn compact_shared_buffer(
             key_range,
             context.clone(),
             sub_compaction_sstable_size as usize,
+            split_weight_by_vnode as u32,
         );
         let iter = OrderedMergeIteratorInner::new(
             payload.iter().map(|imm| imm.clone().into_forward_iter()),
@@ -418,6 +445,7 @@ impl SharedBufferCompactRunner {
         key_range: KeyRange,
         context: Arc<CompactorContext>,
         sub_compaction_sstable_size: usize,
+        split_weight_by_vnode: u32,
     ) -> Self {
         let mut options: SstableBuilderOptions = context.storage_opts.as_ref().into();
         options.capacity = sub_compaction_sstable_size;
@@ -433,7 +461,7 @@ impl SharedBufferCompactRunner {
                 task_type: compact_task::TaskType::SharedBuffer,
                 is_target_l0_or_lbase: true,
                 split_by_table: false,
-                split_weight_by_vnode: 0,
+                split_weight_by_vnode,
             },
         );
         Self {

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -24,6 +24,7 @@ use std::sync::{Arc, LazyLock};
 use bytes::{Bytes, BytesMut};
 use itertools::Itertools;
 use risingwave_common::catalog::TableId;
+use risingwave_common::hash::VirtualNode;
 use risingwave_hummock_sdk::key::{FullKey, PointRange, TableKey, TableKeyRange, UserKey};
 
 use crate::hummock::event_handler::LocalInstanceId;
@@ -577,6 +578,42 @@ impl SharedBufferBatch {
 
     pub fn get_delete_range_tombstones(&self) -> Vec<MonotonicDeleteEvent> {
         self.inner.monotonic_tombstone_events.clone()
+    }
+
+    pub fn collect_vnodes(&self) -> Vec<usize> {
+        let mut vnodes = Vec::with_capacity(VirtualNode::COUNT);
+        let mut next_vnode_id = 0;
+        while next_vnode_id < VirtualNode::COUNT {
+            let seek_key = TableKey(
+                VirtualNode::from_index(next_vnode_id)
+                    .to_be_bytes()
+                    .to_vec(),
+            );
+            let idx = match self
+                .inner
+                .payload
+                .binary_search_by(|m| (m.0[..]).cmp(seek_key.as_slice()))
+            {
+                Ok(idx) => idx,
+                Err(idx) => idx,
+            };
+            if idx >= self.inner.payload.len() {
+                break;
+            }
+            let item = &self.inner.payload[idx];
+            if item.0.len() <= VirtualNode::SIZE {
+                break;
+            }
+            let current_vnode_id = VirtualNode::from_be_bytes(
+                item.0.as_ref()[..VirtualNode::SIZE]
+                    .try_into()
+                    .expect("slice with incorrect length"),
+            )
+            .to_index();
+            vnodes.push(current_vnode_id);
+            next_vnode_id = current_vnode_id + 1;
+        }
+        vnodes
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).


Merged after https://github.com/risingwavelabs/risingwave/pull/9750

## Background

 In our system, we must flush sstable files to overlapping-level and then compact them again to non-overlapping level. But if the size of one overlapping-level  is large enough, it is not necessary to compact them again.

There is a compaction-size-limit in l0 compaction picker, and the value of it is usual set 128MB (which is the size limit of sub-level).  It means that if the size of a just flushed sub-level exceed 128MB, we can not compact it with other sub-level. We must compact it single just to make it to non-overlapping-level. 


If we found that all sstables flushed in this group are sorted and not overlap with each other, we can mark this sub-level as non-overlapping directly to avoid once compact.



## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
