### PR TITLE
feat(streaming): add single-row cache for monotonically increasing dynamic filter

### DIFF
--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -19,13 +19,13 @@ use itertools::Itertools;
 use risingwave_pb::data::{PbOp, PbStreamChunk};
 
 use super::{ArrayImpl, ArrayRef, ArrayResult, DataChunkTestExt};
-use crate::array::{DataChunk, Vis};
+use crate::array::{DataChunk, RowRef, Vis};
 use crate::buffer::Bitmap;
 use crate::estimate_size::EstimateSize;
 use crate::field_generator::VarcharProperty;
 use crate::row::{OwnedRow, Row};
 use crate::types::{DataType, DefaultOrdered, ToText};
-use crate::util::iter_util::ZipEqFast;
+use crate::util::iter_util::{ZipEqDebug, ZipEqFast};
 
 /// `Op` represents three operations in `StreamChunk`.
 ///
@@ -275,6 +275,10 @@ impl StreamChunk {
                 data: self.data.reorder_columns(column_mapping),
             }
         }
+    }
+
+    pub fn iter_rows_and_ops(&self) -> impl Iterator<Item = (&Op, RowRef)> {
+        self.ops.iter().zip_eq_debug(self.data.rows())
     }
 }
 

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -276,10 +276,6 @@ impl StreamChunk {
             }
         }
     }
