### PR TITLE
refactor(explain): introduce `formatter_debug_plan_node` for convenient display of plan node properties

### DIFF
--- a/src/frontend/planner_test/tests/testdata/output/append_only.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/append_only.yaml
@@ -5,7 +5,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, mx2], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.v1, max(t1.v2)] }
-      └─StreamHashAgg [in_append_only] { group_key: [t1.v1], aggs: [max(t1.v2), count] }
+      └─StreamHashAgg [append_only] { group_key: [t1.v1], aggs: [max(t1.v2), count] }
         └─StreamExchange { dist: HashShard(t1.v1) }
           └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
 - sql: |
@@ -14,7 +14,7 @@
     select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
   stream_plan: |
     StreamMaterialize { columns: [id, v2, v3, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, id], pk_columns: [t1._row_id, t2._row_id, id], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.v1) }

--- a/src/frontend/planner_test/tests/testdata/output/append_only.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/append_only.yaml
@@ -5,7 +5,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, mx2], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.v1, max(t1.v2)] }
-      └─StreamAppendOnlyHashAgg { group_key: [t1.v1], aggs: [max(t1.v2), count] }
+      └─StreamHashAgg [append_only] { group_key: [t1.v1], aggs: [max(t1.v2), count] }
         └─StreamExchange { dist: HashShard(t1.v1) }
           └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
 - sql: |
@@ -14,7 +14,7 @@
     select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
   stream_plan: |
     StreamMaterialize { columns: [id, v2, v3, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, id], pk_columns: [t1._row_id, t2._row_id, id], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.v1) }

--- a/src/frontend/planner_test/tests/testdata/output/append_only.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/append_only.yaml
@@ -5,7 +5,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, mx2], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.v1, max(t1.v2)] }
-      └─StreamHashAgg [append_only] { group_key: [t1.v1], aggs: [max(t1.v2), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [t1.v1], aggs: [max(t1.v2), count] }
         └─StreamExchange { dist: HashShard(t1.v1) }
           └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
 - sql: |
@@ -14,7 +14,7 @@
     select t1.v1 as id, v2, v3 from t1 join t2 on t1.v1=t2.v1;
   stream_plan: |
     StreamMaterialize { columns: [id, v2, v3, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, id], pk_columns: [t1._row_id, t2._row_id, id], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: t1.v1 = t2.v1, output: [t1.v1, t1.v2, t2.v3, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.v1) }

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -17,7 +17,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamHashAgg [in_append_only] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [append_only] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -25,7 +25,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamHashAgg [in_append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -35,7 +35,7 @@
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-        └── StreamHashAgg [in_append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+        └── StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: [ (distinct key: v3, table id: 1) ]
@@ -83,14 +83,14 @@
   stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   eowc_stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -99,7 +99,7 @@
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-        └── StreamHashAgg [in_append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+        └── StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -17,7 +17,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamHashAgg [append_only] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [in_append_only] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -25,7 +25,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [in_append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -35,7 +35,7 @@
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-        └── StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+        └── StreamHashAgg [in_append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: [ (distinct key: v3, table id: 1) ]
@@ -83,14 +83,14 @@
   stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   eowc_stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -99,7 +99,7 @@
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-        └── StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+        └── StreamHashAgg [in_append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -17,7 +17,7 @@
   stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamAppendOnlyHashAgg { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [append_only] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -25,7 +25,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     └─StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-      └─StreamAppendOnlyHashAgg { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+      └─StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
         └─StreamExchange { dist: HashShard(v1) }
           └─StreamRowIdGen { row_id_index: 3 }
             └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - 10:Int32)] }
@@ -35,7 +35,7 @@
     StreamMaterialize { columns: [v1, min, agg], stream_key: [v1], pk_columns: [v1], pk_conflict: "NoCheck", watermark_columns: [v1] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [v1, min(v2), count(distinct v3)], output_watermarks: [v1] }
-        └── StreamAppendOnlyHashAgg { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
+        └── StreamHashAgg [append_only, eowc] { group_key: [v1], aggs: [min(v2), count(distinct v3), count], output_watermarks: [v1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: [ (distinct key: v3, table id: 1) ]
@@ -83,14 +83,14 @@
   stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   eowc_stream_plan: |
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     └─StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+      └─StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [TumbleStart(t.a, '01:00:00':Interval) as $expr1, t.b, t._row_id], output_watermarks: [$expr1] }
             └─StreamTableScan { table: t, columns: [t.a, t.b, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
@@ -99,7 +99,7 @@
     StreamMaterialize { columns: [window_start, max], stream_key: [window_start], pk_columns: [window_start], pk_conflict: "NoCheck", watermark_columns: [window_start] }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, max(t.b)], output_watermarks: [$expr1] }
-        └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
+        └── StreamHashAgg [append_only, eowc] { group_key: [$expr1], aggs: [max(t.b), count], output_watermarks: [$expr1] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -437,7 +437,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 5 }
-          |   └─StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
           |       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
           |         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -446,7 +446,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 5 }
-                  └─StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
                       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -468,7 +468,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -559,7 +559,7 @@
           | └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           └─StreamExchange { dist: HashShard(max(bid.price)) }
             └─StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(bid.price), count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, bid.price, bid._row_id] }
                     └─StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -580,7 +580,7 @@
 
     Fragment 2
     StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 3
 
     Fragment 3
@@ -982,14 +982,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1049,14 +1049,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(bid.channel, $expr1) }
         └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr2, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1110,7 +1110,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-      └─StreamHashAgg [in_append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+      └─StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─StreamExchange { dist: HashShard(bid.auction, $expr1) }
           └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price, bid._row_id] }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -1118,7 +1118,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-        └── StreamHashAgg [in_append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+        └── StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1423,7 +1423,7 @@
       ├─StreamExchange { dist: HashShard(auction.id) }
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction, max(bid.price)] }
-        └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] }
+        └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] }
           └─StreamExchange { dist: HashShard(bid.auction) }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1437,7 +1437,7 @@
         ├── right degree table: 3
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction, max(bid.price)] }
-            └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1518,7 +1518,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(bid.auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(bid.auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(bid.auction) }
                   └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1549,7 +1549,7 @@
         └──  StreamExchange Single from 4
 
     Fragment 4
-    StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 5
 
     Fragment 5
@@ -1631,7 +1631,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1646,7 +1646,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []
@@ -1749,7 +1749,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1764,7 +1764,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -437,7 +437,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 5 }
-          |   └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
           |       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
           |         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -446,7 +446,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 5 }
-                  └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
                       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -468,7 +468,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -559,7 +559,7 @@
           | └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           └─StreamExchange { dist: HashShard(max(bid.price)) }
             └─StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] }
+              └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(bid.price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, bid.price, bid._row_id] }
                     └─StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -580,7 +580,7 @@
 
     Fragment 2
     StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 3
 
     Fragment 3
@@ -982,14 +982,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1049,14 +1049,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(bid.channel, $expr1) }
         └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr2, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1110,7 +1110,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-      └─StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+      └─StreamHashAgg [in_append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─StreamExchange { dist: HashShard(bid.auction, $expr1) }
           └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price, bid._row_id] }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -1118,7 +1118,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-        └── StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+        └── StreamHashAgg [in_append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1423,7 +1423,7 @@
       ├─StreamExchange { dist: HashShard(auction.id) }
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction, max(bid.price)] }
-        └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] }
+        └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] }
           └─StreamExchange { dist: HashShard(bid.auction) }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1437,7 +1437,7 @@
         ├── right degree table: 3
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction, max(bid.price)] }
-            └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1518,7 +1518,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(bid.auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(bid.auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
+              └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(bid.auction) }
                   └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1549,7 +1549,7 @@
         └──  StreamExchange Single from 4
 
     Fragment 4
-    StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 5
 
     Fragment 5
@@ -1631,7 +1631,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1646,7 +1646,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []
@@ -1749,7 +1749,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1764,7 +1764,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [in_append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -437,7 +437,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 5 }
-          |   └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
           |       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
           |         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -446,7 +446,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 5 }
-                  └─StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(bid.auction, window_start) }
                       └─StreamHopWindow { time_col: bid.date_time, slide: 00:00:02, size: 00:00:10, output: [bid.auction, window_start, bid._row_id] }
                         └─StreamFilter { predicate: IsNotNull(bid.date_time) }
@@ -468,7 +468,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamAppendOnlyHashAgg { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [bid.auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -559,7 +559,7 @@
           | └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
           └─StreamExchange { dist: HashShard(max(bid.price)) }
             └─StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(bid.price), count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(bid.date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, bid.price, bid._row_id] }
                     └─StreamTableScan { table: bid, columns: [bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -580,7 +580,7 @@
 
     Fragment 2
     StreamProject { exprs: [$expr1, max(bid.price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 3
 
     Fragment 3
@@ -982,14 +982,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1049,14 +1049,14 @@
                 └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time], distribution: SomeShard }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(bid.channel, $expr1) }
         └─StreamProject { exprs: [bid.channel, ToChar(bid.date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(bid.date_time, 'HH:mm':Varchar) as $expr2, bid.price, bid.bidder, bid.auction, bid._row_id] }
           └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [bid.channel, $expr1], aggs: [max($expr2), count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), count(distinct bid.bidder), count(distinct bid.bidder) filter((bid.price < 10000:Int32)), count(distinct bid.bidder) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.bidder) filter((bid.price >= 1000000:Int32)), count(distinct bid.auction), count(distinct bid.auction) filter((bid.price < 10000:Int32)), count(distinct bid.auction) filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count(distinct bid.auction) filter((bid.price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bid.bidder, table id: 1), (distinct key: bid.auction, table id: 2) ]
@@ -1110,7 +1110,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-      └─StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+      └─StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
         └─StreamExchange { dist: HashShard(bid.auction, $expr1) }
           └─StreamProject { exprs: [bid.auction, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, bid.price, bid._row_id] }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -1118,7 +1118,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [bid.auction, $expr1, count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), (sum(bid.price) / count(bid.price)::Decimal) as $expr2, sum(bid.price)] }
-        └── StreamAppendOnlyHashAgg { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
+        └── StreamHashAgg [append_only] { group_key: [bid.auction, $expr1], aggs: [count, count filter((bid.price < 10000:Int32)), count filter((bid.price >= 10000:Int32) AND (bid.price < 1000000:Int32)), count filter((bid.price >= 1000000:Int32)), min(bid.price), max(bid.price), sum(bid.price), count(bid.price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1423,7 +1423,7 @@
       ├─StreamExchange { dist: HashShard(auction.id) }
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction, max(bid.price)] }
-        └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [max(bid.price), count] }
+        └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] }
           └─StreamExchange { dist: HashShard(bid.auction) }
             └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1437,7 +1437,7 @@
         ├── right degree table: 3
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction, max(bid.price)] }
-            └── StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [max(bid.price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1518,7 +1518,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(bid.auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(bid.auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(bid.auction) }
                   └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1549,7 +1549,7 @@
         └──  StreamExchange Single from 4
 
     Fragment 4
-    StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 5
 
     Fragment 5
@@ -1631,7 +1631,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1646,7 +1646,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []
@@ -1749,7 +1749,7 @@
       | └─StreamTableScan { table: auction, columns: [auction.id, auction.item_name], pk: [auction.id], dist: UpstreamHashShard(auction.id) }
       └─StreamProject { exprs: [bid.auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(bid.auction) }
               └─StreamTableScan { table: bid, columns: [bid.auction, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_dist_plan: |+
@@ -1764,7 +1764,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [bid.auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [bid.auction], aggs: [count] }
+                └── StreamHashAgg [append_only] { group_key: [bid.auction], aggs: [count] }
                     ├── result table: 5
                     ├── state tables: []
                     ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -160,7 +160,7 @@
           └─BatchSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
       ├─StreamExchange { dist: HashShard(seller) }
       | └─StreamFilter { predicate: (category = 10:Int32) }
       |   └─StreamRowIdGen { row_id_index: 10 }
@@ -173,7 +173,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([7]) from 1
         └──  StreamExchange Hash([0]) from 2
 
@@ -247,10 +247,10 @@
       └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
-            └─StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
+            └─StreamHashAgg [in_append_only] { group_key: [id, category], aggs: [max(price), count] }
               └─StreamProject { exprs: [id, category, price, _row_id, _row_id] }
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                  └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
+                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamRowIdGen { row_id_index: 10 }
                     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -270,13 +270,13 @@
 
     Fragment 1
     StreamProject { exprs: [id, category, max(price)] }
-    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
+    └── StreamHashAgg [in_append_only] { group_key: [id, category], aggs: [max(price), count] }
         ├── result table: 1
         ├── state tables: []
         ├── distinct tables: []
         └── StreamProject { exprs: [id, category, price, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
+                └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
                     ├── left table: 2
                     ├── right table: 4
                     ├── left degree table: 3
@@ -401,7 +401,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -412,7 +412,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -436,7 +436,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -530,7 +530,7 @@
           |       └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
             └─StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] }
+              └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
                     └─StreamShare { id = 3 }
@@ -558,7 +558,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -634,7 +634,7 @@
             └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
       | └─StreamAppendOnlyDedup { dedup_cols: [id, name, $expr1, $expr2] }
       |   └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
@@ -650,7 +650,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [seller, $expr3, $expr4] } { state table: 6 }
             └──  StreamExchange Hash([0, 1, 2]) from 3
@@ -729,7 +729,7 @@
     └─StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] }
       └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
         └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-          └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
+          └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
             ├─StreamExchange { dist: HashShard(id) }
             | └─StreamRowIdGen { row_id_index: 10 }
             |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -743,7 +743,7 @@
     └── StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] } { state table: 0 }
         └── StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+                └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
                     ├──  StreamExchange Hash([0]) from 1
                     └──  StreamExchange Hash([0]) from 2
 
@@ -945,7 +945,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -953,7 +953,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1012,7 +1012,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(channel, $expr1) }
         └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -1020,7 +1020,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1073,7 +1073,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-      └─StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+      └─StreamHashAgg [in_append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
@@ -1082,7 +1082,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+        └── StreamHashAgg [in_append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1254,7 +1254,7 @@
           └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(auction) }
       | └─StreamRowIdGen { row_id_index: 7 }
       |   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1266,7 +1266,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -1388,7 +1388,7 @@
       | └─StreamRowIdGen { row_id_index: 10 }
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
-        └─StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] }
+        └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [max(price), count] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1399,7 +1399,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: id = auction, output: [id, item_name, max(price), _row_id, auction] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction, max(price)] }
-            └── StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1473,8 +1473,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] }
       ├─StreamProject { exprs: [id, item_name, count(auction)] }
-      | └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
-      |   └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+      | └─StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard(id) }
       |     | └─StreamRowIdGen { row_id_index: 10 }
       |     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1487,7 +1487,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
+              └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(auction) }
                   └─StreamShare { id = 5 }
                     └─StreamProject { exprs: [auction, _row_id] }
@@ -1499,8 +1499,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [id, item_name, count(auction)] }
-        │   └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        │   └── StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1529,7 +1529,7 @@
         └──  StreamExchange Single from 5
 
     Fragment 5
-    StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 6
 
     Fragment 6
@@ -1604,7 +1604,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1620,7 +1620,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1692,7 +1692,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1708,7 +1708,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1779,8 +1779,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-              └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+              └─StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard(id) }
                   | └─StreamRowIdGen { row_id_index: 10 }
                   |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1798,8 +1798,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-        └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        └── StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -1892,10 +1892,10 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr1], aggs: [min(max(price)), count] }
             └─StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-              └─StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
+              └─StreamHashAgg [in_append_only] { group_key: [id], aggs: [max(price), count] }
                 └─StreamProject { exprs: [id, price, _row_id, _row_id] }
                   └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
+                    └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
                       ├─StreamExchange { dist: HashShard(id) }
                       | └─StreamRowIdGen { row_id_index: 10 }
                       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1919,13 +1919,13 @@
     ├── state tables: [ 2 ]
     ├── distinct tables: []
     └── StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-        └── StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [id], aggs: [max(price), count] }
             ├── result table: 4
             ├── state tables: []
             ├── distinct tables: []
             └── StreamProject { exprs: [id, price, _row_id, _row_id] }
                 └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
+                    └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
                         ├── left table: 5
                         ├── right table: 7
                         ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -160,7 +160,7 @@
           └─BatchSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
       ├─StreamExchange { dist: HashShard(seller) }
       | └─StreamFilter { predicate: (category = 10:Int32) }
       |   └─StreamRowIdGen { row_id_index: 10 }
@@ -173,7 +173,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([7]) from 1
         └──  StreamExchange Hash([0]) from 2
 
@@ -247,10 +247,10 @@
       └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
-            └─StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [max(price), count] }
+            └─StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
               └─StreamProject { exprs: [id, category, price, _row_id, _row_id] }
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                  └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamRowIdGen { row_id_index: 10 }
                     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -270,13 +270,13 @@
 
     Fragment 1
     StreamProject { exprs: [id, category, max(price)] }
-    └── StreamAppendOnlyHashAgg { group_key: [id, category], aggs: [max(price), count] }
+    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
         ├── result table: 1
         ├── state tables: []
         ├── distinct tables: []
         └── StreamProject { exprs: [id, category, price, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                     ├── left table: 2
                     ├── right table: 4
                     ├── left degree table: 3
@@ -401,7 +401,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -412,7 +412,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -436,7 +436,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -530,7 +530,7 @@
           |       └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
             └─StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(price), count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
                     └─StreamShare { id = 3 }
@@ -558,7 +558,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -634,7 +634,7 @@
             └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
       | └─StreamAppendOnlyDedup { dedup_cols: [id, name, $expr1, $expr2] }
       |   └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
@@ -650,7 +650,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [seller, $expr3, $expr4] } { state table: 6 }
             └──  StreamExchange Hash([0, 1, 2]) from 3
@@ -729,7 +729,7 @@
     └─StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] }
       └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
         └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-          └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+          └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
             ├─StreamExchange { dist: HashShard(id) }
             | └─StreamRowIdGen { row_id_index: 10 }
             |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -743,7 +743,7 @@
     └── StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] } { state table: 0 }
         └── StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
                     ├──  StreamExchange Hash([0]) from 1
                     └──  StreamExchange Hash([0]) from 2
 
