### PR TITLE
feat(meta): add tracing for barrier commands & recovery

### DIFF
--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -221,6 +221,11 @@ pub struct CommandContext<S: MetaStore> {
 
     source_manager: SourceManagerRef<S>,
 
+    /// The tracing span of this command.
+    ///
+    /// Differs from [`TracedEpoch`], this span focuses on the lifetime of the corresponding
+    /// barrier, including the process of waiting for the barrier to be sent, flowing through the
+    /// stream graph on compute nodes, and finishing its `post_collect` stuffs.
     pub span: tracing::Span,
 }
 

--- a/src/meta/src/barrier/command.rs
+++ b/src/meta/src/barrier/command.rs
@@ -220,6 +220,8 @@ pub struct CommandContext<S: MetaStore> {
     pub checkpoint: bool,
 
     source_manager: SourceManagerRef<S>,
+
+    pub span: tracing::Span,
 }
 
 impl<S: MetaStore> CommandContext<S> {
@@ -233,6 +235,7 @@ impl<S: MetaStore> CommandContext<S> {
         command: Command,
         checkpoint: bool,
         source_manager: SourceManagerRef<S>,
+        span: tracing::Span,
     ) -> Self {
         Self {
             fragment_manager,
@@ -243,6 +246,7 @@ impl<S: MetaStore> CommandContext<S> {
             command,
             checkpoint,
             source_manager,
+            span,
         }
     }
 }

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -891,9 +891,14 @@ where
             self.set_status(BarrierManagerStatus::Recovering).await;
             let mut tracker = self.tracker.lock().await;
             *tracker = CreateMviewProgressTracker::new();
+            let prev_epoch = state.in_flight_prev_epoch();
             let new_epoch = self
-                .recovery(state.in_flight_prev_epoch())
-                .instrument(tracing::info_span!("failure_recovery"))
+                .recovery(prev_epoch.clone())
+                .instrument(tracing::info_span!(
+                    "failure_recovery",
+                    %err,
+                    prev_epoch = prev_epoch.value().0
+                ))
                 .await;
             state
                 .update_inflight_prev_epoch(self.env.meta_store(), new_epoch)

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -39,6 +39,7 @@ use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::oneshot::{Receiver, Sender};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use tracing::Instrument;
 use uuid::Uuid;
 
 use self::command::CommandContext;
@@ -85,6 +86,7 @@ struct Scheduled {
     command: Command,
     notifiers: Vec<Notifier>,
     send_latency_timer: HistogramTimer,
+    span: tracing::Span,
     /// Choose a different barrier(checkpoint == true) according to it
     checkpoint: bool,
 }
@@ -559,7 +561,10 @@ where
             let new_epoch = state.in_flight_prev_epoch().next();
 
             self.set_status(BarrierManagerStatus::Recovering).await;
-            let new_epoch = self.recovery(new_epoch).await;
+            let new_epoch = self
+                .recovery(new_epoch)
+                .instrument(tracing::info_span!("bootstrap_recovery"))
+                .await;
             state
                 .update_inflight_prev_epoch(self.env.meta_store(), new_epoch)
                 .await
@@ -634,6 +639,7 @@ where
             notifiers,
             send_latency_timer,
             checkpoint,
+            span,
         } = self.scheduled_barriers.pop_or_default().await;
         let info = self.resolve_actor_info(checkpoint_control, &command).await;
 
@@ -645,9 +651,11 @@ where
             .await
             .unwrap();
 
+        // Tracing related stuff
         prev_epoch.span().in_scope(|| {
             tracing::info!(target: "rw_tracing", epoch = new_epoch.value().0, "new barrier enqueued");
         });
+        span.record("epoch", new_epoch.value().0);
 
         let command_ctx = Arc::new(CommandContext::new(
             self.fragment_manager.clone(),
@@ -658,13 +666,16 @@ where
             command,
             checkpoint,
             self.source_manager.clone(),
+            span.clone(),
         ));
         let mut notifiers = notifiers;
         notifiers.iter_mut().for_each(Notifier::notify_to_send);
         send_latency_timer.observe_duration();
 
         checkpoint_control.enqueue_command(command_ctx.clone(), notifiers);
