### PR TITLE
chore(sqlsmith): bump timeout temporarily

### DIFF
--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -468,7 +468,7 @@ fn validate_response<_Row>(response: PgResult<_Row>) -> Result<i64> {
 /// If takes too long return the query which timed out + execution time + timeout error
 /// Returns: Number of skipped queries.
 async fn run_query(client: &Client, query: &str) -> Result<i64> {
-    let timeout_duration = 3;
+    let timeout_duration = 12;
     let query_task = client.simple_query(query);
     let result = timeout(Duration::from_secs(timeout_duration), query_task).await;
     let response = match result {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/pull/10430 changes timeout to 6s while generating, and 12s when actually running them in pre-generated queries to allow some buffer. It may take a while to review #10430. So adding this as workaround first.

We have already re-generated the snapshot in #10430, hence main-cron is failing with timeout error.

As we can see in the recent main-cron, tests are timing out as a result:
<img width="1117" alt="Screenshot 2023-06-23 at 9 11 37 AM" src="https://github.com/risingwavelabs/risingwave/assets/47273164/851e2704-5ba9-438a-8c7a-875ba2b2573f">


<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
