### PR TITLE
refactor: set stream_exchange_concurrent_barriers = 100

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -928,7 +928,7 @@ mod default {
         }
 
         pub fn stream_exchange_concurrent_barriers() -> usize {
-            1
+            100
         }
 
         pub fn stream_dml_channel_initial_permits() -> usize {

--- a/src/config/ci.toml
+++ b/src/config/ci.toml
@@ -5,9 +5,6 @@ max_heartbeat_interval_secs = 600
 [streaming]
 in_flight_barrier_nums = 10
 
-[streaming.developer]
-stream_exchange_concurrent_barriers = 10
-
 [storage]
 imm_merge_threshold = 2
 

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -52,7 +52,7 @@ stream_unsafe_extreme_cache_size = 10
 stream_chunk_size = 256
 stream_exchange_initial_permits = 2048
 stream_exchange_batched_permits = 256
-stream_exchange_concurrent_barriers = 1
+stream_exchange_concurrent_barriers = 100
 stream_dml_channel_initial_permits = 32768
 
 [storage]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Backgroud: https://github.com/risingwavelabs/risingwave/issues/10755#issuecomment-1623142011

This PR effectively reverts #9427 but we can re-enable it by setting the argument at any time.

Previsouly, #9427 was introduced to reduce streaming latency for a user's case. In that case, the source throughput is low, but the computation is complex, so massive events piled in the streaming pipeline, and the streaming latency as well as the number of in-flight barriers soared.

However, recently we found a side effect of #9427 was it blocks new data to be processed when the processing duration of one barrier is longer than barrier interval. This is because SourceExecutor polls barrier with higher priority than data. See #10755 for detailed description. 

Tested on TPC-H Q2 https://buildkite.com/risingwave-test/tpch-benchmark/builds/878#018929a4-ee90-476e-82ce-bbd752087bb8 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