@@ -945,7 +945,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -953,7 +953,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1012,7 +1012,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(channel, $expr1) }
         └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -1020,7 +1020,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1073,7 +1073,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-      └─StreamAppendOnlyHashAgg { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+      └─StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
@@ -1082,7 +1082,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-        └── StreamAppendOnlyHashAgg { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1254,7 +1254,7 @@
           └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(auction) }
       | └─StreamRowIdGen { row_id_index: 7 }
       |   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1266,7 +1266,11 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+        ├── left table: 0
+        ├── right table: 2
+        ├── left degree table: 1
+        ├── right degree table: 3
         ├──  StreamExchange Hash([0]) from 1
         └──  StreamExchange Hash([0]) from 2
 
@@ -1384,7 +1388,7 @@
       | └─StreamRowIdGen { row_id_index: 10 }
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
-        └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [max(price), count] }
+        └─StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1395,7 +1399,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: id = auction, output: [id, item_name, max(price), _row_id, auction] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction, max(price)] }
-            └── StreamAppendOnlyHashAgg { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1469,8 +1473,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] }
       ├─StreamProject { exprs: [id, item_name, count(auction)] }
-      | └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
-      |   └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+      | └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard(id) }
       |     | └─StreamRowIdGen { row_id_index: 10 }
       |     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1483,7 +1487,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(auction) }
                   └─StreamShare { id = 5 }
                     └─StreamProject { exprs: [auction, _row_id] }
@@ -1495,8 +1499,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [id, item_name, count(auction)] }
-        │   └── StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        │   └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1525,7 +1529,7 @@
         └──  StreamExchange Single from 5
 
     Fragment 5
-    StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 6
 
     Fragment 6
@@ -1600,7 +1604,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1616,7 +1620,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1688,7 +1692,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1704,7 +1708,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1775,8 +1779,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-              └─StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard(id) }
                   | └─StreamRowIdGen { row_id_index: 10 }
                   |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1794,8 +1798,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-        └── StreamAppendOnlyHashAgg { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -1888,10 +1892,10 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr1], aggs: [min(max(price)), count] }
             └─StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-              └─StreamAppendOnlyHashAgg { group_key: [id], aggs: [max(price), count] }
+              └─StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
                 └─StreamProject { exprs: [id, price, _row_id, _row_id] }
                   └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                    └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                       ├─StreamExchange { dist: HashShard(id) }
                       | └─StreamRowIdGen { row_id_index: 10 }
                       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1915,13 +1919,13 @@
     ├── state tables: [ 2 ]
     ├── distinct tables: []
     └── StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-        └── StreamAppendOnlyHashAgg { group_key: [id], aggs: [max(price), count] }
+        └── StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
             ├── result table: 4
             ├── state tables: []
             ├── distinct tables: []
             └── StreamProject { exprs: [id, price, _row_id, _row_id] }
                 └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └── StreamAppendOnlyHashJoin { type: Inner, predicate: id = auction, output: all }
+                    └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                         ├── left table: 5
                         ├── right table: 7
                         ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_source.yaml
@@ -160,7 +160,7 @@
           └─BatchSource { source: "person", columns: ["id", "name", "email_address", "credit_card", "city", "state", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] }
       ├─StreamExchange { dist: HashShard(seller) }
       | └─StreamFilter { predicate: (category = 10:Int32) }
       |   └─StreamRowIdGen { row_id_index: 10 }
@@ -173,7 +173,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), seller(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, seller], pk_columns: [_row_id, _row_id#1, seller], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: seller = id, output: [name, city, state, id, _row_id, seller, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([7]) from 1
         └──  StreamExchange Hash([0]) from 2
 
@@ -247,10 +247,10 @@
       └─StreamHashAgg { group_key: [category], aggs: [sum(max(price)), count(max(price)), count] }
         └─StreamExchange { dist: HashShard(category) }
           └─StreamProject { exprs: [id, category, max(price)] }
-            └─StreamHashAgg [in_append_only] { group_key: [id, category], aggs: [max(price), count] }
+            └─StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
               └─StreamProject { exprs: [id, category, price, _row_id, _row_id] }
                 └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                     ├─StreamExchange { dist: HashShard(id) }
                     | └─StreamRowIdGen { row_id_index: 10 }
                     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -270,13 +270,13 @@
 
     Fragment 1
     StreamProject { exprs: [id, category, max(price)] }
-    └── StreamHashAgg [in_append_only] { group_key: [id, category], aggs: [max(price), count] }
+    └── StreamHashAgg [append_only] { group_key: [id, category], aggs: [max(price), count] }
         ├── result table: 1
         ├── state tables: []
         ├── distinct tables: []
         └── StreamProject { exprs: [id, category, price, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
+                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                     ├── left table: 2
                     ├── right table: 4
                     ├── left degree table: 3
@@ -401,7 +401,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -412,7 +412,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -436,7 +436,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -530,7 +530,7 @@
           |       └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
           └─StreamExchange { dist: HashShard(max(price)) }
             └─StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-              └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(price), count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] }
                 └─StreamExchange { dist: HashShard($expr1) }
                   └─StreamProject { exprs: [(TumbleStart(date_time, '00:00:10':Interval) + '00:00:10':Interval) as $expr1, price, _row_id] }
                     └─StreamShare { id = 3 }
@@ -558,7 +558,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr1, max(price), ($expr1 - '00:00:10':Interval) as $expr2] }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -634,7 +634,7 @@
             └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all }
       ├─StreamExchange { dist: HashShard(id, $expr1, $expr2) }
       | └─StreamAppendOnlyDedup { dedup_cols: [id, name, $expr1, $expr2] }
       |   └─StreamExchange { dist: HashShard(id, name, $expr1, $expr2) }
@@ -650,7 +650,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr2(hidden), seller(hidden), $expr3(hidden), $expr4(hidden)], stream_key: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_columns: [id, name, starttime, $expr2, seller, $expr3, $expr4], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: id = seller AND $expr1 = $expr3 AND $expr2 = $expr4, output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [seller, $expr3, $expr4] } { state table: 6 }
             └──  StreamExchange Hash([0, 1, 2]) from 3
@@ -729,7 +729,7 @@
     └─StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] }
       └─StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
         └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-          └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
+          └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
             ├─StreamExchange { dist: HashShard(id) }
             | └─StreamRowIdGen { row_id_index: 10 }
             |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -743,7 +743,7 @@
     └── StreamAppendOnlyGroupTopN { order: "[price DESC, date_time ASC]", limit: 1, offset: 0, group_key: [0] } { state table: 0 }
         └── StreamProject { exprs: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, date_time, _row_id, _row_id] }
             └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+                └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
                     ├──  StreamExchange Hash([0]) from 1
                     └──  StreamExchange Hash([0]) from 2
 
@@ -945,7 +945,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr1) }
         └─StreamProject { exprs: [ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -953,7 +953,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1012,7 +1012,7 @@
                 └─BatchSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard(channel, $expr1) }
         └─StreamProject { exprs: [channel, ToChar(date_time, 'yyyy-MM-dd':Varchar) as $expr1, ToChar(date_time, 'HH:mm':Varchar) as $expr2, price, bidder, auction, _row_id] }
           └─StreamRowIdGen { row_id_index: 7 }
@@ -1020,7 +1020,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [channel, $expr1], aggs: [max($expr2), count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), count(distinct bidder), count(distinct bidder) filter((price < 10000:Int32)), count(distinct bidder) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct bidder) filter((price >= 1000000:Int32)), count(distinct auction), count(distinct auction) filter((price < 10000:Int32)), count(distinct auction) filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count(distinct auction) filter((price >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: bidder, table id: 1), (distinct key: auction, table id: 2) ]
@@ -1073,7 +1073,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-      └─StreamHashAgg [in_append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+      └─StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
         └─StreamExchange { dist: HashShard(auction, $expr1) }
           └─StreamProject { exprs: [auction, ToChar(date_time, 'YYYY-MM-DD':Varchar) as $expr1, price, _row_id] }
             └─StreamRowIdGen { row_id_index: 7 }
@@ -1082,7 +1082,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [auction, $expr1, count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), (sum(price) / count(price)::Decimal) as $expr2, sum(price)] }
-        └── StreamHashAgg [in_append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
+        └── StreamHashAgg [append_only] { group_key: [auction, $expr1], aggs: [count, count filter((price < 10000:Int32)), count filter((price >= 10000:Int32) AND (price < 1000000:Int32)), count filter((price >= 1000000:Int32)), min(price), max(price), sum(price), count(price)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1254,7 +1254,7 @@
           └─BatchSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(auction) }
       | └─StreamRowIdGen { row_id_index: 7 }
       |   └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1266,7 +1266,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: auction = id, output: [auction, bidder, price, channel, url, date_time, item_name, description, initial_bid, reserve, date_time, expires, seller, category, _row_id, _row_id] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -1388,7 +1388,7 @@
       | └─StreamRowIdGen { row_id_index: 10 }
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction, max(price)] }
-        └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [max(price), count] }
+        └─StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] }
           └─StreamExchange { dist: HashShard(auction) }
             └─StreamRowIdGen { row_id_index: 7 }
               └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1399,7 +1399,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: id = auction, output: [id, item_name, max(price), _row_id, auction] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction, max(price)] }
-            └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [auction], aggs: [max(price), count] } { result table: 5, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1473,8 +1473,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] }
       ├─StreamProject { exprs: [id, item_name, count(auction)] }
-      | └─StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
-      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+      | └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard(id) }
       |     | └─StreamRowIdGen { row_id_index: 10 }
       |     |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1487,7 +1487,7 @@
         └─StreamProject { exprs: [(sum0(count) / count(auction)) as $expr1] }
           └─StreamSimpleAgg { aggs: [sum0(count), count(auction), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
                 └─StreamExchange { dist: HashShard(auction) }
                   └─StreamShare { id = 5 }
                     └─StreamProject { exprs: [auction, _row_id] }
@@ -1499,8 +1499,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count(auction) >= $expr1), output: [id, item_name, count(auction)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [id, item_name, count(auction)] }
-        │   └── StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        │   └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1529,7 +1529,7 @@
         └──  StreamExchange Single from 5
 
     Fragment 5
-    StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 6
 
     Fragment 6
@@ -1604,7 +1604,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1620,7 +1620,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1692,7 +1692,7 @@
       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
       └─StreamProject { exprs: [auction] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [auction], aggs: [count] }
             └─StreamExchange { dist: HashShard(auction) }
               └─StreamRowIdGen { row_id_index: 7 }
                 └─StreamSource { source: "bid", columns: ["auction", "bidder", "price", "channel", "url", "date_time", "extra", "_row_id"] }
@@ -1708,7 +1708,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [auction] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [auction], aggs: [count] } { result table: 5, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 2
 
     Fragment 1
@@ -1779,8 +1779,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-              └─StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard(id) }
                   | └─StreamRowIdGen { row_id_index: 10 }
                   |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1798,8 +1798,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count(auction) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [id, item_name, count(auction), Vnode(id) as $expr1] }
-        └── StreamHashAgg [in_append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [id, item_name], aggs: [count(auction), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: [id, item_name, auction, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -1892,10 +1892,10 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr1], aggs: [min(max(price)), count] }
             └─StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-              └─StreamHashAgg [in_append_only] { group_key: [id], aggs: [max(price), count] }
+              └─StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
                 └─StreamProject { exprs: [id, price, _row_id, _row_id] }
                   └─StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
+                    └─StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                       ├─StreamExchange { dist: HashShard(id) }
                       | └─StreamRowIdGen { row_id_index: 10 }
                       |   └─StreamSource { source: "auction", columns: ["id", "item_name", "description", "initial_bid", "reserve", "date_time", "expires", "seller", "category", "extra", "_row_id"] }
@@ -1919,13 +1919,13 @@
     ├── state tables: [ 2 ]
     ├── distinct tables: []
     └── StreamProject { exprs: [id, max(price), Vnode(id) as $expr1] }
-        └── StreamHashAgg [in_append_only] { group_key: [id], aggs: [max(price), count] }
+        └── StreamHashAgg [append_only] { group_key: [id], aggs: [max(price), count] }
             ├── result table: 4
             ├── state tables: []
             ├── distinct tables: []
             └── StreamProject { exprs: [id, price, _row_id, _row_id] }
                 └── StreamFilter { predicate: (date_time >= date_time) AND (date_time <= expires) }
-                    └── StreamHashJoin [in_append_only] { type: Inner, predicate: id = auction, output: all }
+                    └── StreamHashJoin [append_only] { type: Inner, predicate: id = auction, output: all }
                         ├── left table: 5
                         ├── right table: 7
                         ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -127,7 +127,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
       ├─StreamExchange { dist: HashShard($expr3) }
       | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 7:Int32) as $expr3, _row_id] }
       |   └─StreamFilter { predicate: (Field(auction, 8:Int32) = 10:Int32) AND (event_type = 1:Int32) }
@@ -152,7 +152,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -230,8 +230,8 @@
       └─StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] }
         └─StreamExchange { dist: HashShard($expr4) }
           └─StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-            └─StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
-              └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+            └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
+              └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
                 ├─StreamExchange { dist: HashShard($expr2) }
                 | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, Field(auction, 8:Int32) as $expr4, _row_id], output_watermarks: [$expr1] }
                 |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -265,8 +265,8 @@
 
     Fragment 1
     StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
-        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
+        └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
             ├── left table: 2
             ├── right table: 4
             ├── left degree table: 3
@@ -394,7 +394,7 @@
         └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 9 }
-          |   └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+          |   └─StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
           |     └─StreamExchange { dist: HashShard($expr2, window_start) }
           |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
           |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -407,7 +407,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 9 }
-                  └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                  └─StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                     └─StreamExchange { dist: HashShard($expr2, window_start) }
                       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -433,7 +433,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -475,7 +475,7 @@
           └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
             ├─StreamExchange { dist: HashShard(window_start) }
             | └─StreamShare { id = 9 }
-            |   └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+            |   └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
             |     └─StreamExchange { dist: HashShard($expr2, window_start) }
             |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
             |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -488,7 +488,7 @@
               └─StreamHashAgg [eowc] { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
                 └─StreamExchange { dist: HashShard(window_start) }
                   └─StreamShare { id = 9 }
-                    └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                    └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                       └─StreamExchange { dist: HashShard($expr2, window_start) }
                         └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -565,7 +565,7 @@
       |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamExchange { dist: HashShard(max($expr4)) }
         └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-          └─StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+          └─StreamHashAgg [in_append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
             └─StreamExchange { dist: HashShard($expr5) }
               └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                 └─StreamShare { id = 6 }
@@ -600,7 +600,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-    └── StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -635,7 +635,7 @@
         |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
         └─StreamExchange { dist: HashShard(max($expr4)) }
           └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-            └─StreamHashAgg [append_only, eowc] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+            └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
               └─StreamExchange { dist: HashShard($expr5) }
                 └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                   └─StreamShare { id = 6 }
@@ -699,7 +699,7 @@
                 └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
-    └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
       ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
       | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
       |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -727,7 +727,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] } { state table: 7 }
             └──  StreamExchange Hash([0, 1, 2]) from 4
@@ -773,7 +773,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime] }
     └─StreamSort { sort_column_index: 2 }
-      └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+      └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
         ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
         | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
         |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -853,7 +853,7 @@
   stream_plan: |
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-      └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+      └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
         ├─StreamExchange { dist: HashShard($expr2) }
         | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
         |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -878,7 +878,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] } { materialized table: 4294967294 }
     └── StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] } { state table: 0 }
-        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
             ├── left table: 1
             ├── right table: 3
             ├── left degree table: 2
@@ -922,7 +922,7 @@
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamSort { sort_column_index: 12 }
       └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-        └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
           ├─StreamExchange { dist: HashShard($expr2) }
           | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
           |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1129,7 +1129,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2) }
         └─StreamProject { exprs: [ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr2, Field(bid, 2:Int32) as $expr3, Field(bid, 1:Int32) as $expr4, Field(bid, 0:Int32) as $expr5, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1140,7 +1140,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr4, table id: 1), (distinct key: $expr5, table id: 2) ]
@@ -1207,7 +1207,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2, $expr3) }
         └─StreamProject { exprs: [Field(bid, 3:Int32) as $expr2, ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr3, ToChar($expr1, 'HH:mm':Varchar) as $expr4, Field(bid, 2:Int32) as $expr5, Field(bid, 1:Int32) as $expr6, Field(bid, 0:Int32) as $expr7, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1218,7 +1218,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr6, table id: 1), (distinct key: $expr7, table id: 2) ]
@@ -1279,7 +1279,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-      └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+      └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
         └─StreamExchange { dist: HashShard($expr2, $expr3) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, ToChar($expr1, 'YYYY-MM-DD':Varchar) as $expr3, Field(bid, 2:Int32) as $expr4, _row_id] }
             └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1291,7 +1291,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+        └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1502,7 +1502,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
+    └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard($expr2) }
       | └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, Field(bid, 3:Int32) as $expr5, Field(bid, 4:Int32) as $expr6, $expr1, _row_id], output_watermarks: [$expr1] }
       |   └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1527,7 +1527,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └──  StreamExchange Hash([0]) from 3
 
@@ -1674,7 +1674,7 @@
       |               └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4, max($expr5)] }
-        └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] }
+        └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [max($expr5), count] }
           └─StreamExchange { dist: HashShard($expr4) }
             └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, Field(bid, 2:Int32) as $expr5, _row_id] }
               └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1692,7 +1692,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: $expr2 = $expr4, output: [$expr2, $expr3, max($expr5), _row_id, $expr4] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4, max($expr5)] }
-            └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -1776,8 +1776,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] }
       ├─StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-      | └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-      |   └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+      | └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard($expr2) }
       |     | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
       |     |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1803,7 +1803,7 @@
         └─StreamProject { exprs: [(sum0(count) / count($expr4)) as $expr5] }
           └─StreamSimpleAgg { aggs: [sum0(count), count($expr4), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
+              └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
                 └─StreamExchange { dist: HashShard($expr4) }
                   └─StreamShare { id = 12 }
                     └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
@@ -1821,8 +1821,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-        │   └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        │   └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1859,7 +1859,7 @@
         └──  StreamExchange Single from 6
 
     Fragment 6
-    StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 7
 
     Fragment 7
@@ -1938,7 +1938,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1957,7 +1957,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2042,7 +2042,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -2061,7 +2061,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2138,8 +2138,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-              └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+              └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2171,8 +2171,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -2265,8 +2265,8 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] }
             └─StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-              └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+              └─StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [max($expr5), count] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, _row_id], output_watermarks: [$expr1] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2301,8 +2301,8 @@
     Fragment 1
     StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] } { result table: 3, state tables: [ 2 ], distinct tables: [] }
     └── StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-        └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+        └── StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                 ├── left table: 5
                 ├── right table: 7
                 ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -127,7 +127,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
       ├─StreamExchange { dist: HashShard($expr3) }
       | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 7:Int32) as $expr3, _row_id] }
       |   └─StreamFilter { predicate: (Field(auction, 8:Int32) = 10:Int32) AND (event_type = 1:Int32) }
