### PR TITLE
refactor(expr): rewrite `timestamptz +- interval` to zone-explicit variant

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -61,6 +61,8 @@ message ExprNode {
     TO_TIMESTAMP1 = 107;
     // Performs a cast with additional timezone information.
     CAST_WITH_TIME_ZONE = 108;
+    ADD_WITH_TIME_ZONE = 109;
+    SUBTRACT_WITH_TIME_ZONE = 110;
     // other functions
     CAST = 201;
     SUBSTR = 202;

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -286,33 +286,6 @@ pub fn timestamp_interval_sub(l: Timestamp, r: Interval) -> Result<Timestamp> {
     interval_timestamp_add(r.checked_neg().ok_or(ExprError::NumericOutOfRange)?, l)
 }
 
-#[function("add(timestamptz, interval) -> timestamptz")]
-pub fn timestamptz_interval_add(l: i64, r: Interval) -> Result<i64> {
-    timestamptz_interval_inner(l, r, i64::checked_add)
-}
-
-#[function("subtract(timestamptz, interval) -> timestamptz")]
-pub fn timestamptz_interval_sub(l: i64, r: Interval) -> Result<i64> {
-    timestamptz_interval_inner(l, r, i64::checked_sub)
-}
-
-#[function("add(interval, timestamptz) -> timestamptz")]
-pub fn interval_timestamptz_add(l: Interval, r: i64) -> Result<i64> {
-    timestamptz_interval_add(r, l)
-}
-
-#[inline(always)]
-fn timestamptz_interval_inner(l: i64, r: Interval, f: fn(i64, i64) -> Option<i64>) -> Result<i64> {
-    // Without session TimeZone, we cannot add month/day in local time. See #5826.
-    if r.months() != 0 || r.days() != 0 {
-        return Err(ExprError::UnsupportedFunction(
-            "timestamp with time zone +/- interval of days".into(),
-        ));
-    }
-    let delta_usecs = r.usecs();
-    f(l, delta_usecs).ok_or(ExprError::NumericOutOfRange)
-}
-
 #[function("multiply(interval, *int) -> interval")]
 pub fn interval_int_mul(l: Interval, r: impl TryInto<i32> + Debug) -> Result<Interval> {
     l.checked_mul_int(r).ok_or(ExprError::NumericOutOfRange)

--- a/src/expr/src/vector_op/timestamptz.rs
+++ b/src/expr/src/vector_op/timestamptz.rs
@@ -16,8 +16,9 @@ use std::fmt::Write;
 
 use chrono::{TimeZone, Utc};
 use chrono_tz::Tz;
+use num_traits::CheckedNeg;
 use risingwave_common::cast::{str_to_timestamp, str_with_time_zone_to_timestamptz};
-use risingwave_common::types::{IntoOrdered, Timestamp, F64};
+use risingwave_common::types::{CheckedAdd, Interval, IntoOrdered, Timestamp, F64};
 use risingwave_expr_macro::function;
 
 use crate::{ExprError, Result};
@@ -102,6 +103,67 @@ pub fn timestamptz_at_time_zone(input: i64, time_zone: &str) -> Result<Timestamp
     let instant_local = instant_utc.with_timezone(&time_zone);
     let naive = instant_local.naive_local();
     Ok(Timestamp(naive))
+}
+
+#[function("subtract_with_time_zone(timestamptz, interval, varchar) -> timestamptz")]
+pub fn timestamptz_interval_sub(input: i64, interval: Interval, time_zone: &str) -> Result<i64> {
+    timestamptz_interval_add(
+        input,
+        interval.checked_neg().ok_or(ExprError::NumericOverflow)?,
+        time_zone,
+    )
+}
+
+#[function("add_with_time_zone(timestamptz, interval, varchar) -> timestamptz")]
+pub fn timestamptz_interval_add(input: i64, interval: Interval, time_zone: &str) -> Result<i64> {
+    // A month may have 28-31 days, a day may have 23 or 25 hours during Daylight Saving switch.
+    // So their interpretation depends on the local time of a specific zone.
+    let qualitative = interval.truncate_day();
+    // Units smaller than `day` are zone agnostic.
+    let quantitative = interval - qualitative;
+
+    // Note the current implementation simply follows the frontend-rewrite chains of exprs before
+    // refactor. There may be chances to improve.
+    let t = timestamptz_at_time_zone(input, time_zone)?;
+    let t = t
+        .checked_add(qualitative)
+        .ok_or(ExprError::NumericOverflow)?;
+    let t = timestamp_at_time_zone(t, time_zone)?;
+    let t = timestamptz_interval_quantitative(t, quantitative, i64::checked_add)?;
+    Ok(t)
+}
+
+// Retained mostly for backward compatibility with old query plans. The signature is also useful for
+// binder type inference.
+#[function("add(timestamptz, interval) -> timestamptz")]
+pub fn timestamptz_interval_add_legacy(l: i64, r: Interval) -> Result<i64> {
+    timestamptz_interval_quantitative(l, r, i64::checked_add)
+}
+
+#[function("subtract(timestamptz, interval) -> timestamptz")]
+pub fn timestamptz_interval_sub_legacy(l: i64, r: Interval) -> Result<i64> {
+    timestamptz_interval_quantitative(l, r, i64::checked_sub)
+}
+
+#[function("add(interval, timestamptz) -> timestamptz")]
+pub fn interval_timestamptz_add_legacy(l: Interval, r: i64) -> Result<i64> {
+    timestamptz_interval_add_legacy(r, l)
+}
+
+#[inline(always)]
+fn timestamptz_interval_quantitative(
+    l: i64,
+    r: Interval,
+    f: fn(i64, i64) -> Option<i64>,
+) -> Result<i64> {
+    // Without session TimeZone, we cannot add month/day in local time. See #5826.
+    if r.months() != 0 || r.days() != 0 {
+        return Err(ExprError::UnsupportedFunction(
+            "timestamp with time zone +/- interval of days".into(),
+        ));
+    }
+    let delta_usecs = r.usecs();
+    f(l, delta_usecs).ok_or(ExprError::NumericOutOfRange)
 }
 
 #[cfg(test)]

--- a/src/frontend/planner_test/tests/testdata/output/expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/expr.yaml
@@ -527,7 +527,7 @@
     └─StreamDynamicFilter { predicate: (t.v1 >= $expr1), output_watermarks: [t.v1], output: [t.v1, t._row_id] }
       ├─StreamTableScan { table: t, columns: [t.v1, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange { dist: Broadcast }
-        └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '00:00:02':Interval) as $expr1], output_watermarks: [$expr1] }
+        └─StreamProject { exprs: [SubtractWithTimeZone(now, '00:00:02':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [$expr1] }
           └─StreamNow { output: [now] }
 - name: and of two now expression condition
   sql: |

--- a/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
@@ -266,7 +266,7 @@
       | └─StreamDynamicFilter { predicate: (t1.v1 > $expr1), output_watermarks: [t1.v1], output: [t1.v1, t1._row_id] }
       |   ├─StreamTableScan { table: t1, columns: [t1.v1, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       |   └─StreamExchange { dist: Broadcast }
-      |     └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '01:00:00':Interval) as $expr1], output_watermarks: [$expr1] }
+      |     └─StreamProject { exprs: [AddWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [$expr1] }
       |       └─StreamNow { output: [now] }
       └─StreamExchange { dist: HashShard(t2.v2) }
         └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
@@ -304,7 +304,7 @@
       ├─StreamFilter { predicate: (t1.v2 > 5:Int32) }
       | └─StreamTableScan { table: t1, columns: [t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: Broadcast }
-        └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:30:00':Interval) as $expr1], output_watermarks: [$expr1] }
+        └─StreamProject { exprs: [AddWithTimeZone(now, '00:30:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [$expr1] }
           └─StreamNow { output: [now] }
 - name: eq-predicate derived condition other side pushdown in inner join
   sql: |

--- a/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_filter.yaml
@@ -7,7 +7,7 @@
     StreamMaterialize { columns: [ts, t1._row_id(hidden)], stream_key: [t1._row_id], pk_columns: [t1._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.ts, t1._row_id] }
       └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [$expr1], output: [t1.ts, $expr1, t1._row_id] }
-        ├─StreamProject { exprs: [t1.ts, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '01:00:00':Interval) as $expr1, t1._row_id] }
+        ├─StreamProject { exprs: [t1.ts, AddWithTimeZone(t1.ts, '01:00:00':Interval, 'UTC':Varchar) as $expr1, t1._row_id] }
         | └─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamNow { output: [now] }
@@ -19,7 +19,7 @@
     StreamMaterialize { columns: [ts, time_to_live, t1._row_id(hidden)], stream_key: [t1._row_id], pk_columns: [t1._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.ts, t1.time_to_live, t1._row_id] }
       └─StreamDynamicFilter { predicate: ($expr1 > now), output_watermarks: [$expr1], output: [t1.ts, t1.time_to_live, $expr1, t1._row_id] }
-        ├─StreamProject { exprs: [t1.ts, t1.time_to_live, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + DateTrunc('day':Varchar, (t1.time_to_live * 1.5:Decimal))), 'UTC':Varchar) + ((t1.time_to_live * 1.5:Decimal) - DateTrunc('day':Varchar, (t1.time_to_live * 1.5:Decimal)))) as $expr1, t1._row_id] }
+        ├─StreamProject { exprs: [t1.ts, t1.time_to_live, AddWithTimeZone(t1.ts, (t1.time_to_live * 1.5:Decimal), 'UTC':Varchar) as $expr1, t1._row_id] }
         | └─StreamTableScan { table: t1, columns: [t1.ts, t1.time_to_live, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: Broadcast }
           └─StreamNow { output: [now] }
@@ -31,10 +31,10 @@
     StreamMaterialize { columns: [ts, additional_time_to_live, t1._row_id(hidden)], stream_key: [t1._row_id], pk_columns: [t1._row_id], pk_conflict: "NoCheck" }
     └─StreamProject { exprs: [t1.ts, t1.additional_time_to_live, t1._row_id] }
       └─StreamDynamicFilter { predicate: ($expr1 > $expr2), output_watermarks: [$expr1], output: [t1.ts, t1.additional_time_to_live, $expr1, t1._row_id] }
-        ├─StreamProject { exprs: [t1.ts, t1.additional_time_to_live, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + DateTrunc('day':Varchar, (t1.additional_time_to_live * 1.5:Decimal))), 'UTC':Varchar) + ((t1.additional_time_to_live * 1.5:Decimal) - DateTrunc('day':Varchar, (t1.additional_time_to_live * 1.5:Decimal)))) as $expr1, t1._row_id] }
+        ├─StreamProject { exprs: [t1.ts, t1.additional_time_to_live, AddWithTimeZone(t1.ts, (t1.additional_time_to_live * 1.5:Decimal), 'UTC':Varchar) as $expr1, t1._row_id] }
         | └─StreamTableScan { table: t1, columns: [t1.ts, t1.additional_time_to_live, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
         └─StreamExchange { dist: Broadcast }
-          └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '00:15:00':Interval) as $expr2], output_watermarks: [$expr2] }
+          └─StreamProject { exprs: [SubtractWithTimeZone(now, '00:15:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [$expr2] }
             └─StreamNow { output: [now] }
 - name: Temporal filter fails without `now()` in lower bound
   sql: |-
@@ -51,10 +51,10 @@
       ├─StreamDynamicFilter { predicate: (t1.ts >= $expr1), output_watermarks: [t1.ts], output: [t1.ts, t1._row_id] }
       | ├─StreamTableScan { table: t1, columns: [t1.ts, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       | └─StreamExchange { dist: Broadcast }
-      |   └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '02:00:00':Interval) as $expr1], output_watermarks: [$expr1] }
+      |   └─StreamProject { exprs: [SubtractWithTimeZone(now, '02:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [$expr1] }
       |     └─StreamNow { output: [now] }
       └─StreamExchange { dist: Broadcast }
-        └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '01:00:00':Interval) as $expr2], output_watermarks: [$expr2] }
+        └─StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [$expr2] }
           └─StreamNow { output: [now] }
   stream_dist_plan: |+
     Fragment 0
@@ -72,18 +72,28 @@
         └──  StreamExchange Broadcast from 2
 
     Fragment 1
-    StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '02:00:00':Interval) as $expr1], output_watermarks: [$expr1] }
+    StreamProject { exprs: [SubtractWithTimeZone(now, '02:00:00':Interval, 'UTC':Varchar) as $expr1], output_watermarks: [$expr1] }
     └──  StreamNow { output: [now] } { state table: 5 }
 
     Fragment 2
