### PR TITLE
feat(storage): enable setting the flush threshold in storage

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -331,6 +331,11 @@ pub struct StorageConfig {
     #[serde(default)]
     pub shared_buffer_capacity_mb: Option<usize>,
 
+    /// The shared buffer will start flushing data to object when the ratio of memory usage to the
+    /// shared buffer capacity exceed such ratio.
+    #[serde(default = "default::storage::shared_buffer_flush_ratio")]
+    pub shared_buffer_flush_ratio: f32,
+
     /// The threshold for the number of immutable memtables to merge to a new imm.
     #[serde(default = "default::storage::imm_merge_threshold")]
     pub imm_merge_threshold: usize,
@@ -642,6 +647,10 @@ mod default {
 
         pub fn shared_buffer_capacity_mb() -> usize {
             1024
+        }
+
+        pub fn shared_buffer_flush_ratio() -> f32 {
+            0.8
         }
 
         pub fn imm_merge_threshold() -> usize {

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -50,6 +50,7 @@ stream_exchange_concurrent_barriers = 2
 [storage]
 share_buffers_sync_parallelism = 1
 share_buffer_compaction_worker_threads_number = 4
+shared_buffer_flush_ratio = 0.800000011920929
 imm_merge_threshold = 4
 write_conflict_detection_enabled = true
 disable_remote_compactor = false

--- a/src/storage/src/hummock/event_handler/hummock_event_handler.rs
+++ b/src/storage/src/hummock/event_handler/hummock_event_handler.rs
@@ -62,7 +62,13 @@ impl BufferTracker {
         global_upload_task_size: GenericGauge<AtomicU64>,
     ) -> Self {
         let capacity = config.shared_buffer_capacity_mb * (1 << 20);
-        let flush_threshold = capacity * 4 / 5;
+        let flush_threshold = (capacity as f32 * config.shared_buffer_flush_ratio) as usize;
+        assert!(
+            flush_threshold < capacity,
+            "flush_threshold {} should be less or equal to capacity {}",
+            flush_threshold,
+            capacity
+        );
         Self::new(capacity, flush_threshold, global_upload_task_size)
     }
 

--- a/src/storage/src/opts.rs
+++ b/src/storage/src/opts.rs
@@ -32,6 +32,9 @@ pub struct StorageOpts {
     /// Maximum shared buffer size, writes attempting to exceed the capacity will stall until there
     /// is enough space.
     pub shared_buffer_capacity_mb: usize,
+    /// The shared buffer will start flushing data to object when the ratio of memory usage to the
+    /// shared buffer capacity exceed such ratio.
+    pub shared_buffer_flush_ratio: f32,
     /// The threshold for the number of immutable memtables to merge to a new imm.
     pub imm_merge_threshold: usize,
     /// Remote directory for storing data and metadata objects.
@@ -92,6 +95,7 @@ impl From<(&RwConfig, &SystemParamsReader, &StorageMemoryConfig)> for StorageOpt
                 .storage
                 .share_buffer_compaction_worker_threads_number,
             shared_buffer_capacity_mb: s.shared_buffer_capacity_mb,
+            shared_buffer_flush_ratio: c.storage.shared_buffer_flush_ratio,
             imm_merge_threshold: c.storage.imm_merge_threshold,
             data_directory: p.data_directory().to_string(),
             write_conflict_detection_enabled: c.storage.write_conflict_detection_enabled,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled.

With this PR, we can set the storage config `shared_buffer_flush_ratio` to set the ratio that starts spilling data to object store when ratio of the current memory usage exceeds the shared buffer capacity.

Default value is the previous `0.8`.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
