### PR TITLE
feat(sqlsmith): differential testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,6 +6562,7 @@ dependencies = [
  "risingwave_expr",
  "risingwave_frontend",
  "risingwave_sqlparser",
+ "similar",
  "tokio-postgres",
  "tracing",
  "tracing-subscriber",

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -44,7 +44,7 @@ cargo make ci-start ci-3cn-1fe
 echo "--- e2e, ci-3cn-1fe, run fuzzing"
 ./target/debug/sqlsmith test \
   --count "$SQLSMITH_COUNT" \
-  --testdata ./src/tests/sqlsmith/tests/testdata
+  --testdata ./src/tests/sqlsmith/tests/testdata \
   --differential-testing
 
 # Sqlsmith does not write to stdout, so we need this to ensure buildkite

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Exits as soon as any line fails.
+set -euo pipefail
+
+export LOGDIR=.risingwave/log
+export RUST_LOG=info
+
+while getopts 'p:' opt; do
+    case ${opt} in
+        p )
+            profile=$OPTARG
+            ;;
+        \? )
+            echo "Invalid Option: -$OPTARG" 1>&2
+            exit 1
+            ;;
+        : )
+            echo "Invalid option: $OPTARG requires an argument" 1>&2
+            ;;
+    esac
+done
+shift $((OPTIND -1))
+
+download_and_prepare_rw "$profile" common
+
+# TODO(kwannoel): Support differential testing in madsim
+#echo "--- Download artifacts"
+#download-and-decompress-artifact risingwave_simulation .
+#chmod +x ./risingwave_simulation
+
+echo "--- Download sqlsmith e2e bin"
+download-and-decompress-artifact sqlsmith-"$profile" target/debug/
+mv target/debug/sqlsmith-"$profile" target/debug/sqlsmith
+chmod +x ./target/debug/sqlsmith
+
+echo "--- e2e, ci-3cn-1fe, build"
+cargo make ci-start ci-3cn-1fe
+
+echo "--- e2e, ci-3cn-1fe, run fuzzing"
+./target/debug/sqlsmith test \
+  --count "$SQLSMITH_COUNT" \
+  --testdata ./src/tests/sqlsmith/tests/testdata
+  --differential-testing
+
+# Sqlsmith does not write to stdout, so we need this to ensure buildkite
+# shows the right timing.
+echo "Fuzzing complete"
+
+# Using `kill` instead of `ci-kill` avoids storing excess logs.
+# If there's errors, the failing query will be printed to stderr.
+# Use that to reproduce logs on local machine.
+echo "--- Kill cluster"
+cargo make kill

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 source ci/scripts/common.sh
 
 export RUST_LOG=info
+export SQLSMITH_COUNT=100
 
 while getopts 'p:' opt; do
     case ${opt} in

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -3,7 +3,8 @@
 # Exits as soon as any line fails.
 set -euo pipefail
 
-export LOGDIR=.risingwave/log
+source ci/scripts/common.sh
+
 export RUST_LOG=info
 
 while getopts 'p:' opt; do

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -23,6 +23,8 @@ while getopts 'p:' opt; do
 done
 shift $((OPTIND -1))
 
+git config --global --add safe.directory /risingwave
+
 download_and_prepare_rw "$profile" common
 
 # TODO(kwannoel): Support differential testing in madsim

--- a/ci/scripts/sqlsmith-differential-test.sh
+++ b/ci/scripts/sqlsmith-differential-test.sh
@@ -45,7 +45,7 @@ echo "--- e2e, ci-3cn-1fe, run fuzzing"
 ./target/debug/sqlsmith test \
   --count "$SQLSMITH_COUNT" \
   --testdata ./src/tests/sqlsmith/tests/testdata \
-  --differential-testing
+  --differential-testing 1>.risingwave/log/diff.log 2>&1 && rm .risingwave/log/diff.log
 
 # Sqlsmith does not write to stdout, so we need this to ensure buildkite
 # shows the right timing.

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -302,3 +302,16 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 20
+
+  # Sqlsmith differential testing
+  - label: "Sqlsmith Differential Testing"
+    command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
+    depends_on:
+      - "build"
+    plugins:
+      - docker-compose#v4.9.0:
+          run: ci-flamegraph-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 40
+    soft_fail: true

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -390,7 +390,7 @@ steps:
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
     command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
-    if: build.pull_request.labels includes ci/run-sqlsmith-differential-tests
+    if: build.pull_request.labels includes "ci/run-sqlsmith-differential-tests"
     depends_on:
       - "build"
     plugins:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -386,3 +386,17 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 20
+
+  # Sqlsmith differential testing
+  - label: "Sqlsmith Differential Testing"
+    command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
+    if: build.pull_request.labels includes ci/run-sqlsmith-differential-tests
+    depends_on:
+      - "build"
+    plugins:
+      - docker-compose#v4.9.0:
+          run: ci-flamegraph-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+    timeout_in_minutes: 40
+    soft_fail: true

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -389,7 +389,7 @@ steps:
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
-    command: "ci/scripts/sqlsmith-differential-test.sh -p ci-release"
+    command: "ci/scripts/sqlsmith-differential-test.sh -p ci-dev"
     if: build.pull_request.labels includes "ci/run-sqlsmith-differential-tests"
     depends_on:
       - "build"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -399,4 +399,3 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 40
