### PR TITLE
fix(optimizer): handle escape correctly in RewriteLike

### DIFF
--- a/e2e_test/batch/functions/like.slt.part
+++ b/e2e_test/batch/functions/like.slt.part
@@ -1,0 +1,19 @@
+# Begin https://github.com/risingwavelabs/risingwave/issues/10018
+
+statement ok
+create table test_table(name varchar);
+
+statement ok
+insert into test_table values('test_table');
+
+query T
+select * from test_table where name like 'test_table';
+----
+test_table
+
+query T
+select * from test_table where name like 'test\_table';
+----
+test_table
+
+# End

--- a/e2e_test/batch/functions/like.slt.part
+++ b/e2e_test/batch/functions/like.slt.part
@@ -16,4 +16,7 @@ select * from test_table where name like 'test\_table';
 ----
 test_table
 
+statement ok
+drop table test_table;
+
 # End

--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -374,6 +374,16 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test_table';
+  expected_outputs:
+  - batch_plan
+- sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test\_table';
+  expected_outputs:
+  - batch_plan
+- sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);
     select v1 +1 , v2_p1 from t1, (select v2+2 as v2_p1, k2 from t2) where k1 = k2;

--- a/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/index_selection.yaml
@@ -384,6 +384,11 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test\_table_2';
+  expected_outputs:
+  - batch_plan
+- sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);
     select v1 +1 , v2_p1 from t1, (select v2+2 as v2_p1, k2 from t2) where k1 = k2;

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -665,6 +665,13 @@
     └─BatchFilter { predicate: (test_table.name = 'test_table':Varchar) }
       └─BatchScan { table: test_table, columns: [test_table.name], distribution: SomeShard }
 - sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test\_table_2';
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (test_table.name >= 'test_table':Varchar) AND (test_table.name < 'test_tablf':Varchar) AND Like(test_table.name, 'test\_table_2':Varchar) }
+      └─BatchScan { table: test_table, columns: [test_table.name], distribution: SomeShard }
+- sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);
     select v1 +1 , v2_p1 from t1, (select v2+2 as v2_p1, k2 from t2) where k1 = k2;

--- a/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/index_selection.yaml
@@ -651,6 +651,20 @@
     BatchExchange { order: [], dist: Single }
     └─BatchScan { table: idx, columns: [idx.a, idx.b, idx.c, idx.d], scan_ranges: [idx.a = Utf8("ABC")], distribution: UpstreamHashShard(idx.a) }
 - sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test_table';
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (test_table.name >= 'test':Varchar) AND (test_table.name < 'tesu':Varchar) AND Like(test_table.name, 'test_table':Varchar) }
+      └─BatchScan { table: test_table, columns: [test_table.name], distribution: SomeShard }
+- sql: |
+    create table test_table(name varchar);
+    select * from test_table where name like 'test\_table';
+  batch_plan: |
+    BatchExchange { order: [], dist: Single }
+    └─BatchFilter { predicate: (test_table.name = 'test_table':Varchar) }
+      └─BatchScan { table: test_table, columns: [test_table.name], distribution: SomeShard }
+- sql: |
     create table t1 (k1 int primary key, v1 int);
     create table t2 (k2 int primary key, v2 int);
     select v1 +1 , v2_p1 from t1, (select v2+2 as v2_p1, k2 from t2) where k1 = k2;

--- a/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
+++ b/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
@@ -83,20 +83,20 @@ impl LikeExprRewriter {
 
         let mut in_escape = false;
         const ESCAPE: u8 = b'\\';
-        for i in 0..bytes.len() {
-            if !in_escape && bytes[i] == ESCAPE {
+        for &c in bytes {
+            if !in_escape && c == ESCAPE {
                 in_escape = true;
                 continue;
             }
             if in_escape {
                 in_escape = false;
-                unescaped_bytes.push(bytes[i]);
+                unescaped_bytes.push(c);
                 continue;
             }
-            unescaped_bytes.push(bytes[i]);
-            if bytes[i] == b'_' {
+            unescaped_bytes.push(c);
+            if c == b'_' {
                 char_wildcard_idx.get_or_insert(unescaped_bytes.len() - 1);
-            } else if bytes[i] == b'%' {
+            } else if c == b'%' {
                 str_wildcard_idx.get_or_insert(unescaped_bytes.len() - 1);
             }
         }
@@ -232,6 +232,7 @@ impl RewriteLikeExprRule {
 mod tests {
     #[test]
     fn test_cal_index_and_unescape() {
+        #[expect(clippy::type_complexity, reason = "in testcase")]
         let testcases: [(&str, (Option<usize>, Option<usize>, &str)); 7] = [
             ("testname", (None, None, "testname")),
             ("test_name", (Some(4), None, "test_name")),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #10018 

The rule doesn't handle escape correctly.

It's still incorrect in some UTF-8 inputs, but the PR doesn't make it worse :(

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
