### PR TITLE
fix(frontend): cast `default` exprs when creating table

### DIFF
--- a/e2e_test/batch/basic/table_with_default_columns.slt.part
+++ b/e2e_test/batch/basic/table_with_default_columns.slt.part
@@ -32,4 +32,19 @@ statement error
 update t1 set (v1, v2) = (0, default);
 
 statement ok
+create table t2 (v1 int, v2 int default 1.5);
+
+statement ok
+insert into t2 values (1), (2);
+
+query II
+select * from t2;
+----
+1 2
+2 2
+
+statement ok
 drop table t1;
+
+statement ok
+drop table t2;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -258,9 +258,15 @@ pub fn bind_sql_column_constraints(
                 ColumnOption::DefaultColumns(expr) => {
                     let idx = binder
                         .get_column_binding_index(table_name.clone(), &column.name.real_value())?;
-                    let expr_impl = binder.bind_expr(expr)?;
+                    let mut expr_impl = binder.bind_expr(expr)?;
 
                     check_default_column_constraints(&expr_impl, column_catalogs)?;
+
+                    let target = column_catalogs[idx].data_type().clone();
+
+                    if expr_impl.return_type() != target {
+                        expr_impl = expr_impl.cast_assign(target)?;
+                    }
 
                     column_catalogs[idx].column_desc.generated_or_default_column =
                         Some(GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc {

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -258,15 +258,11 @@ pub fn bind_sql_column_constraints(
                 ColumnOption::DefaultColumns(expr) => {
                     let idx = binder
                         .get_column_binding_index(table_name.clone(), &column.name.real_value())?;
-                    let mut expr_impl = binder.bind_expr(expr)?;
+                    let expr_impl = binder
+                        .bind_expr(expr)?
+                        .cast_assign(column_catalogs[idx].data_type().clone())?;
 
                     check_default_column_constraints(&expr_impl, column_catalogs)?;
-
-                    let target = column_catalogs[idx].data_type().clone();
-
-                    if expr_impl.return_type() != target {
-                        expr_impl = expr_impl.cast_assign(target)?;
-                    }
 
                     column_catalogs[idx].column_desc.generated_or_default_column =
                         Some(GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
`default` exprs are casted when creating table, if applicable.
<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
`default` exprs are casted when creating table
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
