### PR TITLE
refactor: use clap for multicall of all-in-one binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,6 +1408,7 @@ dependencies = [
  "anstyle",
  "bitflags 1.3.2",
  "clap_lex 0.4.1",
+ "once_cell",
  "strsim",
 ]
 
@@ -5765,6 +5766,8 @@ dependencies = [
  "risingwave_frontend",
  "risingwave_meta",
  "risingwave_rt",
+ "strum",
+ "strum_macros",
  "task_stats_alloc",
  "tempfile",
  "tikv-jemallocator",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -461,10 +461,11 @@ script = '''
 
 set -ex
 
-RUST_BACKTRACE=1 RW_NODE=playground \
+RUST_BACKTRACE=1 \
 cargo run --bin risingwave \
           --profile "${RISINGWAVE_BUILD_PROFILE}" \
-          ${RISINGWAVE_FEATURE_FLAGS}
+          ${RISINGWAVE_FEATURE_FLAGS} \
+          -- playground
 '''
 
 [tasks.ctl]

--- a/src/cmd_all/Cargo.toml
+++ b/src/cmd_all/Cargo.toml
@@ -20,7 +20,7 @@ ignored = ["workspace-hack", "workspace-config", "task_stats_alloc"]
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["cargo", "derive"] }
 console = "0.15"
 risingwave_common = { path = "../common" }
 risingwave_compactor = { path = "../storage/compactor" }
@@ -29,6 +29,8 @@ risingwave_ctl = { path = "../ctl" }
 risingwave_frontend = { path = "../frontend" }
 risingwave_meta = { path = "../meta" }
 risingwave_rt = { path = "../utils/runtime" }
+strum = "0.24"
+strum_macros = "0.24"
 tempfile = "3"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "rt",

--- a/src/cmd_all/src/playground.rs
+++ b/src/cmd_all/src/playground.rs
@@ -167,14 +167,18 @@ fn osstrs<const N: usize>(s: [&str; N]) -> Vec<OsString> {
     s.iter().map(OsString::from).collect()
 }
 
