### PR TITLE
feat(frontend): add atttypmod column on pg_attribute table

### DIFF
--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -561,14 +561,14 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(view.id as i32)),
                             Some(ScalarImpl::Utf8(column.name.clone().into())),
                             Some(ScalarImpl::Int32(column.data_type().to_oid())),
-                            // From https://www.postgresql.org/docs/current/catalog-pg-attribute.html
-                            // The value will generally be -1 for types that do not need
-                            // `atttypmod`.
-                            Some(ScalarImpl::Int32(-1)),
                             Some(ScalarImpl::Int16(column.data_type().type_len())),
                             Some(ScalarImpl::Int16(index as i16 + 1)),
                             Some(ScalarImpl::Bool(false)),
                             Some(ScalarImpl::Bool(false)),
+                            // From https://www.postgresql.org/docs/current/catalog-pg-attribute.html
+                            // The value will generally be -1 for types that do not need
+                            // `atttypmod`.
+                            Some(ScalarImpl::Int32(-1)),
                         ])
                     })
                 });

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -561,6 +561,9 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(view.id as i32)),
                             Some(ScalarImpl::Utf8(column.name.clone().into())),
                             Some(ScalarImpl::Int32(column.data_type().to_oid())),
+                            /// From https://www.postgresql.org/docs/current/catalog-pg-attribute.html
+                            /// The value will generally be -1 for types that do not need `atttypmod`.
+                            Some(ScalarImpl::Int32(-1)),
                             Some(ScalarImpl::Int16(column.data_type().type_len())),
                             Some(ScalarImpl::Int16(index as i16 + 1)),
                             Some(ScalarImpl::Bool(false)),

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/mod.rs
@@ -561,8 +561,9 @@ impl SysCatalogReaderImpl {
                             Some(ScalarImpl::Int32(view.id as i32)),
                             Some(ScalarImpl::Utf8(column.name.clone().into())),
                             Some(ScalarImpl::Int32(column.data_type().to_oid())),
-                            /// From https://www.postgresql.org/docs/current/catalog-pg-attribute.html
-                            /// The value will generally be -1 for types that do not need `atttypmod`.
+                            // From https://www.postgresql.org/docs/current/catalog-pg-attribute.html
+                            // The value will generally be -1 for types that do not need
+                            // `atttypmod`.
                             Some(ScalarImpl::Int32(-1)),
                             Some(ScalarImpl::Int16(column.data_type().type_len())),
                             Some(ScalarImpl::Int16(index as i16 + 1)),

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
@@ -28,9 +28,9 @@ pub const PG_ATTRIBUTE_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "attrelid"),
     (DataType::Varchar, "attname"),
     (DataType::Int32, "atttypid"),
-    (DataType::Int32, "atttypmod"),
     (DataType::Int16, "attlen"),
     (DataType::Int16, "attnum"),
     (DataType::Boolean, "attnotnull"),
     (DataType::Boolean, "attisdropped"),
+    (DataType::Int32, "atttypmod"),
 ];

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_attribute.rs
@@ -28,6 +28,7 @@ pub const PG_ATTRIBUTE_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "attrelid"),
     (DataType::Varchar, "attname"),
     (DataType::Int32, "atttypid"),
+    (DataType::Int32, "atttypmod"),
     (DataType::Int16, "attlen"),
     (DataType::Int16, "attnum"),
     (DataType::Boolean, "attnotnull"),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix https://github.com/risingwavelabs/risingwave/issues/10019

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
