### PR TITLE
fix: unbounded variables in integration test

### DIFF
--- a/ci/scripts/integration-tests.sh
+++ b/ci/scripts/integration-tests.sh
@@ -44,6 +44,8 @@ if [[ -n "${RW_IMAGE_VERSION+x}" ]]; then
 fi
 sed -i "s|risingwave:latest|risingwave:$rw_image_tag|g" docker/docker-compose.yml
 
+grep "risingwave:" docker/docker-compose.yml
+
 cd integration_tests/scripts
 
 echo "--- case: ${case}, format: ${format}"

--- a/ci/scripts/integration-tests.sh
+++ b/ci/scripts/integration-tests.sh
@@ -39,7 +39,7 @@ sudo yum install -y postgresql
 
 rw_image_tag="latest"
 # Check if the variable is set and not empty
-if [ -n ${RW_IMAGE_VERSION:-} ]; then
+if [[ -n "${RW_IMAGE_VERSION+x}" ]]; then
   rw_image_tag=$RW_IMAGE_VERSION
 fi
 sed -i "s|risingwave:latest|risingwave:$rw_image_tag|g" docker/docker-compose.yml


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Let me test once on buildkite, I copied from risingwave-test's scripts

https://buildkite.com/risingwavelabs/integration-tests/builds/173#01891e6e-e0f1-47b9-b9d7-7841ee8da9c2 without variable set

https://buildkite.com/risingwavelabs/integration-tests/builds/174#01891e76-dda3-4557-bb49-687319d48728 with `RW_IMAGE_VERSION` set to `nightly-20230628`.

seems working now

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
