### PR TITLE
feat: adapt `get_reschedule_plan` with `cordon`

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -361,38 +361,51 @@ where
             .into_iter()
             .map(|worker_node| (worker_node.id, worker_node))
             .collect();
+
         if worker_nodes.is_empty() {
             bail!("no available compute node in the cluster");
         }
 
         // Check if we are trying to move a fragment to a node marked as unschedulable
-        let unschedulable_pu_ids: HashSet<ParallelUnitId> = worker_nodes
+        let unschedulable_parallel_unit_ids: HashMap<_, _> = worker_nodes
             .values()
-            .filter(|w| w.property.as_ref().unwrap().is_unschedulable)
-            .flat_map(|w| w.parallel_units.iter().map(|pu| pu.id))
+            .filter(|w| {
+                w.property
+                    .as_ref()
+                    .map(|property| property.is_unschedulable)
+                    .unwrap_or(false)
+            })
+            .flat_map(|w| {
+                w.parallel_units
+                    .iter()
+                    .map(|parallel_unit| (parallel_unit.id as ParallelUnitId, w.id as WorkerId))
+            })
             .collect();
 
-        if reschedule
-            .values()
-            .flat_map(|p| &p.added_parallel_units)
-            .any(|pu| unschedulable_pu_ids.contains(pu))
-        {
-            bail!("unable to move fragment to unschedulable node");
+        for (fragment_id, reschedule) in reschedule.iter() {
+            for parallel_unit_id in &reschedule.added_parallel_units {
+                if let Some(worker_id) = unschedulable_parallel_unit_ids.get(parallel_unit_id) {
+                    bail!(
+                        "unable to move fragment {} to unschedulable parallel unit {} from worker {}",
+                        fragment_id,
+                        parallel_unit_id,
+                        worker_id
+                    );
+                }
+            }
         }
 
         // Associating ParallelUnit with Worker
-        let parallel_unit_id_to_worker_id: BTreeMap<_, _> = self
-            .cluster_manager
-            .list_active_streaming_parallel_units()
-            .await
-            .into_iter()
-            .map(|parallel_unit| {
-                (
-                    parallel_unit.id as ParallelUnitId,
-                    parallel_unit.worker_node_id as WorkerId,
-                )
+        let parallel_unit_id_to_worker_id: BTreeMap<_, _> = worker_nodes
+            .iter()
+            .flat_map(|(worker_id, worker_node)| {
+                worker_node
+                    .parallel_units
+                    .iter()
+                    .map(move |parallel_unit| (parallel_unit.id as ParallelUnitId, *worker_id))
             })
             .collect();
+
 
         // Index for StreamActor
         let mut actor_map = HashMap::new();
@@ -1524,6 +1537,26 @@ where
             .cluster_manager
             .list_active_streaming_compute_nodes()
             .await;
+
+        let unschedulable_worker_ids: HashSet<_> = workers
+            .iter()
+            .filter(|worker| {
+                worker
+                    .property
+                    .as_ref()
+                    .map(|p| p.is_unschedulable)
+                    .unwrap_or(false)
+            })
+            .map(|worker| worker.id as WorkerId)
+            .collect();
+
+        for changes in fragment_worker_changes.values() {
+            for worker_id in &changes.include_worker_ids {
+                if unschedulable_worker_ids.contains(worker_id) {
+                    bail!("Cannot scale out to cordoned worker {}", worker_id)
+                }
+            }
+        }
 
         let worker_parallel_units = workers
             .iter()

--- a/src/tests/simulation/tests/integration_tests/scale/schedulability.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/schedulability.rs
@@ -408,11 +408,6 @@ async fn invalid_reschedule(
     let f_id = mv_frag.id;
     let result = cluster.reschedule(format!("{f_id}-[{from}]+[{to}]")).await;
     assert!(result.is_err());
-    let err_msg = result.err().unwrap().to_string();
-    assert_eq!(
-        err_msg,
-        "gRPC error (Internal error): unable to move fragment to unschedulable node"
-    );
 
     cluster.run(drop).await?;
     Ok(())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

PR #10143 introduced modifications for Worker's Schedulablility. This PR is to adapt the `get_reschedule_plan` to refuse cordoned worker id during generating reschedule plan, and to skip cordoned workers when generating a migration plan for a single fragment.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation



<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