@@ -152,7 +152,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -230,8 +230,8 @@
       └─StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] }
         └─StreamExchange { dist: HashShard($expr4) }
           └─StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-            └─StreamAppendOnlyHashAgg { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
-              └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+            └─StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
                 ├─StreamExchange { dist: HashShard($expr2) }
                 | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, Field(auction, 8:Int32) as $expr4, _row_id], output_watermarks: [$expr1] }
                 |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -265,8 +265,8 @@
 
     Fragment 1
     StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
-        └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
             ├── left table: 2
             ├── right table: 4
             ├── left degree table: 3
@@ -391,10 +391,10 @@
     StreamMaterialize { columns: [auction, num, window_start(hidden), window_start#1(hidden)], stream_key: [auction, window_start, window_start#1], pk_columns: [auction, window_start, window_start#1], pk_conflict: "NoCheck", watermark_columns: [window_start(hidden), window_start#1(hidden)] }
     └─StreamProject { exprs: [$expr2, count, window_start, window_start], output_watermarks: [window_start, window_start] }
       └─StreamFilter { predicate: (count >= max(count)) }
-        └─StreamWindowJoin { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
+        └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 9 }
-          |   └─StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+          |   └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
           |     └─StreamExchange { dist: HashShard($expr2, window_start) }
           |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
           |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -407,7 +407,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 9 }
-                  └─StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                  └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                     └─StreamExchange { dist: HashShard($expr2, window_start) }
                       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -422,7 +422,7 @@
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr2, count, window_start, window_start], output_watermarks: [window_start, window_start] }
         └── StreamFilter { predicate: (count >= max(count)) }
-            └── StreamWindowJoin { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+            └── StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
                 ├──  StreamExchange Hash([1]) from 1
                 └── StreamProject { exprs: [window_start, max(count)], output_watermarks: [window_start] }
                     └── StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] } { result table: 8, state tables: [ 7 ], distinct tables: [] }
@@ -433,7 +433,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -472,10 +472,10 @@
     └─StreamSort { sort_column_index: 2 }
       └─StreamProject { exprs: [$expr2, count, window_start, window_start], output_watermarks: [window_start, window_start] }
         └─StreamFilter { predicate: (count >= max(count)) }
-          └─StreamWindowJoin { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
+          └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
             ├─StreamExchange { dist: HashShard(window_start) }
             | └─StreamShare { id = 9 }
-            |   └─StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+            |   └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
             |     └─StreamExchange { dist: HashShard($expr2, window_start) }
             |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
             |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -485,10 +485,10 @@
             |                 └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
             |                   └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
             └─StreamProject { exprs: [window_start, max(count)], output_watermarks: [window_start] }
-              └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
+              └─StreamHashAgg [eowc] { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
                 └─StreamExchange { dist: HashShard(window_start) }
                   └─StreamShare { id = 9 }
-                    └─StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                    └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                       └─StreamExchange { dist: HashShard($expr2, window_start) }
                         └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -554,7 +554,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bidder, date_time, _row_id(hidden), $expr5(hidden)], stream_key: [_row_id, $expr5, price], pk_columns: [_row_id, $expr5, price], pk_conflict: "NoCheck", watermark_columns: [date_time, $expr5(hidden)] }
-    └─StreamIntervalJoin { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
+    └─StreamHashJoin [interval] { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
       ├─StreamExchange { dist: HashShard($expr4) }
       | └─StreamShare { id = 6 }
       |   └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -565,7 +565,7 @@
       |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamExchange { dist: HashShard(max($expr4)) }
         └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-          └─StreamAppendOnlyHashAgg { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+          └─StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
             └─StreamExchange { dist: HashShard($expr5) }
               └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                 └─StreamShare { id = 6 }
@@ -578,7 +578,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [auction, price, bidder, date_time, _row_id(hidden), $expr5(hidden)], stream_key: [_row_id, $expr5, price], pk_columns: [_row_id, $expr5, price], pk_conflict: "NoCheck", watermark_columns: [date_time, $expr5(hidden)] } { materialized table: 4294967294 }
-    └── StreamIntervalJoin { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
+    └── StreamHashJoin [interval] { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -600,7 +600,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -624,7 +624,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [auction, price, bidder, date_time, _row_id(hidden), $expr5(hidden)], stream_key: [_row_id, $expr5, price], pk_columns: [_row_id, $expr5, price], pk_conflict: "NoCheck", watermark_columns: [date_time] }
     └─StreamSort { sort_column_index: 3 }
-      └─StreamIntervalJoin { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
+      └─StreamHashJoin [interval] { type: Inner, predicate: $expr4 = max($expr4) AND ($expr1 >= $expr6) AND ($expr1 <= $expr5), conditions_to_clean_left_state_table: ($expr1 >= $expr6), conditions_to_clean_right_state_table: ($expr1 <= $expr5), output_watermarks: [$expr1, $expr5], output: [$expr2, $expr4, $expr3, $expr1, _row_id, $expr5] }
         ├─StreamExchange { dist: HashShard($expr4) }
         | └─StreamShare { id = 6 }
         |   └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -635,7 +635,7 @@
         |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
         └─StreamExchange { dist: HashShard(max($expr4)) }
           └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-            └─StreamAppendOnlyHashAgg { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+            └─StreamHashAgg [append_only, eowc] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
               └─StreamExchange { dist: HashShard($expr5) }
                 └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                   └─StreamShare { id = 6 }
@@ -699,7 +699,7 @@
                 └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
-    └─StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
       ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
       | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
       |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -727,7 +727,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
     ├── materialized table: 4294967294
-    └── StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] } { state table: 7 }
             └──  StreamExchange Hash([0, 1, 2]) from 4
@@ -773,7 +773,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime] }
     └─StreamSort { sort_column_index: 2 }
-      └─StreamWindowJoin { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+      └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
         ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
         | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
         |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -853,7 +853,7 @@
   stream_plan: |
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-      └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+      └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
         ├─StreamExchange { dist: HashShard($expr2) }
         | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
         |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -878,7 +878,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] } { materialized table: 4294967294 }
     └── StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] } { state table: 0 }
-        └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
             ├── left table: 1
             ├── right table: 3
             ├── left degree table: 2
@@ -922,7 +922,7 @@
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamSort { sort_column_index: 12 }
       └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-        └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
           ├─StreamExchange { dist: HashShard($expr2) }
           | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
           |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1129,7 +1129,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2) }
         └─StreamProject { exprs: [ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr2, Field(bid, 2:Int32) as $expr3, Field(bid, 1:Int32) as $expr4, Field(bid, 0:Int32) as $expr5, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1140,7 +1140,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr4, table id: 1), (distinct key: $expr5, table id: 2) ]
@@ -1207,7 +1207,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2, $expr3) }
         └─StreamProject { exprs: [Field(bid, 3:Int32) as $expr2, ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr3, ToChar($expr1, 'HH:mm':Varchar) as $expr4, Field(bid, 2:Int32) as $expr5, Field(bid, 1:Int32) as $expr6, Field(bid, 0:Int32) as $expr7, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1218,7 +1218,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr6, table id: 1), (distinct key: $expr7, table id: 2) ]
@@ -1279,7 +1279,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+      └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
         └─StreamExchange { dist: HashShard($expr2, $expr3) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, ToChar($expr1, 'YYYY-MM-DD':Varchar) as $expr3, Field(bid, 2:Int32) as $expr4, _row_id] }
             └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1291,7 +1291,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-        └── StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1502,7 +1502,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard($expr2) }
       | └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, Field(bid, 3:Int32) as $expr5, Field(bid, 4:Int32) as $expr6, $expr1, _row_id], output_watermarks: [$expr1] }
       |   └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1527,7 +1527,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └──  StreamExchange Hash([0]) from 3
 
@@ -1674,7 +1674,7 @@
       |               └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4, max($expr5)] }
-        └─StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [max($expr5), count] }
+        └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] }
           └─StreamExchange { dist: HashShard($expr4) }
             └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, Field(bid, 2:Int32) as $expr5, _row_id] }
               └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1692,7 +1692,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: $expr2 = $expr4, output: [$expr2, $expr3, max($expr5), _row_id, $expr4] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4, max($expr5)] }
-            └── StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -1776,8 +1776,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] }
       ├─StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-      | └─StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-      |   └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+      | └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard($expr2) }
       |     | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
       |     |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1803,7 +1803,7 @@
         └─StreamProject { exprs: [(sum0(count) / count($expr4)) as $expr5] }
           └─StreamSimpleAgg { aggs: [sum0(count), count($expr4), count] }
             └─StreamExchange { dist: Single }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
                 └─StreamExchange { dist: HashShard($expr4) }
                   └─StreamShare { id = 12 }
                     └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
@@ -1821,8 +1821,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-        │   └── StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        │   └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1859,7 +1859,7 @@
         └──  StreamExchange Single from 6
 
     Fragment 6
-    StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 7
 
     Fragment 7
@@ -1938,7 +1938,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1957,7 +1957,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2042,7 +2042,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -2061,7 +2061,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamAppendOnlyHashAgg { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2138,8 +2138,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2171,8 +2171,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-        └── StreamAppendOnlyHashAgg { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -2265,8 +2265,8 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] }
             └─StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-              └─StreamAppendOnlyHashAgg { group_key: [$expr2], aggs: [max($expr5), count] }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, _row_id], output_watermarks: [$expr1] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2301,8 +2301,8 @@
     Fragment 1
     StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] } { result table: 3, state tables: [ 2 ], distinct tables: [] }
     └── StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-        └── StreamAppendOnlyHashAgg { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
-            └── StreamAppendOnlyHashJoin { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                 ├── left table: 5
                 ├── right table: 7
                 ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -127,7 +127,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
       ├─StreamExchange { dist: HashShard($expr3) }
       | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 7:Int32) as $expr3, _row_id] }
       |   └─StreamFilter { predicate: (Field(auction, 8:Int32) = 10:Int32) AND (event_type = 1:Int32) }
@@ -152,7 +152,7 @@
     Fragment 0
     StreamMaterialize { columns: [name, city, state, id, _row_id(hidden), $expr3(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, $expr3], pk_columns: [_row_id, _row_id#1, $expr3], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr3 = $expr4, output: [$expr5, $expr6, $expr7, $expr2, _row_id, $expr3, _row_id] }
         ├── left table: 0
         ├── right table: 2
         ├── left degree table: 1
@@ -230,8 +230,8 @@
       └─StreamHashAgg { group_key: [$expr4], aggs: [sum(max($expr6)), count(max($expr6)), count] }
         └─StreamExchange { dist: HashShard($expr4) }
           └─StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-            └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
-              └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+            └─StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
                 ├─StreamExchange { dist: HashShard($expr2) }
                 | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, Field(auction, 8:Int32) as $expr4, _row_id], output_watermarks: [$expr1] }
                 |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -265,8 +265,8 @@
 
     Fragment 1
     StreamProject { exprs: [$expr2, $expr4, max($expr6)] }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
-        └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr4], aggs: [max($expr6), count] } { result table: 1, state tables: [], distinct tables: [] }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr5 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr4, $expr6, _row_id, _row_id] }
             ├── left table: 2
             ├── right table: 4
             ├── left degree table: 3
@@ -394,7 +394,7 @@
         └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 9 }
-          |   └─StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+          |   └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
           |     └─StreamExchange { dist: HashShard($expr2, window_start) }
           |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
           |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -407,7 +407,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 9 }
-                  └─StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                  └─StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                     └─StreamExchange { dist: HashShard($expr2, window_start) }
                       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -433,7 +433,7 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashAgg [in_append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] } { result table: 4, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0, 1]) from 3
 
     Fragment 3
@@ -475,7 +475,7 @@
           └─StreamHashJoin [window] { type: Inner, predicate: window_start = window_start, output_watermarks: [window_start, window_start], output: all }
             ├─StreamExchange { dist: HashShard(window_start) }
             | └─StreamShare { id = 9 }
-            |   └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+            |   └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
             |     └─StreamExchange { dist: HashShard($expr2, window_start) }
             |       └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
             |         └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -488,7 +488,7 @@
               └─StreamHashAgg [eowc] { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
                 └─StreamExchange { dist: HashShard(window_start) }
                   └─StreamShare { id = 9 }
-                    └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
+                    └─StreamHashAgg [append_only, eowc] { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }
                       └─StreamExchange { dist: HashShard($expr2, window_start) }
                         └─StreamHopWindow { time_col: $expr1, slide: 00:00:02, size: 00:00:10, output: [$expr2, window_start, _row_id], output_watermarks: [window_start] }
                           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, $expr1, _row_id], output_watermarks: [$expr1] }
@@ -565,7 +565,7 @@
       |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamExchange { dist: HashShard(max($expr4)) }
         └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-          └─StreamHashAgg [in_append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+          └─StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
             └─StreamExchange { dist: HashShard($expr5) }
               └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                 └─StreamShare { id = 6 }
@@ -600,7 +600,7 @@
 
     Fragment 3
     StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
+    └── StreamHashAgg [append_only] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] } { result table: 6, state tables: [], distinct tables: [] }
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 4
@@ -635,7 +635,7 @@
         |             └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
         └─StreamExchange { dist: HashShard(max($expr4)) }
           └─StreamProject { exprs: [$expr5, max($expr4), ($expr5 - '00:00:10':Interval) as $expr6], output_watermarks: [$expr5, $expr6] }
-            └─StreamHashAgg [in_append_only, eowc] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
+            └─StreamHashAgg [append_only, eowc] { group_key: [$expr5], aggs: [max($expr4), count], output_watermarks: [$expr5] }
               └─StreamExchange { dist: HashShard($expr5) }
                 └─StreamProject { exprs: [(TumbleStart($expr1, '00:00:10':Interval) + '00:00:10':Interval) as $expr5, $expr4, _row_id], output_watermarks: [$expr5] }
                   └─StreamShare { id = 6 }
@@ -699,7 +699,7 @@
                 └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
-    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
       ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
       | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
       |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -727,7 +727,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime, $expr5(hidden), $expr7(hidden), $expr8(hidden)] }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0, 2, 3]) from 1
         └── StreamAppendOnlyDedup { dedup_cols: [$expr6, $expr7, $expr8] } { state table: 7 }
             └──  StreamExchange Hash([0, 1, 2]) from 4
@@ -773,7 +773,7 @@
   eowc_stream_plan: |
     StreamMaterialize { columns: [id, name, starttime, $expr5(hidden), $expr6(hidden), $expr7(hidden), $expr8(hidden)], stream_key: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_columns: [id, name, starttime, $expr5, $expr6, $expr7, $expr8], pk_conflict: "NoCheck", watermark_columns: [starttime] }
     └─StreamSort { sort_column_index: 2 }
-      └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
+      └─StreamHashJoin [window, append_only] { type: Inner, predicate: $expr4 = $expr7 AND $expr5 = $expr8 AND $expr2 = $expr6, output_watermarks: [$expr4, $expr5, $expr7, $expr8], output: all }
         ├─StreamExchange { dist: HashShard($expr2, $expr4, $expr5) }
         | └─StreamAppendOnlyDedup { dedup_cols: [$expr2, $expr3, $expr4, $expr5] }
         |   └─StreamExchange { dist: HashShard($expr2, $expr3, $expr4, $expr5) }
@@ -853,7 +853,7 @@
   stream_plan: |
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-      └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+      └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
         ├─StreamExchange { dist: HashShard($expr2) }
         | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
         |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -878,7 +878,7 @@
     Fragment 0
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] } { materialized table: 4294967294 }
     └── StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] } { state table: 0 }
-        └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
             ├── left table: 1
             ├── right table: 3
             ├── left degree table: 2
@@ -922,7 +922,7 @@
     StreamMaterialize { columns: [id, item_name, description, initial_bid, reserve, date_time, expires, seller, category, auction, bidder, price, bid_date_time, _row_id(hidden), _row_id#1(hidden)], stream_key: [id], pk_columns: [id], pk_conflict: "NoCheck", watermark_columns: [bid_date_time] }
     └─StreamSort { sort_column_index: 12 }
       └─StreamAppendOnlyGroupTopN { order: "[$expr12 DESC, $expr1 ASC]", limit: 1, offset: 0, group_key: [0], output_watermarks: [$expr1] }
-        └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
+        └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr10 AND ($expr1 >= $expr1) AND ($expr1 <= $expr7), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output_watermarks: [$expr1], output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr7, $expr8, $expr9, $expr10, $expr11, $expr12, $expr1, _row_id, _row_id] }
           ├─StreamExchange { dist: HashShard($expr2) }
           | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, Field(auction, 2:Int32) as $expr4, Field(auction, 3:Int32) as $expr5, Field(auction, 4:Int32) as $expr6, $expr1, Field(auction, 6:Int32) as $expr7, Field(auction, 7:Int32) as $expr8, Field(auction, 8:Int32) as $expr9, _row_id], output_watermarks: [$expr1] }
           |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1129,7 +1129,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2) }
         └─StreamProject { exprs: [ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr2, Field(bid, 2:Int32) as $expr3, Field(bid, 1:Int32) as $expr4, Field(bid, 0:Int32) as $expr5, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1140,7 +1140,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [day, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [day], pk_columns: [day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [count, count filter(($expr3 < 10000:Int32)), count filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count filter(($expr3 >= 1000000:Int32)), count(distinct $expr4), count(distinct $expr4) filter(($expr3 < 10000:Int32)), count(distinct $expr4) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr4) filter(($expr3 >= 1000000:Int32)), count(distinct $expr5), count(distinct $expr5) filter(($expr3 < 10000:Int32)), count(distinct $expr5) filter(($expr3 >= 10000:Int32) AND ($expr3 < 1000000:Int32)), count(distinct $expr5) filter(($expr3 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr4, table id: 1), (distinct key: $expr5, table id: 2) ]
@@ -1207,7 +1207,7 @@
                     └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" }
-    └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
       └─StreamExchange { dist: HashShard($expr2, $expr3) }
         └─StreamProject { exprs: [Field(bid, 3:Int32) as $expr2, ToChar($expr1, 'yyyy-MM-dd':Varchar) as $expr3, ToChar($expr1, 'HH:mm':Varchar) as $expr4, Field(bid, 2:Int32) as $expr5, Field(bid, 1:Int32) as $expr6, Field(bid, 0:Int32) as $expr7, _row_id] }
           └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1218,7 +1218,7 @@
   stream_dist_plan: |+
     Fragment 0
     StreamMaterialize { columns: [channel, day, minute, total_bids, rank1_bids, rank2_bids, rank3_bids, total_bidders, rank1_bidders, rank2_bidders, rank3_bidders, total_auctions, rank1_auctions, rank2_auctions, rank3_auctions], stream_key: [channel, day], pk_columns: [channel, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
-    └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
+    └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [max($expr4), count, count filter(($expr5 < 10000:Int32)), count filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count filter(($expr5 >= 1000000:Int32)), count(distinct $expr6), count(distinct $expr6) filter(($expr5 < 10000:Int32)), count(distinct $expr6) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr6) filter(($expr5 >= 1000000:Int32)), count(distinct $expr7), count(distinct $expr7) filter(($expr5 < 10000:Int32)), count(distinct $expr7) filter(($expr5 >= 10000:Int32) AND ($expr5 < 1000000:Int32)), count(distinct $expr7) filter(($expr5 >= 1000000:Int32))] }
         ├── result table: 0
         ├── state tables: []
         ├── distinct tables: [ (distinct key: $expr6, table id: 1), (distinct key: $expr7, table id: 2) ]
@@ -1279,7 +1279,7 @@
   stream_plan: |
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-      └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+      └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
         └─StreamExchange { dist: HashShard($expr2, $expr3) }
           └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, ToChar($expr1, 'YYYY-MM-DD':Varchar) as $expr3, Field(bid, 2:Int32) as $expr4, _row_id] }
             └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1291,7 +1291,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, day, total_bids, rank1_bids, rank2_bids, rank3_bids, min_price, max_price, avg_price, sum_price], stream_key: [auction, day], pk_columns: [auction, day], pk_conflict: "NoCheck" } { materialized table: 4294967294 }
     └── StreamProject { exprs: [$expr2, $expr3, count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), (sum($expr4) / count($expr4)::Decimal) as $expr5, sum($expr4)] }
