### PR TITLE
feat(eowc): support eowc in create sink

### DIFF
--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -758,6 +758,7 @@ impl TestCase {
                     sink_name.to_string(),
                     format!("CREATE SINK {sink_name} AS {}", stmt),
                     options,
+                    false,
                 ) {
                     Ok(sink_plan) => {
                         ret.sink_plan = Some(explain_plan(&sink_plan.into()));

--- a/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/emit_on_window_close.yaml
@@ -28,3 +28,14 @@
     - eowc_stream_dist_plan
     - stream_error
     - eowc_stream_plan
+- sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    explain create sink s1 emit on window close as select
+      tm, foo, bar,
+      lag(foo, 2) over (partition by bar order by tm),
+      max(foo) over (partition by bar order by tm rows between 1 preceding and 1 following),
+      sum(foo) over (partition by bar order by tm rows 2 preceding exclude current row)
+      from t WITH (connector = 'blackhole');
+  expected_outputs:
+    - explain_output
+  

--- a/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/emit_on_window_close.yaml
@@ -172,3 +172,18 @@
   stream_error: |-
     Feature is not yet implemented: General version of streaming over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
+- sql: |
+    create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;
+    explain create sink s1 emit on window close as select
+      tm, foo, bar,
+      lag(foo, 2) over (partition by bar order by tm),
+      max(foo) over (partition by bar order by tm rows between 1 preceding and 1 following),
+      sum(foo) over (partition by bar order by tm rows 2 preceding exclude current row)
+      from t WITH (connector = 'blackhole');
+  explain_output: |
+    StreamSink { type: upsert, columns: [tm, foo, bar, t._row_id(hidden), lag, max, sum], pk: [t._row_id] }
+    └─StreamExchange { dist: HashShard(t._row_id) }
+      └─StreamEowcOverWindow { window_functions: [first_value(t.foo) OVER(PARTITION BY t.bar ORDER BY t.tm ASC ROWS BETWEEN 2 PRECEDING AND 2 PRECEDING), max(t.foo) OVER(PARTITION BY t.bar ORDER BY t.tm ASC ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING), sum(t.foo) OVER(PARTITION BY t.bar ORDER BY t.tm ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW EXCLUDE CURRENT ROW)] }
+        └─StreamSort { sort_column_index: 0 }
+          └─StreamExchange { dist: HashShard(t.bar) }
+            └─StreamTableScan { table: t, columns: [tm, foo, bar, _row_id] }

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -22,7 +22,7 @@ use risingwave_connector::sink::catalog::SinkCatalog;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_sqlparser::ast::{
     CreateSink, CreateSinkStatement, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor,
-    TableWithJoins,
+    TableWithJoins, EmitMode,
 };
 
 use super::create_mv::get_column_names;
@@ -102,12 +102,17 @@ pub fn gen_sink_plan(
         conn_id.map(ConnectionId)
     };
 
+    let emit_on_window_close = stmt.emit_mode == Some(EmitMode::OnWindowClose);
+    if emit_on_window_close {
+        context.warn_to_user("EMIT ON WINDOW CLOSE is currently an experimental feature. Please use it with caution.");
+    }
+
     let mut plan_root = Planner::new(context).plan_query(bound)?;
     if let Some(col_names) = col_names {
         plan_root.set_out_names(col_names)?;
     };
 
-    let sink_plan = plan_root.gen_sink_plan(sink_table_name, definition, with_options)?;
+    let sink_plan = plan_root.gen_sink_plan(sink_table_name, definition, with_options, emit_on_window_close)?;
     let sink_desc = sink_plan.sink_desc().clone();
     let sink_plan: PlanRef = sink_plan.into();
 

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -21,8 +21,8 @@ use risingwave_common::error::Result;
 use risingwave_connector::sink::catalog::SinkCatalog;
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
 use risingwave_sqlparser::ast::{
-    CreateSink, CreateSinkStatement, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor,
-    TableWithJoins, EmitMode,
+    CreateSink, CreateSinkStatement, EmitMode, ObjectName, Query, Select, SelectItem, SetExpr,
+    TableFactor, TableWithJoins,
 };
 
 use super::create_mv::get_column_names;
@@ -112,7 +112,12 @@ pub fn gen_sink_plan(
         plan_root.set_out_names(col_names)?;
     };
 
-    let sink_plan = plan_root.gen_sink_plan(sink_table_name, definition, with_options, emit_on_window_close)?;
+    let sink_plan = plan_root.gen_sink_plan(
+        sink_table_name,
+        definition,
+        with_options,
+        emit_on_window_close,
+    )?;
     let sink_desc = sink_plan.sink_desc().clone();
     let sink_plan: PlanRef = sink_plan.into();
 

--- a/src/frontend/src/optimizer/mod.rs
+++ b/src/frontend/src/optimizer/mod.rs
@@ -521,8 +521,9 @@ impl PlanRoot {
         sink_name: String,
         definition: String,
         properties: WithOptions,
+        emit_on_window_close: bool,
     ) -> Result<StreamSink> {
-        let stream_plan = self.gen_optimized_stream_plan(false)?;
+        let stream_plan = self.gen_optimized_stream_plan(emit_on_window_close)?;
 
         StreamSink::create(
             stream_plan,

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::ddl::SourceWatermark;
-use super::{Ident, ObjectType, Query};
+use super::{Ident, ObjectType, Query, EmitMode};
 use crate::ast::{
     display_comma_separated, display_separated, ColumnDef, ObjectName, SqlOption, TableConstraint,
 };
@@ -448,6 +448,7 @@ pub struct CreateSinkStatement {
     pub with_properties: WithProperties,
     pub sink_from: CreateSink,
     pub columns: Vec<Ident>,
+    pub emit_mode: Option<EmitMode>,
 }
 
 impl ParseTo for CreateSinkStatement {
@@ -456,6 +457,8 @@ impl ParseTo for CreateSinkStatement {
         impl_parse_to!(sink_name: ObjectName, p);
 
         let columns = p.parse_parenthesized_column_list(IsOptional::Optional)?;
+        
+        let emit_mode = p.parse_emit_mode()?;
 
         let sink_from = if p.parse_keyword(Keyword::FROM) {
             impl_parse_to!(from_name: ObjectName, p);
@@ -480,6 +483,7 @@ impl ParseTo for CreateSinkStatement {
             with_properties,
             sink_from,
             columns,
+            emit_mode,
         })
     }
 }

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use super::ddl::SourceWatermark;
-use super::{Ident, ObjectType, Query, EmitMode};
+use super::{EmitMode, Ident, ObjectType, Query};
 use crate::ast::{
     display_comma_separated, display_separated, ColumnDef, ObjectName, SqlOption, TableConstraint,
 };
@@ -457,7 +457,7 @@ impl ParseTo for CreateSinkStatement {
         impl_parse_to!(sink_name: ObjectName, p);
 
         let columns = p.parse_parenthesized_column_list(IsOptional::Optional)?;
-        
+
         let emit_mode = p.parse_emit_mode()?;
 
         let sink_from = if p.parse_keyword(Keyword::FROM) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- support eowc in create sink
- The usage is the same as create mv

example: 
```sql
create table t (tm timestamp, foo int, bar int, watermark for tm as tm - interval '5 minutes') append only;

create sink s1 emit on window close as select
      tm, foo, bar,
      lag(foo, 2) over (partition by bar order by tm),
      max(foo) over (partition by bar order by tm rows between 1 preceding and 1 following),
      sum(foo) over (partition by bar order by tm rows 2 preceding exclude current row)
      from t WITH (connector = 'blackhole');
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
