### PR TITLE
chore(ci): disable integtarion test debezium mongo && install cyrus-sasl-devel in release build

### DIFF
--- a/ci/scripts/release.sh
+++ b/ci/scripts/release.sh
@@ -11,7 +11,7 @@ if [ "${BUILDKITE_SOURCE}" != "schedule" ] && [ "${BUILDKITE_SOURCE}" != "webhoo
 fi
 
 echo "--- Install java and maven"
-yum install -y java-11-openjdk wget python3 cyrus-sasl
+yum install -y java-11-openjdk wget python3 cyrus-sasl-devel
 pip3 install toml-cli
 wget https://ci-deps-dist.s3.amazonaws.com/apache-maven-3.9.3-bin.tar.gz && tar -zxvf apache-maven-3.9.3-bin.tar.gz
 export PATH="${REPO_ROOT}/apache-maven-3.9.3/bin:$PATH"

--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -93,7 +93,7 @@ steps:
         testcase:
           - "twitter"
           - "twitter-pulsar"
-          - "debezium-mongo"
+        # - "debezium-mongo"
           - "debezium-postgres"
           - "tidb-cdc-sink"
           - "debezium-sqlserver"
@@ -105,10 +105,10 @@ steps:
             testcase: "twitter-pulsar"
             format: "protobuf"
           skip: true
-        - with:
-            testcase: "debezium-mongo"
-            format: "protobuf"
-          skip: true
+      # - with:
+      #     testcase: "debezium-mongo"
+      #     format: "protobuf"
+      #   skip: true
         - with:
             testcase: "debezium-postgres"
             format: "protobuf"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- disable integtarion test debezium mongo because it always fails now.
- install cyrus-sasl-devel in release build

## Documentation

- [ ] My PR contains user-facing changes.


