### PR TITLE
feat: show flags in `rw_fragments`

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -184,6 +184,7 @@ message ListFragmentDistributionResponse {
     TableFragments.Fragment.FragmentDistributionType distribution_type = 3;
     repeated uint32 state_table_ids = 4;
     repeated uint32 upstream_fragment_ids = 5;
+    uint32 fragment_type_mask = 6;
   }
   repeated FragmentDistribution distributions = 1;
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_fragments.rs
@@ -30,5 +30,6 @@ pub static RW_FRAGMENTS_COLUMNS: LazyLock<Vec<SystemCatalogColumnsDef<'_>>> = La
             DataType::List(Box::new(DataType::Int32)),
             "upstream_fragment_ids",
         ),
+        (DataType::List(Box::new(DataType::Varchar)), "flags"),
     ]
 });

--- a/src/meta/src/rpc/service/stream_service.rs
+++ b/src/meta/src/rpc/service/stream_service.rs
@@ -180,6 +180,7 @@ where
                                 distribution_type: fragment.distribution_type,
                                 state_table_ids: fragment.state_table_ids,
                                 upstream_fragment_ids: fragment.upstream_fragment_ids,
+                                fragment_type_mask: fragment.fragment_type_mask,
                             }
                         })
                 })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

```
dev=> select * from rw_fragments;
 fragment_id | table_id | distribution_type |      state_table_ids       | upstream_fragment_ids |       flags
-------------+----------+-------------------+----------------------------+-----------------------+--------------------
           1 |     1001 | HASH              | {1001}                     | {2}                   | {MVIEW}
           2 |     1001 | HASH              | {}                         | {}                    | {SOURCE,DML}
           3 |     1002 | HASH              | {1003,1002}                | {1}                   | {MVIEW,CHAIN_NODE}
           4 |     1004 | HASH              | {1005,1004}                | {1}                   | {MVIEW,CHAIN_NODE}
           5 |     1006 | HASH              | {1007,1006}                | {4}                   | {MVIEW,CHAIN_NODE}
           6 |     1008 | HASH              | {1009,1008}                | {4}                   | {MVIEW,CHAIN_NODE}
           7 |     1010 | HASH              | {1011,1010}                | {5}                   | {MVIEW,CHAIN_NODE}
           8 |     1012 | HASH              | {1013,1012}                | {5}                   | {MVIEW,CHAIN_NODE}
           9 |     1014 | HASH              | {1015,1016,1017,1018,1014} | {10,11}               | {MVIEW}
          10 |     1014 | HASH              | {1019}                     | {3}                   | {CHAIN_NODE}
          11 |     1014 | HASH              | {1020}                     | {7}                   | {CHAIN_NODE}
          12 |     1021 | HASH              | {1022,1023,1024,1021}      | {13,9}                | {MVIEW,CHAIN_NODE}
          13 |     1021 | SINGLE            | {1026,1025}                | {14}                  | {}
          14 |     1021 | HASH              | {1028,1027,1029}           | {6}                   | {CHAIN_NODE}
(14 rows)
```

This pull request introduces several changes related to the `fragment_type_mask` field and its usage in various files. The main code changes are as follows:

1. In the `meta.proto` file, a new field `fragment_type_mask` is added to the `ListFragmentDistributionResponse` message. This new field enhances the message structure to include the fragment type mask.

2. The `risingwave_pb::stream_plan::FragmentTypeFlag` is imported in the `rw_catalog/mod.rs` file. This import statement allows for the usage of `FragmentTypeFlag` in that file.

3. In the `SysCatalogReaderImpl` implementation, a new function `extract_fragment_type_flag` is added. This function enables the extraction of `FragmentTypeFlag`s from the `fragment_type_mask`, providing a convenient way to retrieve and work with the fragment type flags.

4. The `RW_FRAGMENTS_COLUMNS` in the `rw_fragments.rs` file is updated with the addition of a new column named `flags`. This column has a type of `List(Varchar)` and allows for storing and retrieving multiple flag values for fragments.

5. Finally, in the `stream_service.rs` file, the `fragment_type_mask` field is added to the `GetListFragmentDistributionResponse` message. By adding this field, the response message now includes information about the fragment type mask, enhancing the functionality and usefulness of the message.

These code changes make the necessary additions and modifications to support the `fragment_type_mask` field, improving the overall functionality and flexibility of the codebase.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
