### PR TITLE
fix(sqlsmith): output `count(*)` correctly

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -604,10 +604,16 @@ fn make_agg_func(
     filter: Option<Box<Expr>>,
     order_by: Vec<OrderByExpr>,
 ) -> Function {
-    let args = exprs
-        .iter()
-        .map(|e| FunctionArg::Unnamed(FunctionArgExpr::Expr(e.clone())))
-        .collect();
+    let args = if exprs.is_empty() {
+        // The only agg without args is `count`.
+        // `select proname from pg_proc where array_length(proargtypes, 1) = 0 and prokind = 'a';`
+        vec![FunctionArg::Unnamed(FunctionArgExpr::Wildcard)]
+    } else {
+        exprs
+            .iter()
+            .map(|e| FunctionArg::Unnamed(FunctionArgExpr::Expr(e.clone())))
+            .collect()
+    };
 
     Function {
         name: ObjectName(vec![Ident::new_unchecked(func_name)]),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #9780

Similar to #9763

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
