### PR TITLE
chore(types): cleanup `StructType`

### DIFF
--- a/src/batch/src/executor/insert.rs
+++ b/src/batch/src/executor/insert.rs
@@ -254,7 +254,7 @@ mod tests {
     use risingwave_common::catalog::{
         schema_test_utils, ColumnDesc, ColumnId, INITIAL_TABLE_VERSION_ID,
     };
-    use risingwave_common::types::DataType;
+    use risingwave_common::types::{DataType, StructType};
     use risingwave_source::dml_manager::DmlManager;
     use risingwave_storage::hummock::CachePolicy;
     use risingwave_storage::memory::MemoryStateStore;
@@ -289,14 +289,14 @@ mod tests {
 
         let col1 = Arc::new(I32Array::from_iter([1, 3, 5, 7, 9]).into());
         let col2 = Arc::new(I32Array::from_iter([2, 4, 6, 8, 10]).into());
-        let array = StructArray::from_slices(
-            &[true, false, false, false, false],
+        let array = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]),
             vec![
-                I32Array::from_iter([Some(1), None, None, None, None]).into(),
-                I32Array::from_iter([Some(2), None, None, None, None]).into(),
-                I32Array::from_iter([Some(3), None, None, None, None]).into(),
+                I32Array::from_iter([Some(1), None, None, None, None]).into_ref(),
+                I32Array::from_iter([Some(2), None, None, None, None]).into_ref(),
+                I32Array::from_iter([Some(3), None, None, None, None]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Int32, DataType::Int32],
+            [true, false, false, false, false].into_iter().collect(),
         );
         let col3 = Arc::new(array.into());
         let data_chunk: DataChunk = DataChunk::new(vec![col1, col2, col3], 5);
@@ -361,14 +361,14 @@ mod tests {
             vec![Some(2), Some(4), Some(6), Some(8), Some(10)]
         );
 
-        let array: ArrayImpl = StructArray::from_slices(
-            &[true, false, false, false, false],
+        let array: ArrayImpl = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]),
             vec![
-                I32Array::from_iter([Some(1), None, None, None, None]).into(),
-                I32Array::from_iter([Some(2), None, None, None, None]).into(),
-                I32Array::from_iter([Some(3), None, None, None, None]).into(),
+                I32Array::from_iter([Some(1), None, None, None, None]).into_ref(),
+                I32Array::from_iter([Some(2), None, None, None, None]).into_ref(),
+                I32Array::from_iter([Some(3), None, None, None, None]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Int32, DataType::Int32],
+            [true, false, false, false, false].into_iter().collect(),
         )
         .into();
         assert_eq!(*chunk.chunk.columns()[2], array);

