### PR TITLE
feat(ci): add tidb-cdc-sink integration test to ci

### DIFF
--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -23,7 +23,6 @@ steps:
           - "postgres-sink"
           - "iceberg-sink"
           - "debezium-mysql"
-          - "tidb-cdc-sink"
         format:
           - "json"
           - "protobuf"
@@ -76,10 +75,6 @@ steps:
             testcase: "debezium-mysql"
             format: "protobuf"
           skip: true
-        - with:
-            testcase: "tidb-cdc-sink"
-            format: "protobuf"
-          skip: true
 
   # NOTE: buildkite matrix-limits
   # Each build matrix has a limit of 6 dimensions, 20 elements in each dimension and a total of 12 adjustments.
@@ -98,6 +93,7 @@ steps:
           - "twitter-pulsar"
           - "debezium-mongo"
           - "debezium-postgres"
+          - "tidb-cdc-sink"
         format:
           - "json"
           - "protobuf"
@@ -112,5 +108,9 @@ steps:
           skip: true
         - with:
             testcase: "debezium-postgres"
+            format: "protobuf"
+          skip: true
+        - with:
+            testcase: "tidb-cdc-sink"
             format: "protobuf"
           skip: true

--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -76,6 +76,10 @@ steps:
             testcase: "debezium-mysql"
             format: "protobuf"
           skip: true
+        - with:
+            testcase: "tidb-cdc-sink"
+            format: "protobuf"
+          skip: true
 
   # NOTE: buildkite matrix-limits
   # Each build matrix has a limit of 6 dimensions, 20 elements in each dimension and a total of 12 adjustments.

--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -23,6 +23,7 @@ steps:
           - "postgres-sink"
           - "iceberg-sink"
           - "debezium-mysql"
+          - "tidb-cdc-sink"
         format:
           - "json"
           - "protobuf"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- add tidb-cdc-sink integration test to ci
- close https://github.com/risingwavelabs/risingwave/issues/9376

## Checklist For Contributors

~~- [ ] I have written necessary rustdoc comments~~
~~- [ ] I have added necessary unit tests and integration tests~~
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
~~- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)~~

## Checklist For Reviewers

~~- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.~~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

