### PR TITLE
feat: Add resign functionality to the etcd election client.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3588,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-etcd-client"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d983cdf1cd40f94b64cbf89e17f9113a77846a19afaec77d6c9a16ad487a50"
+checksum = "6ad4d69f43b9dc6463eca29edd83ac0dba36308c0e7b88ea83b87aff43649a1a"
 dependencies = [
  "etcd-client",
  "futures-util",

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -26,7 +26,7 @@ crepe = "0.1"
 easy-ext = "1"
 either = "1"
 enum-as-inner = "0.5"
-etcd-client = { version = "0.2", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2.23", package = "madsim-etcd-client" }
 fail = "0.5"
 function_name = "0.3.0"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -26,7 +26,7 @@ crepe = "0.1"
 easy-ext = "1"
 either = "1"
 enum-as-inner = "0.5"
-etcd-client = { version = "0.2.23", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2", package = "madsim-etcd-client" }
 fail = "0.5"
 function_name = "0.3.0"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -16,7 +16,7 @@ use std::borrow::BorrowMut;
 use std::collections::HashSet;
 use std::time::Duration;
 
-use etcd_client::{ConnectOptions, Error, GetOptions};
+use etcd_client::{ConnectOptions, Error, GetOptions, LeaderKey, ResignOptions};
 use risingwave_common::bail;
 use tokio::sync::watch::Receiver;
 use tokio::sync::{oneshot, watch};
@@ -213,25 +213,31 @@ impl ElectionClient for EtcdElectionClient {
         if !restored_leader {
             self.is_leader_sender.send_replace(false);
             tracing::info!("no restored leader, campaigning");
-            tokio::select! {
-                biased;
-
-                _ = stop.changed() => {
-                    tracing::info!("stop signal received when campaigning");
-                    return Ok(());
-                }
-
-                _ = keep_alive_fail_rx.borrow_mut() => {
-                    tracing::error!("keep alive failed, stopping main loop");
-                    bail!("keep alive failed, stopping main loop");
-                },
-
-                campaign_resp = self.client.campaign(META_ELECTION_KEY, self.id.as_bytes().to_vec(), lease_id) => {
-                    campaign_resp?;
-                    tracing::info!("client {} wins election {}", self.id, META_ELECTION_KEY);
-                }
-            };
         }
+
+        // Even if we are already a restored leader, we still need to campaign to obtain the correct
+        // `LeaderKey` from campaign response, which is used to provide the parameter for the
+        // resign call.
+        let leader_key: Option<LeaderKey> = tokio::select! {
+            biased;
+
+            _ = stop.changed() => {
+                tracing::info!("stop signal received when campaigning");
+                return Ok(());
+            }
+
+            _ = keep_alive_fail_rx.borrow_mut() => {
+                tracing::error!("keep alive failed, stopping main loop");
+                bail!("keep alive failed, stopping main loop");
+            },
+
+
+            campaign_resp = self.client.campaign(META_ELECTION_KEY, self.id.as_bytes().to_vec(), lease_id) => {
+                let campaign_resp = campaign_resp?;
+                tracing::info!("client {} wins election {}", self.id, META_ELECTION_KEY);
+                campaign_resp.leader().cloned()
+            }
+        };
 
         self.is_leader_sender.send_replace(true);
 
@@ -242,6 +248,12 @@ impl ElectionClient for EtcdElectionClient {
                 biased;
                 _ = stop.changed() => {
                     tracing::info!("stop signal received when observing");
+
+                    if let Some(leader_key) = leader_key {
+                        tracing::info!("leader key found with lease {}, resigning", leader_key.lease());
+                        self.client.resign(Some(ResignOptions::new().with_leader(leader_key))).await?;
+                    }
+
                     break;
                 },
                 _ = keep_alive_fail_rx.borrow_mut() => {
@@ -350,70 +362,20 @@ mod tests {
     use etcd_client::GetOptions;
     use itertools::Itertools;
     use tokio::sync::watch;
+    use tokio::sync::watch::Sender;
     use tokio::time;
 
     use crate::rpc::election_client::{ElectionClient, EtcdElectionClient, META_ELECTION_KEY};
 
+    type ElectionHandle = (Sender<()>, Arc<dyn ElectionClient>);
+
     #[tokio::test]
     async fn test_election() {
-        let handle = tokio::spawn(async move {
-            let addr = "0.0.0.0:2388".parse().unwrap();
-            let mut builder = etcd_client::SimServer::builder();
-            builder.serve(addr).await.unwrap();
-        });
-
-        let mut clients: Vec<(watch::Sender<()>, Arc<dyn ElectionClient>)> = vec![];
-
-        for i in 0..3 {
-            let (stop_sender, stop_receiver) = watch::channel(());
-            clients.push((
-                stop_sender,
-                Arc::new(
-                    EtcdElectionClient::new(
-                        vec!["localhost:2388".to_string()],
-                        None,
-                        false,
-                        format!("client_{}", i).to_string(),
-                    )
-                    .await
-                    .unwrap(),
-                ),
-            ));
-        }
-
-        for client in &clients {
-            assert!(!client.1.is_leader().await);
-        }
-
-        for (stop_sender, client) in &clients {
-            let client_ = client.clone();
-            let stop = stop_sender.subscribe();
-
-            tokio::spawn(async move {
-                let mut ticker = time::interval(Duration::from_secs(1));
-                loop {
-                    ticker.tick().await;
-                    if let Ok(_) = client_.run_once(5, stop.clone()).await {
-                        break;
-                    }
-                }
-            });
-        }
+        let clients = prepare_election_client(3, 5).await;
 
         time::sleep(Duration::from_secs(10)).await;
 
-        let mut leaders = vec![];
-        let mut followers = vec![];
-        for (sender, client) in &clients {
-            if client.is_leader().await {
-                leaders.push((sender, client));
-            } else {
-                followers.push((sender, client));
-            }
-        }
-
-        assert_eq!(leaders.len(), 1);
-        assert_eq!(followers.len(), 2);
+        let (leaders, followers) = check_role(clients, 1, 2).await;
 
         let leader = leaders.into_iter().next().unwrap();
 
@@ -422,18 +384,7 @@ mod tests {
 
         time::sleep(Duration::from_secs(10)).await;
 
-        let mut new_leaders = vec![];
-        let mut new_followers = vec![];
-        for (sender, client) in followers {
-            if client.is_leader().await {
-                new_leaders.push((sender, client));
-            } else {
-                new_followers.push((sender, client));
-            }
-        }
-
-        assert_eq!(new_leaders.len(), 1);
-        assert_eq!(new_followers.len(), 1);
+        let (new_leaders, new_followers) = check_role(followers, 1, 1).await;
 
         let leader = new_leaders.into_iter().next().unwrap();
         let election_leader = leader.1.leader().await.unwrap().unwrap();
@@ -466,5 +417,95 @@ mod tests {
         let leader = new_followers.into_iter().next().unwrap();
 
         assert!(leader.1.is_leader().await);
+    }
+
+    #[tokio::test]
+    async fn test_resign() {
+        // with a long ttl
+        let clients = prepare_election_client(3, 1000).await;
+
+        time::sleep(Duration::from_secs(10)).await;
+
+        let (leaders, followers) = check_role(clients, 1, 2).await;
+
+        let leader = leaders.into_iter().next().unwrap();
+
+        // stop leader
+        leader.0.send(()).unwrap();
+
+        time::sleep(Duration::from_secs(10)).await;
+
+        check_role(followers, 1, 1).await;
+    }
+
+    async fn check_role(
+        clients: Vec<ElectionHandle>,
+        leader_count: usize,
+        follower_count: usize,
+    ) -> (Vec<ElectionHandle>, Vec<ElectionHandle>) {
+        let mut leaders = vec![];
+        let mut followers = vec![];
+        for (sender, client) in clients {
+            if client.is_leader().await {
+                leaders.push((sender, client));
+            } else {
+                followers.push((sender, client));
+            }
+        }
+
+        assert_eq!(leaders.len(), leader_count);
+        assert_eq!(followers.len(), follower_count);
+        (leaders, followers)
+    }
+
+    async fn prepare_election_client(
+        count: i32,
+        ttl: i64,
+    ) -> Vec<(Sender<()>, Arc<dyn ElectionClient>)> {
+        let handle = tokio::spawn(async move {
+            let addr = "0.0.0.0:2388".parse().unwrap();
+            let mut builder = etcd_client::SimServer::builder();
+            builder.serve(addr).await.unwrap();
+        });
+
+        let mut clients: Vec<(watch::Sender<()>, Arc<dyn ElectionClient>)> = vec![];
+
+        for i in 0..count {
+            let (stop_sender, stop_receiver) = watch::channel(());
+            clients.push((
+                stop_sender,
+                Arc::new(
+                    EtcdElectionClient::new(
+                        vec!["localhost:2388".to_string()],
+                        None,
+                        false,
+                        format!("client_{}", i).to_string(),
+                    )
+                    .await
+                    .unwrap(),
+                ),
+            ));
+        }
+
+        for client in &clients {
+            assert!(!client.1.is_leader().await);
+        }
+
+        for (stop_sender, client) in &clients {
+            let client_ = client.clone();
+            let stop = stop_sender.subscribe();
+
+            tokio::spawn(async move {
+                let mut ticker = time::interval(Duration::from_secs(1));
+                loop {
+                    ticker.tick().await;
+                    if let Ok(_) = client_.run_once(ttl, stop.clone()).await {
+                        break;
+                    }
+                }
+            });
+        }
+
+        clients
     }
 }

--- a/src/meta/src/rpc/election_client.rs
+++ b/src/meta/src/rpc/election_client.rs
@@ -440,8 +440,8 @@ mod tests {
 
     async fn check_role(
         clients: Vec<ElectionHandle>,
-        leader_count: usize,
-        follower_count: usize,
+        expected_leader_count: usize,
+        expected_follower_count: usize,
     ) -> (Vec<ElectionHandle>, Vec<ElectionHandle>) {
         let mut leaders = vec![];
         let mut followers = vec![];
@@ -453,8 +453,8 @@ mod tests {
             }
         }
 
-        assert_eq!(leaders.len(), leader_count);
-        assert_eq!(followers.len(), follower_count);
+        assert_eq!(leaders.len(), expected_leader_count);
+        assert_eq!(followers.len(), expected_follower_count);
         (leaders, followers)
     }
 

--- a/src/meta/src/storage/wrapped_etcd_client.rs
+++ b/src/meta/src/storage/wrapped_etcd_client.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use etcd_client::{
     CampaignResponse, ConnectOptions, DeleteOptions, DeleteResponse, GetOptions, GetResponse,
     LeaderResponse, LeaseGrantOptions, LeaseGrantResponse, LeaseKeepAliveStream, LeaseKeeper,
-    ObserveStream, PutOptions, PutResponse, Txn, TxnResponse,
+    ObserveStream, PutOptions, PutResponse, ResignOptions, ResignResponse, Txn, TxnResponse,
 };
 use tokio::sync::RwLock;
 
@@ -163,6 +163,13 @@ impl_etcd_client_command_proxy!(
     election_client,
     (name: impl Into<Vec<u8>>),
     ObserveStream
+);
+
+impl_etcd_client_command_proxy!(
+    resign,
+    election_client,
+    (option: Option<ResignOptions>),
+    ResignResponse
 );
 
 impl WrappedEtcdClient {

--- a/src/tests/simulation/Cargo.toml
+++ b/src/tests/simulation/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 aws-sdk-s3 = { version = "0.2.17", package = "madsim-aws-sdk-s3" }
 clap = { version = "4", features = ["derive"] }
 console = "0.15"
-etcd-client = { version = "0.2.20", package = "madsim-etcd-client" }
+etcd-client = { version = "0.2.23", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 glob = "0.3"
 itertools = "0.10"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds the resign functionality to the etcd election client. The etcd election client actively resigns after the planned stop is executed, preventing downtime when `meta_leader_lease_secs` is too long.

This pull request adds a new `ResignOptions` parameter to the `ElectionClient` in the `etcd_client` library, enabling the provision of the correct `LeaderKey` which is used for the `resign` call. Additionally, it extends the `impl_etcd_client_command_proxy` macro to include `resign` and `ResignResponse` functionality. 

The test cases have also been updated to include tests for the newly added `resign` function.


## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
