### PR TITLE
SOS: async lifetime issues

### DIFF
--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -901,12 +901,12 @@ where
             .map(get_second))
     }
 
-    // Same as above, but uses the macro to yield instead.
+    // NOTE: Same as above, but uses the macro to yield instead.
     /// This function scans rows from the relational table with specific `pk_prefix`.
     #[try_stream(ok = OwnedRow, error=StreamExecutorError)]
     pub async fn iter_with_pk_prefix_v2(
         &self,
-        pk_prefix: impl Row + '_async0,
+        pk_prefix: impl Row + '_async0, // <-------- HACKS HERE
         prefetch_options: PrefetchOptions,
     ) {
         let stream = self

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -874,7 +874,7 @@ fn get_second<T, U>(arg: StreamExecutorResult<(T, U)>) -> StreamExecutorResult<U
 }
 
 // Iterator functions
-impl<'a, S, SD, W> StateTableInner<S, SD, W>
+impl<S, SD, W> StateTableInner<S, SD, W>
 where
     S: StateStore,
     SD: ValueRowSerde,

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -901,7 +901,8 @@ where
             .map(get_second))
     }
 
-    // NOTE: Same as above, but uses the macro to yield instead.
+    // NOTE: Same as `iter_with_pk_prefix` directly above,
+    // but uses the macro to yield instead.
     /// This function scans rows from the relational table with specific `pk_prefix`.
     #[try_stream(ok = OwnedRow, error=StreamExecutorError)]
     pub async fn iter_with_pk_prefix_v2(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Seems like `try_stream` introduces some lifetimes. If some argument is an `impl`, it needs to match that lifetime too, otherwise `try_stream` will complain:
```
error[E0309]: the parameter type `impl Row` may not live long enough
   --> src/stream/src/common/table/state_table.rs:906:5
    |
906 |     #[try_stream(ok = OwnedRow, error=StreamExecutorError)]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ...so that the type `impl Row` will meet its required lifetime bounds
    |
    = note: this error originates in the attribute macro `try_stream` (in Nightly builds, run with -Z macro-backtrace for more info)
help: consider adding an explicit lifetime bound...
    |
909 |         pk_prefix: impl Row + '_async0,
    |                             ++++++++++


```

It compiles if I just follow the suggestion, but seems very hacky 🤣 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
