### PR TITLE
fix(ci): add build-other dependency for running e2e test

### DIFF
--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -60,6 +60,7 @@ steps:
     command: "ci/scripts/e2e-test.sh -p ci-dev"
     depends_on:
       - "build-dev"
+      - "build-other"
       - "docslt"
     plugins:
       - seek-oss/aws-sm#v2.3.1:
@@ -79,6 +80,7 @@ steps:
     command: "ci/scripts/e2e-test.sh -p ci-release"
     depends_on:
       - "build-release"
+      - "build-other"
       - "docslt"
     plugins:
       - seek-oss/aws-sm#v2.3.1:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After implementing java-udf, the running e2e test implicitly depends on the `build-other` of CI, which builds the java-udf jar. After https://github.com/risingwavelabs/risingwave/pull/10552, the time of `build-other` increases, and therefore running e2e test will fail if starting before `build-other` finishes. 

In this PR we added the dependency on build-other for e2e test

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
