### PR TITLE
fix(sqlparser): allow single quoted value for `set time zone`

### DIFF
--- a/e2e_test/database/timezone.slt
+++ b/e2e_test/database/timezone.slt
@@ -30,3 +30,44 @@ query T
 show timezone;
 ----
 GMT
+
+statement ok
+set time zone local;
+
+statement ok
+set time zone default;
+
+statement ok
+set time zone 'utc';
+
+statement error Invalid value
+set time zone 'utcx';
+
+statement ok
+set time zone utc;
+
+statement error Invalid value
+set time zone utcx;
+
+statement ok
+set time zone "utc";
+
+statement error Invalid value
+set time zone "utcx";
+
+statement error Invalid value
+set time zone "default";
+
+statement error Invalid value
+set time zone "local";
+
+statement error Invalid value
+set time zone null;
+
+# The following are valid in PostgreSQL but we do not support them for simplicity.
+
+statement error Invalid value
+set time zone 12.3;
+
+statement error
+set time zone interval '1' hour;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3581,15 +3581,17 @@ impl Parser {
     pub fn parse_set(&mut self) -> Result<Statement, ParserError> {
         let modifier = self.parse_one_of_keywords(&[Keyword::SESSION, Keyword::LOCAL]);
         if self.parse_keywords(&[Keyword::TIME, Keyword::ZONE]) {
-            let value = if self.parse_keyword(Keyword::DEFAULT) {
-                SetTimeZoneValue::Default
-            } else if self.parse_keyword(Keyword::LOCAL) {
-                SetTimeZoneValue::Local
-            } else if let Ok(ident) = self.parse_identifier() {
-                SetTimeZoneValue::Ident(ident)
-            } else {
-                let value = self.parse_value()?;
-                SetTimeZoneValue::Literal(value)
+            let token = self.peek_token();
+            let value = match (self.parse_value(), token.token) {
+                (Ok(value), _) => SetTimeZoneValue::Literal(value),
+                (Err(_), Token::Word(w)) if w.keyword == Keyword::DEFAULT => {
+                    SetTimeZoneValue::Default
+                }
+                (Err(_), Token::Word(w)) if w.keyword == Keyword::LOCAL => SetTimeZoneValue::Local,
+                (Err(_), Token::Word(w)) => SetTimeZoneValue::Ident(w.to_ident()?),
+                (Err(_), unexpected) => {
+                    self.expected("variable value", unexpected.with_location(token.location))?
+                }
             };
 
             return Ok(Statement::SetTimeZone {

--- a/src/sqlparser/tests/testdata/set.yaml
+++ b/src/sqlparser/tests/testdata/set.yaml
@@ -6,9 +6,7 @@
 - input: SET TIME ZONE "Asia/Shanghai"
   formatted_sql: SET TIME ZONE "Asia/Shanghai"
 - input: SET TIME ZONE 'Asia/Shanghai'
-  error_msg: |-
-    sql parser error: Expected a value, found: EOF at the end
-    Near "SET TIME ZONE 'Asia/Shanghai'"
+  formatted_sql: SET TIME ZONE 'Asia/Shanghai'
 - input: SET TIME ZONE "UTC"
   formatted_sql: SET TIME ZONE "UTC"
 - input: SET TIME ZONE UTC


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Allow `set time zone 'utc';` (in addition to `set time zone utc;` without quotes).

see https://github.com/risingwavelabs/risingwave/pull/8572#discussion_r1138158571
used by cube #9946

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
