### PR TITLE
fix(docslt): panic on malformed slt block

### DIFF
--- a/src/expr/src/vector_op/string.rs
+++ b/src/expr/src/vector_op/string.rs
@@ -161,7 +161,7 @@ pub fn lpad_fill(s: &str, length: i32, fill: &str, writer: &mut dyn Write) {
 /// query T
 /// select rpad('abc', 5);
 /// ----
-/// abc  
+/// abc
 ///
 /// query T
 /// select rpad('abcdef', 3);

--- a/src/risedevtool/src/bin/risedev-docslt.rs
+++ b/src/risedevtool/src/bin/risedev-docslt.rs
@@ -36,15 +36,14 @@ fn extract_slt(filepath: &Path) -> Vec<SltBlock> {
 
     let mut blocks = vec![];
     let mut iter = content.lines().enumerate();
-    'block: while let Some((i, line)) = iter.next() {
+    while let Some((i, line)) = iter.next() {
         if !line.trim_end().ends_with("```slt") {
             continue;
         }
         let mut content = String::new();
         loop {
             let Some((i, mut line)) = iter.next() else {
-                error!("unexpected end of file at {}", filepath.display());
-                break 'block;
+                panic!("unexpected end of file at {}", filepath.display());
             };
             line = line.trim();
             // skip empty lines
@@ -52,8 +51,7 @@ fn extract_slt(filepath: &Path) -> Vec<SltBlock> {
                 continue;
             }
             if !(line.starts_with("///") || line.starts_with("//!")) {
-                error!("expect /// or //! at {}:{}", filepath.display(), i + 1);
-                continue 'block;
+                panic!("expect /// or //! at {}:{}", filepath.display(), i + 1);
             }
             line = line[3..].trim();
             if line == "```" {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #10749

## Checklist

- ~~[ ] I have written necessary rustdoc comments~~
- ~~[ ] I have added necessary unit tests and integration tests~~
- ~~[ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).~~
- ~~[ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- ~~[ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)~~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- ~~[ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details]~~(https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- ~~[ ] My PR contains user-facing changes.~~

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
