### PR TITLE
refactor: set checkpoint frequency to 1

### DIFF
--- a/src/common/src/system_param/mod.rs
+++ b/src/common/src/system_param/mod.rs
@@ -37,7 +37,7 @@ macro_rules! for_all_undeprecated_params {
         $(, { $field:ident, $type:ty, $default:expr, $is_mutable:expr })*) => {
         $macro! {
             { barrier_interval_ms, u32, Some(1000_u32), false },
-            { checkpoint_frequency, u64, Some(10_u64), true },
+            { checkpoint_frequency, u64, Some(1_u64), true },
             { sstable_size_mb, u32, Some(256_u32), false },
             { block_size_kb, u32, Some(64_u32), false },
             { bloom_false_positive, f64, Some(0.001_f64), false },

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -82,7 +82,7 @@ cache_file_max_write_size_mb = 4
 
 [system]
 barrier_interval_ms = 1000
-checkpoint_frequency = 10
+checkpoint_frequency = 1
 sstable_size_mb = 256
 block_size_kb = 64
 bloom_false_positive = 0.001


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. 

The major motivation is to make the system more stable. We have observed more than once that the system fluctuates more under `checkpoint_frequency = 10`. For example, the SST uploader consumes more memory and uses more time to upload one checkpoint.

Performance tests show that there is no difference between `checkpoint_frequency = 1` and `10`. 

- [Performance dashboard: bench-checkpoint-interval](http://risingwave-perf-test-dashboard-metabase.us-west-2.elasticbeanstalk.com/dashboard/36-risingwave-cn-compactor-2-8c16g-nexmark-blackhole-source-throughput-history?namespace=bench-checkpoint-interval&start_date=2023-03-01)
- [Performance dashboard: daily](http://risingwave-perf-test-dashboard-metabase.us-west-2.elasticbeanstalk.com/dashboard/36-risingwave-cn-compactor-2-8c16g-nexmark-blackhole-source-throughput-history?namespace=daily&start_date=2023-03-01)

![image](https://github.com/risingwavelabs/risingwave/assets/10192522/2bd77708-fa08-4952-8f97-903ab5ec54d6)

(Sorry, the test was done 3 months ago...)

In addition, if this can work well, the design of dedicated serving cluster will be significantly simplified, because we won't worry about the freshness anymore.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [x] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

NA
