### PR TITLE
feat(streaming): use no-shuffle exchange for share & fix scaling

### DIFF
--- a/src/frontend/planner_test/tests/testdata/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark.yaml
@@ -423,7 +423,7 @@
 
     Fragment 1
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
@@ -438,7 +438,7 @@
 
     Fragment 4
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ bid_auction, window_start, count ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
 

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -433,7 +433,7 @@
 
     Fragment 1
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
@@ -448,7 +448,7 @@
 
     Fragment 4
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ auction, window_start, count ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
 
@@ -549,7 +549,7 @@
 
     Fragment 1
     StreamNoOp
-    └──  StreamExchange Hash([4]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [auction, bidder, price, date_time, _row_id] }
@@ -563,7 +563,7 @@
 
     Fragment 4
     StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
-    └──  StreamExchange Hash([4]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ auction, bidder, price, date_time, _row_id ], primary key: [ $2 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 2 ], read pk prefix len hint: 1 }
 
@@ -1512,7 +1512,7 @@
 
     Fragment 2
     StreamNoOp
-    └──  StreamExchange Hash([1]) from 3
+    └──  StreamExchange NoShuffle from 3
 
     Fragment 3
     StreamProject { exprs: [auction, _row_id] }
@@ -1530,7 +1530,7 @@
 
     Fragment 6
     StreamNoOp
-    └──  StreamExchange Hash([1]) from 3
+    └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ id, item_name, count(auction) ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 

