### PR TITLE
feat(frontend): initial support for read-only transaction

### DIFF
--- a/e2e_test/batch/basic/basic.slt.part
+++ b/e2e_test/batch/basic/basic.slt.part
@@ -24,13 +24,6 @@ select 1+2*3, 4*5;
 ----
 7 20
 
-statement ok
-start transaction;
-
-
-statement ok
-abort;
-
 query I
 show RW_IMPLICIT_FLUSH;
 ----

--- a/e2e_test/batch/transaction/read_only.slt
+++ b/e2e_test/batch/transaction/read_only.slt
@@ -1,0 +1,63 @@
+statement ok
+create user setsuna;
+
+statement ok
+create table t (v int);
+
+statement ok
+insert into t values (1), (2);
+
+statement ok
+flush;
+
+statement ok
+start transaction read only;
+
+query I rowsort
+select * from t;
+----
+1
+2
+
+statement error read-only transaction
+insert into t values (3);
+
+statement error read-only transaction
+create table if not exists t2 (v int);
+
+statement ok
+create table if not exists t (v int);
+
+statement error read-only transaction
+drop table t;
+
+statement error read-only transaction
+alter table t add column v2 int;
+
+statement error read-only transaction
+create user touma;
+
+statement error read-only transaction
+grant all privileges on all materialized views in schema public to setsuna;
+
+statement ok
+commit;
+
+statement ok
+insert into t values (3);
+
+statement ok
+flush;
+
+query I rowsort
+select * from t;
+----
+1
+2
+3
+
+statement ok
+drop table t;
+
+statement ok
+drop user setsuna;

--- a/e2e_test/batch/transaction/tolerance.slt
+++ b/e2e_test/batch/transaction/tolerance.slt
@@ -1,0 +1,21 @@
+# there is no transaction in progress
+statement ok
+commit
+
+# there is no transaction in progress
+statement ok
+rollback
+
+statement ok
+start transaction
+
+# there is already a transaction in progress
+statement ok
+start transaction
+
+statement ok
+rollback
+
+# there is no transaction in progress
+statement ok
+commit

--- a/src/frontend/planner_test/src/lib.rs
+++ b/src/frontend/planner_test/src/lib.rs
@@ -370,6 +370,7 @@ impl TestCase {
         for stmt in statements {
             // TODO: `sql` may contain multiple statements here.
             let handler_args = HandlerArgs::new(session.clone(), &stmt, sql)?;
+            let _guard = session.txn_begin_implicit();
             match stmt.clone() {
                 Statement::Query(_)
                 | Statement::Insert { .. }

--- a/src/frontend/src/handler/alter_relation_rename.rs
+++ b/src/frontend/src/handler/alter_relation_rename.rs
@@ -53,7 +53,7 @@ pub async fn handle_rename_table(
         table.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .alter_table_name(table_id.table_id, &new_table_name)
         .await?;
@@ -89,7 +89,7 @@ pub async fn handle_rename_index(
         index.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .alter_index_name(index_id.index_id, &new_index_name)
         .await?;
@@ -119,7 +119,7 @@ pub async fn handle_rename_view(
         view.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .alter_view_name(view_id, &new_view_name)
         .await?;
@@ -149,7 +149,7 @@ pub async fn handle_rename_sink(
         sink.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .alter_sink_name(sink_id.sink_id, &new_sink_name)
         .await?;
@@ -189,7 +189,7 @@ pub async fn handle_rename_source(
         source.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .alter_source_name(source_id, &new_source_name)
         .await?;

--- a/src/frontend/src/handler/alter_table_column.rs
+++ b/src/frontend/src/handler/alter_table_column.rs
@@ -222,7 +222,7 @@ pub async fn handle_alter_table_column(
             .collect(),
     );
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
 
     catalog_writer
         .replace_table(table, graph, col_index_mapping)

--- a/src/frontend/src/handler/alter_user.rs
+++ b/src/frontend/src/handler/alter_user.rs
@@ -169,7 +169,7 @@ pub async fn handle_alter_user(
         }
     };
 
-    let user_info_writer = session.env().user_info_writer();
+    let user_info_writer = session.user_info_writer()?;
     user_info_writer
         .update_user(user_info, update_fields)
         .await?;

--- a/src/frontend/src/handler/create_connection.rs
+++ b/src/frontend/src/handler/create_connection.rs
@@ -131,7 +131,7 @@ pub async fn handle_create_connection(
 
     let create_connection_payload = resolve_create_connection_payload(&with_properties)?;
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .create_connection(
             connection_name,

--- a/src/frontend/src/handler/create_database.rs
+++ b/src/frontend/src/handler/create_database.rs
@@ -57,7 +57,7 @@ pub async fn handle_create_database(
         }
     }
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .create_database(&database_name, session.user_id())
         .await?;

--- a/src/frontend/src/handler/create_function.rs
+++ b/src/frontend/src/handler/create_function.rs
@@ -153,7 +153,7 @@ pub async fn handle_create_function(
         owner: session.user_id(),
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_function(function).await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_FUNCTION))

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -451,7 +451,7 @@ pub async fn handle_create_index(
                 index.name.clone(),
             ));
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .create_index(index, index_table, graph)
         .await?;

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -196,7 +196,7 @@ It only indicates the physical clustering of the data, which may improve the per
                 table.name.clone(),
             ));
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .create_materialized_view(table, graph)
         .await?;

--- a/src/frontend/src/handler/create_schema.rs
+++ b/src/frontend/src/handler/create_schema.rs
@@ -67,7 +67,7 @@ pub async fn handle_create_schema(
         Object::DatabaseId(db_id),
     )])?;
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .create_schema(db_id, &schema_name, session.user_id())
         .await?;

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -179,7 +179,7 @@ pub async fn handle_create_sink(
                 sink.name.clone(),
             ));
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_sink(sink.to_proto(), graph).await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_SINK))

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -823,7 +823,7 @@ pub async fn handle_create_source(
         optional_associated_table_id: None,
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_source(source).await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_SOURCE))

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -713,7 +713,7 @@ pub async fn handle_create_table(
         serde_json::to_string_pretty(&graph).unwrap()
     );
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_table(source, table, graph).await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_TABLE))

--- a/src/frontend/src/handler/create_table_as.rs
+++ b/src/frontend/src/handler/create_table_as.rs
@@ -123,7 +123,7 @@ pub async fn handle_create_as(
         serde_json::to_string_pretty(&graph).unwrap()
     );
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_table(source, table, graph).await?;
 
     // Generate insert

--- a/src/frontend/src/handler/create_user.rs
+++ b/src/frontend/src/handler/create_user.rs
@@ -120,7 +120,7 @@ pub async fn handle_create_user(
         make_prost_user_info(user_name, &stmt.with_options, session_user, database_id)?
     };
 
-    let user_info_writer = session.env().user_info_writer();
+    let user_info_writer = session.user_info_writer()?;
     user_info_writer.create_user(user_info).await?;
     Ok(PgResponse::empty_result(StatementType::CREATE_USER))
 }

