### PR TITLE
refactor(sink): prune out hidden columns within sink executor

### DIFF
--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -145,15 +145,17 @@ message SourceNode {
 }
 
 message SinkDesc {
+  reserved 4;
+  reserved "columns";
   uint32 id = 1;
   string name = 2;
   string definition = 3;
-  repeated plan_common.ColumnDesc columns = 4;
   repeated common.ColumnOrder plan_pk = 5;
   repeated uint32 downstream_pk = 6;
   repeated uint32 distribution_key = 7;
   map<string, string> properties = 8;
   catalog.SinkType sink_type = 9;
+  repeated plan_common.ColumnCatalog column_catalogs = 10;
 }
 
 message SinkNode {

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -19,7 +19,6 @@ use risingwave_common::catalog::{
     ColumnCatalog, ConnectionId, DatabaseId, SchemaId, TableId, UserId,
 };
 use risingwave_common::util::sort_util::ColumnOrder;
-use risingwave_pb::plan_common::PbColumnDesc;
 use risingwave_pb::stream_plan::PbSinkDesc;
 
 use super::{SinkCatalog, SinkId, SinkType};
@@ -89,10 +88,10 @@ impl SinkDesc {
             id: self.id.sink_id,
             name: self.name.clone(),
             definition: self.definition.clone(),
-            columns: self
+            column_catalogs: self
                 .columns
                 .iter()
-                .map(|column| Into::<PbColumnDesc>::into(&column.column_desc))
+                .map(|column| column.to_protobuf())
                 .collect_vec(),
             plan_pk: self.plan_pk.iter().map(|k| k.to_protobuf()).collect_vec(),
             downstream_pk: self.downstream_pk.iter().map(|idx| *idx as _).collect_vec(),

--- a/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/nexmark.yaml
@@ -43,10 +43,9 @@
     BatchExchange { order: [], dist: Single }
     └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, bidder, price, date_time] }
-    └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time] }
-      └─StreamExchange { dist: Single }
-        └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, bidder, price, date_time, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
@@ -89,11 +88,10 @@
     └─BatchProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, bid.date_time] }
       └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, bidder, price, date_time] }
-    └─StreamProject { exprs: [bid.auction, bid.bidder, $expr1, bid.date_time] }
-      └─StreamExchange { dist: Single }
-        └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, bid.date_time, bid._row_id] }
-          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, bidder, price, date_time, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, bid.date_time, bid._row_id] }
+        └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, bid.date_time, bid._row_id] }
@@ -132,11 +130,10 @@
     └─BatchFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
       └─BatchScan { table: bid, columns: [bid.auction, bid.price], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, price] }
-    └─StreamProject { exprs: [bid.auction, bid.price] }
-      └─StreamExchange { dist: Single }
-        └─StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
-          └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, price, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
+        └─StreamTableScan { table: bid, columns: [bid.auction, bid.price, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, price, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamFilter { predicate: (((((bid.auction = 1007:Int32) OR (bid.auction = 1020:Int32)) OR (bid.auction = 2001:Int32)) OR (bid.auction = 2019:Int32)) OR (bid.auction = 2087:Int32)) }
@@ -820,11 +817,10 @@
     └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(bid.date_time, 'HH:MI':Varchar) as $expr2] }
       └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, bidder, price, date_time, date, time] }
-    └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, $expr1, $expr2] }
-      └─StreamExchange { dist: Single }
-        └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(bid.date_time, 'HH:MI':Varchar) as $expr2, bid._row_id] }
-          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(bid.date_time, 'HH:MI':Varchar) as $expr2, bid._row_id] }
+        └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, date_time, date, time, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.date_time, ToChar(bid.date_time, 'YYYY-MM-DD':Varchar) as $expr1, ToChar(bid.date_time, 'HH:MI':Varchar) as $expr2, bid._row_id] }
@@ -927,12 +923,11 @@
       └─BatchFilter { predicate: ((0.908:Decimal * bid.price::Decimal) > 1000000:Decimal) AND ((0.908:Decimal * bid.price::Decimal) < 50000000:Decimal) }
         └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, bidder, price, bidtimetype, date_time, extra] }
