### PR TITLE
fix: add hashtag to link to the old PR

### DIFF
--- a/.github/workflows/cherry-pick-to-release-branch.yml
+++ b/.github/workflows/cherry-pick-to-release-branch.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           pr_branch: 'v0.19.0-rc'
           pr_labels: 'cherry-pick'
-          pr_body: ${{ format('Cherry picking {0} onto branch v0.19.0-rc', github.event.number) }}
+          pr_body: ${{ format('Cherry picking \#{0} onto branch v0.19.0-rc', github.event.number) }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
add a hashtag before the pull request number so that we can click into the PR.

see a examepl https://github.com/risingwavelabs/risingwave/issues/10644 without `#`