### PR TITLE
fix: fix cancel of streaming job when create command is stashed

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -477,6 +477,24 @@ where
         }
     }
 
+    /// For `CancelStreamingJob`, returns the table id of the target table.
+    pub fn table_to_cancel(&self) -> Option<TableId> {
+        match &self.command {
+            Command::CancelStreamingJob(table_fragments) => Some(table_fragments.table_id()),
+            _ => None,
+        }
+    }
+
+    /// For `CreateStreamingJob`, returns the table id of the target table.
+    pub fn table_to_create(&self) -> Option<TableId> {
+        match &self.command {
+            Command::CreateStreamingJob {
+                table_fragments, ..
+            } => Some(table_fragments.table_id()),
+            _ => None,
+        }
+    }
+
     /// Clean up actors in CNs if needed, used by drop, cancel and reschedule commands.
     async fn clean_up(
         &self,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title, while running an issued canceling command for streaming job, the target command is possibly stashed in `finished_commands` and waiting for checkpoint, we should clear it rather than finish it.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