-    StreamProject { exprs: [(AtTimeZone((AtTimeZone(now, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '01:00:00':Interval) as $expr2], output_watermarks: [$expr2] }
+    StreamProject { exprs: [SubtractWithTimeZone(now, '01:00:00':Interval, 'UTC':Varchar) as $expr2], output_watermarks: [$expr2] }
     └──  StreamNow { output: [now] } { state table: 6 }
 
-    Table 0 { columns: [ t1_ts, t1__row_id ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 0
+    ├── columns: [ t1_ts, t1__row_id ]
+    ├── primary key: [ $0 ASC, $1 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: [ 1 ]
+    └── read pk prefix len hint: 1
 
     Table 1 { columns: [ $expr2 ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
-    Table 2 { columns: [ t1_ts, t1__row_id ], primary key: [ $0 ASC, $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 2
+    ├── columns: [ t1_ts, t1__row_id ]
+    ├── primary key: [ $0 ASC, $1 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: [ 1 ]
+    └── read pk prefix len hint: 1
 
     Table 3 { columns: [ $expr1 ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
@@ -99,5 +109,10 @@
 
     Table 6 { columns: [ now ], primary key: [], value indices: [ 0 ], distribution key: [], read pk prefix len hint: 0 }
 
-    Table 4294967294 { columns: [ ts, t1._row_id ], primary key: [ $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 4294967294
+    ├── columns: [ ts, t1._row_id ]
+    ├── primary key: [ $1 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: [ 1 ]
+    └── read pk prefix len hint: 1
 

--- a/src/frontend/planner_test/tests/testdata/output/watermark.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/watermark.yaml
@@ -8,21 +8,32 @@
     └─LogicalSource { source: t, columns: [v1, _row_id], time_range: [(Unbounded, Unbounded)] }
   stream_plan: |
     StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck", watermark_columns: [v1] }
-    └─StreamProject { exprs: [(AtTimeZone((AtTimeZone(v1, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '00:00:02':Interval) as $expr1, _row_id], output_watermarks: [$expr1] }
+    └─StreamProject { exprs: [SubtractWithTimeZone(v1, '00:00:02':Interval, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [$expr1] }
       └─StreamRowIdGen { row_id_index: 1 }
         └─StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - '00:00:01':Interval)] }
           └─StreamSource { source: "t", columns: ["v1", "_row_id"] }
   stream_dist_plan: |+
     Fragment 0
-    StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck", watermark_columns: [v1] } { materialized table: 4294967294 }
-    └── StreamProject { exprs: [(AtTimeZone((AtTimeZone(v1, 'UTC':Varchar) - '00:00:00':Interval), 'UTC':Varchar) - '00:00:02':Interval) as $expr1, _row_id], output_watermarks: [$expr1] }
+    StreamMaterialize { columns: [v1, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: "NoCheck", watermark_columns: [v1] }
+    ├── materialized table: 4294967294
+    └── StreamProject { exprs: [SubtractWithTimeZone(v1, '00:00:02':Interval, 'UTC':Varchar) as $expr1, _row_id], output_watermarks: [$expr1] }
         └── StreamRowIdGen { row_id_index: 1 }
             └── StreamWatermarkFilter { watermark_descs: [idx: 0, expr: (v1 - '00:00:01':Interval)] }
                 └──  StreamSource { source: "t", columns: ["v1", "_row_id"] } { source state table: 1 }
 
-    Table 1 { columns: [ partition_id, offset_info ], primary key: [ $0 ASC ], value indices: [ 0, 1 ], distribution key: [], read pk prefix len hint: 1 }
+    Table 1
+    ├── columns: [ partition_id, offset_info ]
+    ├── primary key: [ $0 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: []
+    └── read pk prefix len hint: 1
 
-    Table 4294967294 { columns: [ v1, _row_id ], primary key: [ $1 ASC ], value indices: [ 0, 1 ], distribution key: [ 1 ], read pk prefix len hint: 1 }
+    Table 4294967294
+    ├── columns: [ v1, _row_id ]
+    ├── primary key: [ $1 ASC ]
+    ├── value indices: [ 0, 1 ]
+    ├── distribution key: [ 1 ]
+    └── read pk prefix len hint: 1
 
 - name: watermark on append only table with source
   sql: |
@@ -90,10 +101,10 @@
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
     └─StreamHashJoin [interval] { type: LeftOuter, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
-      | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
+      | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, AddWithTimeZone(t1.ts, '00:00:01':Interval, 'UTC':Varchar) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.v1) }
-        └─StreamProject { exprs: [t2.ts, t2.v1, t2.v2, (AtTimeZone((AtTimeZone(t2.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr2, t2._row_id], output_watermarks: [t2.ts, $expr2] }
+        └─StreamProject { exprs: [t2.ts, t2.v1, t2.v2, AddWithTimeZone(t2.ts, '00:00:01':Interval, 'UTC':Varchar) as $expr2, t2._row_id], output_watermarks: [t2.ts, $expr2] }
           └─StreamTableScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: interval join (inner join)
   sql: |
@@ -109,10 +120,10 @@
     StreamMaterialize { columns: [t1_ts, t1_v1, t1_v2, t2_ts, t2_v1, t2_v2, t1._row_id(hidden), t2._row_id(hidden)], stream_key: [t1._row_id, t2._row_id, t1_v1], pk_columns: [t1._row_id, t2._row_id, t1_v1], pk_conflict: "NoCheck", watermark_columns: [t1_ts, t2_ts] }
     └─StreamHashJoin [interval, append_only] { type: Inner, predicate: t1.v1 = t2.v1 AND (t1.ts >= $expr2) AND ($expr1 <= t2.ts), conditions_to_clean_left_state_table: (t1.ts >= $expr2), conditions_to_clean_right_state_table: ($expr1 <= t2.ts), output_watermarks: [t1.ts, t2.ts], output: [t1.ts, t1.v1, t1.v2, t2.ts, t2.v1, t2.v2, t1._row_id, t2._row_id] }
       ├─StreamExchange { dist: HashShard(t1.v1) }
-      | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, (AtTimeZone((AtTimeZone(t1.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
+      | └─StreamProject { exprs: [t1.ts, t1.v1, t1.v2, AddWithTimeZone(t1.ts, '00:00:01':Interval, 'UTC':Varchar) as $expr1, t1._row_id], output_watermarks: [t1.ts, $expr1] }
       |   └─StreamTableScan { table: t1, columns: [t1.ts, t1.v1, t1.v2, t1._row_id], pk: [t1._row_id], dist: UpstreamHashShard(t1._row_id) }
       └─StreamExchange { dist: HashShard(t2.v1) }
-        └─StreamProject { exprs: [t2.ts, t2.v1, t2.v2, (AtTimeZone((AtTimeZone(t2.ts, 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:00:01':Interval) as $expr2, t2._row_id], output_watermarks: [t2.ts, $expr2] }
+        └─StreamProject { exprs: [t2.ts, t2.v1, t2.v2, AddWithTimeZone(t2.ts, '00:00:01':Interval, 'UTC':Varchar) as $expr2, t2._row_id], output_watermarks: [t2.ts, $expr2] }
           └─StreamTableScan { table: t2, columns: [t2.ts, t2.v1, t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
 - name: union all
   sql: |
@@ -151,7 +162,7 @@
     select * from tumble(t, ts, interval '3' minute);
   stream_plan: |
     StreamMaterialize { columns: [ts, v1, v2, window_start, window_end, t._row_id(hidden)], stream_key: [t._row_id], pk_columns: [t._row_id], pk_conflict: "NoCheck", watermark_columns: [ts, window_start, window_end] }
-    └─StreamProject { exprs: [t.ts, t.v1, t.v2, TumbleStart(t.ts, '00:03:00':Interval) as $expr1, (AtTimeZone((AtTimeZone(TumbleStart(t.ts, '00:03:00':Interval), 'UTC':Varchar) + '00:00:00':Interval), 'UTC':Varchar) + '00:03:00':Interval) as $expr2, t._row_id], output_watermarks: [t.ts, $expr1, $expr2] }
+    └─StreamProject { exprs: [t.ts, t.v1, t.v2, TumbleStart(t.ts, '00:03:00':Interval) as $expr1, AddWithTimeZone(TumbleStart(t.ts, '00:03:00':Interval), '00:03:00':Interval, 'UTC':Varchar) as $expr2, t._row_id], output_watermarks: [t.ts, $expr1, $expr2] }
       └─StreamTableScan { table: t, columns: [t.ts, t.v1, t.v2, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - name: hop all
   sql: |

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -65,6 +65,8 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
             | expr_node::Type::DateTrunc
             | expr_node::Type::ToTimestamp1
             | expr_node::Type::CastWithTimeZone
+            | expr_node::Type::AddWithTimeZone
+            | expr_node::Type::SubtractWithTimeZone
             | expr_node::Type::Cast
             | expr_node::Type::Substr
             | expr_node::Type::Length


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We used to rewrite `timestamptz + interval` into the following expr tree in frontend:
```
Add
  AtTimeZone
    Add
      AtTimeZone
        timestamptz
      interval year, month, day ("qualitative" or variable length units)
  interval hour, minute, seconds, microseconds ("quantitative" or fixed length units)
```
This PR introduces dedicated `AddWithTimeZone` (and `SubtractWithTimeZone`):
* The rewrite would be simply `Add(timestamptz, interval)` to `AddWithTimeZone(timestamptz, interval, text)`
* The backend implement is still composed by the expr tree shown above. But this is now an implementation detail and can be improved later.
* Original backend implementation is retained for backward compatibility. Plans generated by older version continue working. The frontend will start generating plans with the new expr.

**The primary goal of this refactor is to unify the handling of implicit session timezone, by always rewriting to a corresponding variant that accepts an extra explicit timezone parameter.**

PostgreSQL already have the following overloads since 12.0:
* `date_trunc(text, timestamptz)`
* `date_trunc(text, timestamptz, text)`
* `make_timestamptz(int, int, int, int, int, double precision)`
* `make_timestamptz(int, int, int, int, int, double precision, text)`

and upcoming PostgreSQL 16 is adding more:
* `date_add(timestamptz, interval)`
* `date_add(timestamptz, interval, text)`
* `date_subtract(timestamptz, interval)`
* `date_subtract(timestamptz, interval, text)`
* `generate_series(timestamptz, timestamptz, interval)` (existing)
* `generate_series(timestamptz, timestamptz, interval, text)`

That is, we can support `date_trunc(text, timestamptz)` by rewriting it to `date_trunc(text, timestamptz, text)`, and the new `AddWithTimeZone` is essentially `date_add(timestamptz, interval, text)`. (About naming: there will be no implicit zone variant in backend so the `AddWithTimeZone` naming is appropriate.)

Following this method, we would also add a zone parameter to the following later:
* `extract / date_part(text, timestamptz)`
* `to_timestamp(text, text)` #7780
* `to_char(timestamptz, text)`
* `age(timestamptz, timestamptz)`

These will be overloaded on their existing expr type rather than introducing a dedicated `FooWithTimeZone`. This approach is similar to `date_trunc` / `make_timestamptz` / `generate_series` but not `cast` / `add` / `subtract`. Dedicated exprs are only introduced because it makes things simpler by keeping `cast` as unary and `add` / `subtract` as binary.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
