### PR TITLE
chore: add more logs in EtcdElectionClient

### DIFF
--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -146,7 +146,7 @@ impl ElectionClient for EtcdElectionClient {
             // timeout controller, when keep alive fails for more than a certain period of time
             // before it is considered a complete failure
             let keep_alive_timeout_duration = Duration::from_secs_f64(ttl as f64 / 2.0);
-            let mut timeout = time::interval(keep_alive_timeout_duration.clone());
+            let mut timeout = time::interval(keep_alive_timeout_duration);
             timeout.reset();
 
             let mut keep_alive_sending = false;
@@ -187,7 +187,7 @@ impl ElectionClient for EtcdElectionClient {
 
                                 // try to re-create lease keeper, with timeout as ttl / 2
                                 // TODO: should we introduce retry with backoff here?
-                                match time::timeout(keep_alive_timeout_duration.clone(), lease_client.keep_alive(lease_id)).await {
+                                match time::timeout(keep_alive_timeout_duration, lease_client.keep_alive(lease_id)).await {
                                     Ok(Ok((keeper_, resp_stream_))) => {
                                         keeper = keeper_;
                                         resp_stream = resp_stream_;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled, this PR adds more logs when the etcd lease keeper response stream is closed.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
