### PR TITLE
fix: Temporarily rolling back the Kinesis split reduction feature

### DIFF
--- a/src/connector/src/source/base.rs
+++ b/src/connector/src/source/base.rs
@@ -224,15 +224,6 @@ pub enum ConnectorProperties {
 }
 
 impl ConnectorProperties {
-    // Used to support the reduction of split
-    pub fn enable_split_reduction(&self) -> bool {
-        // for now, we only support kinesis
-        match self {
-            ConnectorProperties::Kinesis(prop) => prop.enable_split_reduction.unwrap_or(false),
-            _ => false,
-        }
-    }
-
     fn new_cdc_properties(
         connector_name: &str,
         properties: HashMap<String, String>,

--- a/src/connector/src/source/kinesis/mod.rs
+++ b/src/connector/src/source/kinesis/mod.rs
@@ -34,12 +34,6 @@ pub struct KinesisProperties {
     )]
     pub seq_offset: Option<String>,
 
-    #[serde(
-        rename = "enable.split.reduction",
-        alias = "kinesis.enable.split.reduction"
-    )]
-    pub enable_split_reduction: Option<bool>,
-
     #[serde(flatten)]
     pub common: KinesisCommon,
 }

--- a/src/connector/src/source/kinesis/source/reader.rs
+++ b/src/connector/src/source/kinesis/source/reader.rs
@@ -289,7 +289,6 @@ mod tests {
 
             scan_startup_mode: None,
             seq_offset: None,
-            enable_split_reduction: None,
         };
 
         let mut trim_horizen_reader = KinesisSplitReader::new(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title, revert due to unstable behavior

## Checklist For Contributors

~- [ ] I have written necessary rustdoc comments~
~- [ ] I have added necessary unit tests and integration tests~
~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~
~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~
~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
