### PR TITLE
feat(frontend): send application_name when set changed

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -143,7 +143,7 @@ impl<const NAME: usize, const DEFAULT: bool> Deref for ConfigBool<NAME, DEFAULT>
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone, PartialEq, Eq)]
 struct ConfigString<const NAME: usize>(String);
 
 impl<const NAME: usize> Deref for ConfigString<NAME> {
@@ -295,6 +295,11 @@ type EnableJoinOrdering = ConfigBool<RW_ENABLE_JOIN_ORDERING, true>;
 type ServerVersion = ConfigString<SERVER_VERSION>;
 type ServerVersionNum = ConfigI32<SERVER_VERSION_NUM, 80_300>;
 
+/// Report status or notice to caller.
+pub trait ConfigReporter {
+    fn report_status(&mut self, key: &str, new_val: String);
+}
+
 #[derive(Educe)]
 #[educe(Default)]
 pub struct ConfigMap {
@@ -386,7 +391,12 @@ pub struct ConfigMap {
 }
 
 impl ConfigMap {
-    pub fn set(&mut self, key: &str, val: Vec<String>) -> Result<(), RwError> {
+    pub fn set(
+        &mut self,
+        key: &str,
+        val: Vec<String>,
+        mut reporter: impl ConfigReporter,
+    ) -> Result<(), RwError> {
         info!(%key, ?val, "set config");
         let val = val.iter().map(AsRef::as_ref).collect_vec();
         if key.eq_ignore_ascii_case(ImplicitFlush::entry_name()) {
@@ -398,7 +408,11 @@ impl ConfigMap {
         } else if key.eq_ignore_ascii_case(ExtraFloatDigit::entry_name()) {
             self.extra_float_digit = val.as_slice().try_into()?;
         } else if key.eq_ignore_ascii_case(ApplicationName::entry_name()) {
-            self.application_name = val.as_slice().try_into()?;
+            let new_application_name = val.as_slice().try_into()?;
+            if self.application_name != new_application_name {
+                self.application_name = new_application_name.clone();
+                reporter.report_status(ApplicationName::entry_name(), new_application_name.0);
+            }
         } else if key.eq_ignore_ascii_case(DateStyle::entry_name()) {
             self.date_style = val.as_slice().try_into()?;
         } else if key.eq_ignore_ascii_case(BatchEnableLookupJoin::entry_name()) {
@@ -445,8 +459,6 @@ impl ConfigMap {
             self.interval_style = val.as_slice().try_into()?;
         } else if key.eq_ignore_ascii_case(BatchParallelism::entry_name()) {
             self.batch_parallelism = val.as_slice().try_into()?;
-        } else if key.eq_ignore_ascii_case(ApplicationName::entry_name()) {
-            self.application_name = val.as_slice().try_into()?;
         } else {
             return Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into());
         }
@@ -482,7 +494,7 @@ impl ConfigMap {
         } else if key.eq_ignore_ascii_case(QueryEpoch::entry_name()) {
             Ok(self.query_epoch.to_string())
         } else if key.eq_ignore_ascii_case(Timezone::entry_name()) {
-            Ok(self.timezone.clone())
+            Ok(self.timezone.to_string())
         } else if key.eq_ignore_ascii_case(StreamingParallelism::entry_name()) {
             Ok(self.streaming_parallelism.to_string())
         } else if key.eq_ignore_ascii_case(StreamingEnableDeltaJoin::entry_name()) {
@@ -502,11 +514,11 @@ impl ConfigMap {
         } else if key.eq_ignore_ascii_case(BatchParallelism::entry_name()) {
             Ok(self.batch_parallelism.to_string())
         } else if key.eq_ignore_ascii_case(ServerVersion::entry_name()) {
-            Ok(self.server_version.clone())
+            Ok(self.server_version.to_string())
         } else if key.eq_ignore_ascii_case(ServerVersionNum::entry_name()) {
             Ok(self.server_version_num.to_string())
         } else if key.eq_ignore_ascii_case(ApplicationName::entry_name()) {
-            Ok(self.application_name.clone())
+            Ok(self.application_name.to_string())
         } else {
             Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into())
         }

--- a/src/utils/pgwire/src/pg_extended.rs
+++ b/src/utils/pgwire/src/pg_extended.rs
@@ -52,6 +52,14 @@ where
         for notice in self.result.notices() {
             msg_stream.write_no_flush(&BeMessage::NoticeResponse(notice))?;
         }
+
+        let status = self.result.status();
+        if let Some(ref application_name) = status.application_name {
+            msg_stream.write_no_flush(&BeMessage::ParameterStatus(
+                crate::pg_message::BeParameterStatusMessage::ApplicationName(application_name),
+            ))?;
+        }
+
         if self.result.is_empty() {
             // Run the callback before sending the response.
             self.result.run_callback().await?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Related #10339 

Now the BeMessageStatus will be set when the application_name was changed dynamicly.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
