### PR TITLE
fix(expr): `array_to_string` should handle multidimensional array recursively

### DIFF
--- a/src/tests/regress/data/sql/arrays.sql
+++ b/src/tests/regress/data/sql/arrays.sql
@@ -572,7 +572,7 @@ select array_to_string(array[1,2,3,4,NULL,6], ',', '*');
 select array_to_string(array[1,2,3,4,NULL,6], NULL);
 --@ select array_to_string(array[1,2,3,4,NULL,6], ',', NULL);
 
---@ select array_to_string(string_to_array('1|2|3', '|'), '|');
+select array_to_string(string_to_array('1|2|3', '|'), '|');
 
 select array_length(array[1,2,3], 1);
 select array_length(array[[1,2,3], [4,5,6]], 0);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #8680. See https://github.com/risingwavelabs/risingwave/issues/3811#issuecomment-1556656529 for rationale.

This is consistent with `unnest` and `cardinality` (and `array_replace` in the future).

Note the following (with `::text[]` rather than `::text[][]`) is still different from PostgreSQL:
```
select array_to_string(array[array['one', 'two'], array['three', 'four']]::text[], ',');
```
This is not related to the `array_to_string` function. In PostgreSQL, `::text[]` still returns a 2d array with 4 elements, while we return a 1d array with 2 elements, first of which is a result of `array['one', 'two']::text`. This is intentional.

We do not guarantee backward compatibility of experimental multidimensional array.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
