### PR TITLE
chore(frontend): remove workaround for query hang in frontend

### DIFF
--- a/src/frontend/src/scheduler/distributed/stage.rs
+++ b/src/frontend/src/scheduler/distributed/stage.rs
@@ -491,28 +491,13 @@ impl StageRunner {
         }
 
         tracing::trace!(
-            "Stage [{:?}-{:?}], running task count: {}, finished task count: {}",
+            "Stage [{:?}-{:?}], running task count: {}, finished task count: {}, sent signal to next: {}",
             self.stage.query_id,
             self.stage.id,
             running_task_cnt,
-            finished_task_cnt
+            finished_task_cnt,
+            sent_signal_to_next,
         );
-
-        if !sent_signal_to_next || finished_task_cnt != self.tasks.keys().len() {
-            // This situation may come from recovery test: CN may get killed before reporting
-            // status. In this case, batch query is expected to fail. Client in
-            // simulation test should retry this query (w/o kill nodes).
-            self.notify_stage_state_changed(
-                |_| StageState::Failed,
-                QueryMessage::Stage(Failed {
-                    id: self.stage.id,
-                    reason: SchedulerError::Internal(anyhow!(
-                        "Compute node lost connection before finishing responding"
-                    )),
-                }),
-            )
-            .await;
-        }
 
         if let Some(shutdown) = all_streams.take_future() {
             tracing::trace!(
@@ -537,7 +522,7 @@ impl StageRunner {
         self.cancel_all_scheducancled_tasks().await?;
 
         tracing::trace!(
-            "Stage runner [{:?}-{:?}] existed. ",
+            "Stage runner [{:?}-{:?}] exited.",
             self.stage.query_id,
             self.stage.id
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Since the issue in madsim has been resolved in https://github.com/madsim-rs/madsim/pull/133, we can remove this workaround now which was introduced in #8399 .

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
