### PR TITLE
refactor(batch agg): simplify batch agg generation

### DIFF
--- a/src/frontend/planner_test/tests/testdata/agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/agg.yaml
@@ -218,9 +218,9 @@
     select v1, max(v2) from t group by v1 order by v1 desc;
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
-    └─BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-      └─BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
-        └─BatchSort { order: [t.v1 DESC] }
+    └─BatchSort { order: [t.v1 DESC] }
+      └─BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+        └─BatchExchange { order: [], dist: HashShard(t.v1) }
           └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - name: Use BatchSortAgg, when required order satisfies input order
   sql: |
@@ -229,9 +229,9 @@
   batch_plan: |
     BatchExchange { order: [t.k1 ASC], dist: Single }
     └─BatchProject { exprs: [max(t.v1), t.k1, t.k2] }
-      └─BatchSortAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
-        └─BatchExchange { order: [t.k1 ASC, t.k2 ASC], dist: HashShard(t.k1, t.k2) }
-          └─BatchSort { order: [t.k1 ASC, t.k2 ASC] }
+      └─BatchSort { order: [t.k1 ASC] }
+        └─BatchHashAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
+          └─BatchExchange { order: [], dist: HashShard(t.k1, t.k2) }
             └─BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
 - name: Use BatchSortAgg, when output requires order with swapped output
   sql: |
@@ -240,9 +240,9 @@
   batch_plan: |
     BatchExchange { order: [t.v1 DESC], dist: Single }
     └─BatchProject { exprs: [max(t.v2), t.v1] }
-      └─BatchSortAgg { group_key: [t.v1], aggs: [max(t.v2)] }
-        └─BatchExchange { order: [t.v1 DESC], dist: HashShard(t.v1) }
-          └─BatchSort { order: [t.v1 DESC] }
+      └─BatchSort { order: [t.v1 DESC] }
+        └─BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
+          └─BatchExchange { order: [], dist: HashShard(t.v1) }
             └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
 - name: Not use BatchSortAgg, when input provides order
   sql: |
@@ -265,8 +265,7 @@
     └─BatchSort { order: [t.v1 DESC] }
       └─BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
         └─BatchExchange { order: [], dist: HashShard(t.v1) }
-          └─BatchSort { order: [t.v1 DESC] }
-            └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+          └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   with_config_map:
     RW_BATCH_ENABLE_SORT_AGG: 'false'
 - name: Not use BatchSortAgg, when required order satisfies input order
@@ -279,8 +278,7 @@
       └─BatchSort { order: [t.k1 ASC] }
         └─BatchHashAgg { group_key: [t.k1, t.k2], aggs: [max(t.v1)] }
           └─BatchExchange { order: [], dist: HashShard(t.k1, t.k2) }
-            └─BatchSort { order: [t.k1 ASC, t.k2 ASC] }
-              └─BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
+            └─BatchScan { table: t, columns: [t.k1, t.k2, t.v1], distribution: SomeShard }
   with_config_map:
     RW_BATCH_ENABLE_SORT_AGG: 'false'
 - name: Not use BatchSortAgg, when output requires order with swapped output
@@ -293,8 +291,7 @@
       └─BatchSort { order: [t.v1 DESC] }
         └─BatchHashAgg { group_key: [t.v1], aggs: [max(t.v2)] }
           └─BatchExchange { order: [], dist: HashShard(t.v1) }
-            └─BatchSort { order: [t.v1 DESC] }
-              └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
+            └─BatchScan { table: t, columns: [t.v1, t.v2], distribution: SomeShard }
   with_config_map:
     RW_BATCH_ENABLE_SORT_AGG: 'false'
 - sql: |
@@ -1297,9 +1294,11 @@
     create index idx_desc on t(a desc);
     select a, count(*) cnt from t group by a order by a asc;
   batch_plan: |
-    BatchExchange { order: [idx_asc.a ASC], dist: Single }
-    └─BatchSortAgg { group_key: [idx_asc.a], aggs: [count] }
-      └─BatchScan { table: idx_asc, columns: [idx_asc.a], distribution: UpstreamHashShard(idx_asc.a) }
+    BatchExchange { order: [t.a ASC], dist: Single }
+    └─BatchSort { order: [t.a ASC] }
+      └─BatchHashAgg { group_key: [t.a], aggs: [count] }
+        └─BatchExchange { order: [], dist: HashShard(t.a) }
+          └─BatchScan { table: t, columns: [t.a], distribution: SomeShard }
 - name: sort agg on a descending index
   sql: |
     create table t (a int, b int);
@@ -1307,6 +1306,8 @@
     create index idx_desc on t(a desc);
     select a, count(*) cnt from t group by a order by a desc;
   batch_plan: |
-    BatchExchange { order: [idx_desc.a DESC], dist: Single }
-    └─BatchSortAgg { group_key: [idx_desc.a], aggs: [count] }
-      └─BatchScan { table: idx_desc, columns: [idx_desc.a], distribution: UpstreamHashShard(idx_desc.a) }
+    BatchExchange { order: [t.a DESC], dist: Single }
+    └─BatchSort { order: [t.a DESC] }
+      └─BatchHashAgg { group_key: [t.a], aggs: [count] }
+        └─BatchExchange { order: [], dist: HashShard(t.a) }
+          └─BatchScan { table: t, columns: [t.a], distribution: SomeShard }

