### PR TITLE
feat(expr): support `sign` and distinguish `is_positive` vs `is_sign_positive`

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -5,6 +5,9 @@ disallowed-methods = [
     { path = "risingwave_common::array::JsonbVal::from_serde", reason = "Please add dedicated methods as part of `JsonbRef`/`JsonbVal`, rather than take inner `serde_json::Value` out, process, and put back." },
     { path = "std::panic::catch_unwind", reason = "Please use `risingwave_common::util::panic::rw_catch_unwind` instead." },
     { path = "futures::FutureExt::catch_unwind", reason = "Please use `risingwave_common::util::panic::FutureCatchUnwindExt::rw_catch_unwind` instead." },
+    { path = "num_traits::sign::Signed::is_positive", reason = "This returns true for 0.0 but false for 0." },
+    { path = "num_traits::sign::Signed::is_negative", reason = "This returns true for -0.0 but false for 0." },
+    { path = "num_traits::sign::Signed::signum", reason = "This returns 1.0 for 0.0 but 0 for 0." },
 ]
 disallowed-types = [
     { path = "num_traits::AsPrimitive", reason = "Please use `From` or `TryFrom` with `OrderedFloat` instead." },

--- a/e2e_test/batch/functions/abs.slt.part
+++ b/e2e_test/batch/functions/abs.slt.part
@@ -17,3 +17,22 @@ query I
 SELECT abs(2134) 
 ----
 2134
+
+query TRR
+with t(s) as (values
+	('-inf'),
+	('-2'),
+	('-0'),
+	('0'),
+	('2'),
+	('inf'),
+	('nan')
+) select s, sign(s::decimal), sign(s::double precision) from t;
+----
+-inf  -1 -1
+-2    -1 -1
+-0     0  0
+0      0  0
+2      1  1
+inf    1  1
+nan  NaN  0

--- a/e2e_test/batch/functions/abs.slt.part
+++ b/e2e_test/batch/functions/abs.slt.part
@@ -18,7 +18,7 @@ SELECT abs(2134)
 ----
 2134
 
-query TRR
+query TRRRR
 with t(s) as (values
 	('-inf'),
 	('-2'),
@@ -27,12 +27,18 @@ with t(s) as (values
 	('2'),
 	('inf'),
 	('nan')
-) select s, sign(s::decimal), sign(s::double precision) from t;
+) select
+	s,
+	sign(s::decimal),
+	sign(s::double precision),
+	abs(s::decimal),
+	abs(s::double precision)
+from t;
 ----
--inf  -1 -1
--2    -1 -1
--0     0  0
-0      0  0
-2      1  1
-inf    1  1
-nan  NaN  0
+-inf  -1 -1 Infinity Infinity
+-2    -1 -1        2        2
+-0     0  0        0        0
+0      0  0        0        0
+2      1  1        2        2
+inf    1  1 Infinity Infinity
+nan  NaN  0      NaN      NaN

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -140,6 +140,7 @@ message ExprNode {
     LN = 272;
     LOG10 = 273;
     CBRT = 274;
+    SIGN = 275;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/common/src/types/interval.rs
+++ b/src/common/src/types/interval.rs
@@ -29,7 +29,6 @@ use regex::Regex;
 use risingwave_pb::data::PbInterval;
 use rust_decimal::prelude::Decimal;
 
-use super::ops::IsNegative;
 use super::to_binary::ToBinary;
 use super::*;
 use crate::error::{ErrorCode, Result, RwError};
@@ -971,12 +970,6 @@ impl Zero for Interval {
 
     fn is_zero(&self) -> bool {
         self.months == 0 && self.days == 0 && self.usecs == 0
-    }
-}
-
-impl IsNegative for Interval {
-    fn is_negative(&self) -> bool {
-        self < &Self::from_month_day_usec(0, 0, 0)
     }
 }
 

--- a/src/common/src/types/num256.rs
+++ b/src/common/src/types/num256.rs
@@ -23,7 +23,7 @@ use std::str::FromStr;
 use bytes::{BufMut, Bytes};
 use ethnum::{i256, u256, AsI256};
 use num_traits::{
-    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, One, Signed, Zero,
+    CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, One, Zero,
 };
 use risingwave_pb::data::ArrayType;
 use serde::{Deserialize, Serialize};
@@ -323,32 +323,6 @@ impl Num for Int256 {
     }
 }
 
-impl Signed for Int256 {
-    fn abs(&self) -> Self {
-        self.0.abs().into()
-    }
-
-    fn abs_sub(&self, other: &Self) -> Self {
-        if self <= other {
-            Self::zero()
-        } else {
-            self.abs()
-        }
-    }
-
-    fn signum(&self) -> Self {
-        self.0.signum().into()
-    }
-
-    fn is_positive(&self) -> bool {
-        self.0.is_positive()
-    }
-
-    fn is_negative(&self) -> bool {
-        self.0.is_negative()
-    }
-}
-
 impl From<arrow_buffer::i256> for Int256 {
     fn from(value: arrow_buffer::i256) -> Self {
         let buffer = value.to_be_bytes();
@@ -441,13 +415,6 @@ mod tests {
         assert_eq!(-Int256::from(1), Int256::from(-1));
         assert_eq!(Int256::from(0).neg(), Int256::from(0));
         assert_eq!(-Int256::from(0), Int256::from(0));
-    }
-
-    #[test]
-    fn test_abs() {
-        assert_eq!(Int256::from(-1).abs(), Int256::from(1));
-        assert_eq!(Int256::from(1).abs(), Int256::from(1));
-        assert_eq!(Int256::from(0).abs(), Int256::from(0));
     }
 
     #[test]

--- a/src/common/src/types/ops.rs
+++ b/src/common/src/types/ops.rs
@@ -37,12 +37,14 @@ impl<T: num_traits::CheckedAdd> CheckedAdd for T {
 }
 
 /// A simplified version of [`num_traits::Signed`].
-pub trait IsNegative: Zero {
+/// Unlike `Signed::is_negative` or `f64::is_sign_negative`, this returns `false` for `-0.0` to keep
+/// consistency among integers, decimals and floats.
+pub trait IsNegative: Zero + Ord {
     fn is_negative(&self) -> bool;
 }
 
-impl<T: num_traits::Signed> IsNegative for T {
+impl<T: Zero + Ord> IsNegative for T {
     fn is_negative(&self) -> bool {
-        num_traits::Signed::is_negative(self)
+        self < &Self::zero()
     }
 }

--- a/src/common/src/types/ordered_float.rs
+++ b/src/common/src/types/ordered_float.rs
@@ -53,7 +53,7 @@ use core::str::FromStr;
 pub use num_traits::Float;
 use num_traits::{
     Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedNeg, CheckedRem, CheckedSub, Num, One, Pow,
-    Signed, Zero,
+    Zero,
 };
 
 // masks for the parts of the IEEE 754 float
@@ -467,32 +467,6 @@ impl<'a, T: Float + Product + 'a> Product<&'a OrderedFloat<T>> for OrderedFloat<
     #[inline]
     fn product<I: Iterator<Item = &'a OrderedFloat<T>>>(iter: I) -> Self {
         iter.cloned().product()
-    }
-}
-
-impl<T: Float + Signed> Signed for OrderedFloat<T> {
-    #[inline]
-    fn abs(&self) -> Self {
-        OrderedFloat(self.0.abs())
-    }
-
-    fn abs_sub(&self, other: &Self) -> Self {
-        OrderedFloat(Signed::abs_sub(&self.0, &other.0))
-    }
-
-    #[inline]
-    fn signum(&self) -> Self {
-        OrderedFloat(self.0.signum())
-    }
-
-    #[inline]
-    fn is_positive(&self) -> bool {
-        self.0.is_positive()
-    }
-
-    #[inline]
-    fn is_negative(&self) -> bool {
-        self.0.is_negative()
     }
 }
 
@@ -1042,8 +1016,8 @@ mod tests {
         let nan = OrderedFloat::<f64>::from(nan_prim);
         assert_eq!(nan, nan);
 
-        use num_traits::Signed as _;
-        assert_eq!(nan.abs(), nan.abs());
+        use crate::types::FloatExt as _;
+        assert_eq!(nan.round(), nan.round());
     }
 
     fn test_into_f32(expected: [u8; 4], v: impl Into<OrderedFloat<f32>>) {

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -128,13 +128,17 @@ where
 }
 
 #[function("abs(*int) -> auto")]
-#[function("abs(*float) -> auto")]
 pub fn general_abs<T1: IsNegative + CheckedNeg>(expr: T1) -> Result<T1> {
     if expr.is_negative() {
         general_neg(expr)
     } else {
         Ok(expr)
     }
+}
+
+#[function("abs(*float) -> auto")]
+pub fn float_abs<F: num_traits::Float, T1: FloatExt<F>>(expr: T1) -> T1 {
+    expr.abs()
 }
 
 #[function("abs(int256) -> int256")]

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -405,6 +405,21 @@ pub fn cbrt_f64(expr: F64) -> F64 {
     expr.cbrt()
 }
 
+#[function("sign(float64) -> float64")]
+pub fn sign_f64(input: F64) -> F64 {
+    match input.0.partial_cmp(&0.) {
+        Some(std::cmp::Ordering::Less) => (-1).into(),
+        Some(std::cmp::Ordering::Equal) => 0.into(),
+        Some(std::cmp::Ordering::Greater) => 1.into(),
+        None => 0.into(),
+    }
+}
+
+#[function("sign(decimal) -> decimal")]
+pub fn sign_dec(input: Decimal) -> Decimal {
+    input.signum()
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use num_traits::Zero;
 use risingwave_common::types::{Decimal, F64};
 use risingwave_expr_macro::function;
 

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -572,6 +572,7 @@ impl Binder {
                 ("radians", raw_call(ExprType::Radians)),
                 ("sqrt", raw_call(ExprType::Sqrt)),
                 ("cbrt", raw_call(ExprType::Cbrt)),
+                ("sign", raw_call(ExprType::Sign)),
 
                 (
                     "to_timestamp",

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -124,6 +124,7 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
             | expr_node::Type::Atan2
             | expr_node::Type::Sqrt
             | expr_node::Type::Cbrt
+            | expr_node::Type::Sign
             | expr_node::Type::Left
             | expr_node::Type::Right
             | expr_node::Type::Degrees

--- a/src/tests/regress/data/sql/float8.sql
+++ b/src/tests/regress/data/sql/float8.sql
@@ -100,7 +100,7 @@ select ceiling(f1) as ceiling_f1 from float8_tbl f;
 select floor(f1) as floor_f1 from float8_tbl f;
 
 -- sign
---@ select sign(f1) as sign_f1 from float8_tbl f;
+select sign(f1) as sign_f1 from float8_tbl f;
 
 -- avoid bit-exact output here because operations may not be bit-exact.
 SET extra_float_digits = 0;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Support PostgreSQL expression `sign` for `decimal` and `double precision` (Resolves #8900). Input numeral of other types would be implicitly casted to `double precision` as in PostgreSQL.

It does not map to rust `signum` directly:
| value | sign | signum | is_positive | is_negative | is_sign_positive | is_sign_negative | num_traits is_positive | num_traits is_negative |
|-|-|-|-|-|-|-|-|-|
| -0.0 | 0 | -1 | x | x | false | true | false | true |
| 0.0 | 0 | 1 | x | x | true | false | true | false |
| 0 | 0 | 0 | false | false | x | x | false | false |

Given that `num_traits::Signed` confuses between `is_positive` and `is_sign_positive`. We removed its usage.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Support PostgreSQL expression `sign` for `decimal` and `double precision`.