### PR TITLE
refactor(expr): cleanup non-function-call expression `Type` variants

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -10,6 +10,11 @@ option optimize_for = SPEED;
 
 message ExprNode {
   enum Type {
+    // `InputRef`, `Constant`, and `UserDefinedFunction` are indicated by the viriant of `rex_node`.
+    // Their types are therefore deprecated and should be `UNSPECIFIED` instead.
+    reserved 1, 2, 3000;
+    reserved "INPUT_REF", "CONSTANT_VALUE", "UDF";
+
     UNSPECIFIED = 0;
     // arithmetics operators
     ADD = 3;

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -191,7 +191,7 @@ message ExprNode {
     // Non-deterministic functions
     PROCTIME = 2023;
   }
-  Type expr_type = 1;
+  Type function_type = 1;
   data.DataType return_type = 3;
   oneof rex_node {
     uint32 input_ref = 4;

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -9,13 +9,16 @@ option java_package = "com.risingwave.proto";
 option optimize_for = SPEED;
 
 message ExprNode {
+  // TODO: move this into `FunctionCall`.
   enum Type {
     // `InputRef`, `Constant`, and `UserDefinedFunction` are indicated by the viriant of `rex_node`.
     // Their types are therefore deprecated and should be `UNSPECIFIED` instead.
     reserved 1, 2, 3000;
     reserved "INPUT_REF", "CONSTANT_VALUE", "UDF";
 
+    // Used for `InputRef`, `Constant`, and `UserDefinedFunction`.
     UNSPECIFIED = 0;
+
     // arithmetics operators
     ADD = 3;
     SUBTRACT = 4;

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -11,8 +11,6 @@ option optimize_for = SPEED;
 message ExprNode {
   enum Type {
     UNSPECIFIED = 0;
-    INPUT_REF = 1;
-    CONSTANT_VALUE = 2;
     // arithmetics operators
     ADD = 3;
     SUBTRACT = 4;
@@ -192,8 +190,6 @@ message ExprNode {
     VNODE = 1101;
     // Non-deterministic functions
     PROCTIME = 2023;
-    // User defined functions
-    UDF = 3000;
   }
   Type expr_type = 1;
   data.DataType return_type = 3;

--- a/src/expr/src/expr/build.rs
+++ b/src/expr/src/expr/build.rs
@@ -49,7 +49,7 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
         RexNode::FuncCall(func_call) => func_call,
     };
 
-    let func_type = prost.expr_type();
+    let func_type = prost.function_type();
 
     match func_type {
         E::Unspecified => unreachable!(),
@@ -71,7 +71,6 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
             ArrayConcatExpression::try_from_boxed(prost)
         }
         E::Vnode => VnodeExpression::try_from_boxed(prost),
-        E::ArrayRemove => ArrayRemoveExpression::try_from_boxed(prost),
         E::Proctime => ProcTimeExpression::try_from_boxed(prost),
 
         _ => {

--- a/src/expr/src/expr/build.rs
+++ b/src/expr/src/expr/build.rs
@@ -42,15 +42,24 @@ use crate::{bail, ExprError, Result};
 pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
     use PbType as E;
 
-    match prost.expr_type() {
+    let func_call = match prost.get_rex_node()? {
+        RexNode::InputRef(_) => return InputRefExpression::try_from_boxed(prost),
+        RexNode::Constant(_) => return LiteralExpression::try_from_boxed(prost),
+        RexNode::Udf(_) => return UdfExpression::try_from_boxed(prost),
+        RexNode::FuncCall(func_call) => func_call,
+    };
+
+    let func_type = prost.expr_type();
+
+    match func_type {
+        E::Unspecified => unreachable!(),
+
         // Dedicated types
         E::All | E::Some => SomeAllExpression::try_from_boxed(prost),
         E::In => InExpression::try_from_boxed(prost),
         E::Case => CaseExpression::try_from_boxed(prost),
         E::Coalesce => CoalesceExpression::try_from_boxed(prost),
         E::ConcatWs => ConcatWsExpression::try_from_boxed(prost),
-        E::ConstantValue => LiteralExpression::try_from_boxed(prost),
-        E::InputRef => InputRefExpression::try_from_boxed(prost),
         E::Field => FieldExpression::try_from_boxed(prost),
         E::Array => NestedConstructExpression::try_from_boxed(prost),
         E::Row => NestedConstructExpression::try_from_boxed(prost),
@@ -62,23 +71,18 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
             ArrayConcatExpression::try_from_boxed(prost)
         }
         E::Vnode => VnodeExpression::try_from_boxed(prost),
-        E::Udf => UdfExpression::try_from_boxed(prost),
+        E::ArrayRemove => ArrayRemoveExpression::try_from_boxed(prost),
         E::Proctime => ProcTimeExpression::try_from_boxed(prost),
 
         _ => {
-            let Some(RexNode::FuncCall(call)) = &prost.rex_node else {
-                return Err(ExprError::UnsupportedFunction(format!("{:?}", prost.rex_node)));
-            };
-
-            let func = prost.expr_type();
             let ret_type = DataType::from(prost.get_return_type().unwrap());
-            let children = call
+            let children = func_call
                 .get_children()
                 .iter()
                 .map(build_from_prost)
                 .try_collect()?;
 
-            build_func(func, ret_type, children)
+            build_func(func_type, ret_type, children)
         }
     }
 }

--- a/src/expr/src/expr/build.rs
+++ b/src/expr/src/expr/build.rs
@@ -52,8 +52,6 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
     let func_type = prost.function_type();
 
     match func_type {
-        E::Unspecified => unreachable!(),
-
         // Dedicated types
         E::All | E::Some => SomeAllExpression::try_from_boxed(prost),
         E::In => InExpression::try_from_boxed(prost),

--- a/src/expr/src/expr/expr_array_concat.rs
+++ b/src/expr/src/expr/expr_array_concat.rs
@@ -389,7 +389,7 @@ mod tests {
 
     fn make_i64_expr_node(value: i64) -> ExprNode {
         ExprNode {
-            expr_type: PbType::ConstantValue as i32,
+            expr_type: PbType::Unspecified as _,
             return_type: Some(DataType::Int64.to_protobuf()),
             rex_node: Some(RexNode::Constant(PbDatum {
                 body: value.to_be_bytes().to_vec(),

--- a/src/expr/src/expr/expr_array_concat.rs
+++ b/src/expr/src/expr/expr_array_concat.rs
@@ -354,7 +354,7 @@ impl<'a> TryFrom<&'a ExprNode> for ArrayConcatExpression {
         let left_type = left.return_type();
         let right_type = right.return_type();
         let ret_type = DataType::from(prost.get_return_type()?);
-        let op = match prost.get_expr_type()? {
+        let op = match prost.get_function_type()? {
             // the types are checked in frontend, so no need for type checking here
             Type::ArrayCat => {
                 if left_type == right_type {
@@ -389,7 +389,7 @@ mod tests {
 
     fn make_i64_expr_node(value: i64) -> ExprNode {
         ExprNode {
-            expr_type: PbType::Unspecified as _,
+            function_type: PbType::Unspecified as _,
             return_type: Some(DataType::Int64.to_protobuf()),
             rex_node: Some(RexNode::Constant(PbDatum {
                 body: value.to_be_bytes().to_vec(),
@@ -399,7 +399,7 @@ mod tests {
 
     fn make_i64_array_expr_node(values: Vec<i64>) -> ExprNode {
         ExprNode {
-            expr_type: PbType::Array as i32,
+            function_type: PbType::Array as i32,
             return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
                 children: values.into_iter().map(make_i64_expr_node).collect(),
@@ -409,7 +409,7 @@ mod tests {
 
     fn make_i64_array_array_expr_node(values: Vec<Vec<i64>>) -> ExprNode {
         ExprNode {
-            expr_type: PbType::Array as i32,
+            function_type: PbType::Array as i32,
             return_type: Some(
                 DataType::List(Box::new(DataType::List(Box::new(DataType::Int64)))).to_protobuf(),
             ),
@@ -425,7 +425,7 @@ mod tests {
             let left = make_i64_array_expr_node(vec![42]);
             let right = make_i64_array_expr_node(vec![43]);
             let expr = ExprNode {
-                expr_type: PbType::ArrayCat as i32,
+                function_type: PbType::ArrayCat as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
@@ -438,7 +438,7 @@ mod tests {
             let left = make_i64_array_array_expr_node(vec![vec![42]]);
             let right = make_i64_array_array_expr_node(vec![vec![43]]);
             let expr = ExprNode {
-                expr_type: PbType::ArrayCat as i32,
+                function_type: PbType::ArrayCat as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
@@ -451,7 +451,7 @@ mod tests {
             let left = make_i64_array_expr_node(vec![42]);
             let right = make_i64_expr_node(43);
             let expr = ExprNode {
-                expr_type: PbType::ArrayAppend as i32,
+                function_type: PbType::ArrayAppend as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
@@ -464,7 +464,7 @@ mod tests {
             let left = make_i64_array_array_expr_node(vec![vec![42]]);
             let right = make_i64_array_expr_node(vec![43]);
             let expr = ExprNode {
-                expr_type: PbType::ArrayAppend as i32,
+                function_type: PbType::ArrayAppend as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
@@ -477,7 +477,7 @@ mod tests {
             let left = make_i64_expr_node(43);
             let right = make_i64_array_expr_node(vec![42]);
             let expr = ExprNode {
-                expr_type: PbType::ArrayPrepend as i32,
+                function_type: PbType::ArrayPrepend as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],
@@ -490,7 +490,7 @@ mod tests {
             let left = make_i64_array_expr_node(vec![43]);
             let right = make_i64_array_array_expr_node(vec![vec![42]]);
             let expr = ExprNode {
-                expr_type: PbType::ArrayPrepend as i32,
+                function_type: PbType::ArrayPrepend as i32,
                 return_type: Some(DataType::List(Box::new(DataType::Int64)).to_protobuf()),
                 rex_node: Some(RexNode::FuncCall(FunctionCall {
                     children: vec![left, right],

--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -27,20 +27,11 @@ use super::{BoxedExpression, Expression};
 use crate::vector_op::conjunction::{and, or};
 use crate::Result;
 
+#[derive(Debug)]
 pub struct BinaryShortCircuitExpression {
     expr_ia1: BoxedExpression,
     expr_ia2: BoxedExpression,
     expr_type: Type,
-}
-
-impl std::fmt::Debug for BinaryShortCircuitExpression {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BinaryShortCircuitExpression")
-            .field("expr_ia1", &self.expr_ia1)
-            .field("expr_ia2", &self.expr_ia2)
-            .field("expr_type", &self.expr_type)
-            .finish()
-    }
 }
 
 #[async_trait::async_trait]

--- a/src/expr/src/expr/expr_case.rs
+++ b/src/expr/src/expr/expr_case.rs
@@ -116,7 +116,7 @@ impl<'a> TryFrom<&'a ExprNode> for CaseExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == PbType::Case);
+        ensure!(prost.get_function_type().unwrap() == PbType::Case);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {

--- a/src/expr/src/expr/expr_coalesce.rs
+++ b/src/expr/src/expr/expr_coalesce.rs
@@ -95,7 +95,7 @@ impl<'a> TryFrom<&'a ExprNode> for CoalesceExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::Coalesce);
+        ensure!(prost.get_function_type().unwrap() == Type::Coalesce);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
@@ -130,7 +130,7 @@ mod tests {
 
     pub fn make_coalesce_function(children: Vec<ExprNode>, ret: TypeName) -> ExprNode {
         ExprNode {
-            expr_type: Coalesce as i32,
+            function_type: Coalesce as i32,
             return_type: Some(PbDataType {
                 type_name: ret as i32,
                 ..Default::default()

--- a/src/expr/src/expr/expr_concat_ws.rs
+++ b/src/expr/src/expr/expr_concat_ws.rs
@@ -137,7 +137,7 @@ impl<'a> TryFrom<&'a ExprNode> for ConcatWsExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::ConcatWs);
+        ensure!(prost.get_function_type().unwrap() == Type::ConcatWs);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
@@ -173,7 +173,7 @@ mod tests {
 
     pub fn make_concat_ws_function(children: Vec<ExprNode>, ret: TypeName) -> ExprNode {
         ExprNode {
-            expr_type: ConcatWs as i32,
+            function_type: ConcatWs as i32,
             return_type: Some(PbDataType {
                 type_name: ret as i32,
                 ..Default::default()

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -74,7 +74,7 @@ impl<'a> TryFrom<&'a ExprNode> for FieldExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::Field);
+        ensure!(prost.get_function_type().unwrap() == Type::Field);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -98,7 +98,7 @@ impl<'a> TryFrom<&'a ExprNode> for InExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::In);
+        ensure!(prost.get_function_type().unwrap() == Type::In);
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn test_in_expr() {
         let input_ref_expr_node = ExprNode {
-            expr_type: Type::Unspecified as i32,
+            function_type: Type::Unspecified as i32,
             return_type: Some(PbDataType {
                 type_name: TypeName::Varchar as i32,
                 ..Default::default()
@@ -151,7 +151,7 @@ mod tests {
         };
         let constant_values = vec![
             ExprNode {
-                expr_type: Type::Unspecified as i32,
+                function_type: Type::Unspecified as i32,
                 return_type: Some(PbDataType {
                     type_name: TypeName::Varchar as i32,
                     ..Default::default()
@@ -161,7 +161,7 @@ mod tests {
                 })),
             },
             ExprNode {
-                expr_type: Type::Unspecified as i32,
+                function_type: Type::Unspecified as i32,
                 return_type: Some(PbDataType {
                     type_name: TypeName::Varchar as i32,
                     ..Default::default()
@@ -177,7 +177,7 @@ mod tests {
             children: in_children,
         };
         let p = ExprNode {
-            expr_type: Type::In as i32,
+            function_type: Type::In as i32,
             return_type: Some(PbDataType {
                 type_name: TypeName::Boolean as i32,
                 ..Default::default()

--- a/src/expr/src/expr/expr_in.rs
+++ b/src/expr/src/expr/expr_in.rs
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn test_in_expr() {
         let input_ref_expr_node = ExprNode {
-            expr_type: Type::InputRef as i32,
+            expr_type: Type::Unspecified as i32,
             return_type: Some(PbDataType {
                 type_name: TypeName::Varchar as i32,
                 ..Default::default()
@@ -151,7 +151,7 @@ mod tests {
         };
         let constant_values = vec![
             ExprNode {
-                expr_type: Type::ConstantValue as i32,
+                expr_type: Type::Unspecified as i32,
                 return_type: Some(PbDataType {
                     type_name: TypeName::Varchar as i32,
                     ..Default::default()
@@ -161,7 +161,7 @@ mod tests {
                 })),
             },
             ExprNode {
-                expr_type: Type::ConstantValue as i32,
+                expr_type: Type::Unspecified as i32,
                 return_type: Some(PbDataType {
                     type_name: TypeName::Varchar as i32,
                     ..Default::default()

--- a/src/expr/src/expr/expr_input_ref.rs
+++ b/src/expr/src/expr/expr_input_ref.rs
@@ -18,11 +18,10 @@ use std::ops::Index;
 use risingwave_common::array::{ArrayRef, DataChunk};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum};
-use risingwave_pb::expr::expr_node::{RexNode, Type};
 use risingwave_pb::expr::ExprNode;
 
 use crate::expr::Expression;
-use crate::{bail, ensure, ExprError, Result};
+use crate::{ExprError, Result};
 
 /// A reference to a column in input relation.
 #[derive(Debug, Clone)]
@@ -65,17 +64,13 @@ impl<'a> TryFrom<&'a ExprNode> for InputRefExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::InputRef);
-
         let ret_type = DataType::from(prost.get_return_type().unwrap());
-        if let RexNode::InputRef(input_col_idx) = prost.get_rex_node().unwrap() {
-            Ok(Self {
-                return_type: ret_type,
-                idx: *input_col_idx as _,
-            })
-        } else {
-            bail!("Expect an input ref node")
-        }
+        let input_col_idx = prost.get_rex_node().unwrap().as_input_ref().unwrap();
+
+        Ok(Self {
+            return_type: ret_type,
+            idx: *input_col_idx as _,
+        })
     }
 }
 

--- a/src/expr/src/expr/expr_jsonb_access.rs
+++ b/src/expr/src/expr/expr_jsonb_access.rs
@@ -307,7 +307,7 @@ mod tests {
         let values = FunctionCall {
             children: vec![
                 ExprNode {
-                    expr_type: Type::Unspecified as i32,
+                    function_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Varchar as i32,
                         ..Default::default()
@@ -317,7 +317,7 @@ mod tests {
                     })),
                 },
                 ExprNode {
-                    expr_type: Type::Unspecified as i32,
+                    function_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Varchar as i32,
                         ..Default::default()
@@ -331,7 +331,7 @@ mod tests {
         let array_index = FunctionCall {
             children: vec![
                 ExprNode {
-                    expr_type: Type::Array as i32,
+                    function_type: Type::Array as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::List as i32,
                         field_type: vec![ProstDataType {
@@ -343,7 +343,7 @@ mod tests {
                     rex_node: Some(RexNode::FuncCall(values)),
                 },
                 ExprNode {
-                    expr_type: Type::Unspecified as i32,
+                    function_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Int32 as i32,
                         ..Default::default()
@@ -355,7 +355,7 @@ mod tests {
             ],
         };
         let access = ExprNode {
-            expr_type: Type::ArrayAccess as i32,
+            function_type: Type::ArrayAccess as i32,
             return_type: Some(ProstDataType {
                 type_name: TypeName::Varchar as i32,
                 ..Default::default()

--- a/src/expr/src/expr/expr_jsonb_access.rs
+++ b/src/expr/src/expr/expr_jsonb_access.rs
@@ -307,7 +307,7 @@ mod tests {
         let values = FunctionCall {
             children: vec![
                 ExprNode {
-                    expr_type: Type::ConstantValue as i32,
+                    expr_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Varchar as i32,
                         ..Default::default()
@@ -317,7 +317,7 @@ mod tests {
                     })),
                 },
                 ExprNode {
-                    expr_type: Type::ConstantValue as i32,
+                    expr_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Varchar as i32,
                         ..Default::default()
@@ -343,7 +343,7 @@ mod tests {
                     rex_node: Some(RexNode::FuncCall(values)),
                 },
                 ExprNode {
-                    expr_type: Type::ConstantValue as i32,
+                    expr_type: Type::Unspecified as i32,
                     return_type: Some(ProstDataType {
                         type_name: TypeName::Int32 as i32,
                         ..Default::default()

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -142,68 +142,69 @@ mod tests {
         let t = TypeName::Boolean;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
 
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i16;
         let t = TypeName::Int16;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
 
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i32;
         let t = TypeName::Int32;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1i64;
         let t = TypeName::Int64;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1f32.into_ordered();
         let t = TypeName::Float;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 1f64.into_ordered();
         let t = TypeName::Double;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = None;
         let t = TypeName::Float;
-        let expr = LiteralExpression::try_from(&make_expression(None, t)).unwrap();
+        let bytes = serialize_datum(Datum::None);
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v, expr.literal());
 
         let v: Box<str> = "varchar".into();
         let t = TypeName::Varchar;
         let bytes = serialize_datum(Some(v.clone().to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = Decimal::new(3141, 3);
         let t = TypeName::Decimal;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
         let v = 32i32;
         let t = TypeName::Interval;
         let bytes = serialize_datum(Some(Interval::from_month(v).to_scalar_value()).as_ref());
-        let expr = LiteralExpression::try_from(&make_expression(Some(bytes), t)).unwrap();
+        let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(
             Interval::from_month(v).to_scalar_value(),
             expr.literal().unwrap()
         );
     }
 
-    fn make_expression(bytes: Option<Vec<u8>>, data_type: TypeName) -> ExprNode {
+    fn make_expression(bytes: Vec<u8>, data_type: TypeName) -> ExprNode {
         ExprNode {
             function_type: Type::Unspecified as i32,
             return_type: Some(PbDataType {
@@ -211,7 +212,7 @@ mod tests {
                 interval_type: IntervalType::Month as i32,
                 ..Default::default()
             }),
-            rex_node: bytes.map(|bs| RexNode::Constant(PbDatum { body: bs })),
+            rex_node: Some(RexNode::Constant(PbDatum { body: bytes })),
         }
     }
 

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -111,7 +111,7 @@ mod tests {
         ]);
         let body = serialize_datum(Some(value.clone().to_scalar_value()).as_ref());
         let expr = ExprNode {
-            expr_type: Type::Unspecified as i32,
+            function_type: Type::Unspecified as i32,
             return_type: Some(PbDataType {
                 type_name: TypeName::Struct as i32,
                 field_type: vec![
@@ -205,7 +205,7 @@ mod tests {
 
     fn make_expression(bytes: Option<Vec<u8>>, data_type: TypeName) -> ExprNode {
         ExprNode {
-            expr_type: Type::Unspecified as i32,
+            function_type: Type::Unspecified as i32,
             return_type: Some(PbDataType {
                 type_name: data_type as i32,
                 interval_type: IntervalType::Month as i32,

--- a/src/expr/src/expr/expr_nested_construct.rs
+++ b/src/expr/src/expr/expr_nested_construct.rs
@@ -98,7 +98,7 @@ impl<'a> TryFrom<&'a ExprNode> for NestedConstructExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!([Type::Array, Type::Row].contains(&prost.get_expr_type().unwrap()));
+        ensure!([Type::Array, Type::Row].contains(&prost.get_function_type().unwrap()));
 
         let ret_type = DataType::from(prost.get_return_type().unwrap());
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {

--- a/src/expr/src/expr/expr_proctime.rs
+++ b/src/expr/src/expr/expr_proctime.rs
@@ -35,7 +35,7 @@ impl<'a> TryFrom<&'a ExprNode> for ProcTimeExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::Proctime);
+        ensure!(prost.get_function_type().unwrap() == Type::Proctime);
         ensure!(DataType::from(prost.get_return_type().unwrap()) == DataType::Timestamptz);
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
             bail!("Expected RexNode::FuncCall");

--- a/src/expr/src/expr/expr_regexp.rs
+++ b/src/expr/src/expr/expr_regexp.rs
@@ -114,7 +114,7 @@ impl<'a> TryFrom<&'a ExprNode> for RegexpMatchExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::RegexpMatch);
+        ensure!(prost.get_function_type().unwrap() == Type::RegexpMatch);
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
             bail!("Expected RexNode::FuncCall");
         };

--- a/src/expr/src/expr/expr_some_all.rs
+++ b/src/expr/src/expr/expr_some_all.rs
@@ -223,12 +223,12 @@ impl<'a> TryFrom<&'a ExprNode> for SomeAllExpression {
 
         let eval_func = {
             let left_expr_input_ref = ExprNode {
-                expr_type: Type::InputRef as i32,
+                expr_type: Type::Unspecified as i32,
                 return_type: Some(left_expr.return_type().to_protobuf()),
                 rex_node: Some(RexNode::InputRef(0)),
             };
             let right_expr_input_ref = ExprNode {
-                expr_type: Type::InputRef as i32,
+                expr_type: Type::Unspecified as i32,
                 return_type: Some(right_expr_return_type.to_protobuf()),
                 rex_node: Some(RexNode::InputRef(1)),
             };

--- a/src/expr/src/expr/expr_vnode.rs
+++ b/src/expr/src/expr/expr_vnode.rs
@@ -40,7 +40,7 @@ impl<'a> TryFrom<&'a ExprNode> for VnodeExpression {
     type Error = ExprError;
 
     fn try_from(prost: &'a ExprNode) -> Result<Self> {
-        ensure!(prost.get_expr_type().unwrap() == Type::Vnode);
+        ensure!(prost.get_function_type().unwrap() == Type::Vnode);
         ensure!(DataType::from(prost.get_return_type().unwrap()) == DataType::Int16);
 
         let RexNode::FuncCall(func_call_node) = prost.get_rex_node().unwrap() else {
@@ -99,7 +99,7 @@ mod tests {
 
     pub fn make_vnode_function(children: Vec<ExprNode>) -> ExprNode {
         ExprNode {
-            expr_type: Vnode as i32,
+            function_type: Vnode as i32,
             return_type: Some(PbDataType {
                 type_name: TypeName::Int16 as i32,
                 ..Default::default()

--- a/src/expr/src/expr/expr_vnode.rs
+++ b/src/expr/src/expr/expr_vnode.rs
@@ -47,10 +47,6 @@ impl<'a> TryFrom<&'a ExprNode> for VnodeExpression {
             bail!("Expected RexNode::FuncCall");
         };
 
-        for child in func_call_node.get_children() {
-            ensure!(child.get_expr_type().unwrap() == Type::InputRef);
-        }
-
         let dist_key_input_refs = func_call_node
             .get_children()
             .iter()

--- a/src/expr/src/expr/test_utils.rs
+++ b/src/expr/src/expr/test_utils.rs
@@ -30,7 +30,7 @@ use crate::ExprError;
 
 pub fn make_func_call(kind: Type, ret: TypeName, children: Vec<ExprNode>) -> ExprNode {
     ExprNode {
-        expr_type: kind as i32,
+        function_type: kind as i32,
         return_type: Some(PbDataType {
             type_name: ret as i32,
             ..Default::default()
@@ -41,7 +41,7 @@ pub fn make_func_call(kind: Type, ret: TypeName, children: Vec<ExprNode>) -> Exp
 
 pub fn make_input_ref(idx: usize, ret: TypeName) -> ExprNode {
     ExprNode {
-        expr_type: Type::Unspecified as i32,
+        function_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: ret as i32,
             ..Default::default()
@@ -52,7 +52,7 @@ pub fn make_input_ref(idx: usize, ret: TypeName) -> ExprNode {
 
 pub fn make_i32_literal(data: i32) -> ExprNode {
     ExprNode {
-        expr_type: Type::Unspecified as i32,
+        function_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: TypeName::Int32 as i32,
             ..Default::default()
@@ -65,7 +65,7 @@ pub fn make_i32_literal(data: i32) -> ExprNode {
 
 fn make_interval_literal(data: Interval) -> ExprNode {
     ExprNode {
-        expr_type: Type::Unspecified as i32,
+        function_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: TypeName::Interval as i32,
             ..Default::default()
@@ -78,7 +78,7 @@ fn make_interval_literal(data: Interval) -> ExprNode {
 
 pub fn make_field_function(children: Vec<ExprNode>, ret: TypeName) -> ExprNode {
     ExprNode {
-        expr_type: Field as i32,
+        function_type: Field as i32,
         return_type: Some(PbDataType {
             type_name: ret as i32,
             ..Default::default()

--- a/src/expr/src/expr/test_utils.rs
+++ b/src/expr/src/expr/test_utils.rs
@@ -21,14 +21,14 @@ use risingwave_common::types::{DataType, Interval, ScalarImpl};
 use risingwave_common::util::value_encoding::serialize_datum;
 use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::{PbDataType, PbDatum};
-use risingwave_pb::expr::expr_node::Type::{Field, InputRef};
+use risingwave_pb::expr::expr_node::Type::Field;
 use risingwave_pb::expr::expr_node::{self, RexNode, Type};
 use risingwave_pb::expr::{ExprNode, FunctionCall};
 
 use super::{build_from_prost, BoxedExpression, Result};
 use crate::ExprError;
 
-pub fn make_expression(kind: Type, ret: TypeName, children: Vec<ExprNode>) -> ExprNode {
+pub fn make_func_call(kind: Type, ret: TypeName, children: Vec<ExprNode>) -> ExprNode {
     ExprNode {
         expr_type: kind as i32,
         return_type: Some(PbDataType {
@@ -41,7 +41,7 @@ pub fn make_expression(kind: Type, ret: TypeName, children: Vec<ExprNode>) -> Ex
 
 pub fn make_input_ref(idx: usize, ret: TypeName) -> ExprNode {
     ExprNode {
-        expr_type: InputRef as i32,
+        expr_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: ret as i32,
             ..Default::default()
@@ -52,7 +52,7 @@ pub fn make_input_ref(idx: usize, ret: TypeName) -> ExprNode {
 
 pub fn make_i32_literal(data: i32) -> ExprNode {
     ExprNode {
-        expr_type: Type::ConstantValue as i32,
+        expr_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: TypeName::Int32 as i32,
             ..Default::default()
@@ -65,7 +65,7 @@ pub fn make_i32_literal(data: i32) -> ExprNode {
 
 fn make_interval_literal(data: Interval) -> ExprNode {
     ExprNode {
-        expr_type: Type::ConstantValue as i32,
+        expr_type: Type::Unspecified as i32,
         return_type: Some(PbDataType {
             type_name: TypeName::Interval as i32,
             ..Default::default()
@@ -127,11 +127,11 @@ pub fn make_hop_window_expression(
         })
         .unwrap();
 
-    let hop_window_start = make_expression(
+    let hop_window_start = make_func_call(
         expr_node::Type::TumbleStart,
         output_type,
         vec![
-            make_expression(
+            make_func_call(
                 expr_node::Type::Subtract,
                 output_type,
                 vec![time_col_ref, make_interval_literal(window_size_sub_slide)],
@@ -164,7 +164,7 @@ pub fn make_hop_window_expression(
                         window_slide, i
                     ),
                 })?;
-        let window_start_expr = make_expression(
+        let window_start_expr = make_func_call(
             expr_node::Type::Add,
             output_type,
             vec![
@@ -173,7 +173,7 @@ pub fn make_hop_window_expression(
             ],
         );
         window_start_exprs.push(build_from_prost(&window_start_expr).unwrap());
-        let window_end_expr = make_expression(
+        let window_end_expr = make_func_call(
             expr_node::Type::Add,
             output_type,
             vec![

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -263,7 +263,7 @@ impl FunctionCall {
         (self.func_type, input)
     }
 
-    pub fn get_expr_type(&self) -> ExprType {
+    pub fn gett_expr_type(&self) -> ExprType {
         self.func_type
     }
 
@@ -278,8 +278,8 @@ impl FunctionCall {
 
     pub(super) fn from_expr_proto(
         function_call: &risingwave_pb::expr::FunctionCall,
-        expr_type: ExprType,
-        ret_type: DataType,
+        func_type: ExprType,
+        return_type: DataType,
     ) -> RwResult<Self> {
         let inputs: Vec<_> = function_call
             .get_children()
@@ -287,8 +287,8 @@ impl FunctionCall {
             .map(ExprImpl::from_expr_proto)
             .try_collect()?;
         Ok(Self {
-            func_type: expr_type,
-            return_type: ret_type,
+            func_type,
+            return_type,
             inputs,
         })
     }
@@ -303,7 +303,7 @@ impl Expr for FunctionCall {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: self.get_expr_type().into(),
+            function_type: self.gett_expr_type().into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
                 children: self.inputs().iter().map(Expr::to_expr_proto).collect(),
@@ -419,7 +419,7 @@ fn explain_verbose_binary_op(
 
 pub fn is_row_function(expr: &ExprImpl) -> bool {
     if let ExprImpl::FunctionCall(func) = expr {
-        if func.get_expr_type() == ExprType::Row {
+        if func.gett_expr_type() == ExprType::Row {
             return true;
         }
     }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -263,7 +263,7 @@ impl FunctionCall {
         (self.func_type, input)
     }
 
-    pub fn gett_expr_type(&self) -> ExprType {
+    pub fn func_type(&self) -> ExprType {
         self.func_type
     }
 
@@ -303,7 +303,7 @@ impl Expr for FunctionCall {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            function_type: self.gett_expr_type().into(),
+            function_type: self.func_type().into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::FuncCall(FunctionCall {
                 children: self.inputs().iter().map(Expr::to_expr_proto).collect(),
@@ -419,7 +419,7 @@ fn explain_verbose_binary_op(
 
 pub fn is_row_function(expr: &ExprImpl) -> bool {
     if let ExprImpl::FunctionCall(func) = expr {
-        if func.gett_expr_type() == ExprType::Row {
+        if func.func_type() == ExprType::Row {
             return true;
         }
     }

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -142,7 +142,7 @@ impl Expr for InputRef {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: ExprType::Unspecified.into(),
+            function_type: ExprType::Unspecified.into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::InputRef(self.index() as _)),
         }

--- a/src/frontend/src/expr/input_ref.rs
+++ b/src/frontend/src/expr/input_ref.rs
@@ -142,7 +142,7 @@ impl Expr for InputRef {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: ExprType::InputRef.into(),
+            expr_type: ExprType::Unspecified.into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::InputRef(self.index() as _)),
         }

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -73,10 +73,6 @@ impl Literal {
         Literal { data, data_type }
     }
 
-    pub fn get_expr_type(&self) -> ExprType {
-        ExprType::ConstantValue
-    }
-
     pub fn get_data(&self) -> &Datum {
         &self.data
     }
@@ -100,7 +96,7 @@ impl Expr for Literal {
     fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: self.get_expr_type() as i32,
+            expr_type: ExprType::Unspecified as i32,
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(literal_to_value_encoding(self.get_data())),
         }

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -96,7 +96,7 @@ impl Expr for Literal {
     fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: ExprType::Unspecified as i32,
+            function_type: ExprType::Unspecified as i32,
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(literal_to_value_encoding(self.get_data())),
         }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -594,7 +594,7 @@ impl ExprImpl {
     /// ordered by the canonical ordering (lower, higher), else returns None
     pub fn as_eq_cond(&self) -> Option<(InputRef, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::Equal
+            && function_call.func_type() == ExprType::Equal
             && let (_, ExprImpl::InputRef(x), ExprImpl::InputRef(y)) =
                 function_call.clone().decompose_as_binary()
         {
@@ -610,7 +610,7 @@ impl ExprImpl {
 
     pub fn as_is_not_distinct_from_cond(&self) -> Option<(InputRef, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::IsNotDistinctFrom
+            && function_call.func_type() == ExprType::IsNotDistinctFrom
             && let (_, ExprImpl::InputRef(x), ExprImpl::InputRef(y)) =
                 function_call.clone().decompose_as_binary()
         {
@@ -637,7 +637,7 @@ impl ExprImpl {
 
     pub fn as_comparison_cond(&self) -> Option<(InputRef, ExprType, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.gett_expr_type() {
+            match function_call.func_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -667,7 +667,7 @@ impl ExprImpl {
     /// Canonicalizes to the first ordering and returns `(input_expr, cmp, now_expr)`
     pub fn as_now_comparison_cond(&self) -> Option<(ExprImpl, ExprType, ExprImpl)> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.gett_expr_type() {
+            match function_call.func_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -700,7 +700,7 @@ impl ExprImpl {
     /// `InputRef [+- const_expr] cmp InputRef`.
     pub(crate) fn as_input_comparison_cond(&self) -> Option<InequalityInputPair> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.gett_expr_type() {
+            match function_call.func_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -749,7 +749,7 @@ impl ExprImpl {
         if let ExprImpl::Now(_) = self {
             true
         } else if let ExprImpl::FunctionCall(f) = self {
-            match f.gett_expr_type() {
+            match f.func_type() {
                 ExprType::Add | ExprType::Subtract => {
                     let (_, lhs, rhs) = f.clone().decompose_as_binary();
                     lhs.is_now_offset() && rhs.is_const()
@@ -767,7 +767,7 @@ impl ExprImpl {
         match self {
             ExprImpl::InputRef(input_ref) => Some((input_ref.index(), None)),
             ExprImpl::FunctionCall(function_call) => {
-                let expr_type = function_call.gett_expr_type();
+                let expr_type = function_call.func_type();
                 match expr_type {
                     ExprType::Add | ExprType::Subtract => {
                         let (_, lhs, rhs) = function_call.clone().decompose_as_binary();
@@ -795,7 +795,7 @@ impl ExprImpl {
 
     pub fn as_eq_const(&self) -> Option<(InputRef, ExprImpl)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::Equal
+            && function_call.func_type() == ExprType::Equal
         {
             match function_call.clone().decompose_as_binary() {
                 (_, ExprImpl::InputRef(x), y) if y.is_const() => Some((*x, y)),
@@ -809,7 +809,7 @@ impl ExprImpl {
 
     pub fn as_eq_correlated_input_ref(&self) -> Option<(InputRef, CorrelatedInputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::Equal
+            && function_call.func_type() == ExprType::Equal
         {
             match function_call.clone().decompose_as_binary() {
                 (_, ExprImpl::InputRef(x), ExprImpl::CorrelatedInputRef(y)) => Some((*x, *y)),
@@ -823,7 +823,7 @@ impl ExprImpl {
 
     pub fn as_is_null(&self) -> Option<InputRef> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::IsNull
+            && function_call.func_type() == ExprType::IsNull
         {
             match function_call.clone().decompose_as_unary() {
                 (_, ExprImpl::InputRef(x)) => Some(*x),
@@ -846,7 +846,7 @@ impl ExprImpl {
         }
 
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.gett_expr_type() {
+            match function_call.func_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -869,7 +869,7 @@ impl ExprImpl {
 
     pub fn as_in_const_list(&self) -> Option<(InputRef, Vec<ExprImpl>)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::In
+            && function_call.func_type() == ExprType::In
         {
             let mut inputs = function_call.inputs().iter().cloned();
             let input_ref = match inputs.next().unwrap() {
@@ -892,7 +892,7 @@ impl ExprImpl {
 
     pub fn as_or_disjunctions(&self) -> Option<Vec<ExprImpl>> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.gett_expr_type() == ExprType::Or
+            && function_call.func_type() == ExprType::Or
         {
             Some(to_disjunctions(self.clone()))
         } else {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -594,7 +594,7 @@ impl ExprImpl {
     /// ordered by the canonical ordering (lower, higher), else returns None
     pub fn as_eq_cond(&self) -> Option<(InputRef, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::Equal
+            && function_call.gett_expr_type() == ExprType::Equal
             && let (_, ExprImpl::InputRef(x), ExprImpl::InputRef(y)) =
                 function_call.clone().decompose_as_binary()
         {
@@ -610,7 +610,7 @@ impl ExprImpl {
 
     pub fn as_is_not_distinct_from_cond(&self) -> Option<(InputRef, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::IsNotDistinctFrom
+            && function_call.gett_expr_type() == ExprType::IsNotDistinctFrom
             && let (_, ExprImpl::InputRef(x), ExprImpl::InputRef(y)) =
                 function_call.clone().decompose_as_binary()
         {
@@ -637,7 +637,7 @@ impl ExprImpl {
 
     pub fn as_comparison_cond(&self) -> Option<(InputRef, ExprType, InputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.get_expr_type() {
+            match function_call.gett_expr_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -667,7 +667,7 @@ impl ExprImpl {
     /// Canonicalizes to the first ordering and returns `(input_expr, cmp, now_expr)`
     pub fn as_now_comparison_cond(&self) -> Option<(ExprImpl, ExprType, ExprImpl)> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.get_expr_type() {
+            match function_call.gett_expr_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -700,7 +700,7 @@ impl ExprImpl {
     /// `InputRef [+- const_expr] cmp InputRef`.
     pub(crate) fn as_input_comparison_cond(&self) -> Option<InequalityInputPair> {
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.get_expr_type() {
+            match function_call.gett_expr_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -749,7 +749,7 @@ impl ExprImpl {
         if let ExprImpl::Now(_) = self {
             true
         } else if let ExprImpl::FunctionCall(f) = self {
-            match f.get_expr_type() {
+            match f.gett_expr_type() {
                 ExprType::Add | ExprType::Subtract => {
                     let (_, lhs, rhs) = f.clone().decompose_as_binary();
                     lhs.is_now_offset() && rhs.is_const()
@@ -767,7 +767,7 @@ impl ExprImpl {
         match self {
             ExprImpl::InputRef(input_ref) => Some((input_ref.index(), None)),
             ExprImpl::FunctionCall(function_call) => {
-                let expr_type = function_call.get_expr_type();
+                let expr_type = function_call.gett_expr_type();
                 match expr_type {
                     ExprType::Add | ExprType::Subtract => {
                         let (_, lhs, rhs) = function_call.clone().decompose_as_binary();
@@ -795,7 +795,7 @@ impl ExprImpl {
 
     pub fn as_eq_const(&self) -> Option<(InputRef, ExprImpl)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::Equal
+            && function_call.gett_expr_type() == ExprType::Equal
         {
             match function_call.clone().decompose_as_binary() {
                 (_, ExprImpl::InputRef(x), y) if y.is_const() => Some((*x, y)),
@@ -809,7 +809,7 @@ impl ExprImpl {
 
     pub fn as_eq_correlated_input_ref(&self) -> Option<(InputRef, CorrelatedInputRef)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::Equal
+            && function_call.gett_expr_type() == ExprType::Equal
         {
             match function_call.clone().decompose_as_binary() {
                 (_, ExprImpl::InputRef(x), ExprImpl::CorrelatedInputRef(y)) => Some((*x, *y)),
@@ -823,7 +823,7 @@ impl ExprImpl {
 
     pub fn as_is_null(&self) -> Option<InputRef> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::IsNull
+            && function_call.gett_expr_type() == ExprType::IsNull
         {
             match function_call.clone().decompose_as_unary() {
                 (_, ExprImpl::InputRef(x)) => Some(*x),
@@ -846,7 +846,7 @@ impl ExprImpl {
         }
 
         if let ExprImpl::FunctionCall(function_call) = self {
-            match function_call.get_expr_type() {
+            match function_call.gett_expr_type() {
                 ty @ (ExprType::LessThan
                 | ExprType::LessThanOrEqual
                 | ExprType::GreaterThan
@@ -869,7 +869,7 @@ impl ExprImpl {
 
     pub fn as_in_const_list(&self) -> Option<(InputRef, Vec<ExprImpl>)> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::In
+            && function_call.gett_expr_type() == ExprType::In
         {
             let mut inputs = function_call.inputs().iter().cloned();
             let input_ref = match inputs.next().unwrap() {
@@ -892,7 +892,7 @@ impl ExprImpl {
 
     pub fn as_or_disjunctions(&self) -> Option<Vec<ExprImpl>> {
         if let ExprImpl::FunctionCall(function_call) = self
-            && function_call.get_expr_type() == ExprType::Or
+            && function_call.gett_expr_type() == ExprType::Or
         {
             Some(to_disjunctions(self.clone()))
         } else {
@@ -927,7 +927,7 @@ impl ExprImpl {
             RexNode::FuncCall(function_call) => {
                 Self::FunctionCall(Box::new(FunctionCall::from_expr_proto(
                     function_call,
-                    proto.get_expr_type()?, // only interpret if it's a function call
+                    proto.get_function_type()?, // only interpret if it's a function call
                     ret_type,
                 )?))
             }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -914,7 +914,7 @@ impl ExprImpl {
     pub fn from_expr_proto(proto: &ExprNode) -> RwResult<Self> {
         let rex_node = proto.get_rex_node()?;
         let ret_type = proto.get_return_type()?.into();
-        let expr_type = proto.get_expr_type()?;
+
         Ok(match rex_node {
             RexNode::InputRef(column_index) => Self::InputRef(Box::new(InputRef::from_expr_proto(
                 *column_index as _,
@@ -924,9 +924,13 @@ impl ExprImpl {
             RexNode::Udf(udf) => Self::UserDefinedFunction(Box::new(
                 UserDefinedFunction::from_expr_proto(udf, ret_type)?,
             )),
-            RexNode::FuncCall(function_call) => Self::FunctionCall(Box::new(
-                FunctionCall::from_expr_proto(function_call, expr_type, ret_type)?,
-            )),
+            RexNode::FuncCall(function_call) => {
+                Self::FunctionCall(Box::new(FunctionCall::from_expr_proto(
+                    function_call,
+                    proto.get_expr_type()?, // only interpret if it's a function call
+                    ret_type,
+                )?))
+            }
         })
     }
 }

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -32,7 +32,7 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
     }
 
     fn visit_function_call(&mut self, func_call: &super::FunctionCall) -> bool {
-        match func_call.gett_expr_type() {
+        match func_call.func_type() {
             expr_node::Type::Unspecified => unreachable!(),
             expr_node::Type::Add
             | expr_node::Type::Subtract

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -33,10 +33,8 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
 
     fn visit_function_call(&mut self, func_call: &super::FunctionCall) -> bool {
         match func_call.get_expr_type() {
-            expr_node::Type::Unspecified
-            | expr_node::Type::InputRef
-            | expr_node::Type::ConstantValue
-            | expr_node::Type::Add
+            expr_node::Type::Unspecified => unreachable!(),
+            expr_node::Type::Add
             | expr_node::Type::Subtract
             | expr_node::Type::Multiply
             | expr_node::Type::Divide
@@ -187,7 +185,7 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
                 x
             }
             // expression output is not deterministic
-            expr_node::Type::Vnode | expr_node::Type::Proctime | expr_node::Type::Udf => true,
+            expr_node::Type::Vnode | expr_node::Type::Proctime => true,
         }
     }
 }

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -32,7 +32,7 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
     }
 
     fn visit_function_call(&mut self, func_call: &super::FunctionCall) -> bool {
-        match func_call.get_expr_type() {
+        match func_call.gett_expr_type() {
             expr_node::Type::Unspecified => unreachable!(),
             expr_node::Type::Add
             | expr_node::Type::Subtract

--- a/src/frontend/src/expr/user_defined_function.rs
+++ b/src/frontend/src/expr/user_defined_function.rs
@@ -74,7 +74,7 @@ impl Expr for UserDefinedFunction {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: Type::Unspecified.into(),
+            function_type: Type::Unspecified.into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::Udf(UserDefinedFunction {
                 children: self.args.iter().map(Expr::to_expr_proto).collect(),

--- a/src/frontend/src/expr/user_defined_function.rs
+++ b/src/frontend/src/expr/user_defined_function.rs
@@ -74,7 +74,7 @@ impl Expr for UserDefinedFunction {
         use risingwave_pb::expr::expr_node::*;
         use risingwave_pb::expr::*;
         ExprNode {
-            expr_type: Type::Udf.into(),
+            expr_type: Type::Unspecified.into(),
             return_type: Some(self.return_type().to_protobuf()),
             rex_node: Some(RexNode::Udf(UserDefinedFunction {
                 children: self.args.iter().map(Expr::to_expr_proto).collect(),

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -21,7 +21,7 @@ use crate::expr::ExprType;
 
 fn split_expr_by(expr: ExprImpl, op: ExprType, rets: &mut Vec<ExprImpl>) {
     match expr {
-        ExprImpl::FunctionCall(func_call) if func_call.get_expr_type() == op => {
+        ExprImpl::FunctionCall(func_call) if func_call.gett_expr_type() == op => {
             let (_, exprs, _) = func_call.decompose();
             for expr in exprs {
                 split_expr_by(expr, op, rets);
@@ -486,7 +486,7 @@ impl WatermarkAnalyzer {
     }
 
     fn visit_function_call(&self, func_call: &FunctionCall) -> WatermarkDerivation {
-        match func_call.get_expr_type() {
+        match func_call.gett_expr_type() {
             ExprType::Unspecified => unreachable!(),
             ExprType::Add | ExprType::Multiply => match self.visit_binary_op(func_call.inputs()) {
                 (WatermarkDerivation::Constant, WatermarkDerivation::Constant) => {

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -21,7 +21,7 @@ use crate::expr::ExprType;
 
 fn split_expr_by(expr: ExprImpl, op: ExprType, rets: &mut Vec<ExprImpl>) {
     match expr {
-        ExprImpl::FunctionCall(func_call) if func_call.gett_expr_type() == op => {
+        ExprImpl::FunctionCall(func_call) if func_call.func_type() == op => {
             let (_, exprs, _) = func_call.decompose();
             for expr in exprs {
                 split_expr_by(expr, op, rets);
@@ -486,7 +486,7 @@ impl WatermarkAnalyzer {
     }
 
     fn visit_function_call(&self, func_call: &FunctionCall) -> WatermarkDerivation {
-        match func_call.gett_expr_type() {
+        match func_call.func_type() {
             ExprType::Unspecified => unreachable!(),
             ExprType::Add | ExprType::Multiply => match self.visit_binary_op(func_call.inputs()) {
                 (WatermarkDerivation::Constant, WatermarkDerivation::Constant) => {

--- a/src/frontend/src/expr/utils.rs
+++ b/src/frontend/src/expr/utils.rs
@@ -487,7 +487,7 @@ impl WatermarkAnalyzer {
 
     fn visit_function_call(&self, func_call: &FunctionCall) -> WatermarkDerivation {
         match func_call.get_expr_type() {
-            ExprType::Unspecified | ExprType::InputRef | ExprType::ConstantValue => unreachable!(),
+            ExprType::Unspecified => unreachable!(),
             ExprType::Add | ExprType::Multiply => match self.visit_binary_op(func_call.inputs()) {
                 (WatermarkDerivation::Constant, WatermarkDerivation::Constant) => {
                     WatermarkDerivation::Constant

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -348,7 +348,7 @@ fn assemble_materialize(
                 .name
                 .clone(),
             ExprImpl::FunctionCall(func) => {
-                let func_name = func.gett_expr_type().as_str_name().to_string();
+                let func_name = func.func_type().as_str_name().to_string();
                 let mut name = func_name.clone();
                 while !col_names.insert(name.clone()) {
                     count += 1;

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -348,7 +348,7 @@ fn assemble_materialize(
                 .name
                 .clone(),
             ExprImpl::FunctionCall(func) => {
-                let func_name = func.get_expr_type().as_str_name().to_string();
+                let func_name = func.gett_expr_type().as_str_name().to_string();
                 let mut name = func_name.clone();
                 while !col_names.insert(name.clone()) {
                     count += 1;

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -1235,7 +1235,7 @@ mod tests {
 
             assert_eq_input_ref!(&exprs[0], 0);
             if let ExprImpl::FunctionCall(func_call) = &exprs[1] {
-                assert_eq!(func_call.gett_expr_type(), ExprType::Add);
+                assert_eq!(func_call.func_type(), ExprType::Add);
                 let inputs = func_call.inputs();
                 assert_eq_input_ref!(&inputs[0], 1);
                 assert_eq_input_ref!(&inputs[1], 2);

--- a/src/frontend/src/optimizer/plan_node/logical_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_agg.rs
@@ -1235,7 +1235,7 @@ mod tests {
 
             assert_eq_input_ref!(&exprs[0], 0);
             if let ExprImpl::FunctionCall(func_call) = &exprs[1] {
-                assert_eq!(func_call.get_expr_type(), ExprType::Add);
+                assert_eq!(func_call.gett_expr_type(), ExprType::Add);
                 let inputs = func_call.inputs();
                 assert_eq_input_ref!(&inputs[0], 1);
                 assert_eq_input_ref!(&inputs[1], 2);

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -267,7 +267,7 @@ impl LogicalJoin {
 
         for expr in &predicate.conjunctions {
             if let ExprImpl::FunctionCall(func) = expr {
-                match func.get_expr_type() {
+                match func.gett_expr_type() {
                     ExprType::Equal
                     | ExprType::NotEqual
                     | ExprType::LessThan

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -267,7 +267,7 @@ impl LogicalJoin {
 
         for expr in &predicate.conjunctions {
             if let ExprImpl::FunctionCall(func) = expr {
-                match func.gett_expr_type() {
+                match func.func_type() {
                     ExprType::Equal
                     | ExprType::NotEqual
                     | ExprType::LessThan

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -384,7 +384,7 @@ fn expr_to_kafka_timestamp_range(
         ExprImpl::FunctionCall(function_call) => {
             if let Some((timestampz_literal, reverse)) = extract_timestampz_literal(&expr).unwrap()
             {
-                match function_call.gett_expr_type() {
+                match function_call.func_type() {
                     ExprType::GreaterThan => {
                         if reverse {
                             range.1 = merge_upper_bound(range.1, Excluded(timestampz_literal));

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -384,7 +384,7 @@ fn expr_to_kafka_timestamp_range(
         ExprImpl::FunctionCall(function_call) => {
             if let Some((timestampz_literal, reverse)) = extract_timestampz_literal(&expr).unwrap()
             {
-                match function_call.get_expr_type() {
+                match function_call.gett_expr_type() {
                     ExprType::GreaterThan => {
                         if reverse {
                             range.1 = merge_upper_bound(range.1, Excluded(timestampz_literal));

--- a/src/frontend/src/optimizer/rule/apply_eliminate_rule.rs
+++ b/src/frontend/src/optimizer/rule/apply_eliminate_rule.rs
@@ -145,7 +145,7 @@ impl ApplyEliminateRule {
     /// `LogicalApply`'s left and right.
     fn check(func_call: &FunctionCall, apply_left_len: usize) -> Option<(usize, usize, DataType)> {
         let inputs = func_call.inputs();
-        if func_call.get_expr_type() == ExprType::Equal && inputs.len() == 2 {
+        if func_call.gett_expr_type() == ExprType::Equal && inputs.len() == 2 {
             let left = &inputs[0];
             let right = &inputs[1];
             match (left, right) {

--- a/src/frontend/src/optimizer/rule/apply_eliminate_rule.rs
+++ b/src/frontend/src/optimizer/rule/apply_eliminate_rule.rs
@@ -145,7 +145,7 @@ impl ApplyEliminateRule {
     /// `LogicalApply`'s left and right.
     fn check(func_call: &FunctionCall, apply_left_len: usize) -> Option<(usize, usize, DataType)> {
         let inputs = func_call.inputs();
-        if func_call.gett_expr_type() == ExprType::Equal && inputs.len() == 2 {
+        if func_call.func_type() == ExprType::Equal && inputs.len() == 2 {
             let left = &inputs[0];
             let right = &inputs[1];
             match (left, right) {

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -393,7 +393,7 @@ impl IndexSelectionRule {
         for expr in conjunctions {
             // it's OR clause!
             if let ExprImpl::FunctionCall(function_call) = expr
-                && function_call.gett_expr_type() == ExprType::Or
+                && function_call.func_type() == ExprType::Or
             {
                 let mut index_to_be_merged = vec![];
 
@@ -914,7 +914,7 @@ impl IndexCost {
 
 impl ExprVisitor<IndexCost> for TableScanIoEstimator<'_> {
     fn visit_function_call(&mut self, func_call: &FunctionCall) -> IndexCost {
-        match func_call.gett_expr_type() {
+        match func_call.func_type() {
             ExprType::Or => func_call
                 .inputs()
                 .iter()

--- a/src/frontend/src/optimizer/rule/index_selection_rule.rs
+++ b/src/frontend/src/optimizer/rule/index_selection_rule.rs
@@ -393,7 +393,7 @@ impl IndexSelectionRule {
         for expr in conjunctions {
             // it's OR clause!
             if let ExprImpl::FunctionCall(function_call) = expr
-                && function_call.get_expr_type() == ExprType::Or
+                && function_call.gett_expr_type() == ExprType::Or
             {
                 let mut index_to_be_merged = vec![];
 
@@ -914,7 +914,7 @@ impl IndexCost {
 
 impl ExprVisitor<IndexCost> for TableScanIoEstimator<'_> {
     fn visit_function_call(&mut self, func_call: &FunctionCall) -> IndexCost {
-        match func_call.get_expr_type() {
+        match func_call.gett_expr_type() {
             ExprType::Or => func_call
                 .inputs()
                 .iter()

--- a/src/frontend/src/optimizer/rule/push_calculation_of_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/push_calculation_of_join_rule.rs
@@ -158,7 +158,7 @@ impl PushCalculationOfJoinRule {
         };
         for (index, expr) in exprs.iter().enumerate() {
             let ExprImpl::FunctionCall(func) = expr else { continue };
-            if !is_comparison_type(func.get_expr_type()) {
+            if !is_comparison_type(func.gett_expr_type()) {
                 continue;
             }
             // Do not decompose the comparison if it contains `now()`

--- a/src/frontend/src/optimizer/rule/push_calculation_of_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/push_calculation_of_join_rule.rs
@@ -158,7 +158,7 @@ impl PushCalculationOfJoinRule {
         };
         for (index, expr) in exprs.iter().enumerate() {
             let ExprImpl::FunctionCall(func) = expr else { continue };
-            if !is_comparison_type(func.gett_expr_type()) {
+            if !is_comparison_type(func.func_type()) {
                 continue;
             }
             // Do not decompose the comparison if it contains `now()`

--- a/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
+++ b/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
@@ -54,7 +54,7 @@ impl ExprVisitor<bool> for HasLikeExprVisitor {
     }
 
     fn visit_function_call(&mut self, func_call: &FunctionCall) -> bool {
-        if func_call.gett_expr_type() == ExprType::Like
+        if func_call.func_type() == ExprType::Like
             && let (_, ExprImpl::InputRef(_), ExprImpl::Literal(_)) =
                 func_call.clone().decompose_as_binary()
         {
@@ -116,7 +116,7 @@ impl ExprRewriter for LikeExprRewriter {
             .collect();
         let func_call = FunctionCall::new_unchecked(func_type, inputs, ret.clone());
 
-        if func_call.gett_expr_type() != ExprType::Like {
+        if func_call.func_type() != ExprType::Like {
             return func_call.into();
         }
 

--- a/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
+++ b/src/frontend/src/optimizer/rule/rewrite_like_expr_rule.rs
@@ -54,7 +54,7 @@ impl ExprVisitor<bool> for HasLikeExprVisitor {
     }
 
     fn visit_function_call(&mut self, func_call: &FunctionCall) -> bool {
-        if func_call.get_expr_type() == ExprType::Like
+        if func_call.gett_expr_type() == ExprType::Like
             && let (_, ExprImpl::InputRef(_), ExprImpl::Literal(_)) =
                 func_call.clone().decompose_as_binary()
         {
@@ -116,7 +116,7 @@ impl ExprRewriter for LikeExprRewriter {
             .collect();
         let func_call = FunctionCall::new_unchecked(func_type, inputs, ret.clone());
 
-        if func_call.get_expr_type() != ExprType::Like {
+        if func_call.gett_expr_type() != ExprType::Like {
             return func_call.into();
         }
 

--- a/src/frontend/src/optimizer/rule/stream/filter_with_now_to_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/stream/filter_with_now_to_join_rule.rs
@@ -55,12 +55,12 @@ impl Rule for FilterWithNowToJoinRule {
         // We want to put `input_expr >/>= now_expr` before `input_expr </<= now_expr` as the former
         // will introduce a watermark that can reduce state (since `now_expr` is monotonically
         // increasing)
-        now_filters.sort_by_key(|l| rank_cmp(l.gett_expr_type()));
+        now_filters.sort_by_key(|l| rank_cmp(l.func_type()));
 
         // Ignore no now filter & forbid now filters that do not create a watermark
         if now_filters.is_empty()
             || !matches!(
-                now_filters[0].gett_expr_type(),
+                now_filters[0].func_type(),
                 Type::GreaterThan | Type::GreaterThanOrEqual
             )
         {

--- a/src/frontend/src/optimizer/rule/stream/filter_with_now_to_join_rule.rs
+++ b/src/frontend/src/optimizer/rule/stream/filter_with_now_to_join_rule.rs
@@ -55,12 +55,12 @@ impl Rule for FilterWithNowToJoinRule {
         // We want to put `input_expr >/>= now_expr` before `input_expr </<= now_expr` as the former
         // will introduce a watermark that can reduce state (since `now_expr` is monotonically
         // increasing)
-        now_filters.sort_by_key(|l| rank_cmp(l.get_expr_type()));
+        now_filters.sort_by_key(|l| rank_cmp(l.gett_expr_type()));
 
         // Ignore no now filter & forbid now filters that do not create a watermark
         if now_filters.is_empty()
             || !matches!(
-                now_filters[0].get_expr_type(),
+                now_filters[0].gett_expr_type(),
                 Type::GreaterThan | Type::GreaterThanOrEqual
             )
         {

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -226,7 +226,7 @@ impl Planner {
                 .group_by::<_, 3>(|expr| match expr {
                     ExprImpl::Subquery(_) => 0,
                     ExprImpl::FunctionCall(func_call)
-                        if func_call.gett_expr_type() == ExprType::Not
+                        if func_call.func_type() == ExprType::Not
                             && matches!(func_call.inputs()[0], ExprImpl::Subquery(_)) =>
                     {
                         1

--- a/src/frontend/src/planner/select.rs
+++ b/src/frontend/src/planner/select.rs
@@ -226,7 +226,7 @@ impl Planner {
                 .group_by::<_, 3>(|expr| match expr {
                     ExprImpl::Subquery(_) => 0,
                     ExprImpl::FunctionCall(func_call)
-                        if func_call.get_expr_type() == ExprType::Not
+                        if func_call.gett_expr_type() == ExprType::Not
                             && matches!(func_call.inputs()[0], ExprImpl::Subquery(_)) =>
                     {
                         1

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -26,7 +26,7 @@ use risingwave_pb::data::data_type::TypeName;
 use risingwave_pb::data::DataType;
 use risingwave_pb::expr::agg_call::Type;
 use risingwave_pb::expr::expr_node::RexNode;
-use risingwave_pb::expr::expr_node::Type::{Add, GreaterThan, InputRef};
+use risingwave_pb::expr::expr_node::Type::{Add, GreaterThan};
 use risingwave_pb::expr::{AggCall, ExprNode, FunctionCall, PbInputRef};
 use risingwave_pb::plan_common::{ColumnCatalog, ColumnDesc, Field};
 use risingwave_pb::stream_plan::stream_fragment_graph::{StreamFragment, StreamFragmentEdge};
@@ -46,7 +46,7 @@ use crate::MetaResult;
 
 fn make_inputref(idx: u32) -> ExprNode {
     ExprNode {
-        expr_type: InputRef as i32,
+        expr_type: Type::Unspecified as i32,
         return_type: Some(DataType {
             type_name: TypeName::Int32 as i32,
             ..Default::default()

--- a/src/meta/src/stream/test_fragmenter.rs
+++ b/src/meta/src/stream/test_fragmenter.rs
@@ -46,7 +46,7 @@ use crate::MetaResult;
 
 fn make_inputref(idx: u32) -> ExprNode {
     ExprNode {
-        expr_type: Type::Unspecified as i32,
+        function_type: Type::Unspecified as i32,
         return_type: Some(DataType {
             type_name: TypeName::Int32 as i32,
             ..Default::default()
@@ -247,7 +247,7 @@ fn make_stream_fragments() -> Vec<StreamFragment> {
     let filter_node = StreamNode {
         node_body: Some(NodeBody::Filter(FilterNode {
             search_condition: Some(ExprNode {
-                expr_type: GreaterThan as i32,
+                function_type: GreaterThan as i32,
                 return_type: Some(DataType {
                     type_name: TypeName::Boolean as i32,
                     ..Default::default()
@@ -333,7 +333,7 @@ fn make_stream_fragments() -> Vec<StreamFragment> {
             select_list: vec![
                 ExprNode {
                     rex_node: Some(RexNode::FuncCall(function_call_1)),
-                    expr_type: Add as i32,
+                    function_type: Add as i32,
                     return_type: Some(DataType {
                         type_name: TypeName::Int64 as i32,
                         ..Default::default()

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -56,6 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .protoc_arg("--experimental_allow_proto3_optional")
         .type_attribute(".", "#[derive(prost_helpers::AnyPB)]")
         .type_attribute("node_body", "#[derive(::enum_as_inner::EnumAsInner)]")
+        .type_attribute("rex_node", "#[derive(::enum_as_inner::EnumAsInner)]")
         .type_attribute("catalog.WatermarkDesc", "#[derive(Eq, Hash)]")
         .type_attribute("expr.ExprNode", "#[derive(Eq, Hash)]")
         .type_attribute("data.DataType", "#[derive(Eq, Hash)]")

--- a/src/stream/src/from_proto/dynamic_filter.rs
+++ b/src/stream/src/from_proto/dynamic_filter.rs
@@ -45,7 +45,7 @@ impl ExecutorBuilder for DynamicFilterExecutorBuilder {
         );
 
         let prost_condition = node.get_condition()?;
-        let comparator = prost_condition.get_expr_type()?;
+        let comparator = prost_condition.get_function_type()?;
         if !matches!(
             comparator,
             GreaterThan | GreaterThanOrEqual | LessThan | LessThanOrEqual

--- a/src/stream/src/from_proto/project.rs
+++ b/src/stream/src/from_proto/project.rs
@@ -15,7 +15,7 @@
 use multimap::MultiMap;
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr::expr::build_from_prost;
-use risingwave_pb::expr::expr_node;
+use risingwave_pb::expr::expr_node::RexNode;
 use risingwave_pb::stream_plan::ProjectNode;
 
 use super::*;
@@ -51,8 +51,10 @@ impl ExecutorBuilder for ProjectExecutorBuilder {
                 ),
         );
         let extremely_light = node.get_select_list().iter().all(|expr| {
-            let expr_type = expr.get_expr_type().unwrap();
-            expr_type == expr_node::Type::InputRef || expr_type == expr_node::Type::ConstantValue
+            matches!(
+                expr.get_rex_node().unwrap(),
+                RexNode::InputRef(_) | RexNode::Constant(_)
+            )
         });
         let materialize_selectivity_threshold = if extremely_light { 0.0 } else { 0.5 };
         Ok(ProjectExecutor::new(


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Make `PbExpr::Type` actually the type for **function**s, where `InputRef`, `Constant`, and `Udf` is removed and should be indicated by the variant of `rex_node` in the future.

All implementations now ensure that we interpret the `i32` value to the enum variant only if we're sure it's a function call. So even if removing these fields seems to be a breaking change (`Err` for `get_expr_type()` and `Unspecified` for `expr_type()`), it's actually not.

It's obvious that it's better for us to move this field into the `FunctionCall` message, but it seems unacceptable for backward compatibility as we persist expressions in the catalog for default values and generated columns. :(

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