-        self.inject_barrier(command_ctx, barrier_complete_tx).await;
+        self.inject_barrier(command_ctx, barrier_complete_tx)
+            .instrument(span)
+            .await;
     }
 
     /// Inject a barrier to all CNs and spawn a task to collect it
@@ -835,7 +846,12 @@ where
         let (mut index, mut err_msg) = (0, None);
         for (i, node) in complete_nodes.iter_mut().enumerate() {
             assert!(matches!(node.state, Completed(_)));
-            if let Err(err) = self.complete_barrier(node, checkpoint_control).await {
+            let span = node.command_ctx.span.clone();
+            if let Err(err) = self
+                .complete_barrier(node, checkpoint_control)
+                .instrument(span)
+                .await
+            {
                 index = i;
                 err_msg = Some(err);
                 break;
@@ -875,7 +891,10 @@ where
             self.set_status(BarrierManagerStatus::Recovering).await;
             let mut tracker = self.tracker.lock().await;
             *tracker = CreateMviewProgressTracker::new();
-            let new_epoch = self.recovery(state.in_flight_prev_epoch()).await;
+            let new_epoch = self
+                .recovery(state.in_flight_prev_epoch())
+                .instrument(tracing::info_span!("failure_recovery"))
+                .await;
             state
                 .update_inflight_prev_epoch(self.env.meta_store(), new_epoch)
                 .await

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -26,7 +26,7 @@ use risingwave_pb::stream_service::{
     ForceStopActorsRequest, UpdateActorsRequest,
 };
 use tokio_retry::strategy::{jitter, ExponentialBackoff};
-use tracing::{debug, warn};
+use tracing::{debug, warn, Instrument};
 use uuid::Uuid;
 
 use super::TracedEpoch;
@@ -123,94 +123,98 @@ where
         // We take retry into consideration because this is the latency user sees for a cluster to
         // get recovered.
         let recovery_timer = self.metrics.recovery_latency.start_timer();
-        let (new_epoch, _responses) = tokio_retry::Retry::spawn(retry_strategy, || async {
-            let recovery_result: MetaResult<(TracedEpoch, Vec<BarrierCompleteResponse>)> = try {
-                let mut info = self.resolve_actor_info_for_recovery().await;
-                let mut new_epoch = prev_epoch.next();
+        let (new_epoch, _responses) = tokio_retry::Retry::spawn(retry_strategy, || {
+            async {
+                let recovery_result: MetaResult<(TracedEpoch, Vec<BarrierCompleteResponse>)> = try {
+                    let mut info = self.resolve_actor_info_for_recovery().await;
+                    let mut new_epoch = prev_epoch.next();
 
-                // Migrate actors in expired CN to newly joined one.
-                let migrated = self.migrate_actors(&info).await.inspect_err(|err| {
-                    warn!(err = ?err, "migrate actors failed");
-                })?;
-                if migrated {
-                    info = self.resolve_actor_info_for_recovery().await;
-                }
-
-                // Reset all compute nodes, stop and drop existing actors.
-                self.reset_compute_nodes(&info).await.inspect_err(|err| {
-                    warn!(err = ?err, "reset compute nodes failed");
-                })?;
-
-                // update and build all actors.
-                self.update_actors(&info).await.inspect_err(|err| {
-                    warn!(err = ?err, "update actors failed");
-                })?;
-                self.build_actors(&info).await.inspect_err(|err| {
-                    warn!(err = ?err, "build_actors failed");
-                })?;
-
-                // get split assignments for all actors
-                let source_split_assignments = self.source_manager.list_assignments().await;
-                let command = Command::Plain(Some(Mutation::Add(AddMutation {
-                    // Actors built during recovery is not treated as newly added actors.
-                    actor_dispatchers: Default::default(),
-                    added_actors: Default::default(),
-                    actor_splits: build_actor_connector_splits(&source_split_assignments),
-                })));
-
-                let prev_epoch = new_epoch;
-                new_epoch = prev_epoch.next();
-                // checkpoint, used as init barrier to initialize all executors.
-                let command_ctx = Arc::new(CommandContext::new(
-                    self.fragment_manager.clone(),
-                    self.env.stream_client_pool_ref(),
-                    info,
-                    prev_epoch,
-                    new_epoch.clone(),
-                    command,
-                    true,
-                    self.source_manager.clone(),
-                ));
-
-                #[cfg(not(all(test, feature = "failpoints")))]
-                {
-                    use risingwave_common::util::epoch::INVALID_EPOCH;
-
-                    let mce = self
-                        .hummock_manager
-                        .get_current_version()
-                        .await
-                        .max_committed_epoch;
-
-                    if mce != INVALID_EPOCH {
-                        command_ctx.wait_epoch_commit(mce).await?;
+                    // Migrate actors in expired CN to newly joined one.
+                    let migrated = self.migrate_actors(&info).await.inspect_err(|err| {
+                        warn!(err = ?err, "migrate actors failed");
+                    })?;
+                    if migrated {
+                        info = self.resolve_actor_info_for_recovery().await;
                     }
-                }
 
-                let (barrier_complete_tx, mut barrier_complete_rx) =
-                    tokio::sync::mpsc::unbounded_channel();
-                self.inject_barrier(command_ctx.clone(), &barrier_complete_tx)
-                    .await;
-                let res = match barrier_complete_rx.recv().await.unwrap().result {
-                    Ok(response) => {
-                        if let Err(err) = command_ctx.post_collect().await {
-                            warn!(err = ?err, "post_collect failed");
-                            Err(err)
-                        } else {
-                            Ok((new_epoch, response))
+                    // Reset all compute nodes, stop and drop existing actors.
+                    self.reset_compute_nodes(&info).await.inspect_err(|err| {
+                        warn!(err = ?err, "reset compute nodes failed");
+                    })?;
+
+                    // update and build all actors.
+                    self.update_actors(&info).await.inspect_err(|err| {
+                        warn!(err = ?err, "update actors failed");
+                    })?;
+                    self.build_actors(&info).await.inspect_err(|err| {
+                        warn!(err = ?err, "build_actors failed");
+                    })?;
+
+                    // get split assignments for all actors
+                    let source_split_assignments = self.source_manager.list_assignments().await;
+                    let command = Command::Plain(Some(Mutation::Add(AddMutation {
+                        // Actors built during recovery is not treated as newly added actors.
+                        actor_dispatchers: Default::default(),
+                        added_actors: Default::default(),
+                        actor_splits: build_actor_connector_splits(&source_split_assignments),
+                    })));
+
+                    let prev_epoch = new_epoch;
+                    new_epoch = prev_epoch.next();
+                    // checkpoint, used as init barrier to initialize all executors.
+                    let command_ctx = Arc::new(CommandContext::new(
+                        self.fragment_manager.clone(),
+                        self.env.stream_client_pool_ref(),
+                        info,
+                        prev_epoch,
+                        new_epoch.clone(),
+                        command,
+                        true,
+                        self.source_manager.clone(),
+                        tracing::Span::current(),
+                    ));
+
+                    #[cfg(not(all(test, feature = "failpoints")))]
+                    {
+                        use risingwave_common::util::epoch::INVALID_EPOCH;
+
+                        let mce = self
+                            .hummock_manager
+                            .get_current_version()
+                            .await
+                            .max_committed_epoch;
+
+                        if mce != INVALID_EPOCH {
+                            command_ctx.wait_epoch_commit(mce).await?;
                         }
                     }
-                    Err(err) => {
-                        warn!(err = ?err, "inject_barrier failed");
-                        Err(err)
-                    }
+
+                    let (barrier_complete_tx, mut barrier_complete_rx) =
+                        tokio::sync::mpsc::unbounded_channel();
+                    self.inject_barrier(command_ctx.clone(), &barrier_complete_tx)
+                        .await;
+                    let res = match barrier_complete_rx.recv().await.unwrap().result {
+                        Ok(response) => {
+                            if let Err(err) = command_ctx.post_collect().await {
+                                warn!(err = ?err, "post_collect failed");
+                                Err(err)
+                            } else {
+                                Ok((new_epoch, response))
+                            }
+                        }
+                        Err(err) => {
+                            warn!(err = ?err, "inject_barrier failed");
+                            Err(err)
+                        }
+                    };
+                    res?
                 };
-                res?
-            };
-            if recovery_result.is_err() {
-                self.metrics.recovery_failure_cnt.inc();
+                if recovery_result.is_err() {
+                    self.metrics.recovery_failure_cnt.inc();
+                }
+                recovery_result
             }
-            recovery_result
+            .instrument(tracing::info_span!("recovery_attempt"))
         })
         .await
         .expect("Retry until recovery success.");

--- a/src/meta/src/barrier/recovery.rs
+++ b/src/meta/src/barrier/recovery.rs
@@ -161,6 +161,7 @@ where
 
                     let prev_epoch = new_epoch;
                     new_epoch = prev_epoch.next();
+
                     // checkpoint, used as init barrier to initialize all executors.
                     let command_ctx = Arc::new(CommandContext::new(
                         self.fragment_manager.clone(),
@@ -171,7 +172,7 @@ where
                         command,
                         true,
                         self.source_manager.clone(),
-                        tracing::Span::current(),
+                        tracing::Span::current(), // recovery span
                     ));
 
                     #[cfg(not(all(test, feature = "failpoints")))]

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -53,12 +53,14 @@ struct Inner {
 }
 
 impl Inner {
+    /// Create a new scheduled barrier with the given `checkpoint`, `command` and `notifiers`.
     fn new_scheduled(
         &self,
         checkpoint: bool,
         command: Command,
         notifiers: impl IntoIterator<Item = Notifier>,
     ) -> Scheduled {
+        // Create a span only if we're being traced, instead of for every periodic barrier.
         let span = if tracing::Span::current().is_none() {
             tracing::Span::none()
         } else {

--- a/src/meta/src/barrier/schedule.rs
+++ b/src/meta/src/barrier/schedule.rs
@@ -52,6 +52,29 @@ struct Inner {
     metrics: Arc<MetaMetrics>,
 }
 
+impl Inner {
+    fn new_scheduled(
+        &self,
+        checkpoint: bool,
+        command: Command,
+        notifiers: impl IntoIterator<Item = Notifier>,
+    ) -> Scheduled {
+        let span = if tracing::Span::current().is_none() {
+            tracing::Span::none()
+        } else {
+            tracing::info_span!("barrier", checkpoint, epoch = tracing::field::Empty)
+        };
+
+        Scheduled {
+            command,
+            notifiers: notifiers.into_iter().collect(),
+            send_latency_timer: self.metrics.barrier_send_latency.start_timer(),
+            span,
+            checkpoint,
+        }
+    }
+}
+
 /// The sender side of the barrier scheduling queue.
 /// Can be cloned and held by other managers to schedule and run barriers.
 #[derive(Clone)]
@@ -140,12 +163,11 @@ impl<S: MetaStore> BarrierScheduler<S> {
             }
             None => {
                 // If no command scheduled, create a periodic barrier by default.
-                queue.push_back(Scheduled {
-                    notifiers: new_notifiers,
-                    command: Command::barrier(),
-                    send_latency_timer: self.inner.metrics.barrier_send_latency.start_timer(),
-                    checkpoint: new_checkpoint,
-                });
+                queue.push_back(self.inner.new_scheduled(
+                    new_checkpoint,
+                    Command::barrier(),
+                    new_notifiers,
+                ));
                 self.inner.changed_tx.send(()).ok();
             }
         }
@@ -184,17 +206,15 @@ impl<S: MetaStore> BarrierScheduler<S> {
                 collect_rx,
                 finish_rx,
             });
-            scheduleds.push(Scheduled {
-                checkpoint: command.need_checkpoint(),
+            scheduleds.push(self.inner.new_scheduled(
+                command.need_checkpoint(),
                 command,
-                send_latency_timer: self.inner.metrics.barrier_send_latency.start_timer(),
-                notifiers: once(Notifier {
+                once(Notifier {
                     collected: Some(collect_tx),
                     finished: Some(finish_tx),
                     ..Default::default()
-                })
-                .collect(),
-            });
+                }),
+            ));
         }
 
         self.push(scheduleds).await;
@@ -263,12 +283,8 @@ impl ScheduledBarriers {
             }
             None => {
                 // If no command scheduled, create a periodic barrier by default.
-                Scheduled {
-                    command: Command::barrier(),
-                    send_latency_timer: self.inner.metrics.barrier_send_latency.start_timer(),
-                    notifiers: Default::default(),
-                    checkpoint,
-                }
+                self.inner
+                    .new_scheduled(checkpoint, Command::barrier(), std::iter::empty())
             }
         };
         self.update_num_uncheckpointed_barrier(scheduled.checkpoint);

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -34,6 +34,7 @@
 #![feature(is_sorted)]
 #![feature(string_leak)]
 #![feature(impl_trait_in_assoc_type)]
+#![feature(type_name_of_val)]
 
 pub mod backup_restore;
 mod barrier;

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -83,7 +83,7 @@ macro_rules! commit_meta_with_trx {
             }
             .instrument(tracing::info_span!(
                 "meta_store_commit",
-                manager = std::any::type_name_of_val(&$manager)
+                manager = std::any::type_name_of_val(&*$manager)
             ))
             .await
         }

--- a/src/meta/src/manager/catalog/mod.rs
+++ b/src/meta/src/manager/catalog/mod.rs
@@ -62,36 +62,12 @@ pub type FunctionId = u32;
 pub type UserId = u32;
 pub type ConnectionId = u32;
 
-/// `commit_meta` provides a wrapper for committing metadata changes to both in-memory and
-/// meta store.
-/// * $`manager`: metadata manager, which should contains an env field to access meta store.
-/// * $`val_txn`: transactions to commit.
-macro_rules! commit_meta {
-    ($manager:expr, $($val_txn:expr),*) => {
-        {
-            async {
-                let mut trx = Transaction::default();
-                // Apply the change in `ValTransaction` to trx
-                $(
-                    $val_txn.apply_to_txn(&mut trx)?;
-                )*
-                // Commit to meta store
-                $manager.env.meta_store().txn(trx).await?;
-                // Upon successful commit, commit the change to in-mem meta
-                $(
-                    $val_txn.commit();
-                )*
-                MetaResult::Ok(())
-            }.await
-        }
-    };
-}
-
 /// `commit_meta_with_trx` is similar to `commit_meta`, but it accepts an external trx (transaction)
 /// and commits it.
 macro_rules! commit_meta_with_trx {
     ($manager:expr, $trx:ident, $($val_txn:expr),*) => {
         {
+            use tracing::Instrument;
             async {
                 // Apply the change in `ValTransaction` to trx
                 $(
@@ -104,7 +80,25 @@ macro_rules! commit_meta_with_trx {
                     $val_txn.commit();
                 )*
                 MetaResult::Ok(())
-            }.await
+            }
+            .instrument(tracing::info_span!(
+                "meta_store_commit",
+                manager = std::any::type_name_of_val(&$manager)
+            ))
+            .await
+        }
+    };
+}
+
+/// `commit_meta` provides a wrapper for committing metadata changes to both in-memory and
+/// meta store.
+/// * $`manager`: metadata manager, which should contains an env field to access meta store.
+/// * $`val_txn`: transactions to commit.
+macro_rules! commit_meta {
+    ($manager:expr, $($val_txn:expr),*) => {
+        {
+            let mut trx = Transaction::default();
+            $crate::manager::commit_meta_with_trx!($manager, trx, $($val_txn),*)
         }
     };
 }

--- a/src/meta/src/manager/catalog/user.rs
+++ b/src/meta/src/manager/catalog/user.rs
@@ -403,7 +403,7 @@ mod tests {
         let user_core = &mut catalog_manager.core.lock().await.user;
         let mut users = BTreeMapTransaction::new(&mut user_core.user_info);
         CatalogManager::<MemStore>::update_user_privileges(&mut users, &[object]);
-        commit_meta!(catalog_manager, users)?;
+        commit_meta!(&catalog_manager, users)?;
         let user = user_core.user_info.get(&test_user_id).unwrap();
         assert!(user.grant_privileges.is_empty());
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

#10000

Follow-up of #10660. This PR further adds tracing for the execution of barrier commands, and the recovery progress. RPC calls to compute node will be included as well.

### Previews

- DML with implicit `FLUSH`
  <img width="1776" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/fc702d92-ad57-4fa1-bc1e-52aebe0f35b7">
- Create table
  <img width="1791" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/f20ac7c1-2603-494a-b30b-8574b761c4e3">
- Bootstrap recovery
  <img width="1492" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/3e7fd3a9-6ca4-4e97-b983-0f3ce3febd6b">


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)