-    └─StreamProject { exprs: [bid.auction, bid.bidder, $expr1, $expr2, bid.date_time, bid.extra] }
-      └─StreamExchange { dist: Single }
-        └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Decimal) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Decimal)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Decimal) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Decimal)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, bid.date_time, bid.extra, bid._row_id] }
-          └─StreamFilter { predicate: ((0.908:Decimal * bid.price::Decimal) > 1000000:Decimal) AND ((0.908:Decimal * bid.price::Decimal) < 50000000:Decimal) }
-            └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Decimal) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Decimal)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Decimal) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Decimal)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, bid.date_time, bid.extra, bid._row_id] }
+        └─StreamFilter { predicate: ((0.908:Decimal * bid.price::Decimal) > 1000000:Decimal) AND ((0.908:Decimal * bid.price::Decimal) < 50000000:Decimal) }
+          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.date_time, bid.extra, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, bidtimetype, date_time, extra, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, bid.bidder, (0.908:Decimal * bid.price::Decimal) as $expr1, Case(((Extract('HOUR':Varchar, bid.date_time) >= 8:Decimal) AND (Extract('HOUR':Varchar, bid.date_time) <= 18:Decimal)), 'dayTime':Varchar, ((Extract('HOUR':Varchar, bid.date_time) <= 6:Decimal) OR (Extract('HOUR':Varchar, bid.date_time) >= 20:Decimal)), 'nightTime':Varchar, 'otherTime':Varchar) as $expr2, bid.date_time, bid.extra, bid._row_id] }
@@ -1385,11 +1380,10 @@
     └─BatchProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32) as $expr1, SplitPart(bid.url, '/':Varchar, 5:Int32) as $expr2, SplitPart(bid.url, '/':Varchar, 6:Int32) as $expr3] }
       └─BatchScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url], distribution: SomeShard }
   sink_plan: |
