### PR TITLE
fix(over-window): don't produce watermark from eowc over window

### DIFF
--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -397,7 +397,6 @@ impl ToBatch for LogicalOverWindow {
 impl ToStream for LogicalOverWindow {
     fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<PlanRef> {
         let stream_input = self.core.input.to_stream(ctx)?;
-        stream_input.watermark_columns();
 
         if ctx.emit_on_window_close() {
             if !self.core.funcs_have_same_partition_and_order() {

--- a/src/frontend/src/optimizer/plan_node/stream_eowc_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_eowc_over_window.rs
@@ -48,9 +48,9 @@ impl StreamEowcOverWindow {
         let input_watermark_cols = logical.input.watermark_columns();
         assert!(input_watermark_cols.contains(order_key_idx));
 
-        // `EowcOverWindowExecutor` only maintains watermark on the order key column.
-        let mut watermark_columns = FixedBitSet::with_capacity(logical.output_len());
-        watermark_columns.insert(order_key_idx);
+        // `EowcOverWindowExecutor` cannot produce any watermark columns, because there may be some
+        // ancient rows in some rarely updated partitions that are emitted at the end of time.
+        let watermark_columns = FixedBitSet::with_capacity(logical.output_len());
 
         let base = PlanBase::new_stream_with_logical(
             &logical,

--- a/src/stream/src/executor/over_window/eowc.rs
+++ b/src/stream/src/executor/over_window/eowc.rs
@@ -24,7 +24,7 @@ use risingwave_common::array::{ArrayRef, Op, StreamChunk};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::estimate_size::EstimateSize;
 use risingwave_common::row::{OwnedRow, Row, RowExt};
-use risingwave_common::types::{DataType, DefaultOrd, ScalarImpl, ToDatumRef, ToOwnedDatum};
+use risingwave_common::types::{DataType, ToDatumRef, ToOwnedDatum};
 use risingwave_common::util::iter_util::{ZipEqDebug, ZipEqFast};
 use risingwave_common::util::memcmp_encoding;
 use risingwave_common::util::sort_util::OrderType;
@@ -41,7 +41,6 @@ use crate::executor::over_window::state::{StateEvictHint, StateKey};
 use crate::executor::{
     expect_first_barrier, ActorContextRef, BoxedExecutor, BoxedMessageStream, Executor,
     ExecutorInfo, Message, PkIndices, PkIndicesRef, StreamExecutorError, StreamExecutorResult,
-    Watermark,
 };
 use crate::task::AtomicU64Ref;
 
@@ -149,7 +148,6 @@ struct ExecutorInner<S: StateStore> {
 
 struct ExecutionVars<S: StateStore> {
     partitions: PartitionCache,
-    last_watermark: Option<ScalarImpl>,
     _phantom: PhantomData<S>,
 }
 
@@ -426,7 +424,6 @@ impl<S: StateStore> EowcOverWindowExecutor<S> {
 
         let mut vars = ExecutionVars {
             partitions: new_unbounded(this.watermark_epoch.clone()),
-            last_watermark: None,
             _phantom: PhantomData::<S>,
         };
 
@@ -442,33 +439,11 @@ impl<S: StateStore> EowcOverWindowExecutor<S> {
             let msg = msg?;
             match msg {
                 Message::Watermark(_) => {
-                    // Since we assume the input a `Sort`, we can emit watermarks by ourselves and
-                    // ignore any input watermarks.
                     continue;
                 }
                 Message::Chunk(chunk) => {
                     let output_chunk = Self::apply_chunk(&mut this, &mut vars, chunk).await?;
                     if let Some(chunk) = output_chunk {
-                        let first_order_key = chunk.columns()[this.order_key_index]
-                            .datum_at(0)
-                            .expect("order key must not be NULL");
-
-                        if vars.last_watermark.is_none()
-                            || vars
-                                .last_watermark
-                                .as_ref()
-                                .unwrap()
-                                .default_cmp(&first_order_key)
-                                .is_lt()
-                        {
-                            vars.last_watermark = Some(first_order_key.clone());
-                            yield Message::Watermark(Watermark::new(
-                                this.order_key_index,
-                                this.info.schema.fields()[this.order_key_index].data_type(),
-                                first_order_key,
-                            ));
-                        }
-
                         yield Message::Chunk(chunk);
                     }
                 }

--- a/src/stream/tests/integration_tests/eowc.rs
+++ b/src/stream/tests/integration_tests/eowc.rs
@@ -125,9 +125,6 @@ async fn test_over_window() {
                 | + | 4 | p2 | 200 | 20 |
                 +---+---+----+-----+----+
               output:
-              - !watermark
-                col_idx: 0
-                val: 1
               - !chunk |-
                 +---+---+----+-----+----+---+----+
                 | + | 1 | p1 | 100 | 10 |   | 16 |
@@ -159,9 +156,6 @@ async fn test_over_window() {
                 | + | 13 | p3 | 301 | 39 |
                 +---+----+----+-----+----+
               output:
-              - !watermark
-                col_idx: 0
-                val: 5
               - !chunk |-
                 +---+---+----+-----+----+----+----+
                 | + | 5 | p1 | 102 | 18 | 16 | 13 |
@@ -207,9 +201,6 @@ async fn test_over_window_aggregate() {
                 | + | 4 | p1 | 102 | 20 |
                 +---+---+----+-----+----+
               output:
-              - !watermark
-                col_idx: 0
-                val: 1
               - !chunk |-
                 +---+---+----+-----+----+----+
                 | + | 1 | p1 | 100 | 10 | 26 |


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

I found that the watermark produced by `EowcOverWindow` can be totally wrong. E.g.

```
lead(x) over (partition by $1 order by $0)
(1, 'a')
(2, 'b')
(3, 'b')
(7, 'b')
```

For the above input, the result of `'a'` won't be emitted until next `'a'` which may come several years later. Hence, no watermark can be produced on the `order by` column.

After some discussion with @st1page, we decided to not produce watermark in `EowcOverWindow`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
