### PR TITLE
fix(meta): fix level not exist

### DIFF
--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -509,31 +509,13 @@ impl HummockVersionUpdateExt for HummockVersion {
                     delete_sst_levels.is_empty() && delete_sst_ids_set.is_empty() || has_destroy,
                     "no sst should be deleted when committing an epoch"
                 );
-                // The sst may be flushed by spill-to-s3, so we must sort them as epoch
-                // order.
-                for (max_epoch, ssts) in &insert_table_infos
-                    .into_iter()
-                    .sorted_by(|sst1, sst2| sst1.max_epoch.cmp(&sst2.max_epoch))
-                    .group_by(|sst| sst.max_epoch)
-                {
-                    let mut level_type = LevelType::Overlapping;
-                    let mut ssts = ssts.collect_vec();
-                    ssts.sort_by(|sst1, sst2| {
-                        let a = sst1.key_range.as_ref().unwrap();
-                        let b = sst2.key_range.as_ref().unwrap();
-                        a.compare(b)
-                    });
-                    if can_concat(&ssts) {
-                        level_type = LevelType::Nonoverlapping;
-                    }
-                    insert_new_sub_level(
-                        levels.l0.as_mut().unwrap(),
-                        max_epoch,
-                        level_type,
-                        ssts,
-                        None,
-                    );
-                }
+                insert_new_sub_level(
+                    levels.l0.as_mut().unwrap(),
+                    insert_sub_level_id,
+                    LevelType::Overlapping,
+                    insert_table_infos,
+                    None,
+                );
             } else {
                 // `max_committed_epoch` is not changed. The delta is caused by compaction.
                 levels.apply_compact_ssts(summary);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix https://github.com/risingwavelabs/risingwave/issues/10240

## Checklist For Contributors

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
