### PR TITLE
doc(expr): add docs for `#[function]` macro

### DIFF
--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -25,7 +25,7 @@ mod parse;
 mod types;
 mod utils;
 
-/// Defining expression from a Rust Function.
+/// Defining the RisingWave SQL function from a Rust function.
 ///
 /// [Online version of this doc.](https://risingwavelabs.github.io/risingwave/risingwave_expr_macro/attr.function.html)
 ///
@@ -43,7 +43,7 @@ mod utils;
 ///     - [Functions Returning Strings](#functions-returning-strings)
 ///     - [Preprocessing Constant Arguments](#preprocessing-constant-arguments)
 /// - [Table Function](#table-function)
-/// - [Function Registration and Invocation](#function-registration-and-invocation)
+/// - [Registration and Invocation](#registration-and-invocation)
 /// - [Appendix: Type Matrix](#appendix-type-matrix)
 ///
 /// The following example demonstrates a simple usage:
@@ -59,9 +59,11 @@ mod utils;
 ///
 /// Each function must have a signature, specified in the `function("...")` part of the macro
 /// invocation. The signature follows this pattern:
-/// ```
+///
+/// ```text
 /// name([arg_types],*) -> [setof] return_type
 /// ```
+///
 /// Where `name` is the function name, which must match the function name defined in `prost`.
 ///
 /// The allowed data types are listed in the `name` column of the appendix's [type matrix].
@@ -101,6 +103,9 @@ mod utils;
 /// #[function("cast(varchar) -> int32")]
 /// #[function("cast(varchar) -> int64")]
 /// ```
+///
+/// Please note the difference between `*` and `any`. `*` will generate a function for each type,
+/// whereas `any` will only generate one function with a dynamic data type `Scalar`.
 ///
 /// ## Automatic Type Inference
 ///
@@ -154,6 +159,7 @@ mod utils;
 /// The `#[function]` macro can handle various types of Rust functions.
 ///
 /// Each argument corresponds to the *reference type* in the [type matrix].
+///
 /// The return value type can be the *reference type* or *owned type* in the [type matrix].
 ///
 /// For instance:
@@ -263,7 +269,7 @@ mod utils;
 /// Currently, table function arguments do not support the `Option` type. That is, the function will
 /// only be invoked when all arguments are not null.
 ///
-/// # Function Registration and Invocation
+/// # Registration and Invocation
 ///
 /// Every function defined by `#[function]` is automatically registered in the global function
 /// table.
@@ -311,7 +317,7 @@ mod utils;
 /// | jsonb       | `jsonb`            | `JsonbVal`    | `JsonbRef<'_>`     | no         |
 /// | list        | `any[]`            | `ListValue`   | `ListRef<'_>`      | no         |
 /// | struct      | `record`           | `StructValue` | `StructRef<'_>`    | no         |
-/// | any         | `any`              | `Scalar`      | `ScalarRef<'_>`    | no         |
+/// | any         | `any`              | `ScalarImpl`  | `ScalarRef<'_>`    | no         |
 ///
 /// [type matrix]: #appendix-type-matrix
 #[proc_macro_attribute]

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -25,6 +25,274 @@ mod parse;
 mod types;
 mod utils;
 