-        └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count, count filter(($expr4 < 10000:Int32)), count filter(($expr4 >= 10000:Int32) AND ($expr4 < 1000000:Int32)), count filter(($expr4 >= 1000000:Int32)), min($expr4), max($expr4), sum($expr4), count($expr4)] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1502,7 +1502,7 @@
               └─BatchSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"], filter: (None, None) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
-    └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
+    └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard($expr2) }
       | └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr2, Field(bid, 1:Int32) as $expr3, Field(bid, 2:Int32) as $expr4, Field(bid, 3:Int32) as $expr5, Field(bid, 4:Int32) as $expr6, $expr1, _row_id], output_watermarks: [$expr1] }
       |   └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1527,7 +1527,7 @@
     Fragment 0
     StreamMaterialize { columns: [auction, bidder, price, channel, url, date_timeb, item_name, description, initial_bid, reserve, date_timea, expires, seller, category, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, auction], pk_columns: [_row_id, _row_id#1, auction], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr7, output: [$expr2, $expr3, $expr4, $expr5, $expr6, $expr1, $expr8, $expr9, $expr10, $expr11, $expr1, $expr12, $expr13, $expr14, _row_id, _row_id] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └──  StreamExchange Hash([0]) from 3
 
@@ -1674,7 +1674,7 @@
       |               └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4, max($expr5)] }
-        └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [max($expr5), count] }
+        └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] }
           └─StreamExchange { dist: HashShard($expr4) }
             └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, Field(bid, 2:Int32) as $expr5, _row_id] }
               └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1692,7 +1692,7 @@
     └── StreamHashJoin { type: LeftOuter, predicate: $expr2 = $expr4, output: [$expr2, $expr3, max($expr5), _row_id, $expr4] } { left table: 0, right table: 2, left degree table: 1, right degree table: 3 }
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4, max($expr5)] }
-            └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
+            └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [max($expr5), count] } { result table: 6, state tables: [], distinct tables: [] }
                 └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -1776,8 +1776,8 @@
     StreamMaterialize { columns: [auction_id, auction_item_name, bid_count], stream_key: [auction_id, auction_item_name], pk_columns: [auction_id, auction_item_name], pk_conflict: "NoCheck" }
     └─StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] }
       ├─StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-      | └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+      | └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
       |     ├─StreamExchange { dist: HashShard($expr2) }
       |     | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
       |     |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -1803,7 +1803,7 @@
         └─StreamProject { exprs: [(sum0(count) / count($expr4)) as $expr5] }
           └─StreamSimpleAgg { aggs: [sum0(count), count($expr4), count] }
             └─StreamExchange { dist: Single }
-              └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
+              └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
                 └─StreamExchange { dist: HashShard($expr4) }
                   └─StreamShare { id = 12 }
                     └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
@@ -1821,8 +1821,8 @@
     ├── materialized table: 4294967294
     └── StreamDynamicFilter { predicate: (count($expr4) >= $expr5), output: [$expr2, $expr3, count($expr4)] } { left table: 0, right table: 1 }
         ├── StreamProject { exprs: [$expr2, $expr3, count($expr4)] }
-        │   └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-        │       └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        │   └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+        │       └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
         │           ├── left table: 3
         │           ├── right table: 5
         │           ├── left degree table: 4
@@ -1859,7 +1859,7 @@
         └──  StreamExchange Single from 6
 
     Fragment 6
-    StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
+    StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 10, state tables: [], distinct tables: [] }
     └──  StreamExchange Hash([0]) from 7
 
     Fragment 7
@@ -1938,7 +1938,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count >= 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -1957,7 +1957,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count >= 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2042,7 +2042,7 @@
       |                 └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
       └─StreamProject { exprs: [$expr4] }
         └─StreamFilter { predicate: (count < 20:Int32) }
-          └─StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] }
+          └─StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] }
             └─StreamExchange { dist: HashShard($expr4) }
               └─StreamProject { exprs: [Field(bid, 0:Int32) as $expr4, _row_id] }
                 └─StreamFilter { predicate: (event_type = 2:Int32) }
@@ -2061,7 +2061,7 @@
         ├──  StreamExchange Hash([0]) from 1
         └── StreamProject { exprs: [$expr4] }
             └── StreamFilter { predicate: (count < 20:Int32) }
-                └── StreamHashAgg [in_append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
+                └── StreamHashAgg [append_only] { group_key: [$expr4], aggs: [count] } { result table: 6, state tables: [], distinct tables: [] }
                     └──  StreamExchange Hash([0]) from 3
 
     Fragment 1
@@ -2138,8 +2138,8 @@
         └─StreamExchange { dist: Single }
           └─StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] }
             └─StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-              └─StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, Field(auction, 1:Int32) as $expr3, _row_id] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2171,8 +2171,8 @@
     Fragment 1
     StreamGroupTopN { order: "[count($expr4) DESC]", limit: 1000, offset: 0, group_key: [3] } { state table: 1 }
     └── StreamProject { exprs: [$expr2, $expr3, count($expr4), Vnode($expr2) as $expr5] }
-        └── StreamHashAgg [in_append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2, $expr3], aggs: [count($expr4), count] } { result table: 2, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4, output: [$expr2, $expr3, $expr4, _row_id, _row_id] }
                 ├── left table: 3
                 ├── right table: 5
                 ├── left degree table: 4
@@ -2265,8 +2265,8 @@
         └─StreamExchange { dist: Single }
           └─StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] }
             └─StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-              └─StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [max($expr5), count] }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+              └─StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                   ├─StreamExchange { dist: HashShard($expr2) }
                   | └─StreamProject { exprs: [Field(auction, 0:Int32) as $expr2, $expr1, Field(auction, 6:Int32) as $expr3, _row_id], output_watermarks: [$expr1] }
                   |   └─StreamFilter { predicate: (event_type = 1:Int32) }
@@ -2301,8 +2301,8 @@
     Fragment 1
     StreamHashAgg { group_key: [$expr6], aggs: [min(max($expr5)), count] } { result table: 3, state tables: [ 2 ], distinct tables: [] }
     └── StreamProject { exprs: [$expr2, max($expr5), Vnode($expr2) as $expr6] }
