### PR TITLE
feat(compaction): support compact partial files of overlapping level

### DIFF
--- a/src/meta/src/hummock/compaction/mod.rs
+++ b/src/meta/src/hummock/compaction/mod.rs
@@ -80,6 +80,7 @@ pub struct CompactionTask {
     pub target_file_size: u64,
     pub compaction_task_type: compact_task::TaskType,
     pub enable_split_by_table: bool,
+    pub partial_compact_overlapping: bool,
 }
 
 pub fn create_overlap_strategy(compaction_mode: CompactionMode) -> Arc<dyn OverlapStrategy> {
@@ -152,6 +153,7 @@ impl CompactStatus {
             task_type: ret.compaction_task_type as i32,
             split_by_state_table: group.compaction_config.split_by_state_table,
             split_weight_by_vnode: group.compaction_config.split_weight_by_vnode,
+            partial_compact_overlapping: ret.partial_compact_overlapping,
         };
         Some(compact_task)
     }
@@ -307,6 +309,7 @@ pub fn create_compaction_task(
     };
 
     CompactionTask {
+        partial_compact_overlapping: input.partial_compact_overlapping,
         compression_algorithm: get_compression_algorithm(
             compaction_config,
             base_level,

--- a/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/base_level_compaction_picker.rs
@@ -209,6 +209,7 @@ impl LevelCompactionPicker {
                 input_levels: select_level_inputs,
                 target_level: self.target_level,
                 target_sub_level_id: 0,
+                ..Default::default()
             });
         }
         stats.skip_by_write_amp_limit += 1;
@@ -310,6 +311,7 @@ impl LevelCompactionPicker {
                     input_levels: select_level_inputs,
                     target_level: 0,
                     target_sub_level_id: level.sub_level_id,
+                    ..Default::default()
                 });
             }
 
@@ -394,6 +396,7 @@ impl LevelCompactionPicker {
                 input_levels,
                 target_level: 0,
                 target_sub_level_id: l0.sub_levels[target_level_idx].sub_level_id,
+                ..Default::default()
             });
         }
         None
@@ -832,6 +835,7 @@ pub mod tests {
             }],
             target_level: 1,
             target_sub_level_id: pending_level.sub_level_id,
+            ..Default::default()
         };
         assert!(!levels_handler[0].is_level_pending_compact(&pending_level));
         tier_task_input.add_pending_task(1, &mut levels_handler);

--- a/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/manual_compaction_picker.rs
@@ -101,6 +101,7 @@ impl ManualCompactionPicker {
             input_levels,
             target_level: 0,
             target_sub_level_id: sub_level_id,
+            ..Default::default()
         })
     }
 
@@ -170,6 +171,7 @@ impl ManualCompactionPicker {
             input_levels,
             target_level: self.target_level,
             target_sub_level_id: 0,
+            ..Default::default()
         })
     }
 
@@ -315,6 +317,7 @@ impl CompactionPicker for ManualCompactionPicker {
             ],
             target_level,
             target_sub_level_id: 0,
+            ..Default::default()
         })
     }
 }

--- a/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/min_overlap_compaction_picker.rs
@@ -143,6 +143,7 @@ impl CompactionPicker for MinOverlappingPicker {
             ],
             target_level: self.target_level,
             target_sub_level_id: 0,
+            ..Default::default()
         })
     }
 }

--- a/src/meta/src/hummock/compaction/picker/mod.rs
+++ b/src/meta/src/hummock/compaction/picker/mod.rs
@@ -37,10 +37,13 @@ pub struct LocalPickerStatistic {
     pub skip_by_pending_files: u64,
     pub skip_by_overlapping: u64,
 }
+
+#[derive(Default)]
 pub struct CompactionInput {
     pub input_levels: Vec<InputLevel>,
     pub target_level: usize,
     pub target_sub_level_id: u64,
+    pub partial_compact_overlapping: bool,
 }
 
 impl CompactionInput {

--- a/src/meta/src/hummock/compaction/picker/space_reclaim_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/space_reclaim_compaction_picker.rs
@@ -94,6 +94,7 @@ impl SpaceReclaimCompactionPicker {
                         ],
                         target_level: level.level_idx as usize,
                         target_sub_level_id: level.sub_level_id,
+                        ..Default::default()
                     });
                 }
             }
@@ -149,6 +150,7 @@ impl SpaceReclaimCompactionPicker {
                     ],
                     target_level: state.last_level,
                     target_sub_level_id: 0,
+                    ..Default::default()
                 });
             }
             state.last_level += 1;

--- a/src/meta/src/hummock/compaction/picker/ttl_reclaim_compaction_picker.rs
+++ b/src/meta/src/hummock/compaction/picker/ttl_reclaim_compaction_picker.rs
@@ -213,6 +213,7 @@ impl TtlReclaimCompactionPicker {
             ],
             target_level: reclaimed_level.level_idx as usize,
             target_sub_level_id: 0,
+            ..Default::default()
         })
     }
 }

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -2472,6 +2472,7 @@ fn gen_version_delta<'a>(
         prev_id: old_version.id,
         max_committed_epoch: old_version.max_committed_epoch,
         trivial_move,
+        partial_compact_overlapping: compact_task.partial_compact_overlapping,
         ..Default::default()
     };
     let group_deltas = &mut version_delta


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

If the data during one barrier is too large, we may flush a big sub-level. And when we try to compact this big sub-level, we found that compactor-node OOM.

We need to limit the size of compact task even if it is a task for overlapping level, so we can not select the whole sub level

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
