### PR TITLE
feat(meta): Cordon send individual requests

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -211,7 +211,7 @@ message DeleteWorkerNodeResponse {
 
 // Mark CN as schedulable or as unschedulable
 message UpdateWorkerNodeSchedulabilityRequest {
-  repeated uint32 worker_ids = 1;
+  uint32 worker_id = 1;
   bool set_is_unschedulable = 2;
 }
 

--- a/src/ctl/src/cmd_impl/scale/resize.rs
+++ b/src/ctl/src/cmd_impl/scale/resize.rs
@@ -330,8 +330,10 @@ pub async fn update_schedulability(
 
     let target_worker_ids = target_worker_ids.into_iter().collect_vec();
 
-    meta_client
-        .update_schedulability(&target_worker_ids, is_unschedulable)
-        .await?;
+    for target_worker_id in target_worker_ids {
+        meta_client
+            .update_schedulability(target_worker_id, is_unschedulable)
+            .await?;
+    }
     Ok(())
 }

--- a/src/meta/src/rpc/service/cluster_service.rs
+++ b/src/meta/src/rpc/service/cluster_service.rs
@@ -86,9 +86,9 @@ where
         req: Request<UpdateWorkerNodeSchedulabilityRequest>,
     ) -> Result<Response<UpdateWorkerNodeSchedulabilityResponse>, Status> {
         let inner = req.into_inner();
-        let worker_ids = inner.worker_ids;
+        let worker_id = inner.worker_id;
         self.cluster_manager
-            .update_schedulability(&worker_ids, inner.set_is_unschedulable)
+            .update_schedulability(worker_id, inner.set_is_unschedulable)
             .await?;
         Ok(Response::new(UpdateWorkerNodeSchedulabilityResponse {
             status: None,

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -581,11 +581,11 @@ impl MetaClient {
 
     pub async fn update_schedulability(
         &self,
-        worker_ids: &[u32],
+        worker_id: u32,
         set_is_unschedulable: bool,
     ) -> Result<UpdateWorkerNodeSchedulabilityResponse> {
         let request = UpdateWorkerNodeSchedulabilityRequest {
-            worker_ids: worker_ids.to_vec(),
+            worker_id,
             set_is_unschedulable,
         };
         let resp = self


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Send individual requests for each node that should be (un)cordoned

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