-        └── StreamHashAgg [in_append_only] { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
-            └── StreamHashJoin [in_append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
+        └── StreamHashAgg [append_only] { group_key: [$expr2], aggs: [max($expr5), count] } { result table: 4, state tables: [], distinct tables: [] }
+            └── StreamHashJoin [append_only] { type: Inner, predicate: $expr2 = $expr4 AND ($expr1 >= $expr1) AND ($expr1 <= $expr3), conditions_to_clean_right_state_table: ($expr1 >= $expr1), output: [$expr2, $expr5, _row_id, _row_id] }
                 ├── left table: 5
                 ├── right table: 7
                 ├── left degree table: 6

--- a/src/frontend/planner_test/tests/testdata/output/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/share.yaml
@@ -37,7 +37,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamFilter { predicate: (initial_bid = 1:Int32) }
               |   └─StreamShare { id = 4 }
@@ -127,7 +127,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -138,7 +138,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -199,7 +199,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamShare { id = 3 }
               |   └─StreamProject { exprs: [id, _row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/share.yaml
@@ -37,7 +37,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamFilter { predicate: (initial_bid = 1:Int32) }
               |   └─StreamShare { id = 4 }
@@ -127,7 +127,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -138,7 +138,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [in_append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -199,7 +199,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamShare { id = 3 }
               |   └─StreamProject { exprs: [id, _row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/share.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/share.yaml
@@ -37,7 +37,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamFilter { predicate: (initial_bid = 1:Int32) }
               |   └─StreamShare { id = 4 }
@@ -127,7 +127,7 @@
         └─StreamHashJoin { type: Inner, predicate: window_start = window_start, output: all }
           ├─StreamExchange { dist: HashShard(window_start) }
           | └─StreamShare { id = 7 }
-          |   └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+          |   └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
           |     └─StreamExchange { dist: HashShard(auction, window_start) }
           |       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
           |         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -138,7 +138,7 @@
             └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count] }
               └─StreamExchange { dist: HashShard(window_start) }
                 └─StreamShare { id = 7 }
-                  └─StreamAppendOnlyHashAgg { group_key: [auction, window_start], aggs: [count] }
+                  └─StreamHashAgg [append_only] { group_key: [auction, window_start], aggs: [count] }
                     └─StreamExchange { dist: HashShard(auction, window_start) }
                       └─StreamHopWindow { time_col: date_time, slide: 00:00:02, size: 00:00:10, output: [auction, window_start, _row_id] }
                         └─StreamProject { exprs: [auction, date_time, _row_id] }
@@ -199,7 +199,7 @@
       └─StreamAppendOnlySimpleAgg { aggs: [sum0(count), count] }
         └─StreamExchange { dist: Single }
           └─StreamStatelessSimpleAgg { aggs: [count] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: id = id, output: [_row_id, id, _row_id] }
               ├─StreamExchange { dist: HashShard(id) }
               | └─StreamShare { id = 3 }
               |   └─StreamProject { exprs: [id, _row_id] }

--- a/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
@@ -1261,7 +1261,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [max(ao.v), ao.k] }
-      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1269,7 +1269,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [max(ao.v), ao.k] }
-        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1473,7 +1473,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [sum(ao.v), ao.k] }
-      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1481,7 +1481,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [sum(ao.v), ao.k] }
-        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1685,7 +1685,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [count(ao.v), ao.k] }
-      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1693,7 +1693,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [count(ao.v), ao.k] }
-        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1928,7 +1928,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -1937,7 +1937,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
@@ -1261,7 +1261,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [max(ao.v), ao.k] }
-      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1269,7 +1269,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [max(ao.v), ao.k] }
-        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1473,7 +1473,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [sum(ao.v), ao.k] }
-      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1481,7 +1481,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [sum(ao.v), ao.k] }
-        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1685,7 +1685,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [count(ao.v), ao.k] }
-      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1693,7 +1693,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [count(ao.v), ao.k] }
-        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1928,7 +1928,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -1937,7 +1937,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/stream_dist_agg.yaml
@@ -1261,7 +1261,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [max(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [max(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1269,7 +1269,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [max(ao.v), ao.k] }
-        └── StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [max(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [max(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1473,7 +1473,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [sum(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [sum(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1481,7 +1481,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [sum(ao.v), ao.k] }
-        └── StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [sum(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [sum(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1685,7 +1685,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [count(ao.v), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count(ao.v), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamTableScan { table: ao, columns: [ao.k, ao.v, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
   stream_dist_plan: |+
@@ -1693,7 +1693,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [count(ao.v), ao.k] }
-        └── StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [count(ao.v), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [count(ao.v), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1928,7 +1928,7 @@
   stream_plan: |
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-      └─StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+      └─StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
         └─StreamExchange { dist: HashShard(ao.k) }
           └─StreamProject { exprs: [ao.k, ao.s, ',':Varchar, ao.o, ao._row_id] }
             └─StreamTableScan { table: ao, columns: [ao.k, ao.o, ao.s, ao._row_id], pk: [ao._row_id], dist: UpstreamHashShard(ao._row_id) }
@@ -1937,7 +1937,7 @@
     StreamMaterialize { columns: [a1, ao.k(hidden)], stream_key: [ao.k], pk_columns: [ao.k], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), ao.k] }
-        └── StreamAppendOnlyHashAgg { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
+        └── StreamHashAgg [append_only] { group_key: [ao.k], aggs: [string_agg(ao.s, ',':Varchar order_by(ao.o ASC)), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -9,7 +9,7 @@
     └─StreamTemporalJoin { type: LeftOuter, predicate: stream.id1 = version.id2, output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
       ├─StreamExchange { dist: HashShard(stream.id1) }
       | └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version.id2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
         └─StreamTableScan { table: version, columns: [version.id2, version.a2], pk: [version.id2], dist: UpstreamHashShard(version.id2) }
   batch_error: |-
     Not supported: do not support temporal join for batch queries
@@ -24,7 +24,7 @@
     └─StreamTemporalJoin { type: Inner, predicate: stream.id1 = version.id2 AND (version.a2 < 10:Int32), output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
       ├─StreamExchange { dist: HashShard(stream.id1) }
       | └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version.id2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
         └─StreamTableScan { table: version, columns: [version.id2, version.a2], pk: [version.id2], dist: UpstreamHashShard(version.id2) }
 - name: implicit join with temporal tables
   sql: |
@@ -36,7 +36,7 @@
     └─StreamTemporalJoin { type: Inner, predicate: stream.id1 = version.id2 AND (version.a2 < 10:Int32), output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
       ├─StreamExchange { dist: HashShard(stream.id1) }
       | └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version.id2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
         └─StreamTableScan { table: version, columns: [version.id2, version.a2], pk: [version.id2], dist: UpstreamHashShard(version.id2) }
 - name: Multi join key for temporal join
   sql: |
@@ -48,7 +48,7 @@
     └─StreamTemporalJoin { type: Inner, predicate: stream.id1 = version.id2 AND stream.a1 = version.a2 AND (version.b2 <> version.a2), output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id] }
       ├─StreamExchange { dist: HashShard(stream.id1, stream.a1) }
       | └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version.id2, version.a2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2, version.a2) }
         └─StreamTableScan { table: version, columns: [version.id2, version.a2, version.b2], pk: [version.id2, version.a2], dist: UpstreamHashShard(version.id2, version.a2) }
 - name: Temporal join with Aggregation
   sql: |
@@ -64,7 +64,7 @@
             └─StreamTemporalJoin { type: Inner, predicate: stream.id1 = version.id2 AND (version.a2 < 10:Int32), output: [stream._row_id, stream.id1, version.id2] }
               ├─StreamExchange { dist: HashShard(stream.id1) }
               | └─StreamTableScan { table: stream, columns: [stream.id1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-              └─StreamNoShuffleExchange { dist: UpstreamHashShard(version.id2) }
+              └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
                 └─StreamTableScan { table: version, columns: [version.id2, version.a2], pk: [version.id2], dist: UpstreamHashShard(version.id2) }
 - name: Temporal join join keys requirement test
   sql: |
@@ -106,9 +106,9 @@
       | ├─StreamExchange { dist: HashShard(stream.k) }
       | | └─StreamFilter { predicate: (stream.a1 < 10:Int32) }
       | |   └─StreamTableScan { table: stream, columns: [stream.k, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      | └─StreamNoShuffleExchange { dist: UpstreamHashShard(version1.k) }
+      | └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version1.k) }
       |   └─StreamTableScan { table: version1, columns: [version1.k, version1.x1], pk: [version1.k], dist: UpstreamHashShard(version1.k) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version2.k) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version2.k) }
         └─StreamTableScan { table: version2, columns: [version2.k, version2.x2], pk: [version2.k], dist: UpstreamHashShard(version2.k) }
 - name: multi-way temporal join with different keys
   sql: |
@@ -127,9 +127,9 @@
       |   ├─StreamExchange { dist: HashShard(stream.id1) }
       |   | └─StreamFilter { predicate: (stream.a1 < 10:Int32) }
       |   |   └─StreamTableScan { table: stream, columns: [stream.id1, stream.id2, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      |   └─StreamNoShuffleExchange { dist: UpstreamHashShard(version1.id1) }
+      |   └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version1.id1) }
       |     └─StreamTableScan { table: version1, columns: [version1.id1, version1.x1], pk: [version1.id1], dist: UpstreamHashShard(version1.id1) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version2.id2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version2.id2) }
         └─StreamTableScan { table: version2, columns: [version2.id2, version2.x2], pk: [version2.id2], dist: UpstreamHashShard(version2.id2) }
 - name: multi-way temporal join with different keys
   sql: |
@@ -148,7 +148,7 @@
       |   ├─StreamExchange { dist: HashShard(stream.id1) }
       |   | └─StreamFilter { predicate: (stream.a1 < 10:Int32) }
       |   |   └─StreamTableScan { table: stream, columns: [stream.id1, stream.id2, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
-      |   └─StreamNoShuffleExchange { dist: UpstreamHashShard(version1.id1) }
+      |   └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version1.id1) }
       |     └─StreamTableScan { table: version1, columns: [version1.id1, version1.x1], pk: [version1.id1], dist: UpstreamHashShard(version1.id1) }
-      └─StreamNoShuffleExchange { dist: UpstreamHashShard(version2.id2) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version2.id2) }
         └─StreamTableScan { table: version2, columns: [version2.id2, version2.x2], pk: [version2.id2], dist: UpstreamHashShard(version2.id2) }

--- a/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
@@ -246,9 +246,9 @@
     └─StreamHashJoin { type: Inner, predicate: p_partkey IS NOT DISTINCT FROM p_partkey AND ps_supplycost = min(ps_supplycost), output: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id, _row_id, r_regionkey, _row_id, _row_id, _row_id, ps_suppkey, n_nationkey, ps_supplycost, p_partkey] }
       ├─StreamExchange { dist: HashShard(p_partkey) }
       | └─StreamShare { id = 26 }
-      |   └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
       |     ├─StreamExchange { dist: HashShard(n_nationkey) }
-      |     | └─StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+      |     | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
       |     |   ├─StreamExchange { dist: HashShard(r_regionkey) }
       |     |   | └─StreamShare { id = 3 }
       |     |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -260,9 +260,9 @@
       |     |         └─StreamRowIdGen { row_id_index: 4 }
       |     |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
       |     └─StreamExchange { dist: HashShard(s_nationkey) }
-      |       └─StreamAppendOnlyHashJoin { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+      |       └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
       |         ├─StreamExchange { dist: HashShard(ps_suppkey) }
-      |         | └─StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+      |         | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
       |         |   ├─StreamExchange { dist: HashShard(p_partkey) }
       |         |   | └─StreamRowIdGen { row_id_index: 9 }
       |         |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -283,9 +283,9 @@
             | └─StreamExchange { dist: HashShard(p_partkey) }
             |   └─StreamProject { exprs: [p_partkey] }
             |     └─StreamShare { id = 26 }
-            |       └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+            |       └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
             |         ├─StreamExchange { dist: HashShard(n_nationkey) }
-            |         | └─StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+            |         | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
             |         |   ├─StreamExchange { dist: HashShard(r_regionkey) }
             |         |   | └─StreamShare { id = 3 }
             |         |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -297,9 +297,9 @@
             |         |         └─StreamRowIdGen { row_id_index: 4 }
             |         |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
             |         └─StreamExchange { dist: HashShard(s_nationkey) }
-            |           └─StreamAppendOnlyHashJoin { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+            |           └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
             |             ├─StreamExchange { dist: HashShard(ps_suppkey) }
-            |             | └─StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+            |             | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
             |             |   ├─StreamExchange { dist: HashShard(p_partkey) }
             |             |   | └─StreamRowIdGen { row_id_index: 9 }
             |             |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -314,9 +314,9 @@
             |                   └─StreamRowIdGen { row_id_index: 7 }
             |                     └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
             └─StreamExchange { dist: HashShard(ps_partkey) }
-              └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
                 ├─StreamExchange { dist: HashShard(s_nationkey) }
-                | └─StreamAppendOnlyHashJoin { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
+                | └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(ps_suppkey) }
                 |   | └─StreamFilter { predicate: IsNotNull(ps_partkey) }
                 |   |   └─StreamShare { id = 15 }
@@ -329,7 +329,7 @@
                 |         └─StreamRowIdGen { row_id_index: 7 }
                 |           └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(n_nationkey) }
-                  └─StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(r_regionkey) }
                     | └─StreamShare { id = 3 }
                     |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -358,12 +358,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([5]) from 8
 
     Fragment 3
-    StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 6
 
@@ -386,12 +386,12 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 13 }
 
     Fragment 8
-    StreamAppendOnlyHashJoin { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
+    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
     ├──  StreamExchange Hash([2]) from 9
     └──  StreamExchange Hash([0]) from 13
 
     Fragment 9
-    StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -422,12 +422,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 16
-    StreamAppendOnlyHashJoin { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
     ├──  StreamExchange Hash([2]) from 17
     └──  StreamExchange Hash([0]) from 20
 
     Fragment 17
-    StreamAppendOnlyHashJoin { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
+    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
     ├──  StreamExchange Hash([1]) from 18
     └──  StreamExchange Hash([0]) from 19
 
@@ -440,7 +440,7 @@
     └──  StreamExchange NoShuffle from 14
 
     Fragment 20
-    StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
     ├──  StreamExchange Hash([0]) from 21
     └──  StreamExchange Hash([2]) from 22
 
@@ -627,12 +627,12 @@
   stream_plan: |
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, sum($expr1)] }
-      └─StreamAppendOnlyHashAgg { group_key: [n_name], aggs: [sum($expr1), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
         └─StreamExchange { dist: HashShard(n_name) }
           └─StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
               ├─StreamExchange { dist: HashShard(n_nationkey, n_nationkey) }
-              | └─StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -641,9 +641,9 @@
               |       └─StreamRowIdGen { row_id_index: 4 }
               |         └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(c_nationkey, s_nationkey) }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
                   ├─StreamExchange { dist: HashShard(o_orderkey, c_nationkey) }
-                  | └─StreamAppendOnlyHashJoin { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(o_custkey) }
                   |   | └─StreamRowIdGen { row_id_index: 9 }
                   |   |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -651,7 +651,7 @@
                   |     └─StreamRowIdGen { row_id_index: 8 }
                   |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
                   └─StreamExchange { dist: HashShard(l_orderkey, s_nationkey) }
-                    └─StreamAppendOnlyHashJoin { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
+                    └─StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
                       ├─StreamExchange { dist: HashShard(l_suppkey) }
                       | └─StreamRowIdGen { row_id_index: 16 }
                       |   └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
@@ -663,7 +663,7 @@
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, sum($expr1)] }
-        └── StreamAppendOnlyHashAgg { group_key: [n_name], aggs: [sum($expr1), count] }
+        └── StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -671,7 +671,7 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -680,7 +680,7 @@
         └──  StreamExchange Hash([0, 3]) from 5
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([2]) from 4
 
@@ -694,7 +694,7 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
     ├── left table: 11
     ├── right table: 13
     ├── left degree table: 12
@@ -703,7 +703,7 @@
     └──  StreamExchange Hash([0, 3]) from 9
 
     Fragment 6
-    StreamAppendOnlyHashJoin { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([1]) from 7
     └──  StreamExchange Hash([0]) from 8
 
@@ -716,7 +716,7 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 9
-    StreamAppendOnlyHashJoin { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([2]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -899,14 +899,14 @@
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-      └─StreamAppendOnlyHashAgg { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, n_name, $expr1) }
           └─StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
               ├─StreamExchange { dist: HashShard(l_orderkey) }
-              | └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-              |   | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
               |   |   | └─StreamShare { id = 3 }
               |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -919,9 +919,9 @@
               |     └─StreamRowIdGen { row_id_index: 16 }
               |       └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_orderkey) }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(c_custkey) }
-                  | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   | └─StreamShare { id = 3 }
                   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -938,12 +938,12 @@
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-        └── StreamAppendOnlyHashAgg { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
+        └── StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
             └──  StreamExchange Hash([0, 1, 2]) from 1
 
     Fragment 1
     StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -952,7 +952,7 @@
         └──  StreamExchange Hash([1]) from 8
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
     ├── left table: 5
     ├── right table: 7
     ├── left degree table: 6
@@ -961,7 +961,7 @@
     └──  StreamExchange Hash([2]) from 7
 
     Fragment 3
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([3]) from 6
 
@@ -984,12 +984,12 @@
         └── source state table: 15
 
     Fragment 8
-    StreamAppendOnlyHashJoin { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([1]) from 12
 
     Fragment 9
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([3]) from 11
 
@@ -1186,14 +1186,14 @@
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-      └─StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
               ├─StreamExchange { dist: HashShard(c_custkey) }
-              | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(n_nationkey) }
-              |   | └─StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -1206,11 +1206,11 @@
               |     └─StreamRowIdGen { row_id_index: 8 }
               |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_custkey) }
-                └─StreamAppendOnlyHashJoin { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(l_orderkey) }
-                  | └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
                   |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-                  |   | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                  |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                   |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   |   | └─StreamShare { id = 5 }
                   |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, n_regionkey, _row_id] }
@@ -1220,7 +1220,7 @@
                   |   |     └─StreamRowIdGen { row_id_index: 7 }
                   |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                   |   └─StreamExchange { dist: HashShard(l_suppkey) }
-                  |     └─StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
+                  |     └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
                   |       ├─StreamExchange { dist: HashShard(p_partkey) }
                   |       | └─StreamRowIdGen { row_id_index: 9 }
                   |       |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1235,7 +1235,7 @@
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-        └── StreamAppendOnlyHashAgg { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+        └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1243,17 +1243,17 @@
 
     Fragment 1
     StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
         ├──  StreamExchange Hash([0]) from 2
         └──  StreamExchange Hash([3]) from 8
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([3]) from 7
 
     Fragment 3
-    StreamAppendOnlyHashJoin { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 5
 
@@ -1275,17 +1275,17 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 15 }
 
     Fragment 8
-    StreamAppendOnlyHashJoin { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([0]) from 16
 
     Fragment 9
-    StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([1]) from 10
     └──  StreamExchange Hash([1]) from 13
 
     Fragment 10
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
     ├──  StreamExchange Hash([0]) from 11
     └──  StreamExchange Hash([3]) from 12
 
@@ -1298,7 +1298,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 28 }
 
     Fragment 13
-    StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
     ├──  StreamExchange Hash([0]) from 14
     └──  StreamExchange Hash([1]) from 15
 
@@ -1496,12 +1496,12 @@
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-      └─StreamAppendOnlyHashAgg { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, $expr1) }
           └─StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-            └─StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
               ├─StreamExchange { dist: HashShard(ps_suppkey) }
-              | └─StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
               |   ├─StreamExchange { dist: HashShard(p_partkey) }
               |   | └─StreamRowIdGen { row_id_index: 9 }
               |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1509,9 +1509,9 @@
               |     └─StreamFilter { predicate: (ps_suppkey = ps_suppkey) }
               |       └─StreamRowIdGen { row_id_index: 5 }
               |         └─StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] }
-              └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
                 ├─StreamExchange { dist: HashShard(s_suppkey) }
-                | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                 |   | └─StreamRowIdGen { row_id_index: 4 }
                 |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -1519,7 +1519,7 @@
                 |     └─StreamRowIdGen { row_id_index: 7 }
                 |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(l_suppkey) }
-                  └─StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(o_orderkey) }
                     | └─StreamRowIdGen { row_id_index: 9 }
                     |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -1532,7 +1532,7 @@
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-        └── StreamAppendOnlyHashAgg { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+        └── StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1540,18 +1540,18 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-    └── StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
         ├── right degree table: 4
         ├──  StreamExchange Hash([2]) from 2
-        └── StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
             ├──  StreamExchange Hash([1]) from 5
             └──  StreamExchange Hash([2]) from 8
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([0]) from 4
 
@@ -1565,7 +1565,7 @@
         └──  StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([0]) from 6
     └──  StreamExchange Hash([3]) from 7
 
@@ -1578,7 +1578,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 8
-    StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([0]) from 9
     └──  StreamExchange Hash([0]) from 10
 
@@ -1773,7 +1773,7 @@
     StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden), s_nationkey(hidden), s_suppkey(hidden)], stream_key: [_row_id, _row_id#1, s_nationkey, s_suppkey], pk_columns: [s_name, _row_id, _row_id#1, s_nationkey, s_suppkey], pk_conflict: "NoCheck" }
     └─StreamHashJoin { type: LeftSemi, predicate: s_suppkey = ps_suppkey, output: [s_name, s_address, _row_id, _row_id, s_nationkey, s_suppkey] }
       ├─StreamExchange { dist: HashShard(s_suppkey) }
-      | └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
+      | └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
       |   ├─StreamExchange { dist: HashShard(s_nationkey) }
       |   | └─StreamRowIdGen { row_id_index: 7 }
       |   |   └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
@@ -1824,7 +1824,7 @@
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 1
-    StreamAppendOnlyHashJoin { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([3]) from 2
     └──  StreamExchange Hash([0]) from 3
 
@@ -2050,9 +2050,9 @@
         └─StreamHashJoin { type: LeftAnti, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, l_orderkey] }
           ├─StreamHashJoin { type: LeftSemi, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
           | ├─StreamExchange { dist: HashShard(l_orderkey) }
-          | | └─StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+          | | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
           | |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-          | |   | └─StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+          | |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
           | |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
           | |   |   | └─StreamRowIdGen { row_id_index: 4 }
           | |   |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -2060,7 +2060,7 @@
           | |   |     └─StreamRowIdGen { row_id_index: 7 }
           | |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
           | |   └─StreamExchange { dist: HashShard(l_suppkey) }
-          | |     └─StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+          | |     └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
           | |       ├─StreamExchange { dist: HashShard(o_orderkey) }
           | |       | └─StreamRowIdGen { row_id_index: 9 }
           | |       |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -2106,7 +2106,7 @@
     └──  StreamExchange Hash([0]) from 11
 
     Fragment 2
-    StreamAppendOnlyHashJoin { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
     ├── left table: 9
     ├── right table: 11
     ├── left degree table: 10
@@ -2115,7 +2115,7 @@
     └──  StreamExchange Hash([1]) from 6
 
     Fragment 3
-    StreamAppendOnlyHashJoin { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
     ├── left table: 13
     ├── right table: 15
     ├── left degree table: 14
@@ -2132,7 +2132,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 18 }
 
     Fragment 6
-    StreamAppendOnlyHashJoin { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
     ├── left table: 19
     ├── right table: 21
     ├── left degree table: 20

--- a/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
@@ -246,9 +246,9 @@
     └─StreamHashJoin { type: Inner, predicate: p_partkey IS NOT DISTINCT FROM p_partkey AND ps_supplycost = min(ps_supplycost), output: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id, _row_id, r_regionkey, _row_id, _row_id, _row_id, ps_suppkey, n_nationkey, ps_supplycost, p_partkey] }
       ├─StreamExchange { dist: HashShard(p_partkey) }
       | └─StreamShare { id = 26 }
-      |   └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
       |     ├─StreamExchange { dist: HashShard(n_nationkey) }
-      |     | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+      |     | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
       |     |   ├─StreamExchange { dist: HashShard(r_regionkey) }
       |     |   | └─StreamShare { id = 3 }
       |     |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -260,9 +260,9 @@
       |     |         └─StreamRowIdGen { row_id_index: 4 }
       |     |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
       |     └─StreamExchange { dist: HashShard(s_nationkey) }
-      |       └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+      |       └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
       |         ├─StreamExchange { dist: HashShard(ps_suppkey) }
-      |         | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+      |         | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
       |         |   ├─StreamExchange { dist: HashShard(p_partkey) }
       |         |   | └─StreamRowIdGen { row_id_index: 9 }
       |         |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -283,9 +283,9 @@
             | └─StreamExchange { dist: HashShard(p_partkey) }
             |   └─StreamProject { exprs: [p_partkey] }
             |     └─StreamShare { id = 26 }
-            |       └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+            |       └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
             |         ├─StreamExchange { dist: HashShard(n_nationkey) }
-            |         | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+            |         | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
             |         |   ├─StreamExchange { dist: HashShard(r_regionkey) }
             |         |   | └─StreamShare { id = 3 }
             |         |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -297,9 +297,9 @@
             |         |         └─StreamRowIdGen { row_id_index: 4 }
             |         |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
             |         └─StreamExchange { dist: HashShard(s_nationkey) }
-            |           └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+            |           └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
             |             ├─StreamExchange { dist: HashShard(ps_suppkey) }
-            |             | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+            |             | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
             |             |   ├─StreamExchange { dist: HashShard(p_partkey) }
             |             |   | └─StreamRowIdGen { row_id_index: 9 }
             |             |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -314,9 +314,9 @@
             |                   └─StreamRowIdGen { row_id_index: 7 }
             |                     └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
             └─StreamExchange { dist: HashShard(ps_partkey) }
-              └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
+              └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
                 ├─StreamExchange { dist: HashShard(s_nationkey) }
-                | └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
+                | └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(ps_suppkey) }
                 |   | └─StreamFilter { predicate: IsNotNull(ps_partkey) }
                 |   |   └─StreamShare { id = 15 }
@@ -329,7 +329,7 @@
                 |         └─StreamRowIdGen { row_id_index: 7 }
                 |           └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(n_nationkey) }
-                  └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(r_regionkey) }
                     | └─StreamShare { id = 3 }
                     |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -358,12 +358,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([5]) from 8
 
     Fragment 3
-    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 6
 
@@ -386,12 +386,12 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 13 }
 
     Fragment 8
-    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
     ├──  StreamExchange Hash([2]) from 9
     └──  StreamExchange Hash([0]) from 13
 
     Fragment 9
-    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -422,12 +422,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 16
-    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
     ├──  StreamExchange Hash([2]) from 17
     └──  StreamExchange Hash([0]) from 20
 
     Fragment 17
-    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
     ├──  StreamExchange Hash([1]) from 18
     └──  StreamExchange Hash([0]) from 19
 
@@ -440,7 +440,7 @@
     └──  StreamExchange NoShuffle from 14
 
     Fragment 20
-    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
     ├──  StreamExchange Hash([0]) from 21
     └──  StreamExchange Hash([2]) from 22
 
@@ -627,12 +627,12 @@
   stream_plan: |
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, sum($expr1)] }
-      └─StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
         └─StreamExchange { dist: HashShard(n_name) }
           └─StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
               ├─StreamExchange { dist: HashShard(n_nationkey, n_nationkey) }
-              | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -641,9 +641,9 @@
               |       └─StreamRowIdGen { row_id_index: 4 }
               |         └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(c_nationkey, s_nationkey) }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
                   ├─StreamExchange { dist: HashShard(o_orderkey, c_nationkey) }
-                  | └─StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
+                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(o_custkey) }
                   |   | └─StreamRowIdGen { row_id_index: 9 }
                   |   |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -651,7 +651,7 @@
                   |     └─StreamRowIdGen { row_id_index: 8 }
                   |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
                   └─StreamExchange { dist: HashShard(l_orderkey, s_nationkey) }
-                    └─StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
+                    └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
                       ├─StreamExchange { dist: HashShard(l_suppkey) }
                       | └─StreamRowIdGen { row_id_index: 16 }
                       |   └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
@@ -663,7 +663,7 @@
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, sum($expr1)] }
-        └── StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -671,7 +671,7 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-    └── StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -680,7 +680,7 @@
         └──  StreamExchange Hash([0, 3]) from 5
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([2]) from 4
 
