### PR TITLE
feat(over window): support general streaming `row_number` window function

### DIFF
--- a/e2e_test/streaming/eowc/eowc_over_window.slt
+++ b/e2e_test/streaming/eowc/eowc_over_window.slt
@@ -37,6 +37,15 @@ select
 from t;
 
 statement ok
+create materialized view mv3
+emit on window close
+as
+select
+    *,
+    row_number() over (partition by bar order by tm) as rn
+from t;
+
+statement ok
 insert into t values
   ('2023-05-06 16:51:00', 1, 100)
 , ('2023-05-06 16:56:00', 8, 100)
@@ -57,6 +66,14 @@ query Tiiii
 select * from mv2 order by tm;
 ----
 
+query TiiI
+select * from mv3 order by tm;
+----
+2023-05-06 16:51:00  1  100  1
+2023-05-06 16:56:00  8  100  2
+2023-05-06 17:30:00  3  200  1
+2023-05-06 17:35:00  5  100  3
+
 statement ok
 insert into t values
   ('2023-05-06 18:10:00', 7, 100)
@@ -76,11 +93,24 @@ select * from mv2 order by tm;
 ----
 2023-05-06 16:51:00  1  100  8  4
 
+query TiiI
+select * from mv3 order by tm;
+----
+2023-05-06 16:51:00  1  100  1
+2023-05-06 16:56:00  8  100  2
+2023-05-06 17:30:00  3  200  1
+2023-05-06 17:35:00  5  100  3
+2023-05-06 17:59:00  4  100  4
+2023-05-06 18:01:00  6  200  2
+
 statement ok
 drop materialized view mv1;
 
 statement ok
 drop materialized view mv2;
+
+statement ok
+drop materialized view mv3;
 
 statement ok
 drop table t;

--- a/e2e_test/streaming/over_window/over_window/create.slt.part
+++ b/e2e_test/streaming/over_window/over_window/create.slt.part
@@ -38,6 +38,15 @@ select
     , lead(v2, 2) over (partition by p1, p2 order by v1, v2) as out9
 from t;
 
+# row_number
+statement ok
+create materialized view mv_d as
+select
+    *
+    , row_number() over (partition by p1 order by time, id) as out10
+    , row_number() over (partition by p1 order by p2 desc, id) as out11
+from t;
+
 statement ok
 create materialized view mv_a_b as
 select

--- a/e2e_test/streaming/over_window/over_window/drop.slt.part
+++ b/e2e_test/streaming/over_window/over_window/drop.slt.part
@@ -8,6 +8,9 @@ statement ok
 drop materialized view mv_c;
 
 statement ok
+drop materialized view mv_d;
+
+statement ok
 drop materialized view mv_a_b;
 
 statement ok

--- a/e2e_test/streaming/over_window/over_window/mod.slt.part
+++ b/e2e_test/streaming/over_window/over_window/mod.slt.part
@@ -31,6 +31,14 @@ select * from mv_c order by id;
 100003  100  208  2  723  807  723  NULL  NULL  NULL  NULL
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 
+query II
+select * from mv_d order by id;
+----
+100001  100  200  1  701  805  1  2
+100002  100  200  2  700  806  2  3
+100003  100  208  2  723  807  3  1
+100004  103  200  2  702  808  1  1
+
 include ./cross_check.slt.part
 
 statement ok
@@ -67,6 +75,16 @@ select * from mv_c order by id;
 100004  103  200  2  702  808  702  NULL  NULL  NULL  NULL
 100005  100  200  3  717  810  717   700   700  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query II
+select * from mv_d order by id;
+----
+100001  100  200  1  701  805  1  2
+100002  100  200  2  700  806  2  3
+100003  100  208  2  723  807  3  1
+100004  103  200  2  702  808  1  1
+100005  100  200  3  717  810  4  4
+100006  105  204  5  703  828  1  1
 
 include ./cross_check.slt.part
 
@@ -109,6 +127,16 @@ select * from mv_c order by id;
 100005  100  200  1  717  810  717   723   701   806   806
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
 
+query II
+select * from mv_d order by id;
+----
+100001  100  200  1  701  805  1  1
+100002  100  200  2  799  806  3  2
+100003  100  200  2  723  807  4  3
+100004  103  200  2  702  808  1  1
+100005  100  200  1  717  810  2  4
+100006  105  204  5  703  828  1  1
+
 include ./cross_check.slt.part
 
 statement ok
@@ -134,6 +162,13 @@ select * from mv_c order by id;
 100001  100  200  1  701  805  701  NULL  NULL   810  NULL
 100005  100  200  1  717  810  717   701   701  NULL  NULL
 100006  105  204  5  703  828  703  NULL  NULL  NULL  NULL
+
+query II
+select * from mv_d order by id;
+----
+100001  100  200  1  701  805  1  1
+100005  100  200  1  717  810  2  2
+100006  105  204  5  703  828  1  1
 
 include ./cross_check.slt.part
 

--- a/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/over_window_function.yaml
@@ -188,6 +188,14 @@
     - logical_plan
     - stream_error
     - batch_error
+- id: row_number with valid over clause
+  sql: |
+    create table t(x int, y int);
+    select row_number() over (PARTITION BY x ORDER BY y) from t;
+  expected_outputs:
+    - logical_plan
+    - stream_plan
+    - batch_error
 
 # TopN pattern
 - id: TopN by row_number with rank output
@@ -198,7 +206,7 @@
     where rank < 3;
   expected_outputs:
     - logical_plan
-    - stream_error
+    - stream_plan
     - batch_error
 - id: TopN by row_number without rank output, 1
   sql: |
@@ -316,7 +324,7 @@
   # TODO(rc): seems this can be optimized
   expected_outputs:
     - logical_plan
-    - stream_error
+    - stream_plan
     - batch_error
 # <<< TopN by row_number, with offset
 - id: Deduplication (Top1) by row_number

--- a/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/over_window_function.yaml
@@ -351,8 +351,26 @@
     Feature is not yet implemented: Batch over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
   stream_error: |-
-    Feature is not yet implemented: Rank function calls that don't match TopN pattern are not supported yet
+    Feature is not yet implemented: `rank` and `dense_rank` function calls that don't match TopN pattern are not supported yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/8965
+- id: row_number with valid over clause
+  sql: |
+    create table t(x int, y int);
+    select row_number() over (PARTITION BY x ORDER BY y) from t;
+  logical_plan: |-
+    LogicalProject { exprs: [row_number] }
+    └─LogicalOverWindow { window_functions: [row_number() OVER(PARTITION BY t.x ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
+      └─LogicalProject { exprs: [t.x, t.y, t._row_id] }
+        └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [row_number, t._row_id(hidden), t.x(hidden)], stream_key: [t._row_id, t.x], pk_columns: [t._row_id, t.x], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [row_number, t._row_id, t.x] }
+      └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.x ORDER BY t.y ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
+        └─StreamExchange { dist: HashShard(t.x) }
+          └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+  batch_error: |-
+    Feature is not yet implemented: Batch over window is not implemented yet
+    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
 - id: TopN by row_number with rank output
   sql: |
     create table t(x int);
@@ -366,12 +384,15 @@
         └─LogicalOverWindow { window_functions: [row_number() OVER(PARTITION BY t.x ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
           └─LogicalProject { exprs: [t.x, t._row_id] }
             └─LogicalScan { table: t, columns: [t.x, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, t._row_id(hidden), rank], stream_key: [t._row_id, x], pk_columns: [t._row_id, x], pk_conflict: NoCheck }
+    └─StreamFilter { predicate: (row_number < 3:Int32) }
+      └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.x ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
+        └─StreamExchange { dist: HashShard(t.x) }
+          └─StreamTableScan { table: t, columns: [t.x, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   batch_error: |-
     Feature is not yet implemented: Batch over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
-  stream_error: |-
-    Feature is not yet implemented: Rank function calls that don't match TopN pattern are not supported yet
-    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/8965
 - id: TopN by row_number without rank output, 1
   sql: |
     create table t(x int, y int);
@@ -473,7 +494,7 @@
     Feature is not yet implemented: Batch over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
   stream_error: |-
-    Feature is not yet implemented: Rank function calls that don't match TopN pattern are not supported yet
+    Feature is not yet implemented: `rank` and `dense_rank` function calls that don't match TopN pattern are not supported yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/8965
 - sql: |
     create table t(x int, y int);
@@ -559,12 +580,16 @@
         └─LogicalOverWindow { window_functions: [row_number() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
           └─LogicalProject { exprs: [t.x, t.y, t._row_id] }
             └─LogicalScan { table: t, columns: [t.x, t.y, t._row_id] }
+  stream_plan: |-
+    StreamMaterialize { columns: [x, y, t._row_id(hidden)], stream_key: [t._row_id, y], pk_columns: [t._row_id, y], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.x, t.y, t._row_id] }
+      └─StreamFilter { predicate: (3:Int32 < row_number) AND (row_number = 6:Int32) AND (row_number <= 5:Int32) }
+        └─StreamOverWindow { window_functions: [row_number() OVER(PARTITION BY t.y ORDER BY t.x ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)] }
+          └─StreamExchange { dist: HashShard(t.y) }
+            └─StreamTableScan { table: t, columns: [t.x, t.y, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
   batch_error: |-
     Feature is not yet implemented: Batch over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
-  stream_error: |-
-    Feature is not yet implemented: Rank function calls that don't match TopN pattern are not supported yet
-    Tracking issue: https://github.com/risingwavelabs/risingwave/issues/8965
 - id: Deduplication (Top1) by row_number
   sql: |
     create table t(x int, y int);
@@ -821,5 +846,5 @@
     Feature is not yet implemented: Batch over window is not implemented yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/9124
   stream_error: |-
-    Feature is not yet implemented: Rank function calls that don't match TopN pattern are not supported yet
+    Feature is not yet implemented: `rank` and `dense_rank` function calls that don't match TopN pattern are not supported yet
     Tracking issue: https://github.com/risingwavelabs/risingwave/issues/8965

--- a/src/frontend/src/optimizer/plan_node/generic/over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/generic/over_window.rs
@@ -160,10 +160,6 @@ impl<PlanRef: GenericPlanRef> OverWindow<PlanRef> {
             .map(|f| (&f.partition_by, &f.order_by))
             .all_equal()
     }
-
-    pub fn has_rank_function(&self) -> bool {
-        self.window_functions.iter().any(|f| f.kind.is_rank())
-    }
 }
 
 impl<PlanRef: GenericPlanRef> DistillUnit for OverWindow<PlanRef> {

--- a/src/frontend/src/optimizer/plan_node/logical_over_window.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_over_window.rs
@@ -668,9 +668,13 @@ impl ToBatch for LogicalOverWindow {
 
 impl ToStream for LogicalOverWindow {
     fn to_stream(&self, ctx: &mut ToStreamContext) -> Result<PlanRef> {
-        if self.core.has_rank_function() {
+        if self
+            .window_functions()
+            .iter()
+            .any(|x| matches!(x.kind, WindowFuncKind::Rank | WindowFuncKind::DenseRank))
+        {
             return Err(ErrorCode::NotImplemented(
-                "Rank function calls that don't match TopN pattern are not supported yet"
+                "`rank` and `dense_rank` function calls that don't match TopN pattern are not supported yet"
                     .to_string(),
                 8965.into(),
             )

--- a/src/stream/src/executor/over_window/state/mod.rs
+++ b/src/stream/src/executor/over_window/state/mod.rs
@@ -27,6 +27,7 @@ use crate::executor::{StreamExecutorError, StreamExecutorResult};
 mod buffer;
 
 mod aggregate;
+mod row_number;
 
 /// Unique and ordered identifier for a row in internal states.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, EstimateSize)]
@@ -114,7 +115,8 @@ pub(super) fn create_window_state(
 
     use WindowFuncKind::*;
     Ok(match call.kind {
-        RowNumber | Rank | DenseRank => {
+        RowNumber => Box::new(row_number::RowNumberState::new(call)),
+        Rank | DenseRank => {
             return Err(StreamExecutorError::not_implemented(
                 format!(
                     "window function `{}` is only supported by converting to TopN",

--- a/src/stream/src/executor/over_window/state/row_number.rs
+++ b/src/stream/src/executor/over_window/state/row_number.rs
@@ -55,9 +55,9 @@ impl WindowState for RowNumberState {
 
     fn curr_output(&self) -> StreamExecutorResult<Datum> {
         if self.curr_window().is_ready {
-            return Ok(Some(self.curr_row_number.into()));
+            Ok(Some(self.curr_row_number.into()))
         } else {
-            return Ok(None);
+            Ok(None)
         }
     }
 

--- a/src/stream/src/executor/over_window/state/row_number.rs
+++ b/src/stream/src/executor/over_window/state/row_number.rs
@@ -1,0 +1,71 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use risingwave_common::estimate_size::EstimateSize;
+use risingwave_common::types::Datum;
+use risingwave_expr::function::window::WindowFuncCall;
+use smallvec::SmallVec;
+
+use super::{EstimatedVecDeque, StateEvictHint, StateKey, StatePos, WindowState};
+use crate::executor::StreamExecutorResult;
+
+#[derive(EstimateSize)]
+pub(super) struct RowNumberState {
+    first_key: Option<StateKey>,
+    buffer: EstimatedVecDeque<StateKey>,
+    curr_row_number: i64,
+}
+
+impl RowNumberState {
+    pub fn new(_call: &WindowFuncCall) -> Self {
+        Self {
+            first_key: None,
+            buffer: Default::default(),
+            curr_row_number: 1,
+        }
+    }
+}
+
+impl WindowState for RowNumberState {
+    fn append(&mut self, key: StateKey, _args: SmallVec<[Datum; 2]>) {
+        if self.first_key.is_none() {
+            self.first_key = Some(key.clone());
+        }
+        self.buffer.push_back(key);
+    }
+
+    fn curr_window(&self) -> StatePos<'_> {
+        let curr_key = self.buffer.front();
+        StatePos {
+            key: curr_key,
+            is_ready: curr_key.is_some(),
+        }
+    }
+
+    fn curr_output(&self) -> StreamExecutorResult<Datum> {
+        Ok(Some(self.curr_row_number.into()))
+    }
+
+    fn slide_forward(&mut self) -> StateEvictHint {
+        self.curr_row_number += 1;
+        self.buffer
+            .pop_front()
+            .expect("should not slide forward when the current window is not ready");
+        StateEvictHint::CannotEvict(
+            self.first_key
+                .clone()
+                .expect("should have appended some rows"),
+        )
+    }
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Support general `row_number` window function that doesn't match TopN pattern

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- ~~[ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).~~
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- ~~[ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)~~
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- ~~[ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details]~~(https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators

### Release note

- Support `row_number` window function that doesn't match TopN pattern 

</details>
