### PR TITLE
refactor(plan_node_fmt): now returns `XmlNode`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4959,9 +4959,9 @@ dependencies = [
 
 [[package]]
 name = "pretty-xmlish"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3571b8a349f2ae161a00e08b9c36cd34dfb53a3451a5a266becd0ff1d83b0c"
+checksum = "4b8521f917709e972580e93427ac30d777c94689f61abeaf211b518ccc4e324d"
 
 [[package]]
 name = "pretty_assertions"

--- a/src/frontend/src/optimizer/plan_node/batch_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_exchange.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{ExchangeNode, MergeSortExchangeNode};
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch};
 use crate::optimizer::plan_node::ToLocalBatch;
 use crate::optimizer::property::{Distribution, DistributionDisplay, Order, OrderDisplay};
@@ -59,9 +59,9 @@ impl fmt::Display for BatchExchange {
     }
 }
 impl Distill for BatchExchange {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let input_schema = self.input.schema();
-        Pretty::childless_record(
+        childless_record(
             "BatchExchange",
             vec![
                 (

--- a/src/frontend/src/optimizer/plan_node/batch_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_exchange.rs
@@ -61,25 +61,15 @@ impl fmt::Display for BatchExchange {
 impl Distill for BatchExchange {
     fn distill<'a>(&self) -> XmlNode<'a> {
         let input_schema = self.input.schema();
-        childless_record(
-            "BatchExchange",
-            vec![
-                (
-                    "order",
-                    Pretty::display(&OrderDisplay {
-                        order: &self.base.order,
-                        input_schema,
-                    }),
-                ),
-                (
-                    "dist",
-                    Pretty::display(&DistributionDisplay {
-                        distribution: &self.base.dist,
-                        input_schema,
-                    }),
-                ),
-            ],
-        )
+        let order = Pretty::display(&OrderDisplay {
+            order: &self.base.order,
+            input_schema,
+        });
+        let dist = Pretty::display(&DistributionDisplay {
+            distribution: &self.base.dist,
+            input_schema,
+        });
+        childless_record("BatchExchange", vec![("order", order), ("dist", dist)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_hash_join.rs
@@ -14,14 +14,14 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::HashJoinNode;
 use risingwave_pb::plan_common::JoinType;
 
 use super::generic::{self, GenericPlanRef};
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     EqJoinPredicate, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatchPb,
     ToDistributedBatch,
@@ -100,7 +100,7 @@ impl BatchHashJoin {
 }
 
 impl Distill for BatchHashJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
         vec.push(("type", Pretty::debug(&self.logical.join_type)));
@@ -118,7 +118,7 @@ impl Distill for BatchHashJoin {
                 .map_or_else(|| Pretty::from("all"), |id| Pretty::display(&id));
             vec.push(("output", data));
         }
-        Pretty::childless_record("BatchHashJoin", vec)
+        childless_record("BatchHashJoin", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_insert.rs
@@ -14,13 +14,13 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::InsertNode;
 use risingwave_pb::plan_common::{DefaultColumns, IndexAndExpr};
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{generic, ExprRewritable, PlanRef, PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch};
 use crate::expr::Expr;
 use crate::optimizer::plan_node::{PlanBase, ToLocalBatch};
@@ -47,11 +47,11 @@ impl BatchInsert {
 }
 
 impl Distill for BatchInsert {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let vec = self
             .logical
             .fields_pretty(self.base.ctx.is_explain_verbose());
-        Pretty::childless_record("BatchInsert", vec)
+        childless_record("BatchInsert", vec)
     }
 }
 impl fmt::Display for BatchInsert {

--- a/src/frontend/src/optimizer/plan_node/batch_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_insert.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::InsertNode;

--- a/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_lookup_join.rs
@@ -14,14 +14,14 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnId, TableDesc};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::{DistributedLookupJoinNode, LocalLookupJoinNode};
 
 use super::generic::{self};
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::ExprRewritable;
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::utils::IndicesDisplay;
@@ -115,7 +115,7 @@ impl BatchLookupJoin {
 }
 
 impl Distill for BatchLookupJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
         vec.push(("type", Pretty::debug(&self.logical.join_type)));
@@ -135,7 +135,7 @@ impl Distill for BatchLookupJoin {
             vec.push(("output", data));
         }
 
-        Pretty::childless_record("BatchLookupJoin", vec)
+        childless_record("BatchLookupJoin", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_nested_loop_join.rs
@@ -14,13 +14,13 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::NestedLoopJoinNode;
 
 use super::generic::{self};
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, ToBatchPb, ToDistributedBatch};
 use crate::expr::{Expr, ExprImpl, ExprRewriter};
 use crate::optimizer::plan_node::utils::IndicesDisplay;
@@ -52,7 +52,7 @@ impl BatchNestedLoopJoin {
 }
 
 impl Distill for BatchNestedLoopJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
         vec.push(("type", Pretty::debug(&self.logical.join_type)));
@@ -72,7 +72,7 @@ impl Distill for BatchNestedLoopJoin {
             vec.push(("output", data));
         }
 
-        Pretty::childless_record("BatchNestedLoopJoin", vec)
+        childless_record("BatchNestedLoopJoin", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::ProjectNode;

--- a/src/frontend/src/optimizer/plan_node/batch_project.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_project.rs
@@ -14,13 +14,13 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::ProjectNode;
 use risingwave_pb::expr::ExprNode;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch,
 };
@@ -65,8 +65,8 @@ impl fmt::Display for BatchProject {
 }
 
 impl Distill for BatchProject {
-    fn distill<'a>(&self) -> Pretty<'a> {
-        Pretty::childless_record("BatchProject", self.logical.fields_pretty(self.schema()))
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        childless_record("BatchProject", self.logical.fields_pretty(self.schema()))
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_seq_scan.rs
@@ -16,7 +16,7 @@ use std::fmt;
 use std::ops::Bound;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_common::types::ScalarImpl;
 use risingwave_common::util::scan_range::{is_full_range, ScanRange};
@@ -25,7 +25,7 @@ use risingwave_pb::batch_plan::row_seq_scan_node::ChunkSize;
 use risingwave_pb::batch_plan::{RowSeqScanNode, SysRowSeqScanNode};
 use risingwave_pb::plan_common::PbColumnDesc;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{generic, ExprRewritable, PlanBase, PlanRef, ToBatchPb, ToDistributedBatch};
 use crate::catalog::ColumnId;
 use crate::expr::ExprRewriter;
@@ -180,7 +180,7 @@ fn range_to_string(name: &str, range: &(Bound<ScalarImpl>, Bound<ScalarImpl>)) -
 }
 
 impl Distill for BatchSeqScan {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(4);
         vec.push(("table", Pretty::from(self.logical.table_name.clone())));
@@ -202,7 +202,7 @@ impl Distill for BatchSeqScan {
             vec.push(("distribution", dist));
         }
 
-        Pretty::childless_record("BatchScan", vec)
+        childless_record("BatchScan", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_sort.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::SortNode;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, ToBatchPb, ToDistributedBatch};
 use crate::optimizer::plan_node::ToLocalBatch;
 use crate::optimizer::property::{Order, OrderDisplay};
@@ -56,12 +56,12 @@ impl fmt::Display for BatchSort {
 }
 
 impl Distill for BatchSort {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = Pretty::display(&OrderDisplay {
             order: self.order(),
             input_schema: self.input.schema(),
         });
-        Pretty::childless_record("BatchSort", vec![("order", data)])
+        childless_record("BatchSort", vec![("order", data)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_source.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_source.rs
@@ -15,12 +15,12 @@
 use std::fmt;
 use std::rc::Rc;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::SourceNode;
 
-use super::utils::{column_names_pretty, Distill};
+use super::utils::{childless_record, column_names_pretty, Distill};
 use super::{
     generic, ExprRewritable, PlanBase, PlanRef, ToBatchPb, ToDistributedBatch, ToLocalBatch,
 };
@@ -82,14 +82,14 @@ impl fmt::Display for BatchSource {
 }
 
 impl Distill for BatchSource {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let src = Pretty::from(self.source_catalog().unwrap().name.clone());
         let fields = vec![
             ("source", src),
             ("columns", column_names_pretty(self.schema())),
             ("filter", Pretty::debug(&self.kafka_timestamp_range_value())),
         ];
-        Pretty::childless_record("BatchSource", fields)
+        childless_record("BatchSource", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_table_function.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::TableFunctionNode;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeLeaf, ToBatchPb, ToDistributedBatch};
 use crate::expr::ExprRewriter;
 use crate::optimizer::plan_node::logical_table_function::LogicalTableFunction;
@@ -62,9 +62,9 @@ impl fmt::Display for BatchTableFunction {
     }
 }
 impl Distill for BatchTableFunction {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = Pretty::debug(&self.logical.table_function);
-        Pretty::childless_record("BatchTableFunction", vec![("table_function", data)])
+        childless_record("BatchTableFunction", vec![("table_function", data)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/batch_values.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_values.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::values_node::ExprTuple;

--- a/src/frontend/src/optimizer/plan_node/batch_values.rs
+++ b/src/frontend/src/optimizer/plan_node/batch_values.rs
@@ -14,13 +14,13 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::error::Result;
 use risingwave_pb::batch_plan::plan_node::NodeBody;
 use risingwave_pb::batch_plan::values_node::ExprTuple;
 use risingwave_pb::batch_plan::ValuesNode;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     ExprRewritable, LogicalValues, PlanBase, PlanRef, PlanTreeNodeLeaf, ToBatchPb,
     ToDistributedBatch,
@@ -69,9 +69,9 @@ impl fmt::Display for BatchValues {
     }
 }
 impl Distill for BatchValues {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = self.logical.rows_pretty();
-        Pretty::childless_record("BatchValues", vec![("rows", data)])
+        childless_record("BatchValues", vec![("rows", data)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/dedup.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dedup.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::{FieldDisplay, Schema};
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 use crate::OptimizerContextRef;
 
@@ -56,8 +57,8 @@ impl<PlanRef: GenericPlanRef> Dedup<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for Dedup<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
-        Pretty::childless_record(name, vec![("dedup_cols", self.dedup_cols_pretty())])
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
+        childless_record(name, vec![("dedup_cols", self.dedup_cols_pretty())])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/dedup.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dedup.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use itertools::Itertools;

--- a/src/frontend/src/optimizer/plan_node/generic/delete.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/delete.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+
 // Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,12 @@ use std::fmt;
 use std::hash::Hash;
 
 use educe::Educe;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::{Schema, TableVersionId};
 
 use super::{DistillUnit, GenericPlanRef};
 use crate::catalog::TableId;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::OptimizerContextRef;
 
 #[derive(Debug, Clone, Educe)]
@@ -78,12 +79,12 @@ impl<PlanRef: Eq + Hash> Delete<PlanRef> {
 }
 
 impl<PlanRef: Eq + Hash> DistillUnit for Delete<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let mut vec = Vec::with_capacity(if self.returning { 2 } else { 1 });
         vec.push(("table", Pretty::from(self.table_name.clone())));
         if self.returning {
             vec.push(("returning", Pretty::display(&true)));
         }
-        Pretty::childless_record(name, vec)
+        childless_record(name, vec)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/delete.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/delete.rs
@@ -1,4 +1,3 @@
-
 // Copyright 2023 RisingWave Labs
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty};
 use risingwave_common::catalog::Schema;
 use risingwave_common::util::sort_util::OrderType;
 pub use risingwave_pb::expr::expr_node::Type as ExprType;

--- a/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/dynamic_filter.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::{Pretty};
+use pretty_xmlish::Pretty;
 use risingwave_common::catalog::Schema;
 use risingwave_common::util::sort_util::OrderType;
 pub use risingwave_pb::expr::expr_node::Type as ExprType;

--- a/src/frontend/src/optimizer/plan_node/generic/except.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/except.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use pretty_xmlish::{Pretty, Str, XmlNode};

--- a/src/frontend/src/optimizer/plan_node/generic/except.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/except.rs
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::Schema;
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 
 /// `Except` returns the rows of its first input except any
@@ -57,7 +58,7 @@ impl<PlanRef: GenericPlanRef> Except<PlanRef> {
 }
 
 impl<PlanRef> DistillUnit for Except<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
-        Pretty::childless_record(name, vec![("all", Pretty::debug(&self.all))])
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
+        childless_record(name, vec![("all", Pretty::debug(&self.all))])
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/expand.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/expand.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use itertools::Itertools;

--- a/src/frontend/src/optimizer/plan_node/generic/expand.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/expand.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::{Field, FieldDisplay, Schema};
 use risingwave_common::types::DataType;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 
 /// [`Expand`] expand one row multiple times according to `column_subsets` and also keep
@@ -103,8 +104,8 @@ impl<PlanRef: GenericPlanRef> GenericPlanNode for Expand<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for Expand<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
-        Pretty::childless_record(name, vec![("column_subsets", self.column_subsets_pretty())])
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
+        childless_record(name, vec![("column_subsets", self.column_subsets_pretty())])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/filter.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use pretty_xmlish::{Pretty, Str, XmlNode};

--- a/src/frontend/src/optimizer/plan_node/generic/filter.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/filter.rs
@@ -12,15 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::Schema;
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::expr::ExprRewriter;
 use crate::optimizer::optimizer_context::OptimizerContextRef;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 use crate::utils::{Condition, ConditionDisplay};
 
@@ -35,13 +36,13 @@ pub struct Filter<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for Filter<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let input_schema = self.input.schema();
         let predicate = ConditionDisplay {
             condition: &self.predicate,
             input_schema,
         };
-        Pretty::childless_record(name, vec![("predicate", Pretty::display(&predicate))])
+        childless_record(name, vec![("predicate", Pretty::display(&predicate))])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/limit.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/limit.rs
@@ -11,14 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-use std::borrow::Cow;
+
 use std::fmt;
 use std::hash::Hash;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::Schema;
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 use crate::OptimizerContextRef;
 
@@ -65,8 +66,8 @@ impl<PlanRef> Limit<PlanRef> {
 }
 
 impl<PlanRef> DistillUnit for Limit<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
-        Pretty::childless_record(
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
+        childless_record(
             name,
             vec![
                 ("limit", Pretty::debug(&self.limit)),

--- a/src/frontend/src/optimizer/plan_node/generic/mod.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/mod.rs
@@ -15,7 +15,7 @@
 use std::borrow::Cow;
 use std::hash::Hash;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::Schema;
 
 use super::{stream, EqJoinPredicate};
@@ -66,17 +66,18 @@ mod limit;
 pub use limit::*;
 
 pub trait DistillUnit {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a>;
+    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> XmlNode<'a>;
 }
 
 macro_rules! impl_distill_unit_from_fields {
     ($name:ident, $bound:path) => {
         use std::borrow::Cow;
 
+        use pretty_xmlish::XmlNode;
         use $crate::optimizer::plan_node::generic::DistillUnit;
         impl<PlanRef: $bound> DistillUnit for $name<PlanRef> {
-            fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
-                Pretty::childless_record(name, self.fields_pretty())
+            fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> XmlNode<'a> {
+                XmlNode::simple_record(name, self.fields_pretty(), vec![])
             }
         }
     };

--- a/src/frontend/src/optimizer/plan_node/generic/over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/over_window.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
@@ -26,6 +26,7 @@ use risingwave_pb::expr::PbWindowFunction;
 
 use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::expr::{InputRef, InputRefDisplay};
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::FunctionalDependencySet;
 use crate::utils::ColIndexMappingRewriteExt;
 use crate::OptimizerContextRef;
@@ -181,7 +182,7 @@ impl<PlanRef: GenericPlanRef> OverWindow<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for OverWindow<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let f = |func| {
             Pretty::debug(&PlanWindowFunctionDisplay {
                 window_function: func,
@@ -190,7 +191,7 @@ impl<PlanRef: GenericPlanRef> DistillUnit for OverWindow<PlanRef> {
         };
         let wf = Pretty::Array(self.window_functions.iter().map(f).collect());
         let vec = vec![("window_functions", wf)];
-        Pretty::childless_record(name, vec)
+        childless_record(name, vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/over_window.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use itertools::Itertools;

--- a/src/frontend/src/optimizer/plan_node/generic/project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/project_set.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 
 use pretty_xmlish::{Pretty, Str, XmlNode};

--- a/src/frontend/src/optimizer/plan_node/generic/project_set.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/project_set.rs
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
 
@@ -23,6 +23,7 @@ use super::{DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::expr::{Expr, ExprDisplay, ExprImpl, ExprRewriter};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
 use crate::optimizer::plan_node::batch::BatchPlanRef;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::{FunctionalDependencySet, Order};
 use crate::utils::{ColIndexMapping, ColIndexMappingRewriteExt};
 
@@ -61,9 +62,9 @@ impl<PlanRef> ProjectSet<PlanRef> {
 }
 
 impl<PlanRef> DistillUnit for ProjectSet<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let fields = vec![("select_list", Pretty::debug(&self.select_list))];
-        Pretty::childless_record(name, fields)
+        childless_record(name, fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/scan.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/scan.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 
 use educe::Educe;
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty};
 use risingwave_common::catalog::{ColumnDesc, Field, Schema, TableDesc};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::sort_util::ColumnOrder;

--- a/src/frontend/src/optimizer/plan_node/generic/scan.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/scan.rs
@@ -17,7 +17,7 @@ use std::rc::Rc;
 
 use educe::Educe;
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::{Pretty};
+use pretty_xmlish::Pretty;
 use risingwave_common::catalog::{ColumnDesc, Field, Schema, TableDesc};
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_common::util::sort_util::ColumnOrder;

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -12,19 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::collections::HashSet;
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::Schema;
 use risingwave_common::util::sort_util::OrderType;
 
 use super::super::utils::TableCatalogBuilder;
 use super::{stream, DistillUnit, GenericPlanNode, GenericPlanRef};
 use crate::optimizer::optimizer_context::OptimizerContextRef;
+use crate::optimizer::plan_node::utils::childless_record;
 use crate::optimizer::property::{FunctionalDependencySet, Order, OrderDisplay};
 use crate::TableCatalog;
+
 /// `TopN` sorts the input data and fetches up to `limit` rows from `offset`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TopN<PlanRef> {
@@ -149,7 +151,7 @@ impl<PlanRef: GenericPlanRef> TopN<PlanRef> {
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for TopN<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let mut vec = Vec::with_capacity(5);
         let input_schema = self.input.schema();
         let order_d = Pretty::display(&OrderDisplay {
@@ -165,7 +167,7 @@ impl<PlanRef: GenericPlanRef> DistillUnit for TopN<PlanRef> {
         if !self.group_key.is_empty() {
             vec.push(("group_key", Pretty::debug(&self.group_key)));
         }
-        Pretty::childless_record(name, vec)
+        childless_record(name, vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/generic/top_n.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/top_n.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::collections::HashSet;
 use std::fmt;
 

--- a/src/frontend/src/optimizer/plan_node/generic/update.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/update.rs
@@ -12,17 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::borrow::Cow;
+
 use std::fmt;
 use std::hash::Hash;
 
 use educe::Educe;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, XmlNode};
 use risingwave_common::catalog::TableVersionId;
 
 use super::DistillUnit;
 use crate::catalog::TableId;
 use crate::expr::{ExprImpl, ExprRewriter};
+use crate::optimizer::plan_node::utils::childless_record;
 
 #[derive(Debug, Clone, Educe)]
 #[educe(PartialEq, Eq, Hash)]
@@ -81,13 +82,13 @@ impl<PlanRef: Eq + Hash> Update<PlanRef> {
 }
 
 impl<PlanRef: Eq + Hash> DistillUnit for Update<PlanRef> {
-    fn distill_with_name<'a>(&self, name: impl Into<Cow<'a, str>>) -> Pretty<'a> {
+    fn distill_with_name<'a>(&self, name: impl Into<Str<'a>>) -> XmlNode<'a> {
         let mut vec = Vec::with_capacity(if self.returning { 3 } else { 2 });
         vec.push(("table", Pretty::Text(self.table_name.clone().into())));
         vec.push(("exprs", Pretty::debug(&self.exprs)));
         if self.returning {
             vec.push(("returning", Pretty::display(&true)));
         }
-        Pretty::childless_record(name, vec)
+        childless_record(name, vec)
     }
 }

--- a/src/frontend/src/optimizer/plan_node/generic/update.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/update.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::fmt;
 use std::hash::Hash;
 

--- a/src/frontend/src/optimizer/plan_node/logical_apply.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_apply.rs
@@ -14,13 +14,13 @@
 //
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_pb::plan_common::JoinType;
 
 use super::generic::{self, push_down_into_join, push_down_join_condition, GenericPlanNode};
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     ColPrunable, LogicalJoin, LogicalProject, PlanBase, PlanRef, PlanTreeNodeBinary,
     PredicatePushdown, ToBatch, ToStream,
@@ -54,7 +54,7 @@ pub struct LogicalApply {
 }
 
 impl Distill for LogicalApply {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let mut vec = Vec::with_capacity(if self.max_one_row { 4 } else { 3 });
         vec.push(("type", Pretty::debug(&self.join_type)));
 
@@ -70,7 +70,7 @@ impl Distill for LogicalApply {
             vec.push(("max_one_row", Pretty::debug(&true)));
         }
 
-        Pretty::childless_record("LogicalApply", vec)
+        childless_record("LogicalApply", vec)
     }
 }
 impl fmt::Display for LogicalApply {

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::{Field, Schema, TableVersionId};
 use risingwave_common::error::Result;
 use risingwave_common::types::DataType;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     gen_filter_and_pushdown, generic, BatchInsert, ColPrunable, ExprRewritable, PlanBase, PlanRef,
     PlanTreeNodeUnary, PredicatePushdown, ToBatch, ToStream,
@@ -100,9 +100,9 @@ impl PlanTreeNodeUnary for LogicalInsert {
 impl_plan_tree_node_for_unary! {LogicalInsert}
 
 impl Distill for LogicalInsert {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let vec = self.core.fields_pretty(self.base.ctx.is_explain_verbose());
-        Pretty::childless_record("LogicalInsert", vec)
+        childless_record("LogicalInsert", vec)
     }
 }
 impl fmt::Display for LogicalInsert {

--- a/src/frontend/src/optimizer/plan_node/logical_insert.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_insert.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::{Field, Schema, TableVersionId};
 use risingwave_common::error::Result;
 use risingwave_common::types::DataType;

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -18,7 +18,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::{EitherOrBoth, Itertools};
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::ChainType;
@@ -26,7 +26,7 @@ use risingwave_pb::stream_plan::ChainType;
 use super::generic::{
     push_down_into_join, push_down_join_condition, GenericPlanNode, GenericPlanRef,
 };
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     generic, ColPrunable, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, PredicatePushdown,
     StreamHashJoin, StreamProject, ToBatch, ToStream,
@@ -57,7 +57,7 @@ pub struct LogicalJoin {
 }
 
 impl Distill for LogicalJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
         vec.push(("type", Pretty::debug(&self.join_type())));
@@ -75,7 +75,7 @@ impl Distill for LogicalJoin {
             vec.push(("output", data));
         }
 
-        Pretty::childless_record("LogicalJoin", vec)
+        childless_record("LogicalJoin", vec)
     }
 }
 impl fmt::Display for LogicalJoin {

--- a/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_multi_join.rs
@@ -17,12 +17,12 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::Schema;
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_pb::plan_common::JoinType;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     ColPrunable, ExprRewritable, LogicalFilter, LogicalJoin, LogicalProject, PlanBase,
     PlanNodeType, PlanRef, PlanTreeNodeBinary, PlanTreeNodeUnary, PredicatePushdown, ToBatch,
@@ -61,7 +61,7 @@ pub struct LogicalMultiJoin {
 }
 
 impl Distill for LogicalMultiJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let fields = (self.inputs.iter())
             .flat_map(|input| input.schema().fields.clone())
             .collect();
@@ -70,7 +70,7 @@ impl Distill for LogicalMultiJoin {
             condition: self.on(),
             input_schema: &input_schema,
         });
-        Pretty::childless_record("LogicalMultiJoin", vec![("on", cond)])
+        childless_record("LogicalMultiJoin", vec![("on", cond)])
     }
 }
 impl fmt::Display for LogicalMultiJoin {

--- a/src/frontend/src/optimizer/plan_node/logical_now.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_now.rs
@@ -14,13 +14,13 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::bail;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::types::DataType;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     ColPrunable, ColumnPruningContext, ExprRewritable, LogicalFilter, PlanBase, PlanRef,
     PredicatePushdown, RewriteStreamContext, StreamNow, ToBatch, ToStream, ToStreamContext,
@@ -49,14 +49,14 @@ impl LogicalNow {
 }
 
 impl Distill for LogicalNow {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let vec = if self.base.ctx.is_explain_verbose() {
             vec![("output", column_names_pretty(self.schema()))]
         } else {
             vec![]
         };
 
-        Pretty::childless_record("LogicalNow", vec)
+        childless_record("LogicalNow", vec)
     }
 }
 impl fmt::Display for LogicalNow {

--- a/src/frontend/src/optimizer/plan_node/logical_now.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_now.rs
@@ -14,7 +14,7 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::bail;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::Result;

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::error::Result;
 
 use super::utils::{childless_record, Distill};

--- a/src/frontend/src/optimizer/plan_node/logical_project.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_project.rs
@@ -16,10 +16,10 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::error::Result;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     gen_filter_and_pushdown, generic, BatchProject, ColPrunable, ExprRewritable, PlanBase, PlanRef,
     PlanTreeNodeUnary, PredicatePushdown, StreamProject, ToBatch, ToStream,
@@ -139,8 +139,8 @@ impl fmt::Display for LogicalProject {
     }
 }
 impl Distill for LogicalProject {
-    fn distill<'a>(&self) -> Pretty<'a> {
-        Pretty::childless_record(
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        childless_record(
             "LogicalProject",
             self.core.fields_pretty(self.base.schema()),
         )

--- a/src/frontend/src/optimizer/plan_node/logical_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_scan.rs
@@ -18,13 +18,13 @@ use std::rc::Rc;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnDesc, TableDesc};
 use risingwave_common::error::{ErrorCode, Result, RwError};
 use risingwave_common::util::sort_util::ColumnOrder;
 
 use super::generic::{GenericPlanNode, GenericPlanRef};
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     generic, BatchFilter, BatchProject, ColPrunable, ExprRewritable, PlanBase, PlanRef,
     PredicatePushdown, StreamTableScan, ToBatch, ToStream,
@@ -290,7 +290,7 @@ impl LogicalScan {
 impl_plan_tree_node_for_leaf! {LogicalScan}
 
 impl Distill for LogicalScan {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(5);
         vec.push(("table", Pretty::from(self.table_name().to_owned())));
@@ -332,7 +332,7 @@ impl Distill for LogicalScan {
             ))
         }
 
-        Pretty::childless_record("LogicalScan", vec)
+        childless_record("LogicalScan", vec)
     }
 }
 impl fmt::Display for LogicalScan {

--- a/src/frontend/src/optimizer/plan_node/logical_share.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_share.rs
@@ -15,11 +15,11 @@
 use std::cell::RefCell;
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::error::ErrorCode::NotImplemented;
 use risingwave_common::error::Result;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     generic, ColPrunable, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, PredicatePushdown,
     ToBatch, ToStream,
@@ -77,8 +77,8 @@ impl LogicalShare {
         write!(f, "{} {{ id = {} }}", name, &base.id.0)
     }
 
-    pub(super) fn pretty_fields<'a>(base: &PlanBase, name: &'a str) -> Pretty<'a> {
-        Pretty::childless_record(name, vec![("id", Pretty::debug(&base.id.0))])
+    pub(super) fn pretty_fields<'a>(base: &PlanBase, name: &'a str) -> XmlNode<'a> {
+        childless_record(name, vec![("id", Pretty::debug(&base.id.0))])
     }
 }
 
@@ -115,7 +115,7 @@ impl fmt::Display for LogicalShare {
     }
 }
 impl Distill for LogicalShare {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         Self::pretty_fields(&self.base, "LogicalShare")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/logical_source.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_source.rs
@@ -19,7 +19,7 @@ use std::ops::Bound::{Excluded, Included, Unbounded};
 use std::rc::Rc;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnCatalog, Schema};
 use risingwave_common::error::Result;
 use risingwave_connector::source::DataType;
@@ -27,7 +27,7 @@ use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
 use risingwave_pb::plan_common::GeneratedColumnDesc;
 
 use super::stream_watermark_filter::StreamWatermarkFilter;
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     generic, BatchProject, BatchSource, ColPrunable, ExprRewritable, LogicalFilter, LogicalProject,
     PlanBase, PlanRef, PredicatePushdown, StreamProject, StreamRowIdGen, StreamSource, ToBatch,
@@ -249,7 +249,7 @@ impl fmt::Display for LogicalSource {
     }
 }
 impl Distill for LogicalSource {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let fields = if let Some(catalog) = self.source_catalog() {
             let src = Pretty::from(catalog.name.clone());
             let time = Pretty::debug(&self.core.kafka_timestamp_range);
@@ -261,7 +261,7 @@ impl Distill for LogicalSource {
         } else {
             vec![]
         };
-        Pretty::childless_record("LogicalSource", fields)
+        childless_record("LogicalSource", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/logical_table_function.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_table_function.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::DataType;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     ColPrunable, ExprRewritable, LogicalFilter, PlanBase, PlanRef, PredicatePushdown, ToBatch,
     ToStream,
@@ -70,9 +70,9 @@ impl fmt::Display for LogicalTableFunction {
     }
 }
 impl Distill for LogicalTableFunction {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = Pretty::debug(&self.table_function);
-        Pretty::childless_record("LogicalTableFunction", vec![("table_function", data)])
+        childless_record("LogicalTableFunction", vec![("table_function", data)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/logical_values.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_values.rs
@@ -16,12 +16,12 @@ use std::sync::Arc;
 use std::{fmt, vec};
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::error::Result;
 use risingwave_common::types::{DataType, ScalarImpl};
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{
     BatchValues, ColPrunable, ExprRewritable, LogicalFilter, PlanBase, PlanRef, PredicatePushdown,
     StreamValues, ToBatch, ToStream,
@@ -112,10 +112,10 @@ impl fmt::Display for LogicalValues {
     }
 }
 impl Distill for LogicalValues {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = self.rows_pretty();
         let fields = vec![("rows", data), ("schema", Pretty::debug(&self.schema()))];
-        Pretty::childless_record("LogicalValues", fields)
+        childless_record("LogicalValues", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_delta_join.rs
@@ -15,14 +15,14 @@
 use std::fmt;
 use std::ops::BitAnd;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::ColumnDesc;
 use risingwave_pb::plan_common::JoinType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{ArrangementInfo, DeltaIndexJoinNode};
 
 use super::generic::{self};
-use super::utils::{formatter_debug_plan_node, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeBinary, StreamNode};
 use crate::expr::{Expr, ExprRewriter};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
@@ -116,7 +116,7 @@ impl fmt::Display for StreamDeltaJoin {
     }
 }
 impl Distill for StreamDeltaJoin {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
         vec.push(("type", Pretty::debug(&self.logical.join_type)));
@@ -136,7 +136,7 @@ impl Distill for StreamDeltaJoin {
             vec.push(("output", data));
         }
 
-        Pretty::childless_record("StreamDeltaJoin", vec)
+        childless_record("StreamDeltaJoin", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_dml.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dml.rs
@@ -15,11 +15,11 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnDesc, INITIAL_TABLE_VERSION_ID};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 
@@ -68,14 +68,14 @@ impl fmt::Display for StreamDml {
     }
 }
 impl Distill for StreamDml {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let col = self
             .column_names()
             .iter()
             .map(|n| Pretty::from(n.to_string()))
             .collect();
         let col = Pretty::Array(col);
-        Pretty::childless_record("StreamDml", vec![("columns", col)])
+        childless_record("StreamDml", vec![("columns", col)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -15,14 +15,16 @@
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::FieldDisplay;
 pub use risingwave_pb::expr::expr_node::Type as ExprType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::DynamicFilterNode;
 
 use super::generic::DynamicFilter;
-use super::utils::{column_names_pretty, formatter_debug_plan_node, watermark_pretty, Distill};
+use super::utils::{
+    childless_record, column_names_pretty, formatter_debug_plan_node, watermark_pretty, Distill,
+};
 use super::{generic, ExprRewritable};
 use crate::expr::Expr;
 use crate::optimizer::plan_node::{PlanBase, PlanTreeNodeBinary, StreamNode};
@@ -57,7 +59,7 @@ impl StreamDynamicFilter {
 }
 
 impl Distill for StreamDynamicFilter {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let verbose = self.base.ctx.is_explain_verbose();
         let pred = self.core.pretty_field();
         let mut vec = Vec::with_capacity(if verbose { 3 } else { 2 });
@@ -66,7 +68,7 @@ impl Distill for StreamDynamicFilter {
             vec.push(("output_watermarks", ow));
         }
         vec.push(("output", column_names_pretty(self.schema())));
-        Pretty::childless_record("StreamDynamicFilter", vec)
+        childless_record("StreamDynamicFilter", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_dynamic_filter.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::FieldDisplay;
 pub use risingwave_pb::expr::expr_node::Type as ExprType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;

--- a/src/frontend/src/optimizer/plan_node/stream_exchange.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_exchange.rs
@@ -14,12 +14,12 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_pb::stream_plan::stream_node::NodeBody;
 use risingwave_pb::stream_plan::{DispatchStrategy, DispatcherType, ExchangeNode};
 
 use super::stream::StreamPlanRef;
-use super::utils::{formatter_debug_plan_node, plan_node_name, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, plan_node_name, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::optimizer::property::{Distribution, DistributionDisplay};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -80,12 +80,12 @@ impl StreamExchange {
 }
 
 impl Distill for StreamExchange {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let distribution_display = DistributionDisplay {
             distribution: &self.base.dist,
             input_schema: self.input.schema(),
         };
-        Pretty::childless_record(
+        childless_record(
             plan_node_name!(
                 "StreamExchange",
                 { "no_shuffle", self.no_shuffle },

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;

--- a/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hash_agg.rs
@@ -16,13 +16,15 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{self, PlanAggCall};
-use super::utils::{formatter_debug_plan_node, plan_node_name, watermark_pretty, Distill};
+use super::utils::{
+    childless_record, formatter_debug_plan_node, plan_node_name, watermark_pretty, Distill,
+};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::ExprRewriter;
 use crate::optimizer::property::Distribution;
@@ -147,12 +149,12 @@ impl StreamHashAgg {
 }
 
 impl Distill for StreamHashAgg {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let mut vec = self.logical.fields_pretty();
         if let Some(ow) = watermark_pretty(&self.base.watermark_columns, self.schema()) {
             vec.push(("output_watermarks", ow));
         }
-        Pretty::childless_record(
+        childless_record(
             plan_node_name!(
                 "StreamHashAgg",
                 { "append_only", self.input().append_only() },

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -15,14 +15,14 @@
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::HopWindowNode;
 
 use super::stream::StreamPlanRef;
-use super::utils::{formatter_debug_plan_node, watermark_pretty, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, watermark_pretty, Distill};
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::{Expr, ExprImpl, ExprRewriter};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -78,12 +78,12 @@ impl StreamHopWindow {
 }
 
 impl Distill for StreamHopWindow {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let mut vec = self.logical.fields_pretty();
         if let Some(ow) = watermark_pretty(&self.base.watermark_columns, self.schema()) {
             vec.push(("output_watermarks", ow));
         }
-        Pretty::childless_record("StreamHopWindow", vec)
+        childless_record("StreamHopWindow", vec)
     }
 }
 impl fmt::Display for StreamHopWindow {

--- a/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_hop_window.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;

--- a/src/frontend/src/optimizer/plan_node/stream_now.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_now.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::{Field, Schema};
 use risingwave_common::types::DataType;
 use risingwave_pb::stream_plan::stream_node::NodeBody;
@@ -23,7 +23,7 @@ use risingwave_pb::stream_plan::NowNode;
 
 use super::generic::GenericPlanRef;
 use super::stream::StreamPlanRef;
-use super::utils::{formatter_debug_plan_node, Distill, TableCatalogBuilder};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill, TableCatalogBuilder};
 use super::{ExprRewritable, LogicalNow, PlanBase, StreamNode};
 use crate::optimizer::plan_node::utils::column_names_pretty;
 use crate::optimizer::property::{Distribution, FunctionalDependencySet};
@@ -60,14 +60,14 @@ impl StreamNow {
 }
 
 impl Distill for StreamNow {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let vec = if self.base.ctx.is_explain_verbose() {
             vec![("output", column_names_pretty(self.schema()))]
         } else {
             vec![]
         };
 
-        Pretty::childless_record("StreamNow", vec)
+        childless_record("StreamNow", vec)
     }
 }
 impl fmt::Display for StreamNow {

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::ProjectNode;

--- a/src/frontend/src/optimizer/plan_node/stream_project.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_project.rs
@@ -16,13 +16,13 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::ProjectNode;
 
 use super::stream::StreamPlanRef;
-use super::utils::{formatter_debug_plan_node, watermark_fields_pretty, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, watermark_fields_pretty, Distill};
 use super::{generic, ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::{try_derive_watermark, Expr, ExprImpl, ExprRewriter};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -40,7 +40,7 @@ pub struct StreamProject {
 }
 
 impl Distill for StreamProject {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let schema = self.schema();
         let mut vec = self.logical.fields_pretty(schema);
         let watermark_derivations = &self.watermark_derivations;
@@ -48,7 +48,7 @@ impl Distill for StreamProject {
             let wc = watermark_derivations.iter().map(|(_, i)| *i);
             vec.push(("output_watermarks", watermark_fields_pretty(wc, schema)));
         }
-        Pretty::childless_record("StreamProject", vec)
+        childless_record("StreamProject", vec)
     }
 }
 impl fmt::Display for StreamProject {

--- a/src/frontend/src/optimizer/plan_node/stream_row_id_gen.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_row_id_gen.rs
@@ -14,10 +14,10 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use super::utils::Distill;
+use super::utils::{childless_record, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::optimizer::plan_node::stream::StreamPlanRef;
 use crate::optimizer::property::Distribution;
@@ -67,9 +67,9 @@ impl fmt::Display for StreamRowIdGen {
     }
 }
 impl Distill for StreamRowIdGen {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let fields = vec![("row_id_index", Pretty::debug(&self.row_id_index))];
-        Pretty::childless_record("StreamRowIdGen", fields)
+        childless_record("StreamRowIdGen", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_share.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_share.rs
@@ -14,11 +14,11 @@
 
 use std::fmt;
 
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::PbStreamNode;
 
-use super::utils::Distill;
+use super::utils::{Distill};
 use super::{generic, ExprRewritable, PlanRef, PlanTreeNodeUnary, StreamExchange, StreamNode};
 use crate::optimizer::plan_node::{LogicalShare, PlanBase, PlanTreeNode};
 use crate::stream_fragmenter::BuildFragmentGraphState;
@@ -52,7 +52,7 @@ impl fmt::Display for StreamShare {
     }
 }
 impl Distill for StreamShare {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         LogicalShare::pretty_fields(&self.base, "StreamShare")
     }
 }

--- a/src/frontend/src/optimizer/plan_node/stream_share.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_share.rs
@@ -14,11 +14,11 @@
 
 use std::fmt;
 
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::PbStreamNode;
 
-use super::utils::{Distill};
+use super::utils::Distill;
 use super::{generic, ExprRewritable, PlanRef, PlanTreeNodeUnary, StreamExchange, StreamNode};
 use crate::optimizer::plan_node::{LogicalShare, PlanBase, PlanTreeNode};
 use crate::stream_fragmenter::BuildFragmentGraphState;

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -16,7 +16,7 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{self, PlanAggCall};

--- a/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_simple_agg.rs
@@ -16,11 +16,11 @@ use std::fmt;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{self, PlanAggCall};
-use super::utils::{plan_node_name, Distill};
+use super::utils::{childless_record, plan_node_name, Distill};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::expr::ExprRewriter;
 use crate::optimizer::property::Distribution;
@@ -74,11 +74,11 @@ impl fmt::Display for StreamSimpleAgg {
 }
 
 impl Distill for StreamSimpleAgg {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let name = plan_node_name!("StreamSimpleAgg",
             { "append_only", self.input().append_only() },
         );
-        Pretty::childless_record(name, self.logical.fields_pretty())
+        childless_record(name, self.logical.fields_pretty())
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_sink.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sink.rs
@@ -18,6 +18,7 @@ use std::io::{Error, ErrorKind};
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::ColumnCatalog;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_connector::sink::catalog::desc::SinkDesc;
@@ -30,7 +31,7 @@ use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use tracing::info;
 
 use super::derive::{derive_columns, derive_pk};
-use super::utils::{formatter_debug_plan_node, IndicesDisplay};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill, IndicesDisplay};
 use super::{ExprRewritable, PlanBase, PlanRef, StreamNode};
 use crate::optimizer::plan_node::PlanTreeNodeUnary;
 use crate::optimizer::property::{Distribution, Order, RequiredDist};
@@ -256,6 +257,39 @@ impl PlanTreeNodeUnary for StreamSink {
 
 impl_plan_tree_node_for_unary! { StreamSink }
 
+impl Distill for StreamSink {
+    fn distill<'a>(&self) -> XmlNode<'a> {
+        let sink_type = if self.sink_desc.sink_type.is_append_only() {
+            "append-only"
+        } else {
+            "upsert"
+        };
+        let column_names = self
+            .sink_desc
+            .columns
+            .iter()
+            .map(|col| col.name_with_hidden().to_string())
+            .map(Pretty::from)
+            .collect();
+        let column_names = Pretty::Array(column_names);
+        let mut vec = Vec::with_capacity(3);
+        vec.push(("type", Pretty::from(sink_type)));
+        vec.push(("columns", column_names));
+        if self.sink_desc.sink_type.is_upsert() {
+            let pk = IndicesDisplay {
+                indices: &self
+                    .sink_desc
+                    .plan_pk
+                    .iter()
+                    .map(|k| k.column_index)
+                    .collect_vec(),
+                input_schema: &self.base.schema,
+            };
+            vec.push(("pk", Pretty::display(&pk)));
+        }
+        childless_record("StreamSink", vec)
+    }
+}
 impl fmt::Display for StreamSink {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = formatter_debug_plan_node!(f, "StreamSink");

--- a/src/frontend/src/optimizer/plan_node/stream_sort.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_sort.rs
@@ -16,11 +16,11 @@ use std::collections::HashSet;
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::util::sort_util::OrderType;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
-use super::utils::{formatter_debug_plan_node, Distill, TableCatalogBuilder};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill, TableCatalogBuilder};
 use super::{ExprRewritable, PlanBase, PlanRef, PlanTreeNodeUnary, StreamNode};
 use crate::stream_fragmenter::BuildFragmentGraphState;
 use crate::TableCatalog;
@@ -42,9 +42,9 @@ impl fmt::Display for StreamSort {
     }
 }
 impl Distill for StreamSort {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let fields = vec![("sort_column_index", Pretty::debug(&self.sort_column_index))];
-        Pretty::childless_record("StreamSort", fields)
+        childless_record("StreamSort", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_source.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_source.rs
@@ -17,11 +17,11 @@ use std::rc::Rc;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::{PbStreamSource, SourceNode};
 
-use super::utils::{formatter_debug_plan_node, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill};
 use super::{generic, ExprRewritable, PlanBase, StreamNode};
 use crate::catalog::source_catalog::SourceCatalog;
 use crate::optimizer::plan_node::utils::column_names_pretty;
@@ -74,7 +74,7 @@ impl fmt::Display for StreamSource {
     }
 }
 impl Distill for StreamSource {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let fields = if let Some(catalog) = self.source_catalog() {
             let src = Pretty::from(catalog.name.clone());
             let col = column_names_pretty(self.schema());
@@ -82,7 +82,7 @@ impl Distill for StreamSource {
         } else {
             vec![]
         };
-        Pretty::childless_record("StreamSource", fields)
+        childless_record("StreamSource", fields)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{DistillUnit, TopNLimit};
@@ -69,7 +69,7 @@ impl fmt::Display for StreamTopN {
     }
 }
 impl Distill for StreamTopN {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let name = plan_node_name!("StreamTopN",
             { "append_only", self.input().append_only() },
         );

--- a/src/frontend/src/optimizer/plan_node/stream_topn.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_topn.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 
 use super::generic::{DistillUnit, TopNLimit};

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -17,7 +17,7 @@ use std::ops::BitAnd;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::UnionNode;

--- a/src/frontend/src/optimizer/plan_node/stream_union.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_union.rs
@@ -17,12 +17,12 @@ use std::ops::BitAnd;
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_common::catalog::FieldDisplay;
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
 use risingwave_pb::stream_plan::UnionNode;
 
-use super::utils::{formatter_debug_plan_node, watermark_pretty, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, watermark_pretty, Distill};
 use super::{generic, ExprRewritable, PlanRef};
 use crate::optimizer::plan_node::generic::GenericPlanNode;
 use crate::optimizer::plan_node::stream::StreamPlanRef;
@@ -82,12 +82,12 @@ impl fmt::Display for StreamUnion {
     }
 }
 impl Distill for StreamUnion {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let mut vec = self.logical.fields_pretty();
         if let Some(ow) = watermark_pretty(&self.base.watermark_columns, self.schema()) {
             vec.push(("output_watermarks", ow));
         }
-        Pretty::childless_record("StreamUnion", vec)
+        childless_record("StreamUnion", vec)
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_values.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_values.rs
@@ -15,12 +15,12 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{XmlNode};
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 use risingwave_pb::stream_plan::values_node::ExprTuple;
 use risingwave_pb::stream_plan::ValuesNode;
 
-use super::utils::{formatter_debug_plan_node, Distill};
+use super::utils::{childless_record, formatter_debug_plan_node, Distill};
 use super::{ExprRewritable, LogicalValues, PlanBase, StreamNode};
 use crate::expr::{Expr, ExprImpl};
 use crate::optimizer::property::Distribution;
@@ -71,9 +71,9 @@ impl fmt::Display for StreamValues {
     }
 }
 impl Distill for StreamValues {
-    fn distill<'a>(&self) -> Pretty<'a> {
+    fn distill<'a>(&self) -> XmlNode<'a> {
         let data = self.logical.rows_pretty();
-        Pretty::childless_record("StreamValues", vec![("rows", data)])
+        childless_record("StreamValues", vec![("rows", data)])
     }
 }
 

--- a/src/frontend/src/optimizer/plan_node/stream_values.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_values.rs
@@ -15,7 +15,7 @@
 use std::fmt;
 
 use fixedbitset::FixedBitSet;
-use pretty_xmlish::{XmlNode};
+use pretty_xmlish::XmlNode;
 use risingwave_pb::stream_plan::stream_node::NodeBody as ProstStreamNode;
 use risingwave_pb::stream_plan::values_node::ExprTuple;
 use risingwave_pb::stream_plan::ValuesNode;

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -17,7 +17,7 @@ use std::{fmt, vec};
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
-use pretty_xmlish::Pretty;
+use pretty_xmlish::{Pretty, Str, StrAssocArr, XmlNode};
 use risingwave_common::catalog::{
     ColumnCatalog, ColumnDesc, ConflictBehavior, Field, FieldDisplay, Schema,
 };
@@ -164,16 +164,23 @@ impl TableCatalogBuilder {
 
 /// See also [`super::generic::DistillUnit`].
 pub trait Distill {
-    fn distill<'a>(&self) -> Pretty<'a>;
+    fn distill<'a>(&self) -> XmlNode<'a>;
+}
+
+pub(super) fn childless_record<'a>(
+    name: impl Into<Str<'a>>,
+    fields: StrAssocArr<'a>,
+) -> XmlNode<'a> {
+    XmlNode::simple_record(name, fields, Default::default())
 }
 
 macro_rules! impl_distill_by_unit {
     ($ty:ty, $core:ident, $name:expr) => {
-        use pretty_xmlish::Pretty;
+        use pretty_xmlish::XmlNode;
         use $crate::optimizer::plan_node::generic::DistillUnit;
         use $crate::optimizer::plan_node::utils::Distill;
         impl Distill for $ty {
-            fn distill<'a>(&self) -> Pretty<'a> {
+            fn distill<'a>(&self) -> XmlNode<'a> {
                 self.$core.distill_with_name($name)
             }
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Overhaul the interface