### PR TITLE
fix(expr): `pow` behavior for decimal and special values

### DIFF
--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -43,10 +43,8 @@ select pow(100000, 0);
 ----
 1
 
-query R
+statement error underflow
 select pow(100000, -200000000000000);
-----
-0
 
 statement error QueryError: Expr error: Numeric out of range
 select pow(100000, 200000000000000);
@@ -100,10 +98,8 @@ select 100000 ^ 0;
 ----
 1
 
-query R
+statement error underflow
 select 100000 ^ -200000000000000;
-----
-0
 
 statement error QueryError: Expr error: Numeric out of range
 select 100000 ^ 200000000000000;
@@ -111,6 +107,84 @@ select 100000 ^ 200000000000000;
 
 statement error QueryError: Expr error: Numeric out of range
 select -100000 ^ 200000000000001;
+
+query RRR
+with t(x, y) as (values
+	('1', 'nan'),
+	('0', 'nan'),
+	('nan', '0'),
+	('nan', '-0'),
+	('0', 'inf'),
+	('-0', 'inf'),
+	('-1', 'inf'),
+	('-1', '-inf'),
+	('0.5', 'inf'),
+	('0.5', '-inf'),
+	('2', 'inf'),
+	('2', '-inf'),
+	('-0.5', 'inf'),
+	('-0.5', '-inf'),
+	('-2', 'inf'),
+	('-2', '-inf'),
+	('inf', '0'),
+	('inf', '-0'),
+	('-inf', '0'),
+	('-inf', '-0'),
+	('inf', '0.5'),
+	('inf', '-0.5'),
+	('-inf', '2'),
+	('-inf', '3'),
+	('-inf', '-2'),
+	('-inf', '-3'),
+	('-0', '3'),
+	('-0', '0.5'),
+	('0'::float8, '-0'::float8))
+select x, y, x ^ y from t;
+----
+        1       NaN         1
+        0       NaN       NaN
+      NaN         0         1
+      NaN        -0         1
+        0  Infinity         0
+       -0  Infinity         0
+       -1  Infinity         1
+       -1 -Infinity         1
+      0.5  Infinity         0
+      0.5 -Infinity  Infinity
+        2  Infinity  Infinity
+        2 -Infinity         0
+     -0.5  Infinity         0
+     -0.5 -Infinity  Infinity
+       -2  Infinity  Infinity
+       -2 -Infinity         0
+ Infinity         0         1
+ Infinity        -0         1
+-Infinity         0         1
+-Infinity        -0         1
+ Infinity       0.5  Infinity
+ Infinity      -0.5         0
+-Infinity         2  Infinity
+-Infinity         3 -Infinity
+-Infinity        -2         0
+-Infinity        -3        -0
+       -0         3        -0
+       -0       0.5         0
+        0        -0         1
+
+query RRR
+with t(v) as (
+	values ('-inf'::float8), ('inf'), ('nan')
+) select x, y, x ^ y from t as a(x), t as b(y);
+----
+-Infinity -Infinity        0
+-Infinity  Infinity Infinity
+-Infinity       NaN      NaN
+ Infinity -Infinity        0
+ Infinity  Infinity Infinity
+ Infinity       NaN      NaN
+      NaN -Infinity      NaN
+      NaN  Infinity      NaN
+      NaN       NaN      NaN
 
 query R
 select exp(0.0);

--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -34,7 +34,7 @@ select pow(2.0, -2);
 0.25
 
 query R
-select pow(2.23, -2.33);
+select pow(2.23::float8, -2.33);
 ----
 0.15432975583772085
 
@@ -89,7 +89,7 @@ select 2.0 ^ -2;
 0.25
 
 query R
-select 2.23 ^ -2.33;
+select 2.23::float8 ^ -2.33;
 ----
 0.15432975583772085
 
@@ -108,7 +108,7 @@ select 100000 ^ 200000000000000;
 statement error QueryError: Expr error: Numeric out of range
 select -100000 ^ 200000000000001;
 
