### PR TITLE
fix(meta): refine ddl progress based on consumed row

### DIFF
--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -126,7 +126,6 @@ impl Progress {
 
     /// `progress` = `consumed_rows` / `upstream_total_key_count`
     fn calculate_progress(&self) -> f64 {
-        println!("{:?}", self);
         if self.is_done() || self.states.is_empty() {
             return 1.0;
         }

--- a/src/meta/src/barrier/progress.rs
+++ b/src/meta/src/barrier/progress.rs
@@ -55,6 +55,9 @@ struct Progress {
     /// Upstream mvs total key count.
     upstream_total_key_count: u64,
 
+    /// Consumed rows
+    consumed_rows: u64,
+
     /// DDL definition
     definition: String,
 }
@@ -80,6 +83,7 @@ impl Progress {
             creating_mv_id,
             upstream_mv_count,
             upstream_total_key_count,
+            consumed_rows: 0,
             definition,
         }
     }
@@ -87,15 +91,25 @@ impl Progress {
     /// Update the progress of `actor`.
     fn update(&mut self, actor: ActorId, new_state: ChainState, upstream_total_key_count: u64) {
         self.upstream_total_key_count = upstream_total_key_count;
-        match self.states.get_mut(&actor).unwrap() {
-            state @ (ChainState::Init | ChainState::ConsumingUpstream(_, _)) => {
-                if matches!(new_state, ChainState::Done) {
-                    self.done_count += 1;
+        match self.states.remove(&actor).unwrap() {
+            ChainState::Init => {}
+            ChainState::ConsumingUpstream(_, old_consumed_rows) => {
+                if !matches!(new_state, ChainState::Done) {
+                    self.consumed_rows -= old_consumed_rows;
                 }
-                *state = new_state;
             }
             ChainState::Done => panic!("should not report done multiple times"),
-        }
+        };
+        match &new_state {
+            ChainState::Init => {}
+            ChainState::ConsumingUpstream(_, new_consumed_rows) => {
+                self.consumed_rows += new_consumed_rows;
+            }
+            ChainState::Done => {
+                self.done_count += 1;
+            }
+        };
+        self.states.insert(actor, new_state);
         self.calculate_progress();
     }
 
@@ -110,26 +124,17 @@ impl Progress {
         self.states.keys().cloned()
     }
 
-    /// `progress` = `done_ratio` + (1 - `done_ratio`) * (`consumed_rows` / `remaining_rows`).
+    /// `progress` = `consumed_rows` / `upstream_total_key_count`
     fn calculate_progress(&self) -> f64 {
+        println!("{:?}", self);
         if self.is_done() || self.states.is_empty() {
             return 1.0;
         }
-        let done_ratio: f64 = (self.done_count) as f64 / self.states.len() as f64;
-        let mut remaining_rows = self.upstream_total_key_count as f64 * (1_f64 - done_ratio);
-        if remaining_rows == 0.0 {
-            remaining_rows = 1.0;
+        let mut upstream_total_key_count = self.upstream_total_key_count as f64;
+        if upstream_total_key_count == 0.0 {
+            upstream_total_key_count = 1.0
         }
-        let consumed_rows: u64 = self
-            .states
-            .values()
-            .map(|x| match x {
-                ChainState::ConsumingUpstream(_, rows) => *rows,
-                _ => 0,
-            })
-            .sum();
-        let mut progress =
-            done_ratio + (1_f64 - done_ratio) * consumed_rows as f64 / remaining_rows;
+        let mut progress = self.consumed_rows as f64 / upstream_total_key_count;
         if progress >= 1.0 {
             progress = 0.99;
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Recently, we used `rw_ddl_progress` to track the mview creation progress in customers' environment and found that it could be inaccurate in some cases. For example, when the mview contains a lot of joins and most of the tables are small tables and one or two tables are large tables, our `progress` will show `99%` all the time, because we assume each backfill actor has the same data volume, but that is not true. Therefore, we should calculate progress by `consumed_rows` / `upstream_total_key_count`. 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
