### PR TITLE
feat(meta): build info to telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6284,6 +6284,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "vergen",
  "workspace-hack",
 ]
 
@@ -8430,6 +8431,17 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vergen"
+version = "8.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b3c89c2c7e50f33e4d35527e5bf9c11d6d132226dbbd1753f0fbe9f19ef88c6"
+dependencies = [
+ "anyhow",
+ "rustversion",
+ "time 0.3.21",
+]
 
 [[package]]
 name = "version_check"

--- a/src/meta/Cargo.toml
+++ b/src/meta/Cargo.toml
@@ -6,6 +6,7 @@ homepage = { workspace = true }
 keywords = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+build = "build.rs"
 
 [package.metadata.cargo-machete]
 ignored = ["workspace-hack"]
@@ -85,6 +86,9 @@ rand = "0.8"
 risingwave_test_runner = { path = "../test_runner" }
 static_assertions = "1"
 tempfile = "3"
+
+[build-dependencies]
+vergen = { version = "8", features = ["build", "git", "gitcl"] }
 
 [features]
 test = []

--- a/src/meta/build.rs
+++ b/src/meta/build.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::error::Error;
 
 use vergen::EmitBuilder;

--- a/src/meta/build.rs
+++ b/src/meta/build.rs
@@ -1,0 +1,14 @@
+use std::error::Error;
+
+use vergen::EmitBuilder;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    EmitBuilder::builder()
+        .git_branch()
+        .git_sha(true)
+        // date when it is built
+        .build_date()
+        .quiet()
+        .emit()?;
+    Ok(())
+}

--- a/src/meta/src/telemetry.rs
+++ b/src/meta/src/telemetry.rs
@@ -27,6 +27,23 @@ use crate::model::ClusterId;
 use crate::storage::MetaStore;
 
 #[derive(Debug, Serialize, Deserialize)]
+struct BuildInfo {
+    build_date: String,
+    git_branch: String,
+    git_sha: String,
+}
+
+impl BuildInfo {
+    fn new() -> Self {
+        Self {
+            build_date: env!("VERGEN_BUILD_DATE").to_string(),
+            git_branch: env!("VERGEN_GIT_BRANCH").to_string(),
+            git_sha: env!("VERGEN_GIT_SHA").to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
 struct NodeCount {
     meta_count: u64,
     compute_count: u64,
@@ -41,6 +58,8 @@ pub(crate) struct MetaTelemetryReport {
     node_count: NodeCount,
     // At this point, it will always be etcd, but we will enable telemetry when using memory.
     meta_backend: MetaBackend,
+
+    build_info: BuildInfo,
 }
 
 impl TelemetryReport for MetaTelemetryReport {
@@ -107,6 +126,7 @@ impl<S: MetaStore> TelemetryReportCreator for MetaReportCreator<S> {
                 compactor_count: *node_map.get(&WorkerType::Compactor).unwrap_or(&0),
             },
             meta_backend: self.meta_backend,
+            build_info: BuildInfo::new(),
         })
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Telemetry reports git sha and branch.

Example:
```json
{
.......
        "build_info": {
                "build_date": "2023-05-25",
                "git_branch": "feature/telemetry-version",
                "git_sha": "b80004956"
        },
}
```

<!--
copilot:all
-->
### <samp>🤖 Generated by Copilot at b800049</samp>

### Summary
🛠️📜📡

<!--
1.  🛠️ - This emoji represents the build script and the use of the `vergen` crate, which are tools for generating and accessing build information.
2.  📜 - This emoji represents the metadata and the `BuildInfo` struct, which are data sources that provide information about the project and its version.
3.  📡 - This emoji represents the telemetry data and the server communication, which are features that allow the node to report its status and performance.
-->
The meta crate now includes git and build information in the telemetry data of the risingwave node. This is done by using a build script and the `vergen` crate to generate and access these data at compile time.

> _`BuildInfo` struct_
> _sends git and build data_
> _telemetry in spring_

### Walkthrough
* Create a build script for the meta crate that generates environment variables for the git and build information using the vergen crate ([link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-901efd17070f14afd27c10d9387d8b956930cad81161c1d0adb94a4e64f1199fR1-R14), [link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-70b47595d20570400ebd4c680a4ea950f9d03b538ce682617b1333183cfd8bacR9), [link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-70b47595d20570400ebd4c680a4ea950f9d03b538ce682617b1333183cfd8bacR90-R92))
* Define a BuildInfo struct that holds the build date, the git branch, and the git sha as strings and can be created from the environment variables ([link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-eac347e281f44c7401ace0a5e0628564aae8579b38e7ed5bf43fe1e094138533R30-R46))
* Add a build_info field to the Telemetry struct that contains the BuildInfo struct and represents the git and build information of the node ([link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-eac347e281f44c7401ace0a5e0628564aae8579b38e7ed5bf43fe1e094138533R61-R62))
* Initialize the build_info field of the Telemetry struct with a new instance of BuildInfo from the environment variables in the `src/meta/src/telemetry.rs` file ([link](https://github.com/risingwavelabs/risingwave/pull/9995/files?diff=unified&w=0#diff-eac347e281f44c7401ace0a5e0628564aae8579b38e7ed5bf43fe1e094138533R129))



## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
