### PR TITLE
fix: fix memcomparable encoding for bytea type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5818,6 +5818,7 @@ dependencies = [
  "rusty-fork",
  "ryu",
  "serde",
+ "serde_bytes",
  "serde_default",
  "serde_json",
  "serde_with 2.3.3",
@@ -7075,6 +7076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float 2.10.0",
+ "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
+dependencies = [
  "serde",
 ]
 

--- a/src/common/Cargo.toml
+++ b/src/common/Cargo.toml
@@ -68,6 +68,7 @@ risingwave_pb = { path = "../prost" }
 rust_decimal = { version = "1", features = ["db-postgres", "maths"] }
 ryu = "1.0"
 serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
 serde_default = "0.1"
 serde_json = "1"
 serde_with = "2"

--- a/src/common/src/array/list_array.rs
+++ b/src/common/src/array/list_array.rs
@@ -22,7 +22,7 @@ use bytes::{Buf, BufMut};
 use either::Either;
 use itertools::Itertools;
 use risingwave_pb::data::{ListArrayData, PbArray, PbArrayType};
-use serde::{Deserializer, Serializer};
+use serde::{Deserialize, Serializer};
 
 use super::{Array, ArrayBuilder, ArrayBuilderImpl, ArrayImpl, ArrayResult, RowRef};
 use crate::buffer::{Bitmap, BitmapBuilder};
@@ -383,25 +383,7 @@ impl ListValue {
         datatype: &DataType,
         deserializer: &mut memcomparable::Deserializer<impl Buf>,
     ) -> memcomparable::Result<Self> {
-        // This is a bit dirty, but idk how to correctly deserialize bytes in memcomparable
-        // format without this...
-        struct Visitor<'a>(&'a DataType);
-        impl<'a> serde::de::Visitor<'a> for Visitor<'a> {
-            type Value = Vec<u8>;
-
-            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                write!(formatter, "a list of {}", self.0)
-            }
-
-            fn visit_byte_buf<E>(self, v: Vec<u8>) -> Result<Self::Value, E>
-            where
-                E: serde::de::Error,
-            {
-                Ok(v)
-            }
-        }
-        let visitor = Visitor(datatype);
-        let bytes = deserializer.deserialize_byte_buf(visitor)?;
+        let bytes = serde_bytes::ByteBuf::deserialize(deserializer)?;
         let mut inner_deserializer = memcomparable::Deserializer::new(bytes.as_slice());
         let mut values = Vec::new();
         while inner_deserializer.has_remaining() {

--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -30,7 +30,7 @@ use paste::paste;
 use postgres_types::{FromSql, IsNull, ToSql, Type};
 use risingwave_pb::data::data_type::PbTypeName;
 use risingwave_pb::data::PbDataType;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 use strum_macros::EnumDiscriminants;
 
 use crate::array::{
@@ -1070,7 +1070,7 @@ impl ScalarRefImpl<'_> {
             Self::Float32(v) => v.serialize(ser)?,
             Self::Float64(v) => v.serialize(ser)?,
             Self::Utf8(v) => v.serialize(ser)?,
-            Self::Bytea(v) => v.serialize(ser)?,
+            Self::Bytea(v) => ser.serialize_bytes(v)?,
             Self::Bool(v) => v.serialize(ser)?,
             Self::Decimal(v) => ser.serialize_decimal((*v).into())?,
             Self::Interval(v) => v.serialize(ser)?,
@@ -1116,7 +1116,7 @@ impl ScalarImpl {
             Ty::Float32 => Self::Float32(f32::deserialize(de)?.into()),
             Ty::Float64 => Self::Float64(f64::deserialize(de)?.into()),
             Ty::Varchar => Self::Utf8(Box::<str>::deserialize(de)?),
-            Ty::Bytea => Self::Bytea(Box::<[u8]>::deserialize(de)?),
+            Ty::Bytea => Self::Bytea(serde_bytes::ByteBuf::deserialize(de)?.into_vec().into()),
             Ty::Boolean => Self::Bool(bool::deserialize(de)?),
             Ty::Decimal => Self::Decimal(de.deserialize_decimal()?.into()),
             Ty::Interval => Self::Interval(Interval::deserialize(de)?),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR fixes a bug in encoding when a bytea value is used as primary key.

To reproduce:

```sh
./risedev p
```

```sql
CREATE TABLE b(i bytea primary key, id int);
INSERT INTO b VALUES ('abc', 3);
SELECT * from b;
```

```
thread 'risingwave-compaction' panicked at 'range start index 8 out of range for slice of length 6', 
/Users/wangrunji/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bytes-1.4.0/src/buf/buf_impl.rs:1354:18
```

The reason is that the bytea value is [encoded](https://github.com/risingwavelabs/risingwave/blob/8ef743f56b1655ee7731bf885b5428421322eaba/src/common/src/types/mod.rs#L1073) through [`serialize_seq`](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_seq) (&[T] T=u8), where "abc" is encoded as:

```
1, 97, 1, 98, 1, 99, 0
```

But when [calculating size](https://github.com/risingwavelabs/risingwave/blob/8ef743f56b1655ee7731bf885b5428421322eaba/src/common/src/util/memcmp_encoding.rs#L170), the data is assumed to be generated by [`serialize_bytes`](https://docs.rs/serde/latest/serde/trait.Serializer.html#tymethod.serialize_bytes):

```
1, 97, 98, 99, 0, 0, 0, 0, 0, 3
```

To fix this issue, we change its encoding and decoding method to make sure it is encoded as the latter, which is more efficient for large bytes.

**Note for Compatibility**: This PR changes the memcomparable encoding of bytea type. I'm not sure if it will cause any compatibility issues.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] ~~I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->

## Documentation

- [ ] My PR contains user-facing changes.
