### PR TITLE
chore: refine reschedule lock

### DIFF
--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -281,6 +281,8 @@ where
         mut stream_job: StreamingJob,
         fragment_graph: StreamFragmentGraphProto,
     ) -> MetaResult<NotificationVersion> {
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
+
         let env = StreamEnvironment::from_protobuf(fragment_graph.get_env().unwrap());
         let fragment_graph = self
             .prepare_stream_job(&mut stream_job, fragment_graph)
@@ -321,7 +323,7 @@ where
     }
 
     async fn drop_streaming_job(&self, job_id: StreamingJobId) -> MetaResult<NotificationVersion> {
-        let _streaming_job_lock = self.stream_manager.streaming_job_lock.lock().await;
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
         let table_fragments = self
             .fragment_manager
             .select_table_fragments_by_table_id(&job_id.id().into())
@@ -628,7 +630,7 @@ where
         fragment_graph: StreamFragmentGraphProto,
         table_col_index_mapping: ColIndexMapping,
     ) -> MetaResult<NotificationVersion> {
-        let _streaming_job_lock = self.stream_manager.streaming_job_lock.lock().await;
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
         let env = StreamEnvironment::from_protobuf(fragment_graph.get_env().unwrap());
 
         let fragment_graph = self

--- a/src/meta/src/rpc/service/scale_service.rs
+++ b/src/meta/src/rpc/service/scale_service.rs
@@ -85,7 +85,7 @@ where
         &self,
         _: Request<GetClusterInfoRequest>,
     ) -> Result<Response<GetClusterInfoResponse>, Status> {
-        let _streaming_job_lock = self.stream_manager.streaming_job_lock.lock().await;
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
 
         let table_fragments = self
             .fragment_manager
@@ -137,7 +137,7 @@ where
     ) -> Result<Response<RescheduleResponse>, Status> {
         let req = request.into_inner();
 
-        let _streaming_job_lock = self.stream_manager.streaming_job_lock.lock().await;
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.write().await;
 
         let current_revision = self.fragment_manager.get_revision().await;
 
@@ -193,7 +193,7 @@ where
     ) -> Result<Response<GetReschedulePlanResponse>, Status> {
         let req = request.into_inner();
 
-        let _streaming_job_lock = self.stream_manager.streaming_job_lock.lock().await;
+        let _reschedule_job_lock = self.stream_manager.reschedule_lock.read().await;
 
         let current_revision = self.fragment_manager.get_revision().await;
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -25,7 +25,7 @@ use risingwave_pb::stream_service::{
     BroadcastActorInfoTableRequest, BuildActorsRequest, DropActorsRequest, UpdateActorsRequest,
 };
 use tokio::sync::mpsc::Sender;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use uuid::Uuid;
 
 use super::Locations;
@@ -172,7 +172,7 @@ pub struct GlobalStreamManager<S: MetaStore> {
 
     hummock_manager: HummockManagerRef<S>,
 
-    pub(crate) streaming_job_lock: Mutex<()>,
+    pub(crate) reschedule_lock: RwLock<()>,
 }
 
 impl<S> GlobalStreamManager<S>
@@ -195,7 +195,7 @@ where
             source_manager,
             hummock_manager,
             creating_job_info: Arc::new(CreatingStreamingJobInfo::default()),
-            streaming_job_lock: Mutex::new(()),
+            reschedule_lock: RwLock::new(()),
         })
     }
 

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -536,6 +536,7 @@ where
     }
 
     pub async fn cancel_streaming_jobs(&self, table_ids: Vec<TableId>) {
+        let _reschedule_job_lock = self.reschedule_lock.read().await;
         self.creating_job_info.cancel_jobs(table_ids).await;
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR upgrades the reschedule lock to a rwlock, and also locks during the create mv stage, which will help in preventing occasional race conditions.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation



<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