-    soft_fail: true

--- a/src/tests/sqlsmith/Cargo.toml
+++ b/src/tests/sqlsmith/Cargo.toml
@@ -25,6 +25,7 @@ risingwave_common = { path = "../../common" }
 risingwave_expr = { path = "../../expr" }
 risingwave_frontend = { path = "../../frontend" }
 risingwave_sqlparser = { path = "../../sqlparser" }
+similar = "2.2.1"
 tokio = { version = "0.2", package = "madsim-tokio" }
 tokio-postgres = "0.7"
 tracing = "0.1"

--- a/src/tests/sqlsmith/README.md
+++ b/src/tests/sqlsmith/README.md
@@ -59,15 +59,29 @@ RUST_LOG=info RUST_BACKTRACE=1 MADSIM_TEST_SEED=1 ./target/sim/ci-sim/risingwave
 cat sqlsmith.log | less
 ```
 
-## E2E
+## E2E - random fuzzing
 
-In the second mode, it will test the entire query handling end-to-end. We provide a CLI tool that represents a Postgres client. You can run this tool via:
+This mode will test the entire query handling end-to-end. We provide a CLI tool that represents a Postgres client. You can run this tool via:
 
 ```sh
 cargo build
 ./risedev d
 ./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata
 ```
+
+## E2E - differential testing
+
+This mode will generate batch and stream queries and **diff them after sorting**.
+
+You can run this tool like so:
+
+```sh
+cargo build
+./risedev d
+./target/debug/sqlsmith test --testdata ./src/tests/sqlsmith/tests/testdata --differential-testing
+```
+
+## Generating function signatures
 
 Additionally, in some cases where you may want to debug whether we have defined some function/operator incorrectly,
 you can try:

--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 
 use clap::Parser as ClapParser;
 use risingwave_sqlsmith::print_function_table;
-use risingwave_sqlsmith::runner::{generate, run};
+use risingwave_sqlsmith::runner::{generate, run, run_differential_testing};
 use tokio_postgres::NoTls;
 
 #[derive(ClapParser, Debug, Clone)]
@@ -61,6 +61,10 @@ struct TestOptions {
     /// query while testing.
     #[clap(long)]
     generate: Option<String>,
+
+    /// Whether to run differential testing mode.
+    #[clap(long)]
+    differential_testing: bool,
 }
 
 #[derive(clap::Subcommand, Clone, Debug)]
@@ -101,6 +105,11 @@ async fn main() {
             tracing::error!("Postgres connection error: {:?}", e);
         }
     });
+    if opt.differential_testing {
+        return run_differential_testing(&client, &opt.testdata, opt.count, None)
+            .await
+            .unwrap();
+    }
     if let Some(outdir) = opt.generate {
         generate(&client, &opt.testdata, opt.count, &outdir, None).await;
     } else {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -71,10 +71,10 @@ pub fn differential_sql_gen<R: Rng>(
     let mut gen = SqlGenerator::new_for_mview(rng, tables);
     let (stream, table) = gen.gen_mview_stmt(name);
     let batch = match stream {
-        Statement::CreateView { ref query, .. } => format!("{:?}", query),
+        Statement::CreateView { ref query, .. } => query.to_string(),
         _ => bail!("Differential pair should be mview statement!"),
     };
-    Ok((batch, format!("{:?}", stream), table))
+    Ok((batch, stream.to_string(), table))
 }
 
 /// TODO(noel): Eventually all session variables should be fuzzed.

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -71,10 +71,10 @@ pub fn differential_sql_gen<R: Rng>(
     let mut gen = SqlGenerator::new_for_mview(rng, tables);
     let (stream, table) = gen.gen_mview_stmt(name);
     let batch = match stream {
-        Statement::CreateView { ref query, .. } => query.to_string(),
+        Statement::CreateView { ref query, .. } => format!("{:?}", query),
         _ => bail!("Differential pair should be mview statement!"),
     };
-    Ok((batch, stream.to_string(), table))
+    Ok((batch, format!("{:?}", stream), table))
 }
 
 /// TODO(noel): Eventually all session variables should be fuzzed.

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -620,14 +620,15 @@ async fn diff_stream_and_batch(
     } else {
         bail!(
             "
-Different number of rows for:
-BATCH:
+Different results for batch and stream:
+
+BATCH SQL:
 {batch}
 
-STREAM:
+STREAM SQL:
 {stream}
 
-SELECT:
+SELECT FROM STREAM SQL:
 {select}
 
 BATCH_ROW_LEN:
@@ -642,7 +643,7 @@ BATCH_ROWS:
 STREAM_ROWS:
 {formatted_stream_rows}
 
-DIFF:
+ROW DIFF (+/-):
 {diff}
 ",
         )

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -216,16 +216,6 @@ pub async fn run_differential_testing(
     // Generate an update for some inserts, on the corresponding table.
     update_base_tables(client, &mut rng, &base_tables, &inserts).await;
     tracing::info!("Ran updates");
-    // let max_rows_inserted = rows_per_table * base_tables.len();
-    // test_sqlsmith(
-    //     client,
-    //     &mut rng,
-    //     tables.clone(),
-    //     base_tables.clone(),
-    //     max_rows_inserted,
-    // )
-    // .await;
-    // tracing::info!("Passed sqlsmith tests");
 
     for i in 0..count {
         diff_stream_and_batch(&mut rng, tables.clone(), client, i).await?

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -614,7 +614,8 @@ async fn diff_stream_and_batch(
             ChangeTag::Delete => Some(format!("-{}", change)),
             ChangeTag::Insert => Some(format!("+{}", change)),
             ChangeTag::Equal => None,
-        }).collect();
+        })
+        .collect();
 
     if diff.is_empty() {
         tracing::info!(

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -596,15 +596,13 @@ async fn diff_stream_and_batch(
     let n_batch_rows = batch_result.len();
     let formatted_stream_rows = format_rows(&batch_result);
     let formatted_batch_rows = format_rows(&stream_result);
-    tracing::trace!(
-        "[EXECUTING DIFF - STREAM_FORMATTED_ROW id={}]: {:#?}",
+    tracing::info!(
+        "[EXECUTING DIFF - STREAM_FORMATTED_ROW id={}]: {formatted_stream_rows}",
         i,
-        formatted_stream_rows
     );
-    tracing::trace!(
-        "[EXECUTING DIFF - BATCH_FORMATTED_ROW id={}]: {:#?}",
+    tracing::info!(
+        "[EXECUTING DIFF - BATCH_FORMATTED_ROW id={}]: {formatted_batch_rows}",
         i,
-        formatted_batch_rows
     );
     if formatted_batch_rows == formatted_stream_rows {
         tracing::info!(
@@ -636,13 +634,11 @@ STREAM_ROW_LEN:
 {n_stream_rows}
 
 BATCH_ROWS:
-{:#?}
+{formatted_batch_rows}
 
 STREAM_ROWS:
-{:#?}
+{formatted_stream_rows}
 ",
-            &formatted_batch_rows,
-            &formatted_stream_rows,
         )
     }
 }
@@ -654,7 +650,12 @@ fn format_rows(rows: &[SimpleQueryMessage]) -> String {
             SimpleQueryMessage::Row(row) => {
                 let n_cols = row.columns().len();
                 let formatted_row: String =
-                    (0..n_cols).map(|i| format!("{:#?}", row.get(i))).collect();
+                    (0..n_cols)
+                        .map(|i| format!("{:#?}", match row.get(i) {
+                            Some(s) => s,
+                            _ => "NULL",
+                        }))
+                        .join(", ");
                 Some(formatted_row)
             }
             SimpleQueryMessage::CommandComplete(_n_rows) => None,

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -597,11 +597,11 @@ async fn diff_stream_and_batch(
     let n_batch_rows = batch_result.len();
     let formatted_stream_rows = format_rows(&batch_result);
     let formatted_batch_rows = format_rows(&stream_result);
-    tracing::info!(
+    tracing::debug!(
         "[EXECUTING DIFF - STREAM_FORMATTED_ROW id={}]: {formatted_stream_rows}",
         i,
     );
-    tracing::info!(
+    tracing::debug!(
         "[EXECUTING DIFF - BATCH_FORMATTED_ROW id={}]: {formatted_batch_rows}",
         i,
     );

--- a/src/tests/sqlsmith/src/runner.rs
+++ b/src/tests/sqlsmith/src/runner.rs
@@ -563,7 +563,7 @@ async fn diff_stream_and_batch(
 
     let select = format!("SELECT * FROM {}", &mview_name);
     tracing::info!(
-        "[EXECUTING DIFF - SELECT * FROM MVIEW id={}], {}",
+        "[EXECUTING DIFF - SELECT * FROM MVIEW id={}]: {}",
         i,
         select
     );


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Closes #10427 

- Adds differential testing executable.
- Differential testing works by generating stream query, extracting the inner query of it, and running it as a batch query.
- It is expected that after sorting, the results of most queries should match.
- Add to main-cron and PR workflow, but soft fail it, currently seems like there are some unresolved errors.
- Adds `similar` as a dependency.

---

Further improvements:
- Perhaps this mode should have more inserts? 🤔 
- If there are exceptions to differential testing, we can add them later. For now it seems the tests usually pass.
- Support session variable fuzzing.
- Better error reproducibility. Currently all we have are the logs to work with for reproducing errors. We should adapt existing tool to extract DDL, DML, diffed queries.
- For reproducibility this should definitely run in madsim too.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