-    StreamSink { type: append-only, columns: [auction, bidder, price, channel, dir1, dir2, dir3] }
-    └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, $expr1, $expr2, $expr3] }
-      └─StreamExchange { dist: Single }
-        └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32) as $expr1, SplitPart(bid.url, '/':Varchar, 5:Int32) as $expr2, SplitPart(bid.url, '/':Varchar, 6:Int32) as $expr3, bid._row_id] }
-          └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
+    StreamSink { type: append-only, columns: [auction, bidder, price, channel, dir1, dir2, dir3, bid._row_id(hidden)] }
+    └─StreamExchange { dist: Single }
+      └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32) as $expr1, SplitPart(bid.url, '/':Varchar, 5:Int32) as $expr2, SplitPart(bid.url, '/':Varchar, 6:Int32) as $expr3, bid._row_id] }
+        └─StreamTableScan { table: bid, columns: [bid.auction, bid.bidder, bid.price, bid.channel, bid.url, bid._row_id], pk: [bid._row_id], dist: UpstreamHashShard(bid._row_id) }
   stream_plan: |
     StreamMaterialize { columns: [auction, bidder, price, channel, dir1, dir2, dir3, bid._row_id(hidden)], stream_key: [bid._row_id], pk_columns: [bid._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [bid.auction, bid.bidder, bid.price, bid.channel, SplitPart(bid.url, '/':Varchar, 4:Int32) as $expr1, SplitPart(bid.url, '/':Varchar, 5:Int32) as $expr2, SplitPart(bid.url, '/':Varchar, 6:Int32) as $expr3, bid._row_id] }

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -269,7 +269,7 @@ impl fmt::Display for StreamSink {
             .sink_desc
             .columns
             .iter()
-            .map(|col| col.column_desc.name.clone())
+            .map(|col| col.name_with_hidden())
             .collect_vec()
             .join(", ");
         builder

--- a/src/stream/src/executor/sink.rs
+++ b/src/stream/src/executor/sink.rs
@@ -18,9 +18,10 @@ use std::time::Instant;
 use futures::stream::select;
 use futures::{FutureExt, StreamExt};
 use futures_async_stream::try_stream;
+use itertools::Itertools;
 use prometheus::Histogram;
 use risingwave_common::array::{Op, StreamChunk};
-use risingwave_common::catalog::Schema;
+use risingwave_common::catalog::{ColumnCatalog, Schema};
 use risingwave_common::row::Row;
 use risingwave_common::types::DataType;
 use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
@@ -40,6 +41,7 @@ pub struct SinkExecutor<F: LogStoreFactory> {
     sink: SinkImpl,
     config: SinkConfig,
     identity: String,
+    columns: Vec<ColumnCatalog>,
     schema: Schema,
     pk_indices: Vec<usize>,
     sink_type: SinkType,
@@ -89,12 +91,12 @@ fn force_append_only(chunk: StreamChunk, data_types: Vec<DataType>) -> Option<St
 impl<F: LogStoreFactory> SinkExecutor<F> {
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
-        materialize_executor: BoxedExecutor,
+        input: BoxedExecutor,
         metrics: Arc<StreamingMetrics>,
         config: SinkConfig,
         executor_id: u64,
         connector_params: ConnectorParams,
-        schema: Schema,
+        columns: Vec<ColumnCatalog>,
         pk_indices: Vec<usize>,
         sink_type: SinkType,
         sink_id: u64,
@@ -102,6 +104,10 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         log_store_factory: F,
     ) -> StreamExecutorResult<Self> {
         let (log_reader, log_writer) = log_store_factory.build().await;
+        let schema: Schema = columns
+            .iter()
+            .map(|column| column.column_desc.clone().into())
+            .collect();
         let sink = build_sink(
             config.clone(),
             schema.clone(),
@@ -112,11 +118,12 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         )
         .await?;
         Ok(Self {
-            input: materialize_executor,
+            input,
             metrics,
             sink,
             config,
             identity: format!("SinkExecutor {:X?}", executor_id),
+            columns,
             schema,
             sink_type,
             pk_indices,
@@ -140,6 +147,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
             self.input,
             self.log_writer,
             self.schema,
+            self.columns,
             self.sink_type,
             self.actor_context,
         );
@@ -155,6 +163,7 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         input: BoxedExecutor,
         mut log_writer: impl LogWriter,
         schema: Schema,
+        columns: Vec<ColumnCatalog>,
         sink_type: SinkType,
         actor_context: ActorContextRef,
     ) {
@@ -170,6 +179,12 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
         // Propagate the first barrier
         yield Message::Barrier(barrier);
 
+        let visible_columns = columns
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, column)| (!column.is_hidden).then(|| idx))
+            .collect_vec();
+
         #[for_await]
         for msg in input {
             match msg? {
@@ -184,7 +199,12 @@ impl<F: LogStoreFactory> SinkExecutor<F> {
                         Some(chunk.clone().compact())
                     };
 
-                    if let Some(chunk) = visible_chunk {
+                    if let Some(mut chunk) = visible_chunk {
+                        if visible_columns.len() != columns.len() {
+                            // Do projection here because we may have columns that aren't visible to
+                            // the downstream.
+                            chunk = chunk.reorder_columns(&visible_columns);
+                        }
                         // NOTE: We start the txn here because a force-append-only sink might
                         // receive a data chunk full of DELETE messages and then drop all of them.
                         // At this point (instead of the point above when we receive the upstream
@@ -312,7 +332,7 @@ impl<F: LogStoreFactory> Executor for SinkExecutor<F> {
     }
 
     fn schema(&self) -> &Schema {
-        self.input.schema()
+        &self.schema
     }
 
     fn pk_indices(&self) -> super::PkIndicesRef<'_> {
@@ -326,6 +346,8 @@ impl<F: LogStoreFactory> Executor for SinkExecutor<F> {
 
 #[cfg(test)]
 mod test {
+    use risingwave_common::catalog::{ColumnDesc, ColumnId};
+
     use super::*;
     use crate::common::log_store::BoundedInMemLogStoreFactory;
     use crate::executor::test_utils::*;
@@ -335,7 +357,6 @@ mod test {
     async fn test_force_append_only_sink() {
         use risingwave_common::array::stream_chunk::StreamChunk;
         use risingwave_common::array::StreamChunkTestExt;
-        use risingwave_common::catalog::Field;
         use risingwave_common::types::DataType;
 
         use crate::executor::Barrier;
@@ -345,31 +366,48 @@ mod test {
             "type".into() => "append-only".into(),
             "force_append_only".into() => "true".into()
         };
-        let schema = Schema::new(vec![
-            Field::with_name(DataType::Int64, "v1"),
-            Field::with_name(DataType::Int64, "v2"),
-        ]);
+
+        // We have two visible columns and one hidden column. The hidden column will be pruned out
+        // within the sink executor.
+        let columns = vec![
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(1), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(2), DataType::Int64),
+                is_hidden: true,
+            },
+        ];
+        let schema: Schema = columns
+            .iter()
+            .map(|column| column.column_desc.clone().into())
+            .collect();
         let pk = vec![0];
 
         let mock = MockSource::with_messages(
-            schema.clone(),
+            schema,
             pk.clone(),
             vec![
                 Message::Barrier(Barrier::new_test_barrier(1)),
                 Message::Chunk(std::mem::take(&mut StreamChunk::from_pretty(
-                    " I I
-                    + 3 2",
+                    " I I I
+                    + 3 2 1",
                 ))),
                 Message::Barrier(Barrier::new_test_barrier(2)),
                 Message::Chunk(std::mem::take(&mut StreamChunk::from_pretty(
-                    "  I I
-                    U- 3 2
-                    U+ 3 4
-                     + 5 6",
+                    "  I I I
+                    U- 3 2 1
+                    U+ 3 4 1
+                     + 5 6 7",
                 ))),
                 Message::Chunk(std::mem::take(&mut StreamChunk::from_pretty(
-                    " I I
-                    - 5 6",
+                    " I I I
+                    - 5 6 7",
                 ))),
             ],
         );
@@ -381,7 +419,7 @@ mod test {
             config,
             0,
             Default::default(),
-            schema.clone(),
+            columns.clone(),
             pk.clone(),
             SinkType::ForceAppendOnly,
             0,
@@ -427,7 +465,6 @@ mod test {
 
     #[tokio::test]
     async fn test_empty_barrier_sink() {
-        use risingwave_common::catalog::Field;
         use risingwave_common::types::DataType;
 
         use crate::executor::Barrier;
@@ -437,14 +474,24 @@ mod test {
             "type".into() => "append-only".into(),
             "force_append_only".into() => "true".into()
         };
-        let schema = Schema::new(vec![
-            Field::with_name(DataType::Int64, "v1"),
-            Field::with_name(DataType::Int64, "v2"),
-        ]);
+        let columns = vec![
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(0), DataType::Int64),
+                is_hidden: false,
+            },
+            ColumnCatalog {
+                column_desc: ColumnDesc::unnamed(ColumnId::new(1), DataType::Int64),
+                is_hidden: false,
+            },
+        ];
+        let schema: Schema = columns
+            .iter()
+            .map(|column| column.column_desc.clone().into())
+            .collect();
         let pk = vec![0];
 
         let mock = MockSource::with_messages(
-            schema.clone(),
+            schema,
             pk.clone(),
             vec![
                 Message::Barrier(Barrier::new_test_barrier(1)),
@@ -460,7 +507,7 @@ mod test {
             config,
             0,
             Default::default(),
-            schema.clone(),
+            columns,
             pk.clone(),
             SinkType::ForceAppendOnly,
             0,

--- a/src/stream/src/from_proto/sink.rs
+++ b/src/stream/src/from_proto/sink.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use risingwave_common::catalog::ColumnCatalog;
 use risingwave_connector::sink::catalog::SinkType;
 use risingwave_connector::sink::kafka::KAFKA_SINK;
 use risingwave_connector::sink::{SinkConfig, DOWNSTREAM_SINK_KEY};
@@ -44,7 +45,12 @@ impl ExecutorBuilder for SinkExecutorBuilder {
             .iter()
             .map(|i| *i as usize)
             .collect_vec();
-        let schema = sink_desc.columns.iter().map(Into::into).collect();
+        let columns = sink_desc
+            .column_catalogs
+            .clone()
+            .into_iter()
+            .map(ColumnCatalog::from)
+            .collect_vec();
         // This field can be used to distinguish a specific actor in parallelism to prevent
         // transaction execution errors
         if let Some(connector) = properties.get(DOWNSTREAM_SINK_KEY) && connector == KAFKA_SINK {
@@ -62,7 +68,7 @@ impl ExecutorBuilder for SinkExecutorBuilder {
                 config,
                 params.executor_id,
                 params.env.connector_params(),
-                schema,
+                columns,
                 pk_indices,
                 sink_type,
                 sink_id,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously, we insert a `Project` node before the sink executor if the sink's output columns are a subset of its input columns. After we introduce the log store in sink, however, we'll have to compute the vnode (i.e. distribution) within the sink executor. In this PR, we thereby input all columns into the sink executor for the sake of vnode computation, and do the column pruning within the sink executor instead of using a `Project` node.

## Checklist For Contributors

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Checklist For Reviewers

- [ ] I have requested macro/micro-benchmarks as this PR can affect performance substantially, and the results are shown.
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR **DOES NOT** contain user-facing changes.

<!-- 

You can ignore or delete the section below if you ticked the checkbox above.

Otherwise, remove the checkbox above and write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