--- a/src/frontend/planner_test/tests/testdata/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_watermark.yaml
@@ -163,7 +163,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 7:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (Field(auction, 8:Int32) = 10:Int32) AND (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, person, auction, _row_id] }
@@ -176,7 +176,7 @@
     Fragment 3
     StreamProject { exprs: [Field(person, 0:Int32) as $expr4, Field(person, 1:Int32) as $expr5, Field(person, 4:Int32) as $expr6, Field(person, 5:Int32) as $expr7, _row_id] }
     └── StreamFilter { predicate: (((Field(person, 5:Int32) = 'or':Varchar) OR (Field(person, 5:Int32) = 'id':Varchar)) OR (Field(person, 5:Int32) = 'ca':Varchar)) AND (event_type = 0:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, _row_id ], primary key: [ $1 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
 
@@ -277,7 +277,7 @@
     Fragment 2
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, Field(auction, 8:Int32) as $expr4, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Fragment 3
     StreamProject { exprs: [event_type, auction, bid, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -290,7 +290,7 @@
     Fragment 4
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr5, Field(bid, 2:Int32) as $expr6, $expr1, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ $expr4, sum(max($expr6)), count(max($expr6)), count ], primary key: [ $0 ASC ], value indices: [ 1, 2, 3 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -430,7 +430,7 @@
 
     Fragment 1
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
@@ -447,7 +447,7 @@
 
     Fragment 4
     StreamNoOp
-    └──  StreamExchange Hash([0, 1]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, window_start, count ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
 
@@ -588,7 +588,7 @@
 
     Fragment 1
     StreamNoOp
-    └──  StreamExchange Hash([4]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -605,7 +605,7 @@
 
     Fragment 4
     StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
-    └──  StreamExchange Hash([4]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, $expr4, $expr1, _row_id ], primary key: [ $2 ASC, $4 ASC ], value indices: [ 0, 1, 2, 3, 4 ], distribution key: [ 2 ], read pk prefix len hint: 1 }
 
@@ -743,7 +743,7 @@
     Fragment 2
     StreamProject { exprs: [Field(person, 0:Int32) as $expr2, Field(person, 1:Int32) as $expr3, TumbleStart($expr1, '00:00:10':Interval) as $expr4, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, _row_id], output_watermarks: [$expr4, $expr5] }
     └── StreamFilter { predicate: (event_type = 0:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Fragment 3
     StreamProject { exprs: [event_type, person, auction, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -756,7 +756,7 @@
     Fragment 4
     StreamProject { exprs: [Field(auction, 7:Int32) as $expr6, TumbleStart($expr1, '00:00:10':Interval) as $expr7, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr8, _row_id], output_watermarks: [$expr7, $expr8] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ $expr2, $expr3, $expr4, $expr5 ], primary key: [ $2 ASC, $3 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [ 0, 2, 3 ], read pk prefix len hint: 3 }
 
@@ -894,7 +894,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([4]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -907,7 +907,7 @@
     Fragment 3
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr10, Field(bid, 1:Int32) as $expr11, Field(bid, 2:Int32) as $expr12, $expr1, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([4]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1_0, _row_id, _row_id_0 ], primary key: [ $0 ASC, $11 DESC, $12 ASC, $13 ASC, $14 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -1536,7 +1536,7 @@
     Fragment 1
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, Field(bid, 3:Int32) as $expr5, Field(bid, 4:Int32) as $expr6, $expr1, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([4]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -1549,7 +1549,7 @@
     Fragment 3
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr7, Field(auction, 1:Int32) as $expr8, Field(auction, 2:Int32) as $expr9, Field(auction, 3:Int32) as $expr10, Field(auction, 4:Int32) as $expr11, $expr1, Field(auction, 6:Int32) as $expr12, Field(auction, 7:Int32) as $expr13, Field(auction, 8:Int32) as $expr14, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (Field(auction, 8:Int32) = 10:Int32) AND (event_type = 1:Int32) }
-        └──  StreamExchange Hash([4]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, $expr4, $expr5, $expr6, $expr1, _row_id ], primary key: [ $0 ASC, $6 ASC ], value indices: [ 0, 1, 2, 3, 4, 5, 6 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -1700,7 +1700,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, _row_id] }
@@ -1713,7 +1713,7 @@
     Fragment 3
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, Field(bid, 2:Int32) as $expr5, _row_id] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, _row_id ], primary key: [ $0 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -1836,7 +1836,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, _row_id] }
@@ -1848,12 +1848,12 @@
 
     Fragment 3
     StreamNoOp
-    └──  StreamExchange Hash([1]) from 4
+    └──  StreamExchange NoShuffle from 4
 
     Fragment 4
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 5
     StreamProject { exprs: [(sum0(count) / count($expr4)) as $expr5] }
@@ -1866,7 +1866,7 @@
 
     Fragment 7
     StreamNoOp
-    └──  StreamExchange Hash([1]) from 4
+    └──  StreamExchange NoShuffle from 4
 
     Table 0 { columns: [ $expr2, $expr3, count($expr4) ], primary key: [ $2 ASC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -1965,7 +1965,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, _row_id] }
@@ -1978,7 +1978,7 @@
     Fragment 3
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, _row_id ], primary key: [ $0 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -2069,7 +2069,7 @@
     Fragment 1
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamProject { exprs: [event_type, auction, bid, _row_id] }
@@ -2082,7 +2082,7 @@
     Fragment 3
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([3]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ $expr2, $expr3, _row_id ], primary key: [ $0 ASC, $2 ASC ], value indices: [ 0, 1, 2 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -2185,7 +2185,7 @@
     Fragment 2
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([3]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Fragment 3
     StreamProject { exprs: [event_type, auction, bid, _row_id] }
@@ -2198,7 +2198,7 @@
     Fragment 4
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([3]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ $expr2, $expr3, count($expr4), $expr5 ], primary key: [ $2 DESC, $0 ASC, $1 ASC ], value indices: [ 0, 1, 2, 3 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -2315,7 +2315,7 @@
     Fragment 2
     StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 1:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Fragment 3
     StreamProject { exprs: [event_type, auction, bid, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -2328,7 +2328,7 @@
     Fragment 4
     StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, Field(bid, 2:Int32) as $expr5, $expr1, _row_id], output_watermarks: [$expr1] }
     └── StreamFilter { predicate: (event_type = 2:Int32) }
-        └──  StreamExchange Hash([4]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ min(max($expr5)), $expr6 ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 0 }
 

--- a/src/frontend/planner_test/tests/testdata/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/share.yaml
@@ -249,8 +249,8 @@
         ├── right table: 3
         ├── left degree table: 2
         ├── right degree table: 4
-        ├──  StreamExchange Hash([0]) from 2
-        └──  StreamExchange Hash([0]) from 4
+        ├──  StreamExchange NoShuffle from 2
+        └──  StreamExchange NoShuffle from 4
 
     Fragment 2
     StreamProject { exprs: [t.a] }

--- a/src/frontend/planner_test/tests/testdata/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch.yaml
@@ -2260,7 +2260,7 @@
 
     Fragment 1
     StreamProject { exprs: [partsupp.ps_partkey, (partsupp.ps_supplycost * partsupp.ps_availqty::Decimal) as $expr1, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-    └──  StreamExchange Hash([5]) from 2
+    └──  StreamExchange NoShuffle from 2
 
     Fragment 2
     StreamHashJoin { type: Inner, predicate: supplier.s_nationkey = nation.n_nationkey, output: [partsupp.ps_partkey, partsupp.ps_availqty, partsupp.ps_supplycost, partsupp.ps_suppkey, supplier.s_suppkey, supplier.s_nationkey, nation.n_nationkey] }
@@ -2305,7 +2305,7 @@
     Fragment 8
     StreamStatelessSimpleAgg { aggs: [sum($expr2)] }
     └── StreamProject { exprs: [(partsupp.ps_supplycost * partsupp.ps_availqty::Decimal) as $expr2, partsupp.ps_partkey, partsupp.ps_suppkey, supplier.s_suppkey, nation.n_nationkey, supplier.s_nationkey] }
-        └──  StreamExchange Hash([5]) from 2
+        └──  StreamExchange NoShuffle from 2
 
     Table 0 { columns: [ partsupp_ps_partkey, sum($expr1) ], primary key: [ $1 ASC, $0 ASC ], value indices: [ 0, 1 ], distribution key: [ 0 ], read pk prefix len hint: 1 }
 
@@ -2798,7 +2798,7 @@
     ├── left degree table: 5
     ├── right degree table: 7
     ├──  StreamExchange Hash([0]) from 2
-    └──  StreamExchange Hash([0]) from 3
+    └──  StreamExchange NoShuffle from 3
 
     Fragment 2
     Chain { table: supplier, columns: [supplier.s_suppkey, supplier.s_name, supplier.s_address, supplier.s_phone], pk: [supplier.s_suppkey], dist: UpstreamHashShard(supplier.s_suppkey) }
@@ -2825,7 +2825,7 @@
     Fragment 6
     StreamHashAgg { group_key: [$expr2], aggs: [max(sum($expr1)), count] } { result table: 12, state tables: [ 11 ], distinct tables: [] }
     └── StreamProject { exprs: [lineitem.l_suppkey, sum($expr1), Vnode(lineitem.l_suppkey) as $expr2] }
-        └──  StreamExchange Hash([0]) from 3
+        └──  StreamExchange NoShuffle from 3
 
     Table 0 { columns: [ supplier_s_suppkey, supplier_s_name, supplier_s_address, supplier_s_phone, sum($expr1), lineitem_l_suppkey ], primary key: [ $4 ASC, $0 ASC, $5 ASC ], value indices: [ 0, 1, 2, 3, 4, 5 ], distribution key: [ 4 ], read pk prefix len hint: 1 }
 

--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -666,15 +666,10 @@ where
                 BTreeMap<ActorId, ParallelUnitId>,
             >,
             fragment_updated_bitmap: &mut HashMap<FragmentId, HashMap<ActorId, Bitmap>>,
-            no_shuffle_upstream_actor_map: &mut HashMap<ActorId, ActorId>,
+            no_shuffle_upstream_actor_map: &mut HashMap<ActorId, HashMap<FragmentId, ActorId>>,
             no_shuffle_downstream_actors_map: &mut HashMap<ActorId, HashMap<FragmentId, ActorId>>,
         ) {
             if !ctx.no_shuffle_target_fragment_ids.contains(fragment_id) {
-                return;
-            }
-
-            if fragment_updated_bitmap.contains_key(fragment_id) {
-                // Diamond dependency
                 return;
             }
 
@@ -707,7 +702,10 @@ where
                     fragment_bitmap.insert(*actor_id, bitmap);
                 }
 
-                no_shuffle_upstream_actor_map.insert(*actor_id as ActorId, upstream_actor_id);
+                no_shuffle_upstream_actor_map
+                    .entry(*actor_id as ActorId)
+                    .or_default()
+                    .insert(*upstream_fragment_id, upstream_actor_id);
                 no_shuffle_downstream_actors_map
                     .entry(upstream_actor_id)
                     .or_default()
@@ -723,10 +721,15 @@ where
                 FragmentDistributionType::Unspecified => unreachable!(),
             }
 
-            fragment_updated_bitmap
-                .try_insert(*fragment_id, fragment_bitmap)
-                .unwrap();
+            if let Err(e) = fragment_updated_bitmap.try_insert(*fragment_id, fragment_bitmap) {
+                assert_eq!(
+                    e.entry.get(),
+                    &e.value,
+                    "bitmaps derived from different no-shuffle upstreams mismatch"
+                );
+            }
 
+            // Visit downstream fragments recursively.
             if let Some(downstream_fragments) = ctx.fragment_dispatcher_map.get(fragment_id) {
                 let no_shuffle_downstreams = downstream_fragments
                     .iter()
@@ -1249,7 +1252,7 @@ where
         fragment_actors_to_remove: &HashMap<FragmentId, BTreeMap<ActorId, ParallelUnitId>>,
         fragment_actors_to_create: &HashMap<FragmentId, BTreeMap<ActorId, ParallelUnitId>>,
         fragment_actor_bitmap: &HashMap<FragmentId, HashMap<ActorId, Bitmap>>,
-        no_shuffle_upstream_actor_map: &HashMap<ActorId, ActorId>,
+        no_shuffle_upstream_actor_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
         no_shuffle_downstream_actors_map: &HashMap<ActorId, HashMap<FragmentId, ActorId>>,
         new_actor: &mut StreamActor,
     ) -> MetaResult<()> {
@@ -1293,9 +1296,9 @@ where
                     );
                 }
                 DispatcherType::NoShuffle => {
-                    let no_shuffle_upstream_actor_id = no_shuffle_upstream_actor_map
+                    let no_shuffle_upstream_actor_id = *no_shuffle_upstream_actor_map
                         .get(&new_actor.actor_id)
-                        .cloned()
+                        .and_then(|map| map.get(upstream_fragment_id))
                         .unwrap();
 
                     applied_upstream_fragment_actor_ids.insert(

--- a/src/tests/simulation/src/ctl_ext.rs
+++ b/src/tests/simulation/src/ctl_ext.rs
@@ -103,7 +103,7 @@ pub mod predicate {
             // The rescheduling of no-shuffle downstreams must be derived from the most upstream
             // fragment. So if a fragment has no-shuffle upstreams, it cannot be rescheduled.
             !any(root(f), &|n| {
-                let NodeBody::Merge(merge) = n.node_body else { return false };
+                let Some(NodeBody::Merge(merge)) = &n.node_body else { return false };
                 merge.upstream_dispatcher_type() == DispatcherType::NoShuffle
             })
         };

--- a/src/tests/simulation/src/ctl_ext.rs
+++ b/src/tests/simulation/src/ctl_ext.rs
@@ -33,6 +33,9 @@ use crate::cluster::Cluster;
 
 /// Predicates used for locating fragments.
 pub mod predicate {
+    use risingwave_pb::stream_plan::stream_node::NodeBody;
+    use risingwave_pb::stream_plan::DispatcherType;
+
     use super::*;
 
     trait Predicate = Fn(&PbFragment) -> bool + Send + 'static;
@@ -96,10 +99,14 @@ pub mod predicate {
 
     /// The fragment is able to be rescheduled. Used for locating random fragment.
     pub fn can_reschedule() -> BoxedPredicate {
-        // The rescheduling of no-shuffle downstreams must be derived from the upstream
-        // `Materialize`, not specified by the user.
-        let p =
-            |f: &PbFragment| no_identity_contains("Chain")(f) && no_identity_contains("Lookup")(f);
+        let p = |f: &PbFragment| {
+            // The rescheduling of no-shuffle downstreams must be derived from the most upstream
+            // fragment. So if a fragment has no-shuffle upstreams, it cannot be rescheduled.
+            !any(root(f), &|n| {
+                let NodeBody::Merge(merge) = n.node_body else { return false };
+                merge.upstream_dispatcher_type() == DispatcherType::NoShuffle
+            })
+        };
         Box::new(p)
     }
 

--- a/src/tests/simulation/tests/it/scale/mod.rs
+++ b/src/tests/simulation/tests/it/scale/mod.rs
@@ -13,11 +13,11 @@
 // limitations under the License.
 
 mod cascade_materialized_view;
-mod delta_join;
 mod dynamic_filter;
 mod nexmark_chaos;
 mod nexmark_q4;
 mod nexmark_source;
+mod no_shuffle;
 mod singleton_migration;
 mod streaming_parallelism;
 mod table;

--- a/src/tests/simulation/tests/it/scale/no_shuffle.rs
+++ b/src/tests/simulation/tests/it/scale/no_shuffle.rs
@@ -125,13 +125,13 @@ async fn test_share_multiple_no_shuffle_upstream() -> Result<()> {
     let mut cluster = Cluster::start(Configuration::for_scale()).await?;
     let mut session = cluster.start_session();
 
-    session.run("create table t (v int);").await?;
+    session.run("create table t (a int, b int);").await?;
     session
         .run("create materialized view mv as with cte as (select a, sum(b) sum from t group by a) select count(*) from cte c1 join cte c2 on c1.a = c2.a;")
         .await?;
 
     let fragment = cluster
-        .locate_one_fragment([identity_contains("hash_agg")])
+        .locate_one_fragment([identity_contains("hashagg")])
         .await?;
 
     cluster.reschedule(fragment.reschedule([0], [])).await?;

--- a/src/tests/simulation/tests/it/scale/no_shuffle.rs
+++ b/src/tests/simulation/tests/it/scale/no_shuffle.rs
@@ -119,3 +119,23 @@ async fn test_delta_join() -> Result<()> {
 
     Ok(())
 }
+
+#[madsim::test]
+async fn test_share_multiple_no_shuffle_upstream() -> Result<()> {
+    let mut cluster = Cluster::start(Configuration::for_scale()).await?;
+    let mut session = cluster.start_session();
+
+    session.run("create table t (v int);").await?;
+    session
+        .run("create materialized view mv as with cte as (select a, sum(b) sum from t group by a) select count(*) from cte c1 join cte c2 on c1.a = c2.a;")
+        .await?;
+
+    let fragment = cluster
+        .locate_one_fragment([identity_contains("hash_agg")])
+        .await?;
+
+    cluster.reschedule(fragment.reschedule([0], [])).await?;
+    cluster.reschedule(fragment.reschedule([], [0])).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As mentioned in https://github.com/risingwavelabs/risingwave/pull/9381/files#r1174785930. This PR makes `Share` always be transformed into a `NoShuffle` exchange.

After that, I also found an issue of not handling multiple no-shuffle upstream fragments when scaling (like the topology below, fragment 4 has two no-shuffle upstreams 5 and 7). This PR also fixes that.

<img width="1080" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/8eb134fa-5ed6-4eeb-bcec-beef433643ae">

Since we've introduced more no-shuffles in nexmark chaos scaling test, this PR also makes `can_reschedule` more general to avoid trying to reschedule a non-upstream-most no-shuffle fragment.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
