### PR TITLE
fix(meta): add more log for insert sub level

### DIFF
--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -652,16 +652,11 @@ impl HummockLevelsExt for Levels {
             }
         }
         if delete_sst_levels.iter().any(|level_id| *level_id == 0) {
-            self.l0.as_mut().unwrap().sub_levels.retain(|level| {
-                let keep = !level.table_infos.is_empty();
-                if !keep && level.level_type() == LevelType::Nonoverlapping {
-                    info!(
-                        "remove sub-level-{} when rest sstable files are removed {:?}",
-                        level.sub_level_id, delete_sst_ids_set
-                    );
-                }
-                keep
-            });
+            self.l0
+                .as_mut()
+                .unwrap()
+                .sub_levels
+                .retain(|level| !level.table_infos.is_empty());
             self.l0.as_mut().unwrap().total_file_size = self
                 .l0
                 .as_mut()

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -47,7 +47,7 @@ pub fn summarize_group_deltas(group_deltas: &GroupDeltas) -> GroupDeltasSummary 
     let mut delete_sst_ids_set = HashSet::new();
     let mut insert_sst_level_id = u32::MAX;
     let mut insert_sub_level_id = u64::MAX;
-    let mut insert_table_mnfos = vec![];
+    let mut insert_table_infos = vec![];
     let mut group_construct = None;
     let mut group_destroy = None;
     let mut group_meta_changes = vec![];

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -24,7 +24,6 @@ use risingwave_pb::hummock::{
     CompactionConfig, GroupConstruct, GroupDestroy, GroupMetaChange, GroupTableChange,
     HummockVersion, HummockVersionDelta, Level, LevelType, OverlappingLevel, SstableInfo,
 };
-use tracing::info;
 
 use super::StateTableId;
 use crate::compaction_group::StaticCompactionGroupId;
@@ -48,7 +47,7 @@ pub fn summarize_group_deltas(group_deltas: &GroupDeltas) -> GroupDeltasSummary 
     let mut delete_sst_ids_set = HashSet::new();
     let mut insert_sst_level_id = u32::MAX;
     let mut insert_sub_level_id = u64::MAX;
-    let mut insert_table_infos = vec![];
+    let mut insert_table_mnfos = vec![];
     let mut group_construct = None;
     let mut group_destroy = None;
     let mut group_meta_changes = vec![];

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -654,7 +654,7 @@ impl HummockLevelsExt for Levels {
         if delete_sst_levels.iter().any(|level_id| *level_id == 0) {
             self.l0.as_mut().unwrap().sub_levels.retain(|level| {
                 let keep = !level.table_infos.is_empty();
-                if !keep {
+                if !keep && level.level_type() == LevelType::Nonoverlapping {
                     info!(
                         "remove sub-level-{} when rest sstable files are removed {:?}",
                         level.sub_level_id, delete_sst_ids_set


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We meet some error when try to insert sstable files to sub level for an intra-l0 compaction task. We need more log information to locate the problem root cause.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
