### PR TITLE
feat: add debug profile tools in docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -49,8 +49,7 @@ FROM base AS risingwave
 
 LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
 
-RUN apt-get update \
-  && apt-get -y install gdb \
+RUN apt-get -y install gdb \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 RUN mkdir -p /risingwave/bin/connector-node && mkdir -p /risingwave/lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,13 @@
-FROM ubuntu:22.04 as builder
+FROM ubuntu:22.04 AS base
 
 ENV LANG en_US.utf8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl bash lld maven unzip libsasl2-dev
+RUN apt-get update \
+  && apt-get -y install ca-certificates build-essential libsasl2-dev openjdk-11-jdk
+
+FROM base AS builder
+
+RUN apt-get update && apt-get -y install make cmake protobuf-compiler curl bash lld maven unzip
 
 SHELL ["/bin/bash", "-c"]
 
@@ -30,9 +35,8 @@ RUN rustup self update \
   && rustup show \
   && rustup component add rustfmt
 
-RUN cargo fetch
-
-RUN cargo build -p risingwave_cmd_all --release --features "rw-static-link" && \
+RUN cargo fetch && \
+  cargo build -p risingwave_cmd_all --release --features "rw-static-link" && \
   mkdir -p /risingwave/bin && mv /risingwave/target/release/risingwave /risingwave/bin/ && \
   cp ./target/release/build/tikv-jemalloc-sys-*/out/build/bin/jeprof /risingwave/bin/ && \
   mkdir -p /risingwave/lib && cargo clean
@@ -41,11 +45,12 @@ RUN cd /risingwave/java && mvn -B package -Dmaven.test.skip=true -Djava.binding.
     mkdir -p /risingwave/bin/connector-node && \
     tar -zxvf /risingwave/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
 
-FROM ubuntu:22.04 as risingwave
+FROM base AS risingwave
+
 LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
 
 RUN apt-get update \
-  && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-11-jdk libsasl2-dev build-essential gdb \
+  && apt-get -y install gdb \
   && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 RUN mkdir -p /risingwave/bin/connector-node && mkdir -p /risingwave/lib

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,8 @@
-FROM ubuntu:22.04 as base
+FROM ubuntu:22.04 as builder
 
 ENV LANG en_US.utf8
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install make build-essential cmake protobuf-compiler curl bash lld maven unzip libsasl2-dev
-
-FROM base as builder
 
 SHELL ["/bin/bash", "-c"]
 
@@ -36,24 +34,31 @@ RUN cargo fetch
 
 RUN cargo build -p risingwave_cmd_all --release --features "rw-static-link" && \
   mkdir -p /risingwave/bin && mv /risingwave/target/release/risingwave /risingwave/bin/ && \
+  cp ./target/release/build/tikv-jemalloc-sys-*/out/build/bin/jeprof /risingwave/bin/ && \
   mkdir -p /risingwave/lib && cargo clean
 
 RUN cd /risingwave/java && mvn -B package -Dmaven.test.skip=true -Djava.binding.release=true && \
     mkdir -p /risingwave/bin/connector-node && \
     tar -zxvf /risingwave/java/connector-node/assembly/target/risingwave-connector-1.0.0.tar.gz -C /risingwave/bin/connector-node
 
-FROM ubuntu:22.04 as image-base
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-11-jdk libsasl2-dev && rm -rf /var/lib/{apt,dpkg,cache,log}/
-
-FROM image-base as risingwave
+FROM ubuntu:22.04 as risingwave
 LABEL org.opencontainers.image.source https://github.com/risingwavelabs/risingwave
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -y install ca-certificates openjdk-11-jdk libsasl2-dev build-essential gdb \
+  && rm -rf /var/lib/{apt,dpkg,cache,log}/
+
 RUN mkdir -p /risingwave/bin/connector-node && mkdir -p /risingwave/lib
+
 COPY --from=builder /risingwave/bin/risingwave /risingwave/bin/risingwave
 COPY --from=builder /risingwave/bin/connector-node /risingwave/bin/connector-node
 COPY --from=builder /risingwave/ui /risingwave/ui
+COPY --from=builder /risingwave/bin/jeprof /usr/local/bin/jeprof
+
 # Set default playground mode to docker-playground profile
 ENV PLAYGROUND_PROFILE docker-playground
 # Set default dashboard UI to local path instead of github proxy
 ENV RW_DASHBOARD_UI_PATH /risingwave/ui
+
 ENTRYPOINT [ "/risingwave/bin/risingwave" ]
 CMD [ "playground" ]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. Added `build-essentail`, `gdb` (for analyzing core dump) and `jeperf` (for analyzing heap profiling) into the Docker image.

This is both for online debugging and offline analyzing. These tools need to be used in the same system environment as the process, so the most convenient way is to put them in the Docker image as well.

Off-line debugging example:

```bash
# Download your coredump to ~/coredump, then run the docker image where the bug happened
docker run -it --entrypoint=bash -v ~/coredump:/coredump ghcr.io/risingwavelabs/risingwave@sha256:9cdfaa9972dbe85e8276301aae7ce41736b124d3b3f8eea51734a6759c7049ce
# inside the docker
gdb /risingwave/bin/risingwave coredump
``` 

Also reorganized the file a little bit to speed up build.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation
NA