-pub async fn playground() -> Result<()> {
-    tracing::info!("launching playground");
+#[derive(Debug, Clone, Parser)]
+#[command(about = "The quick way to start a RisingWave cluster for playing around")]
+pub struct PlaygroundOpts {
+    /// The profile to use.
+    #[clap(short, long, env = "PLAYGROUND_PROFILE", default_value = "playground")]
+    profile: String,
+}
 
-    let profile = if let Ok(profile) = std::env::var("PLAYGROUND_PROFILE") {
-        profile.to_string()
-    } else {
-        "playground".to_string()
-    };
+pub async fn playground(opts: PlaygroundOpts) -> Result<()> {
+    let profile = opts.profile;
+
+    tracing::info!("launching playground with profile `{}`", profile);
 
     let (services, idle_exit) = get_services(&profile);
 

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -39,6 +39,10 @@ use serde::{Deserialize, Serialize};
 
 /// Command-line arguments for compute-node.
 #[derive(Parser, Clone, Debug)]
+#[command(
+    version,
+    about = "The worker node that executes query plans and handles data ingestion and output"
+)]
 pub struct ComputeNodeOpts {
     // TODO: rename to listen_addr and separate out the port.
     /// The address that this service listens to.

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -31,7 +31,7 @@ pub mod common;
 /// instead of playground mode to use this tool. risectl will read environment variables
 /// `RW_META_ADDR` and `RW_HUMMOCK_URL` to configure itself.
 #[derive(Parser)]
-#[clap(author, version, about, long_about = None)]
+#[clap(version, about = "The DevOps tool that provides internal access to the RisingWave cluster", long_about = None)]
 #[clap(propagate_version = true)]
 #[clap(infer_subcommands = true)]
 pub struct CliOpts {

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -74,6 +74,10 @@ use session::SessionManagerImpl;
 
 /// Command-line arguments for frontend-node.
 #[derive(Parser, Clone, Debug)]
+#[command(
+    version,
+    about = "The stateless proxy that parses SQL queries and performs planning and optimizations of query jobs"
+)]
 pub struct FrontendOpts {
     // TODO: rename to listen_addr and separate out the port.
     /// The address that this service listens to.

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -59,6 +59,7 @@ use crate::manager::MetaOpts;
 use crate::rpc::server::{rpc_serve, AddressInfo, MetaStoreBackend};
 
 #[derive(Debug, Clone, Parser)]
+#[command(version, about = "The central metadata management service")]
 pub struct MetaNodeOpts {
     #[clap(long, env = "RW_VPC_ID")]
     vpd_id: Option<String>,

--- a/src/storage/compactor/src/lib.rs
+++ b/src/storage/compactor/src/lib.rs
@@ -22,8 +22,12 @@ use risingwave_common_proc_macro::OverrideConfig;
 
 use crate::server::compactor_serve;
 
-/// Command-line arguments for compute-node.
+/// Command-line arguments for compactor-node.
 #[derive(Parser, Clone, Debug)]
+#[command(
+    version,
+    about = "The stateless worker node that compacts data for the storage engine"
+)]
 pub struct CompactorOpts {
     // TODO: rename to listen_addr and separate out the port.
     /// The address that this service listens to.

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -27,8 +27,8 @@ aws-types = { version = "0.51", default-features = false, features = ["hardcoded
 base64 = { version = "0.21" }
 bytes = { version = "1", features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+clap = { version = "4", features = ["cargo", "derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "help", "std", "suggestions", "usage"] }
 combine = { version = "4" }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
@@ -111,8 +111,8 @@ base64 = { version = "0.21" }
 bytes = { version = "1", features = ["serde"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive", "env"] }
-clap_builder = { version = "4", default-features = false, features = ["color", "env", "help", "std", "suggestions", "usage"] }
+clap = { version = "4", features = ["cargo", "derive", "env"] }
+clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "env", "help", "std", "suggestions", "usage"] }
 combine = { version = "4" }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Use `clap` builder for multi-call dispatching of all-in-one binary.

This PR also refactors the playground's profile arguments with `clap`.

Pros: perfectly consistent CLI style with other components

- All-in-one executable help
```
❯ target/debug/risingwave help      
All-in-one executable for components of RisingWave

Usage: risingwave <COMPONENT>

Components:
  compute     The worker node that executes query plans and handles data ingestion and output [aliases: compute-node, compute_node]
  meta        The central metadata management service [aliases: meta-node, meta_node]
  frontend    The stateless proxy that parses SQL queries and performs planning and optimizations of query jobs [aliases: frontend-node, frontend_node]
  compactor   The stateless worker node that compacts data for the storage engine [aliases: compactor-node, compactor_node]
  ctl         The DevOps tool that provides internal access to the RisingWave cluster [aliases: risectl]
  playground  The quick way to start a RisingWave cluster for playing around [aliases: play]
  help        Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

- Component help (`risingwave frontend --help` also works)
```
❯ target/debug/risingwave help frontend
The stateless proxy that parses SQL queries and performs planning and optimizations of query jobs

Usage: risingwave frontend [OPTIONS]

Options:
      --listen-addr <LISTEN_ADDR>
          The address that this service listens to. Usually the localhost + desired port
          
          [env: RW_LISTEN_ADDR=]
          [default: 127.0.0.1:4566]
```

- Multi-call works well
```
❯ ls -l .risingwave/bin/risingwave/frontend-node
lrwxr-xr-x  1 bugenzhao  staff  74 May 23 13:40 .risingwave/bin/risingwave/frontend-node -> /Users/bugenzhao/Developer/S/risingwave-opensource/target/debug/risingwave

❯ .risingwave/bin/risingwave/frontend-node --help         
The stateless proxy that parses SQL queries and performs planning and optimizations of query jobs

Usage: frontend [OPTIONS]

Options:
      --listen-addr <LISTEN_ADDR>
          The address that this service listens to. Usually the localhost + desired port
          
          [env: RW_LISTEN_ADDR=]
          [default: 127.0.0.1:4566]
```

Cons: `RW_NODE` support is removed due to not actually being used

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
