### PR TITLE
feat(source): fill in null value on missing column instead of skipping

### DIFF
--- a/src/compute/tests/integration_tests.rs
+++ b/src/compute/tests/integration_tests.rs
@@ -120,8 +120,13 @@ async fn test_table_materialize() -> StreamResult<()> {
         "fields.v1.seed" => "12345",
     ));
     let row_id_index: usize = 0;
-    let source_builder =
-        create_source_desc_builder(&schema, Some(row_id_index), source_info, properties);
+    let source_builder = create_source_desc_builder(
+        &schema,
+        Some(row_id_index),
+        source_info,
+        properties,
+        vec![row_id_index],
+    );
 
     // Ensure the source exists.
     let source_desc = source_builder.build().await.unwrap();

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -605,6 +605,7 @@ mod tests {
                     fields: vec![],
                     is_row_id: false,
                     is_meta: false,
+                    is_pk: false
                 },
                 SourceColumnDesc::simple("o_enum", DataType::Varchar, ColumnId::from(8)),
                 SourceColumnDesc::simple("o_char", DataType::Varchar, ColumnId::from(9)),

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -605,7 +605,7 @@ mod tests {
                     fields: vec![],
                     is_row_id: false,
                     is_meta: false,
-                    is_pk: false
+                    is_pk: false,
                 },
                 SourceColumnDesc::simple("o_enum", DataType::Varchar, ColumnId::from(8)),
                 SourceColumnDesc::simple("o_char", DataType::Varchar, ColumnId::from(9)),

