### PR TITLE
chore: provide details of cherry pick github action and remind contributors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,6 +25,7 @@ Please explain **IN DETAIL** what the changes are in this PR and why they are ne
 - [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
 - [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
 <!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
+- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ To report bugs, create a [GitHub issue](https://github.com/risingwavelabs/rising
     - [Pull Request title](#pull-request-title)
     - [Pull Request description](#pull-request-description)
     - [Sign the CLA](#sign-the-cla)
+    - [Cherry pick the commit to release candidate branch](#cherry-pick-the-commit-to-release-candidate-branch)
 
 ## Tests and miscellaneous checks
 
@@ -56,3 +57,16 @@ You may also check out previous PRs in the [PR list](https://github.com/risingwa
 ### Sign the CLA
 
 Contributors will need to sign RisingWave Labs' CLA.
+
+### Cherry pick the commit to release candidate branch
+We have a GitHub Action to help cherry-pick commits from `main` branch to a `release candidate` branch, such as `v*.*.*-rc` where `*` is a number.
+
+Checkout details at: https://github.com/risingwavelabs/risingwave/blob/main/.github/workflows/cherry-pick-to-release-branch.yml
+
+To trigger the action, we give a correct label to the PR on `main` branch :
+https://github.com/risingwavelabs/risingwave/blob/main/.github/workflows/cherry-pick-to-release-branch.yml#L10
+
+It will act when the PR on `main` branch merged:
+- If `git cherry-pick` does not find any conflicts, it will open a PR to the `release candidate` branch, and assign the original author as the reviewer.
+
+- If there is a conflict, it will open an issue and make the original author the assignee.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Some contributor-facing documentation and changes to the pull request template.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))