### PR TITLE
feat: implement the delete-workers command for risectl

### DIFF
--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -283,6 +283,17 @@ enum MetaCommands {
 
     /// List fragment to parallel units mapping for serving
     ListServingFragmentMapping,
+
+    /// Delete workers from the cluster
+    DeleteWorkers {
+        /// The worker ids that needs to be deleted
+        #[clap(long, required = true, value_delimiter = ',', value_name = "id,...")]
+        worker_ids: Vec<u32>,
+
+        /// Automatic yes to prompts
+        #[clap(short = 'y', long, default_value_t = false)]
+        yes: bool,
+    },
 }
 
 pub async fn start(opts: CliOpts) -> Result<()> {
@@ -423,6 +434,9 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
         }
         Commands::Meta(MetaCommands::ListServingFragmentMapping) => {
             cmd_impl::meta::list_serving_fragment_mappings(context).await?
+        }
+        Commands::Meta(MetaCommands::DeleteWorkers { worker_ids, yes }) => {
+            cmd_impl::meta::delete_workers(context, worker_ids, yes).await?
         }
         Commands::Trace => cmd_impl::trace::trace(context).await?,
         Commands::Profile { sleep } => cmd_impl::profile::profile(context, sleep).await?,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -984,6 +984,15 @@ impl MetaClient {
             resp.task_progress,
         ))
     }
+
+    pub async fn delete_worker_node(&self, worker: HostAddress) -> Result<()> {
+        let _resp = self
+            .inner
+            .delete_worker_node(DeleteWorkerNodeRequest { host: Some(worker) })
+            .await?;
+
+        Ok(())
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR implements the "delete-workers" command. It requires a list of worker IDs. Before executing the specific "delete_worker_node" RPC, this command calls "get_cluster_info" and performs a thorough check for any occupied fragments. Additionally, it prompts for confirmation with a "yes/no" message before deletion.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [x] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
