### PR TITLE
build: use debug=1 back for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ hashbrown = { version = "0.13.2", features = ["ahash", "inline-more", "nightly"]
 lto = 'off'
 
 [profile.release]
-debug = "line-tables-only"
+debug = 1
 lto = 'thin'
 
 # The profile used for CI in main branch.
@@ -86,6 +86,8 @@ lto = 'thin'
 # better catch bugs in CI.
 [profile.ci-release]
 inherits = "release"
+incremental = false
+debug = "line-tables-only"
 debug-assertions = true
 overflow-checks = true
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/pull/10029#issuecomment-1591316116 It harms profiling, as the function name is less readable. Module path information is lost.

Still uses "line-tables-only" for CI.

Comparison:

`debug = "line-tables-only"`
```
thread 'main' panicked at 'Oh no!', src/bin/hello.rs:14:5
stack backtrace:
   0: begin_panic_handler
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/std/src/panicking.rs:593:5
   1: panic_fmt
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/panicking.rs:67:14
   2: foo
             at ./src/bin/hello.rs:14:5
   3: {async_block#0}
             at ./src/bin/hello.rs:4:5
   4: {closure#0}<hello::main::{async_block_env#0}>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/park.rs:283:63
   5: with_budget<core::task::poll::Poll<()>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<hello::main::{async_block_env#0}>>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/coop.rs:107:5
   6: budget<core::task::poll::Poll<()>, tokio::runtime::park::{impl#4}::block_on::{closure_env#0}<hello::main::{async_block_env#0}>>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/coop.rs:73:5
   7: block_on<hello::main::{async_block_env#0}>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/park.rs:283:31
   8: block_on<hello::main::{async_block_env#0}>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/context.rs:315:13
   9: block_on<hello::main::{async_block_env#0}>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/scheduler/multi_thread/mod.rs:66:9
  10: block_on<hello::main::{async_block_env#0}>
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/runtime.rs:304:45
  11: main
             at ./src/bin/hello.rs:4:5
  12: call_once<fn(), ()>
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/ops/function.rs:250:5
```

`debug = 1`

```
thread 'main' panicked at 'Oh no!', src/bin/hello.rs:14:5
stack backtrace:
   0: begin_panic_handler
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/std/src/panicking.rs:593:5
   1: panic_fmt
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/panicking.rs:67:14
   2: hello::foo
             at ./src/bin/hello.rs:14:5
   3: hello::main::{{closure}}
             at ./src/bin/hello.rs:4:5
   4: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/park.rs:283:63
   5: tokio::runtime::coop::with_budget
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/coop.rs:107:5
   6: tokio::runtime::coop::budget
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/coop.rs:73:5
   7: tokio::runtime::park::CachedParkThread::block_on
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/park.rs:283:31
   8: tokio::runtime::context::BlockingRegionGuard::block_on
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/context.rs:315:13
   9: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/scheduler/multi_thread/mod.rs:66:9
  10: tokio::runtime::runtime::Runtime::block_on
             at /Users/xxchan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/tokio-1.28.2/src/runtime/runtime.rs:304:45
  11: hello::main
             at ./src/bin/hello.rs:4:5
  12: core::ops::function::FnOnce::call_once
             at /rustc/a97c36dd2e6f711949fc9b790476e93bd9e6d1f4/library/core/src/ops/function.rs:250:5
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
