### PR TITLE
feat(expr): (preview) allow expr fns to access `DataType` of arg scalars

### DIFF
--- a/src/expr/src/expr/template.rs
+++ b/src/expr/src/expr/template.rs
@@ -613,7 +613,7 @@ mod tests {
             .unwrap()
             .unwrap()
             .as_int32();
-        assert_eq!(o, 2);
+        assert_eq!(o, 1);
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

**Note**: There is no immediate need to support this. Just initiating the discussion if anyone is interested.

Currently we implement a sql expression by a rust function like this:
```
fn foo(x: i32, y: &str, z: ListRef<'_>) -> Result<String>
```

This works well for parameterless types, such as `int`, `varchar`, `decimal`, `time`.

However, we are not able to tell whether the `ListRef` is an `int[][]` or `int[]` or `bool[]` when it is empty or only contains nulls. We have been avoiding this need by not supporting types `varchar(n)`, `decimal(p, s)`, `time(p)`, but it could be a problem for list and struct type.

This PR demonstrates a way to pass `DataType` into such functions:
```
fn foo(x: WithType<'_, i128>, y: WithType<'_, &str>, z: WithType<'_, ListRef<'_>>) -> Result<String>
```
where `WithType` is a simple struct:
```
pub struct WithType<'a, T> {
    pub value: T,
    pub data_type: &'a DataType,
}
```

Most content of the PR is copied from `UnaryExpresion` and then updated to use the new function signature.

Limitations:
* The expected return type cannot be passed this way. Note that expected return type is also an input argument, rather than an output determined during evaluation. For example the varchar to list cast.

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
