### PR TITLE
refactor(binder): unify array function type checking

### DIFF
--- a/src/expr/src/vector_op/array_length.rs
+++ b/src/expr/src/vector_op/array_length.rs
@@ -56,7 +56,7 @@ use crate::ExprError;
 /// ----
 /// 1
 ///
-/// query error unknown type
+/// query error type unknown
 /// select array_length(null);
 /// ```
 #[function("array_length(list) -> int64")]

--- a/src/expr/src/vector_op/cardinality.rs
+++ b/src/expr/src/vector_op/cardinality.rs
@@ -54,7 +54,7 @@ use risingwave_expr_macro::function;
 /// ----
 /// 1
 ///
-/// query error unknown type
+/// query error type unknown
 /// select cardinality(null);
 /// ```
 #[function("cardinality(list) -> int64")]

--- a/src/frontend/planner_test/tests/testdata/output/concat_op_dispatch.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/concat_op_dispatch.yaml
@@ -36,7 +36,7 @@
     Bind error: failed to bind expression: ARRAY[1] || s
 
     Caused by:
-      Bind error: Cannot append integer[] to varchar
+      Bind error: Cannot append varchar to integer[]
 - name: jsonb || jsonb -> jsonb
   sql: |
     select '1'::jsonb || '2'::jsonb;

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -591,14 +591,11 @@ impl Binder {
                 (
                     "array_ndims",
                     guard_by_len(1, raw(|_binder, inputs| {
-                        let input = &inputs[0];
-                        if input.is_untyped() {
-                            return Err(ErrorCode::BindError("could not determine polymorphic type because input has type unknown".into()).into());
-                        }
-                        match input.return_type().array_ndims() {
-                            0 => Err(ErrorCode::BindError("array_ndims expects an array".into()).into()),
-                            n => Ok(ExprImpl::literal_int(n.try_into().map_err(|_| ErrorCode::BindError("array_ndims integer overflow".into()))?))
-                        }
+                        inputs[0].ensure_array_type()?;
+
+                        let n = inputs[0].return_type().array_ndims()
+                                .try_into().map_err(|_| ErrorCode::BindError("array_ndims integer overflow".into()))?;
+                        Ok(ExprImpl::literal_int(n))
                     })),
                 ),
                 (


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Use `ExprImpl::ensure_array_type` to reject untyped (`null` or `'{1,2}'`) or non-array inputs to array functions:
* `array_ndims`
* `array_lower` (forwards to `array_ndims`)
* `array_upper` (forwards to `array_length`)
* `array_dims`
* `array_length`
* `cardinality`
* `array_to_string`
* `trim_array`
* `array_distinct`

Note the following functions are declared with `anycompatiblearray` rather than `anyarray`, thus using a different rule `align_array_and_element` (done before this PR):
* `array_cat`
* `array_append`
* `array_prepend`
* `array_remove`
* `array_replace` (1d only)
* `array_position`
* `array_positions`

This PR also fixes:
* error message of `array_append`
* type checking of `string_to_array`

Note the return type of `array_length` and `cardinality` are still not fixed from int64 to int32 yet, because that would be breaking and will be handled separately.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.
