### PR TITLE
fix(streaming): fail the sender of permit channel on receiver closed

### DIFF
--- a/src/stream/src/executor/exchange/permit.rs
+++ b/src/stream/src/executor/exchange/permit.rs
@@ -17,7 +17,7 @@
 use std::sync::Arc;
 
 use risingwave_pb::task_service::permits;
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{mpsc, AcquireError, Semaphore, SemaphorePermit};
 
 use crate::executor::Message;
 
@@ -87,6 +87,24 @@ impl Permits {
             permits::Value::Barrier(p) => self.barriers.add_permits(p as usize),
         }
     }
+
+    /// Acquire permits from the semaphores.
+    ///
+    /// This function is cancellation-safe except for the fairness of waking.
+    async fn acquire_permits(&self, permits: &permits::Value) -> Result<(), AcquireError> {
+        match permits {
+            permits::Value::Record(p) => self.records.acquire_many(*p as _),
+            permits::Value::Barrier(p) => self.barriers.acquire_many(*p as _),
+        }
+        .await
+        .map(SemaphorePermit::forget)
+    }
+
+    /// Close the semaphores so that all pending `acquire` will fail immediately.
+    fn close(&self) {
+        self.records.close();
+        self.barriers.close();
+    }
 }
 
 /// The sender of the exchange service with permit-based back-pressure.
@@ -112,20 +130,17 @@ impl Sender {
                 if card == self.max_chunk_permits {
                     tracing::warn!(cardinality = c.cardinality(), "large chunk in exchange")
                 }
-                self.permits
-                    .records
-                    .acquire_many(card as _)
-                    .await
-                    .unwrap()
-                    .forget();
                 Some(permits::Value::Record(card as _))
             }
-            Message::Barrier(_) => {
-                self.permits.barriers.acquire().await.unwrap().forget();
-                Some(permits::Value::Barrier(1))
-            }
+            Message::Barrier(_) => Some(permits::Value::Barrier(1)),
             Message::Watermark(_) => None,
         };
+
+        if let Some(permits) = &permits {
+            if self.permits.acquire_permits(permits).await.is_err() {
+                return Err(mpsc::error::SendError(message));
+            }
+        }
 
         self.tx
             .send(MessageWithPermits { message, permits })
@@ -180,5 +195,42 @@ impl Receiver {
     /// Get a reference to the inner [`Permits`] to manually add permits.
     pub fn permits(&self) -> Arc<Permits> {
         self.permits.clone()
+    }
+}
+
+impl Drop for Receiver {
+    fn drop(&mut self) {
+        // Close the `permits` semaphores so that all pending `acquire` on the sender side will fail
+        // immediately.
+        self.permits.close();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::assert_matches::assert_matches;
+    use std::pin::pin;
+
+    use futures::FutureExt;
+
+    use super::*;
+    use crate::executor::Barrier;
+
+    #[test]
+    fn test_channel_close() {
+        let (tx, rx) = channel(0, 0, 1);
+
+        let send = || {
+            tx.send(Message::Barrier(Barrier::with_prev_epoch_for_test(
+                514, 114,
+            )))
+        };
+
+        assert_matches!(send().now_or_never(), Some(Ok(_))); // send successfully
+
+        let mut send_fut = pin!(send());
+        assert_matches!((&mut send_fut).now_or_never(), None); // would block due to no permits
+        drop(rx);
+        assert_matches!(send_fut.now_or_never(), Some(Err(_))); // channel closed
     }
 }

--- a/src/stream/src/executor/exchange/permit.rs
+++ b/src/stream/src/executor/exchange/permit.rs
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_channel_close() {
-        let (tx, rx) = channel(0, 0, 1);
+        let (tx, mut rx) = channel(0, 0, 1);
 
         let send = || {
             tx.send(Message::Barrier(Barrier::with_prev_epoch_for_test(
@@ -227,6 +227,10 @@ mod tests {
         };
 
         assert_matches!(send().now_or_never(), Some(Ok(_))); // send successfully
+        assert_matches!(rx.recv().now_or_never(), Some(Some(Message::Barrier(_)))); // recv successfully
+
+        assert_matches!(send().now_or_never(), Some(Ok(_))); // send successfully
+                                                             // do not recv, so that the channel is full
 
         let mut send_fut = pin!(send());
         assert_matches!((&mut send_fut).now_or_never(), None); // would block due to no permits

--- a/src/stream/src/lib.rs
+++ b/src/stream/src/lib.rs
@@ -44,6 +44,7 @@
 #![feature(test)]
 #![feature(is_sorted)]
 #![feature(btree_cursors)]
+#![feature(assert_matches)]
 
 #[macro_use]
 extern crate tracing;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously, if the sender is blocking on acquiring the permits, it won't get notified about the closing of the (inner unbounded) channel immediately. This may break the assumption that the error of actor exiting should be naturally propagated to its downstream and upstream.

In this PR, we close the permit semaphores on the drop of the receiver to resolve this problem.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
