### PR TITLE
feat: supports `--from` option for reschedule command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1323,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "80672091db20273a15cf9fdd4e47ed43b5091ec9841bf4c6145c9dfbbcae09ed"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1334,23 +1334,23 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "c1458a1df40e1e2afebb7ab60ce55c1fa8f431146205aa5f4887e0b111c27636"
 dependencies = [
  "anstream",
  "anstyle",
  "bitflags 1.3.2",
- "clap_lex 0.4.1",
+ "clap_lex 0.5.0",
  "once_cell",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -1369,9 +1369,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "cmake"
@@ -3346,7 +3346,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b603516767d1ab23d0de09d023e62966c3322f7148297c35cf3d97aa8b37fa"
 dependencies = [
- "clap 4.2.7",
+ "clap 4.3.4",
  "termcolor",
  "threadpool",
 ]
@@ -5595,7 +5595,7 @@ version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "console",
  "dialoguer",
  "enum-iterator",
@@ -5625,7 +5625,7 @@ name = "risedev-config"
 version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
- "clap 4.2.7",
+ "clap 4.3.4",
  "console",
  "dialoguer",
  "enum-iterator",
@@ -5658,7 +5658,7 @@ dependencies = [
 name = "risingwave_backup_cmd"
 version = "1.0.0-alpha"
 dependencies = [
- "clap 4.2.7",
+ "clap 4.3.4",
  "madsim-tokio",
  "prometheus",
  "risingwave_backup",
@@ -5724,7 +5724,7 @@ dependencies = [
  "bcc",
  "bytes",
  "bytesize",
- "clap 4.2.7",
+ "clap 4.3.4",
  "futures",
  "hdrhistogram",
  "isahc",
@@ -5753,7 +5753,7 @@ name = "risingwave_cmd"
 version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
- "clap 4.2.7",
+ "clap 4.3.4",
  "madsim-tokio",
  "prometheus",
  "risingwave_common",
@@ -5774,7 +5774,7 @@ name = "risingwave_cmd_all"
 version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
- "clap 4.2.7",
+ "clap 4.3.4",
  "console",
  "const-str",
  "madsim-tokio",
@@ -5814,7 +5814,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
- "clap 4.2.7",
+ "clap 4.3.4",
  "comfy-table",
  "crc32fast",
  "criterion",
@@ -5919,7 +5919,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
- "clap 4.2.7",
+ "clap 4.3.4",
  "futures",
  "itertools",
  "madsim-tokio",
@@ -5947,7 +5947,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "await-tree",
- "clap 4.2.7",
+ "clap 4.3.4",
  "madsim-tokio",
  "madsim-tonic",
  "parking_lot 0.12.1",
@@ -5972,7 +5972,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "await-tree",
- "clap 4.2.7",
+ "clap 4.3.4",
  "either",
  "futures",
  "futures-async-stream",
@@ -6083,7 +6083,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "comfy-table",
  "futures",
  "itertools",
@@ -6099,7 +6099,10 @@ dependencies = [
  "risingwave_storage",
  "risingwave_stream",
  "risingwave_tracing",
+ "serde",
+ "serde_derive",
  "serde_json",
+ "serde_yaml",
  "size",
  "tracing",
  "uuid",
@@ -6112,7 +6115,7 @@ version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "madsim-tokio",
  "pg_interval",
  "rust_decimal",
@@ -6188,7 +6191,7 @@ dependencies = [
  "async-trait",
  "bk-tree",
  "bytes",
- "clap 4.2.7",
+ "clap 4.3.4",
  "downcast-rs",
  "dyn-clone",
  "easy-ext",
@@ -6341,7 +6344,7 @@ dependencies = [
  "aws-sdk-ec2",
  "axum",
  "bytes",
- "clap 4.2.7",
+ "clap 4.3.4",
  "crepe",
  "easy-ext",
  "either",
@@ -6465,7 +6468,7 @@ name = "risingwave_regress_test"
 version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
- "clap 4.2.7",
+ "clap 4.3.4",
  "madsim-tokio",
  "path-absolutize",
  "similar",
@@ -6528,7 +6531,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 4.2.7",
+ "clap 4.3.4",
  "console",
  "futures",
  "glob",
@@ -6619,7 +6622,7 @@ version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "expect-test",
  "itertools",
  "libtest-mimic",
@@ -6643,7 +6646,7 @@ version = "1.0.0-alpha"
 dependencies = [
  "anyhow",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "futures",
  "itertools",
  "madsim-tokio",
@@ -8970,7 +8973,7 @@ dependencies = [
  "bytes",
  "cc",
  "chrono",
- "clap 4.2.7",
+ "clap 4.3.4",
  "clap_builder",
  "combine",
  "crossbeam-epoch",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -32,7 +32,10 @@ risingwave_rpc_client = { path = "../rpc_client" }
 risingwave_storage = { path = "../storage" }
 risingwave_stream = { path = "../stream" }
 risingwave_tracing = { path = "../tracing" }
+serde = "1"
+serde_derive = "1"
 serde_json = "1"
+serde_yaml = "0.9.21"
 size = "0.4"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "rt",


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds the `--from` option to the reschedule command, allowing the configuration to be read from a file. It also modifies the rules for the subcommand, making `--from` conflict with the `--plan` parameter.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation



<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
