### PR TITLE
refactor(binder): in-place `cast_mut` or `ExprImpl::take`

### DIFF
--- a/src/frontend/src/binder/relation/join.rs
+++ b/src/frontend/src/binder/relation/join.rs
@@ -35,8 +35,7 @@ impl RewriteExprsRecursive for BoundJoin {
     fn rewrite_exprs_recursive(&mut self, rewriter: &mut impl crate::expr::ExprRewriter) {
         self.left.rewrite_exprs_recursive(rewriter);
         self.right.rewrite_exprs_recursive(rewriter);
-        let dummy = ExprImpl::literal_bool(true);
-        self.cond = rewriter.rewrite_expr(std::mem::replace(&mut self.cond, dummy));
+        self.cond = rewriter.rewrite_expr(self.cond.take());
     }
 }
 

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -111,16 +111,6 @@ impl FunctionCall {
 
     /// Create a cast expr over `child` to `target` type in `allows` context.
     pub fn new_cast(
-        mut child: ExprImpl,
-        target: DataType,
-        allows: CastContext,
-    ) -> Result<ExprImpl, CastError> {
-        Self::new_cast_inner(&mut child, target, allows)?;
-        Ok(child)
-    }
-
-    /// next_gen
-    pub fn new_cast_inner(
         child: &mut ExprImpl,
         target: DataType,
         allows: CastContext,
@@ -196,7 +186,7 @@ impl FunctionCall {
                 func.inputs
                     .iter_mut()
                     .zip_eq_fast(t.types())
-                    .try_for_each(|(e, t)| Self::new_cast_inner(e, t.clone(), allows))?;
+                    .try_for_each(|(e, t)| Self::new_cast(e, t.clone(), allows))?;
                 func.return_type = target_type;
                 Ok(())
             }

--- a/src/frontend/src/expr/function_call.rs
+++ b/src/frontend/src/expr/function_call.rs
@@ -115,15 +115,25 @@ impl FunctionCall {
         target: DataType,
         allows: CastContext,
     ) -> Result<ExprImpl, CastError> {
-        if let ExprImpl::Parameter(expr) = &mut child && !expr.has_infer() {
+        Self::new_cast_inner(&mut child, target, allows)?;
+        Ok(child)
+    }
+
+    /// next_gen
+    pub fn new_cast_inner(
+        child: &mut ExprImpl,
+        target: DataType,
+        allows: CastContext,
+    ) -> Result<(), CastError> {
+        if let ExprImpl::Parameter(expr) = child && !expr.has_infer() {
             expr.cast_infer_type(target);
-            return Ok(child);
+            return Ok(());
         }
-        if is_row_function(&child) {
+        if let ExprImpl::FunctionCall(func) = child && func.func_type == ExprType::Row {
             // Row function will have empty fields in Datatype::Struct at this point. Therefore,
             // we will need to take some special care to generate the cast types. For normal struct
             // types, they will be handled in `cast_ok`.
-            return Self::cast_row_expr(child, target, allows);
+            return Self::cast_row_expr(func, target, allows);
         }
         if child.is_untyped() {
             // `is_unknown` makes sure `as_literal` and `as_utf8` will never panic.
@@ -137,23 +147,26 @@ impl FunctionCall {
                 })
                 .transpose();
             if let Ok(datum) = datum {
-                return Ok(Literal::new(datum, target).into());
+                *child = Literal::new(datum, target).into();
+                return Ok(());
             }
             // else when eager parsing fails, just proceed as normal.
             // Some callers are not ready to handle `'a'::int` error here.
         }
         let source = child.return_type();
         if source == target {
-            Ok(child)
+            Ok(())
         // Casting from unknown is allowed in all context. And PostgreSQL actually does the parsing
         // in frontend.
         } else if child.is_untyped() || cast_ok(&source, &target, allows) {
-            Ok(Self {
+            let owned = std::mem::replace(child, ExprImpl::literal_bool(false));
+            *child = Self {
                 func_type: ExprType::Cast,
                 return_type: target,
-                inputs: vec![child],
+                inputs: vec![owned],
             }
-            .into())
+            .into();
+            Ok(())
         } else {
             Err(CastError(format!(
                 "cannot cast type \"{}\" to \"{}\" in {:?} context",
@@ -166,11 +179,10 @@ impl FunctionCall {
     /// expressions, like `ROW(1)::STRUCT<i INTEGER>` to `STRUCT<VARCHAR>`, although an integer
     /// is castible to VARCHAR. It's to simply the casting rules.
     fn cast_row_expr(
-        expr: ExprImpl,
+        func: &mut FunctionCall,
         target_type: DataType,
         allows: CastContext,
-    ) -> Result<ExprImpl, CastError> {
-        let func = *expr.into_function_call().unwrap();
+    ) -> Result<(), CastError> {
         let DataType::Struct(t) = &target_type else {
             return Err(CastError(format!(
                 "cannot cast type \"{}\" to \"{}\" in {:?} context",
@@ -179,19 +191,14 @@ impl FunctionCall {
                 allows
             )));
         };
-        let (func_type, inputs, _) = func.decompose();
-        match t.len().cmp(&inputs.len()) {
+        match t.len().cmp(&func.inputs.len()) {
             std::cmp::Ordering::Equal => {
-                let inputs = inputs
-                    .into_iter()
+                func.inputs
+                    .iter_mut()
                     .zip_eq_fast(t.types())
-                    .map(|(e, t)| Self::new_cast(e, t.clone(), allows))
-                    .collect::<Result<Vec<_>, CastError>>()?;
-                let return_type = DataType::new_struct(
-                    inputs.iter().map(|i| i.return_type()).collect(),
-                    t.names().map(|s| s.to_string()).collect(),
-                );
-                Ok(FunctionCall::new_unchecked(func_type, inputs, return_type).into())
+                    .try_for_each(|(e, t)| Self::new_cast_inner(e, t.clone(), allows))?;
+                func.return_type = target_type;
+                Ok(())
             }
             std::cmp::Ordering::Less => Err(CastError("Input has too few columns.".to_string())),
             std::cmp::Ordering::Greater => {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -167,6 +167,10 @@ impl ExprImpl {
         .into()
     }
 
+    pub fn take(&mut self) -> Self {
+        std::mem::replace(self, Self::literal_null(self.return_type()))
+    }
+
     /// A `count(*)` aggregate function.
     #[inline(always)]
     pub fn count_star() -> Self {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -216,18 +216,26 @@ impl ExprImpl {
     }
 
     /// Shorthand to create cast expr to `target` type in implicit context.
-    pub fn cast_implicit(self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(self, target, CastContext::Implicit)
+    pub fn cast_implicit(mut self, target: DataType) -> Result<ExprImpl, CastError> {
+        FunctionCall::new_cast(&mut self, target, CastContext::Implicit)?;
+        Ok(self)
     }
 
     /// Shorthand to create cast expr to `target` type in assign context.
-    pub fn cast_assign(self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(self, target, CastContext::Assign)
+    pub fn cast_assign(mut self, target: DataType) -> Result<ExprImpl, CastError> {
+        FunctionCall::new_cast(&mut self, target, CastContext::Assign)?;
+        Ok(self)
     }
 
     /// Shorthand to create cast expr to `target` type in explicit context.
-    pub fn cast_explicit(self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(self, target, CastContext::Explicit)
+    pub fn cast_explicit(mut self, target: DataType) -> Result<ExprImpl, CastError> {
+        FunctionCall::new_cast(&mut self, target, CastContext::Explicit)?;
+        Ok(self)
+    }
+
+    /// Shorthand to inplace cast expr to `target` type in implicit context.
+    pub fn cast_implicit_mut(&mut self, target: DataType) -> Result<(), CastError> {
+        FunctionCall::new_cast(self, target, CastContext::Implicit)
     }
 
     /// Shorthand to enforce implicit cast to boolean

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -167,6 +167,7 @@ impl ExprImpl {
         .into()
     }
 
+    /// Takes the expression, leaving a literal null of the same type in its place.
     pub fn take(&mut self) -> Self {
         std::mem::replace(self, Self::literal_null(self.return_type()))
     }
@@ -221,25 +222,25 @@ impl ExprImpl {
 
     /// Shorthand to create cast expr to `target` type in implicit context.
     pub fn cast_implicit(mut self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(&mut self, target, CastContext::Implicit)?;
+        FunctionCall::cast_mut(&mut self, target, CastContext::Implicit)?;
         Ok(self)
     }
 
     /// Shorthand to create cast expr to `target` type in assign context.
     pub fn cast_assign(mut self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(&mut self, target, CastContext::Assign)?;
+        FunctionCall::cast_mut(&mut self, target, CastContext::Assign)?;
         Ok(self)
     }
 
     /// Shorthand to create cast expr to `target` type in explicit context.
     pub fn cast_explicit(mut self, target: DataType) -> Result<ExprImpl, CastError> {
-        FunctionCall::new_cast(&mut self, target, CastContext::Explicit)?;
+        FunctionCall::cast_mut(&mut self, target, CastContext::Explicit)?;
         Ok(self)
     }
 
     /// Shorthand to inplace cast expr to `target` type in implicit context.
     pub fn cast_implicit_mut(&mut self, target: DataType) -> Result<(), CastError> {
-        FunctionCall::new_cast(self, target, CastContext::Implicit)
+        FunctionCall::cast_mut(self, target, CastContext::Implicit)
     }
 
     /// Shorthand to enforce implicit cast to boolean

--- a/src/frontend/src/expr/type_inference/cast.rs
+++ b/src/frontend/src/expr/type_inference/cast.rs
@@ -46,8 +46,6 @@ pub fn least_restrictive(lhs: DataType, rhs: DataType) -> std::result::Result<Da
 pub fn align_types<'a>(
     exprs: impl Iterator<Item = &'a mut ExprImpl>,
 ) -> std::result::Result<DataType, ErrorCode> {
-    use std::mem::swap;
-
     let exprs = exprs.collect_vec();
     // Essentially a filter_map followed by a try_reduce, which is unstable.
     let mut ret_type = None;
@@ -62,10 +60,8 @@ pub fn align_types<'a>(
     }
     let ret_type = ret_type.unwrap_or(DataType::Varchar);
     for e in exprs {
-        let mut dummy = ExprImpl::literal_bool(false);
-        swap(&mut dummy, e);
         // unwrap: cast to least_restrictive type always succeeds
-        *e = dummy.cast_implicit(ret_type.clone()).unwrap();
+        e.cast_implicit_mut(ret_type.clone()).unwrap();
     }
     Ok(ret_type)
 }
@@ -106,8 +102,7 @@ pub fn align_array_and_element(
     let array_type = DataType::List(Box::new(common_element_type));
 
     // elements are already casted by `align_types`, we cast the array argument here
-    let array_owned = std::mem::replace(&mut inputs[array_idx], ExprImpl::literal_bool(false));
-    inputs[array_idx] = array_owned.cast_implicit(array_type.clone())?;
+    inputs[array_idx].cast_implicit_mut(array_type.clone())?;
 
     Ok(array_type)
 }

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -392,17 +392,10 @@ fn infer_type_for_special(
                         extract_expr_nested_type(&inputs[1])?,
                     )?;
                     if lcast {
-                        let owned0 =
-                            std::mem::replace(&mut inputs[0], ExprImpl::literal_bool(true));
-                        inputs[0] =
-                            FunctionCall::new_unchecked(ExprType::Cast, vec![owned0], ret.clone())
-                                .into();
+                        inputs[0].cast_implicit_mut(ret.clone())?;
                     }
                     if rcast {
-                        let owned1 =
-                            std::mem::replace(&mut inputs[1], ExprImpl::literal_bool(true));
-                        inputs[1] =
-                            FunctionCall::new_unchecked(ExprType::Cast, vec![owned1], ret).into();
+                        inputs[1].cast_implicit_mut(ret)?;
                     }
                     true
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR contains 2 candidate solutions to simplify the repeated pattern below. **We only need one of them.**
```
let expr_owned = std::mem::replace(expr_mut_ref, new_dummy_expr());
*expr_mut_ref = expr_owned.cast_implicit(target_data_type)?;
```

Two straightforward but less desired approaches are:
* Extract this into a reusable `cast_mut` utility function
* `impl Default for ExprImpl` so that we can just `take` rather than `replace` with a dummy value

The first is not a proper abstraction because it may leave the input partially mutated. When the cast fails, the input is already replaced by the dummy expression. It is easier for the caller to have input unchanged when the function call fails.

As for the second, it is hard to select a proper *default* expression that is universally meaningful beyond the use case here. In this case anything works because it is immediately overwritten (or unused when the cast error bubbles up to the user).

The implementations in this PR are slightly improved over the 2 ideas above:
* Define the owned version `cast_implicit` as wrapper of `cast_mut`, rather than `cast_mut` over `cast_implicit`. This way we have finer control to only mutate at last after check for all possible errors (except for `try_for_each`, which may worth further imporvement).
* Define `ExprImpl::take` to update the expression to `null` of its original data type. This way the expression remains properly typed and it is easily accepted that `take` results in `null`.

Most of this PR is about the first approach, which refactors the existing `new_cast` from taking owned `child: ExprImpl` to `child: &mut ExprImpl`. The second is only used at one place that is not related cast - an expr rewriter in BoundJoin.

We only need to choose one of them. The first requires more code change, results in wired naming and signature (`new_cast(&mut ExprImpl) -> Result<()>`), and covers only cast but not expr rewriter. The second feels a little bit like cheating because we are actually cloning its return type - a more naive way of getting owned value from a mut ref is just to clone everything

Your opinions are welcomed.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
