### PR TITLE
chore(frontend): refine dedup display

### DIFF
--- a/src/frontend/planner_test/tests/testdata/distinct_on.yaml
+++ b/src/frontend/planner_test/tests/testdata/distinct_on.yaml
@@ -5,7 +5,7 @@
   stream_plan: |
     StreamMaterialize { columns: [sum, t1.k(hidden)], stream_key: [t1.k], pk_columns: [t1.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr1, t1.k] }
-      └─StreamAppendOnlyDedup { dedup_cols: [1] }
+      └─StreamAppendOnlyDedup { dedup_cols: [t1.k] }
         └─StreamExchange { dist: HashShard(t1.k) }
           └─StreamProject { exprs: [(t1.k + t1.v) as $expr1, t1.k, t1._row_id] }
             └─StreamTableScan { table: t1, columns: [t1.k, t1.v, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_source.yaml
@@ -636,12 +636,12 @@
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
     └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
-      | └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2, 3] }
+      | └─StreamAppendOnlyDedup { dedup_cols: [id, name, $expr1, $expr2] }
       |   └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
       |     └─StreamProject { exprs: [id, name, TumbleStart(date_time, '00:00:10':Interval) as $expr1, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr2] }
       |       └─StreamRowIdGen { row_id_index: 8 }
       |         └─StreamSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "extra", "_row_id"] }
-      └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] }
+      └─StreamAppendOnlyDedup { dedup_cols: [seller, $expr3, $expr4] }
         └─StreamExchange { dist: HashShard(seller, $expr3, $expr4) }
           └─StreamProject { exprs: [seller, TumbleStart(date_time, '00:00:10':Interval) as $expr3, (TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr4] }
             └─StreamRowIdGen { row_id_index: 10 }
@@ -652,11 +652,11 @@
     ├── materialized table: 4294967294
     └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
-        └── StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] } { state table: 6 }
+        └── StreamAppendOnlyDedup { dedup_cols: [seller, $expr3, $expr4] } { state table: 6 }
             └──  StreamExchange Hash([0, 1, 2]) from 3
 
     Fragment 1
-    StreamAppendOnlyDedup { dedup_cols: [0, 1, 2, 3] } { state table: 4 }
+    StreamAppendOnlyDedup { dedup_cols: [id, name, $expr1, $expr2] } { state table: 4 }
     └──  StreamExchange Hash([0, 1, 2, 3]) from 2
 
     Fragment 2

--- a/src/frontend/planner_test/tests/testdata/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/nexmark_watermark.yaml
@@ -701,7 +701,7 @@
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
     └─StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
       ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
-      | └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2, 3] }
+      | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
       |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
       |     └─StreamProject { exprs: [Field(person, 0:Int32) as $expr2, Field(person, 1:Int32) as $expr3, TumbleStart($expr1, '00:00:10':Interval) as $expr4, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5], output_watermarks: [$expr4, $expr5] }
       |       └─StreamFilter { predicate: (event_type = 0:Int32) }
@@ -712,7 +712,7 @@
       |                 └─StreamWatermarkFilter { watermark_descs: [idx: 4, expr: ($expr1 - '00:00:04':Interval)] }
       |                   └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
       |                     └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
-      └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] }
+      └─StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] }
         └─StreamExchange { dist: HashShard($expr6, $expr7, $expr8) }
           └─StreamProject { exprs: [Field(auction, 7:Int32) as $expr6, TumbleStart($expr1, '00:00:10':Interval) as $expr7, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr8], output_watermarks: [$expr7, $expr8] }
             └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -729,11 +729,11 @@
     ├── materialized table: 4294967294
     └── StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
-        └── StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] } { state table: 7 }
+        └── StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] } { state table: 7 }
             └──  StreamExchange Hash([0, 1, 2]) from 4
 
     Fragment 1
-    StreamAppendOnlyDedup { dedup_cols: [0, 1, 2, 3] } { state table: 4 }
+    StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] } { state table: 4 }
     └──  StreamExchange Hash([0, 1, 2, 3]) from 2
 
     Fragment 2
@@ -775,7 +775,7 @@
     └─StreamSort { sort_column_index: 2 }
       └─StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
         ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
-        | └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2, 3] }
+        | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
         |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
         |     └─StreamProject { exprs: [Field(person, 0:Int32) as $expr2, Field(person, 1:Int32) as $expr3, TumbleStart($expr1, '00:00:10':Interval) as $expr4, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5], output_watermarks: [$expr4, $expr5] }
         |       └─StreamFilter { predicate: (event_type = 0:Int32) }