-query RRR
+query RRRR
 with t(x, y) as (values
 	('1', 'nan'),
 	('0', 'nan'),
@@ -139,52 +139,73 @@ with t(x, y) as (values
 	('-0', '3'),
 	('-0', '0.5'),
 	('0'::float8, '-0'::float8))
-select x, y, x ^ y from t;
+select x, y, x ^ y, (x::decimal ^ y::decimal)::float8 from t;
 ----
-        1       NaN         1
-        0       NaN       NaN
-      NaN         0         1
-      NaN        -0         1
-        0  Infinity         0
-       -0  Infinity         0
-       -1  Infinity         1
-       -1 -Infinity         1
-      0.5  Infinity         0
-      0.5 -Infinity  Infinity
-        2  Infinity  Infinity
-        2 -Infinity         0
-     -0.5  Infinity         0
-     -0.5 -Infinity  Infinity
-       -2  Infinity  Infinity
-       -2 -Infinity         0
- Infinity         0         1
- Infinity        -0         1
--Infinity         0         1
--Infinity        -0         1
- Infinity       0.5  Infinity
- Infinity      -0.5         0
--Infinity         2  Infinity
--Infinity         3 -Infinity
--Infinity        -2         0
--Infinity        -3        -0
-       -0         3        -0
-       -0       0.5         0
-        0        -0         1
+        1       NaN         1         1
+        0       NaN       NaN       NaN
+      NaN         0         1         1
+      NaN        -0         1         1
+        0  Infinity         0         0
+       -0  Infinity         0         0
+       -1  Infinity         1         1
+       -1 -Infinity         1         1
+      0.5  Infinity         0         0
+      0.5 -Infinity  Infinity  Infinity
+        2  Infinity  Infinity  Infinity
+        2 -Infinity         0         0
+     -0.5  Infinity         0         0
+     -0.5 -Infinity  Infinity  Infinity
+       -2  Infinity  Infinity  Infinity
+       -2 -Infinity         0         0
+ Infinity         0         1         1
+ Infinity        -0         1         1
+-Infinity         0         1         1
+-Infinity        -0         1         1
+ Infinity       0.5  Infinity  Infinity
+ Infinity      -0.5         0         0
+-Infinity         2  Infinity  Infinity
+-Infinity         3 -Infinity -Infinity
+-Infinity        -2         0         0
+-Infinity        -3        -0         0
+       -0         3        -0         0
+       -0       0.5         0         0
+        0        -0         1         1
 
-query RRR
+query RRRR
 with t(v) as (
 	values ('-inf'::float8), ('inf'), ('nan')
-) select x, y, x ^ y from t as a(x), t as b(y);
+) select x, y, x ^ y, x::decimal ^ y::decimal from t as a(x), t as b(y);
 ----
--Infinity -Infinity        0
--Infinity  Infinity Infinity
--Infinity       NaN      NaN
- Infinity -Infinity        0
- Infinity  Infinity Infinity
- Infinity       NaN      NaN
-      NaN -Infinity      NaN
-      NaN  Infinity      NaN
-      NaN       NaN      NaN
+-Infinity -Infinity        0        0
+-Infinity  Infinity Infinity Infinity
+-Infinity       NaN      NaN      NaN
+ Infinity -Infinity        0        0
+ Infinity  Infinity Infinity Infinity
+ Infinity       NaN      NaN      NaN
+      NaN -Infinity      NaN      NaN
+      NaN  Infinity      NaN      NaN
+      NaN       NaN      NaN      NaN
+
+statement error zero raised to a negative power is undefined
+select pow(0::decimal, '-inf'::decimal);
+
+statement error a negative number raised to a non-integer power yields a complex result
+select pow('-inf'::decimal, 0.5);
+
+statement error zero raised to a negative power is undefined
+select pow(0::decimal, -2::decimal);
+
+statement error a negative number raised to a non-integer power yields a complex result
+select pow(-1::decimal, 0.5);
+
+statement error overflow
+select pow(2::decimal, 96::decimal);
+
+# This is considered underflow error for float8 but okay for decimal
+query R
+select pow(0.5::decimal, 2000::decimal)::float8;
+----
+0
 
 query R
 select exp(0.0);

--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -207,6 +207,10 @@ select pow(0.5::decimal, 2000::decimal)::float8;
 ----
 0
 
