### PR TITLE
fix: more test for select * except

### DIFF
--- a/e2e_test/batch/basic/query.slt.part
+++ b/e2e_test/batch/basic/query.slt.part
@@ -45,6 +45,9 @@ select * except (v1), * except (v2) from t3;
 ----
 2 NULL 1 NULL
 
+statement error
+select * except (v5) from t3;
+
 statement error Division by zero
 select v1/0 from t3;
 

--- a/src/frontend/planner_test/tests/testdata/input/basic_query.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/basic_query.yaml
@@ -37,7 +37,7 @@
 - sql: |
     create table t (v1 int, v2 int, v3 int);
     select * except (v1, v2), v3 from t;
-  expected_outputs:
+  expected_outputs: 
   - batch_plan
 - name: test boolean expression common factor extraction
   sql: |

--- a/src/sqlparser/tests/testdata/select.yaml
+++ b/src/sqlparser/tests/testdata/select.yaml
@@ -44,6 +44,14 @@
   error_msg: |-
     sql parser error: Expected SELECT, VALUES, or a subquery in the query body, found: v1 at line:1, column:21
     Near "SELECT v3 EXCEPT ("
+- input: SELECT * EXCEPT (V1, ) FROM foo
+  error_msg: |-
+    sql parser error: Expected an expression:, found: ) at line:1, column:23
+    Near " * EXCEPT (V1, )"
+- input: SELECT * EXCEPT (v1 FROM foo
+  error_msg: |-
+    sql parser error: Expected an expression:, found: * at line:1, column:9
+    Near "SELECT *"
 - input: SELECT * FROM t LIMIT 1 FETCH FIRST ROWS ONLY
   error_msg: 'sql parser error: Cannot specify both LIMIT and FETCH'
 - input: SELECT * FROM t FETCH FIRST ROWS WITH TIES


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
As title. Below is some analysis for one specific error message.

In #10438 , I only handle `except` after `*` because there is `except` for set substraction. Therefore for `SELECT v3 EXCEPT (v1, v2) FROM foo`, the parser switches to that part and generates the corresponding message.
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

~~- [ ] I have written necessary rustdoc comments~~
- [x] I have added necessary unit tests and integration tests

~~- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
~~- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

~~- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)~~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

~~- [ ] My PR contains user-facing changes.~~

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