@@ -786,7 +786,7 @@
         |                 └─StreamWatermarkFilter { watermark_descs: [idx: 4, expr: ($expr1 - '00:00:04':Interval)] }
         |                   └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
         |                     └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
-        └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] }
+        └─StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] }
           └─StreamExchange { dist: HashShard($expr6, $expr7, $expr8) }
             └─StreamProject { exprs: [Field(auction, 7:Int32) as $expr6, TumbleStart($expr1, '00:00:10':Interval) as $expr7, (TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr8], output_watermarks: [$expr7, $expr8] }
               └─StreamFilter { predicate: (event_type = 1:Int32) }

--- a/src/frontend/planner_test/tests/testdata/tpch_variant.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch_variant.yaml
@@ -279,7 +279,7 @@
       └─StreamProject { exprs: [p_partkey, min(ps_supplycost)] }
         └─StreamHashAgg { group_key: [p_partkey], aggs: [min(ps_supplycost), count] }
           └─StreamHashJoin { type: LeftOuter, predicate: p_partkey IS NOT DISTINCT FROM ps_partkey, output: [p_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, _row_id, _row_id, r_regionkey, s_nationkey] }
-            ├─StreamAppendOnlyDedup { dedup_cols: [0] }
+            ├─StreamAppendOnlyDedup { dedup_cols: [p_partkey] }
             | └─StreamExchange { dist: HashShard(p_partkey) }
             |   └─StreamProject { exprs: [p_partkey] }
             |     └─StreamShare { id = 26 }
@@ -349,7 +349,7 @@
         └── StreamProject { exprs: [p_partkey, min(ps_supplycost)] }
             └── StreamHashAgg { group_key: [p_partkey], aggs: [min(ps_supplycost), count] } { result table: 26, state tables: [ 25 ], distinct tables: [] }
                 └── StreamHashJoin { type: LeftOuter, predicate: p_partkey IS NOT DISTINCT FROM ps_partkey, output: [p_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, _row_id, _row_id, r_regionkey, s_nationkey] } { left table: 27, right table: 29, left degree table: 28, right degree table: 30 }
-                    ├── StreamAppendOnlyDedup { dedup_cols: [0] } { state table: 31 }
+                    ├── StreamAppendOnlyDedup { dedup_cols: [p_partkey] } { state table: 31 }
                     │   └──  StreamExchange Hash([0]) from 15
                     └──  StreamExchange Hash([0]) from 16
 

--- a/src/frontend/planner_test/tests/testdata/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/watermark.yaml
@@ -135,7 +135,7 @@
     select * from t1 Union select * from t2;
   stream_plan: |
     StreamMaterialize { columns: [ts, v1, v2], stream_key: [ts, v1, v2], pk_columns: [ts, v1, v2], pk_conflict: "NoCheck", watermark_columns: [ts] }
-    └─StreamAppendOnlyDedup { dedup_cols: [0, 1, 2] }
+    └─StreamAppendOnlyDedup { dedup_cols: [t1.ts, t1.v1, t1.v2] }
       └─StreamExchange { dist: HashShard(t1.ts, t1.v1, t1.v2) }
         └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2], output_watermarks: [t1.ts] }
           └─StreamUnion { all: true, output_watermarks: [t1.ts] }

--- a/src/frontend/src/optimizer/plan_node/generic/dedup.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dedup.rs
@@ -14,7 +14,8 @@
 
 use std::fmt;
 
-use risingwave_common::catalog::Schema;
+use itertools::Itertools;
+use risingwave_common::catalog::{FieldDisplay, Schema};
 
 use super::{GenericPlanNode, GenericPlanRef};
 use crate::optimizer::property::FunctionalDependencySet;
@@ -30,8 +31,15 @@ pub struct Dedup<PlanRef> {
 impl<PlanRef: GenericPlanRef> Dedup<PlanRef> {
     pub fn fmt_with_name(&self, f: &mut fmt::Formatter<'_>, name: &str) -> fmt::Result {
         let mut builder = f.debug_struct(name);
-        builder.field("dedup_cols", &self.dedup_cols);
+        builder.field("dedup_cols", &self.dedup_cols_display());
         builder.finish()
+    }
+
+    fn dedup_cols_display(&self) -> Vec<FieldDisplay<'_>> {
+        self.dedup_cols
+            .iter()
+            .map(|i| FieldDisplay(self.input.schema().fields.get(*i).unwrap()))
+            .collect_vec()
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Print column names instead of column indexs for `Dedup`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