@@ -694,7 +694,7 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
     ├── left table: 11
     ├── right table: 13
     ├── left degree table: 12
@@ -703,7 +703,7 @@
     └──  StreamExchange Hash([0, 3]) from 9
 
     Fragment 6
-    StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([1]) from 7
     └──  StreamExchange Hash([0]) from 8
 
@@ -716,7 +716,7 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 9
-    StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([2]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -899,14 +899,14 @@
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-      └─StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, n_name, $expr1) }
           └─StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
               ├─StreamExchange { dist: HashShard(l_orderkey) }
-              | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+              |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
               |   |   | └─StreamShare { id = 3 }
               |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -919,9 +919,9 @@
               |     └─StreamRowIdGen { row_id_index: 16 }
               |       └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_orderkey) }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(c_custkey) }
-                  | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
+                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   | └─StreamShare { id = 3 }
                   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -938,12 +938,12 @@
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-        └── StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
+        └── StreamHashAgg [in_append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
             └──  StreamExchange Hash([0, 1, 2]) from 1
 
     Fragment 1
     StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-    └── StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -952,7 +952,7 @@
         └──  StreamExchange Hash([1]) from 8
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
     ├── left table: 5
     ├── right table: 7
     ├── left degree table: 6
@@ -961,7 +961,7 @@
     └──  StreamExchange Hash([2]) from 7
 
     Fragment 3
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([3]) from 6
 
@@ -984,12 +984,12 @@
         └── source state table: 15
 
     Fragment 8
-    StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([1]) from 12
 
     Fragment 9
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([3]) from 11
 
@@ -1186,14 +1186,14 @@
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
               ├─StreamExchange { dist: HashShard(c_custkey) }
-              | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
+              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(n_nationkey) }
-              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+              |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -1206,11 +1206,11 @@
               |     └─StreamRowIdGen { row_id_index: 8 }
               |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_custkey) }
-                └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
+                └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(l_orderkey) }
-                  | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
+                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
                   |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-                  |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                  |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                   |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   |   | └─StreamShare { id = 5 }
                   |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, n_regionkey, _row_id] }
@@ -1220,7 +1220,7 @@
                   |   |     └─StreamRowIdGen { row_id_index: 7 }
                   |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                   |   └─StreamExchange { dist: HashShard(l_suppkey) }
-                  |     └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
+                  |     └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
                   |       ├─StreamExchange { dist: HashShard(p_partkey) }
                   |       | └─StreamRowIdGen { row_id_index: 9 }
                   |       |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1235,7 +1235,7 @@
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-        └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1243,17 +1243,17 @@
 
     Fragment 1
     StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-    └── StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
         ├──  StreamExchange Hash([0]) from 2
         └──  StreamExchange Hash([3]) from 8
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([3]) from 7
 
     Fragment 3
-    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 5
 
@@ -1275,17 +1275,17 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 15 }
 
     Fragment 8
-    StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([0]) from 16
 
     Fragment 9
-    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([1]) from 10
     └──  StreamExchange Hash([1]) from 13
 
     Fragment 10
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
     ├──  StreamExchange Hash([0]) from 11
     └──  StreamExchange Hash([3]) from 12
 
@@ -1298,7 +1298,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 28 }
 
     Fragment 13
-    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
     ├──  StreamExchange Hash([0]) from 14
     └──  StreamExchange Hash([1]) from 15
 
@@ -1496,12 +1496,12 @@
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-      └─StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [in_append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, $expr1) }
           └─StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-            └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+            └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
               ├─StreamExchange { dist: HashShard(ps_suppkey) }
-              | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
               |   ├─StreamExchange { dist: HashShard(p_partkey) }
               |   | └─StreamRowIdGen { row_id_index: 9 }
               |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1509,9 +1509,9 @@
               |     └─StreamFilter { predicate: (ps_suppkey = ps_suppkey) }
               |       └─StreamRowIdGen { row_id_index: 5 }
               |         └─StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] }
-              └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
+              └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
                 ├─StreamExchange { dist: HashShard(s_suppkey) }
-                | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                 |   | └─StreamRowIdGen { row_id_index: 4 }
                 |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -1519,7 +1519,7 @@
                 |     └─StreamRowIdGen { row_id_index: 7 }
                 |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(l_suppkey) }
-                  └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
+                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(o_orderkey) }
                     | └─StreamRowIdGen { row_id_index: 9 }
                     |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -1532,7 +1532,7 @@
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-        └── StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+        └── StreamHashAgg [in_append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1540,18 +1540,18 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-    └── StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+    └── StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
         ├── right degree table: 4
         ├──  StreamExchange Hash([2]) from 2
-        └── StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
+        └── StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
             ├──  StreamExchange Hash([1]) from 5
             └──  StreamExchange Hash([2]) from 8
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([0]) from 4
 
@@ -1565,7 +1565,7 @@
         └──  StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([0]) from 6
     └──  StreamExchange Hash([3]) from 7
 
@@ -1578,7 +1578,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 8
-    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([0]) from 9
     └──  StreamExchange Hash([0]) from 10
 
@@ -1773,7 +1773,7 @@
     StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden), s_nationkey(hidden), s_suppkey(hidden)], stream_key: [_row_id, _row_id#1, s_nationkey, s_suppkey], pk_columns: [s_name, _row_id, _row_id#1, s_nationkey, s_suppkey], pk_conflict: "NoCheck" }
     └─StreamHashJoin { type: LeftSemi, predicate: s_suppkey = ps_suppkey, output: [s_name, s_address, _row_id, _row_id, s_nationkey, s_suppkey] }
       ├─StreamExchange { dist: HashShard(s_suppkey) }
-      | └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
+      | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
       |   ├─StreamExchange { dist: HashShard(s_nationkey) }
       |   | └─StreamRowIdGen { row_id_index: 7 }
       |   |   └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
@@ -1824,7 +1824,7 @@
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 1
-    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([3]) from 2
     └──  StreamExchange Hash([0]) from 3
 
@@ -2050,9 +2050,9 @@
         └─StreamHashJoin { type: LeftAnti, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, l_orderkey] }
           ├─StreamHashJoin { type: LeftSemi, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
           | ├─StreamExchange { dist: HashShard(l_orderkey) }
-          | | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+          | | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
           | |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-          | |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+          | |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
           | |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
           | |   |   | └─StreamRowIdGen { row_id_index: 4 }
           | |   |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -2060,7 +2060,7 @@
           | |   |     └─StreamRowIdGen { row_id_index: 7 }
           | |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
           | |   └─StreamExchange { dist: HashShard(l_suppkey) }
-          | |     └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+          | |     └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
           | |       ├─StreamExchange { dist: HashShard(o_orderkey) }
           | |       | └─StreamRowIdGen { row_id_index: 9 }
           | |       |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -2106,7 +2106,7 @@
     └──  StreamExchange Hash([0]) from 11
 
     Fragment 2
-    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
     ├── left table: 9
     ├── right table: 11
     ├── left degree table: 10
@@ -2115,7 +2115,7 @@
     └──  StreamExchange Hash([1]) from 6
 
     Fragment 3
-    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
     ├── left table: 13
     ├── right table: 15
     ├── left degree table: 14
@@ -2132,7 +2132,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 18 }
 
     Fragment 6
-    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
     ├── left table: 19
     ├── right table: 21
     ├── left degree table: 20

--- a/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/tpch_variant.yaml
@@ -246,9 +246,9 @@
     └─StreamHashJoin { type: Inner, predicate: p_partkey IS NOT DISTINCT FROM p_partkey AND ps_supplycost = min(ps_supplycost), output: [s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment, _row_id, _row_id, r_regionkey, _row_id, _row_id, _row_id, ps_suppkey, n_nationkey, ps_supplycost, p_partkey] }
       ├─StreamExchange { dist: HashShard(p_partkey) }
       | └─StreamShare { id = 26 }
-      |   └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+      |   └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
       |     ├─StreamExchange { dist: HashShard(n_nationkey) }
-      |     | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+      |     | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
       |     |   ├─StreamExchange { dist: HashShard(r_regionkey) }
       |     |   | └─StreamShare { id = 3 }
       |     |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -260,9 +260,9 @@
       |     |         └─StreamRowIdGen { row_id_index: 4 }
       |     |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
       |     └─StreamExchange { dist: HashShard(s_nationkey) }
-      |       └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+      |       └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
       |         ├─StreamExchange { dist: HashShard(ps_suppkey) }
-      |         | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+      |         | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
       |         |   ├─StreamExchange { dist: HashShard(p_partkey) }
       |         |   | └─StreamRowIdGen { row_id_index: 9 }
       |         |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -283,9 +283,9 @@
             | └─StreamExchange { dist: HashShard(p_partkey) }
             |   └─StreamProject { exprs: [p_partkey] }
             |     └─StreamShare { id = 26 }
-            |       └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
+            |       └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] }
             |         ├─StreamExchange { dist: HashShard(n_nationkey) }
-            |         | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+            |         | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
             |         |   ├─StreamExchange { dist: HashShard(r_regionkey) }
             |         |   | └─StreamShare { id = 3 }
             |         |   |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -297,9 +297,9 @@
             |         |         └─StreamRowIdGen { row_id_index: 4 }
             |         |           └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
             |         └─StreamExchange { dist: HashShard(s_nationkey) }
-            |           └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
+            |           └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] }
             |             ├─StreamExchange { dist: HashShard(ps_suppkey) }
-            |             | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+            |             | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] }
             |             |   ├─StreamExchange { dist: HashShard(p_partkey) }
             |             |   | └─StreamRowIdGen { row_id_index: 9 }
             |             |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -314,9 +314,9 @@
             |                   └─StreamRowIdGen { row_id_index: 7 }
             |                     └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
             └─StreamExchange { dist: HashShard(ps_partkey) }
-              └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] }
                 ├─StreamExchange { dist: HashShard(s_nationkey) }
-                | └─StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
+                | └─StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(ps_suppkey) }
                 |   | └─StreamFilter { predicate: IsNotNull(ps_partkey) }
                 |   |   └─StreamShare { id = 15 }
@@ -329,7 +329,7 @@
                 |         └─StreamRowIdGen { row_id_index: 7 }
                 |           └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(n_nationkey) }
-                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(r_regionkey) }
                     | └─StreamShare { id = 3 }
                     |   └─StreamProject { exprs: [r_regionkey, _row_id] }
@@ -358,12 +358,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [p_partkey, p_mfgr, s_name, s_address, s_phone, s_acctbal, s_comment, ps_supplycost, n_name, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, _row_id, ps_suppkey] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([5]) from 8
 
     Fragment 3
-    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 8, right table: 10, left degree table: 9, right degree table: 11 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 6
 
@@ -386,12 +386,12 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 13 }
 
     Fragment 8
-    StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
+    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [p_partkey, p_mfgr, ps_supplycost, s_name, s_address, s_nationkey, s_phone, s_acctbal, s_comment, _row_id, _row_id, ps_suppkey, _row_id] } { left table: 14, right table: 16, left degree table: 15, right degree table: 17 }
     ├──  StreamExchange Hash([2]) from 9
     └──  StreamExchange Hash([0]) from 13
 
     Fragment 9
-    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, p_mfgr, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 18, right table: 20, left degree table: 19, right degree table: 21 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -422,12 +422,12 @@
     └──  StreamExchange NoShuffle from 2
 
     Fragment 16
-    StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [ps_partkey, ps_supplycost, _row_id, _row_id, ps_suppkey, s_nationkey, _row_id, _row_id, r_regionkey] } { left table: 32, right table: 34, left degree table: 33, right degree table: 35 }
     ├──  StreamExchange Hash([2]) from 17
     └──  StreamExchange Hash([0]) from 20
 
     Fragment 17
-    StreamHashJoin [in_append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
+    StreamHashJoin [append_only] { type: Inner, predicate: ps_suppkey = s_suppkey, output: [ps_partkey, ps_supplycost, s_nationkey, _row_id, ps_suppkey, _row_id] } { left table: 36, right table: 38, left degree table: 37, right degree table: 39 }
     ├──  StreamExchange Hash([1]) from 18
     └──  StreamExchange Hash([0]) from 19
 
@@ -440,7 +440,7 @@
     └──  StreamExchange NoShuffle from 14
 
     Fragment 20
-    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 40, right table: 42, left degree table: 41, right degree table: 43 }
     ├──  StreamExchange Hash([0]) from 21
     └──  StreamExchange Hash([2]) from 22
 
@@ -627,12 +627,12 @@
   stream_plan: |
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, sum($expr1)] }
-      └─StreamHashAgg [in_append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
         └─StreamExchange { dist: HashShard(n_name) }
           └─StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
               ├─StreamExchange { dist: HashShard(n_nationkey, n_nationkey) }
-              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -641,9 +641,9 @@
               |       └─StreamRowIdGen { row_id_index: 4 }
               |         └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(c_nationkey, s_nationkey) }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
                   ├─StreamExchange { dist: HashShard(o_orderkey, c_nationkey) }
-                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(o_custkey) }
                   |   | └─StreamRowIdGen { row_id_index: 9 }
                   |   |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -651,7 +651,7 @@
                   |     └─StreamRowIdGen { row_id_index: 8 }
                   |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
                   └─StreamExchange { dist: HashShard(l_orderkey, s_nationkey) }
-                    └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
+                    └─StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] }
                       ├─StreamExchange { dist: HashShard(l_suppkey) }
                       | └─StreamRowIdGen { row_id_index: 16 }
                       |   └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
@@ -663,7 +663,7 @@
     StreamMaterialize { columns: [n_name, revenue], stream_key: [n_name], pk_columns: [revenue, n_name], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, sum($expr1)] }
-        └── StreamHashAgg [in_append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
+        └── StreamHashAgg [append_only] { group_key: [n_name], aggs: [sum($expr1), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -671,7 +671,7 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, (l_extendedprice * (1:Decimal - l_discount)) as $expr1, _row_id, _row_id, r_regionkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey, n_nationkey] }
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey AND n_nationkey = c_nationkey, output: [n_name, l_extendedprice, l_discount, _row_id, _row_id, r_regionkey, n_nationkey, _row_id, _row_id, o_custkey, _row_id, _row_id, l_suppkey, o_orderkey, c_nationkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -680,7 +680,7 @@
         └──  StreamExchange Hash([0, 3]) from 5
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, n_name, _row_id, r_regionkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([2]) from 4
 
@@ -694,7 +694,7 @@
         └──  StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey AND c_nationkey = s_nationkey, output: [c_nationkey, l_extendedprice, l_discount, s_nationkey, _row_id, _row_id, o_custkey, o_orderkey, _row_id, _row_id, l_suppkey] }
     ├── left table: 11
     ├── right table: 13
     ├── left degree table: 12
@@ -703,7 +703,7 @@
     └──  StreamExchange Hash([0, 3]) from 9
 
     Fragment 6
-    StreamHashJoin [in_append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_custkey = c_custkey, output: [o_orderkey, c_nationkey, _row_id, o_custkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([1]) from 7
     └──  StreamExchange Hash([0]) from 8
 
@@ -716,7 +716,7 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 9
-    StreamHashJoin [in_append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [append_only] { type: Inner, predicate: l_suppkey = s_suppkey, output: [l_orderkey, l_extendedprice, l_discount, s_nationkey, _row_id, l_suppkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([2]) from 10
     └──  StreamExchange Hash([0]) from 11
 
@@ -899,14 +899,14 @@
   stream_plan: |
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-      └─StreamHashAgg [in_append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, n_name, $expr1) }
           └─StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
               ├─StreamExchange { dist: HashShard(l_orderkey) }
-              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-              |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
               |   |   | └─StreamShare { id = 3 }
               |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -919,9 +919,9 @@
               |     └─StreamRowIdGen { row_id_index: 16 }
               |       └─StreamSource { source: "lineitem", columns: ["l_orderkey", "l_partkey", "l_suppkey", "l_linenumber", "l_quantity", "l_extendedprice", "l_discount", "l_tax", "l_returnflag", "l_linestatus", "l_shipdate", "l_commitdate", "l_receiptdate", "l_shipinstruct", "l_shipmode", "l_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_orderkey) }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(c_custkey) }
-                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] }
                   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   | └─StreamShare { id = 3 }
                   |   |   └─StreamProject { exprs: [n_nationkey, n_name, _row_id] }
@@ -938,12 +938,12 @@
     StreamMaterialize { columns: [supp_nation, cust_nation, l_year, revenue], stream_key: [supp_nation, cust_nation, l_year], pk_columns: [supp_nation, cust_nation, l_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, n_name, $expr1, sum($expr2)] }
-        └── StreamHashAgg [in_append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
+        └── StreamHashAgg [append_only] { group_key: [n_name, n_name, $expr1], aggs: [sum($expr2), count] } { result table: 0, state tables: [], distinct tables: [] }
             └──  StreamExchange Hash([0, 1, 2]) from 1
 
     Fragment 1
     StreamProject { exprs: [n_name, n_name, Extract('YEAR':Varchar, l_shipdate) as $expr1, (l_extendedprice * (1:Decimal - l_discount)) as $expr2, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey, l_orderkey] }
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, l_shipdate, n_name, _row_id, _row_id, n_nationkey, _row_id, s_suppkey, l_orderkey, _row_id, _row_id, n_nationkey, _row_id, c_custkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
@@ -952,7 +952,7 @@
         └──  StreamExchange Hash([1]) from 8
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, l_shipdate, _row_id, _row_id, n_nationkey, s_suppkey, _row_id] }
     ├── left table: 5
     ├── right table: 7
     ├── left degree table: 6
@@ -961,7 +961,7 @@
     └──  StreamExchange Hash([2]) from 7
 
     Fragment 3
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([3]) from 6
 
@@ -984,12 +984,12 @@
         └── source state table: 15
 
     Fragment 8
-    StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, o_orderkey, _row_id, _row_id, n_nationkey, c_custkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([1]) from 12
 
     Fragment 9
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [n_name, c_custkey, _row_id, n_nationkey, _row_id] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([0]) from 10
     └──  StreamExchange Hash([3]) from 11
 
@@ -1186,14 +1186,14 @@
   stream_plan: |
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-      └─StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+      └─StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
         └─StreamExchange { dist: HashShard($expr1) }
           └─StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] }
               ├─StreamExchange { dist: HashShard(c_custkey) }
-              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] }
               |   ├─StreamExchange { dist: HashShard(n_nationkey) }