-
-    pub fn iter_rows_and_ops(&self) -> impl Iterator<Item = (&Op, RowRef)> {
-        self.ops.iter().zip_eq_debug(self.data.rows())
-    }
 }
 
 impl fmt::Debug for StreamChunk {

--- a/src/common/src/array/stream_chunk.rs
+++ b/src/common/src/array/stream_chunk.rs
@@ -19,13 +19,13 @@ use itertools::Itertools;
 use risingwave_pb::data::{PbOp, PbStreamChunk};
 
 use super::{ArrayImpl, ArrayRef, ArrayResult, DataChunkTestExt};
-use crate::array::{DataChunk, RowRef, Vis};
+use crate::array::{DataChunk, Vis};
 use crate::buffer::Bitmap;
 use crate::estimate_size::EstimateSize;
 use crate::field_generator::VarcharProperty;
 use crate::row::{OwnedRow, Row};
 use crate::types::{DataType, DefaultOrdered, ToText};
-use crate::util::iter_util::{ZipEqDebug, ZipEqFast};
+use crate::util::iter_util::ZipEqFast;
 
 /// `Op` represents three operations in `StreamChunk`.
 ///

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -44,6 +44,11 @@ use crate::common::StreamChunkBuilder;
 use crate::executor::expect_first_barrier_from_aligned_stream;
 
 /// # Monotonically Increasing Cache policy
+/// Requirements:
+/// 1. RHS must be monotonically increasing.
+/// 2. Comparator must be >. i.e. LHS > RHS. e.g. v1 > NOW().
+///
+/// TODO: Remove both restrictions in the future.
 ///
 /// ## Conventions
 /// LHS: Outer side of the join.
@@ -59,11 +64,6 @@ use crate::executor::expect_first_barrier_from_aligned_stream;
 /// B) Or if there LHS cache value is same or smaller than current RHS.
 ///    None are larger than LHS cache value and current RHS value.
 ///
-/// N.B. Largest could be minimal or maximal value,
-/// depending on the sign of the comparator (< / >),
-/// and could be inclusive or exclusive as well (<= / >=).
-///
-/// Assuming sign is '>'.
 /// If RHS 100,
 /// and LHS has the following values: 101, 102,
 /// Cached value will be 101.

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -52,8 +52,10 @@ use crate::executor::expect_first_barrier_from_aligned_stream;
 ///
 /// ## Description
 ///
-/// The cache holds a single value from the LHS, the largest value nearest to current RHS (largest first, then nearest).
-/// N.B. Largest could be minimal or maximal value, depending on the sign of the comparator, and could be inclusive or exclusive as well.
+/// The cache holds a single value from the LHS,
+/// the largest value nearest to current RHS (largest first, then nearest).
+/// N.B. Largest could be minimal or maximal value, depending on the sign of the comparator,
+/// and could be inclusive or exclusive as well.
 ///
 /// Assuming sign is '>'.
 /// If RHS 100,
@@ -68,24 +70,31 @@ use crate::executor::expect_first_barrier_from_aligned_stream;
 /// For monotonically increasing RHS (e.g. NOW()), current_RHS > old_RHS.
 /// The cache_value from LHS partitions the range.
 /// Case 1:
-/// cache_value larger than current_RHS. Need to send all rows between (old_RHS, current_RHS) downstream.
+/// cache_value larger than current_RHS.
+/// Need to send all rows between (old_RHS, current_RHS) downstream.
 /// Case 2:
-/// cache_value smaller or same as current_RHS, larger than prev_RHS. Need to send all rows between (prev_RHS, cache_value) downstream.
+/// cache_value smaller or same as current_RHS, larger than prev_RHS.
+/// Need to send all rows between (prev_RHS, cache_value) downstream.
 /// Case 3:
-/// cache_value smaller than prev_RHS. No need scan any rows, there are no LHS rows between (old_RHS, current_RHS).
+/// cache_value smaller than prev_RHS.
+/// No need scan any rows, there are no LHS rows between (old_RHS, current_RHS).
 /// Case 4:
-/// No cache_value. Need to send all rows between (old_RHS, current_RHS) downstream, cache value could have been deleted.
+/// No cache_value.
+/// Need to send all rows between (old_RHS, current_RHS) downstream,
+/// because cache value could have been deleted.
 ///
 /// ## Initial state
 /// Nothing in cache (None).
 ///
 /// ## Updates
-/// 1. Whenever we receive LHS updates, we need to update the cache. `old_value` refers to `old_value` in cache.
-///    `new_value` refers to the new value received from LHS in the update message.
-///    INSERT: if the new value is (RHS, old_value), replace `old_value` in cache. Otherwise, do nothing.
+/// 1. Whenever we receive LHS updates, we need to update the cache. `old_value` refers to
+/// `old_value` in cache.    `new_value` refers to the new value received from LHS in the update
+/// message.    INSERT: if the new value is (RHS, old_value), replace `old_value` in cache.
+///            Otherwise, do nothing.
 ///    UPDATE: if the new value is (RHS, old_value), OR if has same key as `old_value`,
-///            replace `old_value` in cache. Otherwise, do nothing.
-///    DELETE, if the new value has the same key as `old_value`, empty cache. It is now `None`.
+///            replace `old_value` in cache.
+///            Otherwise, do nothing.
+///    DELETE: if the new value has the same key as `old_value`, empty cache. It is now `None`.
 ///
 ///    Example A:
 ///    FILTER_COL: [1]
@@ -132,7 +141,6 @@ use crate::executor::expect_first_barrier_from_aligned_stream;
 ///    NEW_RHS_VALUE: Row(1, 4)
 ///    ---
 ///    Cache needs update. Largest LHS value that is nearest to RHS can now be Row(1, 5).
-///
 pub struct DynamicFilterExecutor<S: StateStore> {
     ctx: ActorContextRef,
     source_l: Option<BoxedExecutor>,

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -28,7 +28,7 @@ use risingwave_common::types::{
     DataType, Datum, DatumRef, DefaultOrd, ScalarImpl, ToDatumRef, ToOwnedDatum,
 };
 use risingwave_common::util::iter_util::ZipEqDebug;
-use risingwave_common::util::sort_util::{cmp_datum};
+use risingwave_common::util::sort_util::cmp_datum;
 use risingwave_expr::expr::{build_func, BoxedExpression, InputRefExpression, LiteralExpression};
 use risingwave_pb::expr::expr_node::Type as ExprNodeType;
 use risingwave_pb::expr::expr_node::Type::{

--- a/src/stream/src/executor/dynamic_filter.rs
+++ b/src/stream/src/executor/dynamic_filter.rs
@@ -28,7 +28,7 @@ use risingwave_common::types::{
     DataType, Datum, DatumRef, DefaultOrd, ScalarImpl, ToDatumRef, ToOwnedDatum,
 };
 use risingwave_common::util::iter_util::ZipEqDebug;
-use risingwave_common::util::sort_util::{cmp_datum, cmp_datum_iter};
+use risingwave_common::util::sort_util::{cmp_datum};
 use risingwave_expr::expr::{build_func, BoxedExpression, InputRefExpression, LiteralExpression};
 use risingwave_pb::expr::expr_node::Type as ExprNodeType;
 use risingwave_pb::expr::expr_node::Type::{
@@ -196,7 +196,7 @@ impl DynamicFilterCache {
     }
 
     /// All rows are guaranteed to be between
-    /// (prev_epoch_val, cur_epoch_val].
+    /// (`prev_epoch_val`, `cur_epoch_val`].
     /// So we just need to find the minimum
     fn handle_scan_row(&mut self, lhs_row: &OwnedRow) {
         match &self.value {
@@ -218,7 +218,7 @@ impl DynamicFilterCache {
         }
     }
 
-    /// If after table scan CacheEntry is still Empty, means no match.
+    /// If after table scan `CacheEntry` is still Empty, means no match.
     fn ensure_no_match_if_empty(&mut self) {
         if self.value == DynamicFilterCacheEntry::Empty {
             self.value = DynamicFilterCacheEntry::NoMatch;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

### DynamicFilterCache

It only works for `LHS > NOW()` filter conditions. 
- [ ] Support >= NOW also.
- [ ] Assume RHS is monotonically increasing, not strictly increasing.
- [ ] Handle state cleaning with watermark.

Caches a single row that is larger than the filter value, and is the minimal value. Use `Match(Row)` to do so.
If no such row exists, it means all value are smaller than the filter value (current NOW()).
In that case we should also indicate it, so we can avoid table scan. Use `NoMatch` to do so.

We update the cache at 3 occasions:
1. Processing LHS chunk. For insert / updateinsert, we may need to refresh the cached value. For Delete/UpdateDelete, we may need to evict the cache.
2. Processing RHS chunk. Similar to step 1, cases are listed in the implementation.
3. Processing table scan. We will also need to refresh cache here. For instance in RHS / LHS processing, cache may be evicted. In that case, it can only be refreshed in table scan, since we don't know previous values in cache.

### Testing Scenario

1. Create a source stream with LHS values lagging NOW(), i.e. no match.
2. Create dynamic filter query with the source stream on LHS and run it.
3. Observe barrier latency.
4. Observe e2e throughput, make sure no regression.
5. Observe reads.

### TODOs

- [x] Add design of cache (as a docstring)
- [x] Implement it in dynamic filter.
- [x] Add binary comparator function. We need it to update / evict cache.
- [ ] Test it by observing dynamic filter reads, they should decrease.
- [ ] Performance should be the same.
- [ ] Add optimizer check to decide if we can have cache. Only support `> NOW()` for now.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
