### PR TITLE
refactor(pgwire): truncate sql in tracing

### DIFF
--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -978,15 +978,15 @@ mod truncated_fmt {
             }
 
             if self.remaining < s.len() {
-                self.remaining = 0;
                 self.f.write_str(&s[0..self.remaining])?;
+                self.remaining = 0;
                 self.f.write_str("...(truncated)")?;
                 self.finished = true; // so that ...(truncated) is printed exactly once
-                Ok(())
             } else {
+                self.f.write_str(s)?;
                 self.remaining -= s.len();
-                self.f.write_str(s)
             }
+            Ok(())
         }
     }
 

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -363,7 +363,6 @@ where
         let result = self.inner_process_query_msg(sql, session).await;
 
         let mills = start.elapsed().as_millis();
-        let truncated = sql.len() > 1024;
 
         tracing::info!(
             target: PGWIRE_QUERY_LOG,
@@ -371,11 +370,7 @@ where
             session = %session_id,
             status = %if result.is_ok() { "ok" } else { "err" },
             time = %format_args!("{}ms", mills),
-            sql = %format_args!(
-                "{}{}",
-                if truncated { &sql[..1024] } else { sql },
-                if truncated { "...(truncated)" } else { "" }
-            )
+            sql = format_args!("{}", truncated_fmt::TruncatedFmt(&sql, 1024)),
         );
 
         result

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -396,7 +396,7 @@ where
             let span = tracing::info_span!(
                 "process_query_msg_one_stmt",
                 session_id = session.id().0,
-                stmt = format_args!("{:?}", truncated_fmt::TruncatedFmt(&stmt, 1024)),
+                stmt = format_args!("{}", truncated_fmt::TruncatedFmt(&stmt, 1024)),
             );
 
             self.inner_process_query_msg_one_stmt(stmt, session.clone())

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -363,14 +363,19 @@ where
         let result = self.inner_process_query_msg(sql, session).await;
 
         let mills = start.elapsed().as_millis();
-        let truncated_sql = &sql[..std::cmp::min(sql.len(), 1024)];
+        let truncated = sql.len() > 1024;
+
         tracing::info!(
             target: PGWIRE_QUERY_LOG,
             mode = %"(simple query)",
             session = %session_id,
             status = %if result.is_ok() { "ok" } else { "err" },
-            time = %format!("{}ms", mills),
-            sql = %truncated_sql,
+            time = %format_args!("{}ms", mills),
+            sql = %format_args!(
+                "{}{}",
+                if truncated { &sql[..1024] } else { sql },
+                if truncated { "...(truncated)" } else { "" }
+            )
         );
 
         result
@@ -388,7 +393,11 @@ where
 
         // Execute multiple statements in simple query. KISS later.
         for stmt in stmts {
-            let span = tracing::info_span!("run_stmt", %stmt, session_id = session.id().0);
+            let span = tracing::info_span!(
+                "process_query_msg_one_stmt",
+                session_id = session.id().0,
+                stmt = format_args!("{:?}", truncated_fmt::TruncatedFmt(&stmt, 1024)),
+            );
 
             self.inner_process_query_msg_one_stmt(stmt, session.clone())
                 .instrument(span)
@@ -479,14 +488,13 @@ where
         let result = self.inner_process_parse_msg(session, sql, statement_name, msg.type_ids);
 
         let mills = start.elapsed().as_millis();
-        let truncated_sql = &sql[..std::cmp::min(sql.len(), 1024)];
         tracing::info!(
             target: PGWIRE_QUERY_LOG,
             mode = %"(extended query parse)",
             session = %session_id,
             status = %if result.is_ok() { "ok" } else { "err" },
-            time = %format!("{}ms", mills),
-            sql = %truncated_sql,
+            time = %format_args!("{}ms", mills),
+            sql = format_args!("{}", truncated_fmt::TruncatedFmt(&sql, 1024)),
         );
 
         result
@@ -618,7 +626,6 @@ where
             let start = Instant::now();
             let portal = self.get_portal(&portal_name)?;
             let sql = format!("{}", portal);
-            let truncated_sql = &sql[..std::cmp::min(sql.len(), 1024)];
 
             let result = session.execute(portal).await;
 
@@ -629,8 +636,8 @@ where
                 mode = %"(extended query execute)",
                 session = %session_id,
                 status = %if result.is_ok() { "ok" } else { "err" },
-                time = %format!("{}ms", mills),
-                sql = %truncated_sql,
+                time = %format_args!("{}ms", mills),
+                sql = format_args!("{}", truncated_fmt::TruncatedFmt(&sql, 1024)),
             );
 
             let pg_response = result.map_err(PsqlError::ExecuteError)?;
@@ -959,4 +966,62 @@ fn build_ssl_ctx_from_config(tls_config: &TlsConfig) -> PsqlResult<SslContext> {
     let acceptor = acceptor.build();
 
     Ok(acceptor.into_context())
+}
+
+mod truncated_fmt {
+    use std::fmt::*;
+
+    struct TruncatedFormatter<'a, 'b> {
+        remaining: usize,
+        finished: bool,
+        f: &'a mut Formatter<'b>,
+    }
+    impl<'a, 'b> Write for TruncatedFormatter<'a, 'b> {
+        fn write_str(&mut self, s: &str) -> Result {
+            if self.finished {
+                return Ok(());
+            }
+
+            if self.remaining < s.len() {
+                self.remaining = 0;
+                self.f.write_str(&s[0..self.remaining])?;
+                self.f.write_str("...(truncated)")?;
+                self.finished = true; // so that ...(truncated) is printed exactly once
+                Ok(())
+            } else {
+                self.remaining -= s.len();
+                self.f.write_str(s)
+            }
+        }
+    }
+
+    pub struct TruncatedFmt<'a, T>(pub &'a T, pub usize);
+
+    impl<'a, T> Debug for TruncatedFmt<'a, T>
+    where
+        T: Debug,
+    {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+            TruncatedFormatter {
+                remaining: self.1,
+                finished: false,
+                f,
+            }
+            .write_fmt(format_args!("{:?}", self.0))
+        }
+    }
+
+    impl<'a, T> Display for TruncatedFmt<'a, T>
+    where
+        T: Display,
+    {
+        fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+            TruncatedFormatter {
+                remaining: self.1,
+                finished: false,
+                f,
+            }
+            .write_fmt(format_args!("{}", self.0))
+        }
+    }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Since query log truncates sql, I think tracing span might also need to do so. Noticed via developing #10910, where I passed a BASE64 encoded binary in a SQL.
- Also add an `...(truncated)` indicator.
- Also replace some `format!` with `format_args`, which might reduce allocation.
- Error log still contains full sql.

```
  2023-07-12T23:40:57.915277+02:00 ERROR risingwave_frontend::session: failed to handle sql:
INSERT INTO t VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1):
Catalog error: table not found: t
    at src/frontend/src/session.rs:951
    in pgwire::pg_protocol::process_query_msg_one_stmt with session_id: 0, stmt: Insert { table_name: ObjectName([Ident { value: "t", quote_style: None }]), columns: [], source: Query { with: None, body: Values(Values([[Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value(Number("1"))], [Value...(truncated)

  2023-07-12T23:40:57.916446+02:00  INFO pgwire_query_log: mode: (simple query), session: 0, status: err, time: 543ms, sql: INSERT INTO t VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)...(truncated)
    at src/utils/pgwire/src/pg_protocol.rs:368
```

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
