### PR TITLE
fix(stream): fix backfill initial snapshot read

### DIFF
--- a/src/stream/src/executor/backfill.rs
+++ b/src/stream/src/executor/backfill.rs
@@ -151,9 +151,14 @@ where
         // finished state to state store first.
         // As such we will wait for next barrier.
         let is_snapshot_empty: bool = {
-            let snapshot = Self::snapshot_read(&self.upstream_table, init_epoch, None, false);
-            pin_mut!(snapshot);
-            snapshot.try_next().await?.unwrap().is_none()
+            if is_finished {
+                // It is finished, so just assign a value to avoid accessing storage table again.
+                false
+            } else {
+                let snapshot = Self::snapshot_read(&self.upstream_table, init_epoch, None, false);
+                pin_mut!(snapshot);
+                snapshot.try_next().await?.unwrap().is_none()
+            }
         };
 
         // | backfill_is_finished | snapshot_empty | need_to_backfill |


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Bypass the initial snapshot read of the backfill executor if backfilling is finished.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
