### PR TITLE
fix(eowc): mark stream hash agg as `append_only` if eowc

### DIFF
--- a/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark_watermark.yaml
@@ -485,7 +485,7 @@
             |                 └─StreamProject { exprs: [event_type, person, auction, bid, Case((event_type = 0:Int32), Field(person, 6:Int32), (event_type = 1:Int32), Field(auction, 5:Int32), Field(bid, 5:Int32)) as $expr1, _row_id], output_watermarks: [_row_id] }
             |                   └─StreamSource { source: "nexmark", columns: ["event_type", "person", "auction", "bid", "_row_id"] }
             └─StreamProject { exprs: [window_start, max(count)], output_watermarks: [window_start] }
-              └─StreamHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
+              └─StreamAppendOnlyHashAgg { group_key: [window_start], aggs: [max(count), count], output_watermarks: [window_start] }
                 └─StreamExchange { dist: HashShard(window_start) }
                   └─StreamShare { id = 9 }
                     └─StreamAppendOnlyHashAgg { group_key: [$expr2, window_start], aggs: [count], output_watermarks: [window_start] }

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -93,7 +93,7 @@ impl StreamHashAgg {
         let base = PlanBase::new_stream_with_logical(
             &logical,
             dist,
-            false,
+            emit_on_window_close, // in EOWC mode, we produce append only output
             emit_on_window_close,
             watermark_columns,
         );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

`emit_on_window_close` seems to imply `append_only` property.

## Checklist For Contributors

- ~~[ ] I have written necessary rustdoc comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
