### PR TITLE
fix: return early in UserIterator::next() if key is already out of range

### DIFF
--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -255,8 +255,7 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
         self.iterator.collect_local_statistic(stats);
     }
 
-    // Validate whether the current key is already out of range and set `out_of_range`.
-    // Return true if `out_of_range` is set to true.
+    // Validate whether the current key is already out of range.
     fn key_out_of_range(&self) -> bool {
         assert!(self.iterator.is_valid());
         let current_user_key = self.iterator.key().user_key;

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -115,7 +115,7 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
                         };
 
                         // It is better to early return here if the user key is already
-                        // out of range to avoid unneccessary access on the range tomestones
+                        // out of range to avoid unnecessary access on the range tomestones
                         // via `delete_range_iter`.
                         // For example, if we are iterating with key range [0x0a, 0x0c) and the
                         // current key is 0xff, we will access range tombstones in [0x0c, 0xff],

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -99,32 +99,21 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
             }
 
             if self.last_key.user_key.as_ref() != full_key.user_key {
+                // It is better to early return here if the user key is already
+                // out of range to avoid unnecessary access on the range tomestones
+                // via `delete_range_iter`.
+                // For example, if we are iterating with key range [0x0a, 0x0c) and the
+                // current key is 0xff, we will access range tombstones in [0x0c, 0xff],
+                // which is a waste of work.
+                if self.key_out_of_range() {
+                    self.out_of_range = true;
+                    return Ok(());
+                }
+
                 self.last_key = full_key.copy_into();
                 // handle delete operation
                 match self.iterator.value() {
                     HummockValue::Put(val) => {
-                        // handle range scan
-                        match &self.key_range.1 {
-                            Included(end_key) => {
-                                self.out_of_range = full_key.user_key > end_key.as_ref();
-                            }
-                            Excluded(end_key) => {
-                                self.out_of_range = full_key.user_key >= end_key.as_ref();
-                            }
-                            Unbounded => {}
-                        };
-
-                        // It is better to early return here if the user key is already
-                        // out of range to avoid unnecessary access on the range tomestones
-                        // via `delete_range_iter`.
-                        // For example, if we are iterating with key range [0x0a, 0x0c) and the
-                        // current key is 0xff, we will access range tombstones in [0x0c, 0xff],
-                        // which is a waste of work.
-                        if self.out_of_range {
-                            self.stats.processed_key_count += 1;
-                            return Ok(());
-                        }
-
                         self.delete_range_iter.next_until(full_key.user_key).await?;
                         if self.delete_range_iter.current_epoch() >= epoch {
                             self.stats.skip_delete_key_count += 1;
@@ -173,6 +162,9 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
 
     /// Resets the iterating position to the beginning.
     pub async fn rewind(&mut self) -> HummockResult<()> {
+        // Reset
+        self.out_of_range = false;
+
         // Handle range scan
         match &self.key_range.0 {
             Included(begin_key) => {
@@ -181,11 +173,24 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
                     epoch: self.read_epoch,
                 };
                 self.iterator.seek(full_key.to_ref()).await?;
+                if !self.iterator.is_valid() {
+                    return Ok(());
+                }
+
+                if self.key_out_of_range() {
+                    self.out_of_range = true;
+                    return Ok(());
+                }
+
                 self.delete_range_iter.seek(begin_key.as_ref()).await?;
             }
             Excluded(_) => unimplemented!("excluded begin key is not supported"),
             Unbounded => {
                 self.iterator.rewind().await?;
+                if !self.iterator.is_valid() {
+                    return Ok(());
+                }
+
                 self.delete_range_iter.rewind().await?;
             }
         };
@@ -198,6 +203,9 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
 
     /// Resets the iterating position to the first position where the key >= provided key.
     pub async fn seek(&mut self, user_key: UserKey<&[u8]>) -> HummockResult<()> {
+        // Reset
+        self.out_of_range = false;
+
         // Handle range scan when key < begin_key
         let user_key = match &self.key_range.0 {
             Included(begin_key) => {
@@ -217,6 +225,15 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
             epoch: self.read_epoch,
         };
         self.iterator.seek(full_key).await?;
+        if !self.iterator.is_valid() {
+            return Ok(());
+        }
+
+        if self.key_out_of_range() {
+            self.out_of_range = true;
+            return Ok(());
+        }
+
         self.delete_range_iter.seek(full_key.user_key).await?;
 
         // Handle multi-version
@@ -236,6 +253,19 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
     pub fn collect_local_statistic(&self, stats: &mut StoreLocalStatistic) {
         stats.add(&self.stats);
         self.iterator.collect_local_statistic(stats);
+    }
+
+    // Validate whether the current key is already out of range and set `out_of_range`.
+    // Return true if `out_of_range` is set to true.
+    fn key_out_of_range(&self) -> bool {
+        assert!(self.iterator.is_valid());
+        let current_user_key = self.iterator.key().user_key;
+        // handle range scan
+        match &self.key_range.1 {
+            Included(end_key) => current_user_key > end_key.as_ref(),
+            Excluded(end_key) => current_user_key >= end_key.as_ref(),
+            Unbounded => false,
+        }
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR changes the logic in `UserIterator::next()` to return early if the key is already out of the provided key range. This can avoid unnecessary access on the range tombstones under some cases.

For exmaple, , if the key range of UserKeyIterator is `[0x0a, 0x0c)` and the current key is `0xff`, we will access range tombstones in `[0x0c, 0xff]` prior to this PR, which is a waste of work.


## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