--- a/src/connector/src/parser/unified/util.rs
+++ b/src/connector/src/parser/unified/util.rs
@@ -23,11 +23,20 @@ pub fn apply_row_operation_on_stream_chunk_writer(
 ) -> std::result::Result<WriteGuard, RwError> {
     match row_op.op()? {
         super::ChangeEventOperation::Upsert => writer.insert(|column| {
-            let res = row_op.access_field(&column.name, &column.data_type);
+            let res = match row_op.access_field(&column.name, &column.data_type) {
+                Ok(o) => Ok(o),
+                Err(AccessError::Undefined { name, .. }) if !column.is_pk && name == column.name => {
+                    // Fill in null value for non-pk column
+                    // TODO: figure out a way to fill in not-null default value if user specifies one
+                    Ok(None)
+                },
+                Err(e) => Err(e)
+            };
             tracing::debug!(
-                "inserted {:?} {:?} {:?}",
+                "inserted {:?} {:?} is_pk:{:?} {:?} ",
                 &column.name,
                 &column.data_type,
+                &column.is_pk,
                 res
             );
             Ok(res?)
@@ -38,7 +47,12 @@ pub fn apply_row_operation_on_stream_chunk_writer(
                 Ok(datum) => Ok(datum),
                 Err(e) => {
                     tracing::error!(name=?column.name, data_type=?&column.data_type, err=?e, "delete column error");
-                    Ok(None)
+                    if column.is_pk {
+                        // It should be an error when pk column is missing in the message
+                        Err(e)?
+                    } else {
+                        Ok(None)
+                    }
                 }
             }
         }),

--- a/src/connector/src/source/manager.rs
+++ b/src/connector/src/source/manager.rs
@@ -29,6 +29,8 @@ pub struct SourceColumnDesc {
     pub is_row_id: bool,
 
     pub is_meta: bool,
+    // `is_pk` is used to indicate whether the column is part of the primary key columns.
+    pub is_pk: bool,
 }
 
 impl SourceColumnDesc {
@@ -47,6 +49,7 @@ impl SourceColumnDesc {
             fields: vec![],
             is_row_id: false,
             is_meta: false,
+            is_pk: false,
         }
     }
 
@@ -66,6 +69,7 @@ impl From<&ColumnDesc> for SourceColumnDesc {
             fields: c.field_descs.clone(),
             is_row_id: false,
             is_meta,
+            is_pk: false,
         }
     }
 }

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -57,6 +57,7 @@ pub struct SourceDescBuilder {
     source_info: PbStreamSourceInfo,
     connector_params: ConnectorParams,
     connector_message_buffer_size: usize,
+    pk_indicies: Vec<usize>,
 }
 
 impl SourceDescBuilder {
@@ -69,6 +70,7 @@ impl SourceDescBuilder {
         source_info: PbStreamSourceInfo,
         connector_params: ConnectorParams,
         connector_message_buffer_size: usize,
+        pk_indicies: Vec<usize>,
     ) -> Self {
         Self {
             columns,
@@ -78,6 +80,7 @@ impl SourceDescBuilder {
             source_info,
             connector_params,
             connector_message_buffer_size,
+            pk_indicies,
         }
     }
 
@@ -89,6 +92,9 @@ impl SourceDescBuilder {
             .collect();
         if let Some(row_id_index) = self.row_id_index {
             columns[row_id_index].is_row_id = true;
+        }
+        for pk_index in &self.pk_indicies {
+            columns[*pk_index].is_pk = true;
         }
         columns
     }
@@ -181,6 +187,7 @@ pub mod test_utils {
         row_id_index: Option<usize>,
         source_info: StreamSourceInfo,
         properties: HashMap<String, String>,
+        pk_indicies: Vec<usize>,
     ) -> SourceDescBuilder {
         let columns = schema
             .fields
@@ -209,6 +216,7 @@ pub mod test_utils {
             source_info,
             connector_params: Default::default(),
             connector_message_buffer_size: DEFAULT_CONNECTOR_MESSAGE_BUFFER_SIZE,
+            pk_indicies,
         }
     }
 }

--- a/src/source/src/source_desc.rs
+++ b/src/source/src/source_desc.rs
@@ -57,7 +57,7 @@ pub struct SourceDescBuilder {
     source_info: PbStreamSourceInfo,
     connector_params: ConnectorParams,
     connector_message_buffer_size: usize,
-    pk_indicies: Vec<usize>,
+    pk_indices: Vec<usize>,
 }
 
 impl SourceDescBuilder {
@@ -70,7 +70,7 @@ impl SourceDescBuilder {
         source_info: PbStreamSourceInfo,
         connector_params: ConnectorParams,
         connector_message_buffer_size: usize,
-        pk_indicies: Vec<usize>,
+        pk_indices: Vec<usize>,
     ) -> Self {
         Self {
             columns,
@@ -80,7 +80,7 @@ impl SourceDescBuilder {
             source_info,
             connector_params,
             connector_message_buffer_size,
-            pk_indicies,
+            pk_indices,
         }
     }
 
@@ -93,7 +93,7 @@ impl SourceDescBuilder {
         if let Some(row_id_index) = self.row_id_index {
             columns[row_id_index].is_row_id = true;
         }
-        for pk_index in &self.pk_indicies {
+        for pk_index in &self.pk_indices {
             columns[*pk_index].is_pk = true;
         }
         columns
@@ -187,7 +187,7 @@ pub mod test_utils {
         row_id_index: Option<usize>,
         source_info: StreamSourceInfo,
         properties: HashMap<String, String>,
-        pk_indicies: Vec<usize>,
+        pk_indices: Vec<usize>,
     ) -> SourceDescBuilder {
         let columns = schema
             .fields
@@ -216,7 +216,7 @@ pub mod test_utils {
             source_info,
             connector_params: Default::default(),
             connector_message_buffer_size: DEFAULT_CONNECTOR_MESSAGE_BUFFER_SIZE,
-            pk_indicies,
+            pk_indices,
         }
     }
 }

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -624,7 +624,7 @@ mod tests {
             "fields.sequence_int.end" => "11111",
         ));
         let source_desc_builder =
-            create_source_desc_builder(&schema, row_id_index, source_info, properties);
+            create_source_desc_builder(&schema, row_id_index, source_info, properties, vec![]);
         let split_state_store = SourceStateTableHandler::from_table_catalog(
             &default_source_internal_table(0x2333),
             MemoryStateStore::new(),
@@ -706,7 +706,7 @@ mod tests {
         ));
 
         let source_desc_builder =
-            create_source_desc_builder(&schema, row_id_index, source_info, properties);
+            create_source_desc_builder(&schema, row_id_index, source_info, properties, vec![]);
         let mem_state_store = MemoryStateStore::new();
 
         let column_ids = vec![ColumnId::from(0)];

--- a/src/stream/src/from_proto/source.rs
+++ b/src/stream/src/from_proto/source.rs
@@ -62,6 +62,16 @@ impl ExecutorBuilder for SourceExecutorBuilder {
                 source.get_info()?.clone(),
                 params.env.connector_params(),
                 params.env.config().developer.connector_message_buffer_size,
+                // `pk_indices` is used to ensure that a message will be skipped instead of parsed
+                // with null pk when the pk column is missing.
+                //
+                // Currently pk_indices for source is always empty since pk information is not
+                // passed via `StreamSource` so null pk may be emitted to downstream.
+                //
+                // TODO: use the correct information to fill in pk_dicies.
+                // We should consdier add back the "pk_column_ids" field removed by #8841 in
+                // StreamSource
+                params.pk_indices.clone(),
             );
 
             let column_ids: Vec<_> = source


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #10416

This PR changes the source behaviour when encountering a missing column from skipping the message to filling in null.

Caveat: I think the correct behavior is to only allow missing non-pk columns and we should skip the message if any of the pk column is missing. However, after #8841, we cannot get source pk info easily when creating the source executor so this PR still allows missing pk columns. I leave a TODO for this and will address it in a separate PR.

## Checklist

- [x] I have written necessary rustdoc comments
~~- [ ] I have added necessary unit tests and integration tests~~ I tested locally in my env with pg cdc.
~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
