### PR TITLE
feat(frontend): support show create index

### DIFF
--- a/e2e_test/ddl/show.slt
+++ b/e2e_test/ddl/show.slt
@@ -34,6 +34,11 @@ v3 integer
 primary key _row_id
 idx1 index(v1 ASC, v2 ASC) include(v3) distributed by(v1, v2)
 
+query TT
+show create index idx1;
+----
+public.idx1 CREATE INDEX idx1 ON t3(v1, v2)
+
 statement ok
 drop index idx1;
 

--- a/src/frontend/src/handler/show.rs
+++ b/src/frontend/src/handler/show.rs
@@ -298,7 +298,14 @@ pub fn handle_show_create_object(
                 .ok_or_else(|| CatalogError::NotFound("source", name.to_string()))?;
             source.create_sql()
         }
-        _ => {
+        ShowCreateType::Index => {
+            let index = schema
+                .get_table_by_name(&object_name)
+                .filter(|t| t.is_index())
+                .ok_or_else(|| CatalogError::NotFound("index", name.to_string()))?;
+            index.create_sql()
+        }
+        ShowCreateType::Function => {
             return Err(ErrorCode::NotImplemented(
                 format!("show create on: {}", show_create_type),
                 None.into(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Support `SHOW CREATE INDEX idx`.

## Example

```sql
dev=> show create index k_1;
    Name    |           Create Sql
------------+--------------------------------
 public.k_1 | CREATE INDEX k_1 ON sbtest1(k)
(1 row)
```


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

-  Support `SHOW CREATE INDEX idx`.


</details>