-              |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
+              |   | └─StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] }
               |   |   ├─StreamExchange { dist: HashShard(r_regionkey) }
               |   |   | └─StreamRowIdGen { row_id_index: 3 }
               |   |   |   └─StreamSource { source: "region", columns: ["r_regionkey", "r_name", "r_comment", "_row_id"] }
@@ -1206,11 +1206,11 @@
               |     └─StreamRowIdGen { row_id_index: 8 }
               |       └─StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] }
               └─StreamExchange { dist: HashShard(o_custkey) }
-                └─StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
+                └─StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] }
                   ├─StreamExchange { dist: HashShard(l_orderkey) }
-                  | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
+                  | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] }
                   |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-                  |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                  |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                   |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                   |   |   | └─StreamShare { id = 5 }
                   |   |   |   └─StreamProject { exprs: [n_nationkey, n_name, n_regionkey, _row_id] }
@@ -1220,7 +1220,7 @@
                   |   |     └─StreamRowIdGen { row_id_index: 7 }
                   |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                   |   └─StreamExchange { dist: HashShard(l_suppkey) }
-                  |     └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
+                  |     └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] }
                   |       ├─StreamExchange { dist: HashShard(p_partkey) }
                   |       | └─StreamRowIdGen { row_id_index: 9 }
                   |       |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1235,7 +1235,7 @@
     StreamMaterialize { columns: [o_year, mkt_share], stream_key: [o_year], pk_columns: [o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [$expr1, RoundDigit((sum($expr2) / sum($expr3)), 6:Int32) as $expr4] }
-        └── StreamHashAgg [in_append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
+        └── StreamHashAgg [append_only] { group_key: [$expr1], aggs: [sum($expr2), sum($expr3), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1243,17 +1243,17 @@
 
     Fragment 1
     StreamProject { exprs: [Extract('YEAR':Varchar, o_orderdate) as $expr1, Case((n_name <> 'IRAN':Varchar), (l_extendedprice * (1:Decimal - l_discount)), 0:Decimal) as $expr2, (l_extendedprice * (1:Decimal - l_discount)) as $expr3, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey, c_custkey] }
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: c_custkey = o_custkey, output: [n_name, l_extendedprice, l_discount, o_orderdate, _row_id, _row_id, r_regionkey, _row_id, n_nationkey, c_custkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, _row_id, l_orderkey] } { left table: 1, right table: 3, left degree table: 2, right degree table: 4 }
         ├──  StreamExchange Hash([0]) from 2
         └──  StreamExchange Hash([3]) from 8
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = c_nationkey, output: [c_custkey, _row_id, _row_id, r_regionkey, n_nationkey, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([3]) from 7
 
     Fragment 3
-    StreamHashJoin [in_append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
+    StreamHashJoin [append_only] { type: Inner, predicate: r_regionkey = n_regionkey, output: [n_nationkey, _row_id, r_regionkey, _row_id] } { left table: 9, right table: 11, left degree table: 10, right degree table: 12 }
     ├──  StreamExchange Hash([0]) from 4
     └──  StreamExchange Hash([2]) from 5
 
@@ -1275,17 +1275,17 @@
     └──  StreamSource { source: "customer", columns: ["c_custkey", "c_name", "c_address", "c_nationkey", "c_phone", "c_acctbal", "c_mktsegment", "c_comment", "_row_id"] } { source state table: 15 }
 
     Fragment 8
-    StreamHashJoin [in_append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
+    StreamHashJoin [append_only] { type: Inner, predicate: l_orderkey = o_orderkey, output: [n_name, l_extendedprice, l_discount, o_custkey, o_orderdate, _row_id, _row_id, n_nationkey, _row_id, _row_id, p_partkey, s_suppkey, l_orderkey, _row_id] } { left table: 16, right table: 18, left degree table: 17, right degree table: 19 }
     ├──  StreamExchange Hash([1]) from 9
     └──  StreamExchange Hash([0]) from 16
 
     Fragment 9
-    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, l_orderkey, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, p_partkey] } { left table: 20, right table: 22, left degree table: 21, right degree table: 23 }
     ├──  StreamExchange Hash([1]) from 10
     └──  StreamExchange Hash([1]) from 13
 
     Fragment 10
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 24, right table: 26, left degree table: 25, right degree table: 27 }
     ├──  StreamExchange Hash([0]) from 11
     └──  StreamExchange Hash([3]) from 12
 
@@ -1298,7 +1298,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 28 }
 
     Fragment 13
-    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey, output: [l_orderkey, l_suppkey, l_extendedprice, l_discount, _row_id, p_partkey, _row_id] } { left table: 29, right table: 31, left degree table: 30, right degree table: 32 }
     ├──  StreamExchange Hash([0]) from 14
     └──  StreamExchange Hash([1]) from 15
 
@@ -1496,12 +1496,12 @@
   stream_plan: |
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-      └─StreamHashAgg [in_append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+      └─StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
         └─StreamExchange { dist: HashShard(n_name, $expr1) }
           └─StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-            └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+            └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
               ├─StreamExchange { dist: HashShard(ps_suppkey) }
-              | └─StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
+              | └─StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] }
               |   ├─StreamExchange { dist: HashShard(p_partkey) }
               |   | └─StreamRowIdGen { row_id_index: 9 }
               |   |   └─StreamSource { source: "part", columns: ["p_partkey", "p_name", "p_mfgr", "p_brand", "p_type", "p_size", "p_container", "p_retailprice", "p_comment", "_row_id"] }
@@ -1509,9 +1509,9 @@
               |     └─StreamFilter { predicate: (ps_suppkey = ps_suppkey) }
               |       └─StreamRowIdGen { row_id_index: 5 }
               |         └─StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] }
-              └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
+              └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] }
                 ├─StreamExchange { dist: HashShard(s_suppkey) }
-                | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
+                | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] }
                 |   ├─StreamExchange { dist: HashShard(n_nationkey) }
                 |   | └─StreamRowIdGen { row_id_index: 4 }
                 |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -1519,7 +1519,7 @@
                 |     └─StreamRowIdGen { row_id_index: 7 }
                 |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
                 └─StreamExchange { dist: HashShard(l_suppkey) }
-                  └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
+                  └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] }
                     ├─StreamExchange { dist: HashShard(o_orderkey) }
                     | └─StreamRowIdGen { row_id_index: 9 }
                     |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -1532,7 +1532,7 @@
     StreamMaterialize { columns: [nation, o_year, sum_profit], stream_key: [nation, o_year], pk_columns: [nation, o_year], pk_conflict: "NoCheck" }
     ├── materialized table: 4294967294
     └── StreamProject { exprs: [n_name, $expr1, RoundDigit(sum($expr2), 2:Int32) as $expr3] }
-        └── StreamHashAgg [in_append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
+        └── StreamHashAgg [append_only] { group_key: [n_name, $expr1], aggs: [sum($expr2), count] }
             ├── result table: 0
             ├── state tables: []
             ├── distinct tables: []
@@ -1540,18 +1540,18 @@
 
     Fragment 1
     StreamProject { exprs: [n_name, Extract('YEAR':Varchar, o_orderdate) as $expr1, ((l_extendedprice * (1:Decimal - l_discount)) - (ps_supplycost * l_quantity)) as $expr2, _row_id, _row_id, p_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, ps_suppkey, ps_partkey] }
-    └── StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
+    └── StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = l_partkey AND ps_suppkey = l_suppkey AND ps_partkey = l_partkey AND ps_suppkey = s_suppkey, output: [ps_supplycost, n_name, o_orderdate, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, p_partkey, ps_suppkey, ps_partkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
         ├── left table: 1
         ├── right table: 3
         ├── left degree table: 2
         ├── right degree table: 4
         ├──  StreamExchange Hash([2]) from 2
-        └── StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
+        └── StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [n_name, s_suppkey, o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey] } { left table: 11, right table: 13, left degree table: 12, right degree table: 14 }
             ├──  StreamExchange Hash([1]) from 5
             └──  StreamExchange Hash([2]) from 8
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
+    StreamHashJoin [append_only] { type: Inner, predicate: p_partkey = ps_partkey, output: [p_partkey, ps_partkey, ps_suppkey, ps_supplycost, _row_id, _row_id] } { left table: 5, right table: 7, left degree table: 6, right degree table: 8 }
     ├──  StreamExchange Hash([0]) from 3
     └──  StreamExchange Hash([0]) from 4
 
@@ -1565,7 +1565,7 @@
         └──  StreamSource { source: "partsupp", columns: ["ps_partkey", "ps_suppkey", "ps_availqty", "ps_supplycost", "ps_comment", "_row_id"] } { source state table: 10 }
 
     Fragment 5
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [n_name, s_suppkey, _row_id, n_nationkey, _row_id] } { left table: 15, right table: 17, left degree table: 16, right degree table: 18 }
     ├──  StreamExchange Hash([0]) from 6
     └──  StreamExchange Hash([3]) from 7
 
@@ -1578,7 +1578,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 20 }
 
     Fragment 8
-    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [o_orderdate, l_partkey, l_suppkey, l_quantity, l_extendedprice, l_discount, _row_id, o_orderkey, _row_id] } { left table: 21, right table: 23, left degree table: 22, right degree table: 24 }
     ├──  StreamExchange Hash([0]) from 9
     └──  StreamExchange Hash([0]) from 10
 
@@ -1773,7 +1773,7 @@
     StreamMaterialize { columns: [s_name, s_address, _row_id(hidden), _row_id#1(hidden), s_nationkey(hidden), s_suppkey(hidden)], stream_key: [_row_id, _row_id#1, s_nationkey, s_suppkey], pk_columns: [s_name, _row_id, _row_id#1, s_nationkey, s_suppkey], pk_conflict: "NoCheck" }
     └─StreamHashJoin { type: LeftSemi, predicate: s_suppkey = ps_suppkey, output: [s_name, s_address, _row_id, _row_id, s_nationkey, s_suppkey] }
       ├─StreamExchange { dist: HashShard(s_suppkey) }
-      | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
+      | └─StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] }
       |   ├─StreamExchange { dist: HashShard(s_nationkey) }
       |   | └─StreamRowIdGen { row_id_index: 7 }
       |   |   └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
@@ -1824,7 +1824,7 @@
         └──  StreamExchange Hash([0]) from 4
 
     Fragment 1
-    StreamHashJoin [in_append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_nationkey = n_nationkey, output: [s_suppkey, s_name, s_address, _row_id, s_nationkey, _row_id] } { left table: 4, right table: 6, left degree table: 5, right degree table: 7 }
     ├──  StreamExchange Hash([3]) from 2
     └──  StreamExchange Hash([0]) from 3
 
@@ -2050,9 +2050,9 @@
         └─StreamHashJoin { type: LeftAnti, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey, l_orderkey] }
           ├─StreamHashJoin { type: LeftSemi, predicate: l_orderkey = l_orderkey AND (l_suppkey <> l_suppkey), output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, _row_id, _row_id, o_orderkey, s_suppkey] }
           | ├─StreamExchange { dist: HashShard(l_orderkey) }
-          | | └─StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+          | | └─StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
           | |   ├─StreamExchange { dist: HashShard(s_suppkey) }
-          | |   | └─StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+          | |   | └─StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
           | |   |   ├─StreamExchange { dist: HashShard(n_nationkey) }
           | |   |   | └─StreamRowIdGen { row_id_index: 4 }
           | |   |   |   └─StreamSource { source: "nation", columns: ["n_nationkey", "n_name", "n_regionkey", "n_comment", "_row_id"] }
@@ -2060,7 +2060,7 @@
           | |   |     └─StreamRowIdGen { row_id_index: 7 }
           | |   |       └─StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] }
           | |   └─StreamExchange { dist: HashShard(l_suppkey) }
-          | |     └─StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+          | |     └─StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
           | |       ├─StreamExchange { dist: HashShard(o_orderkey) }
           | |       | └─StreamRowIdGen { row_id_index: 9 }
           | |       |   └─StreamSource { source: "orders", columns: ["o_orderkey", "o_custkey", "o_orderstatus", "o_totalprice", "o_orderdate", "o_orderpriority", "o_clerk", "o_shippriority", "o_comment", "_row_id"] }
@@ -2106,7 +2106,7 @@
     └──  StreamExchange Hash([0]) from 11
 
     Fragment 2
-    StreamHashJoin [in_append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
+    StreamHashJoin [append_only] { type: Inner, predicate: s_suppkey = l_suppkey, output: [s_name, l_orderkey, l_suppkey, _row_id, _row_id, n_nationkey, s_suppkey, _row_id, _row_id, o_orderkey] }
     ├── left table: 9
     ├── right table: 11
     ├── left degree table: 10
@@ -2115,7 +2115,7 @@
     └──  StreamExchange Hash([1]) from 6
 
     Fragment 3
-    StreamHashJoin [in_append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: n_nationkey = s_nationkey, output: [s_suppkey, s_name, _row_id, n_nationkey, _row_id] }
     ├── left table: 13
     ├── right table: 15
     ├── left degree table: 14
@@ -2132,7 +2132,7 @@
     └──  StreamSource { source: "supplier", columns: ["s_suppkey", "s_name", "s_address", "s_nationkey", "s_phone", "s_acctbal", "s_comment", "_row_id"] } { source state table: 18 }
 
     Fragment 6
-    StreamHashJoin [in_append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
+    StreamHashJoin [append_only] { type: Inner, predicate: o_orderkey = l_orderkey, output: [l_orderkey, l_suppkey, _row_id, o_orderkey, _row_id] }
     ├── left table: 19
     ├── right table: 21
     ├── left degree table: 20

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -49,7 +49,7 @@
   stream_plan: |
     StreamMaterialize { columns: [count, t.ts(hidden), t.v1(hidden)], stream_key: [t.ts, t.v1], pk_columns: [t.ts, t.v1], pk_conflict: "NoCheck", watermark_columns: [t.ts(hidden)] }
     └─StreamProject { exprs: [count(t.v2), t.ts, t.v1], output_watermarks: [t.ts] }
-      └─StreamHashAgg [append_only] { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
+      └─StreamHashAgg [in_append_only] { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
         └─StreamExchange { dist: HashShard(t.ts, t.v1) }
           └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: inner window join
@@ -59,7 +59,7 @@
     select t1.ts as t1_ts, t2.ts as ts2, t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2 from t1, t2 where t1.ts = t2.ts;
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, ts2, t1_v1, t1_v2, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_ts], pk_columns: [t1._row_id, t2._row_id, t1_ts], pk_conflict: "NoCheck", watermark_columns: [t1_ts, ts2] }
-    └─StreamHashJoin [window, append_only] { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.ts) }
       | └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.ts) }
@@ -107,7 +107,7 @@
       └─LogicalScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
-    └─StreamHashJoin [interval, append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [interval, in_append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -49,7 +49,7 @@
   stream_plan: |
     StreamMaterialize { columns: [count, t.ts(hidden), t.v1(hidden)], stream_key: [t.ts, t.v1], pk_columns: [t.ts, t.v1], pk_conflict: "NoCheck", watermark_columns: [t.ts(hidden)] }
     └─StreamProject { exprs: [count(t.v2), t.ts, t.v1], output_watermarks: [t.ts] }
-      └─StreamHashAgg [in_append_only] { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
+      └─StreamHashAgg [append_only] { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
         └─StreamExchange { dist: HashShard(t.ts, t.v1) }
           └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: inner window join
@@ -59,7 +59,7 @@
     select t1.ts as t1_ts, t2.ts as ts2, t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2 from t1, t2 where t1.ts = t2.ts;
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, ts2, t1_v1, t1_v2, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_ts], pk_columns: [t1._row_id, t2._row_id, t1_ts], pk_conflict: "NoCheck", watermark_columns: [t1_ts, ts2] }
-    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.ts) }
       | └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.ts) }
@@ -107,7 +107,7 @@
       └─LogicalScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
-    └─StreamHashJoin [interval, in_append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [interval, append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -49,7 +49,7 @@
   stream_plan: |
     StreamMaterialize { columns: [count, t.ts(hidden), t.v1(hidden)], stream_key: [t.ts, t.v1], pk_columns: [t.ts, t.v1], pk_conflict: "NoCheck", watermark_columns: [t.ts(hidden)] }
     └─StreamProject { exprs: [count(t.v2), t.ts, t.v1], output_watermarks: [t.ts] }
-      └─StreamAppendOnlyHashAgg { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
+      └─StreamHashAgg [append_only] { group_key: [t.ts, t.v1], aggs: [count(t.v2), count], output_watermarks: [t.ts] }
         └─StreamExchange { dist: HashShard(t.ts, t.v1) }
           └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: inner window join
@@ -59,7 +59,7 @@
     select t1.ts as t1_ts, t2.ts as ts2, t1.v1 as t1_v1, t1.v2 as t1_v2, t2.v1 as t2_v1, t2.v2 as t2_v2 from t1, t2 where t1.ts = t2.ts;
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, ts2, t1_v1, t1_v2, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_ts], pk_columns: [t1._row_id, t2._row_id, t1_ts], pk_conflict: "NoCheck", watermark_columns: [t1_ts, ts2] }
-    └─StreamWindowJoin { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t2.ts, t1.v1, t1.v2, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.ts) }
       | └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.ts) }
@@ -71,7 +71,7 @@
     select t1.ts as t1_ts, t1.v1 as t1_v1, t1.v2 as t1_v2 from t1 where exists (select * from t2 where t1.ts = t2.ts);
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t1._row_id(hidden)], stream_key: [t1._row_id, t1_ts], pk_columns: [t1._row_id, t1_ts], pk_conflict: "NoCheck", watermark_columns: [t1_ts] }
-    └─StreamWindowJoin { type: LeftSemi, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts], output: all }
+    └─StreamHashJoin [window] { type: LeftSemi, predicate: t1.ts = t2.ts, output_watermarks: [t1.ts], output: all }
       ├─StreamExchange { dist: HashShard(t1.ts) }
       | └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.ts) }
@@ -88,7 +88,7 @@
       └─LogicalScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
