### PR TITLE
fix(batch): workaround serving fragment mapping absence due to asynchronism

### DIFF
--- a/src/frontend/src/scheduler/worker_node_manager.rs
+++ b/src/frontend/src/scheduler/worker_node_manager.rs
@@ -335,16 +335,22 @@ impl WorkerNodeSelector {
                         // 1. Stable mapping for most cases.
                         return Ok(o);
                     }
-                    let p = o.iter_unique().count();
-                    (Some(o), p)
+                    let max_parallelism = o.iter_unique().count();
+                    (Some(o), max_parallelism)
                 }
                 Err(e) => {
                     if !matches!(e, SchedulerError::ServingVnodeMappingNotFound(_)) {
                         return Err(e);
                     }
+                    let max_parallelism = 100;
+                    tracing::warn!(
+                        fragment_id,
+                        max_parallelism,
+                        "Serving fragment mapping not found, fall back to temporary one."
+                    );
                     // Workaround the case that new mapping is not available yet due to asynchronous
                     // notification.
-                    (None, 100)
+                    (None, max_parallelism)
                 }
             };
             // 2. Temporary mapping that filters out unavailable workers.

--- a/src/frontend/src/scheduler/worker_node_manager.rs
+++ b/src/frontend/src/scheduler/worker_node_manager.rs
@@ -329,13 +329,27 @@ impl WorkerNodeSelector {
         if self.enable_barrier_read {
             self.manager.get_streaming_fragment_mapping(&fragment_id)
         } else {
-            let origin = self.manager.serving_fragment_mapping(fragment_id)?;
-            if self.manager.worker_node_mask().is_empty() {
-                return Ok(origin);
-            }
+            let (hint, parallelism) = match self.manager.serving_fragment_mapping(fragment_id) {
+                Ok(o) => {
+                    if self.manager.worker_node_mask().is_empty() {
+                        // 1. Stable mapping for most cases.
+                        return Ok(o);
+                    }
+                    let p = o.iter_unique().count();
+                    (Some(o), p)
+                }
+                Err(e) => {
+                    if !matches!(e, SchedulerError::ServingVnodeMappingNotFound(_)) {
+                        return Err(e);
+                    }
+                    // Workaround the case that new mapping is not available yet due to asynchronous
+                    // notification.
+                    (None, 100)
+                }
+            };
+            // 2. Temporary mapping that filters out unavailable workers.
             let new_workers = self.apply_worker_node_mask(self.manager.list_serving_worker_nodes());
-            let masked_mapping =
-                place_vnode(Some(&origin), &new_workers, origin.iter_unique().count());
+            let masked_mapping = place_vnode(hint.as_ref(), &new_workers, parallelism);
             masked_mapping.ok_or_else(|| SchedulerError::EmptyWorkerNodes)
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Due to asynchronism of serving vnode mapping updating, it's expected that query may not find serving fragment mapping immediately after DDL, and subsequently client is responded with `ServingVnodeMappingNotFound` error. This error is transient. Client may retry the query and succeed a few moment later.

This PR eliminates the transient error: when encountering `ServingVnodeMappingNotFound`, frontend node will fall back to a temporary serving vnode mapping, instead of failing query with `ServingVnodeMappingNotFound`.

Fix #10808

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
