### PR TITLE
fix(sqlsmith): don't compute columns and table schema separately

### DIFF
--- a/ci/scripts/run-fuzz-test.sh
+++ b/ci/scripts/run-fuzz-test.sh
@@ -43,7 +43,7 @@ if [[ "$RUN_SQLSMITH" -eq "1" ]]; then
     cargo make ci-start ci-3cn-1fe
 
     echo "--- e2e, ci-3cn-1fe, run fuzzing"
-    timeout 20m ./target/debug/sqlsmith test \
+    ./target/debug/sqlsmith test \
       --count "$SQLSMITH_COUNT" \
       --testdata ./src/tests/sqlsmith/tests/testdata \
       2>"$LOGDIR/fuzzing.log" && rm "$LOGDIR/fuzzing.log"

--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -54,7 +54,7 @@ cargo make sslt-build-all --profile ci-sim
 # The target bin can be found here:
 # target/sim/ci-sim/risingwave_simulation
 # Run fuzzing
-RUST_BACKTRACE=1 MADSIM_TEST_SEED=1 ./target/sim/ci-sim/risingwave_simulation --sqlsmith 100 ./src/tests/sqlsmith/tests/testdata
+RUST_LOG=info RUST_BACKTRACE=1 MADSIM_TEST_SEED=1 ./target/sim/ci-sim/risingwave_simulation --sqlsmith 100 ./src/tests/sqlsmith/tests/testdata
 ```
 
 ## E2E

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -198,6 +198,7 @@ pub async fn run(client: &Client, testdata: &str, count: usize, seed: Option<u64
     tracing::info!("Passed stream queries");
 
     drop_tables(&mviews, testdata, client).await;
+    tracing::info!("[EXECUTION SUCCESS]");
 }
 
 fn generate_rng(seed: Option<u64>) -> impl Rng {

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -155,6 +155,8 @@ pub(crate) struct SqlGenerator<'a, R: Rng> {
     ///    Under this mode certain restrictions and workarounds are applied
     ///    for unsupported stream executors.
     is_mview: bool,
+
+    recursion_weight: f64,
 }
 
 /// Generators
@@ -169,6 +171,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             bound_relations: vec![],
             bound_columns: vec![],
             is_mview: false,
+            recursion_weight: 0.3,
         }
     }
 
@@ -182,6 +185,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
             bound_relations: vec![],
             bound_columns: vec![],
             is_mview: true,
+            recursion_weight: 0.3,
         }
     }
 
@@ -215,6 +219,17 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     /// Provide recursion bounds.
     pub(crate) fn can_recurse(&mut self) -> bool {
-        self.rng.gen_bool(0.3)
+        if self.recursion_weight == 0.0 {
+            return false;
+        }
+
+        let result = self.rng.gen_bool(self.recursion_weight);
+        if result {
+            self.recursion_weight *= 1.0 - self.recursion_weight;
+            if self.recursion_weight < 0.05 {
+                self.recursion_weight = 0.0;
+            }
+        }
+        result
     }
 }

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -219,16 +219,13 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     /// Provide recursion bounds.
     pub(crate) fn can_recurse(&mut self) -> bool {
-        if self.recursion_weight == 0.0 {
+        if self.recursion_weight <= 0.0 {
             return false;
         }
 
         let result = self.rng.gen_bool(self.recursion_weight);
         if result {
-            self.recursion_weight *= 1.0 - self.recursion_weight;
-            if self.recursion_weight < 0.05 {
-                self.recursion_weight = 0.0;
-            }
+            self.recursion_weight -= 0.01;
         }
         result
     }

--- a/src/tests/sqlsmith/src/sql_gen/mod.rs
+++ b/src/tests/sqlsmith/src/sql_gen/mod.rs
@@ -219,14 +219,6 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     /// Provide recursion bounds.
     pub(crate) fn can_recurse(&mut self) -> bool {
-        if self.recursion_weight <= 0.0 {
-            return false;
-        }
-
-        let result = self.rng.gen_bool(self.recursion_weight);
-        if result {
-            self.recursion_weight -= 0.01;
-        }
-        result
+        self.rng.gen_bool(self.recursion_weight)
     }
 }

--- a/src/tests/sqlsmith/src/sql_gen/query.rs
+++ b/src/tests/sqlsmith/src/sql_gen/query.rs
@@ -34,7 +34,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// Generates query expression and returns its
     /// query schema as well.
     pub(crate) fn gen_query(&mut self) -> (Query, Vec<Column>) {
-        if self.can_recurse() {
+        if self.rng.gen_bool(0.3) {
             self.gen_complex_query()
         } else {
             self.gen_simple_query()
@@ -62,7 +62,9 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         )
     }
 
-    /// Generates a simple query which will not recurse.
+    /// This query can still recurse, but it is "simpler"
+    /// does not have "with" clause, "order by".
+    /// Which makes it more unlikely to recurse.
     fn gen_simple_query(&mut self) -> (Query, Vec<Column>) {
         let num_select_items = self.rng.gen_range(1..=4);
         let with_tables = vec![];

--- a/src/tests/sqlsmith/src/sql_gen/relation.rs
+++ b/src/tests/sqlsmith/src/sql_gen/relation.rs
@@ -87,7 +87,13 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
         // TODO: TableFactor::Derived, TableFactor::TableFunction, TableFactor::NestedJoin
         match self.rng.gen_range(0..=2) {
             0 => self.gen_time_window_func(),
-            1 => self.gen_table_subquery(),
+            1 => {
+                if self.can_recurse() {
+                    self.gen_table_subquery()
+                } else {
+                    self.gen_simple_table_factor()
+                }
+            }
             2 => self.gen_simple_table_factor(),
             _ => unreachable!(),
         }

--- a/src/tests/sqlsmith/src/sql_gen/relation.rs
+++ b/src/tests/sqlsmith/src/sql_gen/relation.rs
@@ -354,7 +354,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
     fn gen_table_subquery(&mut self) -> (TableFactor, Table) {
         let (subquery, columns) = self.gen_local_query();
         let alias = self.gen_table_name_with_prefix("sq");
-        let table = Table::new(alias.clone(), columns.clone());
+        let table = Table::new(alias.clone(), columns);
         let factor = TableFactor::Derived {
             lateral: false,
             subquery: Box::new(subquery),

--- a/src/tests/sqlsmith/src/sql_gen/time_window.rs
+++ b/src/tests/sqlsmith/src/sql_gen/time_window.rs
@@ -25,7 +25,7 @@ use crate::sql_gen::{Column, Expr, SqlGenerator, Table};
 
 impl<'a, R: Rng> SqlGenerator<'a, R> {
     /// Generates time window functions.
-    pub(crate) fn gen_time_window_func(&mut self) -> (TableFactor, Vec<Column>, Table) {
+    pub(crate) fn gen_time_window_func(&mut self) -> (TableFactor, Table) {
         match self.flip_coin() {
             true => self.gen_hop(),
             false => self.gen_tumble(),
@@ -34,7 +34,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
     /// Generates `TUMBLE`.
     /// TUMBLE(data: TABLE, timecol: COLUMN, size: INTERVAL, offset?: INTERVAL)
-    fn gen_tumble(&mut self) -> (TableFactor, Vec<Column>, Table) {
+    fn gen_tumble(&mut self) -> (TableFactor, Table) {
         let tables = find_tables_with_timestamp_cols(self.tables.clone());
         let (source_table_name, time_cols, schema) = tables
             .choose(&mut self.rng)
@@ -51,12 +51,12 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         let table = Table::new(table_name, schema.clone());
 
-        (relation, schema.clone(), table)
+        (relation, table)
     }
 
     /// Generates `HOP`.
     /// HOP(data: TABLE, timecol: COLUMN, slide: INTERVAL, size: INTERVAL, offset?: INTERVAL)
-    fn gen_hop(&mut self) -> (TableFactor, Vec<Column>, Table) {
+    fn gen_hop(&mut self) -> (TableFactor, Table) {
         let tables = find_tables_with_timestamp_cols(self.tables.clone());
         let (source_table_name, time_cols, schema) = tables
             .choose(&mut self.rng)
@@ -77,7 +77,7 @@ impl<'a, R: Rng> SqlGenerator<'a, R> {
 
         let table = Table::new(table_name, schema.clone());
 
-        (relation, schema.clone(), table)
+        (relation, table)
     }
 
     fn gen_secs(&mut self) -> u64 {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

It can lead to logic errors, previously we expect columns are already qualified.
If we forgot to qualify columns, it can lead to ambiguity, e.g. in equal join: `select ... join c on c`.

Instead we just don't return columns for table factor, if we need qualified columns just call `get_qualified_columns`.

Resolve error in https://github.com/risingwavelabs/risingwave/pull/10343/files

---

Additionally we:
- Reduce recursion weight at each successful `is_recursive` check.
- Ensure that table subquery does not have unbounded recursion.


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
