### PR TITLE
chore(ci): disable commit SST sanity check in CI

### DIFF
--- a/src/config/ci-iceberg-test.toml
+++ b/src/config/ci-iceberg-test.toml
@@ -1,6 +1,5 @@
 [meta]
 disable_recovery = true
-enable_committed_sst_sanity_check = true
 max_heartbeat_interval_secs = 600
 
 [streaming]

--- a/src/config/ci-recovery.toml
+++ b/src/config/ci-recovery.toml
@@ -1,6 +1,5 @@
 [meta]
 disable_recovery = false
-enable_committed_sst_sanity_check = true
 max_heartbeat_interval_secs = 600
 
 [streaming]

--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -1,6 +1,5 @@
 [meta]
 disable_recovery = true
-enable_committed_sst_sanity_check = true
 max_heartbeat_interval_secs = 600
 
 [streaming]

--- a/src/storage/src/hummock/validator.rs
+++ b/src/storage/src/hummock/validator.rs
@@ -46,9 +46,9 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
         );
         let holder = match sstable_store.sstable(&sst, unused.borrow_mut()).await {
             Ok(holder) => holder,
-            Err(err) => {
+            Err(_err) => {
                 // One reasonable cause is the SST has been vacuumed.
-                tracing::warn!("Skip sanity check for SST {}. {}", sst.get_object_id(), err);
+                tracing::info!("Skip sanity check for SST {}.", sst.get_object_id());
                 continue;
             }
         };
@@ -64,8 +64,8 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
             }),
         );
         let mut previous_key: Option<FullKey<Vec<u8>>> = None;
-        if let Err(err) = iter.rewind().await {
-            tracing::warn!("Skip sanity check for SST {}. {}", sst.get_object_id(), err);
+        if let Err(_err) = iter.rewind().await {
+            tracing::info!("Skip sanity check for SST {}.", sst.get_object_id());
         }
         while iter.is_valid() {
             key_counts += 1;
@@ -96,11 +96,10 @@ pub async fn validate_ssts(task: ValidationTask, sstable_store: SstableStoreRef)
                 }
             }
             previous_key = Some(current_key);
-            if let Err(err) = iter.next().await {
-                tracing::warn!(
-                    "Skip remaining sanity check for SST {}. {}",
+            if let Err(_err) = iter.next().await {
+                tracing::info!(
+                    "Skip remaining sanity check for SST {}",
                     sst.get_object_id(),
-                    err
                 );
                 break;
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As we're free from uniqueness/order violation bugs for a long time, this PR disable this sanity check in CI, hopefully accelerate its execution.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
