### PR TITLE
fix(ci): maven version bump 3.9.3

### DIFF
--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -13,8 +13,8 @@ fi
 echo "--- Install java and maven"
 yum install -y java-11-openjdk wget python3
 pip3 install toml-cli
-wget https://dlcdn.apache.org/maven/maven-3/3.9.2/binaries/apache-maven-3.9.2-bin.tar.gz && tar -zxvf apache-maven-3.9.2-bin.tar.gz
-export PATH="${REPO_ROOT}/apache-maven-3.9.2/bin:$PATH"
+wget https://ci-deps-dist.s3.amazonaws.com/apache-maven-3.9.3-bin.tar.gz && tar -zxvf apache-maven-3.9.3-bin.tar.gz
+export PATH="${REPO_ROOT}/apache-maven-3.9.3/bin:$PATH"
 mvn -v
 
 echo "--- Install rust"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- maven version bump 3.9.3
- store this tar package in s3

## Documentation

- [ ] My PR contains user-facing changes.


