### PR TITLE
fix(sqlsmith): tolerate recovery error

### DIFF
--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -432,7 +432,12 @@ fn validate_response<_Row>(response: PgResult<_Row>) -> Result<i64> {
     }
 }
 
-/// Run query
+/// Run query, handle permissible errors
+/// For recovery error, just do bounded retry.
+/// For other errors, validate them accordingly, skipping if they are permitted.
+/// Otherwise just return success.
+///
+/// Returns: Number of skipped queries.
 async fn run_query(client: &Client, query: &str) -> Result<i64> {
     let response = client.simple_query(query).await;
     if let Err(e) = &response

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -14,7 +14,7 @@
 
 //! Provides E2E Test runner functionality.
 
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use itertools::Itertools;
 use rand::rngs::SmallRng;
 use rand::{Rng, SeedableRng};
@@ -22,9 +22,10 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaChaRng;
 use tokio_postgres::error::Error as PgError;
 use tokio_postgres::Client;
+use tokio::time::{sleep, Duration};
 
 use crate::utils::read_file_contents;
-use crate::validation::is_permissible_error;
+use crate::validation::{is_permissible_error, is_recovery_in_progress_error};
 use crate::{
     create_table_statement_to_table, insert_sql_gen, mview_sql_gen, parse_sql, session_sql_gen,
     sql_gen, Table,
@@ -50,8 +51,9 @@ pub async fn run_pre_generated(client: &Client, outdir: &str) {
     for statement in parse_sql(&queries) {
         let sql = statement.to_string();
         tracing::info!("[EXECUTING STATEMENT]: {}", sql);
-        validate_response(client.simple_query(&sql).await).unwrap();
+        run_query(client, &sql).await.unwrap();
     }
+    tracing::info!("[EXECUTION SUCCESS]");
 }
 
 /// Query Generator
@@ -98,8 +100,8 @@ pub async fn generate(
         test_session_variable(client, &mut rng).await;
         let sql = sql_gen(&mut rng, tables.clone());
         tracing::info!("[EXECUTING TEST_BATCH]: {}", sql);
-        let response = client.simple_query(sql.as_str()).await;
-        match validate_response(response) {
+        let result = run_query(client,sql.as_str()).await;
+        match result {
             Err(_e) => {
                 generated_queries += 1;
                 queries.push_str(&format!("-- {};\n", &sql));
@@ -121,8 +123,8 @@ pub async fn generate(
         test_session_variable(client, &mut rng).await;
         let (sql, table) = mview_sql_gen(&mut rng, tables.clone(), "stream_query");
         tracing::info!("[EXECUTING TEST_STREAM]: {}", sql);
-        let response = client.simple_query(&sql).await;
-        match validate_response(response) {
+        let result = run_query(client,sql.as_str()).await;
+        match result {
             Err(_e) => {
                 generated_queries += 1;
                 queries.push_str(&format!("-- {};\n", &sql));
@@ -304,8 +306,7 @@ async fn test_batch_queries<R: Rng>(
         test_session_variable(client, rng).await;
         let sql = sql_gen(rng, tables.clone());
         tracing::info!("[EXECUTING TEST_BATCH]: {}", sql);
-        let response = client.simple_query(sql.as_str()).await;
-        skipped += validate_response(response)?;
+        skipped += run_query(client,&sql).await?;
     }
     Ok(skipped as f64 / sample_size as f64)
 }
@@ -322,8 +323,7 @@ async fn test_stream_queries<R: Rng>(
         test_session_variable(client, rng).await;
         let (sql, table) = mview_sql_gen(rng, tables.clone(), "stream_query");
         tracing::info!("[EXECUTING TEST_STREAM]: {}", sql);
-        let response = client.simple_query(&sql).await;
-        skipped += validate_response(response)?;
+        skipped += run_query(client,&sql).await?;
         tracing::info!("[EXECUTING DROP MVIEW]: {}", &format_drop_mview(&table));
         drop_mview_table(&table, client).await;
     }
@@ -375,8 +375,7 @@ async fn create_mviews(
         let (create_sql, table) =
             mview_sql_gen(rng, mvs_and_base_tables.clone(), &format!("m{}", i));
         tracing::info!("[EXECUTING CREATE MVIEW]: {}", &create_sql);
-        let response = client.simple_query(&create_sql).await;
-        let skip_count = validate_response(response)?;
+        let skip_count = run_query(client, &create_sql).await?;
         if skip_count == 0 {
             mvs_and_base_tables.push(table.clone());
             mviews.push(table);
@@ -431,4 +430,27 @@ fn validate_response<_Row>(response: PgResult<_Row>) -> Result<i64> {
             Err(anyhow!("Encountered unexpected error: {e}"))
         }
     }
+}
+
+/// Run query
+async fn run_query(client: &Client, query: &str) -> Result<i64> {
+    let response = client.simple_query(query).await;
+    if let Err(e) = &response
+    && let Some(e) = e.as_db_error() {
+        if is_recovery_in_progress_error(&e.to_string()) {
+            let tries = 5;
+            let interval = 1;
+            for _ in 0..tries { // retry 5 times
+                sleep(Duration::from_millis(1 * 1000)).await;
+                let response = client.simple_query(query).await;
+                if let Ok(result) = response {
+                    return Ok(0)
+                }
+            }
+            bail!("Failed to recover after {tries} tries with interval {interval}s")
+        } else {
+            return validate_response(response);
+        }
+    }
+    Ok(0)
 }

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -78,6 +78,23 @@ fn is_broken_channel_error(db_error: &str) -> bool {
     db_error.contains("failed to finish command: channel closed")
 }
 
+/// Permit recovery error
+/// Suppose Out Of Range Error happens in the following query:
+/// ```sql
+/// SELECT sum0(v1) FROM t;
+/// ```
+/// It would be a valid scenario from Sqlsmith.
+/// In that case we would trigger recovery for the materialized view.
+/// We could encounter this error on subsequent queries:
+/// ```text
+/// Barrier read is unavailable for now. Likely the cluster is recovering
+/// ```
+/// Recovery should be successful after a while.
+/// Hence we should retry for some bound.
+pub fn is_recovery_in_progress_error(db_error: &str) -> bool {
+    db_error.contains("Barrier read is unavailable for now. Likely the cluster is recovering")
+}
+
 /// Certain errors are permitted to occur. This is because:
 /// 1. It is more complex to generate queries without these errors.
 /// 2. These errors seldom occur, skipping them won't affect overall effectiveness of sqlsmith.

--- a/src/tests/sqlsmith/src/validation.rs
+++ b/src/tests/sqlsmith/src/validation.rs
@@ -93,6 +93,7 @@ fn is_broken_channel_error(db_error: &str) -> bool {
 /// Hence we should retry for some bound.
 pub fn is_recovery_in_progress_error(db_error: &str) -> bool {
     db_error.contains("Barrier read is unavailable for now. Likely the cluster is recovering")
+        || db_error.contains("Service unavailable: The cluster is starting or recovering")
 }
 
 /// Certain errors are permitted to occur. This is because:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).


## What's changed and what's your intention?

Problem:
1. If stream query has error, it triggers recovery later on.
2. Then subsequent queries encounter `cluster is in recovery` error when they run.

Solution: On sqlsmith side we need to retry until it recovers, and permit recovery error.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