--- a/src/frontend/src/handler/create_view.rs
+++ b/src/frontend/src/handler/create_view.rs
@@ -105,7 +105,7 @@ pub async fn handle_create_view(
         columns: columns.into_iter().map(|f| f.to_prost()).collect(),
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.create_view(view).await?;
 
     Ok(PgResponse::empty_result(StatementType::CREATE_VIEW))

--- a/src/frontend/src/handler/drop_connection.rs
+++ b/src/frontend/src/handler/drop_connection.rs
@@ -58,7 +58,7 @@ pub async fn handle_drop_connection(
         connection.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_connection(connection_id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_CONNECTION))

--- a/src/frontend/src/handler/drop_database.rs
+++ b/src/frontend/src/handler/drop_database.rs
@@ -63,7 +63,7 @@ pub async fn handle_drop_database(
         return Err(ErrorCode::PermissionDenied("Do not have the privilege".to_string()).into());
     }
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_database(database.id()).await?;
     Ok(PgResponse::empty_result(StatementType::DROP_DATABASE))
 }

--- a/src/frontend/src/handler/drop_function.rs
+++ b/src/frontend/src/handler/drop_function.rs
@@ -91,7 +91,7 @@ pub async fn handle_drop_function(
         }
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_function(function_id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_FUNCTION))

--- a/src/frontend/src/handler/drop_index.rs
+++ b/src/frontend/src/handler/drop_index.rs
@@ -80,7 +80,7 @@ pub async fn handle_drop_index(
         }
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_index(index_id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_INDEX))

