### PR TITLE
fix(build): do not fail if there's no `git` context

### DIFF
--- a/src/cmd_all/build.rs
+++ b/src/cmd_all/build.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::error::Error;
-
 use vergen::EmitBuilder;
 
-fn main() -> Result<(), Box<dyn Error>> {
-    EmitBuilder::builder().git_sha(true).emit()?;
-    Ok(())
+fn main() {
+    if let Err(e) = EmitBuilder::builder().git_sha(true).fail_on_error().emit() {
+        // Leave the environment variable unset if error occurs.
+        println!("cargo:warning={}", e)
+    }
 }

--- a/src/common/src/lib.rs
+++ b/src/common/src/lib.rs
@@ -74,10 +74,20 @@ pub mod test_prelude {
 
 pub const RW_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Placeholder for unknown git sha.
+pub const UNKNOWN_GIT_SHA: &str = "unknown";
+
+#[macro_export]
+macro_rules! git_sha {
+    ($env:literal) => {
+        match option_env!($env) {
+            Some(v) if !v.is_empty() => v,
+            _ => $crate::UNKNOWN_GIT_SHA,
+        }
+    };
+}
+
 // FIXME: We expand `unwrap_or` since it's unavailable in const context now.
 // `const_option_ext` was broken by https://github.com/rust-lang/rust/pull/110393
 // Tracking issue: https://github.com/rust-lang/rust/issues/91930
-pub const GIT_SHA: &str = match option_env!("GIT_SHA") {
-    Some(v) => v,
-    None => "unknown",
-};
+pub const GIT_SHA: &str = git_sha!("GIT_SHA");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After #10228, we will fail to compile if there's no `git` context.

- Leave `VERGEN_GIT_SHA` unset if there's no `git` CLI or not in a git repository.
- Treat empty `GIT_SHA` as unset as well.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