+/// Defining expression from a Rust Function.
+///
+/// The following example demonstrates a simple usage:
+///
+/// ```ignore
+/// #[function("add(int32, int32) -> int32")]
+/// fn add(x: i32, y: i32) -> i32 {
+///     x + y
+/// }
+/// ```
+///
+/// ## Function Signature
+///
+/// Each function must have a signature, specified in the `function("...")` part of the macro
+/// invocation. The signature follows this pattern:
+/// ```
+/// name([arg_types],*) -> [setof] return_type
+/// ```
+/// Where `name` is the function name, which must match the function name defined in `prost`.
+///
+/// The allowed data types are listed in the `name` column of the appendix's type matrix. Wildcards
+/// or `auto` can also be used, as explained below.
+///
+/// When `setof` appears before the return type, this indicates that the function is a set-returning
+/// function (table function), meaning it can return multiple values instead of just one. For more
+/// details, see the section on table functions.
+///
+/// ### Multiple Function Definitions
+///
+/// Multiple `#[function]` macros can be applied to a single generic Rust function to define
+/// multiple SQL functions of different types. For example:
+///
+/// ```ignore
+/// #[function("add(int16, int16) -> int16")]
+/// #[function("add(int32, int32) -> int32")]
+/// #[function("add(int64, int64) -> int64")]
+/// fn add<T: Add>(x: T, y: T) -> T {
+///     x + y
+/// }
+/// ```
+///
+/// ### Type Expansion
+///
+/// Types can be automatically expanded to multiple types using wildcards. Here are some examples:
+///
+/// - `*`: expands to all types.
+/// - `*int`: expands to int16, int32, int64.
+/// - `*float`: expands to float32, float64.
+///
+/// For instance, `#[function("count(*int) -> int64")]` will be expanded to the following three
+/// functions:
+///
+/// ```ignore
+/// #[function("count(int16) -> int64")]
+/// #[function("count(int32) -> int64")]
+/// #[function("count(int64) -> int64")]
+/// ```
+///
+/// ### Automatic Type Inference
+///
+/// Correspondingly, the return type can be denoted as `auto` to be automatically inferred based on
+/// the input types. It will be inferred as the smallest type that can accommodate all input types.
+///
+/// For example, `#[function("add(*int, *int) -> auto")]` will be expanded to:
+///
+/// ```ignore
+/// #[function("add(int16, int16) -> int16")]
+/// #[function("add(int16, int32) -> int32")]
+/// #[function("add(int16, int64) -> int64")]
+/// #[function("add(int32, int16) -> int32")]
+/// ...
+/// ```
+///
+/// Especially when there is only one input argument, `auto` will be inferred as the type of that
+/// argument. For example, `#[function("neg(*int) -> auto")]` will be expanded to:
+///
+/// ```ignore
+/// #[function("neg(int16) -> int16")]
+/// #[function("neg(int32) -> int32")]
+/// #[function("neg(int64) -> int64")]
+/// ```
+///
+/// ### Custom Type Inference Function
+///
+/// A few functions might have a return type that dynamically changes based on the input argument
+/// types, such as `unnest`.
+///
+/// In such cases, the `type_infer` option can be used to specify a function to infer the return
+/// type based on the input argument types. Its function signature is
+///
+/// ```ignore
+/// fn(&[DataType]) -> Result<DataType>
+/// ```
+///
+/// For example:
+///
+/// ```ignore
+/// #[function(
+///     "unnest(list) -> setof any",
+///     type_infer = "|args| Ok(args[0].unnest_list())"
+/// )]
+/// ```
+///
+/// This function will be invoked at the frontend.
+///
+/// ## Rust Function Requirements
+///
+/// The `#[function]` macro can handle various types of Rust functions.
+///
+/// Each argument corresponds to the *reference type* in the type matrix.
+/// The return value type can be the *reference type* or *owned type* in the type matrix.
+///
+/// For instance:
+///
+/// ```ignore
+/// #[function("trim_array(list, int32) -> list")]
+/// fn trim_array(array: ListRef<'_>, n: i32) -> ListValue {...}
+/// ```
+///
+/// ### Nullable Arguments
+///
+/// The functions above will only be called when all arguments are not null. If null arguments need
+/// to be considered, the `Option` type can be used:
+///
+/// ```ignore
+/// #[function("trim_array(list, int32) -> list")]
+/// fn trim_array(array: Option<ListRef<'_>>, n: Option<i32>) -> ListValue {...}
+/// ```
+///
+/// Note that we currently only support all arguments being either `Option` or non-`Option`. Mixed
+/// cases are not supported.
+///
+/// ### Return Value
+///
+/// Similarly, the return value type can be one of the following:
+///
+/// - `T`: Indicates that a non-null value is always returned, and errors will not occur.
+/// - `Option<T>`: Indicates that a null value may be returned, but errors will not occur.
+/// - `Result<T>`: Indicates that an error may occur, but a null value will not be returned.
+/// - `Result<Option<T>>`: Indicates that a null value may be returned, and an error may also occur.
+///
+/// ### Optimization
+///
+/// When all input and output types of the function are *primitive type* (refer to the type matrix)
+/// and do not contain any Option or Result, the `#[function]` macro will automatically generate
+/// SIMD vectorized execution code.
+///
+/// ### Functions Returning Strings
+///
+/// For functions that return varchar types, you can also use the writer style function signature to
+/// avoid memory copying and dynamic memory allocation:
+///
+/// ```ignore
+/// #[function("trim(varchar) -> varchar")]
+/// pub fn trim(s: &str, writer: &mut dyn Write) {
+///     writer.write_str(s.trim()).unwrap();
+/// }
+/// ```
+///
+/// If errors may be returned, then the return value should be `Result<()>`:
+///
+/// ```ignore
+/// #[function("trim(varchar) -> varchar")]
+/// pub fn trim(s: &str, writer: &mut dyn Write) -> Result<()> {
+///     writer.write_str(s.trim()).unwrap();
+///     Ok(())
+/// }
+/// ```
+///
+/// ### Preprocessing Constant Arguments
+///
+/// When some input arguments of the function are constants, they can be preprocessed to avoid
+/// calculations every time the function is called.
+///
+/// A classic use case is regular expression matching:
+///
+/// ```ignore
+/// #[function(
+///     "regexp_match(varchar, varchar, varchar) -> varchar[]",
+///     prebuild = "RegexpContext::from_pattern_flags($1, $2)?"
+/// )]
+/// fn regexp_match(text: &str, regex: &RegexpContext) -> ListValue {
+///     regex.captures(text).collect()
+/// }
+/// ```
+///
+/// The `prebuild` argument can be specified, and its value is a Rust expression used to construct a
+/// new variable from the input arguments of the function. Here `$1`, `$2` represent the second and
+/// third arguments of the function (indexed from 0), and their types are `Datum`. In the Rust
+/// function signature, these positions of parameters will be omitted, replaced by an extra new
+/// variable at the end.
+///
+/// TODO: This macro will support both variable and constant inputs, and automatically optimize the
+/// preprocessing of constants. Currently, it only supports constant inputs.
+///
+/// ## Table Function
+///
+/// A table function is a special kind of function that can return multiple values instead of just
+/// one. Its function signature must include the `setof` keyword, and the Rust function should
+/// return an iterator of the form `impl Iterator<Item = T>` or its derived types.
+///
+/// For example:
+/// ```ignore
+/// #[function("generate_series(int32, int32) -> setof int32")]
+/// fn generate_series(start: i32, stop: i32) -> impl Iterator<Item = i32> {
+///     start..=stop
+/// }
+/// ```
+///
+/// Likewise, the return value `Iterator` can include `Option` or `Result` either internally or
+/// externally. For instance:
+///
+/// - `impl Iterator<Item = Result<T>>`
+/// - `Result<impl Iterator<Item = T>>`
+/// - `Result<impl Iterator<Item = Result<Option<T>>>>`
+///
+/// Currently, table function arguments do not support the `Option` type. That is, the function will
+/// only be invoked when all arguments are not null.
+///
+/// ## Function Registration and Invocation
+///
+/// Every function defined by `#[function]` is automatically registered in the global function
+/// table.
+///
+/// You can build expressions through the following functions:
+///
+/// ```ignore
+/// // scalar functions
+/// risingwave_expr::expr::build(...) -> BoxedExpression
+/// risingwave_expr::expr::build_from_prost(...) -> BoxedExpression
+/// // table functions
+/// risingwave_expr::table_function::build(...) -> BoxedTableFunction
+/// risingwave_expr::table_function::build_from_prost(...) -> BoxedTableFunction
+/// ```
+///
+/// Or get their metadata through the following functions:
+///
+/// ```ignore
+/// // scalar functions
+/// risingwave_expr::sig::func::FUNC_SIG_MAP::get(...)
+/// // table functions
+/// risingwave_expr::sig::table_function::FUNC_SIG_MAP::get(...)
+/// ```
+///
+/// ## Appendix: Type Matrix
+///
+/// | name        | SQL type           | owned type    | reference type     | primitive? |
+/// | ----------- | ------------------ | ------------- | ------------------ | ---------- |
+/// | boolean     | `boolean`          | `bool`        | `bool`             | yes        |
+/// | int16       | `smallint`         | `i16`         | `i16`              | yes        |
+/// | int32       | `integer`          | `i32`         | `i32`              | yes        |
+/// | int64       | `bigint`           | `i64`         | `i64`              | yes        |
+/// | int256      | `rw_int256`        | `Int256`      | `Int256Ref<'_>`    | no         |
+/// | float32     | `real`             | `F32`         | `F32`              | yes        |
+/// | float64     | `double precision` | `F64`         | `F64`              | yes        |
+/// | decimal     | `numeric`          | `Decimal`     | `Decimal`          | yes        |
+/// | serial      | `serial`           | `Serial`      | `Serial`           | yes        |
+/// | date        | `date`             | `Date`        | `Date`             | yes        |
+/// | time        | `time`             | `Time`        | `Time`             | yes        |
+/// | timestamp   | `timestamp`        | `Timestamp`   | `Timestamp`        | yes        |
+/// | timestamptz | `timestamptz`      | `i64`         | `i64`              | yes        |
+/// | interval    | `interval`         | `Interval`    | `Interval`         | yes        |
+/// | varchar     | `varchar`          | `Box<str>`    | `&str`             | no         |
+/// | bytea       | `bytea`            | `Box<[u8]>`   | `&[u8]`            | no         |
+/// | jsonb       | `jsonb`            | `JsonbVal`    | `JsonbRef<'_>`     | no         |
+/// | list        | `any[]`            | `ListValue`   | `ListRef<'_>`      | no         |
+/// | struct      | `record`           | `StructValue` | `StructRef<'_>`    | no         |
+/// | any         | `any`              | `Datum`       | `DatumRef<'_>`     | no         |
 #[proc_macro_attribute]
 pub fn function(attr: TokenStream, item: TokenStream) -> TokenStream {
     let attr = parse_macro_input!(attr as syn::AttributeArgs);

--- a/src/expr/src/expr/mod.rs
+++ b/src/expr/src/expr/mod.rs
@@ -18,10 +18,9 @@
 //!
 //! ## Construction
 //!
-//! Expressions can be constructed by functions like [`new_binary_expr`],
-//! which returns a [`BoxedExpression`].
+//! Expressions can be constructed by [`build()`] function, which returns a [`BoxedExpression`].
 //!
-//! They can also be transformed from the prost [`ExprNode`] using the [`build_from_prost`]
+//! They can also be transformed from the prost [`ExprNode`] using the [`build_from_prost()`]
 //! function.
 //!
 //! ## Evaluation

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -32,3 +32,4 @@ pub mod vector_op;
 
 pub use error::{ExprError, Result};
 use risingwave_common::{bail, ensure};
+pub use risingwave_expr_macro::*;

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -109,11 +109,8 @@ where
     })
 }
 
