### PR TITLE
fix(agg): fix count timestamptz

### DIFF
--- a/src/stream/src/executor/aggregation/agg_impl/mod.rs
+++ b/src/stream/src/executor/aggregation/agg_impl/mod.rs
@@ -175,7 +175,7 @@ pub fn create_streaming_agg_impl(
                     (
                         Count,
                         timestamptz,
-                        timestamptz,
+                        int64,
                         StreamingCountAgg::<TimestamptzArray>
                     ),
                     (Count, time, int64, StreamingCountAgg::<TimeArray>),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixed a bug introduced by #10477:

The return type should be `int64` rather than `timestamptz`. The following still crashes

```
create table t (x timestamp, y timestamptz);
create materialized view mv1 as select count(y) from t;
```

_Originally posted by @xiangjinwu in https://github.com/risingwavelabs/risingwave/pull/10477#discussion_r1252547869_

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
