### PR TITLE
feat(planner, overagg): support expression in the agg args

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -329,7 +329,7 @@
   sql: |
     create table t(x int, y int, z int, w int);
     select * from (
-        SELECT x, y, z, avg(z) OVER (PARTITION BY y + 1 order by abs(w)) as res FROM t
+        SELECT x, y, z, avg(z * z) OVER (PARTITION BY y + 1 order by abs(w)) as res FROM t
     )
     WHERE z > 0 and y > 0 and x > 0 and res <= 3;
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -27,7 +27,7 @@
   logical_plan: |
     LogicalProject { exprs: [lead] }
     └─LogicalOverWindow { window_functions: [lead(t.x) OVER(ROWS BETWEEN CURRENT ROW AND 2 FOLLOWING)] }
-      └─LogicalProject { exprs: [t.x, t._row_id] }
+      └─LogicalProject { exprs: [t.x, t._row_id, 2:Int32] }
         └─LogicalScan { table: t, columns: [t.x, t._row_id] }
   batch_error: |-
     Feature is not yet implemented: Batch over window is not implemented yet
@@ -561,19 +561,19 @@
   sql: |
     create table t(x int, y int, z int, w int);
     select * from (
-        SELECT x, y, z, avg(z) OVER (PARTITION BY y + 1 order by abs(w)) as res FROM t
+        SELECT x, y, z, avg(z * z) OVER (PARTITION BY y + 1 order by abs(w)) as res FROM t
     )
     WHERE z > 0 and y > 0 and x > 0 and res <= 3;
   logical_plan: |
     LogicalProject { exprs: [t.x, t.y, t.z, avg] }
     └─LogicalFilter { predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) AND (avg <= 3:Int32::Decimal) }
       └─LogicalProject { exprs: [t.x, t.y, t.z, avg] }
-        └─LogicalOverWindow { window_functions: [avg(t.z) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
-          └─LogicalProject { exprs: [t.x, t.y, t.z, t.w, t._row_id, Abs(t.w) as $expr1, (t.y + 1:Int32) as $expr2] }
+        └─LogicalOverWindow { window_functions: [avg($expr1) OVER(PARTITION BY $expr3 ORDER BY $expr2 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+          └─LogicalProject { exprs: [t.x, t.y, t.z, t.w, t._row_id, (t.z * t.z) as $expr1, Abs(t.w) as $expr2, (t.y + 1:Int32) as $expr3] }
             └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w, t._row_id] }
   optimized_logical_plan_for_batch: |
     LogicalProject { exprs: [t.x, t.y, t.z, avg] }
     └─LogicalFilter { predicate: (avg <= 3:Int32::Decimal) }
-      └─LogicalOverWindow { window_functions: [avg(t.z) OVER(PARTITION BY $expr2 ORDER BY $expr1 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
-        └─LogicalProject { exprs: [t.x, t.y, t.z, Abs(t.w) as $expr1, (t.y + 1:Int32) as $expr2] }
+      └─LogicalOverWindow { window_functions: [avg($expr1) OVER(PARTITION BY $expr3 ORDER BY $expr2 ASC ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW)] }
+        └─LogicalProject { exprs: [t.x, t.y, t.z, (t.z * t.z) as $expr1, Abs(t.w) as $expr2, (t.y + 1:Int32) as $expr3] }
           └─LogicalScan { table: t, columns: [t.x, t.y, t.z, t.w], predicate: (t.z > 0:Int32) AND (t.y > 0:Int32) AND (t.x > 0:Int32) }

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -64,6 +64,14 @@ impl LogicalOverWindow {
         let mut input_len = input.schema().len();
         for expr in &select_exprs {
             if let ExprImpl::WindowFunction(window_function) = expr {
+                let input_idx_in_args: Vec<_> = window_function
+                    .args
+                    .iter()
+                    .map(|x| input_proj_builder.add_expr(x))
+                    .try_collect()
+                    .map_err(|err| {
+                        ErrorCode::NotImplemented(format!("{err} inside args"), None.into())
+                    })?;
                 let input_idx_in_order_by: Vec<_> = window_function
                     .order_by
                     .sort_exprs
@@ -82,6 +90,7 @@ impl LogicalOverWindow {
                         ErrorCode::NotImplemented(format!("{err} inside partition_by"), None.into())
                     })?;
                 input_len = input_len
+                    .max(*input_idx_in_args.iter().max().unwrap_or(&0) + 1)
                     .max(*input_idx_in_order_by.iter().max().unwrap_or(&0) + 1)
                     .max(*input_idx_in_partition_by.iter().max().unwrap_or(&0) + 1);
             }
@@ -215,14 +224,8 @@ impl LogicalOverWindow {
 
         let args = args
             .into_iter()
-            .map(|e| match e.as_input_ref() {
-                Some(i) => Ok(*i.clone()),
-                None => Err(ErrorCode::NotImplemented(
-                    "expression arguments in window function".to_string(),
-                    None.into(),
-                )),
-            })
-            .try_collect()?;
+            .map(|e| InputRef::new(input_proj_builder.expr_index(&e).unwrap(), e.return_type()))
+            .collect_vec();
 
         Ok(PlanWindowFunction {
             kind: window_function.kind,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

```sql
create table t(x int, y int, z int, w int);
select * from (
    SELECT x, y, z, avg(z * z) OVER (PARTITION BY y + 1 order by abs(w)) as res FROM t
)
WHERE z > 0 and y > 0 and x > 0 and res <= 3;
```

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators
