### PR TITLE
fix(compaction): avoid compaction task use too much memory

### DIFF
--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -24,6 +24,8 @@ use super::{CompactionInput, CompactionPicker, LocalPickerStatistic};
 use crate::hummock::compaction::overlap_strategy::OverlapStrategy;
 use crate::hummock::level_handler::LevelHandler;
 
+const MAX_LEVEL_COUNT: usize = 32;
+
 pub struct MinOverlappingPicker {
     level: usize,
     target_level: usize,
@@ -207,7 +209,14 @@ impl NonOverlapSubLevelPicker {
 
             if ret.total_file_size >= self.max_compaction_bytes
                 || ret.total_file_count >= self.max_file_count as usize
+                || ret
+                    .sstable_infos
+                    .iter()
+                    .filter(|ssts| !ssts.is_empty())
+                    .count()
+                    > MAX_LEVEL_COUNT
             {
+                // Too many sub-level will use more memory for merging-iterator.
                 break;
             }
 

--- a/src/storage/hummock_test/src/compactor_tests.rs
+++ b/src/storage/hummock_test/src/compactor_tests.rs
@@ -39,7 +39,7 @@ pub(crate) mod tests {
     use risingwave_meta::hummock::{HummockManagerRef, MockHummockMetaClient};
     use risingwave_meta::storage::MetaStore;
     use risingwave_pb::common::{HostAddress, WorkerType};
-    use risingwave_pb::hummock::{HummockVersion, TableOption};
+    use risingwave_pb::hummock::{HummockVersion, InputLevel, TableOption};
     use risingwave_pb::meta::add_worker_node_request::Property;
     use risingwave_rpc_client::HummockMetaClient;
     use risingwave_storage::filter_key_extractor::{
@@ -203,7 +203,6 @@ pub(crate) mod tests {
         let config = CompactionConfigBuilder::new()
             .level0_tier_compact_file_number(1)
             .level0_max_compact_file_number(130)
-            .level0_sub_level_compact_level_count(124)
             .level0_overlapping_sub_level_compact_level_count(1)
             .build();
         let (env, hummock_manager_ref, _cluster_manager_ref, worker_node) =
@@ -243,12 +242,14 @@ pub(crate) mod tests {
             .await
             .unwrap();
         let key = key.freeze();
+        const SST_COUNT: u64 = 32;
+        const TEST_WATERMARK: u64 = 8;
         prepare_test_put_data(
             &storage,
             &hummock_meta_client,
             &key,
             1 << 10,
-            (1..129).map(|v| (v * 1000) << 16).collect_vec(),
+            (1..SST_COUNT + 1).map(|v| (v * 1000) << 16).collect_vec(),
         )
         .await;
         // 2. get compact task
@@ -261,7 +262,7 @@ pub(crate) mod tests {
             .unwrap()
             .unwrap();
         let compaction_filter_flag = CompactionFilterFlag::TTL;
-        compact_task.watermark = (32 * 1000) << 16;
+        compact_task.watermark = (TEST_WATERMARK * 1000) << 16;
         compact_task.compaction_filter_mask = compaction_filter_flag.bits();
         compact_task.table_options = HashMap::from([(
             0,
@@ -281,9 +282,25 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(compactor.context_id(), worker_node.id);
+        let version = hummock_manager_ref.get_current_version().await;
+        let group =
+            version.get_compaction_group_levels(StaticCompactionGroupId::StateDefault.into());
+
+        compact_task.input_ssts = group
+            .l0
+            .as_ref()
+            .unwrap()
+            .sub_levels
+            .iter()
+            .map(|level| InputLevel {
+                level_idx: 0,
+                level_type: level.level_type,
+                table_infos: level.table_infos.clone(),
+            })
+            .collect();
 
         // assert compact_task
-        assert_eq!(compact_task.input_ssts.len(), 128);
+        assert_eq!(compact_task.input_ssts.len(), SST_COUNT as usize);
 
         // 3. compact
         let (_tx, rx) = tokio::sync::oneshot::channel();
@@ -310,8 +327,11 @@ pub(crate) mod tests {
             .unwrap();
 
         // we have removed these 31 keys before watermark 32.
-        assert_eq!(table.value().meta.key_count, 96);
-        let read_epoch = (32 * 1000) << 16;
+        assert_eq!(
+            table.value().meta.key_count,
+            (SST_COUNT - TEST_WATERMARK + 1) as u32
+        );
+        let read_epoch = (TEST_WATERMARK * 1000) << 16;
 
         let get_ret = storage
             .get(
@@ -335,7 +355,7 @@ pub(crate) mod tests {
         let ret = storage
             .get(
                 key.clone(),
-                (31 * 1000) << 16,
+                ((TEST_WATERMARK - 1) * 1000) << 16,
                 ReadOptions {
                     ignore_range_tombstone: false,
                     prefix_hint: Some(key.clone()),
@@ -377,15 +397,16 @@ pub(crate) mod tests {
         key.put_u16(0);
         key.put_slice(b"same_key");
         let key = key.freeze();
+        const SST_COUNT: u64 = 16;
 
         let mut val = b"0"[..].repeat(1 << 20);
-        val.extend_from_slice(&128u64.to_be_bytes());
+        val.extend_from_slice(&SST_COUNT.to_be_bytes());
         prepare_test_put_data(
             &storage,
             &hummock_meta_client,
             &key,
             1 << 20,
-            (1..129).collect_vec(),
+            (1..SST_COUNT + 1).collect_vec(),
         )
         .await;
 
@@ -418,7 +439,7 @@ pub(crate) mod tests {
                 .iter()
                 .map(|level| level.table_infos.len())
                 .sum::<usize>(),
-            65
+            SST_COUNT as usize / 2 + 1,
         );
         compact_task.target_level = 6;
 
@@ -455,7 +476,7 @@ pub(crate) mod tests {
         let get_val = storage
             .get(
                 key.clone(),
-                129,
+                SST_COUNT + 1,
                 ReadOptions {
                     ignore_range_tombstone: false,
                     prefix_hint: None,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The compact task will create iter for every sub-level in time. So we shall not select too much sub-level

## Checklist

- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [x] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