-    └─StreamIntervalJoin { type: LeftOuter, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [interval] { type: LeftOuter, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
@@ -107,7 +107,7 @@
       └─LogicalScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id] }
   stream_plan: |
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
-    └─StreamIntervalJoin { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
+    └─StreamHashJoin [interval, append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
       | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }

--- a/src/frontend/planner_test/tests/testdata/output/window_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/window_join.yaml
@@ -12,7 +12,7 @@
     select * from t1, t2 where ts1 = ts2 and a1 = a2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, ts1, a1], pk_columns: [_row_id, _row_id#1, ts1, a1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }
@@ -34,7 +34,7 @@
     select * from t1, t2 where a1 = a2 and ts1 = ts2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, a1, ts1], pk_columns: [_row_id, _row_id#1, a1, ts1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }

--- a/src/frontend/planner_test/tests/testdata/output/window_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/window_join.yaml
@@ -12,7 +12,7 @@
     select * from t1, t2 where ts1 = ts2 and a1 = a2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, ts1, a1], pk_columns: [_row_id, _row_id#1, ts1, a1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamWindowJoin { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }
@@ -34,7 +34,7 @@
     select * from t1, t2 where a1 = a2 and ts1 = ts2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, a1, ts1], pk_columns: [_row_id, _row_id#1, a1, ts1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamWindowJoin { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }

--- a/src/frontend/planner_test/tests/testdata/output/window_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/window_join.yaml
@@ -12,7 +12,7 @@
     select * from t1, t2 where ts1 = ts2 and a1 = a2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, ts1, a1], pk_columns: [_row_id, _row_id#1, ts1, a1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }
@@ -34,7 +34,7 @@
     select * from t1, t2 where a1 = a2 and ts1 = ts2;
   stream_plan: |
     StreamMaterialize { columns: [ts1, a1, b1, ts2, a2, b2, _row_id(hidden), _row_id#1(hidden)], stream_key: [_row_id, _row_id#1, a1, ts1], pk_columns: [_row_id, _row_id#1, a1, ts1], pk_conflict: "NoCheck", watermark_columns: [ts1, ts2] }
-    └─StreamHashJoin [window, in_append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
+    └─StreamHashJoin [window, append_only] { type: Inner, predicate: ts1 = ts2 AND a1 = a2, output_watermarks: [ts1, ts2], output: [ts1, a1, b1, ts2, a2, b2, _row_id, _row_id] }
       ├─StreamExchange { dist: HashShard(ts1, a1) }
       | └─StreamRowIdGen { row_id_index: 3 }
       |   └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (ts1 - '00:00:01':Interval)] }

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -21,6 +21,7 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{ArrangementInfo, DeltaIndexJoinNode};
 
 use super::generic::{self, GenericPlanRef};
+use super::utils::formatter_debug_plan_node;
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, StreamNode};
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
@@ -91,7 +92,7 @@ impl StreamDeltaJoin {
 impl fmt::Display for StreamDeltaJoin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
-        let mut builder = f.debug_struct("StreamDeltaJoin");
+        let mut builder = formatter_debug_plan_node!(f, "StreamDeltaJoin");
         builder.field("type", &self.logical.join_type);
 
         let mut concat_schema = self.left().schema().fields.clone();

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -21,7 +21,7 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::DynamicFilterNode;
 
 use super::generic::DynamicFilter;
-use super::utils::IndicesDisplay;
+use super::utils::{formatter_debug_plan_node, IndicesDisplay};
 use super::{generic, ExprRewritable};
 use crate::expr::Expr;
 use crate::optimizer::plan_node::{PlanBase, PlanTreeNodeBinary, StreamNode};
@@ -58,7 +58,7 @@ impl StreamDynamicFilter {
 impl fmt::Display for StreamDynamicFilter {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
-        let mut builder = f.debug_struct("StreamDynamicFilter");
+        let mut builder = formatter_debug_plan_node!(f, "StreamDynamicFilter");
 
         self.core.fmt_fields_with_builder(&mut builder);
         let watermark_columns = &self.base.watermark_columns;

--- a/src/frontend/src/optimizer/plan_node/stream_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_exchange.rs
@@ -18,6 +18,7 @@ use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{DispatchStrategy, DispatcherType, ExchangeNode};
 
 use super::stream::StreamPlanRef;
+use super::utils::formatter_debug_plan_node;
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::optimizer::property::{Distribution, DistributionDisplay};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -79,11 +80,10 @@ impl StreamExchange {
 
 impl fmt::Display for StreamExchange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = if self.no_shuffle {
-            f.debug_struct("StreamNoShuffleExchange")
-        } else {
-            f.debug_struct("StreamExchange")
-        };
+        let mut builder = formatter_debug_plan_node!(
+            f, "StreamExchange"
+            , { "no_shuffle", self.no_shuffle }
+        );
 
         builder
             .field(

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -149,7 +149,7 @@ impl fmt::Display for StreamHashAgg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = formatter_debug_plan_node!(
             f, "StreamHashAgg"
-            , { "in_append_only", self.input().append_only() }
+            , { "append_only", self.input().append_only() }
             , { "eowc", self.emit_on_window_close }
         );
         self.logical.fmt_fields_with_builder(&mut builder);

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -21,6 +21,7 @@ use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{self, PlanAggCall};
+use super::utils::formatter_debug_plan_node;
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::ExprRewriter;
 use crate::optimizer::property::Distribution;
@@ -146,11 +147,11 @@ impl StreamHashAgg {
 
 impl fmt::Display for StreamHashAgg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = if self.input().append_only() {
-            f.debug_struct("StreamAppendOnlyHashAgg")
-        } else {
-            f.debug_struct("StreamHashAgg")
-        };
+        let mut builder = formatter_debug_plan_node!(
+            f, "StreamHashAgg"
+            , { "append_only", self.input().append_only() }
+            , { "eowc", self.emit_on_window_close }
+        );
         self.logical.fmt_fields_with_builder(&mut builder);
 
         let watermark_columns = &self.base.watermark_columns;

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -149,7 +149,7 @@ impl fmt::Display for StreamHashAgg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = formatter_debug_plan_node!(
             f, "StreamHashAgg"
-            , { "append_only", self.input().append_only() }
+            , { "in_append_only", self.input().append_only() }
             , { "eowc", self.emit_on_window_close }
         );
         self.logical.fmt_fields_with_builder(&mut builder);

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -302,7 +302,7 @@ impl fmt::Display for StreamHashJoin {
             f, "StreamHashJoin"
             , { "window", self.left().watermark_columns().contains(ljk) && self.right().watermark_columns().contains(rjk) }
             , { "interval", self.clean_left_state_conjunction_idx.is_some() && self.clean_right_state_conjunction_idx.is_some() }
-            , { "append_only", self.is_append_only }
+            , { "in_append_only", self.is_append_only }
         );
 
         let verbose = self.base.ctx.is_explain_verbose();

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -302,7 +302,7 @@ impl fmt::Display for StreamHashJoin {
             f, "StreamHashJoin"
             , { "window", self.left().watermark_columns().contains(ljk) && self.right().watermark_columns().contains(rjk) }
             , { "interval", self.clean_left_state_conjunction_idx.is_some() && self.clean_right_state_conjunction_idx.is_some() }
-            , { "in_append_only", self.is_append_only }
+            , { "append_only", self.is_append_only }
         );
 
         let verbose = self.base.ctx.is_explain_verbose();

--- a/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_join.rs
@@ -22,6 +22,7 @@ use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{DeltaExpression, HashJoinNode, PbInequalityPair};
 
+use super::utils::formatter_debug_plan_node;
 use super::{
     generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, StreamDeltaJoin, StreamNode,
 };
@@ -297,19 +298,12 @@ impl fmt::Display for StreamHashJoin {
             .cloned()
             .expect("first join key");
 
-        let mut builder = if self.left().watermark_columns().contains(ljk)
-            && self.right().watermark_columns().contains(rjk)
-        {
-            f.debug_struct("StreamWindowJoin")
-        } else if self.clean_left_state_conjunction_idx.is_some()
-            && self.clean_right_state_conjunction_idx.is_some()
-        {
-            f.debug_struct("StreamIntervalJoin")
-        } else if self.is_append_only {
-            f.debug_struct("StreamAppendOnlyHashJoin")
-        } else {
-            f.debug_struct("StreamHashJoin")
-        };
+        let mut builder = formatter_debug_plan_node!(
+            f, "StreamHashJoin"
+            , { "window", self.left().watermark_columns().contains(ljk) && self.right().watermark_columns().contains(rjk) }
+            , { "interval", self.clean_left_state_conjunction_idx.is_some() && self.clean_right_state_conjunction_idx.is_some() }
+            , { "append_only", self.is_append_only }
+        );
 
         let verbose = self.base.ctx.is_explain_verbose();
         builder.field("type", &self.logical.join_type);

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -21,6 +21,7 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::HopWindowNode;
 
 use super::stream::StreamPlanRef;
+use super::utils::formatter_debug_plan_node;
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::{Expr, ExprImpl, ExprRewriter};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -77,7 +78,7 @@ impl StreamHopWindow {
 
 impl fmt::Display for StreamHopWindow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamHopWindow");
+        let mut builder = formatter_debug_plan_node!(f, "StreamHopWindow");
         self.logical.fmt_fields_with_builder(&mut builder);
 
         let watermark_columns = &self.base.watermark_columns;

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -24,6 +24,7 @@ use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::derive::derive_columns;
+use super::utils::formatter_debug_plan_node;
 use super::{reorganize_elements_id, ExprRewritable, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::catalog::table_catalog::{TableCatalog, TableType, TableVersion};
 use crate::catalog::FragmentId;
@@ -248,7 +249,7 @@ impl fmt::Display for StreamMaterialize {
             .map(|o| table.columns()[o.column_index].column_desc.name.clone())
             .join(", ");
 
-        let mut builder = f.debug_struct("StreamMaterialize");
+        let mut builder = formatter_debug_plan_node!(f, "StreamMaterialize");
         builder
             .field("columns", &format_args!("[{}]", column_names))
             .field("stream_key", &format_args!("[{}]", stream_key))

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -23,7 +23,7 @@ use risingwave_pb::stream_plan::NowNode;
 
 use super::generic::GenericPlanRef;
 use super::stream::StreamPlanRef;
-use super::utils::{IndicesDisplay, TableCatalogBuilder};
+use super::utils::{formatter_debug_plan_node, IndicesDisplay, TableCatalogBuilder};
 use super::{ExprRewritable, LogicalNow, PlanBase, StreamNode};
 use crate::optimizer::property::{Distribution, FunctionalDependencySet};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -61,7 +61,7 @@ impl StreamNow {
 impl fmt::Display for StreamNow {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
-        let mut builder = f.debug_struct("StreamNow");
+        let mut builder = formatter_debug_plan_node!(f, "StreamNow");
 
         if verbose {
             // For now, output all columns from the left side. Make it explicit here.

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -21,6 +21,7 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::ProjectNode;
 
 use super::stream::StreamPlanRef;
+use super::utils::formatter_debug_plan_node;
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::{try_derive_watermark, Expr, ExprImpl, ExprRewriter};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -39,7 +40,7 @@ pub struct StreamProject {
 
 impl fmt::Display for StreamProject {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamProject");
+        let mut builder = formatter_debug_plan_node!(f, "StreamProject");
         self.logical
             .fmt_fields_with_builder(&mut builder, self.schema());
         if !self.watermark_derivations.is_empty() {

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -30,7 +30,7 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use tracing::info;
 
 use super::derive::{derive_columns, derive_pk};
-use super::utils::IndicesDisplay;
+use super::utils::{formatter_debug_plan_node, IndicesDisplay};
 use super::{ExprRewritable, PlanBase, PlanRef, StreamNode};
 use crate::optimizer::plan_node::PlanTreeNodeUnary;
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
@@ -258,7 +258,7 @@ impl_plan_tree_node_for_unary! { StreamSink }
 
 impl fmt::Display for StreamSink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamSink");
+        let mut builder = formatter_debug_plan_node!(f, "StreamSink");
 
         let sink_type = if self.sink_desc.sink_type.is_append_only() {
             "append-only"

--- a/src/frontend/src/optimizer/plan_node/stream_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sort.rs
@@ -19,7 +19,7 @@ use fixedbitset::FixedBitSet;
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use super::utils::TableCatalogBuilder;
+use super::utils::{formatter_debug_plan_node, TableCatalogBuilder};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::TableCatalog;
@@ -34,7 +34,8 @@ pub struct StreamSort {
 
 impl fmt::Display for StreamSort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StreamSort")
+        let mut builder = formatter_debug_plan_node!(f, "StreamSort");
+        builder
             .field("sort_column_index", &self.sort_column_index)
             .finish()
     }

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbStreamSource, SourceNode};
 
+use super::utils::formatter_debug_plan_node;
 use super::{generic, ExprRewritable, PlanBase, StreamNode};
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::optimizer::property::Distribution;
@@ -69,7 +70,7 @@ impl_plan_tree_node_for_leaf! { StreamSource }
 
 impl fmt::Display for StreamSource {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamSource");
+        let mut builder = formatter_debug_plan_node!(f, "StreamSource");
         if let Some(catalog) = self.source_catalog() {
             builder
                 .field("source", &catalog.name)

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -24,6 +24,7 @@ use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{ChainType, PbStreamNode};
 
+use super::utils::formatter_debug_plan_node;
 use super::{generic, ExprRewritable, PlanBase, PlanNodeId, PlanRef, StreamNode};
 use crate::catalog::ColumnId;
 use crate::expr::{ExprRewriter, FunctionCall};
@@ -170,7 +171,7 @@ impl_plan_tree_node_for_leaf! { StreamTableScan }
 impl fmt::Display for StreamTableScan {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let verbose = self.base.ctx.is_explain_verbose();
-        let mut builder = f.debug_struct("StreamTableScan");
+        let mut builder = formatter_debug_plan_node!(f, "StreamTableScan");
 
         let v = match verbose {
             false => self.logical.column_names(),

--- a/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_temporal_join.rs
@@ -20,6 +20,7 @@ use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::TemporalJoinNode;
 
+use super::utils::formatter_debug_plan_node;
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, StreamNode};
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::generic::GenericPlanRef;
@@ -94,7 +95,7 @@ impl StreamTemporalJoin {
 
 impl fmt::Display for StreamTemporalJoin {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamTemporalJoin");
+        let mut builder = formatter_debug_plan_node!(f, "StreamTemporalJoin");
 
         let verbose = self.base.ctx.is_explain_verbose();
         builder.field("type", &self.logical.join_type);

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -21,6 +21,7 @@ use risingwave_common::catalog::FieldDisplay;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::UnionNode;
 
+use super::utils::formatter_debug_plan_node;
 use super::{ExprRewritable, PlanRef};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
 use crate::optimizer::plan_node::{LogicalUnion, PlanBase, PlanTreeNode, StreamNode};
@@ -69,7 +70,7 @@ impl StreamUnion {
 
 impl fmt::Display for StreamUnion {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut builder = f.debug_struct("StreamUnion");
+        let mut builder = formatter_debug_plan_node!(f, "StreamUnion");
         self.logical.fmt_fields_with_builder(&mut builder);
 
         let watermark_columns = &self.base.watermark_columns;

--- a/src/frontend/src/optimizer/plan_node/stream_values.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_values.rs
@@ -19,6 +19,7 @@ use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 use risingwave_pb::stream_plan::values_node::ExprTuple;
 use risingwave_pb::stream_plan::ValuesNode;
 
+use super::utils::formatter_debug_plan_node;
 use super::{ExprRewritable, LogicalValues, PlanBase, StreamNode};
 use crate::expr::{Expr, ExprImpl};
 use crate::optimizer::property::Distribution;
@@ -64,9 +65,8 @@ impl StreamValues {
 
 impl fmt::Display for StreamValues {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("StreamValues")
-            .field("rows", &self.logical.rows())
-            .finish()
+        let mut builder = formatter_debug_plan_node!(f, "StreamValues");
+        builder.field("rows", &self.logical.rows()).finish()
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_watermark_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_watermark_filter.rs
@@ -27,6 +27,7 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use super::utils::TableCatalogBuilder;
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::{ExprDisplay, ExprImpl};
+use crate::optimizer::plan_node::utils::formatter_debug_plan_node;
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::{TableCatalog, WithOptions};
 
@@ -83,7 +84,7 @@ impl fmt::Display for StreamWatermarkFilter {
             }
         }
 
-        let mut builder = f.debug_struct("StreamWatermarkFilter");
+        let mut builder = formatter_debug_plan_node!(f, "StreamWatermarkFilter");
         let input_schema = self.input.schema();
 
         let display_watermark_descs: Vec<_> = self

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -181,3 +181,23 @@ impl fmt::Debug for IndicesDisplay<'_> {
         f.finish()
     }
 }
+
+macro_rules! formatter_debug_plan_node {
+    ($formatter:ident, $name:literal) => {
+        $formatter.debug_struct($name)
+    };
+    ($formatter:ident, $name:literal, $( { $prop:literal, $cond:expr } ), *) => {
+        {
+            let mut properties: Vec<&str> = vec![];
+            $( if $cond { properties.push($prop); } )*
+            let mut name = $name.to_string();
+            if !properties.is_empty() {
+                name += " [";
+                name += &properties.join(", ");
+                name += "]";
+            }
+            $formatter.debug_struct(&name)
+        }
+    };
+}
+pub(crate) use formatter_debug_plan_node;

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -182,6 +182,9 @@ impl fmt::Debug for IndicesDisplay<'_> {
     }
 }
 
+/// Call `debug_struct` on the given formatter to create a debug struct builder.
+/// If a property list is provided, properties in it will be added to the struct name according to
+/// the condition of that property.
 macro_rules! formatter_debug_plan_node {
     ($formatter:ident, $name:literal) => {
         $formatter.debug_struct($name)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We now have many bool properties for each stream plan node, including `append_only` and `eowc` for many nodes and `window`/`interval` for `StreamHashJoin`. Previously we display these properties by change the node name, e.g. `StreamAppendOnlyHashAgg`, but this approach cannot handle nodes with multiple properties. This PR changes the display behavior to `StreamHashAgg [append_only, eowc]`, and introduces a macro to ease the construction of the property list:

```rust
let mut builder = formatter_debug_plan_node!(
    f, "StreamHashJoin"
    , { "window", self.left().watermark_columns().contains(ljk) && self.right().watermark_columns().contains(rjk) }
    , { "interval", self.clean_left_state_conjunction_idx.is_some() && self.clean_right_state_conjunction_idx.is_some() }
    , { "append_only", self.is_append_only }
);
```

```rust
let mut builder = formatter_debug_plan_node!(
    f, "StreamHashAgg"
    , { "append_only", self.input().append_only() }
    , { "eowc", self.emit_on_window_close }
);
```

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
