### PR TITLE
refactor: replace minstant/minitrace with tokio instant/tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,35 +320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-executor"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa3dc5f2a8564f07759c008b9109dc0d39de92a88d5588b8a5036d286383afb"
-dependencies = [
- "async-lock",
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "slab",
-]
-
-[[package]]
-name = "async-global-executor"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1b6f5d7df27bd294849f8eec66ecfc63d11814df7a4f5d74168a2394467b776"
-dependencies = [
- "async-channel",
- "async-executor",
- "async-io",
- "async-lock",
- "blocking",
- "futures-lite",
- "once_cell",
-]
-
-[[package]]
 name = "async-io"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,32 +357,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.15",
-]
-
-[[package]]
-name = "async-std"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62565bb4402e926b29953c785397c6dc0391b7b446e45008b0049eb43cec6f5d"
-dependencies = [
- "async-channel",
- "async-global-executor",
- "async-io",
- "async-lock",
- "crossbeam-utils",
- "futures-channel",
- "futures-core",
- "futures-io",
- "futures-lite",
- "gloo-timers",
- "kv-log-macro",
- "log",
- "memchr",
- "once_cell",
- "pin-project-lite",
- "pin-utils",
- "slab",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -461,12 +406,6 @@ checksum = "b88d82667eca772c4aa12f0f1348b3ae643424c8876448f3f7bd5787032e234c"
 dependencies = [
  "autocfg",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1181e1e0d1fce796a03db1ae795d67167da795f9cf4a39c37589e85ef57f26d3"
 
 [[package]]
 name = "atty"
@@ -1109,21 +1048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77231a1c8f801696fc0123ec6150ce92cffb8e164a02afb9c8ddee0e9b65ad65"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
- "log",
 ]
 
 [[package]]
@@ -2748,18 +2672,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "gloo-timers"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "google-cloud-gax"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3325,15 +3237,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kv-log-macro"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
-dependencies = [
- "log",
-]
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3838,43 +3741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minitrace"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317e28b8c337ada2fd437611c241ce053d5b7f5480b79e945597996b87b1de96"
-dependencies = [
- "futures",
- "minitrace-macro",
- "minstant",
- "once_cell",
- "parking_lot 0.12.1",
- "pin-project",
-]
-
-[[package]]
-name = "minitrace-jaeger"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5abe3273cd524b57b11925721595df5f8e957344c70e285a3a31c7e21523ac"
-dependencies = [
- "async-std",
- "minitrace",
- "thrift_codec",
-]
-
-[[package]]
-name = "minitrace-macro"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77814d165883613a1846517efdc50b88fabd9c210b7ff4d3745b38b99d539652"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3890,17 +3756,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "minstant"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5dcfca9a0725105ac948b84cfeb69c3942814c696326743797215413f854b9"
-dependencies = [
- "ctor",
- "libc",
- "wasi 0.7.0",
 ]
 
 [[package]]
@@ -5762,7 +5617,6 @@ dependencies = [
  "itertools",
  "madsim-tokio",
  "madsim-tonic",
- "minitrace",
  "num-traits",
  "parking_lot 0.12.1",
  "paste",
@@ -6743,8 +6597,6 @@ dependencies = [
  "mach2",
  "madsim-tokio",
  "memcomparable",
- "minitrace",
- "minstant",
  "moka",
  "nix 0.25.1",
  "num-integer",
@@ -6808,8 +6660,6 @@ dependencies = [
  "madsim-tonic",
  "maplit",
  "memcomparable",
- "minitrace",
- "minstant",
  "multimap",
  "num-traits",
  "parking_lot 0.12.1",
@@ -6856,8 +6706,6 @@ dependencies = [
  "anyhow",
  "futures",
  "madsim-tokio",
- "minitrace",
- "minitrace-jaeger",
  "rand",
  "tracing",
  "workspace-hack",
@@ -7913,16 +7761,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thrift_codec"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce3200b189fd4733eb2bb22235755c8aa0361ba1c66b67db54893144d147279"
-dependencies = [
- "byteorder",
- "trackable",
-]
-
-[[package]]
 name = "tikv-jemalloc-ctl"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8429,25 +8267,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trackable"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15bd114abb99ef8cee977e517c8f37aee63f184f2d08e3e6ceca092373369ae"
-dependencies = [
- "trackable_derive",
-]
-
-[[package]]
-name = "trackable_derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebeb235c5847e2f82cfe0f07eb971d1e5f6804b18dac2ae16349cc604380f82f"
-dependencies = [
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "triomphe"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8684,12 +8503,6 @@ dependencies = [
  "log",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89c3ce4ce14bdc6fb6beaf9ec7928ca331de5df7e5ea278375642a2f478570d"
 
 [[package]]
 name = "wasi"

--- a/src/batch/Cargo.toml
+++ b/src/batch/Cargo.toml
@@ -26,7 +26,6 @@ futures-async-stream = { workspace = true }
 hashbrown = { workspace = true }
 hytra = "0.1.2"
 itertools = "0.10"
-minitrace = "0.4"
 num-traits = "0.2"
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 paste = "1"

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -191,16 +191,6 @@ pub async fn compute_node_serve(
         state_store_metrics.clone(),
         object_store_metrics,
         TieredCacheMetricsBuilder::new(registry.clone()),
-        if config.streaming.enable_jaeger_tracing {
-            Arc::new(
-                risingwave_tracing::RwTracingService::new(risingwave_tracing::TracingConfig::new(
-                    "127.0.0.1:6831".to_string(),
-                ))
-                .unwrap(),
-            )
-        } else {
-            Arc::new(risingwave_tracing::RwTracingService::disabled())
-        },
         storage_metrics.clone(),
         compactor_metrics.clone(),
     )

--- a/src/ctl/src/common/hummock_service.rs
+++ b/src/ctl/src/common/hummock_service.rs
@@ -137,7 +137,6 @@ For `./risedev apply-compose-deploy` users,
             metrics.state_store_metrics.clone(),
             metrics.object_store_metrics.clone(),
             TieredCacheMetricsBuilder::unused(),
-            Arc::new(risingwave_tracing::RwTracingService::disabled()),
             metrics.storage_metrics.clone(),
             metrics.compactor_metrics.clone(),
         )

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -31,8 +31,6 @@ itertools = "0.10"
 libc = "0.2"
 lz4 = "1.23.1"
 memcomparable = "0.2"
-minitrace = "0.4"
-minstant = "0.1"
 num-integer = "0.1"
 parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["process"] }

--- a/src/storage/src/hummock/compactor/compaction_utils.rs
+++ b/src/storage/src/hummock/compactor/compaction_utils.rs
@@ -18,7 +18,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
 use itertools::Itertools;
-use minstant::Instant;
 use risingwave_common::constants::hummock::CompactionFilterFlag;
 use risingwave_hummock_sdk::key::FullKey;
 use risingwave_hummock_sdk::key_range::KeyRange;
@@ -26,6 +25,7 @@ use risingwave_hummock_sdk::prost_key_range::KeyRangeExt;
 use risingwave_hummock_sdk::table_stats::TableStatsMap;
 use risingwave_hummock_sdk::{HummockEpoch, KeyComparator};
 use risingwave_pb::hummock::{compact_task, CompactTask, KeyRange as KeyRange_vec, SstableInfo};
+use tokio::time::Instant;
 
 pub use super::context::CompactorContext;
 use crate::filter_key_extractor::FilterKeyExtractorImpl;

--- a/src/storage/src/hummock/compactor/mod.rs
+++ b/src/storage/src/hummock/compactor/mod.rs
@@ -495,7 +495,7 @@ impl Compactor {
 
                 // This inner loop is to consume stream or report task progress.
                 'consume_stream: loop {
-                    let message = tokio::select! {
+                    let message: Option<Result<SubscribeCompactTasksResponse, _>> = tokio::select! {
                         _ = task_progress_interval.tick() => {
                             let mut progress_list = Vec::new();
                             for (&task_id, progress) in task_progress.lock().iter() {

--- a/src/storage/src/hummock/mod.rs
+++ b/src/storage/src/hummock/mod.rs
@@ -123,8 +123,6 @@ pub struct HummockStorage {
 
     read_version_mapping: Arc<ReadVersionMappingType>,
 
-    tracing: Arc<risingwave_tracing::RwTracingService>,
-
     backup_reader: BackupReaderRef,
 
     /// current_epoch < min_current_epoch cannot be read.
@@ -143,7 +141,6 @@ impl HummockStorage {
         notification_client: impl NotificationClient,
         filter_key_extractor_manager: Arc<FilterKeyExtractorManager>,
         state_store_metrics: Arc<HummockStateStoreMetrics>,
-        tracing: Arc<risingwave_tracing::RwTracingService>,
         compactor_metrics: Arc<CompactorMetrics>,
     ) -> HummockResult<Self> {
         let sstable_object_id_manager = Arc::new(SstableObjectIdManager::new(
@@ -217,7 +214,6 @@ impl HummockStorage {
                 shutdown_sender: event_tx,
             }),
             read_version_mapping: hummock_event_handler.read_version_mapping(),
-            tracing,
             backup_reader,
             min_current_epoch,
             write_limiter,
@@ -244,7 +240,6 @@ impl HummockStorage {
             self.hummock_version_reader.clone(),
             self.hummock_event_sender.clone(),
             self.buffer_tracker.get_memory_limiter().clone(),
-            self.tracing.clone(),
             self.write_limiter.clone(),
             option,
         )
@@ -332,7 +327,6 @@ impl HummockStorage {
             notification_client,
             Arc::new(FilterKeyExtractorManager::default()),
             Arc::new(HummockStateStoreMetrics::unused()),
-            Arc::new(risingwave_tracing::RwTracingService::disabled()),
             Arc::new(CompactorMetrics::unused()),
         )
         .await

--- a/src/storage/src/hummock/sstable_store.rs
+++ b/src/storage/src/hummock/sstable_store.rs
@@ -29,6 +29,7 @@ use risingwave_object_store::object::{
 };
 use risingwave_pb::hummock::SstableInfo;
 use tokio::task::JoinHandle;
+use tokio::time::Instant;
 use zstd::zstd_safe::WriteBuf;
 
 use super::utils::MemoryTracker;
@@ -393,7 +394,7 @@ impl SstableStore {
                         size: (sst.file_size - sst.meta_offset) as usize,
                     };
                     async move {
-                        let now = minstant::Instant::now();
+                        let now = Instant::now();
                         let buf = store
                             .read(&meta_path, Some(loc))
                             .await

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -20,8 +20,6 @@ use std::sync::Arc;
 
 use bytes::Bytes;
 use itertools::Itertools;
-use minitrace::future::FutureExt;
-use minitrace::Span;
 use parking_lot::RwLock;
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::key::{
@@ -31,6 +29,7 @@ use risingwave_hummock_sdk::key_range::KeyRangeCommon;
 use risingwave_hummock_sdk::{HummockEpoch, LocalSstableInfo};
 use risingwave_pb::hummock::{HummockVersionDelta, LevelType, SstableInfo};
 use sync_point::sync_point;
+use tracing::Instrument;
 
 use super::memtable::{ImmId, ImmutableMemtable};
 use super::state_store::StagingDataIterator;
@@ -689,7 +688,7 @@ impl HummockVersionReader {
             let table_holder = self
                 .sstable_store
                 .sstable(sstable_info, &mut local_stats)
-                .in_span(Span::enter_with_local_parent("get_sstable"))
+                .instrument(tracing::trace_span!("get_sstable"))
                 .await?;
 
             if !table_holder
@@ -781,7 +780,7 @@ impl HummockVersionReader {
                     let sstable = self
                         .sstable_store
                         .sstable(&sstables[0], &mut local_stats)
-                        .in_span(Span::enter_with_local_parent("get_sstable"))
+                        .instrument(tracing::trace_span!("get_sstable"))
                         .await?;
                     if !sstable.value().meta.monotonic_tombstone_events.is_empty()
                         && !read_options.ignore_range_tombstone
@@ -822,7 +821,7 @@ impl HummockVersionReader {
                     let sstable = self
                         .sstable_store
                         .sstable(sstable_info, &mut local_stats)
-                        .in_span(Span::enter_with_local_parent("get_sstable"))
+                        .instrument(tracing::trace_span!("get_sstable"))
                         .await?;
                     assert_eq!(sstable_info.get_object_id(), sstable.value().id);
                     if !sstable.value().meta.monotonic_tombstone_events.is_empty()
@@ -887,7 +886,7 @@ impl HummockVersionReader {
         );
         user_iter
             .rewind()
-            .in_span(Span::enter_with_local_parent("rewind"))
+            .instrument(tracing::trace_span!("rewind"))
             .await?;
         local_stats.found_key = user_iter.is_valid();
         local_stats.sub_iter_count = local_stats.staging_imm_iter_count

--- a/src/storage/src/monitor/monitored_store.rs
+++ b/src/storage/src/monitor/monitored_store.rs
@@ -21,6 +21,7 @@ use futures::{Future, TryFutureExt, TryStreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::TableId;
 use risingwave_hummock_sdk::HummockReadEpoch;
+use tokio::time::Instant;
 use tracing::error;
 
 use super::MonitoredStorageMetrics;
@@ -69,7 +70,7 @@ impl<S> MonitoredStateStore<S> {
         iter_stream_future: impl Future<Output = StorageResult<St>> + 'a,
     ) -> StorageResult<MonitoredStateStoreIterStream<'s, St>> {
         // start time takes iterator build time into account
-        let start_time = minstant::Instant::now();
+        let start_time = Instant::now();
         let table_id_label = table_id.to_string();
 
         // wait for iterator creation (e.g. seek)
@@ -94,7 +95,7 @@ impl<S> MonitoredStateStore<S> {
             stats: MonitoredStateStoreIterStats {
                 total_items: 0,
                 total_size: 0,
-                scan_time: minstant::Instant::now(),
+                scan_time: Instant::now(),
                 storage_metrics: self.storage_metrics.clone(),
                 table_id,
             },
@@ -340,7 +341,7 @@ pub struct MonitoredStateStoreIter<S> {
 struct MonitoredStateStoreIterStats {
     total_items: usize,
     total_size: usize,
-    scan_time: minstant::Instant,
+    scan_time: Instant,
     storage_metrics: Arc<MonitoredStorageMetrics>,
 
     table_id: TableId,

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -546,7 +546,6 @@ impl StateStoreImpl {
         state_store_metrics: Arc<HummockStateStoreMetrics>,
         object_store_metrics: Arc<ObjectStoreMetrics>,
         tiered_cache_metrics_builder: TieredCacheMetricsBuilder,
-        tracing: Arc<risingwave_tracing::RwTracingService>,
         storage_metrics: Arc<MonitoredStorageMetrics>,
         compactor_metrics: Arc<CompactorMetrics>,
     ) -> StorageResult<Self> {
@@ -604,7 +603,6 @@ impl StateStoreImpl {
                     notification_client,
                     key_filter_manager,
                     state_store_metrics.clone(),
-                    tracing,
                     compactor_metrics.clone(),
                 )
                 .await?;

--- a/src/stream/Cargo.toml
+++ b/src/stream/Cargo.toml
@@ -35,8 +35,6 @@ local_stats_alloc = { path = "../utils/local_stats_alloc" }
 lru = { git = "https://github.com/risingwavelabs/lru-rs.git", rev = "cb2d7c7" }
 maplit = "1.0.2"
 memcomparable = "0.2"
-minitrace = "0.4"
-minstant = "0.1"
 multimap = "0.8"
 num-traits = "0.2"
 parking_lot = "0.12"

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -29,6 +29,7 @@ use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_pb::stream_plan::update_mutation::PbDispatcherUpdate;
 use risingwave_pb::stream_plan::PbDispatcher;
 use smallvec::{smallvec, SmallVec};
+use tokio::time::Instant;
 use tracing::event;
 
 use super::exchange::output::{new_output, BoxedOutput};
@@ -65,7 +66,7 @@ impl DispatchExecutorInner {
     }
 
     async fn dispatch(&mut self, msg: Message) -> StreamResult<()> {
-        let start_time = minstant::Instant::now();
+        let start_time = Instant::now();
         match msg {
             Message::Watermark(watermark) => {
                 for dispatcher in &mut self.dispatchers {

--- a/src/stream/src/executor/hash_join.rs
+++ b/src/stream/src/executor/hash_join.rs
@@ -31,6 +31,7 @@ use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_expr::expr::BoxedExpression;
 use risingwave_expr::ExprError;
 use risingwave_storage::StateStore;
+use tokio::time::Instant;
 
 use self::JoinType::{FullOuter, LeftOuter, LeftSemi, RightAnti, RightOuter, RightSemi};
 use super::barrier_align::*;
@@ -707,7 +708,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
         // The first barrier message should be propagated.
         yield Message::Barrier(barrier);
         let actor_id_str = self.ctx.id.to_string();
-        let mut start_time = minstant::Instant::now();
+        let mut start_time = Instant::now();
 
         while let Some(msg) = aligned_stream
             .next()
@@ -735,7 +736,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 }
                 AlignedMessage::Left(chunk) => {
                     let mut left_time = Duration::from_nanos(0);
-                    let mut left_start_time = minstant::Instant::now();
+                    let mut left_start_time = Instant::now();
                     #[for_await]
                     for chunk in Self::eq_join_oneside::<{ SideType::Left }>(
                         &self.ctx,
@@ -752,7 +753,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                     ) {
                         left_time += left_start_time.elapsed();
                         yield Message::Chunk(chunk?);
-                        left_start_time = minstant::Instant::now();
+                        left_start_time = Instant::now();
                     }
                     left_time += left_start_time.elapsed();
                     self.metrics
@@ -762,7 +763,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                 }
                 AlignedMessage::Right(chunk) => {
                     let mut right_time = Duration::from_nanos(0);
-                    let mut right_start_time = minstant::Instant::now();
+                    let mut right_start_time = Instant::now();
                     #[for_await]
                     for chunk in Self::eq_join_oneside::<{ SideType::Right }>(
                         &self.ctx,
@@ -779,7 +780,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                     ) {
                         right_time += right_start_time.elapsed();
                         yield Message::Chunk(chunk?);
-                        right_start_time = minstant::Instant::now();
+                        right_start_time = Instant::now();
                     }
                     right_time += right_start_time.elapsed();
                     self.metrics
@@ -788,7 +789,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                         .inc_by(right_time.as_nanos() as u64);
                 }
                 AlignedMessage::Barrier(barrier) => {
-                    let barrier_start_time = minstant::Instant::now();
+                    let barrier_start_time = Instant::now();
                     self.flush_data(barrier.epoch).await?;
 
                     // Update the vnode bitmap for state tables of both sides if asked.
@@ -829,7 +830,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> HashJoinExecutor<K, 
                     yield Message::Barrier(barrier);
                 }
             }
-            start_time = minstant::Instant::now();
+            start_time = Instant::now();
         }
     }
 

--- a/src/stream/src/executor/merge.rs
+++ b/src/stream/src/executor/merge.rs
@@ -21,6 +21,7 @@ use futures::stream::{FusedStream, FuturesUnordered, StreamFuture};
 use futures::{pin_mut, Stream, StreamExt};
 use futures_async_stream::try_stream;
 use risingwave_common::catalog::Schema;
+use tokio::time::Instant;
 
 use super::error::StreamExecutorError;
 use super::exchange::input::BoxedInput;
@@ -116,7 +117,7 @@ impl MergeExecutor {
         let mut upstream_fragment_id_str = self.upstream_fragment_id.to_string();
 
         // Channels that're blocked by the barrier to align.
-        let mut start_time = minstant::Instant::now();
+        let mut start_time = Instant::now();
         pin_mut!(select_all);
         while let Some(msg) = select_all.next().await {
             self.metrics
@@ -235,7 +236,7 @@ impl MergeExecutor {
             }
 
             yield msg;
-            start_time = minstant::Instant::now();
+            start_time = Instant::now();
         }
     }
 }

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -22,7 +22,6 @@ use futures::stream::BoxStream;
 use futures::{Stream, StreamExt};
 use futures_async_stream::try_stream;
 use itertools::Itertools;
-use minitrace::prelude::*;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;

--- a/src/stream/src/executor/receiver.rs
+++ b/src/stream/src/executor/receiver.rs
@@ -18,6 +18,7 @@ use futures::StreamExt;
 use futures_async_stream::try_stream;
 use itertools::Itertools;
 use risingwave_common::catalog::Schema;
+use tokio::time::Instant;
 
 use super::exchange::input::BoxedInput;
 use super::ActorContextRef;
@@ -119,7 +120,7 @@ impl Executor for ReceiverExecutor {
 
         let stream = #[try_stream]
         async move {
-            let mut start_time = minstant::Instant::now();
+            let mut start_time = Instant::now();
             while let Some(msg) = self.input.next().await {
                 self.metrics
                     .actor_input_buffer_blocking_duration_ns
@@ -196,7 +197,7 @@ impl Executor for ReceiverExecutor {
                 };
 
                 yield msg;
-                start_time = minstant::Instant::now();
+                start_time = Instant::now();
             }
         };
 

--- a/src/stream/src/executor/wrapper/trace.rs
+++ b/src/stream/src/executor/wrapper/trace.rs
@@ -17,8 +17,7 @@ use std::sync::Arc;
 use await_tree::InstrumentAwait;
 use futures::{pin_mut, StreamExt};
 use futures_async_stream::try_stream;
-use minitrace::prelude::*;
-use tracing::event;
+use tracing::{event, Instrument};
 
 use crate::executor::error::StreamExecutorError;
 use crate::executor::monitor::StreamingMetrics;
@@ -39,17 +38,19 @@ pub async fn trace(
     let span_name = format!("{}_{}_next", info.identity, input_pos);
     let actor_id_string = actor_id.to_string();
 
-    let span = || {
-        let mut span = Span::enter_with_local_parent("next");
-        span.add_property(|| ("otel.name", span_name.to_string()));
-        span.add_property(|| ("next", info.identity.to_string()));
-        span.add_property(|| ("input_pos", input_pos.to_string()));
-        span
-    };
-
     pin_mut!(input);
 
-    while let Some(message) = input.next().in_span(span()).await.transpose()? {
+    while let Some(message) = input
+        .next()
+        .instrument(tracing::trace_span!(
+            "next",
+            otel.name = span_name.as_str(),
+            next = info.identity,
+            input_pos = input_pos
+        ))
+        .await
+        .transpose()?
+    {
         if let Message::Chunk(chunk) = &message {
             if chunk.cardinality() > 0 {
                 if enable_executor_row_count {

--- a/src/tests/compaction_test/src/compaction_test_runner.rs
+++ b/src/tests/compaction_test/src/compaction_test_runner.rs
@@ -719,7 +719,6 @@ pub async fn create_hummock_store_with_metrics(
         metrics.state_store_metrics.clone(),
         metrics.object_store_metrics.clone(),
         TieredCacheMetricsBuilder::unused(),
-        Arc::new(risingwave_tracing::RwTracingService::disabled()),
         metrics.storage_metrics.clone(),
         metrics.compactor_metrics.clone(),
     )

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -197,7 +197,6 @@ async fn compaction_test(
         get_notification_client_for_test(env, hummock_manager_ref.clone(), worker_node),
         Arc::new(FilterKeyExtractorManager::default()),
         state_store_metrics.clone(),
-        Arc::new(risingwave_tracing::RwTracingService::disabled()),
         compactor_metrics.clone(),
     )
     .await?;

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -17,8 +17,6 @@ normal = ["workspace-hack"]
 [dependencies]
 anyhow = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc", "executor"] }
-minitrace = "0.4"
-minitrace-jaeger = "0.4"
 rand = "0.8"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "sync",

--- a/src/tracing/src/lib.rs
+++ b/src/tracing/src/lib.rs
@@ -12,156 +12,156 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::net::SocketAddr;
-use std::thread::JoinHandle;
+// use std::env;
+// use std::net::SocketAddr;
+// use std::thread::JoinHandle;
 
-use anyhow::{Error, Result};
-use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
-use minitrace::prelude::*;
+// use anyhow::{Error, Result};
+// use futures::channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender};
+// use minitrace::prelude::*;
 
-pub struct RwTracingService {
-    tx: UnboundedSender<Collector>,
-    _join_handle: Option<JoinHandle<()>>,
-    enabled: bool,
-}
+// pub struct RwTracingService {
+//     tx: UnboundedSender<Collector>,
+//     _join_handle: Option<JoinHandle<()>>,
+//     enabled: bool,
+// }
 
-pub struct TracingConfig {
-    pub jaeger_endpoint: Option<String>,
-    pub print_to_console: bool,
-    pub slow_request_threshold_ms: u64,
-}
+// pub struct TracingConfig {
+//     pub jaeger_endpoint: Option<String>,
+//     pub print_to_console: bool,
+//     pub slow_request_threshold_ms: u64,
+// }
 
-impl TracingConfig {
-    pub fn new(jaeger_endpoint: String) -> Self {
-        let slow_request_threshold_ms: u64 = env::var("RW_TRACE_SLOW_REQUEST_THRESHOLD_MS")
-            .ok()
-            .map_or_else(|| 100, |v| v.parse().unwrap());
-        let print_to_console = env::var("RW_TRACE_SLOW_REQUEST")
-            .ok()
-            .map_or_else(|| false, |v| v == "true");
+// impl TracingConfig {
+//     pub fn new(jaeger_endpoint: String) -> Self {
+//         let slow_request_threshold_ms: u64 = env::var("RW_TRACE_SLOW_REQUEST_THRESHOLD_MS")
+//             .ok()
+//             .map_or_else(|| 100, |v| v.parse().unwrap());
+//         let print_to_console = env::var("RW_TRACE_SLOW_REQUEST")
+//             .ok()
+//             .map_or_else(|| false, |v| v == "true");
 
-        Self {
-            jaeger_endpoint: Some(jaeger_endpoint),
-            print_to_console,
-            slow_request_threshold_ms,
-        }
-    }
-}
+//         Self {
+//             jaeger_endpoint: Some(jaeger_endpoint),
+//             print_to_console,
+//             slow_request_threshold_ms,
+//         }
+//     }
+// }
 
-impl RwTracingService {
-    /// Create a new tracing service instance. Spawn a background thread to observe slow requests.
-    pub fn new(config: TracingConfig) -> Result<Self> {
-        let (tx, rx) = unbounded();
+// impl RwTracingService {
+//     /// Create a new tracing service instance. Spawn a background thread to observe slow
+// requests.     pub fn new(config: TracingConfig) -> Result<Self> {
+//         let (tx, rx) = unbounded();
 
-        let jaeger_addr: Option<SocketAddr> =
-            config.jaeger_endpoint.map(|x| x.parse()).transpose()?;
+//         let jaeger_addr: Option<SocketAddr> =
+//             config.jaeger_endpoint.map(|x| x.parse()).transpose()?;
 
-        let join_handle = if cfg!(madsim) {
-            None
-        } else {
-            Some(Self::start_tracing_listener(
-                rx,
-                config.print_to_console,
-                config.slow_request_threshold_ms,
-                jaeger_addr,
-            ))
-        };
+//         let join_handle = if cfg!(madsim) {
+//             None
+//         } else {
+//             Some(Self::start_tracing_listener(
+//                 rx,
+//                 config.print_to_console,
+//                 config.slow_request_threshold_ms,
+//                 jaeger_addr,
+//             ))
+//         };
 
-        let tr = Self {
-            tx,
-            _join_handle: join_handle,
-            enabled: jaeger_addr.is_some(),
-        };
-        Ok(tr)
-    }
+//         let tr = Self {
+//             tx,
+//             _join_handle: join_handle,
+//             enabled: jaeger_addr.is_some(),
+//         };
+//         Ok(tr)
+//     }
 
-    pub fn disabled() -> Self {
-        let (tx, _) = unbounded();
-        Self {
-            tx,
-            _join_handle: None,
-            enabled: false,
-        }
-    }
+//     pub fn disabled() -> Self {
+//         let (tx, _) = unbounded();
+//         Self {
+//             tx,
+//             _join_handle: None,
+//             enabled: false,
+//         }
+//     }
 
-    /// Create a new tracing event.
-    pub fn new_tracer(&self, event: &'static str) -> Span {
-        if self.enabled {
-            let (span, collector) = Span::root(event);
-            self.tx.unbounded_send(collector).unwrap();
-            span
-        } else {
-            Span::new_noop()
-        }
-    }
+//     /// Create a new tracing event.
+//     pub fn new_tracer(&self, event: &'static str) -> Span {
+//         if self.enabled {
+//             let (span, collector) = Span::root(event);
+//             self.tx.unbounded_send(collector).unwrap();
+//             span
+//         } else {
+//             Span::new_noop()
+//         }
+//     }
 
-    #[cfg(madsim)]
-    fn start_tracing_listener(
-        _rx: UnboundedReceiver<Collector>,
-        _print_to_console: bool,
-        _slow_request_threshold_ms: u64,
-        _jaeger_addr: Option<SocketAddr>,
-    ) -> JoinHandle<()> {
-        unreachable!()
-    }
+//     #[cfg(madsim)]
+//     fn start_tracing_listener(
+//         _rx: UnboundedReceiver<Collector>,
+//         _print_to_console: bool,
+//         _slow_request_threshold_ms: u64,
+//         _jaeger_addr: Option<SocketAddr>,
+//     ) -> JoinHandle<()> {
+//         unreachable!()
+//     }
 
-    #[cfg(not(madsim))]
-    fn start_tracing_listener(
-        rx: UnboundedReceiver<Collector>,
-        print_to_console: bool,
-        slow_request_threshold_ms: u64,
-        jaeger_addr: Option<SocketAddr>,
-    ) -> JoinHandle<()> {
-        use futures::StreamExt;
-        use rand::Rng;
+//     #[cfg(not(madsim))]
+//     fn start_tracing_listener(
+//         rx: UnboundedReceiver<Collector>,
+//         print_to_console: bool,
+//         slow_request_threshold_ms: u64,
+//         jaeger_addr: Option<SocketAddr>,
+//     ) -> JoinHandle<()> {
+//         use futures::StreamExt;
+//         use rand::Rng;
 
-        tracing::info!(
-            "tracing service started with slow_request_threshold_ms={slow_request_threshold_ms}, print_to_console={print_to_console}"
-        );
+//         tracing::info!(
+//             "tracing service started with slow_request_threshold_ms={slow_request_threshold_ms},
+// print_to_console={print_to_console}"         );
 
-        std::thread::Builder::new()
-            .name("minitrace_listener".to_string())
-            .spawn(move || {
-                let func = move || {
-                    let rt = tokio::runtime::Builder::new_current_thread().build()?;
-                    let stream = rx.for_each_concurrent(None, |collector| async {
-                        let spans = collector.collect().await;
-                        if !spans.is_empty() {
-                            // print slow requests
-                            if print_to_console {
-                                // print requests > 100ms
-                                if spans[0].duration_ns >= slow_request_threshold_ms * 1_000_000 {
-                                    tracing::info!("{:?}", spans);
-                                }
-                            }
-                            // report spans to jaeger
-                            if let Some(ref jaeger_addr) = jaeger_addr {
-                                let trace_id = rand::thread_rng().gen::<u64>();
-                                let span_id = rand::thread_rng().gen::<u32>();
-                                let encoded = minitrace_jaeger::encode(
-                                    "risingwave".to_string(),
-                                    trace_id,
-                                    0,
-                                    span_id,
-                                    &spans,
-                                )
-                                .unwrap();
-                                if let Err(err) =
-                                    minitrace_jaeger::report(*jaeger_addr, &encoded).await
-                                {
-                                    tracing::warn!("failed to report spans to jaeger: {}", err);
-                                }
-                            }
-                        }
-                    });
-                    rt.block_on(stream);
-                    Ok::<_, Error>(())
-                };
-                if let Err(err) = func() {
-                    tracing::warn!("tracing thread exited: {:#}", err);
-                }
-            })
-            .unwrap()
-    }
-}
+//         std::thread::Builder::new()
+//             .name("minitrace_listener".to_string())
+//             .spawn(move || {
+//                 let func = move || {
+//                     let rt = tokio::runtime::Builder::new_current_thread().build()?;
+//                     let stream = rx.for_each_concurrent(None, |collector| async {
+//                         let spans = collector.collect().await;
+//                         if !spans.is_empty() {
+//                             // print slow requests
+//                             if print_to_console {
+//                                 // print requests > 100ms
+//                                 if spans[0].duration_ns >= slow_request_threshold_ms * 1_000_000
+// {                                     tracing::info!("{:?}", spans);
+//                                 }
+//                             }
+//                             // report spans to jaeger
+//                             if let Some(ref jaeger_addr) = jaeger_addr {
+//                                 let trace_id = rand::thread_rng().gen::<u64>();
+//                                 let span_id = rand::thread_rng().gen::<u32>();
+//                                 let encoded = minitrace_jaeger::encode(
+//                                     "risingwave".to_string(),
+//                                     trace_id,
+//                                     0,
+//                                     span_id,
+//                                     &spans,
+//                                 )
+//                                 .unwrap();
+//                                 if let Err(err) =
+//                                     minitrace_jaeger::report(*jaeger_addr, &encoded).await
+//                                 {
+//                                     tracing::warn!("failed to report spans to jaeger: {}", err);
+//                                 }
+//                             }
+//                         }
+//                     });
+//                     rt.block_on(stream);
+//                     Ok::<_, Error>(())
+//                 };
+//                 if let Err(err) = func() {
+//                     tracing::warn!("tracing thread exited: {:#}", err);
+//                 }
+//             })
+//             .unwrap()
+//     }
+// }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR attempts to replace minstant/minitrace with tokio instant/tracing. See discussion in #10236. This PR doesn't add back the jarger and slow request support. I think it is accetable because when writing this PR, I realize that only trace spans related to hummock iter are actully being used since we only create root span [here](https://github.com/risingwavelabs/risingwave/blob/2f928526f3ef11ccf55ff8039f47fba213c50112/src/storage/src/hummock/store/state_store.rs#L172). 

I will try add them back in a separate PR.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
