### PR TITLE
fix(cdc): unique `database.server.name` for dbz mysql connector

### DIFF
--- a/e2e_test/source/cdc/cdc.check.slt
+++ b/e2e_test/source/cdc/cdc.check.slt
@@ -27,7 +27,12 @@ select count(*) as cnt from mytable;
 ----
 4
 
-query IIII
+query VI
+select count(*) from orders_2;
+----
+3
+
+query VII
 select count(*) from shipments_2;
 ----
 3

--- a/e2e_test/source/cdc/cdc.load.slt
+++ b/e2e_test/source/cdc/cdc.load.slt
@@ -88,6 +88,24 @@ create table mytable (
  server.id = '5087'
 );
 
+# Some columns missing and reordered (mysql-cdc)
+statement ok
+create table orders_2 (
+   order_id int,
+   price decimal,
+   customer_name string,
+   PRIMARY KEY (order_id)
+) with (
+ connector = 'mysql-cdc',
+ hostname = 'mysql',
+ port = '3306',
+ username = 'root',
+ password = '123456',
+ database.name = 'mydb',
+ table.name = 'orders',
+ server.id = '5087'
+);
+
 # Some columns missing and reordered (postgres-cdc)
 statement ok
 create table shipments_2 (

--- a/e2e_test/source/cdc/cdc.load.slt
+++ b/e2e_test/source/cdc/cdc.load.slt
@@ -88,6 +88,24 @@ create table mytable (
  server.id = '5087'
 );
 
+# Some columns missing and reordered (mysql-cdc)
+statement ok
+create table orders_2 (
+   order_id int,
+   price decimal,
+   customer_name string,
+   PRIMARY KEY (order_id)
+) with (
+ connector = 'mysql-cdc',
+ hostname = 'mysql',
+ port = '3306',
+ username = 'root',
+ password = '123456',
+ database.name = 'mydb',
+ table.name = 'orders',
+ server.id = '5088'
+);
+
 # Some columns missing and reordered (postgres-cdc)
 statement ok
 create table shipments_2 (

--- a/e2e_test/source/cdc/cdc.load.slt
+++ b/e2e_test/source/cdc/cdc.load.slt
@@ -88,24 +88,6 @@ create table mytable (
  server.id = '5087'
 );
 
-# Some columns missing and reordered (mysql-cdc)
-statement ok
-create table orders_2 (
-   order_id int,
-   price decimal,
-   customer_name string,
-   PRIMARY KEY (order_id)
-) with (
- connector = 'mysql-cdc',
- hostname = 'mysql',
- port = '3306',
- username = 'root',
- password = '123456',
- database.name = 'mydb',
- table.name = 'orders',
- server.id = '5087'
-);
-
 # Some columns missing and reordered (postgres-cdc)
 statement ok
 create table shipments_2 (

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/common/PostgresValidator.java
@@ -306,7 +306,11 @@ public class PostgresValidator extends DatabaseValidator implements AutoCloseabl
                     stmt.setString(1, tableOwner);
                     var res = stmt.executeQuery();
                     while (res.next()) {
-                        String[] users = (String[]) res.getArray("members").getArray();
+                        var usersArray = res.getArray("members");
+                        if (usersArray == null) {
+                            break;
+                        }
+                        String[] users = (String[]) usersArray.getArray();
                         if (null != users
                                 && Arrays.asList(users)
                                         .contains(userProps.get(DbzConnectorConfig.USER))) {

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/SourceHandlerFactory.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/source/core/SourceHandlerFactory.java
@@ -17,6 +17,7 @@ package com.risingwave.connector.source.core;
 import com.risingwave.connector.api.source.SourceHandler;
 import com.risingwave.connector.api.source.SourceTypeE;
 import com.risingwave.connector.source.common.DbzConnectorConfig;
+import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,7 +27,10 @@ public abstract class SourceHandlerFactory {
 
     public static SourceHandler createSourceHandler(
             SourceTypeE source, long sourceId, String startOffset, Map<String, String> userProps) {
-        var config = new DbzConnectorConfig(source, sourceId, startOffset, userProps);
+        // userProps extracted from grpc request, underlying implementation is UnmodifiableMap
+        Map<String, String> modifiableUserProps = new HashMap<>(userProps);
+        modifiableUserProps.put("source.id", Long.toString(sourceId));
+        var config = new DbzConnectorConfig(source, sourceId, startOffset, modifiableUserProps);
         LOG.info("resolved config for source#{}: {}", sourceId, config.getResolvedDebeziumProps());
         return new DbzSourceHandler(config);
     }

--- a/java/connector-node/risingwave-connector-service/src/main/resources/mysql.properties
+++ b/java/connector-node/risingwave-connector-service/src/main/resources/mysql.properties
@@ -16,6 +16,6 @@ table.include.list=${database.name}.${table.name}
 # default to disable schema change events
 include.schema.changes=${debezium.include.schema.changes:-false}
 database.server.id=${server.id}
-database.server.name=RW_CDC_${database.name}.${table.name}
+database.server.name=RW_CDC_${database.name}.${table.name}.${source.id}
 
 name=${hostname}:${port}:${database.name}.${table.name}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- related issue: https://github.com/risingwavelabs/risingwave/issues/10206
- the debezium property `database.server.name` should be unique for each connector
  - otherwise the metrics within debezium cannot be registered properly, causing a delay
- now for mysql connectors, `database.server.name=RW_CDC_${database.name}.${table.name}.${source.id}` since `source.id` is unique in rw

reference:
- https://groups.google.com/g/debezium/c/a2HE1Zgd6sQ?pli=1

## Checklist For Contributors

~~- [ ] I have written necessary rustdoc comments~~
- [x] I have added necessary unit tests and integration tests
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [x] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

