### PR TITLE
fix(expr): `array_length` and `cardinality` returns int32 as in PostgreSQL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6207,6 +6207,7 @@ dependencies = [
  "dyn-clone",
  "easy-ext",
  "either",
+ "expect-test",
  "futures-async-stream",
  "futures-util",
  "hex",

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -56,8 +56,8 @@ workspace-hack = { path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = "0.4"
-serde_json = "1"
 expect-test = "1"
+serde_json = "1"
 
 [[bench]]
 name = "expr"

--- a/src/expr/Cargo.toml
+++ b/src/expr/Cargo.toml
@@ -57,6 +57,7 @@ workspace-hack = { path = "../workspace-hack" }
 [dev-dependencies]
 criterion = "0.4"
 serde_json = "1"
+expect-test = "1"
 
 [[bench]]
 name = "expr"

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -110,6 +110,8 @@ static mut FUNC_SIG_MAP_INIT: Vec<FuncSign> = Vec::new();
 mod tests {
     use std::collections::BTreeMap;
 
+    use itertools::Itertools;
+
     use super::*;
 
     #[test]
@@ -137,10 +139,24 @@ mod tests {
             .filter_map(|(k, funcs_with_same_name)| {
                 let funcs_with_same_name_type: Vec<_> = funcs_with_same_name
                     .into_values()
-                    .filter(|v| v.len() > 1)
+                    .filter_map(|v| {
+                        if v.len() > 1 {
+                            Some(
+                                format!(
+                                    "{:}({:?}) -> {:?}",
+                                    v[0].func.as_str_name(),
+                                    v[0].inputs_type.iter().format(", "),
+                                    v.iter().map(|sig| sig.ret_type).format("/")
+                                )
+                                .to_ascii_lowercase(),
+                            )
+                        } else {
+                            None
+                        }
+                    })
                     .collect();
                 if !funcs_with_same_name_type.is_empty() {
-                    Some((k, funcs_with_same_name_type.into_iter().flatten().collect()))
+                    Some((k, funcs_with_same_name_type))
                 } else {
                     None
                 }
@@ -152,114 +168,30 @@ mod tests {
         let expected = expect_test::expect![[r#"
             {
                 Cast: [
-                    cast(boolean) -> int32,
-                    cast(boolean) -> varchar,
-                    cast(int16) -> int256,
-                    cast(int16) -> decimal,
-                    cast(int16) -> float64,
-                    cast(int16) -> float32,
-                    cast(int16) -> int64,
-                    cast(int16) -> int32,
-                    cast(int16) -> varchar,
-                    cast(int32) -> int256,
-                    cast(int32) -> int16,
-                    cast(int32) -> decimal,
-                    cast(int32) -> float64,
-                    cast(int32) -> float32,
-                    cast(int32) -> int64,
-                    cast(int32) -> boolean,
-                    cast(int32) -> varchar,
-                    cast(int64) -> int256,
-                    cast(int64) -> int32,
-                    cast(int64) -> int16,
-                    cast(int64) -> decimal,
-                    cast(int64) -> float64,
-                    cast(int64) -> float32,
-                    cast(int64) -> varchar,
-                    cast(float32) -> decimal,
-                    cast(float32) -> int64,
-                    cast(float32) -> int32,
-                    cast(float32) -> int16,
-                    cast(float32) -> float64,
-                    cast(float32) -> varchar,
-                    cast(float64) -> decimal,
-                    cast(float64) -> float32,
-                    cast(float64) -> int64,
-                    cast(float64) -> int32,
-                    cast(float64) -> int16,
-                    cast(float64) -> varchar,
-                    cast(decimal) -> float64,
-                    cast(decimal) -> float32,
-                    cast(decimal) -> int64,
-                    cast(decimal) -> int32,
-                    cast(decimal) -> int16,
-                    cast(decimal) -> varchar,
-                    cast(date) -> timestamp,
-                    cast(date) -> varchar,
-                    cast(varchar) -> date,
-                    cast(varchar) -> time,
-                    cast(varchar) -> timestamp,
-                    cast(varchar) -> jsonb,
-                    cast(varchar) -> interval,
-                    cast(varchar) -> int256,
-                    cast(varchar) -> float32,
-                    cast(varchar) -> float64,
-                    cast(varchar) -> decimal,
-                    cast(varchar) -> int16,
-                    cast(varchar) -> int32,
-                    cast(varchar) -> int64,
-                    cast(varchar) -> varchar,
-                    cast(varchar) -> boolean,
-                    cast(varchar) -> bytea,
-                    cast(varchar) -> list,
-                    cast(time) -> interval,
-                    cast(time) -> varchar,
-                    cast(timestamp) -> date,
-                    cast(timestamp) -> time,
-                    cast(timestamp) -> varchar,
-                    cast(interval) -> time,
-                    cast(interval) -> varchar,
-                    cast(list) -> varchar,
-                    cast(list) -> list,
-                    cast(jsonb) -> boolean,
-                    cast(jsonb) -> float64,
-                    cast(jsonb) -> float32,
-                    cast(jsonb) -> decimal,
-                    cast(jsonb) -> int64,
-                    cast(jsonb) -> int32,
-                    cast(jsonb) -> int16,
-                    cast(jsonb) -> varchar,
-                    cast(int256) -> float64,
-                    cast(int256) -> varchar,
+                    "cast(boolean) -> int32/varchar",
+                    "cast(int16) -> int256/decimal/float64/float32/int64/int32/varchar",
+                    "cast(int32) -> int256/int16/decimal/float64/float32/int64/boolean/varchar",
+                    "cast(int64) -> int256/int32/int16/decimal/float64/float32/varchar",
+                    "cast(float32) -> decimal/int64/int32/int16/float64/varchar",
+                    "cast(float64) -> decimal/float32/int64/int32/int16/varchar",
+                    "cast(decimal) -> float64/float32/int64/int32/int16/varchar",
+                    "cast(date) -> timestamp/varchar",
+                    "cast(varchar) -> date/time/timestamp/jsonb/interval/int256/float32/float64/decimal/int16/int32/int64/varchar/boolean/bytea/list",
+                    "cast(time) -> interval/varchar",
+                    "cast(timestamp) -> date/time/varchar",
+                    "cast(interval) -> time/varchar",
+                    "cast(list) -> varchar/list",
+                    "cast(jsonb) -> boolean/float64/float32/decimal/int64/int32/int16/varchar",
+                    "cast(int256) -> float64/varchar",
                 ],
                 ArrayAccess: [
-                    array_access(list, int32) -> boolean,
-                    array_access(list, int32) -> int16,
-                    array_access(list, int32) -> int32,
-                    array_access(list, int32) -> int64,
-                    array_access(list, int32) -> int256,
-                    array_access(list, int32) -> float32,
-                    array_access(list, int32) -> float64,
-                    array_access(list, int32) -> decimal,
-                    array_access(list, int32) -> serial,
-                    array_access(list, int32) -> date,
-                    array_access(list, int32) -> time,
-                    array_access(list, int32) -> timestamp,
-                    array_access(list, int32) -> timestamptz,
-                    array_access(list, int32) -> interval,
-                    array_access(list, int32) -> varchar,
-                    array_access(list, int32) -> bytea,
-                    array_access(list, int32) -> jsonb,
-                    array_access(list, int32) -> list,
-                    array_access(list, int32) -> struct,
+                    "array_access(list, int32) -> boolean/int16/int32/int64/int256/float32/float64/decimal/serial/date/time/timestamp/timestamptz/interval/varchar/bytea/jsonb/list/struct",
                 ],
                 ArrayLength: [
-                    array_length(list) -> int64,
-                    array_length(list) -> int32,
+                    "array_length(list) -> int64/int32",
                 ],
                 Cardinality: [
-                    cardinality(list) -> int64,
-                    cardinality(list) -> int32,
+                    "cardinality(list) -> int64/int32",
                 ],
             }
         "#]];

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -105,3 +105,164 @@ pub unsafe fn _register(desc: FuncSign) {
 /// vector. The calls are guaranteed to be sequential. The vector will be drained and moved into
 /// `FUNC_SIG_MAP` on the first access of `FUNC_SIG_MAP`.
 static mut FUNC_SIG_MAP_INIT: Vec<FuncSign> = Vec::new();
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+
+    #[test]
+    fn test_func_sig_map() {
+        // convert FUNC_SIG_MAP to a more convenient map for testing
+        let mut new_map: BTreeMap<PbType, BTreeMap<Vec<DataTypeName>, Vec<FuncSign>>> =
+            BTreeMap::new();
+        for ((func, num_args), sigs) in FUNC_SIG_MAP.0.iter() {
+            for sig in sigs {
+                // validate the FUNC_SIG_MAP is consistent
+                assert_eq!(func, &sig.func);
+                assert_eq!(num_args, &sig.inputs_type.len());
+
+                new_map
+                    .entry(*func)
+                    .or_default()
+                    .entry(sig.inputs_type.to_vec())
+                    .or_default()
+                    .push(sig.clone());
+            }
+        }
+
+        let duplicated: BTreeMap<_, Vec<_>> = new_map
+            .into_iter()
+            .filter_map(|(k, funcs_with_same_name)| {
+                let funcs_with_same_name_type: Vec<_> = funcs_with_same_name
+                    .into_values()
+                    .filter(|v| v.len() > 1)
+                    .collect();
+                if !funcs_with_same_name_type.is_empty() {
+                    Some((k, funcs_with_same_name_type.into_iter().flatten().collect()))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // This snapshot shows the function signatures without a unique match. Frontend has to
+        // handle them specially without relying on FuncSigMap.
+        let expected = expect_test::expect![[r#"
+            {
+                Cast: [
+                    cast(boolean) -> int32,
+                    cast(boolean) -> varchar,
+                    cast(int16) -> int256,
+                    cast(int16) -> decimal,
+                    cast(int16) -> float64,
+                    cast(int16) -> float32,
+                    cast(int16) -> int64,
+                    cast(int16) -> int32,
+                    cast(int16) -> varchar,
+                    cast(int32) -> int256,
+                    cast(int32) -> int16,
+                    cast(int32) -> decimal,
+                    cast(int32) -> float64,
+                    cast(int32) -> float32,
+                    cast(int32) -> int64,
+                    cast(int32) -> boolean,
+                    cast(int32) -> varchar,
+                    cast(int64) -> int256,
+                    cast(int64) -> int32,
+                    cast(int64) -> int16,
+                    cast(int64) -> decimal,
+                    cast(int64) -> float64,
+                    cast(int64) -> float32,
+                    cast(int64) -> varchar,
+                    cast(float32) -> decimal,
+                    cast(float32) -> int64,
+                    cast(float32) -> int32,
+                    cast(float32) -> int16,
+                    cast(float32) -> float64,
+                    cast(float32) -> varchar,
+                    cast(float64) -> decimal,
+                    cast(float64) -> float32,
+                    cast(float64) -> int64,
+                    cast(float64) -> int32,
+                    cast(float64) -> int16,
+                    cast(float64) -> varchar,
+                    cast(decimal) -> float64,
+                    cast(decimal) -> float32,
+                    cast(decimal) -> int64,
+                    cast(decimal) -> int32,
+                    cast(decimal) -> int16,
+                    cast(decimal) -> varchar,
+                    cast(date) -> timestamp,
+                    cast(date) -> varchar,
+                    cast(varchar) -> date,
+                    cast(varchar) -> time,
+                    cast(varchar) -> timestamp,
+                    cast(varchar) -> jsonb,
+                    cast(varchar) -> interval,
+                    cast(varchar) -> int256,
+                    cast(varchar) -> float32,
+                    cast(varchar) -> float64,
+                    cast(varchar) -> decimal,
+                    cast(varchar) -> int16,
+                    cast(varchar) -> int32,
+                    cast(varchar) -> int64,
+                    cast(varchar) -> varchar,
+                    cast(varchar) -> boolean,
+                    cast(varchar) -> bytea,
+                    cast(varchar) -> list,
+                    cast(time) -> interval,
+                    cast(time) -> varchar,
+                    cast(timestamp) -> date,
+                    cast(timestamp) -> time,
+                    cast(timestamp) -> varchar,
+                    cast(interval) -> time,
+                    cast(interval) -> varchar,
+                    cast(list) -> varchar,
+                    cast(list) -> list,
+                    cast(jsonb) -> boolean,
+                    cast(jsonb) -> float64,
+                    cast(jsonb) -> float32,
+                    cast(jsonb) -> decimal,
+                    cast(jsonb) -> int64,
+                    cast(jsonb) -> int32,
+                    cast(jsonb) -> int16,
+                    cast(jsonb) -> varchar,
+                    cast(int256) -> float64,
+                    cast(int256) -> varchar,
+                ],
+                ArrayAccess: [
+                    array_access(list, int32) -> boolean,
+                    array_access(list, int32) -> int16,
+                    array_access(list, int32) -> int32,
+                    array_access(list, int32) -> int64,
+                    array_access(list, int32) -> int256,
+                    array_access(list, int32) -> float32,
+                    array_access(list, int32) -> float64,
+                    array_access(list, int32) -> decimal,
+                    array_access(list, int32) -> serial,
+                    array_access(list, int32) -> date,
+                    array_access(list, int32) -> time,
+                    array_access(list, int32) -> timestamp,
+                    array_access(list, int32) -> timestamptz,
+                    array_access(list, int32) -> interval,
+                    array_access(list, int32) -> varchar,
+                    array_access(list, int32) -> bytea,
+                    array_access(list, int32) -> jsonb,
+                    array_access(list, int32) -> list,
+                    array_access(list, int32) -> struct,
+                ],
+                ArrayLength: [
+                    array_length(list) -> int64,
+                    array_length(list) -> int32,
+                ],
+                Cardinality: [
+                    cardinality(list) -> int64,
+                    cardinality(list) -> int32,
+                ],
+            }
+        "#]];
+        expected.assert_debug_eq(&duplicated);
+    }
+}

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -119,7 +119,7 @@ mod tests {
         // convert FUNC_SIG_MAP to a more convenient map for testing
         let mut new_map: BTreeMap<PbType, BTreeMap<Vec<DataTypeName>, Vec<FuncSign>>> =
             BTreeMap::new();
-        for ((func, num_args), sigs) in FUNC_SIG_MAP.0.iter() {
+        for ((func, num_args), sigs) in &FUNC_SIG_MAP.0 {
             for sig in sigs {
                 // validate the FUNC_SIG_MAP is consistent
                 assert_eq!(func, &sig.func);

--- a/src/expr/src/vector_op/array_length.rs
+++ b/src/expr/src/vector_op/array_length.rs
@@ -59,8 +59,9 @@ use crate::ExprError;
 /// query error type unknown
 /// select array_length(null);
 /// ```
-#[function("array_length(list) -> int64")]
-fn array_length(array: ListRef<'_>) -> Result<i64, ExprError> {
+#[function("array_length(list) -> int32")]
+#[function("array_length(list) -> int64")] // for compatibility with plans from old version
+fn array_length<T: TryFrom<usize>>(array: ListRef<'_>) -> Result<T, ExprError> {
     array
         .len()
         .try_into()
@@ -126,8 +127,8 @@ fn array_length(array: ListRef<'_>) -> Result<i64, ExprError> {
 /// statement error
 /// select array_length(array[null, array[2]], 2);
 /// ```
-#[function("array_length(list, int32) -> int64")]
-fn array_length_d(array: ListRef<'_>, d: i32) -> Result<Option<i64>, ExprError> {
+#[function("array_length(list, int32) -> int32")]
+fn array_length_of_dim(array: ListRef<'_>, d: i32) -> Result<Option<i32>, ExprError> {
     match d {
         ..=0 => Ok(None),
         1 => array_length(array).map(Some),

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -604,7 +604,7 @@ fn infer_type_for_special(
                 arg1.cast_implicit_mut(DataType::Int32)?;
             }
 
-            Ok(Some(DataType::Int64))
+            Ok(Some(DataType::Int32))
         }
         ExprType::StringToArray => {
             ensure_arity!("string_to_array", 2 <= | inputs | <= 3);
@@ -619,7 +619,7 @@ fn infer_type_for_special(
             ensure_arity!("cardinality", | inputs | == 1);
             inputs[0].ensure_array_type()?;
 
-            Ok(Some(DataType::Int64))
+            Ok(Some(DataType::Int32))
         }
         ExprType::TrimArray => {
             ensure_arity!("trim_array", | inputs | == 2);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Since this commit, the frontend will generate plans with `int32`.

For backward compatibility, the backend will run both `int32` and `int64` variants as requested by the query plan.

Note: Having both `cardinality(list) -> int32` and `cardinality(list) -> int64` in the function signature map means the type inferring logic cannot find a unique match. But we have them covered in `infer_type_for_special` to always return `int32`. Eventually it is still better to clean them up from the function signature map.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have demonstrated that backward compatibility is not broken by breaking changes and created issues to track deprecated features to be removed in the future. (Please refer to the issue)
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

`array_length` and `cardinality` returns int32 as in PostgreSQL