-#[function("neg(int16) -> int16")]
-#[function("neg(int32) -> int32")]
-#[function("neg(int64) -> int64")]
-#[function("neg(float32) -> float32")]
-#[function("neg(float64) -> float64")]
+#[function("neg(*int) -> auto")]
+#[function("neg(*float) -> auto")]
 #[function("neg(decimal) -> decimal")]
 pub fn general_neg<T1: CheckedNeg>(expr: T1) -> Result<T1> {
     expr.checked_neg().ok_or(ExprError::NumericOutOfRange)
@@ -130,11 +127,8 @@ where
         .ok_or(ExprError::NumericOutOfRange)
 }
 
-#[function("abs(int16) -> int16")]
-#[function("abs(int32) -> int32")]
-#[function("abs(int64) -> int64")]
-#[function("abs(float32) -> float32")]
-#[function("abs(float64) -> float64")]
+#[function("abs(*int) -> auto")]
+#[function("abs(*float) -> auto")]
 pub fn general_abs<T1: Signed + CheckedNeg>(expr: T1) -> Result<T1> {
     if expr.is_negative() {
         general_neg(expr)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title.

It's generated by GPT4 based on my draft.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] ~~I have added necessary unit tests and integration tests~~
- [x] ~~I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] ~~I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] ~~I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.~~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
