### PR TITLE
chore(connector-node): assign id to cdc engine runner thread

### DIFF
--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngineRunner.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngineRunner.java
@@ -21,6 +21,7 @@ import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,8 +33,8 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final CdcEngine engine;
 
-    public DbzCdcEngineRunner(CdcEngine engine) {
-        this.executor = Executors.newSingleThreadExecutor();
+    private DbzCdcEngineRunner(CdcEngine engine) {
+        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "rw-dbz-engine-runner-" + engine.getId()));
         this.engine = engine;
     }
 
@@ -42,6 +43,7 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
             StreamObserver<ConnectorServiceProto.GetEventStreamResponse> responseObserver) {
         DbzCdcEngineRunner runner = null;
         try {
+            var sourceId = config.getSourceId();
             var engine =
                     new DbzCdcEngine(
                             config.getSourceId(),
@@ -50,10 +52,12 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
                                 if (!success) {
                                     responseObserver.onError(error);
                                     LOG.error(
-                                            "the engine terminated with error. message: {}",
+                                            "engine#{} terminated with error. message: {}",
+                                            sourceId,
                                             message,
                                             error);
                                 } else {
+                                    LOG.info("engine#{} stopped normally. {}", sourceId, message);
                                     responseObserver.onCompleted();
                                 }
                             });
@@ -68,20 +72,20 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
     /** Start to run the cdc engine */
     public void start() {
         if (isRunning()) {
-            LOG.info("CdcEngine#{} already started", engine.getId());
+            LOG.info("engine#{} already started", engine.getId());
             return;
         }
 
         executor.execute(engine);
         running.set(true);
-        LOG.info("CdcEngine#{} started", engine.getId());
+        LOG.info("engine#{} started", engine.getId());
     }
 
     public void stop() throws Exception {
         if (isRunning()) {
             engine.stop();
             cleanUp();
-            LOG.info("CdcEngine#{} terminated", engine.getId());
+            LOG.info("engine#{} terminated", engine.getId());
         }
     }
 
@@ -97,6 +101,7 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
 
     private void cleanUp() {
         running.set(false);
+        // interrupt the runner thread if it is still running
         executor.shutdownNow();
     }
 }

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngineRunner.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/DbzCdcEngineRunner.java
@@ -21,7 +21,6 @@ import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +33,9 @@ public class DbzCdcEngineRunner implements CdcEngineRunner {
     private final CdcEngine engine;
 
     private DbzCdcEngineRunner(CdcEngine engine) {
-        this.executor = Executors.newSingleThreadExecutor(r -> new Thread(r, "rw-dbz-engine-runner-" + engine.getId()));
+        this.executor =
+                Executors.newSingleThreadExecutor(
+                        r -> new Thread(r, "rw-dbz-engine-runner-" + engine.getId()));
         this.engine = engine;
     }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