--- a/src/batch/src/executor/order_by.rs
+++ b/src/batch/src/executor/order_by.rs
@@ -143,8 +143,6 @@ impl SortExecutor {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
     use futures::StreamExt;
     use risingwave_common::array::*;
     use risingwave_common::catalog::{Field, Schema};
@@ -572,10 +570,10 @@ mod tests {
         };
         let mut struct_builder = StructArrayBuilder::with_type(
             0,
-            DataType::Struct(Arc::new(StructType::unnamed(vec![
+            DataType::Struct(StructType::unnamed(vec![
                 DataType::Varchar,
                 DataType::Float32,
-            ]))),
+            ])),
         );
         let mut list_builder =
             ListArrayBuilder::with_type(0, DataType::List(Box::new(DataType::Int64)));
@@ -634,10 +632,10 @@ mod tests {
         );
         let mut struct_builder = StructArrayBuilder::with_type(
             0,
-            DataType::Struct(Arc::new(StructType::unnamed(vec![
+            DataType::Struct(StructType::unnamed(vec![
                 DataType::Varchar,
                 DataType::Float32,
-            ]))),
+            ])),
         );
         let mut list_builder =
             ListArrayBuilder::with_type(0, DataType::List(Box::new(DataType::Int64)));

--- a/src/batch/src/executor/table_function.rs
+++ b/src/batch/src/executor/table_function.rs
@@ -85,7 +85,7 @@ impl BoxedExecutorBuilder for TableFunctionExecutorBuilder {
         let table_function = build_from_prost(node.table_function.as_ref().unwrap(), chunk_size)?;
 
         let schema = if let DataType::Struct(fields) = table_function.return_type() {
-            (&*fields).into()
+            (&fields).into()
         } else {
             Schema {
                 // TODO: should be named

--- a/src/batch/src/executor/values.rs
+++ b/src/batch/src/executor/values.rs
@@ -142,7 +142,7 @@ mod tests {
         Array, ArrayImpl, I16Array, I32Array, I64Array, StructArray, StructValue,
     };
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::types::{DataType, ScalarImpl, StructType};
     use risingwave_expr::expr::{BoxedExpression, LiteralExpression};
 
     use crate::executor::{Executor, ValuesExecutor};
@@ -200,14 +200,14 @@ mod tests {
 
         let mut stream = values_executor.execute();
         let result = stream.next().await.unwrap();
-        let array: ArrayImpl = StructArray::from_slices(
-            &[true],
+        let array: ArrayImpl = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]),
             vec![
-                I32Array::from_iter([1]).into(),
-                I32Array::from_iter([2]).into(),
-                I32Array::from_iter([3]).into(),
+                I32Array::from_iter([1]).into_ref(),
+                I32Array::from_iter([2]).into_ref(),
+                I32Array::from_iter([3]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Int32, DataType::Int32],
+            [true].into_iter().collect(),
         )
         .into();
 

--- a/src/common/benches/bench_encoding.rs
+++ b/src/common/benches/bench_encoding.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::env;
-use std::sync::Arc;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use risingwave_common::array::{ListValue, StructValue};
@@ -118,13 +117,10 @@ fn bench_encoding(c: &mut Criterion) {
         // encoding.
         Case::new(
             "Struct of Bool (len = 100)",
-            DataType::Struct(Arc::new(StructType::new(vec![
-                (
-                    DataType::Boolean,
-                    "".to_string()
-                );
+            DataType::Struct(StructType::new(vec![
+                ("".to_string(), DataType::Boolean);
                 100
-            ]))),
+            ])),
             ScalarImpl::Struct(StructValue::new(vec![Some(ScalarImpl::Bool(true)); 100])),
         ),
         Case::new(

--- a/src/common/benches/bench_encoding.rs
+++ b/src/common/benches/bench_encoding.rs
@@ -117,10 +117,7 @@ fn bench_encoding(c: &mut Criterion) {
         // encoding.
         Case::new(
             "Struct of Bool (len = 100)",
-            DataType::Struct(StructType::new(vec![
-                ("".to_string(), DataType::Boolean);
-                100
-            ])),
+            DataType::Struct(StructType::new(vec![("", DataType::Boolean); 100])),
             ScalarImpl::Struct(StructValue::new(vec![Some(ScalarImpl::Bool(true)); 100])),
         ),
         Case::new(

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -168,7 +168,7 @@ impl From<&DataType> for arrow_schema::DataType {
             DataType::Decimal => Self::Decimal128(28, 0), // arrow precision can not be 0
             DataType::Struct(struct_type) => Self::Struct(
                 struct_type
-                    .name_types()
+                    .iter()
                     .map(|(name, ty)| Field::new(name, ty.into(), true))
                     .collect(),
             ),
@@ -593,7 +593,7 @@ impl From<&StructArray> for arrow_array::StructArray {
     fn from(array: &StructArray) -> Self {
         let struct_data_vector: Vec<(arrow_schema::Field, arrow_array::ArrayRef)> = array
             .fields()
-            .zip_eq_debug(array.data_type().as_struct().name_types())
+            .zip_eq_debug(array.data_type().as_struct().iter())
             .map(|(arr, (name, ty))| (Field::new(name, ty.into(), true), arr.as_ref().into()))
             .collect();
         arrow_array::StructArray::from(struct_data_vector)

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -22,7 +22,7 @@ use itertools::Itertools;
 
 use super::*;
 use crate::types::{Int256, StructType};
-use crate::util::iter_util::ZipEqFast;
+use crate::util::iter_util::ZipEqDebug;
 
 // Implement bi-directional `From` between `DataChunk` and `arrow_array::RecordBatch`.
 
@@ -122,15 +122,23 @@ impl From<&arrow_schema::DataType> for DataType {
             Binary => Self::Bytea,
             Utf8 => Self::Varchar,
             LargeUtf8 => Self::Jsonb,
-            Struct(field) => Self::Struct(Arc::new(StructType {
-                fields: field.iter().map(|f| f.data_type().into()).collect(),
-                field_names: field.iter().map(|f| f.name().clone()).collect(),
-            })),
+            Struct(field) => Self::Struct(field.as_slice().into()),
             List(field) => Self::List(Box::new(field.data_type().into())),
             Decimal128(_, _) => Self::Decimal,
             Decimal256(_, _) => Self::Int256,
             _ => todo!("Unsupported arrow data type: {value:?}"),
         }
+    }
+}
+
+impl From<&[arrow_schema::Field]> for StructType {
+    fn from(fields: &[arrow_schema::Field]) -> Self {
+        Self::new(
+            fields
+                .iter()
+                .map(|f| (f.name().clone(), f.data_type().into()))
+                .collect(),
+        )
     }
 }
 
@@ -158,9 +166,12 @@ impl From<&DataType> for arrow_schema::DataType {
             DataType::Jsonb => Self::LargeUtf8,
             DataType::Bytea => Self::Binary,
             DataType::Decimal => Self::Decimal128(28, 0), // arrow precision can not be 0
-            DataType::Struct(struct_type) => {
-                Self::Struct(get_field_vector_from_struct_type(struct_type))
-            }
+            DataType::Struct(struct_type) => Self::Struct(
+                struct_type
+                    .name_types()
+                    .map(|(name, ty)| Field::new(name, ty.into(), true))
+                    .collect(),
+            ),
             DataType::List(datatype) => {
                 Self::List(Box::new(Field::new("item", datatype.as_ref().into(), true)))
             }
@@ -172,24 +183,6 @@ impl From<&DataType> for arrow_schema::DataType {
 impl From<DataType> for arrow_schema::DataType {
     fn from(value: DataType) -> Self {
         (&value).into()
-    }
-}
-
-fn get_field_vector_from_struct_type(struct_type: &StructType) -> Vec<Field> {
-    // Check for length equality between field_name vector and datatype vector.
-    if struct_type.field_names.len() != struct_type.fields.len() {
-        struct_type
-            .fields
-            .iter()
-            .map(|f| Field::new("", f.into(), true))
-            .collect()
-    } else {
-        struct_type
-            .fields
-            .iter()
-            .zip_eq_fast(struct_type.field_names.clone())
-            .map(|(f, f_name)| Field::new(f_name, f.into(), true))
-            .collect()
     }
 }
 
@@ -598,28 +591,11 @@ impl TryFrom<&arrow_array::ListArray> for ListArray {
 
 impl From<&StructArray> for arrow_array::StructArray {
     fn from(array: &StructArray) -> Self {
-        let struct_data_vector: Vec<(arrow_schema::Field, arrow_array::ArrayRef)> =
-            if array.children_names().len() != array.children_array_types().len() {
-                array
-                    .fields()
-                    .zip_eq_fast(array.children_array_types())
-                    .map(|(arr, datatype)| {
-                        (Field::new("", datatype.into(), true), arr.as_ref().into())
-                    })
-                    .collect()
-            } else {
-                array
-                    .fields()
-                    .zip_eq_fast(array.children_array_types())
-                    .zip_eq_fast(array.children_names())
-                    .map(|((arr, datatype), field_name)| {
-                        (
-                            Field::new(field_name, datatype.into(), true),
-                            arr.as_ref().into(),
-                        )
-                    })
-                    .collect()
-            };
+        let struct_data_vector: Vec<(arrow_schema::Field, arrow_array::ArrayRef)> = array
+            .fields()
+            .zip_eq_debug(array.data_type().as_struct().name_types())
+            .map(|(arr, (name, ty))| (Field::new(name, ty.into(), true), arr.as_ref().into()))
+            .collect();
         arrow_array::StructArray::from(struct_data_vector)
     }
 }
@@ -628,26 +604,19 @@ impl TryFrom<&arrow_array::StructArray> for StructArray {
     type Error = ArrayError;
 
     fn try_from(array: &arrow_array::StructArray) -> Result<Self, Self::Error> {
-        let mut null_bitmap = Vec::new();
-        for i in 0..arrow_array::Array::len(&array) {
-            null_bitmap.push(!arrow_array::Array::is_null(&array, i))
-        }
-        Ok(match arrow_array::Array::data_type(&array) {
-            arrow_schema::DataType::Struct(fields) => StructArray::from_slices_with_field_names(
-                &(null_bitmap),
-                array
-                    .columns()
-                    .iter()
-                    .map(ArrayImpl::try_from)
-                    .try_collect()?,
-                fields
-                    .iter()
-                    .map(|f| DataType::from(f.data_type()))
-                    .collect(),
-                array.column_names().into_iter().map(String::from).collect(),
-            ),
-            _ => panic!("nested field types cannot be determined."),
-        })
+        use arrow_array::Array;
+        let arrow_schema::DataType::Struct(fields) = array.data_type() else {
+            panic!("nested field types cannot be determined.");
+        };
+        Ok(StructArray::new(
+            fields.as_slice().into(),
+            array
+                .columns()
+                .iter()
+                .map(|a| ArrayImpl::try_from(a).map(Arc::new))
+                .try_collect()?,
+            (0..array.len()).map(|i| array.is_null(i)).collect(),
+        ))
     }
 }
 
@@ -785,7 +754,7 @@ mod tests {
         use arrow_array::Array as _;
 
         // Empty array - risingwave to arrow conversion.
-        let test_arr = StructArray::from_slices(&[true, false, true, false], vec![], vec![]);
+        let test_arr = StructArray::new(StructType::new(vec![]), vec![], Bitmap::ones(0));
         assert_eq!(arrow_array::StructArray::from(&test_arr).len(), 0);
 
         // Empty array - arrow to risingwave conversion.
@@ -816,14 +785,16 @@ mod tests {
         .unwrap();
         let actual_risingwave_struct_array =
             StructArray::try_from(&test_arrow_struct_array).unwrap();
-        let expected_risingwave_struct_array = StructArray::from_slices_with_field_names(
-            &[true, true, true, false],
+        let expected_risingwave_struct_array = StructArray::new(
+            StructType::new(vec![
+                ("a".into(), DataType::Boolean),
+                ("b".into(), DataType::Int32),
+            ]),
             vec![
-                BoolArray::from_iter([Some(false), Some(false), Some(true), None]).into(),
-                I32Array::from_iter([Some(42), Some(28), Some(19), None]).into(),
+                BoolArray::from_iter([Some(false), Some(false), Some(true), None]).into_ref(),
+                I32Array::from_iter([Some(42), Some(28), Some(19), None]).into_ref(),
             ],
-            vec![DataType::Boolean, DataType::Int32],
-            vec![String::from("a"), String::from("b")],
+            [true, true, true, false].into_iter().collect(),
         );
         assert_eq!(
             expected_risingwave_struct_array,

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -754,7 +754,7 @@ mod tests {
         use arrow_array::Array as _;
 
         // Empty array - risingwave to arrow conversion.
-        let test_arr = StructArray::new(StructType::new(vec![]), vec![], Bitmap::ones(0));
+        let test_arr = StructArray::new(StructType::empty(), vec![], Bitmap::ones(0));
         assert_eq!(arrow_array::StructArray::from(&test_arr).len(), 0);
 
         // Empty array - arrow to risingwave conversion.
@@ -786,10 +786,7 @@ mod tests {
         let actual_risingwave_struct_array =
             StructArray::try_from(&test_arrow_struct_array).unwrap();
         let expected_risingwave_struct_array = StructArray::new(
-            StructType::new(vec![
-                ("a".into(), DataType::Boolean),
-                ("b".into(), DataType::Int32),
-            ]),
+            StructType::new(vec![("a", DataType::Boolean), ("b", DataType::Int32)]),
             vec![
                 BoolArray::from_iter([Some(false), Some(false), Some(true), None]).into_ref(),
                 I32Array::from_iter([Some(42), Some(28), Some(19), None]).into_ref(),

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::hash::BuildHasher;
-use std::sync::Arc;
 use std::{fmt, usize};
 
 use bytes::Bytes;
@@ -752,13 +751,12 @@ impl DataChunkTestExt for DataChunk {
                 "T" => DataType::Varchar,
                 "SRL" => DataType::Serial,
                 array if array.starts_with('{') && array.ends_with('}') => {
-                    DataType::Struct(Arc::new(StructType {
-                        fields: array[1..array.len() - 1]
+                    DataType::Struct(StructType::unnamed(
+                        array[1..array.len() - 1]
                             .split(',')
                             .map(parse_type)
-                            .collect_vec(),
-                        field_names: vec![],
-                    }))
+                            .collect(),
+                    ))
                 }
                 _ => todo!("unsupported type: {s:?}"),
             }

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -72,7 +72,7 @@ impl ArrayBuilder for StructArrayBuilder {
 
     #[cfg(test)]
     fn new(capacity: usize) -> Self {
-        Self::with_type(capacity, DataType::Struct(StructType::new(vec![])))
+        Self::with_type(capacity, DataType::Struct(StructType::empty()))
     }
 
     fn with_type(capacity: usize, ty: DataType) -> Self {
@@ -459,7 +459,7 @@ mod tests {
     // `CREATE TYPE foo_empty as ();`, e.g.
     #[test]
     fn test_struct_new_empty() {
-        let arr = StructArray::new(StructType::new(vec![]), vec![], Bitmap::ones(0));
+        let arr = StructArray::new(StructType::empty(), vec![], Bitmap::ones(0));
         let actual = StructArray::from_protobuf(&arr.to_protobuf()).unwrap();
         assert_eq!(ArrayImpl::Struct(arr), actual);
     }

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -58,7 +58,7 @@ macro_rules! iter_fields_ref {
 pub struct StructArrayBuilder {
     bitmap: BitmapBuilder,
     pub(super) children_array: Vec<ArrayBuilderImpl>,
-    type_: Arc<StructType>,
+    type_: StructType,
     len: usize,
 }
 
@@ -72,10 +72,7 @@ impl ArrayBuilder for StructArrayBuilder {
 
     #[cfg(test)]
     fn new(capacity: usize) -> Self {
-        Self::with_type(
-            capacity,
-            DataType::Struct(Arc::new(StructType::new(vec![]))),
-        )
+        Self::with_type(capacity, DataType::Struct(StructType::new(vec![])))
     }
 
     fn with_type(capacity: usize, ty: DataType) -> Self {
@@ -83,7 +80,7 @@ impl ArrayBuilder for StructArrayBuilder {
             panic!("must be DataType::Struct");
         };
         let children_array = ty
-            .fields
+            .types()
             .iter()
             .map(|a| a.create_array_builder(capacity))
             .collect();
@@ -146,17 +143,15 @@ impl ArrayBuilder for StructArrayBuilder {
             .into_iter()
             .map(|b| Arc::new(b.finish()))
             .collect::<Vec<ArrayRef>>();
-        StructArray::new(self.bitmap.finish(), children, self.type_)
+        StructArray::new(self.type_, children, self.bitmap.finish())
     }
 }
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StructArray {
-    // TODO: the same bitmap is also stored in each child array, which is redundant.
     bitmap: Bitmap,
     children: Vec<ArrayRef>,
-    type_: Arc<StructType>,
-
+    type_: StructType,
     heap_size: usize,
 }
 
@@ -184,7 +179,7 @@ impl Array for StructArray {
 
     fn to_protobuf(&self) -> PbArray {
         let children_array = self.children.iter().map(|a| a.to_protobuf()).collect();
-        let children_type = self.type_.fields.iter().map(|t| t.to_protobuf()).collect();
+        let children_type = self.type_.types().iter().map(|t| t.to_protobuf()).collect();
         PbArray {
             array_type: PbArrayType::Struct as i32,
             struct_array_data: Some(StructArrayData {
@@ -215,7 +210,7 @@ impl Array for StructArray {
 }
 
 impl StructArray {
-    fn new(bitmap: Bitmap, children: Vec<ArrayRef>, type_: Arc<StructType>) -> Self {
+    pub fn new(type_: StructType, children: Vec<ArrayRef>, bitmap: Bitmap) -> Self {
         let heap_size = bitmap.estimated_heap_size()
             + children
                 .iter()
@@ -243,18 +238,14 @@ impl StructArray {
             .iter()
             .map(|child| Ok(Arc::new(ArrayImpl::from_protobuf(child, cardinality)?)))
             .collect::<ArrayResult<Vec<ArrayRef>>>()?;
-        let type_ = Arc::new(StructType::unnamed(
+        let type_ = StructType::unnamed(
             array_data
                 .children_type
                 .iter()
                 .map(DataType::from)
                 .collect(),
-        ));
-        Ok(Self::new(bitmap, children, type_).into())
-    }
-
-    pub fn children_array_types(&self) -> &[DataType] {
-        &self.type_.fields
+        );
+        Ok(Self::new(type_, children, bitmap).into())
     }
 
     /// Returns an iterator over the field array.
@@ -262,41 +253,8 @@ impl StructArray {
         self.children.iter()
     }
 
-    pub fn field_at(&self, index: usize) -> ArrayRef {
-        self.children[index].clone()
-    }
-
-    pub fn children_names(&self) -> &[String] {
-        &self.type_.field_names
-    }
-
-    pub fn from_slices(
-        null_bitmap: &[bool],
-        children: Vec<ArrayImpl>,
-        children_type: Vec<DataType>,
-    ) -> StructArray {
-        let bitmap = Bitmap::from_iter(null_bitmap.to_vec());
-        let children = children.into_iter().map(Arc::new).collect();
-        Self::new(
-            bitmap,
-            children,
-            Arc::new(StructType::unnamed(children_type)),
-        )
-    }
-
-    pub fn from_slices_with_field_names(
-        null_bitmap: &[bool],
-        children: Vec<ArrayImpl>,
-        children_type: Vec<DataType>,
-        children_name: Vec<String>,
-    ) -> StructArray {
-        let bitmap = Bitmap::from_iter(null_bitmap.iter().cloned());
-        let children = children.into_iter().map(Arc::new).collect_vec();
-        let type_ = Arc::new(StructType {
-            fields: children_type,
-            field_names: children_name,
-        });
-        Self::new(bitmap, children, type_)
+    pub fn field_at(&self, index: usize) -> &ArrayRef {
+        &self.children[index]
     }
 
     #[cfg(test)]
@@ -318,9 +276,9 @@ impl EstimateSize for StructArray {
 impl From<DataChunk> for StructArray {
     fn from(chunk: DataChunk) -> Self {
         Self::new(
-            chunk.vis().to_bitmap(),
+            StructType::unnamed(chunk.columns().iter().map(|c| c.data_type()).collect()),
             chunk.columns().to_vec(),
-            StructType::unnamed(chunk.columns().iter().map(|c| c.data_type()).collect()).into(),
+            chunk.vis().to_bitmap(),
         )
     }
 }
@@ -502,7 +460,7 @@ mod tests {
     // `CREATE TYPE foo_empty as ();`, e.g.
     #[test]
     fn test_struct_new_empty() {
-        let arr = StructArray::from_slices(&[true, false, true, false], vec![], vec![]);
+        let arr = StructArray::new(StructType::new(vec![]), vec![], Bitmap::ones(0));
         let actual = StructArray::from_protobuf(&arr.to_protobuf()).unwrap();
         assert_eq!(ArrayImpl::Struct(arr), actual);
     }
@@ -510,13 +468,13 @@ mod tests {
     #[test]
     fn test_struct_with_fields() {
         use crate::array::*;
-        let arr = StructArray::from_slices(
-            &[false, true, false, true],
+        let arr = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Float32]),
             vec![
-                I32Array::from_iter([None, Some(1), None, Some(2)]).into(),
-                F32Array::from_iter([None, Some(3.0), None, Some(4.0)]).into(),
+                I32Array::from_iter([None, Some(1), None, Some(2)]).into_ref(),
+                F32Array::from_iter([None, Some(3.0), None, Some(4.0)]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Float32],
+            [false, true, false, true].into_iter().collect(),
         );
         let actual = StructArray::from_protobuf(&arr.to_protobuf()).unwrap();
         assert_eq!(ArrayImpl::Struct(arr), actual);
@@ -541,10 +499,10 @@ mod tests {
 
         let mut builder = StructArrayBuilder::with_type(
             4,
-            DataType::Struct(Arc::new(StructType::unnamed(vec![
+            DataType::Struct(StructType::unnamed(vec![
                 DataType::Int32,
                 DataType::Float32,
-            ]))),
+            ])),
         );
         for v in &struct_values {
             builder.append(v.as_ref().map(|s| s.as_scalar_ref()));
@@ -557,13 +515,13 @@ mod tests {
     #[test]
     fn test_struct_create_builder() {
         use crate::array::*;
-        let arr = StructArray::from_slices(
-            &[true],
+        let arr = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Float32]),
             vec![
-                I32Array::from_iter([Some(1)]).into(),
-                F32Array::from_iter([Some(2.0)]).into(),
+                I32Array::from_iter([Some(1)]).into_ref(),
+                F32Array::from_iter([Some(2.0)]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Float32],
+            Bitmap::ones(1),
         );
         let builder = arr.create_builder(4);
         let arr2 = builder.finish();
@@ -644,7 +602,7 @@ mod tests {
 
         let mut builder = StructArrayBuilder::with_type(
             0,
-            DataType::Struct(Arc::new(StructType::unnamed(fields.to_vec()))),
+            DataType::Struct(StructType::unnamed(fields.to_vec())),
         );
 
         builder.append(Some(struct_ref));
@@ -741,7 +699,7 @@ mod tests {
 
             let mut builder = StructArrayBuilder::with_type(
                 0,
-                DataType::Struct(Arc::new(StructType::unnamed(fields.to_vec()))),
+                DataType::Struct(StructType::unnamed(fields.to_vec())),
             );
             builder.append(Some(StructRef::ValueRef { val: &lhs }));
             builder.append(Some(StructRef::ValueRef { val: &rhs }));

--- a/src/common/src/array/struct_array.rs
+++ b/src/common/src/array/struct_array.rs
@@ -81,7 +81,6 @@ impl ArrayBuilder for StructArrayBuilder {
         };
         let children_array = ty
             .types()
-            .iter()
             .map(|a| a.create_array_builder(capacity))
             .collect();
         Self {
@@ -179,7 +178,7 @@ impl Array for StructArray {
 
     fn to_protobuf(&self) -> PbArray {
         let children_array = self.children.iter().map(|a| a.to_protobuf()).collect();
-        let children_type = self.type_.types().iter().map(|t| t.to_protobuf()).collect();
+        let children_type = self.type_.types().map(|t| t.to_protobuf()).collect();
         PbArray {
             array_type: PbArrayType::Struct as i32,
             struct_array_data: Some(StructArrayData {
@@ -321,12 +320,12 @@ impl StructValue {
         &self.fields
     }
 
-    pub fn memcmp_deserialize(
-        fields: &[DataType],
+    pub fn memcmp_deserialize<'a>(
+        fields: impl IntoIterator<Item = &'a DataType>,
         deserializer: &mut memcomparable::Deserializer<impl Buf>,
     ) -> memcomparable::Result<Self> {
         fields
-            .iter()
+            .into_iter()
             .map(|field| memcmp_encoding::deserialize_datum_in_composite(field, deserializer))
             .try_collect()
             .map(Self::new)

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -278,10 +278,8 @@ impl FromIterator<Field> for Schema {
 impl From<&StructType> for Schema {
     fn from(t: &StructType) -> Self {
         Schema::new(
-            t.fields
-                .iter()
-                .zip_eq_fast(t.field_names.iter())
-                .map(|(d, s)| Field::with_name(d.clone(), s))
+            t.name_types()
+                .map(|(s, d)| Field::with_name(d.clone(), s))
                 .collect(),
         )
     }

--- a/src/common/src/catalog/schema.rs
+++ b/src/common/src/catalog/schema.rs
@@ -278,7 +278,7 @@ impl FromIterator<Field> for Schema {
 impl From<&StructType> for Schema {
     fn from(t: &StructType) -> Self {
         Schema::new(
-            t.name_types()
+            t.iter()
                 .map(|(s, d)| Field::with_name(d.clone(), s))
                 .collect(),
         )

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -359,8 +359,8 @@ impl DataType {
         };
         match self {
             DataType::Struct(t) => {
-                pb.field_type = t.types().iter().map(|f| f.to_protobuf()).collect_vec();
-                pb.field_names = t.names().to_vec();
+                pb.field_type = t.types().map(|f| f.to_protobuf()).collect();
+                pb.field_names = t.names().map(|s| s.into()).collect();
             }
             DataType::List(datatype) => {
                 pb.field_type = vec![datatype.to_protobuf()];
@@ -402,7 +402,7 @@ impl DataType {
 
     pub fn new_struct(fields: Vec<DataType>, field_names: Vec<String>) -> Self {
         Self::Struct(StructType {
-            fields: fields.into(),
+            field_types: fields.into(),
             field_names: field_names.into(),
         })
     }
@@ -439,7 +439,6 @@ impl DataType {
             DataType::Struct(data_types) => ScalarImpl::Struct(StructValue::new(
                 data_types
                     .types()
-                    .iter()
                     .map(|data_type| Some(data_type.min_value()))
                     .collect_vec(),
             )),
@@ -953,11 +952,8 @@ impl ScalarImpl {
                     ))
                     .into());
                 }
-                let mut fields = Vec::with_capacity(s.types().len());
-                for (s, ty) in str[1..str.len() - 1]
-                    .split(',')
-                    .zip_eq_debug(s.types().iter())
-                {
+                let mut fields = Vec::with_capacity(s.len());
+                for (s, ty) in str[1..str.len() - 1].split(',').zip_eq_debug(s.types()) {
                     fields.push(Some(Self::from_text(s.trim().as_bytes(), ty)?));
                 }
                 ScalarImpl::Struct(StructValue::new(fields))

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -1293,8 +1293,8 @@ mod tests {
                         ScalarImpl::Float64(23.33.into()).into(),
                     ])),
                     DataType::Struct(StructType::new(vec![
-                        ("a".to_string(), DataType::Int64),
-                        ("b".to_string(), DataType::Float64),
+                        ("a", DataType::Int64),
+                        ("b", DataType::Float64),
                     ])),
                 ),
                 DataTypeName::List => (

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -21,7 +21,6 @@ use std::convert::TryFrom;
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::str::{FromStr, Utf8Error};
-use std::sync::Arc;
 
 use bytes::{Buf, BufMut, Bytes};
 use chrono::{Datelike, Timelike};
@@ -165,7 +164,7 @@ pub enum DataType {
     Interval,
     #[display("{0}")]
     #[from_str(ignore)]
-    Struct(Arc<StructType>),
+    Struct(StructType),
     #[display("{0}[]")]
     #[from_str(regex = r"(?i)^(?P<0>.+)\[\]$")]
     List(Box<DataType>),
@@ -360,8 +359,8 @@ impl DataType {
         };
         match self {
             DataType::Struct(t) => {
-                pb.field_type = t.fields.iter().map(|f| f.to_protobuf()).collect_vec();
-                pb.field_names = t.field_names.clone();
+                pb.field_type = t.types().iter().map(|f| f.to_protobuf()).collect_vec();
+                pb.field_names = t.names().to_vec();
             }
             DataType::List(datatype) => {
                 pb.field_type = vec![datatype.to_protobuf()];
@@ -402,13 +401,10 @@ impl DataType {
     }
 
     pub fn new_struct(fields: Vec<DataType>, field_names: Vec<String>) -> Self {
-        Self::Struct(
-            StructType {
-                fields,
-                field_names,
-            }
-            .into(),
-        )
+        Self::Struct(StructType {
+            fields: fields.into(),
+            field_names: field_names.into(),
+        })
     }
 
     pub fn as_struct(&self) -> &StructType {
@@ -442,7 +438,7 @@ impl DataType {
             DataType::Jsonb => ScalarImpl::Jsonb(JsonbVal::dummy()), // NOT `min` #7981
             DataType::Struct(data_types) => ScalarImpl::Struct(StructValue::new(
                 data_types
-                    .fields
+                    .types()
                     .iter()
                     .map(|data_type| Some(data_type.min_value()))
                     .collect_vec(),
@@ -957,8 +953,11 @@ impl ScalarImpl {
                     ))
                     .into());
                 }
-                let mut fields = Vec::with_capacity(s.fields.len());
-                for (s, ty) in str[1..str.len() - 1].split(',').zip_eq_debug(&s.fields) {
+                let mut fields = Vec::with_capacity(s.types().len());
+                for (s, ty) in str[1..str.len() - 1]
+                    .split(',')
+                    .zip_eq_debug(s.types().iter())
+                {
                     fields.push(Some(Self::from_text(s.trim().as_bytes(), ty)?));
                 }
                 ScalarImpl::Struct(StructValue::new(fields))
@@ -1134,7 +1133,7 @@ impl ScalarImpl {
                 Date::with_days(days).map_err(|e| memcomparable::Error::Message(format!("{e}")))?
             }),
             Ty::Jsonb => Self::Jsonb(JsonbVal::memcmp_deserialize(de)?),
-            Ty::Struct(t) => StructValue::memcmp_deserialize(&t.fields, de)?.to_scalar_value(),
+            Ty::Struct(t) => StructValue::memcmp_deserialize(t.types(), de)?.to_scalar_value(),
             Ty::List(t) => ListValue::memcmp_deserialize(t, de)?.to_scalar_value(),
         })
     }
@@ -1297,13 +1296,10 @@ mod tests {
                         ScalarImpl::Int64(233).into(),
                         ScalarImpl::Float64(23.33.into()).into(),
                     ])),
-                    DataType::Struct(
-                        StructType::new(vec![
-                            (DataType::Int64, "a".to_string()),
-                            (DataType::Float64, "b".to_string()),
-                        ])
-                        .into(),
-                    ),
+                    DataType::Struct(StructType::new(vec![
+                        ("a".to_string(), DataType::Int64),
+                        ("b".to_string(), DataType::Float64),
+                    ])),
                 ),
                 DataTypeName::List => (
                     ScalarImpl::List(ListValue::new(vec![

--- a/src/common/src/types/struct_type.rs
+++ b/src/common/src/types/struct_type.rs
@@ -35,16 +35,25 @@ pub struct StructType {
 
 impl StructType {
     /// Creates a struct type with named fields.
-    pub fn new(named_fields: Vec<(String, DataType)>) -> Self {
+    pub fn new(named_fields: Vec<(impl Into<String>, DataType)>) -> Self {
         let mut field_types = Vec::with_capacity(named_fields.len());
         let mut field_names = Vec::with_capacity(named_fields.len());
         for (name, ty) in named_fields {
-            field_names.push(name);
+            field_names.push(name.into());
             field_types.push(ty);
         }
         Self {
             field_types: field_types.into(),
             field_names: field_names.into(),
+        }
+    }
+
+    /// Creates a struct type with no fields.
+    #[cfg(test)]
+    pub fn empty() -> Self {
+        Self {
+            field_types: Arc::new([]),
+            field_names: Arc::new([]),
         }
     }
 

--- a/src/common/src/util/memcmp_encoding.rs
+++ b/src/common/src/util/memcmp_encoding.rs
@@ -151,7 +151,7 @@ fn calculate_encoded_size_inner(
             // TODO: need some test for this case (e.g. e2e test)
             DataType::List { .. } => deserializer.skip_bytes()?,
             DataType::Struct(t) => t
-                .fields
+                .types()
                 .iter()
                 .map(|field| {
                     // use default null tags inside composite type

--- a/src/common/src/util/memcmp_encoding.rs
+++ b/src/common/src/util/memcmp_encoding.rs
@@ -152,7 +152,6 @@ fn calculate_encoded_size_inner(
             DataType::List { .. } => deserializer.skip_bytes()?,
             DataType::Struct(t) => t
                 .types()
-                .iter()
                 .map(|field| {
                     // use default null tags inside composite type
                     calculate_encoded_size_inner(

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -378,9 +378,9 @@ fn deserialize_value(ty: &DataType, data: &mut impl Buf) -> Result<ScalarImpl> {
 }
 
 fn deserialize_struct(struct_def: &StructType, data: &mut impl Buf) -> Result<ScalarImpl> {
-    let num_fields = struct_def.fields.len();
+    let num_fields = struct_def.types().len();
     let mut field_values = Vec::with_capacity(num_fields);
-    for field_type in &struct_def.fields {
+    for field_type in struct_def.types().iter() {
         field_values.push(inner_deserialize_datum(data, field_type)?);
     }
 

--- a/src/common/src/util/value_encoding/mod.rs
+++ b/src/common/src/util/value_encoding/mod.rs
@@ -378,9 +378,8 @@ fn deserialize_value(ty: &DataType, data: &mut impl Buf) -> Result<ScalarImpl> {
 }
 
 fn deserialize_struct(struct_def: &StructType, data: &mut impl Buf) -> Result<ScalarImpl> {
-    let num_fields = struct_def.types().len();
-    let mut field_values = Vec::with_capacity(num_fields);
-    for field_type in struct_def.types().iter() {
+    let mut field_values = Vec::with_capacity(struct_def.len());
+    for field_type in struct_def.types() {
         field_values.push(inner_deserialize_datum(data, field_type)?);
     }
 

--- a/src/connector/src/parser/common.rs
+++ b/src/connector/src/parser/common.rs
@@ -162,7 +162,7 @@ pub(crate) fn do_parse_simd_json_value(
         }
         (DataType::Struct(struct_type_info), _) => {
             let fields: Vec<Option<ScalarImpl>> = struct_type_info
-                .name_types()
+                .iter()
                 .map(|(name, ty)| {
                     simd_json_parse_value(format, ty, json_object_smart_get_value(v, name.into()))
                 })

--- a/src/connector/src/parser/common.rs
+++ b/src/connector/src/parser/common.rs
@@ -25,7 +25,6 @@ use risingwave_common::cast::{
 use risingwave_common::types::{
     DataType, Date, Datum, Decimal, Int256, Interval, JsonbVal, ScalarImpl, Time,
 };
-use risingwave_common::util::iter_util::ZipEqFast;
 use simd_json::value::StaticNode;
 use simd_json::{BorrowedValue, ValueAccess};
 
@@ -163,15 +162,9 @@ pub(crate) fn do_parse_simd_json_value(
         }
         (DataType::Struct(struct_type_info), _) => {
             let fields: Vec<Option<ScalarImpl>> = struct_type_info
-                .field_names
-                .iter()
-                .zip_eq_fast(struct_type_info.fields.iter())
-                .map(|field| {
-                    simd_json_parse_value(
-                        format,
-                        field.1,
-                        json_object_smart_get_value(v, field.0.into()),
-                    )
+                .name_types()
+                .map(|(name, ty)| {
+                    simd_json_parse_value(format, ty, json_object_smart_get_value(v, name.into()))
                 })
                 .collect::<Result<Vec<Datum>>>()?;
             ScalarImpl::Struct(StructValue::new(fields))

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -157,9 +157,7 @@ impl DebeziumJsonParser {
 
 #[cfg(test)]
 mod tests {
-
     use std::convert::TryInto;
-    use std::sync::Arc;
 
     use chrono::{NaiveDate, NaiveTime};
     use risingwave_common::array::{Op, StructValue};
@@ -695,10 +693,6 @@ mod tests {
 
         // schema for the remaining types
         fn get_other_types_test_columns() -> Vec<SourceColumnDesc> {
-            let point_type = Arc::new(StructType {
-                fields: vec![DataType::Float32, DataType::Float32],
-                field_names: vec![String::from('x'), String::from('y')],
-            });
             vec![
                 SourceColumnDesc::simple("o_key", DataType::Int32, ColumnId::from(0)),
                 SourceColumnDesc::simple("o_boolean", DataType::Boolean, ColumnId::from(1)),
@@ -709,7 +703,10 @@ mod tests {
                 SourceColumnDesc::simple("o_uuid", DataType::Varchar, ColumnId::from(6)),
                 SourceColumnDesc {
                     name: "o_point".to_string(),
-                    data_type: DataType::Struct(point_type),
+                    data_type: DataType::Struct(StructType::new(vec![
+                        ("x".into(), DataType::Float32),
+                        ("y".into(), DataType::Float32),
+                    ])),
                     column_id: 7.into(),
                     fields: vec![],
                     is_row_id: false,

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -704,8 +704,8 @@ mod tests {
                 SourceColumnDesc {
                     name: "o_point".to_string(),
                     data_type: DataType::Struct(StructType::new(vec![
-                        ("x".into(), DataType::Float32),
-                        ("y".into(), DataType::Float32),
+                        ("x", DataType::Float32),
+                        ("y", DataType::Float32),
                     ])),
                     column_id: 7.into(),
                     fields: vec![],

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -363,9 +363,9 @@ fn datum_to_json_object(
             json!(vec)
         }
         (DataType::Struct(st), ScalarRefImpl::Struct(struct_ref)) => {
-            let mut map = Map::with_capacity(st.types().len());
+            let mut map = Map::with_capacity(st.len());
             for (sub_datum_ref, sub_field) in struct_ref.iter_fields_ref().zip_eq_debug(
-                st.name_types()
+                st.iter()
                     .map(|(name, dt)| Field::with_name(dt.clone(), name)),
             ) {
                 let value =

--- a/src/connector/src/sink/mod.rs
+++ b/src/connector/src/sink/mod.rs
@@ -30,7 +30,7 @@ use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::{ErrorCode, RwError};
 use risingwave_common::row::Row;
 use risingwave_common::types::{DataType, DatumRef, ScalarRefImpl, ToText};
-use risingwave_common::util::iter_util::ZipEqFast;
+use risingwave_common::util::iter_util::{ZipEqDebug, ZipEqFast};
 use risingwave_rpc_client::error::RpcError;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
@@ -363,12 +363,10 @@ fn datum_to_json_object(
             json!(vec)
         }
         (DataType::Struct(st), ScalarRefImpl::Struct(struct_ref)) => {
-            let mut map = Map::with_capacity(st.fields.len());
-            for (sub_datum_ref, sub_field) in struct_ref.iter_fields_ref().zip_eq_fast(
-                st.fields
-                    .iter()
-                    .zip_eq_fast(st.field_names.iter())
-                    .map(|(dt, name)| Field::with_name(dt.clone(), name)),
+            let mut map = Map::with_capacity(st.types().len());
+            for (sub_datum_ref, sub_field) in struct_ref.iter_fields_ref().zip_eq_debug(
+                st.name_types()
+                    .map(|(name, dt)| Field::with_name(dt.clone(), name)),
             ) {
                 let value =
                     datum_to_json_object(&sub_field, sub_datum_ref, timestamp_handling_mode)?;

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -249,7 +249,7 @@ fn generator_from_data_type(
         }
         DataType::Struct(struct_type) => {
             let struct_fields = struct_type
-                .name_types()
+                .iter()
                 .map(|(field_name, data_type)| {
                     let gen = generator_from_data_type(
                         data_type.clone(),

--- a/src/connector/src/source/nexmark/source/combined_event.rs
+++ b/src/connector/src/source/nexmark/source/combined_event.rs
@@ -142,41 +142,41 @@ pub(crate) fn get_event_data_types(
 
 pub(crate) fn get_person_struct_type() -> StructType {
     StructType::new(vec![
-        ("id".into(), DataType::Int64),
-        ("name".into(), DataType::Varchar),
-        ("email_address".into(), DataType::Varchar),
-        ("credit_card".into(), DataType::Varchar),
-        ("city".into(), DataType::Varchar),
-        ("state".into(), DataType::Varchar),
-        ("date_time".into(), DataType::Timestamp),
-        ("extra".into(), DataType::Varchar),
+        ("id", DataType::Int64),
+        ("name", DataType::Varchar),
+        ("email_address", DataType::Varchar),
+        ("credit_card", DataType::Varchar),
+        ("city", DataType::Varchar),
+        ("state", DataType::Varchar),
+        ("date_time", DataType::Timestamp),
+        ("extra", DataType::Varchar),
     ])
 }
 
 pub(crate) fn get_auction_struct_type() -> StructType {
     StructType::new(vec![
-        ("id".into(), DataType::Int64),
-        ("item_name".into(), DataType::Varchar),
-        ("description".into(), DataType::Varchar),
-        ("initial_bid".into(), DataType::Int64),
-        ("reserve".into(), DataType::Int64),
-        ("date_time".into(), DataType::Timestamp),
-        ("expires".into(), DataType::Timestamp),
-        ("seller".into(), DataType::Int64),
-        ("category".into(), DataType::Int64),
-        ("extra".into(), DataType::Varchar),
+        ("id", DataType::Int64),
+        ("item_name", DataType::Varchar),
+        ("description", DataType::Varchar),
+        ("initial_bid", DataType::Int64),
+        ("reserve", DataType::Int64),
+        ("date_time", DataType::Timestamp),
+        ("expires", DataType::Timestamp),
+        ("seller", DataType::Int64),
+        ("category", DataType::Int64),
+        ("extra", DataType::Varchar),
     ])
 }
 
 pub(crate) fn get_bid_struct_type() -> StructType {
     StructType::new(vec![
-        ("auction".into(), DataType::Int64),
-        ("bidder".into(), DataType::Int64),
-        ("price".into(), DataType::Int64),
-        ("channel".into(), DataType::Varchar),
-        ("url".into(), DataType::Varchar),
-        ("date_time".into(), DataType::Timestamp),
-        ("extra".into(), DataType::Varchar),
+        ("auction", DataType::Int64),
+        ("bidder", DataType::Int64),
+        ("price", DataType::Int64),
+        ("channel", DataType::Varchar),
+        ("url", DataType::Varchar),
+        ("date_time", DataType::Timestamp),
+        ("extra", DataType::Varchar),
     ])
 }
 

--- a/src/connector/src/source/nexmark/source/combined_event.rs
+++ b/src/connector/src/source/nexmark/source/combined_event.rs
@@ -86,21 +86,21 @@ pub fn get_event_data_types_with_names(
         Some(EventType::Person) => {
             let struct_type = get_person_struct_type();
             struct_type
-                .name_types()
+                .iter()
                 .map(|(n, t)| (n.into(), t.clone()))
                 .collect()
         }
         Some(EventType::Auction) => {
             let struct_type = get_auction_struct_type();
             struct_type
-                .name_types()
+                .iter()
                 .map(|(n, t)| (n.into(), t.clone()))
                 .collect()
         }
         Some(EventType::Bid) => {
             let struct_type = get_bid_struct_type();
             struct_type
-                .name_types()
+                .iter()
                 .map(|(n, t)| (n.into(), t.clone()))
                 .collect()
         }
@@ -127,9 +127,9 @@ pub(crate) fn get_event_data_types(
                 DataType::Struct(get_bid_struct_type()),
             ]
         }
-        Some(EventType::Person) => get_person_struct_type().types().into(),
-        Some(EventType::Auction) => get_auction_struct_type().types().into(),
-        Some(EventType::Bid) => get_bid_struct_type().types().into(),
+        Some(EventType::Person) => get_person_struct_type().types().cloned().collect(),
+        Some(EventType::Auction) => get_auction_struct_type().types().cloned().collect(),
+        Some(EventType::Bid) => get_bid_struct_type().types().cloned().collect(),
     };
 
     if let Some(row_id_index) = row_id_index {

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -520,7 +520,7 @@ impl FunctionAttr {
             vec![quote! { self.return_type.clone() }]
         } else {
             (0..return_types.len())
-                .map(|i| quote! { self.return_type.as_struct().fields[#i].clone() })
+                .map(|i| quote! { self.return_type.as_struct().types()[#i].clone() })
                 .collect()
         };
         let const_arg = match &self.prebuild {
@@ -651,9 +651,7 @@ fn data_type(ty: &str) -> TokenStream2 {
         return quote! { DataType::List(Box::new(#inner_type)) };
     }
     if ty.starts_with("struct<") {
-        return quote! { DataType::Struct(Arc::new(
-            #ty.parse().expect("invalid struct type")
-        )) };
+        return quote! { DataType::Struct(#ty.parse().expect("invalid struct type")) };
     }
     let variant = format_ident!("{}", types::data_type(ty));
     quote! { DataType::#variant }

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -520,7 +520,7 @@ impl FunctionAttr {
             vec![quote! { self.return_type.clone() }]
         } else {
             (0..return_types.len())
-                .map(|i| quote! { self.return_type.as_struct().types()[#i].clone() })
+                .map(|i| quote! { self.return_type.as_struct().types().nth(#i).unwrap().clone() })
                 .collect()
         };
         let const_arg = match &self.prebuild {

--- a/src/expr/src/expr/expr_field.rs
+++ b/src/expr/src/expr/expr_field.rs
@@ -42,7 +42,7 @@ impl Expression for FieldExpression {
     async fn eval(&self, input: &DataChunk) -> Result<ArrayRef> {
         let array = self.input.eval_checked(input).await?;
         if let ArrayImpl::Struct(struct_array) = array.as_ref() {
-            Ok(struct_array.field_at(self.index))
+            Ok(struct_array.field_at(self.index).clone())
         } else {
             Err(anyhow!("expects a struct array ref").into())
         }
@@ -103,7 +103,7 @@ impl<'a> TryFrom<&'a ExprNode> for FieldExpression {
 mod tests {
 
     use risingwave_common::array::{Array, DataChunk, F32Array, I32Array, StructArray};
-    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::types::{DataType, ScalarImpl, StructType};
     use risingwave_pb::data::data_type::TypeName;
 
     use crate::expr::expr_field::FieldExpression;
@@ -119,13 +119,13 @@ mod tests {
             TypeName::Int32,
         ))
         .unwrap();
-        let array = StructArray::from_slices(
-            &[true],
+        let array = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Float32]),
             vec![
-                I32Array::from_iter([1, 2, 3, 4, 5]).into(),
-                F32Array::from_iter([2.0]).into(),
+                I32Array::from_iter([1, 2, 3, 4, 5]).into_ref(),
+                F32Array::from_iter([2.0, 2.0, 2.0, 2.0, 2.0]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Float32],
+            [true].into_iter().collect(),
         );
 
         let data_chunk = DataChunk::new(vec![array.into_ref()], 1);
@@ -149,21 +149,21 @@ mod tests {
         ))
         .unwrap();
 
-        let struct_array = StructArray::from_slices(
-            &[true],
+        let struct_array = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Float32]),
             vec![
-                I32Array::from_iter([1, 2, 3, 4, 5]).into(),
-                F32Array::from_iter([1.0, 2.0, 3.0, 4.0, 5.0]).into(),
+                I32Array::from_iter([1, 2, 3, 4, 5]).into_ref(),
+                F32Array::from_iter([2.0, 2.0, 2.0, 2.0, 2.0]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Float32],
+            [true; 5].into_iter().collect(),
         );
-        let array = StructArray::from_slices(
-            &[true],
+        let array = StructArray::new(
+            StructType::unnamed(vec![struct_array.data_type(), DataType::Float32]),
             vec![
-                struct_array.into(),
-                F32Array::from_iter([2.0, 2.0, 2.0, 2.0, 2.0]).into(),
+                struct_array.into_ref(),
+                F32Array::from_iter([2.0, 2.0, 2.0, 2.0, 2.0]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Float32],
+            [true; 5].into_iter().collect(),
         );
 
         let data_chunk = DataChunk::new(vec![array.into_ref()], 1);

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -646,14 +646,8 @@ mod tests {
                     Some(F32::from(0.0).to_scalar_value()),
                 ])
                 .as_scalar_ref(),
-                &StructType::new(vec![
-                    ("a".to_string(), DataType::Varchar),
-                    ("b".to_string(), DataType::Float32),
-                ]),
-                &StructType::new(vec![
-                    ("a".to_string(), DataType::Int32),
-                    ("b".to_string(), DataType::Int32),
-                ])
+                &StructType::new(vec![("a", DataType::Varchar), ("b", DataType::Float32),]),
+                &StructType::new(vec![("a", DataType::Int32), ("b", DataType::Int32),])
             )
             .unwrap(),
             StructValue::new(vec![

--- a/src/expr/src/vector_op/cast.rs
+++ b/src/expr/src/vector_op/cast.rs
@@ -409,14 +409,8 @@ fn build_cast_struct_to_struct(
     children: Vec<BoxedExpression>,
 ) -> Result<BoxedExpression> {
     let child = children.into_iter().next().unwrap();
-    let source_elem_type = match child.return_type() {
-        DataType::Struct(s) => (*s).clone(),
-        _ => panic!("expected struct type"),
-    };
-    let target_elem_type = match &return_type {
-        DataType::Struct(s) => (**s).clone(),
-        _ => panic!("expected struct type"),
-    };
+    let source_elem_type = child.return_type().as_struct().clone();
+    let target_elem_type = return_type.as_struct().clone();
     Ok(Box::new(
         UnaryExpression::<StructArray, StructArray, _>::new(child, return_type, move |x| {
             struct_cast(x, &source_elem_type, &target_elem_type)
@@ -431,8 +425,8 @@ fn struct_cast(
     target_elem_type: &StructType,
 ) -> Result<StructValue> {
     let fields = (input.iter_fields_ref())
-        .zip_eq_fast(source_elem_type.fields.iter())
-        .zip_eq_fast(target_elem_type.fields.iter())
+        .zip_eq_fast(source_elem_type.types())
+        .zip_eq_fast(target_elem_type.types())
         .map(|((datum_ref, source_field_type), target_field_type)| {
             if source_field_type == target_field_type {
                 return Ok(datum_ref.map(|scalar_ref| scalar_ref.into_scalar_impl()));
@@ -653,12 +647,12 @@ mod tests {
                 ])
                 .as_scalar_ref(),
                 &StructType::new(vec![
-                    (DataType::Varchar, "a".to_string()),
-                    (DataType::Float32, "b".to_string()),
+                    ("a".to_string(), DataType::Varchar),
+                    ("b".to_string(), DataType::Float32),
                 ]),
                 &StructType::new(vec![
-                    (DataType::Int32, "a".to_string()),
-                    (DataType::Int32, "b".to_string()),
+                    ("a".to_string(), DataType::Int32),
+                    ("b".to_string(), DataType::Int32),
                 ])
             )
             .unwrap(),

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -462,7 +462,7 @@ impl Binder {
                     .into());
                 };
                 let columns = if let DataType::Struct(s) = tf.return_type() {
-                    let schema = Schema::from(&*s);
+                    let schema = Schema::from(&s);
                     schema.fields.into_iter().map(|f| (false, f)).collect_vec()
                 } else {
                     vec![(false, Field::with_name(tf.return_type(), tf.name()))]

--- a/src/frontend/src/binder/struct_field.rs
+++ b/src/frontend/src/binder/struct_field.rs
@@ -101,7 +101,7 @@ impl Binder {
     fn bind_wildcard_field(expr: ExprImpl) -> Result<Vec<(ExprImpl, String)>> {
         let input = expr.return_type();
         if let DataType::Struct(t) = input {
-            Ok(t.name_types()
+            Ok(t.iter()
                 .enumerate()
                 .map(|(i, (name, ty))| {
                     (
@@ -127,8 +127,8 @@ impl Binder {
 
 fn find_field(input: DataType, field_name: String) -> Result<(DataType, usize)> {
     if let DataType::Struct(t) = input {
-        if let Some((pos, _)) = t.names().iter().find_position(|s| **s == field_name) {
-            Ok((t.types()[pos].clone(), pos))
+        if let Some((pos, (_, ty))) = t.iter().find_position(|(name, _)| name == &field_name) {
+            Ok((ty.clone(), pos))
         } else {
             Err(ErrorCode::BindError(format!(
                 "column \"{}\" not found in struct type",

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -171,9 +171,7 @@ impl FunctionCall {
         allows: CastContext,
     ) -> Result<ExprImpl, CastError> {
         let func = *expr.into_function_call().unwrap();
-        let (fields, field_names) = if let DataType::Struct(t) = &target_type {
-            (t.fields.clone(), t.field_names.clone())
-        } else {
+        let DataType::Struct(t) = &target_type else {
             return Err(CastError(format!(
                 "cannot cast type \"{}\" to \"{}\" in {:?} context",
                 func.return_type(),
@@ -182,16 +180,16 @@ impl FunctionCall {
             )));
         };
         let (func_type, inputs, _) = func.decompose();
-        match fields.len().cmp(&inputs.len()) {
+        match t.types().len().cmp(&inputs.len()) {
             std::cmp::Ordering::Equal => {
                 let inputs = inputs
                     .into_iter()
-                    .zip_eq_fast(fields.to_vec())
+                    .zip_eq_fast(t.types().to_vec())
                     .map(|(e, t)| Self::new_cast(e, t, allows))
                     .collect::<Result<Vec<_>, CastError>>()?;
                 let return_type = DataType::new_struct(
                     inputs.iter().map(|i| i.return_type()).collect_vec(),
-                    field_names,
+                    t.names().to_vec(),
                 );
                 Ok(FunctionCall::new_unchecked(func_type, inputs, return_type).into())
             }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -180,16 +180,16 @@ impl FunctionCall {
             )));
         };
         let (func_type, inputs, _) = func.decompose();
-        match t.types().len().cmp(&inputs.len()) {
+        match t.len().cmp(&inputs.len()) {
             std::cmp::Ordering::Equal => {
                 let inputs = inputs
                     .into_iter()
-                    .zip_eq_fast(t.types().to_vec())
-                    .map(|(e, t)| Self::new_cast(e, t, allows))
+                    .zip_eq_fast(t.types())
+                    .map(|(e, t)| Self::new_cast(e, t.clone(), allows))
                     .collect::<Result<Vec<_>, CastError>>()?;
                 let return_type = DataType::new_struct(
-                    inputs.iter().map(|i| i.return_type()).collect_vec(),
-                    t.names().to_vec(),
+                    inputs.iter().map(|i| i.return_type()).collect(),
+                    t.names().map(|s| s.to_string()).collect(),
                 );
                 Ok(FunctionCall::new_unchecked(func_type, inputs, return_type).into())
             }

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -126,17 +126,17 @@ pub fn cast_ok_base(source: DataTypeName, target: DataTypeName, allows: CastCont
 fn cast_ok_struct(source: &DataType, target: &DataType, allows: CastContext) -> bool {
     match (source, target) {
         (DataType::Struct(lty), DataType::Struct(rty)) => {
-            if lty.fields.is_empty() || rty.fields.is_empty() {
+            if lty.types().is_empty() || rty.types().is_empty() {
                 unreachable!("record type should be already processed at this point");
             }
-            if lty.fields.len() != rty.fields.len() {
+            if lty.types().len() != rty.types().len() {
                 // only cast structs of the same length
                 return false;
             }
             // ... and all fields are castable
-            lty.fields
+            lty.types()
                 .iter()
-                .zip_eq_fast(rty.fields.iter())
+                .zip_eq_fast(rty.types().iter())
                 .all(|(src, dst)| src == dst || cast_ok(src, dst, allows))
         }
         // The automatic casts to string types are treated as assignment casts, while the automatic

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -126,17 +126,16 @@ pub fn cast_ok_base(source: DataTypeName, target: DataTypeName, allows: CastCont
 fn cast_ok_struct(source: &DataType, target: &DataType, allows: CastContext) -> bool {
     match (source, target) {
         (DataType::Struct(lty), DataType::Struct(rty)) => {
-            if lty.types().is_empty() || rty.types().is_empty() {
+            if lty.is_empty() || rty.is_empty() {
                 unreachable!("record type should be already processed at this point");
             }
-            if lty.types().len() != rty.types().len() {
+            if lty.len() != rty.len() {
                 // only cast structs of the same length
                 return false;
             }
             // ... and all fields are castable
             lty.types()
-                .iter()
-                .zip_eq_fast(rty.types().iter())
+                .zip_eq_fast(rty.types())
                 .all(|(src, dst)| src == dst || cast_ok(src, dst, allows))
         }
         // The automatic casts to string types are treated as assignment casts, while the automatic

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -183,7 +183,6 @@ pub enum NestedType {
 fn extract_struct_nested_type(ty: &StructType) -> Result<NestedType> {
     let fields = ty
         .types()
-        .iter()
         .map(|f| match f {
             DataType::Struct(s) => extract_struct_nested_type(s),
             _ => Ok(NestedType::Type(f.clone())),

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -182,7 +182,7 @@ pub enum NestedType {
 /// Convert struct type to a nested type
 fn extract_struct_nested_type(ty: &StructType) -> Result<NestedType> {
     let fields = ty
-        .fields
+        .types()
         .iter()
         .map(|f| match f {
             DataType::Struct(s) => extract_struct_nested_type(s),
@@ -237,13 +237,9 @@ fn infer_struct_cast_target_type(
                 let (lcast, rcast, ty) = infer_struct_cast_target_type(func_type, lf, rf)?;
                 lcasts |= lcast;
                 rcasts |= rcast;
-                tys.push((ty, "".to_string())); // TODO(chi): generate field name
+                tys.push(("".to_string(), ty)); // TODO(chi): generate field name
             }
-            Ok((
-                lcasts,
-                rcasts,
-                DataType::Struct(StructType::new(tys).into()),
-            ))
+            Ok((lcasts, rcasts, DataType::Struct(StructType::new(tys))))
         }
         (l, r @ NestedType::Struct(_)) | (l @ NestedType::Struct(_), r) => {
             // If only one side is nested type, these two types can never be casted.

--- a/src/frontend/src/handler/create_function.rs
+++ b/src/frontend/src/handler/create_function.rs
@@ -146,7 +146,7 @@ pub async fn handle_create_function(
             )];
             match &return_type {
                 DataType::Struct(s) => {
-                    fields.extend(s.fields.iter().map(|t| to_field(t.clone().into())))
+                    fields.extend(s.types().iter().map(|t| to_field(t.clone().into())))
                 }
                 _ => fields.push(to_field(return_type.clone().into())),
             }

--- a/src/frontend/src/handler/create_function.rs
+++ b/src/frontend/src/handler/create_function.rs
@@ -145,9 +145,7 @@ pub async fn handle_create_function(
                 true,
             )];
             match &return_type {
-                DataType::Struct(s) => {
-                    fields.extend(s.types().iter().map(|t| to_field(t.clone().into())))
-                }
+                DataType::Struct(s) => fields.extend(s.types().map(|t| to_field(t.clone().into()))),
                 _ => fields.push(to_field(return_type.clone().into())),
             }
             fields

--- a/src/frontend/src/optimizer/plan_node/logical_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_table_function.rs
@@ -42,7 +42,7 @@ impl LogicalTableFunction {
     /// Create a [`LogicalTableFunction`] node. Used internally by optimizer.
     pub fn new(table_function: TableFunction, ctx: OptimizerContextRef) -> Self {
         let schema = if let DataType::Struct(s) = table_function.return_type() {
-            Schema::from(&*s)
+            Schema::from(&s)
         } else {
             Schema {
                 fields: vec![Field::with_name(

--- a/src/stream/src/executor/values.rs
+++ b/src/stream/src/executor/values.rs
@@ -157,7 +157,7 @@ mod tests {
         Array, ArrayImpl, I16Array, I32Array, I64Array, StructArray, StructValue,
     };
     use risingwave_common::catalog::{Field, Schema};
-    use risingwave_common::types::{DataType, ScalarImpl};
+    use risingwave_common::types::{DataType, ScalarImpl, StructType};
     use risingwave_expr::expr::{BoxedExpression, LiteralExpression};
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -236,14 +236,14 @@ mod tests {
             .data_chunk()
             .to_owned();
 
-        let array: ArrayImpl = StructArray::from_slices(
-            &[true],
+        let array: ArrayImpl = StructArray::new(
+            StructType::unnamed(vec![DataType::Int32, DataType::Int32, DataType::Int32]),
             vec![
-                I32Array::from_iter([1]).into(),
-                I32Array::from_iter([2]).into(),
-                I32Array::from_iter([3]).into(),
+                I32Array::from_iter([1]).into_ref(),
+                I32Array::from_iter([2]).into_ref(),
+                I32Array::from_iter([3]).into_ref(),
             ],
-            vec![DataType::Int32, DataType::Int32, DataType::Int32],
+            [true].into_iter().collect(),
         )
         .into();
 

--- a/src/tests/sqlsmith/src/sql_gen/expr.rs
+++ b/src/tests/sqlsmith/src/sql_gen/expr.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use itertools::Itertools;
 use rand::seq::SliceRandom;
 use rand::Rng;
@@ -166,17 +164,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     fn gen_struct_data_type(&mut self, depth: usize) -> DataType {
         let num_fields = self.rng.gen_range(1..4);
-        let fields = (0..num_fields)
-            .map(|_| self.gen_data_type_inner(depth))
-            .collect();
-        let field_names = STRUCT_FIELD_NAMES[0..num_fields]
-            .iter()
-            .map(|s| (*s).into())
-            .collect();
-        DataType::Struct(Arc::new(StructType {
-            fields,
-            field_names,
-        }))
+        DataType::Struct(StructType::new(
+            STRUCT_FIELD_NAMES[0..num_fields]
+                .iter()
+                .map(|s| (s.to_string(), self.gen_data_type_inner(depth)))
+                .collect(),
+        ))
     }
 
     /// Generates an arbitrary expression, but biased towards datatypes present in bound columns.

--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -19,7 +19,6 @@ use std::sync::LazyLock;
 
 use itertools::Itertools;
 use risingwave_common::types::{DataType, DataTypeName};
-use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr::agg::AggKind;
 use risingwave_expr::sig::agg::{agg_func_sigs, AggFuncSig as RwAggFuncSig};
 use risingwave_expr::sig::cast::{cast_sigs, CastContext, CastSig as RwCastSig};
@@ -48,11 +47,9 @@ pub(super) fn data_type_to_ast_data_type(data_type: &DataType) -> AstDataType {
         DataType::Jsonb => AstDataType::Custom(vec!["JSONB".into()].into()),
         DataType::Struct(inner) => AstDataType::Struct(
             inner
-                .field_names
-                .iter()
-                .zip_eq_fast(inner.fields.iter())
+                .name_types()
                 .map(|(name, typ)| StructField {
-                    name: name.as_str().into(),
+                    name: name.into(),
                     data_type: data_type_to_ast_data_type(typ),
                 })
                 .collect(),

--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -47,7 +47,7 @@ pub(super) fn data_type_to_ast_data_type(data_type: &DataType) -> AstDataType {
         DataType::Jsonb => AstDataType::Custom(vec!["JSONB".into()].into()),
         DataType::Struct(inner) => AstDataType::Struct(
             inner
-                .name_types()
+                .iter()
                 .map(|(name, typ)| StructField {
                     name: name.into(),
                     data_type: data_type_to_ast_data_type(typ),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- make `StructType` cheaply cloneable and remove the `Arc` around it
- make fields private and provide iterate methods `names()`, `types()` and `iter()`
  making it look like `HashMap<String, DataType>`
- unify all constructors to `StructArray::new`

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
