### PR TITLE
feat(frontend): introduce system catalog pg_tables

### DIFF
--- a/e2e_test/batch/catalog/pg_tables.slt.part
+++ b/e2e_test/batch/catalog/pg_tables.slt.part
@@ -1,0 +1,10 @@
+statement ok
+create table t(a int, b int);
+
+query TTTT
+select schemaname, tablename, tablespace from pg_tables where tablename = 't';
+----
+public t NULL
+
+statement ok
+drop table t;

--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -207,6 +207,7 @@ prepare_sys_catalog! {
     { PG_CATALOG, PG_INDEXES, vec![0, 2], read_indexes_info },
     { PG_CATALOG, PG_INHERITS, vec![0], read_inherits_info },
     { PG_CATALOG, PG_CONSTRAINT, vec![0], read_constraint_info },
+    { PG_CATALOG, PG_TABLES, vec![], read_pg_tables_info },
     { INFORMATION_SCHEMA, COLUMNS, vec![], read_columns_info },
     { INFORMATION_SCHEMA, TABLES, vec![], read_tables_info },
     { RW_CATALOG, RW_META_SNAPSHOT, vec![], read_meta_snapshot await },

--- a/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/pg_catalog/pg_tables.rs
@@ -1,0 +1,29 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::types::DataType;
+
+use crate::catalog::system_catalog::SystemCatalogColumnsDef;
+
+/// The view `pg_tables` provides access to useful information about each table in the database.
+/// Ref: [`https://www.postgresql.org/docs/current/view-pg-tables.html`]
+pub const PG_TABLES_TABLE_NAME: &str = "pg_tables";
+
+pub const PG_TABLES_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
+    (DataType::Varchar, "schemaname"),
+    (DataType::Varchar, "tablename"),
+    (DataType::Varchar, "tableowner"),
+    (DataType::Varchar, "tablespace"), /* Since we don't have any concept of tablespace, we will
+                                        * set this to null. */
+];


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Part of #10131 , introduce system catalog `pg_tables`.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
Introduce system catalog `pg_tables`, which includes columns `schemaname`, `tablename`, `tableowner` and `tablespace`.

</details>
