### PR TITLE
fix(optimizer): avoid equi-join predicate substitution when types mismatch

### DIFF
--- a/e2e_test/batch/join/issue_10037.slt
+++ b/e2e_test/batch/join/issue_10037.slt
@@ -1,0 +1,30 @@
+statement ok
+create table a(a1 int, a2 bigint);
+
+statement ok
+create table b(b1 int);
+
+statement ok
+insert into a values (3, 3), (7, 2147483648);
+
+statement ok
+insert into b values (3);
+
+statement ok
+flush;
+
+query II
+select a1, a2 from a, b where a1 = b1 and substr('abcde', b1) > 'a';
+----
+3 3
+
+query II
+select a1, a2 from a, b where a2 = b1 and substr('abcde', b1) > 'a';
+----
+3 3
+
+statement ok
+drop table a;
+
+statement ok
+drop table b;

--- a/src/frontend/planner_test/tests/testdata/input/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/predicate_pushdown.yaml
@@ -175,3 +175,10 @@
   expected_outputs:
   - stream_plan
   - optimized_logical_plan_for_batch
+- name: eq-predicate derived condition is banned for mismatching types
+  sql: |
+    create table t1(v1 int, v2 int);
+    create table t2(v1 bigint, v2 int);
+    select * from t1 cross join t2 where t1.v1 = t2.v1 and substr('abcde', t1.v1) > 'a';
+  expected_outputs:
+  - optimized_logical_plan_for_batch

--- a/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/predicate_pushdown.yaml
@@ -351,3 +351,13 @@
       │     └─StreamNow { output: [now] }
       └─StreamExchange { dist: HashShard(t2.v2) }
         └─StreamTableScan { table: t2, columns: [t2.v2, t2._row_id], pk: [t2._row_id], dist: UpstreamHashShard(t2._row_id) }
+- name: eq-predicate derived condition is banned for mismatching types
+  sql: |
+    create table t1(v1 int, v2 int);
+    create table t2(v1 bigint, v2 int);
+    select * from t1 cross join t2 where t1.v1 = t2.v1 and substr('abcde', t1.v1) > 'a';
+  optimized_logical_plan_for_batch: |-
+    LogicalJoin { type: Inner, on: ($expr1 = t2.v1), output: [t1.v1, t1.v2, t2.v1, t2.v2] }
+    ├─LogicalProject { exprs: [t1.v1, t1.v2, t1.v1::Int64 as $expr1] }
+    │ └─LogicalScan { table: t1, columns: [t1.v1, t1.v2], predicate: (Substr('abcde':Varchar, t1.v1) > 'a':Varchar) }
+    └─LogicalScan { table: t2, columns: [t2.v1, t2.v2] }

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -668,11 +668,19 @@ fn derive_predicate_from_eq_condition(
     if expr.is_impure() {
         return None;
     }
-    let eq_indices = if expr_is_left {
-        eq_condition.left_eq_indexes()
-    } else {
-        eq_condition.right_eq_indexes()
-    };
+    let eq_indices = eq_condition
+        .eq_indexes_typed()
+        .iter()
+        .filter_map(|(l, r)| {
+            if l.return_type() != r.return_type() {
+                None
+            } else if expr_is_left {
+                Some(l.index())
+            } else {
+                Some(r.index())
+            }
+        })
+        .collect_vec();
     if expr
         .collect_input_refs(col_num)
         .ones()


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #10037

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
