### PR TITLE
feat(compaction): change default configure for better performance

### DIFF
--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -17,7 +17,7 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::CompactionConfig;
 
 const DEFAULT_MAX_COMPACTION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2GB
-const DEFAULT_MIN_COMPACTION_BYTES: u64 = 256 * 1024 * 1024; // 256MB
+const DEFAULT_MIN_COMPACTION_BYTES: u64 = 256 * 1024 * 1024; // 128MB
 const DEFAULT_MAX_BYTES_FOR_LEVEL_BASE: u64 = 1280 * 1024 * 1024; // 1280MB
 
 // decrease this configure when the generation of checkpoint barrier is not frequent.

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -17,8 +17,8 @@ use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::CompactionConfig;
 
 const DEFAULT_MAX_COMPACTION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2GB
-const DEFAULT_MIN_COMPACTION_BYTES: u64 = 128 * 1024 * 1024; // 128MB
-const DEFAULT_MAX_BYTES_FOR_LEVEL_BASE: u64 = 512 * 1024 * 1024; // 512MB
+const DEFAULT_MIN_COMPACTION_BYTES: u64 = 256 * 1024 * 1024; // 256MB
+const DEFAULT_MAX_BYTES_FOR_LEVEL_BASE: u64 = 1280 * 1024 * 1024; // 1280MB
 
 // decrease this configure when the generation of checkpoint barrier is not frequent.
 const DEFAULT_TIER_COMPACT_TRIGGER_NUMBER: u64 = 6;
@@ -29,7 +29,7 @@ const DEFAULT_LEVEL_MULTIPLIER: u64 = 5;
 const DEFAULT_MAX_SPACE_RECLAIM_BYTES: u64 = 512 * 1024 * 1024; // 512MB;
 const DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER: u64 = 1000;
 const DEFAULT_MAX_COMPACTION_FILE_COUNT: u64 = 96;
-const DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 3;
+const DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 4;
 const DEFAULT_MIN_OVERLAPPING_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 6;
 
 pub struct CompactionConfigBuilder {

--- a/src/meta/src/hummock/compaction/level_selector.rs
+++ b/src/meta/src/hummock/compaction/level_selector.rs
@@ -87,14 +87,16 @@ pub struct DynamicLevelSelector {
     pick_count: usize,
 }
 
-impl DynamicLevelSelector {
-    pub fn new() -> Self {
+impl Default for DynamicLevelSelector {
+    fn default() -> Self {
         Self {
             sample_window_start: Instant::now(),
             pick_count: 0,
         }
     }
+}
 
+impl DynamicLevelSelector {
     pub fn may_switch_window(&mut self) {
         if self.sample_window_start.elapsed() > SAMPLE_PICK_WINDOW_TIME {
             self.sample_window_start = Instant::now();
@@ -589,7 +591,7 @@ impl LevelSelector for TtlCompactionSelector {
 }
 
 pub fn default_level_selector() -> Box<dyn LevelSelector> {
-    Box::new(DynamicLevelSelector::new())
+    Box::<DynamicLevelSelector>::default()
 }
 
 #[cfg(test)]
@@ -936,7 +938,7 @@ pub mod tests {
             ..Default::default()
         };
 
-        let mut selector = DynamicLevelSelector::new();
+        let mut selector = DynamicLevelSelector::default();
         let mut levels_handlers = (0..5).map(LevelHandler::new).collect_vec();
         let mut local_stats = LocalSelectorStatistic::default();
         let compaction = selector
@@ -959,7 +961,7 @@ pub mod tests {
             .compaction_filter_mask(compaction_filter_flag.into())
             .build();
         let group_config = CompactionGroup::new(1, config.clone());
-        let mut selector = DynamicLevelSelector::new();
+        let mut selector = DynamicLevelSelector::default();
 
         levels.l0.as_mut().unwrap().sub_levels.clear();
         levels.l0.as_mut().unwrap().total_file_size = 0;

--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -167,7 +167,7 @@ where
             HashMap::default();
         compaction_selectors.insert(
             compact_task::TaskType::Dynamic,
-            Box::new(DynamicLevelSelector::new()),
+            Box::<DynamicLevelSelector>::default(),
         );
         compaction_selectors.insert(
             compact_task::TaskType::SpaceReclaim,

--- a/src/meta/src/hummock/compaction_scheduler.rs
+++ b/src/meta/src/hummock/compaction_scheduler.rs
@@ -167,7 +167,7 @@ where
             HashMap::default();
         compaction_selectors.insert(
             compact_task::TaskType::Dynamic,
-            Box::<DynamicLevelSelector>::default(),
+            Box::new(DynamicLevelSelector::new()),
         );
         compaction_selectors.insert(
             compact_task::TaskType::SpaceReclaim,

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -549,7 +549,7 @@ impl<S: MetaStore> HummockManager<S> {
                 config.split_by_state_table = allow_split_by_table;
                 if !allow_split_by_table {
                     // TODO: remove it after we increase `max_bytes_for_level_base` for all group.
-                    config.max_bytes_for_level_base *= 4;
+                    config.max_bytes_for_level_base *= 2;
                     config.split_weight_by_vnode = weight_split_by_vnode;
                 }
 

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -47,7 +47,7 @@ pub struct StorageOpts {
     pub disable_remote_compactor: bool,
     /// Number of tasks shared buffer can upload in parallel.
     pub share_buffer_upload_concurrency: usize,
-    /// Capacity of sstable meta cache.
+    /// Capacity of memory for sstable builder
     pub compactor_memory_limit_mb: usize,
     /// Number of SST ids fetched from meta per RPC
     pub sstable_id_remote_fetch_number: u32,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- increase size of base-level to speed up compaction from sub-level to base-level
- choose min-depth for compaction from l0 to base-level according the compaction frequency. If the current workload is write-heavy workload we would wait more data to compact together for smaller write-amplification; If the current workload is read-heavy workload we would compact data to base-level as soon as possible for better read performance.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
