### PR TITLE
fix(streaming): reorganize output of hop window

### DIFF
--- a/e2e_test/streaming/bug_fixes/hop_window_update_10495.slt
+++ b/e2e_test/streaming/bug_fixes/hop_window_update_10495.slt
@@ -1,0 +1,37 @@
+statement ok
+create table t1 (k int primary key, ts timestamp);
+
+statement ok
+create materialized view mv as select * from hop(t1, ts, interval '10' minute, interval '30' minute);
+
+statement ok
+insert into t1 values (1, '2021-01-01 10:15:00');
+
+statement ok
+flush;
+
+query ITTT rowsort
+select * from mv;
+----
+1 2021-01-01 10:15:00 2021-01-01 09:50:00 2021-01-01 10:20:00
+1 2021-01-01 10:15:00 2021-01-01 10:00:00 2021-01-01 10:30:00
+1 2021-01-01 10:15:00 2021-01-01 10:10:00 2021-01-01 10:40:00
+
+statement ok
+update t1 set ts = '2021-01-01 10:25:00' where k = 1;
+
+statement ok
+flush;
+
+query ITTT rowsort
+select * from mv;
+----
+1 2021-01-01 10:25:00 2021-01-01 10:00:00 2021-01-01 10:30:00
+1 2021-01-01 10:25:00 2021-01-01 10:10:00 2021-01-01 10:40:00
+1 2021-01-01 10:25:00 2021-01-01 10:20:00 2021-01-01 10:50:00
+
+statement ok
+drop materialized view mv;
+
+statement ok
+drop table t1;

--- a/src/common/src/array/data_chunk_iter.rs
+++ b/src/common/src/array/data_chunk_iter.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::iter::TrustedLen;
+use std::iter::{FusedIterator, TrustedLen};
 
 use super::ArrayRef;
 use crate::array::DataChunk;
@@ -81,6 +81,8 @@ impl<'a> Iterator for DataChunkRefIter<'a> {
         }
     }
 }
+
+impl<'a> FusedIterator for DataChunkRefIter<'a> {}
 
 pub struct DataChunkRefIterWithHoles<'a> {
     chunk: &'a DataChunk,

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -101,6 +101,12 @@ impl StreamChunk {
         StreamChunk { ops, data }
     }
 
+    /// Create a `StreamChunk` from the given `DataChunk` and `Op`s.
+    pub fn from_data_chunk(ops: Vec<Op>, data: DataChunk) -> Self {
+        assert_eq!(ops.len(), data.capacity());
+        StreamChunk { ops, data }
+    }
+
     /// Build a `StreamChunk` from rows.
     // TODO: introducing something like `StreamChunkBuilder` maybe better.
     pub fn from_rows(rows: &[(Op, OwnedRow)], data_types: &[DataType]) -> Self {

--- a/src/stream/src/from_proto/hop_window.rs
+++ b/src/stream/src/from_proto/hop_window.rs
@@ -37,6 +37,7 @@ impl ExecutorBuilder for HopWindowExecutorBuilder {
             input,
             pk_indices,
             executor_id,
+            env,
             ..
         } = params;
 
@@ -84,6 +85,8 @@ impl ExecutorBuilder for HopWindowExecutorBuilder {
         let window_slide = node.get_window_slide()?.into();
         let window_size = node.get_window_size()?.into();
 
+        let chunk_size = env.config().developer.chunk_size;
+
         Ok(HopWindowExecutor::new(
             actor_context,
             input,
@@ -94,6 +97,7 @@ impl ExecutorBuilder for HopWindowExecutorBuilder {
             window_start_exprs,
             window_end_exprs,
             output_indices,
+            chunk_size,
         )
         .boxed())
     }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As explained in https://github.com/risingwavelabs/risingwave/issues/10495#issuecomment-1619370490. This PR reorganizes the output of the hop window executor to group multiple output rows of a single input row together to avoid `Update` interfering with each other.


Previous:
```
dev=> create table t1 (k int primary key, ts timestamp);
CREATE_TABLE
dev=> create materialized view mv as select * from hop(t1, ts, interval '10' minute, interval '30' minute);
CREATE_MATERIALIZED_VIEW
dev=> insert into t1 values (1, '2021-01-01 10:15:00');
INSERT 0 1
dev=> select * from t1;
 k |         ts          
---+---------------------
 1 | 2021-01-01 10:15:00
(1 row)

dev=> select * from mv;
 k |         ts          |    window_start     |     window_end      
---+---------------------+---------------------+---------------------
 1 | 2021-01-01 10:15:00 | 2021-01-01 09:50:00 | 2021-01-01 10:20:00
 1 | 2021-01-01 10:15:00 | 2021-01-01 10:00:00 | 2021-01-01 10:30:00
 1 | 2021-01-01 10:15:00 | 2021-01-01 10:10:00 | 2021-01-01 10:40:00
(3 rows)

dev=> update t1 set ts = '2021-01-01 10:25:00' where k = 1;
UPDATE 1
dev=> select * from mv;
 k |         ts          |    window_start     |     window_end      
---+---------------------+---------------------+---------------------
 1 | 2021-01-01 10:15:00 | 2021-01-01 10:00:00 | 2021-01-01 10:30:00 <- 😨
 1 | 2021-01-01 10:15:00 | 2021-01-01 10:10:00 | 2021-01-01 10:40:00 <- 😨
 1 | 2021-01-01 10:25:00 | 2021-01-01 10:20:00 | 2021-01-01 10:50:00
(3 rows)
```

Now:
```
 k |         ts          |    window_start     |     window_end      
---+---------------------+---------------------+---------------------
 1 | 2021-01-01 10:25:00 | 2021-01-01 10:00:00 | 2021-01-01 10:30:00
 1 | 2021-01-01 10:25:00 | 2021-01-01 10:10:00 | 2021-01-01 10:40:00
 1 | 2021-01-01 10:25:00 | 2021-01-01 10:20:00 | 2021-01-01 10:50:00
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
