### PR TITLE
fix(storage): force_path_style for minio

### DIFF
--- a/src/object_store/src/object/s3.rs
+++ b/src/object_store/src/object/s3.rs
@@ -587,7 +587,8 @@ impl S3ObjectStore {
         let builder = aws_sdk_s3::config::Builder::new();
         #[cfg(not(madsim))]
         let builder =
-            aws_sdk_s3::config::Builder::from(&aws_config::ConfigLoader::default().load().await);
+            aws_sdk_s3::config::Builder::from(&aws_config::ConfigLoader::default().load().await)
+                .force_path_style(true);
 
         let config = builder
             .region(Region::new("custom"))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix incompatibility between MinIO and AWS SDK of new version.
See https://github.com/awslabs/aws-sdk-rust/issues/727

## Checklist
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
