### PR TITLE
fix(sqlparser): accept `left` and `right` as function

### DIFF
--- a/src/expr/src/vector_op/string.rs
+++ b/src/expr/src/vector_op/string.rs
@@ -401,11 +401,13 @@ pub fn quote_ident(s: &str, writer: &mut dyn Write) {
 /// query T
 /// select left('RisingWave', 0)
 /// ----
+/// (empty)
 ///
 /// query T
 /// select left('RisingWave', -4)
 /// ----
 /// Rising
+/// ```
 #[function("left(varchar, int32) -> varchar")]
 pub fn left(s: &str, n: i32, writer: &mut dyn Write) {
     let n = if n >= 0 {
@@ -438,11 +440,13 @@ pub fn left(s: &str, n: i32, writer: &mut dyn Write) {
 /// query T
 /// select right('RisingWave', 0)
 /// ----
+/// (empty)
 ///
 /// query T
 /// select right('RisingWave', -6)
 /// ----
 /// Wave
+/// ```
 #[function("right(varchar, int32) -> varchar")]
 pub fn right(s: &str, n: i32, writer: &mut dyn Write) {
     let skip = if n >= 0 {

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -520,6 +520,10 @@ impl Parser {
                     self.expect_token(&Token::LBracket)?;
                     self.parse_array_expr(true)
                 }
+                // `LEFT` and `RIGHT` are reserved as identifier but okay as function
+                Keyword::LEFT | Keyword::RIGHT => {
+                    self.parse_function(ObjectName(vec![w.to_ident()?]))
+                }
                 k if keywords::RESERVED_FOR_COLUMN_OR_TABLE_NAME.contains(&k) => {
                     parser_err!(format!("syntax error at or near \"{w}\""))
                 }

--- a/src/tests/regress/data/sql/text.sql
+++ b/src/tests/regress/data/sql/text.sql
@@ -42,7 +42,7 @@ select concat_ws(',',10,20,null,30);
 select concat_ws('',10,20,null,30);
 select concat_ws(NULL,10,20,null,30) is null;
 select reverse('abcde');
---@ select i, left('ahoj', i), right('ahoj', i) from generate_series(-5, 5) t(i) order by i;
+select i, left('ahoj', i), right('ahoj', i) from generate_series(-5, 5) t(i) order by i;
 --@ select quote_literal('');
 --@ select quote_literal('abc''');
 --@ select quote_literal(e'\\');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

`LEFT` and `RIGHT` are reserved keywords in PostgreSQL, except when used as function name. This PR fixes their usage as function #10729

https://www.postgresql.org/docs/current/sql-keywords-appendix.html

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support `left( string, n )` and `right( string, n )` (completes #10729)