+# But rust_decimal is not good at this. Should be 0.
+statement error
+select pow(1e28, -2);
+
 query R
 select exp(0.0);
 ----

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -584,6 +584,7 @@ impl Decimal {
         use std::cmp::Ordering;
 
         match (self, rhs) {
+            // A. Handle `nan`, where `1 ^ nan == 1` and `nan ^ 0 == 1`
             (Decimal::NaN, Decimal::NaN)
             | (Decimal::PositiveInf, Decimal::NaN)
             | (Decimal::NegativeInf, Decimal::NaN)
@@ -598,18 +599,23 @@ impl Decimal {
                 false => Ok(Self::NaN),
             },
 
+            // B. Handle `b ^ inf`
             (Normalized(lhs), Decimal::PositiveInf) => match lhs.abs().cmp(&1.into()) {
                 Ordering::Greater => Ok(Self::PositiveInf),
                 Ordering::Equal => Ok(1.into()),
                 Ordering::Less => Ok(0.into()),
             },
+            // Simply special case of `abs(b) > 1`.
+            // Also consistent with `inf ^ p` and `-inf ^ p` below where p is not fractional or odd.
             (Decimal::PositiveInf, Decimal::PositiveInf)
             | (Decimal::NegativeInf, Decimal::PositiveInf) => Ok(Self::PositiveInf),
 
+            // C. Handle `b ^ -inf`, which is `(1/b) ^ inf`
             (Normalized(lhs), Decimal::NegativeInf) => match lhs.abs().cmp(&1.into()) {
                 Ordering::Greater => Ok(0.into()),
                 Ordering::Equal => Ok(1.into()),
                 Ordering::Less => match lhs.is_zero() {
+                    // Fun fact: ISO 9899 is removing this error to follow IEEE 754 2008.
                     true => Err(PowError::ZeroNegative),
                     false => Ok(Self::PositiveInf),
                 },
@@ -617,22 +623,28 @@ impl Decimal {
             (Decimal::PositiveInf, Decimal::NegativeInf)
             | (Decimal::NegativeInf, Decimal::NegativeInf) => Ok(0.into()),
 
+            // D. Handle `inf ^ p`
             (Decimal::PositiveInf, Normalized(rhs)) => match rhs.cmp(&0.into()) {
                 Ordering::Greater => Ok(Self::PositiveInf),
                 Ordering::Equal => Ok(1.into()),
                 Ordering::Less => Ok(0.into()),
             },
+
+            // E. Handle `-inf ^ p`. Finite `p` can be fractional, odd, or even.
             (Decimal::NegativeInf, Normalized(rhs)) => match !rhs.fract().is_zero() {
+                // Err in PostgreSQL. No err in ISO 9899 which treats fractional as non-odd below.
                 true => Err(PowError::NegativeFract),
-                false => match (rhs.cmp(&0.into()), rhs.rem(&2.into()).is_zero()) {
-                    (Ordering::Greater, true) => Ok(Self::PositiveInf),
-                    (Ordering::Greater, false) => Ok(Self::NegativeInf),
-                    (Ordering::Equal, true) => Ok(1.into()),
-                    (Ordering::Equal, false) => unreachable!(),
-                    (Ordering::Less, true) => Ok(0.into()),
+                false => match (rhs.cmp(&0.into()), rhs.rem(&2.into()).abs().is_one()) {
+                    (Ordering::Greater, true) => Ok(Self::NegativeInf),
+                    (Ordering::Greater, false) => Ok(Self::PositiveInf),
+                    (Ordering::Equal, true) => unreachable!(),
+                    (Ordering::Equal, false) => Ok(1.into()),
+                    (Ordering::Less, true) => Ok(0.into()), // no `-0` in PostgreSQL decimal
                     (Ordering::Less, false) => Ok(0.into()),
                 },
             },
+
+            // F. Finite numbers
             (Normalized(lhs), Normalized(rhs)) => {
                 if lhs.is_zero() && rhs < &0.into() {
                     return Err(PowError::ZeroNegative);

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -61,7 +61,7 @@ mod to_text;
 
 // export data types
 pub use self::datetime::{Date, Time, Timestamp};
-pub use self::decimal::Decimal;
+pub use self::decimal::{Decimal, PowError as DecimalPowError};
 pub use self::interval::{test_utils, DateTimeField, Interval, IntervalDisplay};
 pub use self::jsonb::{JsonbRef, JsonbVal};
 pub use self::native_type::*;

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -162,20 +162,26 @@ pub fn decimal_abs(decimal: Decimal) -> Result<Decimal> {
     Ok(Decimal::abs(&decimal))
 }
 
+fn err_pow_zero_negative() -> ExprError {
+    ExprError::InvalidParam {
+        name: "rhs",
+        reason: "zero raised to a negative power is undefined".into(),
+    }
+}
+fn err_pow_negative_fract() -> ExprError {
+    ExprError::InvalidParam {
+        name: "rhs",
+        reason: "a negative number raised to a non-integer power yields a complex result".into(),
+    }
+}
+
 #[function("pow(float64, float64) -> float64")]
 pub fn pow_f64(l: F64, r: F64) -> Result<F64> {
     if l.is_zero() && r.0 < 0.0 {
-        return Err(ExprError::InvalidParam {
-            name: "rhs",
-            reason: "zero raised to a negative power is undefined".into(),
-        });
+        return Err(err_pow_zero_negative());
     }
     if l.0 < 0.0 && (r.is_finite() && !r.fract().is_zero()) {
-        return Err(ExprError::InvalidParam {
-            name: "rhs",
-            reason: "a negative number raised to a non-integer power yields a complex result"
-                .into(),
-        });
+        return Err(err_pow_negative_fract());
     }
     let res = l.powf(r);
     if res.is_infinite() && l.is_finite() && r.is_finite() {
@@ -193,15 +199,8 @@ pub fn pow_decimal(l: Decimal, r: Decimal) -> Result<Decimal> {
     use risingwave_common::types::DecimalPowError as PowError;
 
     l.checked_powd(&r).map_err(|e| match e {
-        PowError::ZeroNegative => ExprError::InvalidParam {
-            name: "rhs",
-            reason: "zero raised to a negative power is undefined".into(),
-        },
-        PowError::NegativeFract => ExprError::InvalidParam {
-            name: "rhs",
-            reason: "a negative number raised to a non-integer power yields a complex result"
-                .into(),
-        },
+        PowError::ZeroNegative => err_pow_zero_negative(),
+        PowError::NegativeFract => err_pow_negative_fract(),
         PowError::Overflow => ExprError::NumericOverflow,
     })
 }

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -77,8 +77,8 @@ SELECT f.f1, f.f1 - '-10' AS x
    FROM FLOAT8_TBL f
    WHERE f.f1 > '0.0';
 
---@ SELECT f.f1 ^ '2.0' AS square_f1
---@    FROM FLOAT8_TBL f where f.f1 = '1004.3';
+SELECT f.f1 ^ '2.0' AS square_f1
+   FROM FLOAT8_TBL f where f.f1 = '1004.3';
 
 -- absolute value
 SELECT f.f1, @f.f1 AS abs_f1
@@ -115,42 +115,42 @@ SELECT |/ double precision '64' AS eight;
 --@    WHERE f.f1 > '0.0';
 
 -- power
---@ SELECT power(double precision '144', double precision '0.5');
---@ SELECT power(double precision 'NaN', double precision '0.5');
---@ SELECT power(double precision '144', double precision 'NaN');
---@ SELECT power(double precision 'NaN', double precision 'NaN');
---@ SELECT power(double precision '-1', double precision 'NaN');
---@ SELECT power(double precision '1', double precision 'NaN');
---@ SELECT power(double precision 'NaN', double precision '0');
---@ SELECT power(double precision 'inf', double precision '0');
---@ SELECT power(double precision '-inf', double precision '0');
---@ SELECT power(double precision '0', double precision 'inf');
---@ SELECT power(double precision '0', double precision '-inf');
---@ SELECT power(double precision '1', double precision 'inf');
---@ SELECT power(double precision '1', double precision '-inf');
---@ SELECT power(double precision '-1', double precision 'inf');
---@ SELECT power(double precision '-1', double precision '-inf');
---@ SELECT power(double precision '0.1', double precision 'inf');
---@ SELECT power(double precision '-0.1', double precision 'inf');
---@ SELECT power(double precision '1.1', double precision 'inf');
---@ SELECT power(double precision '-1.1', double precision 'inf');
---@ SELECT power(double precision '0.1', double precision '-inf');
---@ SELECT power(double precision '-0.1', double precision '-inf');
---@ SELECT power(double precision '1.1', double precision '-inf');
---@ SELECT power(double precision '-1.1', double precision '-inf');
---@ SELECT power(double precision 'inf', double precision '-2');
---@ SELECT power(double precision 'inf', double precision '2');
---@ SELECT power(double precision 'inf', double precision 'inf');
---@ SELECT power(double precision 'inf', double precision '-inf');
+SELECT power(double precision '144', double precision '0.5');
+SELECT power(double precision 'NaN', double precision '0.5');
+SELECT power(double precision '144', double precision 'NaN');
+SELECT power(double precision 'NaN', double precision 'NaN');
+SELECT power(double precision '-1', double precision 'NaN');
+SELECT power(double precision '1', double precision 'NaN');
+SELECT power(double precision 'NaN', double precision '0');
+SELECT power(double precision 'inf', double precision '0');
+SELECT power(double precision '-inf', double precision '0');
+SELECT power(double precision '0', double precision 'inf');
+SELECT power(double precision '0', double precision '-inf');
+SELECT power(double precision '1', double precision 'inf');
+SELECT power(double precision '1', double precision '-inf');
+SELECT power(double precision '-1', double precision 'inf');
+SELECT power(double precision '-1', double precision '-inf');
+SELECT power(double precision '0.1', double precision 'inf');
+SELECT power(double precision '-0.1', double precision 'inf');
+SELECT power(double precision '1.1', double precision 'inf');
+SELECT power(double precision '-1.1', double precision 'inf');
+SELECT power(double precision '0.1', double precision '-inf');
+SELECT power(double precision '-0.1', double precision '-inf');
+SELECT power(double precision '1.1', double precision '-inf');
+SELECT power(double precision '-1.1', double precision '-inf');
+SELECT power(double precision 'inf', double precision '-2');
+SELECT power(double precision 'inf', double precision '2');
+SELECT power(double precision 'inf', double precision 'inf');
+SELECT power(double precision 'inf', double precision '-inf');
 -- Intel's icc misoptimizes the code that controls the sign of this result,
 -- even with -mp1.  Pending a fix for that, only test for "is it zero".
---@ SELECT power(double precision '-inf', double precision '-2') = '0';
---@ SELECT power(double precision '-inf', double precision '-3');
---@ SELECT power(double precision '-inf', double precision '2');
---@ SELECT power(double precision '-inf', double precision '3');
---@ SELECT power(double precision '-inf', double precision '3.5');
---@ SELECT power(double precision '-inf', double precision 'inf');
---@ SELECT power(double precision '-inf', double precision '-inf');
+SELECT power(double precision '-inf', double precision '-2') = '0';
+SELECT power(double precision '-inf', double precision '-3');
+SELECT power(double precision '-inf', double precision '2');
+SELECT power(double precision '-inf', double precision '3');
+SELECT power(double precision '-inf', double precision '3.5');
+SELECT power(double precision '-inf', double precision 'inf');
+SELECT power(double precision '-inf', double precision '-inf');
 
 -- take exp of ln(f.f1)
 --@ SELECT f.f1, exp(ln(f.f1)) AS exp_ln_f1
@@ -176,7 +176,7 @@ UPDATE FLOAT8_TBL
 
 SELECT f.f1 ^ '1e200' from FLOAT8_TBL f;
 
---@ SELECT 0 ^ 0 + 0 ^ 1 + 0 ^ 0.0 + 0 ^ 0.5;
+SELECT 0 ^ 0 + 0 ^ 1 + 0 ^ 0.0 + 0 ^ 0.5;
 
 SELECT ln(f.f1) from FLOAT8_TBL f where f.f1 = '0.0' ;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously, `pow(decimal, decimal)` would be implicitly casted and handled by `pow(double precision, double precision)`.

This PR:
* Handles decimal directly and returns decimal in this case.
* Handles special values the same way as PostgreSQL (same as posix [math.h](https://www.open-std.org/JTC1/SC22/WG14/www/docs/n2310.pdf)).

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Fix `pow(decimal, decimal)` return type, and `pow(double precision, double precision)` on special values.