### PR TITLE
feat(frontend): support show indexes

### DIFF
--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -23,7 +23,12 @@ v2 integer
 v3 integer
 
 statement ok
-create index idx1 on t3 (v1,v2);;
+create index idx1 on t3 (v1,v2);
+
+query TTTTT
+show indexes from t3;
+----
+idx1 t3 v1 ASC, v2 ASC v3 v1, v2
 
 query TT
 describe t3;

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use itertools::Itertools;
 use pgwire::pg_field_descriptor::PgFieldDescriptor;
 use pgwire::pg_response::{PgResponse, StatementType};
@@ -26,8 +28,8 @@ use serde_json;
 
 use super::RwPgResponse;
 use crate::binder::{Binder, Relation};
-use crate::catalog::CatalogError;
-use crate::handler::util::col_descs_to_rows;
+use crate::catalog::{CatalogError, IndexCatalog};
+use crate::handler::util::{col_descs_to_rows, indexes_to_rows};
 use crate::handler::HandlerArgs;
 use crate::session::SessionImpl;
 
@@ -51,6 +53,22 @@ pub fn get_columns_from_table(
         .filter(|c| !c.is_hidden)
         .map(|c| c.column_desc.clone())
         .collect())
+}
+
+pub fn get_indexes_from_table(
+    session: &SessionImpl,
+    table_name: ObjectName,
+) -> Result<Vec<Arc<IndexCatalog>>> {
+    let mut binder = Binder::new_for_system(session);
+    let relation = binder.bind_relation_by_name(table_name.clone(), None, false)?;
+    let indexes = match relation {
+        Relation::BaseTable(t) => t.table_indexes,
+        _ => {
+            return Err(CatalogError::NotFound("table or source", table_name.to_string()).into());
+        }
+    };
+
+    Ok(indexes)
 }
 
 fn schema_or_default(schema: &Option<Ident>) -> String {
@@ -114,6 +132,43 @@ pub fn handle_show_object(handler_args: HandlerArgs, command: ShowObject) -> Res
                     ),
                     PgFieldDescriptor::new(
                         "Type".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                ],
+            ));
+        }
+        ShowObject::Indexes { table } => {
+            let indexes = get_indexes_from_table(&session, table)?;
+            let rows = indexes_to_rows(indexes);
+
+            return Ok(PgResponse::new_for_stream(
+                StatementType::SHOW_COMMAND,
+                None,
+                rows.into(),
+                vec![
+                    PgFieldDescriptor::new(
+                        "Name".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "On".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Key".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Include".to_owned(),
+                        DataType::Varchar.to_oid(),
+                        DataType::Varchar.type_len(),
+                    ),
+                    PgFieldDescriptor::new(
+                        "Distributed By".to_owned(),
                         DataType::Varchar.to_oid(),
                         DataType::Varchar.type_len(),
                     ),

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -787,6 +787,7 @@ pub enum ShowObject {
     Columns { table: ObjectName },
     Connection { schema: Option<Ident> },
     Function { schema: Option<Ident> },
+    Indexes { table: ObjectName },
 }
 
 impl fmt::Display for ShowObject {
@@ -819,6 +820,7 @@ impl fmt::Display for ShowObject {
             ShowObject::Columns { table } => write!(f, "COLUMNS FROM {}", table),
             ShowObject::Connection { schema } => write!(f, "CONNECTIONS{}", fmt_schema(schema)),
             ShowObject::Function { schema } => write!(f, "FUNCTIONS{}", fmt_schema(schema)),
+            ShowObject::Indexes { table } => write!(f, "INDEXES{}", table),
         }
     }
 }

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -820,7 +820,7 @@ impl fmt::Display for ShowObject {
             ShowObject::Columns { table } => write!(f, "COLUMNS FROM {}", table),
             ShowObject::Connection { schema } => write!(f, "CONNECTIONS{}", fmt_schema(schema)),
             ShowObject::Function { schema } => write!(f, "FUNCTIONS{}", fmt_schema(schema)),
-            ShowObject::Indexes { table } => write!(f, "INDEXES{}", table),
+            ShowObject::Indexes { table } => write!(f, "INDEXES FROM {}", table),
         }
     }
 }

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -257,6 +257,7 @@ define_keywords!(
     IN,
     INCLUDE,
     INDEX,
+    INDEXES,
     INDICATOR,
     INITIALLY,
     INNER,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3705,6 +3705,15 @@ impl Parser {
                         schema: self.parse_from_and_identifier()?,
                     }));
                 }
+                Keyword::INDEXES => {
+                    if self.parse_keyword(Keyword::FROM) {
+                        return Ok(Statement::ShowObjects(ShowObject::Indexes {
+                            table: self.parse_object_name()?,
+                        }));
+                    } else {
+                        return self.expected("from after indexes", self.peek_token());
+                    }
+                }
                 _ => {}
             }
         }

--- a/src/sqlparser/tests/testdata/show.yaml
+++ b/src/sqlparser/tests/testdata/show.yaml
@@ -44,3 +44,6 @@
 - input: SHOW CREATE VIEW schema.v
   formatted_sql: SHOW CREATE VIEW schema.v
   formatted_ast: 'ShowCreateObject { create_type: View, name: ObjectName([Ident { value: "schema", quote_style: None }, Ident { value: "v", quote_style: None }]) }'
+- input: SHOW INDEXES FROM t
+  formatted_sql: SHOW INDEXES FROM t
+  formatted_ast: 'ShowObjects(Indexes { table: ObjectName([Ident { value: "t", quote_style: None }]) })'


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Support `SHOW INDEXES FROM t`. Resolve https://github.com/risingwavelabs/risingwave/issues/9046?notification_referrer_id=NT_kwDOAI61WLI2MDkzODU5NzY1OjkzNTI1MzY&notifications_query=reason%3Aparticipating.

## Example

```sql
dev=> show indexes from sbtest1;
 Name |   On    |      Key      | Include | Distributed By
------+---------+---------------+---------+----------------
 k_1  | sbtest1 | k ASC, id ASC | c, pad  | k
 ck_1 | sbtest1 | k ASC, id ASC | c, pad  | k
(2 rows)
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

- Support `SHOW INDEXES FROM t`.

</details>
