### PR TITLE
fix(binder): distinguish `'a'::varchar` from untyped `'a'`

### DIFF
--- a/e2e_test/batch/basic/func.slt.part
+++ b/e2e_test/batch/basic/func.slt.part
@@ -259,6 +259,31 @@ select pg_typeof('123');
 unknown
 
 query T
+select pg_typeof('123'::varchar);
+----
+varchar
+
+query T
+select pg_typeof('123'::int);
+----
+integer
+
+query T
+select pg_typeof(null);
+----
+unknown
+
+query T
+select pg_typeof(null::varchar);
+----
+varchar
+
+query T
+select pg_typeof(null::bool);
+----
+boolean
+
+query T
 select pg_typeof(-9223372036854775808);
 ----
 bigint

--- a/e2e_test/batch/functions/array_concat.slt.part
+++ b/e2e_test/batch/functions/array_concat.slt.part
@@ -29,12 +29,12 @@ select array[1,2] || array[array[3,4]];
 {{1,2},{3,4}}
 
 query T
-select ('123' || '') || array['abc'];
+select '123'::varchar || array['abc'];
 ----
 {123,abc}
 
 query T
-select array['abc'] || ('123' || '');
+select array['abc'] || '123'::varchar;
 ----
 {abc,123}
 

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -263,7 +263,7 @@ pub fn literal_parsing(
         DataType::Decimal => str_parse::<Decimal>(s)?.into(),
         DataType::Float32 => str_parse::<F32>(s)?.into(),
         DataType::Float64 => str_parse::<F64>(s)?.into(),
-        DataType::Varchar => return Err(None),
+        DataType::Varchar => s.into(),
         DataType::Date => str_to_date(s)?.into(),
         DataType::Timestamp => str_to_timestamp(s)?.into(),
         // We only handle the case with timezone here, and leave the implicit session timezone case

--- a/src/frontend/planner_test/tests/testdata/input/concat_op_dispatch.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/concat_op_dispatch.yaml
@@ -49,6 +49,11 @@
   expected_outputs:
   - batch_plan
 - sql: |
+    select '1'::jsonb || '2'::text;
+  name: jsonb || text -> text
+  expected_outputs:
+  - batch_plan
+- sql: |
     select 1 || 2;
   name: int || int -> err
   expected_outputs:

--- a/src/frontend/planner_test/tests/testdata/output/concat_op_dispatch.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/concat_op_dispatch.yaml
@@ -58,6 +58,11 @@
     with t(s) as (select '2') select '1'::jsonb || s from t;
   batch_plan: |
     BatchValues { rows: [['12':Varchar]] }
+- name: jsonb || text -> text
+  sql: |
+    select '1'::jsonb || '2'::text;
+  batch_plan: |
+    BatchValues { rows: [['12':Varchar]] }
 - name: int || int -> err
   sql: |
     select 1 || 2;

--- a/src/frontend/src/binder/bind_param.rs
+++ b/src/frontend/src/binder/bind_param.rs
@@ -145,7 +145,7 @@ mod test {
 
     fn expect_actual_eq(expect: BoundStatement, actual: BoundStatement) {
         // Use debug format to compare. May modify in future.
-        assert!(format!("{:?}", expect) == format!("{:?}", actual));
+        assert_eq!(format!("{:?}", expect), format!("{:?}", actual));
     }
 
     #[tokio::test]

--- a/src/frontend/src/binder/expr/binary_op.rs
+++ b/src/frontend/src/binder/expr/binary_op.rs
@@ -88,8 +88,8 @@ impl Binder {
             BinaryOperator::LongArrow => ExprType::JsonbAccessStr,
             BinaryOperator::Prefix => ExprType::StartsWith,
             BinaryOperator::Concat => {
-                let left_type = (!bound_left.is_unknown()).then(|| bound_left.return_type());
-                let right_type = (!bound_right.is_unknown()).then(|| bound_right.return_type());
+                let left_type = (!bound_left.is_untyped()).then(|| bound_left.return_type());
+                let right_type = (!bound_right.is_untyped()).then(|| bound_right.return_type());
                 match (left_type, right_type) {
                     // array concatenation
                     (Some(DataType::List { .. }), Some(DataType::List { .. }))

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -530,7 +530,7 @@ impl Binder {
                     "pg_typeof",
                     guard_by_len(1, raw(|_binder, inputs| {
                         let input = &inputs[0];
-                        let v = match input.is_unknown() {
+                        let v = match input.is_untyped() {
                             true => "unknown".into(),
                             false => input.return_type().to_string(),
                         };

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -32,7 +32,7 @@ impl Binder {
             Value::Boolean(b) => self.bind_bool(b),
             // Both null and string literal will be treated as `unknown` during type inference.
             // See [`ExprImpl::is_unknown`].
-            Value::Null => Ok(Literal::new(None, DataType::Varchar)),
+            Value::Null => Ok(Literal::new_untyped(None)),
             Value::Interval {
                 value,
                 leading_field,
@@ -46,10 +46,7 @@ impl Binder {
     }
 
     pub(super) fn bind_string(&mut self, s: String) -> Result<Literal> {
-        Ok(Literal::new(
-            Some(ScalarImpl::Utf8(s.into())),
-            DataType::Varchar,
-        ))
+        Ok(Literal::new_untyped(Some(s)))
     }
 
     fn bind_bool(&mut self, b: bool) -> Result<Literal> {

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -125,7 +125,7 @@ impl FunctionCall {
             // types, they will be handled in `cast_ok`.
             return Self::cast_row_expr(child, target, allows);
         }
-        if child.is_unknown() {
+        if child.is_untyped() {
             // `is_unknown` makes sure `as_literal` and `as_utf8` will never panic.
             let literal = child.as_literal().unwrap();
             let datum = literal
@@ -147,7 +147,7 @@ impl FunctionCall {
             Ok(child)
         // Casting from unknown is allowed in all context. And PostgreSQL actually does the parsing
         // in frontend.
-        } else if child.is_unknown() || cast_ok(&source, &target, allows) {
+        } else if child.is_untyped() || cast_ok(&source, &target, allows) {
             Ok(Self {
                 func_type: ExprType::Cast,
                 return_type: target,

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -89,7 +89,7 @@ impl Literal {
         &self.data
     }
 
-    pub fn is_unknown(&self) -> bool {
+    pub fn is_untyped(&self) -> bool {
         self.data_type.is_none()
     }
 

--- a/src/frontend/src/expr/literal.rs
+++ b/src/frontend/src/expr/literal.rs
@@ -23,7 +23,8 @@ use crate::expr::ExprType;
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Literal {
     data: Datum,
-    data_type: DataType,
+    // `null` or `'foo'` is of `unknown` type until used in a typed context (e.g. func arg)
+    data_type: Option<DataType>,
 }
 
 impl std::fmt::Debug for Literal {
@@ -34,9 +35,10 @@ impl std::fmt::Debug for Literal {
                 .field("data_type", &self.data_type)
                 .finish()
         } else {
+            let data_type = self.return_type();
             match &self.data {
                 None => write!(f, "null"),
-                Some(v) => match self.data_type {
+                Some(v) => match data_type {
                     DataType::Boolean => write!(f, "{}", v.as_bool()),
                     DataType::Int16
                     | DataType::Int32
@@ -57,12 +59,12 @@ impl std::fmt::Debug for Literal {
                     | DataType::Struct(_) => write!(
                         f,
                         "'{}'",
-                        v.as_scalar_ref_impl().to_text_with_type(&self.data_type)
+                        v.as_scalar_ref_impl().to_text_with_type(&data_type)
                     ),
                     DataType::List { .. } => write!(f, "{}", display_for_explain(v.as_list())),
                 },
             }?;
-            write!(f, ":{:?}", self.data_type)
+            write!(f, ":{:?}", data_type)
         }
     }
 }
@@ -70,11 +72,25 @@ impl std::fmt::Debug for Literal {
 impl Literal {
     pub fn new(data: Datum, data_type: DataType) -> Self {
         assert!(literal_type_match(&data_type, data.as_ref()));
-        Literal { data, data_type }
+        Literal {
+            data,
+            data_type: Some(data_type),
+        }
+    }
+
+    pub fn new_untyped(data: Option<String>) -> Self {
+        Literal {
+            data: data.map(Into::into),
+            data_type: None,
+        }
     }
 
     pub fn get_data(&self) -> &Datum {
         &self.data
+    }
+
+    pub fn is_unknown(&self) -> bool {
+        self.data_type.is_none()
     }
 
     pub(super) fn from_expr_proto(
@@ -83,14 +99,14 @@ impl Literal {
         let data_type = proto.get_return_type()?;
         Ok(Self {
             data: value_encoding_to_literal(&proto.rex_node, &data_type.into())?,
-            data_type: data_type.into(),
+            data_type: Some(data_type.into()),
         })
     }
 }
 
 impl Expr for Literal {
     fn return_type(&self) -> DataType {
-        self.data_type.clone()
+        self.data_type.clone().unwrap_or(DataType::Varchar)
     }
 
     fn to_expr_proto(&self) -> risingwave_pb::expr::ExprNode {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -210,8 +210,8 @@ impl ExprImpl {
     }
 
     /// Check whether self is a literal NULL or literal string.
-    pub fn is_unknown(&self) -> bool {
-        matches!(self, ExprImpl::Literal(literal) if literal.is_unknown())
+    pub fn is_untyped(&self) -> bool {
+        matches!(self, ExprImpl::Literal(literal) if literal.is_untyped())
             || matches!(self, ExprImpl::Parameter(parameter) if !parameter.has_infer())
     }
 
@@ -232,7 +232,7 @@ impl ExprImpl {
 
     /// Shorthand to enforce implicit cast to boolean
     pub fn enforce_bool_clause(self, clause: &str) -> RwResult<ExprImpl> {
-        if self.is_unknown() {
+        if self.is_untyped() {
             let inner = self.cast_implicit(DataType::Boolean)?;
             return Ok(inner);
         }

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -211,7 +211,7 @@ impl ExprImpl {
 
     /// Check whether self is a literal NULL or literal string.
     pub fn is_unknown(&self) -> bool {
-        matches!(self, ExprImpl::Literal(literal) if literal.return_type() == DataType::Varchar)
+        matches!(self, ExprImpl::Literal(literal) if literal.is_unknown())
             || matches!(self, ExprImpl::Parameter(parameter) if !parameter.has_infer())
     }
 

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -18,7 +18,7 @@ use risingwave_common::types::{DataType, DataTypeName};
 use risingwave_common::util::iter_util::ZipEqFast;
 pub use risingwave_expr::sig::cast::*;
 
-use crate::expr::{Expr as _, ExprImpl, InputRef};
+use crate::expr::{Expr as _, ExprImpl, InputRef, Literal};
 
 /// Find the least restrictive type. Used by `VALUES`, `CASE`, `UNION`, etc.
 /// It is a simplified version of the rule used in
@@ -84,7 +84,7 @@ pub fn align_array_and_element(
 ) -> std::result::Result<DataType, ErrorCode> {
     let mut dummy_element = match inputs[array_idx].is_unknown() {
         // when array is unknown type, make an unknown typed value (e.g. null)
-        true => ExprImpl::literal_null(DataType::Varchar),
+        true => ExprImpl::from(Literal::new_untyped(None)),
         false => {
             let array_element_type = match inputs[array_idx].return_type() {
                 DataType::List(t) => *t,

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -52,7 +52,7 @@ pub fn align_types<'a>(
     // Essentially a filter_map followed by a try_reduce, which is unstable.
     let mut ret_type = None;
     for e in &exprs {
-        if e.is_unknown() {
+        if e.is_untyped() {
             continue;
         }
         ret_type = match ret_type {
@@ -82,7 +82,7 @@ pub fn align_array_and_element(
     element_indices: &[usize],
     inputs: &mut [ExprImpl],
 ) -> std::result::Result<DataType, ErrorCode> {
-    let mut dummy_element = match inputs[array_idx].is_unknown() {
+    let mut dummy_element = match inputs[array_idx].is_untyped() {
         // when array is unknown type, make an unknown typed value (e.g. null)
         true => ExprImpl::from(Literal::new_untyped(None)),
         false => {
@@ -94,7 +94,7 @@ pub fn align_array_and_element(
             InputRef::new(0, array_element_type).into()
         }
     };
-    assert_eq!(dummy_element.is_unknown(), inputs[array_idx].is_unknown());
+    assert_eq!(dummy_element.is_untyped(), inputs[array_idx].is_untyped());
 
     let common_element_type = align_types(
         inputs

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -45,7 +45,7 @@ pub fn infer_type(func_type: ExprType, inputs: &mut Vec<ExprImpl>) -> Result<Dat
         .into_iter()
         .zip_eq_fast(sig.inputs_type)
         .map(|(expr, t)| {
-            if DataTypeName::from(expr.return_type()) != *t {
+            if expr.is_unknown() || DataTypeName::from(expr.return_type()) != *t {
                 if t.is_scalar() {
                     return expr.cast_implicit((*t).into()).map_err(Into::into);
                 } else {

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -34,7 +34,7 @@ pub fn infer_type(func_type: ExprType, inputs: &mut Vec<ExprImpl>) -> Result<Dat
 
     let actuals = inputs
         .iter()
-        .map(|e| match e.is_unknown() {
+        .map(|e| match e.is_untyped() {
             true => None,
             false => Some(e.return_type().into()),
         })
@@ -45,7 +45,7 @@ pub fn infer_type(func_type: ExprType, inputs: &mut Vec<ExprImpl>) -> Result<Dat
         .into_iter()
         .zip_eq_fast(sig.inputs_type)
         .map(|(expr, t)| {
-            if expr.is_unknown() || DataTypeName::from(expr.return_type()) != *t {
+            if expr.is_untyped() || DataTypeName::from(expr.return_type()) != *t {
                 if t.is_scalar() {
                     return expr.cast_implicit((*t).into()).map_err(Into::into);
                 } else {
@@ -66,7 +66,7 @@ pub fn infer_some_all(
     mut func_types: Vec<ExprType>,
     inputs: &mut Vec<ExprImpl>,
 ) -> Result<DataType> {
-    let element_type = if inputs[1].is_unknown() {
+    let element_type = if inputs[1].is_untyped() {
         None
     } else if let DataType::List(datatype) = inputs[1].return_type() {
         Some(DataTypeName::from(*datatype))
@@ -79,7 +79,7 @@ pub fn infer_some_all(
 
     let final_type = func_types.pop().unwrap();
     let actuals = vec![
-        (!inputs[0].is_unknown()).then_some(inputs[0].return_type().into()),
+        (!inputs[0].is_untyped()).then_some(inputs[0].return_type().into()),
         element_type,
     ];
     let sig = infer_type_name(&FUNC_SIG_MAP, final_type, &actuals)?;
@@ -194,7 +194,7 @@ fn extract_struct_nested_type(ty: &StructType) -> Result<NestedType> {
 
 /// Decompose expression into a nested type to be inferred.
 fn extract_expr_nested_type(expr: &ExprImpl) -> Result<NestedType> {
-    if expr.is_unknown() {
+    if expr.is_untyped() {
         Ok(NestedType::Infer(expr.return_type()))
     } else if is_row_function(expr) {
         // For row function, recursively get the type requirement of each field.
@@ -372,7 +372,7 @@ fn infer_type_for_special(
         | ExprType::IsDistinctFrom
         | ExprType::IsNotDistinctFrom => {
             ensure_arity!("cmp", | inputs | == 2);
-            match (inputs[0].is_unknown(), inputs[1].is_unknown()) {
+            match (inputs[0].is_untyped(), inputs[1].is_untyped()) {
                 // `'a' = null` handled by general rules later
                 (true, true) => return Ok(None),
                 // `null = array[1]` where null should have same type as right side
@@ -477,8 +477,8 @@ fn infer_type_for_special(
         }
         ExprType::ArrayCat => {
             ensure_arity!("array_cat", | inputs | == 2);
-            let left_type = (!inputs[0].is_unknown()).then(|| inputs[0].return_type());
-            let right_type = (!inputs[1].is_unknown()).then(|| inputs[1].return_type());
+            let left_type = (!inputs[0].is_untyped()).then(|| inputs[0].return_type());
+            let right_type = (!inputs[1].is_untyped()).then(|| inputs[1].return_type());
             let return_type = match (left_type, right_type) {
                 (None, t @ None)
                 | (None, t @ Some(DataType::List(_)))
@@ -565,7 +565,7 @@ fn infer_type_for_special(
         ExprType::ArrayDistinct => {
             ensure_arity!("array_distinct", | inputs | == 1);
             let ret_type = inputs[0].return_type();
-            if inputs[0].is_unknown() {
+            if inputs[0].is_untyped() {
                 return Err(ErrorCode::BindError(
                     "could not determine polymorphic type because input has type unknown"
                         .to_string(),
@@ -581,7 +581,7 @@ fn infer_type_for_special(
             ensure_arity!("array_length", | inputs | == 1);
             let return_type = inputs[0].return_type();
 
-            if inputs[0].is_unknown() {
+            if inputs[0].is_untyped() {
                 return Err(ErrorCode::BindError(
                     "Cannot find length for unknown type".to_string(),
                 )
@@ -598,7 +598,7 @@ fn infer_type_for_special(
             ensure_arity!("cardinality", | inputs | == 1);
             let return_type = inputs[0].return_type();
 
-            if inputs[0].is_unknown() {
+            if inputs[0].is_untyped() {
                 return Err(ErrorCode::BindError(
                     "Cannot get cardinality of unknown type".to_string(),
                 )


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Expected:
* `pg_typeof('a')` -> `unknown`
* `pg_typeof('a'::varchar)` -> `varchar`

Actual:
* `pg_typeof('a')` -> `unknown`
* `pg_typeof('a'::varchar)` -> `unknown`

The distinction is more noticable in the following PostgreSQL expressions https://github.com/risingwavelabs/risingwave/pull/10122#discussion_r1212903168:
* `array['a'] || null` -> `{a}`
* `array['a'] || null::varchar` -> `{a,NULL}`

It is fixed by making `Literal::data_type: Option<DataType>`.
* Most existing use cases can just `unwrap_or(DataType::Varchar)`. And for places where it is needed to distinguish the two, the `is_unknown` helper is available.
* Binder calls the new `new_untyped` for `null` and `'foo'`.
* `FuncCall::new_cast` can transforms an untyped/unknown literal to `varchar` type.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
