### PR TITLE
chore(sqlsmith): disable deterministic tests being run per PR

### DIFF
--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -57,8 +57,8 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     echo "--- Kill cluster"
     cargo make kill
 
-    # FIXME(Noel): Disable for now, deterministic e2e fuzzing should only
-    # be ran for pre-generated queries.
-    echo "--- deterministic simulation e2e, ci-3cn-2fe, fuzzing (seed)"
-    seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --sqlsmith 100 ./src/tests/sqlsmith/tests/testdata 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'
+    # NOTE(Noel): This is disabled because once it fails, it keeps failing.
+    # That blocks PRs from getting through.
+    # echo "--- deterministic simulation e2e, ci-3cn-2fe, fuzzing (seed)"
+    # seq $TEST_NUM | parallel MADSIM_TEST_SEED={} './risingwave_simulation --sqlsmith 100 ./src/tests/sqlsmith/tests/testdata 2> $LOGDIR/fuzzing-{}.log && rm $LOGDIR/fuzzing-{}.log'
 fi

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -193,7 +193,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
-    timeout_in_minutes: 15
+    timeout_in_minutes: 25
 
   - label: "check"
     command: "ci/scripts/check.sh"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Sometimes it fails and blocks PRs. Unlike random fuzz test, once deterministic test fails, it keeps failing and blocks the PR. We can't re-run it to try and unblock.

Random fuzz test will still run for PRs with changes to sqlsmith source files or scripts.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
