### PR TITLE
feat(iceberg): support iceberg hive catalog

### DIFF
--- a/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/iceberg/IcebergSinkFactoryTest.java
+++ b/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/iceberg/IcebergSinkFactoryTest.java
@@ -75,9 +75,7 @@ public class IcebergSinkFactoryTest {
                                         "table.name",
                                         tableName));
         try {
-            assertTrue(
-                    sink.getHadoopCatalog()
-                            .tableExists(TableIdentifier.of(databaseName, tableName)));
+            assertTrue(sink.getCatalog().tableExists(TableIdentifier.of(databaseName, tableName)));
             assertEquals(
                     sink.getIcebergTable().location(),
                     warehousePath + "/" + databaseName + "/" + tableName);

--- a/java/connector-node/risingwave-sink-iceberg/pom.xml
+++ b/java/connector-node/risingwave-sink-iceberg/pom.xml
@@ -35,9 +35,33 @@
             <artifactId>connector-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <version>2.3.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.hbase</groupId>
+                    <artifactId>hbase-client</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.protobuf</groupId>
+                    <artifactId>protobuf-java</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>com.risingwave.java</groupId>
             <artifactId>s3-common</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.iceberg</groupId>
+            <artifactId>iceberg-hive-metastore</artifactId>
+            <version>${iceberg.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.iceberg</groupId>

--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/IcebergSinkConfig.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/IcebergSinkConfig.java
@@ -23,6 +23,13 @@ import com.risingwave.connector.common.S3Config;
 public class IcebergSinkConfig extends S3Config {
     private String sinkType;
 
+    @JsonProperty(value = "catalog.type")
+    private String catalogType;
+
+    @JsonProperty(value = "metastore.uri")
+    private String metaStoreUri;
+
+    @JsonProperty(value = "warehouse.path")
     private String warehousePath;
 
     private String databaseName;
@@ -38,11 +45,9 @@ public class IcebergSinkConfig extends S3Config {
     @JsonCreator
     public IcebergSinkConfig(
             @JsonProperty(value = "type") String sinkType,
-            @JsonProperty(value = "warehouse.path") String warehousePath,
             @JsonProperty(value = "database.name") String databaseName,
             @JsonProperty(value = "table.name") String tableName) {
         this.sinkType = sinkType;
-        this.warehousePath = warehousePath;
         this.databaseName = databaseName;
         this.tableName = tableName;
     }
@@ -55,8 +60,12 @@ public class IcebergSinkConfig extends S3Config {
         return warehousePath;
     }
 
-    public void setWarehousePath(String warehousePath) {
-        this.warehousePath = warehousePath;
+    public String getCatalogType() {
+        return catalogType;
+    }
+
+    public String getMetaStoreUri() {
+        return metaStoreUri;
     }
 
     public String getDatabaseName() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Support hive catalog of iceberg.

User facing changes are adding several options when creating iceberg sink.
- `catalog.type`: can be `hive` or `hadoop`. Default is `hadoop`.
- `metastore.uri`: when `catalog.type` is `hive`, this is the uri for the hive metastore. Required when `catalog.type` is `hive`
- `warehouse.path`: it changes from an required field to an optional field. Required when `catalog.type` is `hadoop`.

SQL to create an iceberg table with hive catalog.
```
CREATE sink iceberg_sink
FROM
  sink_table
WITH
  (
    connector='iceberg',
    catalog.type='hive',
    metastore.uri='thrift://localhost:9083',
    primary_key='id',
    type='upsert',
    database.name='test_database',
    TABLE.name='test_table'
  );
```

part of https://github.com/risingwavelabs/risingwave/issues/8280

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators
Added options when creating iceberg sink.
- `catalog.type`: can be `hive` or `hadoop`. Default is `hadoop`.
- `metastore.uri`: when `catalog.type` is `hive`, this is the uri for the hive metastore. Required when `catalog.type` is `hive`
- `warehouse.path`: it changes from an required field to an optional field. Required when `catalog.type` is `hadoop`.

### Release note

Support iceberg hive catalog, which uses hive metastore as the catalog.

Added options when creating iceberg sink.
- `catalog.type`: can be `hive` or `hadoop`. Default is `hadoop`.
- `metastore.uri`: when `catalog.type` is `hive`, this is the uri for the hive metastore. Required when `catalog.type` is `hive`
- `warehouse.path`: it changes from an required field to an optional field. Required when `catalog.type` is `hadoop`.

</details>
