### PR TITLE
feat(config): support for setting default visibility_mode via config

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -286,6 +286,9 @@ pub struct BatchConfig {
     #[serde(default)]
     pub distributed_query_limit: Option<u64>,
 
+    #[serde(default = "default::batch::enable_barrier_read")]
+    pub enable_barrier_read: bool,
+
     #[serde(default, flatten)]
     pub unrecognized: Unrecognized<Self>,
 }
@@ -853,6 +856,12 @@ mod default {
 
         pub fn telemetry_enabled() -> Option<bool> {
             system_param::default::telemetry_enabled()
+        }
+    }
+
+    pub mod batch {
+        pub fn enable_barrier_read() -> bool {
+            true
         }
     }
 }

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -29,7 +29,7 @@ use tracing::info;
 
 use crate::error::{ErrorCode, RwError};
 use crate::session_config::transaction_isolation_level::IsolationLevel;
-use crate::session_config::visibility_mode::VisibilityMode;
+pub use crate::session_config::visibility_mode::VisibilityMode;
 use crate::util::epoch::Epoch;
 
 // This is a hack, &'static str is not allowed as a const generics argument.
@@ -652,8 +652,8 @@ impl ConfigMap {
         self.search_path.clone()
     }
 
-    pub fn only_checkpoint_visible(&self) -> bool {
-        matches!(self.visibility_mode, VisibilityMode::Checkpoint)
+    pub fn get_visible_mode(&self) -> VisibilityMode {
+        self.visibility_mode
     }
 
     pub fn get_query_epoch(&self) -> Option<Epoch> {

--- a/src/common/src/session_config/visibility_mode.rs
+++ b/src/common/src/session_config/visibility_mode.rs
@@ -23,8 +23,12 @@ use crate::session_config::VISIBILITY_MODE;
 
 #[derive(Copy, Default, Debug, Clone, PartialEq, Eq)]
 pub enum VisibilityMode {
+    // apply frontend config.
     #[default]
+    Default,
+    // read barrier from streaming compute node.
     All,
+    // read checkpoint from serving compute node.
     Checkpoint,
 }
 
@@ -51,6 +55,8 @@ impl TryFrom<&[&str]> for VisibilityMode {
             Ok(Self::All)
         } else if s.eq_ignore_ascii_case("checkpoint") {
             Ok(Self::Checkpoint)
+        } else if s.eq_ignore_ascii_case("default") {
+            Ok(Self::Default)
         } else {
             Err(InvalidConfigValue {
                 config_entry: Self::entry_name().to_string(),
@@ -63,6 +69,7 @@ impl TryFrom<&[&str]> for VisibilityMode {
 impl std::fmt::Display for VisibilityMode {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
+            Self::Default => write!(f, "default"),
             Self::All => write!(f, "all"),
             Self::Checkpoint => write!(f, "checkpoint"),
         }
@@ -90,6 +97,10 @@ mod tests {
         assert_eq!(
             VisibilityMode::try_from(["checkPoint"].as_slice()).unwrap(),
             VisibilityMode::Checkpoint
+        );
+        assert_eq!(
+            VisibilityMode::try_from(["default"].as_slice()).unwrap(),
+            VisibilityMode::Default
         );
         assert!(VisibilityMode::try_from(["ab"].as_slice()).is_err());
     }

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -29,6 +29,9 @@ split_group_size_limit = 21474836480
 do_not_config_object_storage_lifecycle = false
 partition_vnode_count = 64
 
+[batch]
+enable_barrier_read = true
+
 [batch.developer]
 batch_connector_message_buffer_size = 16
 batch_output_channel_size = 64

--- a/src/frontend/src/handler/explain.rs
+++ b/src/frontend/src/handler/explain.rs
@@ -181,7 +181,7 @@ async fn do_handle_explain(
                         Convention::Batch => {
                             let worker_node_manager_reader = WorkerNodeSelector::new(
                                 session.env().worker_node_manager_ref(),
-                                !session.config().only_checkpoint_visible(),
+                                session.is_barrier_read(),
                             );
                             batch_plan_fragmenter = Some(BatchPlanFragmenter::new(
                                 worker_node_manager_reader,

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -280,7 +280,7 @@ fn gen_batch_plan_fragmenter(
     );
     let worker_node_manager_reader = WorkerNodeSelector::new(
         session.env().worker_node_manager_ref(),
-        !session.config().only_checkpoint_visible(),
+        session.is_barrier_read(),
     );
     let plan_fragmenter = BatchPlanFragmenter::new(
         worker_node_manager_reader,
@@ -311,7 +311,7 @@ async fn execute(
         ..
     } = plan_fragmenter_result;
 
-    let only_checkpoint_visible = session.config().only_checkpoint_visible();
+    let is_barrier_read = session.is_barrier_read();
     let query_start_time = Instant::now();
     let query = plan_fragmenter.generate_complete_query().await?;
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
@@ -336,7 +336,7 @@ async fn execute(
             let hummock_snapshot_manager = session.env().hummock_snapshot_manager();
             let query_id = query.query_id().clone();
             let pinned_snapshot = hummock_snapshot_manager.acquire(&query_id).await?;
-            PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, only_checkpoint_visible)
+            PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, is_barrier_read)
         };
         match query_mode {
             QueryMode::Auto => unreachable!(),

--- a/src/frontend/src/lib.rs
+++ b/src/frontend/src/lib.rs
@@ -136,6 +136,10 @@ struct OverrideConfigOpts {
     #[clap(long, env = "RW_METRICS_LEVEL")]
     #[override_opts(path = server.metrics_level)]
     pub metrics_level: Option<u32>,
+
+    #[clap(long, env = "RW_ENABLE_BARRIER_READ")]
+    #[override_opts(path = batch.enable_barrier_read)]
+    pub enable_barrier_read: Option<bool>,
 }
 
 impl Default for FrontendOpts {

--- a/src/frontend/src/scheduler/worker_node_manager.rs
+++ b/src/frontend/src/scheduler/worker_node_manager.rs
@@ -98,6 +98,14 @@ impl WorkerNodeManager {
         if node.property.as_ref().map_or(false, |p| p.is_serving) {
             write_guard.serving_fragment_vnode_mapping.clear();
         }
+        // update
+        for w in &mut write_guard.worker_nodes {
+            if w.id == node.id {
+                *w = node;
+                return;
+            }
+        }
+        // insert
         write_guard.worker_nodes.push(node);
     }
 
@@ -106,7 +114,7 @@ impl WorkerNodeManager {
         if node.property.as_ref().map_or(false, |p| p.is_serving) {
             write_guard.serving_fragment_vnode_mapping.clear();
         }
-        write_guard.worker_nodes.retain(|x| *x != node);
+        write_guard.worker_nodes.retain(|x| x.id != node.id);
     }
 
     pub fn refresh(
@@ -231,6 +239,7 @@ impl WorkerNodeManagerInner {
             .worker_nodes
             .iter()
             .filter(|w| w.property.as_ref().map_or(false, |p| p.is_serving))
+            .sorted_by_key(|w| w.id)
             .map(|w| (w.id, w.parallel_units.clone()))
             .collect();
         let serving_pus_total_num = all_serving_pus.values().map(|p| p.len()).sum::<usize>();

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -34,7 +34,7 @@ use risingwave_common::catalog::{
 use risingwave_common::config::{load_config, BatchConfig};
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::monitor::process_linux::monitor_process;
-use risingwave_common::session_config::ConfigMap;
+use risingwave_common::session_config::{ConfigMap, VisibilityMode};
 use risingwave_common::system_param::local_manager::LocalSystemParamsManager;
 use risingwave_common::telemetry::manager::TelemetryManager;
 use risingwave_common::telemetry::telemetry_env_enabled;
@@ -677,6 +677,14 @@ impl SessionImpl {
         let notice = str.into();
         tracing::trace!("notice to user:{}", notice);
         self.notices.write().push(notice);
+    }
+
+    pub fn is_barrier_read(&self) -> bool {
+        match self.config().get_visible_mode() {
+            VisibilityMode::Default => self.env.batch_config.enable_barrier_read,
+            VisibilityMode::All => true,
+            VisibilityMode::Checkpoint => false,
+        }
     }
 }
 

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -151,13 +151,11 @@ where
     pub async fn activate_worker_node(&self, host_address: HostAddress) -> MetaResult<()> {
         let mut core = self.core.write().await;
         let mut worker = core.get_worker_by_host_checked(host_address.clone())?;
-        if worker.worker_node.state == State::Running as i32 {
-            return Ok(());
+        if worker.worker_node.state != State::Running as i32 {
+            worker.worker_node.state = State::Running as i32;
+            worker.insert(self.env.meta_store()).await?;
+            core.update_worker_node(worker.clone());
         }
-        worker.worker_node.state = State::Running as i32;
-        worker.insert(self.env.meta_store()).await?;
-
-        core.update_worker_node(worker.clone());
 
         // Notify frontends of new compute node.
         let worker_type = worker.worker_type();

--- a/src/meta/src/manager/cluster.rs
+++ b/src/meta/src/manager/cluster.rs
@@ -158,6 +158,7 @@ where
         }
 
         // Notify frontends of new compute node.
+        // Always notify because a running worker's property may have been changed.
         let worker_type = worker.worker_type();
         if worker_type == WorkerType::ComputeNode {
             self.env


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously the default value of visibility_mode session var is hard coded. It's inconvenient for a user who wants a different visibility_mode, because it need be set per session. And usually user always use the same visibility_mode for the same cluster.

This PR adds support for setting default visibility_mode for all sessions from a frontend node via its config.
- For a new session, visibility_mode session var is `Default`, which is interpreted as reading from config.
- If visibility_mode session var is set (`All` or `Checkpoint`), it overrides config one.

#8940

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
