### PR TITLE
fix: use github event number instead

### DIFF
--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           pr_branch: 'v0.19.0-rc'
           pr_labels: 'cherry-pick'
-          pr_body: 'Cherry picking #{old_pull_request_id} onto this branch'
+          pr_body: ${{ format('Cherry picking {0} onto branch v0.19.0-rc', github.event.number) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).


Was looking at the wrong documentation of a same-name github action....
