### PR TITLE
fix(storage):  fix memory usage calculation for shared-buffer

### DIFF
--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -379,13 +379,15 @@ impl SharedBufferBatch {
         batch_items
             .iter()
             .map(|(k, v)| {
-                std::mem::size_of::<HummockValue<Bytes>>() +
-                std::mem::size_of::<Bytes>() + k.len() + {
-                    match v {
-                        HummockValue::Put(val) => val.len(),
-                        HummockValue::Delete => 0,
+                std::mem::size_of::<HummockValue<Bytes>>()
+                    + std::mem::size_of::<Bytes>()
+                    + k.len()
+                    + {
+                        match v {
+                            HummockValue::Put(val) => val.len(),
+                            HummockValue::Delete => 0,
+                        }
                     }
-                }
             })
             .sum()
     }

--- a/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
+++ b/src/storage/src/hummock/shared_buffer/shared_buffer_batch.rs
@@ -379,7 +379,8 @@ impl SharedBufferBatch {
         batch_items
             .iter()
             .map(|(k, v)| {
-                k.len() + {
+                std::mem::size_of::<HummockValue<Bytes>>() +
+                std::mem::size_of::<Bytes>() + k.len() + {
                     match v {
                         HummockValue::Put(val) => val.len(),
                         HummockValue::Delete => 0,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We did not calculate the size of shared-buffer correctly. It will cause the wrong usage of memory show in grafana. And it may also make us can not limit the memory used by shared-buffer before compute-node OOM

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests



<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
