### PR TITLE
fix(connector): s3 source up to 1k objects

### DIFF
--- a/e2e_test/s3/json_file.py
+++ b/e2e_test/s3/json_file.py
@@ -77,7 +77,7 @@ def do_test(client, config, N,  prefix):
 if __name__ == "__main__":
     config = json.loads(os.environ["S3_SOURCE_TEST_CONF"])
     run_id = str(random.randint(1000, 9999))
-    N = 100
+    N = 1080
 
     for i in range(N):
         with open(f"data_{i}.json", "w") as f:

--- a/src/connector/src/source/filesystem/s3/enumerator.rs
+++ b/src/connector/src/source/filesystem/s3/enumerator.rs
@@ -94,35 +94,41 @@ impl SplitEnumerator for S3SplitEnumerator {
     }
 
     async fn list_splits(&mut self) -> anyhow::Result<Vec<Self::Split>> {
-        let list_obj_out = self
-            .client
-            .list_objects_v2()
-            .bucket(&self.bucket_name)
-            .set_prefix(self.prefix.clone())
-            .send()
-            .await?;
+        let mut objects = Vec::new();
+        let mut next_continuation_token = None;
+        loop {
+            let mut req = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.bucket_name)
+                .set_prefix(self.prefix.clone());
+            if let Some(continuation_token) = next_continuation_token.take() {
+                req = req.continuation_token(continuation_token);
+            }
+            let mut res = req.send().await?;
+            objects.extend(res.contents.take().unwrap_or_default());
+            if res.is_truncated() {
+                next_continuation_token = Some(res.next_continuation_token().unwrap())
+            } else {
+                break;
+            }
+        }
 
-        let objects = list_obj_out.contents();
-        let splits = if let Some(objs) = objects {
-            let matched_objs = objs
-                .iter()
-                .filter(|obj| obj.key().is_some())
-                .filter(|obj| {
-                    self.matcher
-                        .as_ref()
-                        .map(|m| m.is_match(obj.key().unwrap()))
-                        .unwrap_or(true)
-                })
-                .collect_vec();
+        let matched_objs = objects
+            .iter()
+            .filter(|obj| obj.key().is_some())
+            .filter(|obj| {
+                self.matcher
+                    .as_ref()
+                    .map(|m| m.is_match(obj.key().unwrap()))
+                    .unwrap_or(true)
+            })
+            .collect_vec();
 
-            matched_objs
-                .into_iter()
-                .map(|obj| FsSplit::new(obj.key().unwrap().to_owned(), 0, obj.size() as usize))
-                .collect_vec()
-        } else {
-            Vec::new()
-        };
-        Ok(splits)
+        Ok(matched_objs
+            .into_iter()
+            .map(|obj| FsSplit::new(obj.key().unwrap().to_owned(), 0, obj.size() as usize))
+            .collect_vec())
     }
 }
 

--- a/src/connector/src/source/filesystem/s3/enumerator.rs
+++ b/src/connector/src/source/filesystem/s3/enumerator.rs
@@ -108,7 +108,7 @@ impl SplitEnumerator for S3SplitEnumerator {
             let mut res = req.send().await?;
             objects.extend(res.contents.take().unwrap_or_default());
             if res.is_truncated() {
-                next_continuation_token = Some(res.next_continuation_token().unwrap())
+                next_continuation_token = Some(res.next_continuation_token.unwrap())
             } else {
                 break;
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Our S3 connector uses `list_objects_v2` API to list objects of a bucket, but this API returns up to 1000 objects once. I have improved it to break the limit.



## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
