### PR TITLE
refactor(binder): refactor the logic to valid constraints

### DIFF
--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -22,7 +22,7 @@ use risingwave_common::catalog::{
     ColumnCatalog, ColumnDesc, TableId, TableVersionId, INITIAL_TABLE_VERSION_ID,
     USER_COLUMN_ID_OFFSET,
 };
-use risingwave_common::error::{ErrorCode, Result};
+use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_pb::catalog::source::OptionalAssociatedTableId;
 use risingwave_pb::catalog::{PbSource, PbTable, StreamSourceInfo, WatermarkDesc};
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
@@ -119,6 +119,24 @@ impl ColumnIdGenerator {
     }
 }
 
+fn valid_column_options(c: &ColumnDef) -> Result<()> {
+    for option_def in &c.options {
+        match option_def.option {
+            ColumnOption::GeneratedColumns(_) => {}
+            ColumnOption::DefaultColumns(_) => {}
+            ColumnOption::Unique { is_primary: true } => {}
+            _ => {
+                return Err(ErrorCode::NotImplemented(
+                    format!("column constraints \"{}\"", option_def),
+                    None.into(),
+                )
+                .into())
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Binds the column schemas declared in CREATE statement into `ColumnDesc`.
 /// If a column is marked as `primary key`, its `ColumnId` is also returned.
 /// This primary key is not combined with table constraints yet.
@@ -129,6 +147,7 @@ pub fn bind_sql_columns(
     let mut column_descs = Vec::with_capacity(columns.len());
 
     for column in columns {
+        valid_column_options(&column)?;
         let column_id = col_id_gen.generate(&column.name.real_value());
         // Destruct to make sure all fields are properly handled rather than ignored.
         // Do NOT use `..` to ignore fields you do not want to deal with.
@@ -269,20 +288,68 @@ pub fn bind_sql_column_constraints(
                             expr: Some(expr_impl.to_expr_proto()),
                         }));
                 }
-                ColumnOption::Unique { is_primary: true } => {
-                    // Bind primary key in `bind_sql_table_column_constraints`
-                }
-                _ => {
-                    return Err(ErrorCode::NotImplemented(
-                        format!("column constraints \"{}\"", option_def),
-                        None.into(),
-                    )
-                    .into())
-                }
+                _ => {}
             }
         }
     }
     Ok(())
+}
+
+fn valid_table_constraints(table_constraints: &[TableConstraint]) -> Result<()> {
+    for constraint in table_constraints {
+        match constraint {
+            TableConstraint::Unique {
+                name: _,
+                columns: _,
+                is_primary: true,
+            } => {}
+            _ => {
+                return Err(ErrorCode::NotImplemented(
+                    format!("table constraint \"{}\"", constraint),
+                    None.into(),
+                )
+                .into())
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn bind_pk_names(
+    columns_defs: &[ColumnDef],
+    table_constraints: &[TableConstraint],
+) -> Result<Vec<String>> {
+    let mut pk_column_names = vec![];
+
+    for column in columns_defs {
+        for option_def in &column.options {
+            if let ColumnOption::Unique { is_primary: true } = option_def.option {
+                if !pk_column_names.is_empty() {
+                    return Err(multiple_pk_definition_err());
+                }
+                pk_column_names.push(column.name.real_value());
+            };
+        }
+    }
+
+    for constraint in table_constraints {
+        if let TableConstraint::Unique {
+            name: _,
+            columns,
+            is_primary: true,
+        } = constraint
+        {
+            if !pk_column_names.is_empty() {
+                return Err(multiple_pk_definition_err());
+            }
+            pk_column_names = columns.iter().map(|c| c.real_value()).collect_vec();
+        }
+    }
+    Ok(pk_column_names)
+}
+
+fn multiple_pk_definition_err() -> RwError {
+    ErrorCode::BindError("multiple primary keys are not allowed".into()).into()
 }
 
 /// Binds constraints that can be specified in both column definitions and table definition.
@@ -294,65 +361,14 @@ pub fn bind_sql_table_column_constraints(
     columns_defs: Vec<ColumnDef>,
     table_constraints: Vec<TableConstraint>,
 ) -> Result<(Vec<ColumnCatalog>, Vec<ColumnId>, Option<usize>)> {
-    let mut pk_column_names = vec![];
+    valid_table_constraints(&table_constraints)?;
     // Mapping from column name to column id.
     let name_to_id = columns_descs
         .iter()
         .map(|c| (c.name.as_str(), c.column_id))
         .collect::<HashMap<_, _>>();
 
-    // Bind column constraints
-    for column in columns_defs {
-        for option_def in column.options {
-            match option_def.option {
-                ColumnOption::Unique { is_primary: true } => {
-                    if !pk_column_names.is_empty() {
-                        return Err(ErrorCode::BindError(
-                            "multiple primary keys are not allowed".into(),
-                        )
-                        .into());
-                    }
-                    pk_column_names.push(column.name.real_value());
-                }
-                ColumnOption::GeneratedColumns(_) | ColumnOption::DefaultColumns(_) => {
-                    // Bind generated columns in `bind_sql_column_constraints`
-                }
-                _ => {
-                    return Err(ErrorCode::NotImplemented(
-                        format!("column constraints \"{}\"", option_def),
-                        None.into(),
-                    )
-                    .into())
-                }
-            }
-        }
-    }
-
-    // Bind table constraints.
-    for constraint in table_constraints {
-        match constraint {
-            TableConstraint::Unique {
-                name: _,
-                columns,
-                is_primary: true,
-            } => {
-                if !pk_column_names.is_empty() {
-                    return Err(ErrorCode::BindError(
-                        "multiple primary keys are not allowed".into(),
-                    )
-                    .into());
-                }
-                pk_column_names = columns.iter().map(|c| c.real_value()).collect_vec();
-            }
-            _ => {
-                return Err(ErrorCode::NotImplemented(
-                    format!("table constraint \"{}\"", constraint),
-                    None.into(),
-                )
-                .into())
-            }
-        }
-    }
+    let pk_column_names = bind_pk_names(&columns_defs, &table_constraints)?;
 
     let mut pk_column_ids: Vec<_> = pk_column_names
         .iter()
@@ -363,11 +379,11 @@ pub fn bind_sql_table_column_constraints(
         })
         .try_collect()?;
 
-    let mut columns_catalog = columns_descs
+    let mut columns_catalog: Vec<ColumnCatalog> = columns_descs
         .into_iter()
         .map(|c| {
             // All columns except `_row_id` or starts with `_rw` should be visible.
-            let is_hidden = c.name.starts_with("_rw");
+            let is_hidden: bool = c.name.starts_with("_rw");
             ColumnCatalog {
                 column_desc: c,
                 is_hidden,
@@ -407,7 +423,7 @@ pub(crate) async fn gen_create_table_plan_with_source(
     append_only: bool,
 ) -> Result<(PlanRef, Option<PbSource>, PbTable)> {
     let session = context.session_ctx();
-    let column_descs = bind_sql_columns(column_defs.clone(), &mut col_id_gen)?;
+    let column_descs: Vec<ColumnDesc> = bind_sql_columns(column_defs.clone(), &mut col_id_gen)?;
     let mut properties = context.with_options().inner().clone().into_iter().collect();
 
     let (mut columns, mut pk_column_ids, mut row_id_index) =


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We have actually 2 kinds of bind error's here
1. user writes a sql with syntax that we do not support (such as unique key, foreign key)
2. user writes a syntax illeagle (such as multiple pk definition)

This PR split them to different functions.

<!--

**This section will be used as the commit message. Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
