### PR TITLE
fix(frontend): force user specify at least one pk when create upsert json source 

### DIFF
--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -184,7 +184,7 @@ WITH (
     scan.startup.mode = 'earliest')
 ROW format JSON;
 
-# we cannot create debezium source without pk
+# we cannot create maxwell source without pk
 statement error
 create table s13 (
   id integer,
@@ -316,6 +316,22 @@ WITH (
   properties.bootstrap.server = '127.0.0.1:29092',
 	topic = 'debezium_mongo_json_customers')
 ROW FORMAT DEBEZIUM_MONGO_JSON
+
+# we cannot create upsert_json source without pk
+statement error
+CREATE TABLE upsert_students (
+    "ID" INT,
+    "firstName" VARCHAR,
+    "lastName" VARCHAR,
+    age INT,
+    height REAL,
+    weight REAL
+)
+WITH (
+	connector = 'kafka',
+  properties.bootstrap.server = '127.0.0.1:29092',
+	topic = 'upsert_json')
+ROW FORMAT UPSERT_JSON
 
 statement ok
 CREATE TABLE upsert_students (

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -301,10 +301,21 @@ pub(crate) async fn resolve_source_schema(
             row_format: RowFormatType::Json as i32,
             ..Default::default()
         },
-        SourceSchema::UpsertJson => StreamSourceInfo {
-            row_format: RowFormatType::UpsertJson as i32,
-            ..Default::default()
-        },
+
+        SourceSchema::UpsertJson => {
+            // return err if user has not specified a pk
+            if row_id_index.is_some() {
+                return Err(RwError::from(ProtocolError(
+                    "Primary key must be specified when creating source with row format upsert_json."
+                        .to_string(),
+                )));
+            }
+
+            StreamSourceInfo {
+                row_format: RowFormatType::UpsertJson as i32,
+                ..Default::default()
+            }    
+        }
 
         SourceSchema::Maxwell => {
             // return err if user has not specified a pk

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -314,7 +314,7 @@ pub(crate) async fn resolve_source_schema(
             StreamSourceInfo {
                 row_format: RowFormatType::UpsertJson as i32,
                 ..Default::default()
-            }    
+            }
         }
 
         SourceSchema::Maxwell => {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Fix #9872 according to the discussion in #9771. Reject req if pk is not provided.
<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