--- a/src/frontend/planner_test/tests/testdata/order_by.yaml
+++ b/src/frontend/planner_test/tests/testdata/order_by.yaml
@@ -217,9 +217,9 @@
     SELECT b % 2 AS f, SUM(a) FROM test GROUP BY b % 2 ORDER BY f;
   batch_plan: |
     BatchExchange { order: [$expr1 ASC], dist: Single }
-    └─BatchSortAgg { group_key: [$expr1], aggs: [sum(test.a)] }
-      └─BatchExchange { order: [$expr1 ASC], dist: HashShard($expr1) }
-        └─BatchSort { order: [$expr1 ASC] }
+    └─BatchSort { order: [$expr1 ASC] }
+      └─BatchHashAgg { group_key: [$expr1], aggs: [sum(test.a)] }
+        └─BatchExchange { order: [], dist: HashShard($expr1) }
           └─BatchProject { exprs: [(test.b % 2:Int32) as $expr1, test.a] }
             └─BatchScan { table: test, columns: [test.a, test.b], distribution: SomeShard }
 - name: Orderby with always-false predicate
@@ -239,9 +239,9 @@
     BatchProject { exprs: [1:Int32] }
     └─BatchExchange { order: [t1.v1 ASC], dist: Single }
       └─BatchProject { exprs: [1:Int32, t1.v1] }
-        └─BatchSortAgg { group_key: [t1.v1], aggs: [] }
-          └─BatchExchange { order: [t1.v1 ASC], dist: HashShard(t1.v1) }
-            └─BatchSort { order: [t1.v1 ASC] }
+        └─BatchSort { order: [t1.v1 ASC] }
+          └─BatchHashAgg { group_key: [t1.v1], aggs: [] }
+            └─BatchExchange { order: [], dist: HashShard(t1.v1) }
               └─BatchValues { rows: [] }
 - name: distinct on order by
   sql: |

--- a/src/frontend/planner_test/tests/testdata/tpch.yaml
+++ b/src/frontend/planner_test/tests/testdata/tpch.yaml
@@ -3300,8 +3300,8 @@
             |   └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
             └─BatchProject { exprs: [lineitem.l_orderkey] }
               └─BatchFilter { predicate: (sum(lineitem.l_quantity) > 1:Decimal) }
-                └─BatchHashAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
-                  └─BatchExchange { order: [], dist: HashShard(lineitem.l_orderkey) }
+                └─BatchSortAgg { group_key: [lineitem.l_orderkey], aggs: [sum(lineitem.l_quantity)] }
+                  └─BatchExchange { order: [lineitem.l_orderkey ASC], dist: HashShard(lineitem.l_orderkey) }
                     └─BatchScan { table: lineitem, columns: [lineitem.l_orderkey, lineitem.l_quantity], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, quantity], stream_key: [c_custkey, c_name, o_orderkey, o_totalprice, o_orderdate], pk_columns: [o_totalprice, o_orderdate, c_custkey, c_name, o_orderkey], pk_conflict: "NoCheck" }

--- a/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
@@ -38,6 +38,8 @@ pub struct BatchSortAgg {
 
 impl BatchSortAgg {
     pub fn new(logical: generic::Agg<PlanRef>) -> Self {
+        assert!(logical.input_provides_order_on_group_keys());
+
         let input = logical.input.clone();
         let input_dist = input.distribution();
         let dist = match input_dist {
@@ -55,8 +57,6 @@ impl BatchSortAgg {
                 .cloned()
                 .collect(),
         };
-
-        assert_eq!(input_order.column_orders.len(), logical.group_key.len());
 
         let order = logical
             .i2o_col_mapping()

--- a/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort_agg.rs
@@ -17,7 +17,6 @@ use std::fmt;
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
 use risingwave_common::error::Result;
-use risingwave_common::types::DataType;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::SortAggNode;
 use risingwave_pb::expr::ExprNode;
@@ -114,6 +113,7 @@ impl ToDistributedBatch for BatchSortAgg {
 
 impl ToBatchPb for BatchSortAgg {
     fn to_batch_prost_body(&self) -> NodeBody {
+        let input = self.input();
         NodeBody::SortAgg(SortAggNode {
             agg_calls: self
                 .agg_calls()
@@ -123,7 +123,9 @@ impl ToBatchPb for BatchSortAgg {
             group_key: self
                 .group_key()
                 .ones()
-                .map(|idx| ExprImpl::InputRef(Box::new(InputRef::new(idx, DataType::Int32))))
+                .map(|idx| {
+                    ExprImpl::InputRef(InputRef::new(idx, input.schema()[idx].data_type()).into())
+                })
                 .map(|expr| expr.to_expr_proto())
                 .collect::<Vec<ExprNode>>(),
         })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Because the number of input rows is a lot larger than the number of output rows, sorting before aggregation can cause huge waste. This PR switches the behavior to only generate `BatchSortAgg` when input provides order on group keys.

Also closes #9838 cuz arbitrary group key type is supported in #9850 and this PR unlocks it in frontend.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