--- a/src/frontend/src/handler/drop_mv.rs
+++ b/src/frontend/src/handler/drop_mv.rs
@@ -70,7 +70,7 @@ pub async fn handle_drop_mv(
         table.id()
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_materialized_view(table_id).await?;
 
     Ok(PgResponse::empty_result(

--- a/src/frontend/src/handler/drop_schema.rs
+++ b/src/frontend/src/handler/drop_schema.rs
@@ -94,7 +94,7 @@ pub async fn handle_drop_schema(
         return Err(PermissionDenied("Do not have the privilege".to_string()).into());
     }
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_schema(schema.id()).await?;
     Ok(PgResponse::empty_result(StatementType::DROP_SCHEMA))
 }

--- a/src/frontend/src/handler/drop_sink.rs
+++ b/src/frontend/src/handler/drop_sink.rs
@@ -54,7 +54,7 @@ pub async fn handle_drop_sink(
         sink.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_sink(sink_id.sink_id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_SINK))

--- a/src/frontend/src/handler/drop_source.rs
+++ b/src/frontend/src/handler/drop_source.rs
@@ -61,7 +61,7 @@ pub async fn handle_drop_source(
 
     session.check_privilege_for_drop_alter(schema_name, &*source)?;
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_source(source.id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_SOURCE))

--- a/src/frontend/src/handler/drop_table.rs
+++ b/src/frontend/src/handler/drop_table.rs
@@ -60,7 +60,7 @@ pub async fn handle_drop_table(
         (table.associated_source_id(), table.id())
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer
         .drop_table(source_id.map(|id| id.table_id), table_id)
         .await?;

--- a/src/frontend/src/handler/drop_user.rs
+++ b/src/frontend/src/handler/drop_user.rs
@@ -40,7 +40,7 @@ pub async fn handle_drop_user(
         .cloned();
     match user {
         Some(user) => {
-            let user_info_writer = session.env().user_info_writer();
+            let user_info_writer = session.user_info_writer()?;
             user_info_writer.drop_user(user.id).await?;
         }
         None => {

--- a/src/frontend/src/handler/drop_view.rs
+++ b/src/frontend/src/handler/drop_view.rs
@@ -55,7 +55,7 @@ pub async fn handle_drop_view(
         view.id
     };
 
-    let catalog_writer = session.env().catalog_writer();
+    let catalog_writer = session.catalog_writer()?;
     catalog_writer.drop_view(view_id).await?;
 
     Ok(PgResponse::empty_result(StatementType::DROP_VIEW))

--- a/src/frontend/src/handler/extended_handle.rs
+++ b/src/frontend/src/handler/extended_handle.rs
@@ -169,6 +169,7 @@ pub async fn handle_execute(session: Arc<SessionImpl>, portal: Portal) -> Result
     match portal {
         Portal::Portal(portal) => {
             session.clear_cancel_query_flag();
+            let _guard = session.txn_begin_implicit(); // TODO(bugen): is this behavior correct?
             let str_sql = portal.statement.to_string();
             let handler_args = HandlerArgs::new(session, &portal.statement, &str_sql)?;
             match &portal.statement {

--- a/src/frontend/src/handler/handle_privilege.rs
+++ b/src/frontend/src/handler/handle_privilege.rs
@@ -163,7 +163,7 @@ pub async fn handle_grant_privilege(
     };
 
     let privileges = make_prost_privilege(&session, privileges, objects)?;
-    let user_info_writer = session.env().user_info_writer();
+    let user_info_writer = session.user_info_writer()?;
     user_info_writer
         .grant_privilege(users, privileges, with_grant_option, session.user_id())
         .await?;
@@ -207,7 +207,7 @@ pub async fn handle_revoke_privilege(
         }
     };
     let privileges = make_prost_privilege(&session, privileges, objects)?;
-    let user_info_writer = session.env().user_info_writer();
+    let user_info_writer = session.user_info_writer()?;
     user_info_writer
         .revoke_privilege(
             users,

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -174,7 +174,7 @@ pub async fn handle(
     const IGNORE_NOTICE: &str = "Ignored temporarily. See details in https://github.com/risingwavelabs/risingwave/issues/2541";
 
     session.clear_cancel_query_flag();
-    let _guard = session.begin_impicit();
+    let _guard = session.txn_begin_impicit();
 
     let handler_args = HandlerArgs::new(session, &stmt, sql)?;
 

--- a/src/frontend/src/handler/mod.rs
+++ b/src/frontend/src/handler/mod.rs
@@ -174,7 +174,7 @@ pub async fn handle(
     const IGNORE_NOTICE: &str = "Ignored temporarily. See details in https://github.com/risingwavelabs/risingwave/issues/2541";
 
     session.clear_cancel_query_flag();
-    let _guard = session.txn_begin_impicit();
+    let _guard = session.txn_begin_implicit();
 
     let handler_args = HandlerArgs::new(session, &stmt, sql)?;
 

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -311,6 +311,7 @@ async fn execute(
         ..
     } = plan_fragmenter_result;
 
+    // Acquire the write guard for DML statements.
     match stmt_type {
         StatementType::INSERT
         | StatementType::INSERT_RETURNING
@@ -462,6 +463,7 @@ async fn distribute_execute(
 
 async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<LocalQueryStream> {
     let front_env = session.env();
+    // TODO: if there's no table scan, we don't need to acquire snapshot.
     let snapshot = session.pinned_snapshot(query.query_id()).await?;
 
     // TODO: Passing sql here

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -46,7 +46,7 @@ use crate::scheduler::plan_fragmenter::Query;
 use crate::scheduler::worker_node_manager::WorkerNodeSelector;
 use crate::scheduler::{
     BatchPlanFragmenter, DistributedQueryStream, ExecutionContext, ExecutionContextRef,
-    LocalQueryExecution, LocalQueryStream, PinnedHummockSnapshot,
+    LocalQueryExecution, LocalQueryStream,
 };
 use crate::session::SessionImpl;
 use crate::PlanRef;
@@ -311,7 +311,6 @@ async fn execute(
         ..
     } = plan_fragmenter_result;
 
-    let is_barrier_read = session.is_barrier_read();
     let query_start_time = Instant::now();
     let query = plan_fragmenter.generate_complete_query().await?;
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);
@@ -326,35 +325,22 @@ async fn execute(
     // Used in counting row count.
     let first_field_format = formats.first().copied().unwrap_or(Format::Text);
 
-    let mut row_stream = {
-        let query_epoch = session.config().get_query_epoch();
-        let query_snapshot = if let Some(query_epoch) = query_epoch {
-            PinnedHummockSnapshot::Other(query_epoch)
-        } else {
-            // Acquire hummock snapshot for execution.
-            // TODO: if there's no table scan, we don't need to acquire snapshot.
-            let hummock_snapshot_manager = session.env().hummock_snapshot_manager();
-            let query_id = query.query_id().clone();
-            let pinned_snapshot = hummock_snapshot_manager.acquire(&query_id).await?;
-            PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, is_barrier_read)
-        };
-        match query_mode {
-            QueryMode::Auto => unreachable!(),
-            QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
-                local_execute(session.clone(), query, query_snapshot).await?,
+    let mut row_stream = match query_mode {
+        QueryMode::Auto => unreachable!(),
+        QueryMode::Local => PgResponseStream::LocalQuery(DataChunkToRowSetAdapter::new(
+            local_execute(session.clone(), query).await?,
+            column_types,
+            formats,
+            session.clone(),
+        )),
+        // Local mode do not support cancel tasks.
+        QueryMode::Distributed => {
+            PgResponseStream::DistributedQuery(DataChunkToRowSetAdapter::new(
+                distribute_execute(session.clone(), query).await?,
                 column_types,
                 formats,
                 session.clone(),
-            )),
-            // Local mode do not support cancel tasks.
-            QueryMode::Distributed => {
-                PgResponseStream::DistributedQuery(DataChunkToRowSetAdapter::new(
-                    distribute_execute(session.clone(), query, query_snapshot).await?,
-                    column_types,
-                    formats,
-                    session.clone(),
-                ))
-            }
+            ))
         }
     };
 
@@ -452,30 +438,26 @@ async fn execute(
 async fn distribute_execute(
     session: Arc<SessionImpl>,
     query: Query,
-    pinned_snapshot: PinnedHummockSnapshot,
 ) -> Result<DistributedQueryStream> {
     let execution_context: ExecutionContextRef = ExecutionContext::new(session.clone()).into();
     let query_manager = session.env().query_manager().clone();
+
     query_manager
-        .schedule(execution_context, query, pinned_snapshot)
+        .schedule(execution_context, query)
         .await
         .map_err(|err| err.into())
 }
 
-#[expect(clippy::unused_async)]
-async fn local_execute(
-    session: Arc<SessionImpl>,
-    query: Query,
-    pinned_snapshot: PinnedHummockSnapshot,
-) -> Result<LocalQueryStream> {
+async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<LocalQueryStream> {
     let front_env = session.env();
+    let snapshot = session.pinned_snapshot(query.query_id()).await?;
 
     // TODO: Passing sql here
     let execution = LocalQueryExecution::new(
         query,
         front_env.clone(),
         "",
-        pinned_snapshot,
+        snapshot,
         session.auth_context(),
         session.reset_cancel_query_flag(),
     );

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -464,7 +464,7 @@ async fn distribute_execute(
 async fn local_execute(session: Arc<SessionImpl>, query: Query) -> Result<LocalQueryStream> {
     let front_env = session.env();
     // TODO: if there's no table scan, we don't need to acquire snapshot.
-    let snapshot = session.pinned_snapshot(query.query_id()).await?;
+    let snapshot = session.pinned_snapshot().await?;
 
     // TODO: Passing sql here
     let execution = LocalQueryExecution::new(

--- a/src/frontend/src/handler/query.rs
+++ b/src/frontend/src/handler/query.rs
@@ -311,6 +311,18 @@ async fn execute(
         ..
     } = plan_fragmenter_result;
 
+    match stmt_type {
+        StatementType::INSERT
+        | StatementType::INSERT_RETURNING
+        | StatementType::DELETE
+        | StatementType::DELETE_RETURNING
+        | StatementType::UPDATE
+        | StatementType::UPDATE_RETURNING => {
+            session.txn_write_guard()?;
+        }
+        _ => {}
+    }
+
     let query_start_time = Instant::now();
     let query = plan_fragmenter.generate_complete_query().await?;
     tracing::trace!("Generated query after plan fragmenter: {:?}", &query);

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -25,6 +25,7 @@ macro_rules! not_impl {
     };
 }
 
+#[expect(clippy::unused_async)]
 pub async fn handle_begin(
     handler_args: HandlerArgs,
     stmt_type: StatementType,
@@ -55,9 +56,11 @@ pub async fn handle_begin(
 
     session.txn_begin_explicit(access_mode);
 
-    Ok(RwPgResponse::empty_result(stmt_type).into())
+    // TODO: pgwire integration of the transaction state
+    Ok(RwPgResponse::empty_result(stmt_type))
 }
 
+#[expect(clippy::unused_async)]
 pub async fn handle_commit(
     handler_args: HandlerArgs,
     stmt_type: StatementType,
@@ -71,5 +74,6 @@ pub async fn handle_commit(
 
     session.txn_end_explicit();
 
-    Ok(RwPgResponse::empty_result(stmt_type).into())
+    // TODO: pgwire integration of the transaction state
+    Ok(RwPgResponse::empty_result(stmt_type))
 }

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -33,13 +33,13 @@ pub async fn handle_begin(
             Some(TransactionAccessMode::ReadOnly) => AccessMode::ReadOnly,
             Some(TransactionAccessMode::ReadWrite) => not_impl!("READ WRITE")?,
             None => {
-                session.notice_to_user("Access mode is not specified, using default READ ONLY");
+                session.notice_to_user("access mode is not specified, using default READ ONLY");
                 AccessMode::ReadOnly
             }
         }
     };
 
-    session.begin_explicit(access_mode);
+    session.txn_begin_explicit(access_mode);
 
     Ok(RwPgResponse::empty_result(stmt_type).into())
 }
@@ -55,7 +55,7 @@ pub async fn handle_commit(
         not_impl!("COMMIT AND CHAIN")?;
     }
 
-    session.end_explicit();
+    session.txn_end_explicit();
 
     Ok(RwPgResponse::empty_result(stmt_type).into())
 }

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -1,0 +1,61 @@
+use pgwire::pg_response::StatementType;
+use risingwave_common::error::{ErrorCode, Result};
+use risingwave_sqlparser::ast::{TransactionAccessMode, TransactionMode};
+
+use super::{HandlerArgs, RwPgResponse};
+use crate::session::transaction::AccessMode;
+
+macro_rules! not_impl {
+    ($body:expr) => {
+        Err(ErrorCode::NotImplemented($body.into(), None.into()))
+    };
+}
+
+pub async fn handle_begin(
+    handler_args: HandlerArgs,
+    stmt_type: StatementType,
+    modes: Vec<TransactionMode>,
+) -> Result<RwPgResponse> {
+    let HandlerArgs { session, .. } = handler_args;
+
+    let access_mode = {
+        let mut access_mode = None;
+        for mode in modes {
+            match mode {
+                TransactionMode::AccessMode(mode) => {
+                    let _ = access_mode.replace(mode);
+                }
+                TransactionMode::IsolationLevel(_) => not_impl!("ISOLATION LEVEL")?,
+            }
+        }
+
+        match access_mode {
+            Some(TransactionAccessMode::ReadOnly) => AccessMode::ReadOnly,
+            Some(TransactionAccessMode::ReadWrite) => not_impl!("READ WRITE")?,
+            None => {
+                session.notice_to_user("Access mode is not specified, using default READ ONLY");
+                AccessMode::ReadOnly
+            }
+        }
+    };
+
+    session.begin_explicit(access_mode);
+
+    Ok(RwPgResponse::empty_result(stmt_type).into())
+}
+
+pub async fn handle_commit(
+    handler_args: HandlerArgs,
+    stmt_type: StatementType,
+    chain: bool,
+) -> Result<RwPgResponse> {
+    let HandlerArgs { session, .. } = handler_args;
+
+    if chain {
+        not_impl!("COMMIT AND CHAIN")?;
+    }
+
+    session.end_explicit();
+
+    Ok(RwPgResponse::empty_result(stmt_type).into())
+}

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use pgwire::pg_response::StatementType;
 use risingwave_common::error::{ErrorCode, Result};
 use risingwave_sqlparser::ast::{TransactionAccessMode, TransactionMode};

--- a/src/frontend/src/handler/transaction.rs
+++ b/src/frontend/src/handler/transaction.rs
@@ -21,7 +21,7 @@ use crate::session::transaction::AccessMode;
 
 macro_rules! not_impl {
     ($body:expr) => {
-        Err(ErrorCode::NotImplemented($body.into(), None.into()))
+        Err(ErrorCode::NotImplemented($body.into(), 10736.into()))
     };
 }
 
@@ -72,7 +72,25 @@ pub async fn handle_commit(
         not_impl!("COMMIT AND CHAIN")?;
     }
 
-    session.txn_end_explicit();
+    session.txn_commit_explicit();
+
+    // TODO: pgwire integration of the transaction state
+    Ok(RwPgResponse::empty_result(stmt_type))
+}
+
+#[expect(clippy::unused_async)]
+pub async fn handle_rollback(
+    handler_args: HandlerArgs,
+    stmt_type: StatementType,
+    chain: bool,
+) -> Result<RwPgResponse> {
+    let HandlerArgs { session, .. } = handler_args;
+
+    if chain {
+        not_impl!("ROLLBACK AND CHAIN")?;
+    }
+
+    session.txn_rollback_explicit();
 
     // TODO: pgwire integration of the transaction state
     Ok(RwPgResponse::empty_result(stmt_type))

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -40,7 +40,7 @@ use crate::scheduler::distributed::StageExecution;
 use crate::scheduler::plan_fragmenter::{Query, StageId, ROOT_TASK_ID, ROOT_TASK_OUTPUT_ID};
 use crate::scheduler::worker_node_manager::WorkerNodeSelector;
 use crate::scheduler::{
-    ExecutionContextRef, PinnedHummockSnapshot, SchedulerError, SchedulerResult,
+    ExecutionContextRef, PinnedHummockSnapshotRef, SchedulerError, SchedulerResult,
 };
 
 /// Message sent to a `QueryRunner` to control its execution.
@@ -116,7 +116,7 @@ impl QueryExecution {
         &self,
         context: ExecutionContextRef,
         worker_node_manager: WorkerNodeSelector,
-        pinned_snapshot: PinnedHummockSnapshot,
+        pinned_snapshot: PinnedHummockSnapshotRef,
         compute_client_pool: ComputeClientPoolRef,
         catalog_reader: CatalogReader,
         query_execution_info: QueryExecutionInfoRef,
@@ -200,7 +200,7 @@ impl QueryExecution {
 
     fn gen_stage_executions(
         &self,
-        pinned_snapshot: &PinnedHummockSnapshot,
+        pinned_snapshot: &PinnedHummockSnapshotRef,
         context: ExecutionContextRef,
         worker_node_manager: WorkerNodeSelector,
         compute_client_pool: ComputeClientPoolRef,
@@ -268,7 +268,7 @@ impl Debug for QueryRunner {
 }
 
 impl QueryRunner {
-    async fn run(mut self, pinned_snapshot: PinnedHummockSnapshot) {
+    async fn run(mut self, pinned_snapshot: PinnedHummockSnapshotRef) {
         self.query_metrics.running_query_num.inc();
         // Start leaf stages.
         let leaf_stages = self.query.leaf_stages();
@@ -489,7 +489,7 @@ pub(crate) mod tests {
             .start(
                 ExecutionContext::new(SessionImpl::mock().into()).into(),
                 worker_node_selector,
-                PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, true),
+                PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, true).into(),
                 compute_client_pool,
                 catalog_reader,
                 query_execution_info,

--- a/src/frontend/src/scheduler/distributed/query.rs
+++ b/src/frontend/src/scheduler/distributed/query.rs
@@ -463,7 +463,7 @@ pub(crate) mod tests {
         DistributedQueryMetrics, ExecutionContext, HummockSnapshotManager, PinnedHummockSnapshot,
         QueryExecutionInfo,
     };
-    use crate::session::SessionImpl;
+    use crate::session::{transaction, SessionImpl};
     use crate::test_utils::MockFrontendMetaClient;
     use crate::utils::Condition;
 
@@ -479,7 +479,8 @@ pub(crate) mod tests {
             CatalogReader::new(Arc::new(parking_lot::RwLock::new(Catalog::default())));
         let query = create_query().await;
         let query_id = query.query_id().clone();
-        let pinned_snapshot = hummock_snapshot_manager.acquire(&query_id).await.unwrap();
+        let txn_id = transaction::Id::new();
+        let pinned_snapshot = hummock_snapshot_manager.acquire(txn_id).await.unwrap();
         let query_execution = Arc::new(QueryExecution::new(query, (0, 0)));
         let query_execution_info = Arc::new(RwLock::new(QueryExecutionInfo::new_from_map(
             HashMap::from([(query_id, query_execution.clone())]),

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -177,7 +177,7 @@ impl QueryManager {
             .add_query(query_id.clone(), query_execution.clone());
 
         // TODO: if there's no table scan, we don't need to acquire snapshot.
-        let pinned_snapshot = context.session().pinned_snapshot(&query_id).await?;
+        let pinned_snapshot = context.session().pinned_snapshot().await?;
 
         let worker_node_manager_reader = WorkerNodeSelector::new(
             self.worker_node_manager.clone(),

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -31,7 +31,7 @@ use super::QueryExecution;
 use crate::catalog::catalog_service::CatalogReader;
 use crate::scheduler::plan_fragmenter::{Query, QueryId};
 use crate::scheduler::worker_node_manager::{WorkerNodeManagerRef, WorkerNodeSelector};
-use crate::scheduler::{ExecutionContextRef, PinnedHummockSnapshot, SchedulerResult};
+use crate::scheduler::{ExecutionContextRef, SchedulerResult};
 
 pub struct DistributedQueryStream {
     chunk_rx: tokio::sync::mpsc::Receiver<SchedulerResult<DataChunk>>,
@@ -156,7 +156,6 @@ impl QueryManager {
         &self,
         context: ExecutionContextRef,
         query: Query,
-        pinned_snapshot: PinnedHummockSnapshot,
     ) -> SchedulerResult<DistributedQueryStream> {
         if let Some(query_limit) = self.disrtibuted_query_limit
             && self.query_metrics.running_query_num.get() as u64 == query_limit
@@ -176,6 +175,8 @@ impl QueryManager {
             .env()
             .query_manager()
             .add_query(query_id.clone(), query_execution.clone());
+
+        let pinned_snapshot = context.session().pinned_snapshot(&query_id).await?;
 
         let worker_node_manager_reader = WorkerNodeSelector::new(
             self.worker_node_manager.clone(),

--- a/src/frontend/src/scheduler/distributed/query_manager.rs
+++ b/src/frontend/src/scheduler/distributed/query_manager.rs
@@ -176,6 +176,7 @@ impl QueryManager {
             .query_manager()
             .add_query(query_id.clone(), query_execution.clone());
 
+        // TODO: if there's no table scan, we don't need to acquire snapshot.
         let pinned_snapshot = context.session().pinned_snapshot(&query_id).await?;
 
         let worker_node_manager_reader = WorkerNodeSelector::new(

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -33,6 +33,7 @@ use crate::scheduler::{SchedulerError, SchedulerResult};
 const UNPIN_INTERVAL_SECS: u64 = 10;
 
 pub type HummockSnapshotManagerRef = Arc<HummockSnapshotManager>;
+
 pub enum PinnedHummockSnapshot {
     FrontendPinned(
         HummockSnapshotGuard,
@@ -45,6 +46,8 @@ pub enum PinnedHummockSnapshot {
     /// Currently it's only used for querying meta snapshot backup.
     Other(Epoch),
 }
+
+pub type PinnedHummockSnapshotRef = Arc<PinnedHummockSnapshot>;
 
 impl PinnedHummockSnapshot {
     pub fn get_batch_query_epoch(&self) -> BatchQueryEpoch {

--- a/src/frontend/src/scheduler/hummock_snapshot_manager.rs
+++ b/src/frontend/src/scheduler/hummock_snapshot_manager.rs
@@ -27,8 +27,8 @@ use tokio::sync::oneshot::{channel as once_channel, Sender as Callback};
 use tracing::error;
 
 use crate::meta_client::FrontendMetaClient;
-use crate::scheduler::plan_fragmenter::QueryId;
 use crate::scheduler::{SchedulerError, SchedulerResult};
+use crate::session::transaction::Id as TxnId;
 
 const UNPIN_INTERVAL_SECS: u64 = 10;
 
@@ -91,11 +91,11 @@ pub struct HummockSnapshotManager {
 #[derive(Debug)]
 enum EpochOperation {
     RequestEpoch {
-        query_id: QueryId,
+        txn_id: TxnId,
         sender: Callback<SchedulerResult<HummockSnapshot>>,
     },
     ReleaseEpoch {
-        query_id: QueryId,
+        txn_id: TxnId,
         epoch: u64,
     },
     Tick,
@@ -103,7 +103,7 @@ enum EpochOperation {
 
 pub struct HummockSnapshotGuard {
     snapshot: HummockSnapshot,
-    query_id: QueryId,
+    txn_id: TxnId,
     unpin_snapshot_sender: UnboundedSender<EpochOperation>,
 }
 
@@ -123,7 +123,7 @@ impl Drop for HummockSnapshotGuard {
         let _ = self
             .unpin_snapshot_sender
             .send(EpochOperation::ReleaseEpoch {
-                query_id: self.query_id.clone(),
+                txn_id: self.txn_id,
                 epoch: self.snapshot.committed_epoch,
             })
             .inspect_err(|err| {
@@ -157,22 +157,22 @@ impl HummockSnapshotManager {
                     m = receiver.recv() => m
                 };
                 match msg {
-                    Some(EpochOperation::RequestEpoch { query_id, sender }) => {
-                        pin_batches.push((query_id, sender));
+                    Some(EpochOperation::RequestEpoch { txn_id, sender }) => {
+                        pin_batches.push((txn_id, sender));
                     }
-                    Some(EpochOperation::ReleaseEpoch { query_id, epoch }) => {
-                        unpin_batches.push((query_id, epoch));
+                    Some(EpochOperation::ReleaseEpoch { txn_id, epoch }) => {
+                        unpin_batches.push((txn_id, epoch));
                     }
                     Some(EpochOperation::Tick) => {}
                     None => return,
                 }
                 while let Ok(msg) = receiver.try_recv() {
                     match msg {
-                        EpochOperation::RequestEpoch { query_id, sender } => {
-                            pin_batches.push((query_id, sender));
+                        EpochOperation::RequestEpoch { txn_id, sender } => {
+                            pin_batches.push((txn_id, sender));
                         }
-                        EpochOperation::ReleaseEpoch { query_id, epoch } => {
-                            unpin_batches.push((query_id, epoch));
+                        EpochOperation::ReleaseEpoch { txn_id, epoch } => {
+                            unpin_batches.push((txn_id, epoch));
                         }
                         EpochOperation::Tick => unreachable!(),
                     }
@@ -201,25 +201,22 @@ impl HummockSnapshotManager {
         }
     }
 
-    pub async fn acquire(&self, query_id: &QueryId) -> SchedulerResult<HummockSnapshotGuard> {
+    pub async fn acquire(&self, txn_id: TxnId) -> SchedulerResult<HummockSnapshotGuard> {
         let (sender, rc) = once_channel();
-        let msg = EpochOperation::RequestEpoch {
-            query_id: query_id.clone(),
-            sender,
-        };
+        let msg = EpochOperation::RequestEpoch { txn_id, sender };
         self.sender.send(msg).map_err(|_| {
-            SchedulerError::Internal(anyhow!("Failed to get epoch for query: {:?}", query_id,))
+            SchedulerError::Internal(anyhow!("Failed to get epoch for query: {:?}", txn_id,))
         })?;
         let snapshot = rc.await.unwrap_or_else(|e| {
             Err(SchedulerError::Internal(anyhow!(
                 "Failed to get epoch for query: {:?}, the rpc thread may panic: {:?}",
-                query_id,
+                txn_id,
                 e
             )))
         })?;
         Ok(HummockSnapshotGuard {
             snapshot,
-            query_id: query_id.clone(),
+            txn_id,
             unpin_snapshot_sender: self.sender.clone(),
         })
     }
@@ -241,7 +238,7 @@ impl HummockSnapshotManager {
 struct HummockSnapshotManagerCore {
     /// Record the query ids that pin each snapshot.
     /// Send an `unpin_snapshot` RPC when a snapshot is not pinned any more.
-    epoch_to_query_ids: BTreeMap<u64, HashSet<QueryId>>,
+    epoch_to_txn_ids: BTreeMap<u64, HashSet<TxnId>>,
     meta_client: Arc<dyn FrontendMetaClient>,
     last_unpin_snapshot: Arc<AtomicU64>,
     latest_snapshot: SnapshotRef,
@@ -252,7 +249,7 @@ impl HummockSnapshotManagerCore {
         Self {
             // Initialize by setting `is_outdated` to `true`.
             meta_client,
-            epoch_to_query_ids: BTreeMap::default(),
+            epoch_to_txn_ids: BTreeMap::default(),
             last_unpin_snapshot: Arc::new(AtomicU64::new(INVALID_EPOCH)),
             latest_snapshot,
         }
@@ -262,29 +259,29 @@ impl HummockSnapshotManagerCore {
     /// maintained by meta's notification service.
     fn get_epoch_for_query_from_push(
         &mut self,
-        batches: &mut Vec<(QueryId, Callback<SchedulerResult<HummockSnapshot>>)>,
+        batches: &mut Vec<(TxnId, Callback<SchedulerResult<HummockSnapshot>>)>,
     ) -> HummockSnapshot {
         let snapshot = HummockSnapshot::clone(&self.latest_snapshot.load());
         self.notify_epoch_assigned_for_queries(&snapshot, batches);
         snapshot
     }
 
-    /// Add committed epoch in `epoch_to_query_ids`, notify queries with committed epoch and current
+    /// Add committed epoch in `epoch_to_txn_ids`, notify queries with committed epoch and current
     /// epoch
     fn notify_epoch_assigned_for_queries(
         &mut self,
         snapshot: &HummockSnapshot,
-        batches: &mut Vec<(QueryId, Callback<SchedulerResult<HummockSnapshot>>)>,
+        batches: &mut Vec<(TxnId, Callback<SchedulerResult<HummockSnapshot>>)>,
     ) {
         if batches.is_empty() {
             return;
         }
         let committed_epoch = snapshot.committed_epoch;
-        let queries = match self.epoch_to_query_ids.get_mut(&committed_epoch) {
+        let queries = match self.epoch_to_txn_ids.get_mut(&committed_epoch) {
             None => {
-                self.epoch_to_query_ids
+                self.epoch_to_txn_ids
                     .insert(committed_epoch, HashSet::default());
-                self.epoch_to_query_ids.get_mut(&committed_epoch).unwrap()
+                self.epoch_to_txn_ids.get_mut(&committed_epoch).unwrap()
             }
             Some(queries) => queries,
         };
@@ -294,13 +291,13 @@ impl HummockSnapshotManagerCore {
         }
     }
 
-    pub fn release_epoch(&mut self, queries: &mut Vec<(QueryId, u64)>) {
-        for (query_id, epoch) in queries.drain(..) {
-            let query_ids = self.epoch_to_query_ids.get_mut(&epoch);
-            if let Some(query_ids) = query_ids {
-                query_ids.remove(&query_id);
-                if query_ids.is_empty() {
-                    self.epoch_to_query_ids.remove(&epoch);
+    pub fn release_epoch(&mut self, queries: &mut Vec<(TxnId, u64)>) {
+        for (txn_id, epoch) in queries.drain(..) {
+            let txn_ids = self.epoch_to_txn_ids.get_mut(&epoch);
+            if let Some(txn_ids) = txn_ids {
+                txn_ids.remove(&txn_id);
+                if txn_ids.is_empty() {
+                    self.epoch_to_txn_ids.remove(&epoch);
                 }
             }
         }
@@ -309,10 +306,10 @@ impl HummockSnapshotManagerCore {
     pub fn unpin_snapshot_before(&mut self, last_committed_epoch: u64) {
         // Check the min epoch which still exists running query. If there is no running query,
         // we shall unpin snapshot with the last committed epoch.
-        let min_epoch = match self.epoch_to_query_ids.first_key_value() {
-            Some((epoch, query_ids)) => {
+        let min_epoch = match self.epoch_to_txn_ids.first_key_value() {
+            Some((epoch, txn_ids)) => {
                 assert!(
-                    !query_ids.is_empty(),
+                    !txn_ids.is_empty(),
                     "No query is associated with epoch {}",
                     epoch
                 );

--- a/src/frontend/src/scheduler/local.rs
+++ b/src/frontend/src/scheduler/local.rs
@@ -52,7 +52,7 @@ use crate::optimizer::plan_node::PlanNodeType;
 use crate::scheduler::plan_fragmenter::{ExecutionPlanNode, Query, StageId};
 use crate::scheduler::task_context::FrontendBatchTaskContext;
 use crate::scheduler::worker_node_manager::WorkerNodeSelector;
-use crate::scheduler::{PinnedHummockSnapshot, SchedulerError, SchedulerResult};
+use crate::scheduler::{PinnedHummockSnapshotRef, SchedulerError, SchedulerResult};
 use crate::session::{AuthContext, FrontendEnv};
 
 pub type LocalQueryStream = ReceiverStream<Result<DataChunk, BoxedError>>;
@@ -62,7 +62,8 @@ pub struct LocalQueryExecution {
     query: Query,
     front_env: FrontendEnv,
     // The snapshot will be released when LocalQueryExecution is dropped.
-    snapshot: PinnedHummockSnapshot,
+    // TODO
+    snapshot: PinnedHummockSnapshotRef,
     auth_context: Arc<AuthContext>,
     cancel_flag: Option<Tripwire<Result<DataChunk, BoxedError>>>,
     worker_node_manager: WorkerNodeSelector,
@@ -73,7 +74,7 @@ impl LocalQueryExecution {
         query: Query,
         front_env: FrontendEnv,
         sql: S,
-        snapshot: PinnedHummockSnapshot,
+        snapshot: PinnedHummockSnapshotRef,
         auth_context: Arc<AuthContext>,
         cancel_flag: Tripwire<Result<DataChunk, BoxedError>>,
     ) -> Self {

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -340,6 +340,9 @@ impl FrontendEnv {
     }
 
     /// Get a reference to the frontend env's catalog writer.
+    ///
+    /// This method is intentionally private, and a write guard is required for the caller to
+    /// prove that the write operations are permitted in the current transaction.
     fn catalog_writer(&self, _guard: transaction::WriteGuard) -> &dyn CatalogWriter {
         &*self.catalog_writer
     }
@@ -350,6 +353,9 @@ impl FrontendEnv {
     }
 
     /// Get a reference to the frontend env's user info writer.
+    ///
+    /// This method is intentionally private, and a write guard is required for the caller to
+    /// prove that the write operations are permitted in the current transaction.
     fn user_info_writer(&self, _guard: transaction::WriteGuard) -> &dyn UserInfoWriter {
         &*self.user_info_writer
     }
@@ -437,6 +443,9 @@ pub struct SessionImpl {
     /// Identified by process_id, secret_key. Corresponds to SessionManager.
     id: (i32, i32),
 
+    /// Transaction state.
+    // TODO: get rid of the `Mutex` here as a workaround if the `Send` requirement of
+    // async functions, there should actually be no contention.
     txn: Arc<Mutex<transaction::State>>,
 
     /// Query cancel flag.

--- a/src/frontend/src/session.rs
+++ b/src/frontend/src/session.rs
@@ -340,7 +340,7 @@ impl FrontendEnv {
     }
 
     /// Get a reference to the frontend env's catalog writer.
-    pub fn catalog_writer(&self, _guard: transaction::WriteGuard) -> &dyn CatalogWriter {
+    fn catalog_writer(&self, _guard: transaction::WriteGuard) -> &dyn CatalogWriter {
         &*self.catalog_writer
     }
 
@@ -350,7 +350,7 @@ impl FrontendEnv {
     }
 
     /// Get a reference to the frontend env's user info writer.
-    pub fn user_info_writer(&self, _guard: transaction::WriteGuard) -> &dyn UserInfoWriter {
+    fn user_info_writer(&self, _guard: transaction::WriteGuard) -> &dyn UserInfoWriter {
         &*self.user_info_writer
     }
 

--- a/src/frontend/src/session/transaction.rs
+++ b/src/frontend/src/session/transaction.rs
@@ -1,3 +1,17 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use std::sync::{Arc, Weak};
 
 use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};

--- a/src/frontend/src/session/transaction.rs
+++ b/src/frontend/src/session/transaction.rs
@@ -1,0 +1,108 @@
+use std::sync::{Arc, Weak};
+
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use tokio::sync::OnceCell;
+
+use super::SessionImpl;
+use crate::scheduler::plan_fragmenter::QueryId;
+use crate::scheduler::{PinnedHummockSnapshot, PinnedHummockSnapshotRef, SchedulerError};
+
+#[derive(Default)]
+pub struct TransactionContext {
+    snapshot: Arc<OnceCell<PinnedHummockSnapshotRef>>,
+}
+
+#[derive(Default)]
+pub enum TransactionState {
+    #[default]
+    Initial,
+    Implicit(TransactionContext),
+    Explicit(TransactionContext),
+}
+
+impl SessionImpl {
+    #[must_use]
+    pub fn begin_impicit(&self) -> impl Drop + Send + Sync + 'static {
+        let mut txn = self.txn.write();
+
+        match &mut *txn {
+            TransactionState::Initial => {
+                *txn = TransactionState::Implicit(TransactionContext::default())
+            }
+            TransactionState::Implicit(_) => unreachable!(),
+            TransactionState::Explicit(_) => {}
+        }
+
+        struct ResetGuard(Weak<RwLock<TransactionState>>);
+
+        impl Drop for ResetGuard {
+            fn drop(&mut self) {
+                if let Some(txn) = self.0.upgrade() {
+                    let mut txn = txn.write();
+                    if let TransactionState::Implicit(_) = &mut *txn {
+                        *txn = TransactionState::Initial;
+                    }
+                }
+            }
+        }
+
+        ResetGuard(Arc::downgrade(&self.txn))
+    }
+
+    pub fn begin_explicit(&self) {
+        let mut txn = self.txn.write();
+
+        match &mut *txn {
+            TransactionState::Initial => unreachable!(),
+            TransactionState::Implicit(ctx) => {
+                *txn = TransactionState::Explicit(std::mem::take(ctx))
+            }
+            TransactionState::Explicit(_) => todo!(),
+        }
+    }
+
+    pub fn end_explicit(&self) {
+        let mut txn = self.txn.write();
+
+        match &mut *txn {
+            TransactionState::Initial => unreachable!(),
+            TransactionState::Implicit(_) => todo!(),
+            TransactionState::Explicit(_ctx) => *txn = TransactionState::Initial,
+        }
+    }
+
+    fn transaction_ctx(&self) -> MappedRwLockReadGuard<'_, TransactionContext> {
+        RwLockReadGuard::map(self.txn.read(), |txn| match txn {
+            TransactionState::Initial => unreachable!(),
+            TransactionState::Implicit(ctx) => ctx,
+            TransactionState::Explicit(ctx) => ctx,
+        })
+    }
+
+    pub async fn pinned_snapshot(
+        &self,
+        query_id: &QueryId,
+    ) -> Result<PinnedHummockSnapshotRef, SchedulerError> {
+        let snapshot = self.transaction_ctx().snapshot.clone();
+
+        snapshot
+            .get_or_try_init(|| async move {
+                let query_epoch = self.config().get_query_epoch();
+
+                let query_snapshot = if let Some(query_epoch) = query_epoch {
+                    PinnedHummockSnapshot::Other(query_epoch)
+                } else {
+                    // Acquire hummock snapshot for execution.
+                    // TODO: if there's no table scan, we don't need to acquire snapshot.
+                    let is_barrier_read = self.is_barrier_read();
+                    let hummock_snapshot_manager = self.env().hummock_snapshot_manager();
+                    let pinned_snapshot = hummock_snapshot_manager.acquire(query_id).await?;
+                    PinnedHummockSnapshot::FrontendPinned(pinned_snapshot, is_barrier_read)
+                };
+
+                Ok(query_snapshot.into())
+            })
+            .await
+            .cloned()
+    }
+}

--- a/src/frontend/src/session/transaction.rs
+++ b/src/frontend/src/session/transaction.rs
@@ -1,46 +1,61 @@
 use std::sync::{Arc, Weak};
 
-use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
+use risingwave_common::error::{ErrorCode, Result};
 use tokio::sync::OnceCell;
 
 use super::SessionImpl;
+use crate::catalog::catalog_service::CatalogWriter;
 use crate::scheduler::plan_fragmenter::QueryId;
-use crate::scheduler::{PinnedHummockSnapshot, PinnedHummockSnapshotRef, SchedulerError};
+use crate::scheduler::{PinnedHummockSnapshot, PinnedHummockSnapshotRef, SchedulerResult};
+use crate::user::user_service::UserInfoWriter;
 
 #[derive(Default)]
-pub struct TransactionContext {
+pub enum AccessMode {
+    #[default]
+    Initial,
+    ReadOnly,
+    // WriteOnly,
+    // DdlOnly,
+}
+
+#[derive(Default)]
+pub struct Context {
+    access_mode: AccessMode,
     snapshot: Arc<OnceCell<PinnedHummockSnapshotRef>>,
 }
 
 #[derive(Default)]
-pub enum TransactionState {
+pub enum State {
     #[default]
     Initial,
-    Implicit(TransactionContext),
-    Explicit(TransactionContext),
+    Implicit(Context),
+    Explicit(Context),
+}
+
+pub struct WriteGuard {
+    _private: (),
 }
 
 impl SessionImpl {
     #[must_use]
     pub fn begin_impicit(&self) -> impl Drop + Send + Sync + 'static {
-        let mut txn = self.txn.write();
+        let mut txn = self.txn.lock();
 
         match &mut *txn {
-            TransactionState::Initial => {
-                *txn = TransactionState::Implicit(TransactionContext::default())
-            }
-            TransactionState::Implicit(_) => unreachable!(),
-            TransactionState::Explicit(_) => {}
+            State::Initial => *txn = State::Implicit(Context::default()),
+            State::Implicit(_) => unreachable!(),
+            State::Explicit(_) => {}
         }
 
-        struct ResetGuard(Weak<RwLock<TransactionState>>);
+        struct ResetGuard(Weak<Mutex<State>>);
 
         impl Drop for ResetGuard {
             fn drop(&mut self) {
                 if let Some(txn) = self.0.upgrade() {
-                    let mut txn = txn.write();
-                    if let TransactionState::Implicit(_) = &mut *txn {
-                        *txn = TransactionState::Initial;
+                    let mut txn = txn.lock();
+                    if let State::Implicit(_) = &mut *txn {
+                        *txn = State::Initial;
                     }
                 }
             }
@@ -49,40 +64,49 @@ impl SessionImpl {
         ResetGuard(Arc::downgrade(&self.txn))
     }
 
-    pub fn begin_explicit(&self) {
-        let mut txn = self.txn.write();
+    pub fn begin_explicit(&self, access_mode: AccessMode) {
+        let mut txn = self.txn.lock();
 
         match &mut *txn {
-            TransactionState::Initial => unreachable!(),
-            TransactionState::Implicit(ctx) => {
-                *txn = TransactionState::Explicit(std::mem::take(ctx))
+            State::Initial => unreachable!(),
+            State::Implicit(ctx) => {
+                *txn = State::Explicit(Context {
+                    access_mode,
+                    ..std::mem::take(ctx)
+                })
             }
-            TransactionState::Explicit(_) => todo!(),
+            State::Explicit(_) => {
+                // TODO: should be warning
+                self.notice_to_user("there is already a transaction in progress")
+            }
         }
     }
 
     pub fn end_explicit(&self) {
-        let mut txn = self.txn.write();
+        let mut txn = self.txn.lock();
 
         match &mut *txn {
-            TransactionState::Initial => unreachable!(),
-            TransactionState::Implicit(_) => todo!(),
-            TransactionState::Explicit(_ctx) => *txn = TransactionState::Initial,
+            State::Initial => unreachable!(),
+            State::Implicit(_) => {
+                // TODO: should be warning
+                self.notice_to_user("there is no transaction in progress")
+            }
+            State::Explicit(_ctx) => *txn = State::Initial,
         }
     }
 
-    fn transaction_ctx(&self) -> MappedRwLockReadGuard<'_, TransactionContext> {
-        RwLockReadGuard::map(self.txn.read(), |txn| match txn {
-            TransactionState::Initial => unreachable!(),
-            TransactionState::Implicit(ctx) => ctx,
-            TransactionState::Explicit(ctx) => ctx,
+    fn transaction_ctx(&self) -> MappedMutexGuard<'_, Context> {
+        MutexGuard::map(self.txn.lock(), |txn| match txn {
+            State::Initial => unreachable!(),
+            State::Implicit(ctx) => ctx,
+            State::Explicit(ctx) => ctx,
         })
     }
 
     pub async fn pinned_snapshot(
         &self,
         query_id: &QueryId,
-    ) -> Result<PinnedHummockSnapshotRef, SchedulerError> {
+    ) -> SchedulerResult<PinnedHummockSnapshotRef> {
         let snapshot = self.transaction_ctx().snapshot.clone();
 
         snapshot
@@ -104,5 +128,36 @@ impl SessionImpl {
             })
             .await
             .cloned()
+    }
+
+    pub fn write_guard(&self) -> Result<WriteGuard> {
+        let txn = self.txn.lock();
+
+        let permitted = match &*txn {
+            State::Initial => unreachable!(),
+            State::Implicit(_) => true,
+            State::Explicit(ctx) => match ctx.access_mode {
+                AccessMode::Initial => unreachable!(),
+                AccessMode::ReadOnly => false,
+            },
+        };
+
+        if permitted {
+            Ok(WriteGuard { _private: () })
+        } else {
+            Err(ErrorCode::PermissionDenied(
+                "cannot execute in a read-only transaction".into(),
+            ))?
+        }
+    }
+
+    pub fn catalog_writer(&self) -> Result<&dyn CatalogWriter> {
+        self.write_guard()
+            .map(|guard| self.env().catalog_writer(guard))
+    }
+
+    pub fn user_info_writer(&self) -> Result<&dyn UserInfoWriter> {
+        self.write_guard()
+            .map(|guard| self.env().user_info_writer(guard))
     }
 }

--- a/src/frontend/src/session/transaction.rs
+++ b/src/frontend/src/session/transaction.rs
@@ -38,7 +38,7 @@ impl Id {
 }
 
 /// Transaction access mode.
-// TODO: WriteOnly, DdlOnly
+// TODO: WriteOnly, CreateDdlOnly
 pub enum AccessMode {
     /// Read-write transaction. All operations are permitted.
     ///
@@ -216,17 +216,11 @@ impl SessionImpl {
     /// Returns a [`WriteGuard`], or an error if write operations are not permitted in the current
     /// transaction.
     pub fn txn_write_guard(&self) -> Result<WriteGuard> {
-        let permitted = match self.txn_ctx().access_mode {
-            AccessMode::ReadWrite => true,
-            AccessMode::ReadOnly => false,
-        };
-
-        if permitted {
-            Ok(WriteGuard { _private: () })
-        } else {
-            Err(ErrorCode::PermissionDenied(
+        match self.txn_ctx().access_mode {
+            AccessMode::ReadWrite => Ok(WriteGuard { _private: () }),
+            AccessMode::ReadOnly => Err(ErrorCode::PermissionDenied(
                 "cannot execute in a read-only transaction".into(),
-            ))?
+            ))?,
         }
     }
 

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1122,7 +1122,7 @@ pub enum Statement {
     /// `START TRANSACTION ...`
     StartTransaction { modes: Vec<TransactionMode> },
     /// `BEGIN [ TRANSACTION | WORK ]`
-    BEGIN { modes: Vec<TransactionMode> },
+    Begin { modes: Vec<TransactionMode> },
     /// ABORT
     Abort,
     /// `SET TRANSACTION ...`
@@ -1679,7 +1679,7 @@ impl fmt::Display for Statement {
             Statement::Flush => {
                 write!(f, "FLUSH")
             }
-            Statement::BEGIN { modes } => {
+            Statement::Begin { modes } => {
                 write!(f, "BEGIN")?;
                 if !modes.is_empty() {
                     write!(f, " {}", display_comma_separated(modes))?;

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -4383,7 +4383,7 @@ impl Parser {
 
     pub fn parse_begin(&mut self) -> Result<Statement, ParserError> {
         let _ = self.parse_one_of_keywords(&[Keyword::TRANSACTION, Keyword::WORK]);
-        Ok(Statement::BEGIN {
+        Ok(Statement::Begin {
             modes: self.parse_transaction_modes()?,
         })
     }

--- a/src/tests/simulation/src/slt.rs
+++ b/src/tests/simulation/src/slt.rs
@@ -87,6 +87,9 @@ const KILL_IGNORE_FILES: &[&str] = &[
     "tpch_upstream.slt",
     // Drop is not retryable in search path test.
     "search_path.slt",
+    // Transaction statements are not retryable.
+    "transaction/read_only.slt",
+    "transaction/tolerance.slt",
 ];
 
 /// Run the sqllogictest files in `glob`.

--- a/src/utils/pgwire/src/pg_response.rs
+++ b/src/utils/pgwire/src/pg_response.rs
@@ -249,7 +249,7 @@ impl StatementType {
             Statement::SetVariable { .. } => Ok(StatementType::SET_VARIABLE),
             Statement::ShowVariable { .. } => Ok(StatementType::SHOW_VARIABLE),
             Statement::StartTransaction { .. } => Ok(StatementType::START_TRANSACTION),
-            Statement::BEGIN { .. } => Ok(StatementType::BEGIN),
+            Statement::Begin { .. } => Ok(StatementType::BEGIN),
             Statement::Abort => Ok(StatementType::ABORT),
             Statement::Commit { .. } => Ok(StatementType::COMMIT),
             Statement::Rollback { .. } => Ok(StatementType::ROLLBACK),


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Initial support for read-only transactions with `START TRANSACTION`/`BEGIN` and `COMMIT`. All reads in the transaction perform on the consistent Hummock snapshot.

Refer to the code docs for current limitations and TODOs.

**For end-to-end testing:** we need multiple sessions in the same file to test the isolation. DuckDB has the support for multiple connections in its sqllogictest implementation. Perhaps we can also adopt this to `sqllogictest-rs`.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

**Experimental** support read-only transactions with `START TRANSACTION`/`BEGIN` and `COMMIT`. All reads in the transaction perform on the consistent Hummock snapshot.

</details>
