### PR TITLE
feat: dump etcd meta store in risectl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6038,6 +6038,7 @@ dependencies = [
  "futures",
  "inquire",
  "itertools",
+ "madsim-etcd-client",
  "madsim-tokio",
  "regex",
  "risingwave_common",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6044,6 +6044,7 @@ dependencies = [
  "risingwave_connector",
  "risingwave_frontend",
  "risingwave_hummock_sdk",
+ "risingwave_meta",
  "risingwave_object_store",
  "risingwave_pb",
  "risingwave_rpc_client",

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -27,6 +27,7 @@ risingwave_common = { path = "../common" }
 risingwave_connector = { path = "../connector" }
 risingwave_frontend = { path = "../frontend" }
 risingwave_hummock_sdk = { path = "../storage/hummock_sdk" }
+risingwave_meta = { path = "../meta" }
 risingwave_object_store = { path = "../object_store" }
 risingwave_pb = { path = "../prost" }
 risingwave_rpc_client = { path = "../rpc_client" }

--- a/src/ctl/Cargo.toml
+++ b/src/ctl/Cargo.toml
@@ -19,6 +19,7 @@ bytes = "1"
 chrono = "0.4"
 clap = { version = "4", features = ["derive"] }
 comfy-table = "6"
+etcd-client = { version = "0.2", package = "madsim-etcd-client" }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 inquire = "0.6.2"
 itertools = "0.10"

--- a/src/ctl/src/cmd_impl.rs
+++ b/src/ctl/src/cmd_impl.rs
@@ -14,10 +14,10 @@
 
 pub mod bench;
 pub mod compute;
+pub mod debug;
 pub mod hummock;
 pub mod meta;
 pub mod profile;
 pub mod scale;
 pub mod table;
 pub mod trace;
-pub mod debug;

--- a/src/ctl/src/cmd_impl/debug.rs
+++ b/src/ctl/src/cmd_impl/debug.rs
@@ -12,12 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-pub mod bench;
-pub mod compute;
-pub mod hummock;
-pub mod meta;
-pub mod profile;
-pub mod scale;
-pub mod table;
-pub mod trace;
-pub mod debug;
+mod meta_store;
+
+pub use meta_store::*;

--- a/src/ctl/src/cmd_impl/debug/meta_store.rs
+++ b/src/ctl/src/cmd_impl/debug/meta_store.rs
@@ -12,47 +12,63 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 
-use itertools::Itertools;
-use risingwave_meta::model::{MetadataModel, Worker};
+use risingwave_meta::model::{MetadataModel, TableFragments, Worker};
 use risingwave_meta::storage::meta_store::MetaStore;
-use risingwave_meta::storage::{EtcdMetaStore, WrappedEtcdClient};
+use risingwave_meta::storage::{EtcdMetaStore, Snapshot, WrappedEtcdClient};
+use risingwave_pb::user::UserInfo;
+use serde_yaml::Value;
 
 use crate::{DebugCommon, DebugCommonKind};
 
-async fn list<T, S>(client: &S) -> anyhow::Result<Vec<T>>
-where
-    T: MetadataModel + Send,
-    S: MetaStore,
-{
-    let result = T::list(client).await?;
-    Ok(result)
+macro_rules! fetch_items {
+    ($t:ty, $kind:expr, $snapshot:expr) => {{
+        let result = <$t>::list_at_snapshot::<EtcdMetaStore>($snapshot).await?;
+        result.into_iter().map(|item| {
+            let mut mapping = serde_yaml::Mapping::new();
+
+            mapping.insert(
+                Value::String("kind".to_string()),
+                Value::String($kind.to_string()),
+            );
+
+            let value = serde_yaml::to_value(item.to_protobuf()).unwrap();
+
+            mapping.insert(Value::String("item".to_string()), value);
+
+            Value::Mapping(mapping)
+        })
+    }};
 }
 
 pub async fn dump(common: DebugCommon) -> anyhow::Result<()> {
-    println!("common {:#?}", common);
-
     let DebugCommon {
         etcd_endpoints,
-        mut kinds,
+        kinds,
         ..
     } = common;
-
-    kinds.dedup();
 
     let client = WrappedEtcdClient::connect(etcd_endpoints, None, false).await?;
     let meta_store = Arc::new(EtcdMetaStore::new(client));
     let snapshot = meta_store.snapshot().await;
+    let kinds: BTreeSet<_> = kinds.into_iter().collect();
+
+    let mut total = serde_yaml::Sequence::new();
 
     for kind in kinds {
         match kind {
-            DebugCommonKind::All => {}
-            DebugCommonKind::Worker => {}
-            DebugCommonKind::User => {}
-            DebugCommonKind::Table => {}
-        }
+            DebugCommonKind::Worker => total.extend(fetch_items!(Worker, "worker", &snapshot)),
+            DebugCommonKind::User => total.extend(fetch_items!(UserInfo, "user", &snapshot)),
+            DebugCommonKind::Table => {
+                total.extend(fetch_items!(TableFragments, "table", &snapshot))
+            }
+        };
     }
+
+    serde_yaml::to_writer(std::io::stdout(), &total).unwrap();
 
     Ok(())
 }
+

--- a/src/ctl/src/cmd_impl/debug/meta_store.rs
+++ b/src/ctl/src/cmd_impl/debug/meta_store.rs
@@ -1,0 +1,46 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::Deref;
+use std::sync::Arc;
+
+use risingwave_meta::model::{MetadataModel, TableFragments, Worker};
+use risingwave_meta::storage::meta_store::MetaStore;
+use risingwave_meta::storage::{EtcdMetaStore, WrappedEtcdClient};
+use risingwave_pb::common::WorkerNode;
+
+use crate::common::CtlContext;
+
+pub async fn dump(endpoints: Vec<String>) -> anyhow::Result<()> {
+    let client = WrappedEtcdClient::connect(endpoints, None, false).await?;
+    let meta_store = Arc::new(EtcdMetaStore::new(client));
+    let workers = Worker::list(meta_store.clone().deref()).await?;
+
+    for worker in workers {
+        let s = serde_yaml::to_string(&worker.to_protobuf()).unwrap();
+        println!("{}", s);
+    }
+
+    let tables = TableFragments::list(meta_store.clone().deref()).await?;
+
+    for table in tables {
+        let s = serde_yaml::to_string(&table.to_protobuf()).unwrap();
+        println!("{}", s);
+    }
+
+
+
+
+    Ok(())
+}

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -77,7 +77,7 @@ enum Commands {
     },
 }
 
-#[derive(clap::ValueEnum, Clone, Debug, Eq, PartialEq)]
+#[derive(clap::ValueEnum, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
 enum DebugCommonKind {
     Worker,
     User,

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -86,23 +86,40 @@ enum DebugCommonKind {
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum DebugCommonOutputFormat {
+    Json,
     Yaml,
 }
 
 #[derive(clap::Args, Debug, Clone)]
 pub struct DebugCommon {
-    #[clap(long, required = true, value_delimiter = ',')]
+    /// The address of the etcd cluster
+    #[clap(long, value_delimiter = ',', default_value = "localhost:2388")]
     etcd_endpoints: Vec<String>,
 
+    /// The username for etcd authentication, used if `--enable-etcd-auth` is set
+    #[clap(long)]
+    etcd_username: Option<String>,
+
+    /// The password for etcd authentication, used if `--enable-etcd-auth` is set
+    #[clap(long)]
+    etcd_password: Option<String>,
+
+    /// Whether to enable etcd authentication
+    #[clap(long, default_value_t = false, requires_all = &["etcd_username", "etcd_password"])]
+    enable_etcd_auth: bool,
+
+    /// Kinds of debug info to dump
     #[clap(value_enum, value_delimiter = ',')]
     kinds: Vec<DebugCommonKind>,
 
+    /// The output format
     #[clap(value_enum, long = "output", short = 'o', default_value_t = DebugCommonOutputFormat::Yaml)]
     format: DebugCommonOutputFormat,
 }
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum DebugCommands {
+    /// Dump debug info from the raw state store
     Dump {
         #[command(flatten)]
         common: DebugCommon,

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -79,7 +79,6 @@ enum Commands {
 
 #[derive(clap::ValueEnum, Clone, Debug, Eq, PartialEq)]
 enum DebugCommonKind {
-    All,
     Worker,
     User,
     Table,
@@ -87,9 +86,7 @@ enum DebugCommonKind {
 
 #[derive(clap::ValueEnum, Clone, Debug)]
 enum DebugCommonOutputFormat {
-    Json,
     Yaml,
-    Wide,
 }
 
 #[derive(clap::Args, Debug, Clone)]
@@ -97,24 +94,16 @@ pub struct DebugCommon {
     #[clap(long, required = true, value_delimiter = ',')]
     etcd_endpoints: Vec<String>,
 
-    #[clap(value_enum, long, short, value_delimiter = ',')]
+    #[clap(value_enum, value_delimiter = ',')]
     kinds: Vec<DebugCommonKind>,
 
-    #[clap(value_enum, long, default_value_t = DebugCommonOutputFormat::Yaml)]
+    #[clap(value_enum, long = "output", short = 'o', default_value_t = DebugCommonOutputFormat::Yaml)]
     format: DebugCommonOutputFormat,
 }
 
 #[derive(Subcommand, Clone, Debug)]
 pub enum DebugCommands {
     Dump {
-        #[command(flatten)]
-        common: DebugCommon,
-    },
-    Edit {
-        #[command(flatten)]
-        common: DebugCommon,
-    },
-    Apply {
         #[command(flatten)]
         common: DebugCommon,
     },
@@ -556,8 +545,6 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
                 .await?
         }
         Commands::Debug(DebugCommands::Dump { common }) => cmd_impl::debug::dump(common).await?,
-        Commands::Debug(DebugCommands::Edit { .. }) => {}
-        Commands::Debug(DebugCommands::Apply { .. }) => {}
     }
     Ok(())
 }

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -43,7 +43,7 @@ mod dashboard;
 mod error;
 pub mod hummock;
 pub mod manager;
-mod model;
+pub mod model;
 mod rpc;
 pub(crate) mod serving;
 pub mod storage;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

A simple utility tool that can dump the current stored meta information from etcd, including worker, table, user, using the 
```
risectl debug dump --etcd-endpoints "localhost:2388" user

- kind: user
  item:
    id: 1
    name: root
    isSuper: true
    canCreateDb: true
    canCreateUser: true
    canLogin: true
- kind: user
  item:
    id: 2
    name: postgres
    isSuper: true
    canCreateDb: true
    canCreateUser: true
    canLogin: true

risectl debug dump --etcd-endpoints "localhost:2388" user -o json

[
  {
    "item": {
      "canCreateDb": true,
      "canCreateUser": true,
      "canLogin": true,
      "id": 1,
      "isSuper": true,
      "name": "root"
    },
    "kind": "user"
  },
  {
    "item": {
      "canCreateDb": true,
      "canCreateUser": true,
      "canLogin": true,
      "id": 2,
      "isSuper": true,
      "name": "postgres"
    },
    "kind": "user"
  }
]

```

command

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
