### PR TITLE
fix(expr): `round` to left of decimal point when 2nd arg is negative

### DIFF
--- a/src/connector/src/parser/avro/util.rs
+++ b/src/connector/src/parser/avro/util.rs
@@ -14,7 +14,7 @@
 
 use apache_avro::Schema;
 use itertools::Itertools;
-use risingwave_common::types::DataType;
+use risingwave_common::types::{DataType, Decimal};
 use risingwave_pb::plan_common::ColumnDesc;
 
 pub fn avro_schema_to_column_descs(schema: &Schema) -> anyhow::Result<Vec<ColumnDesc>> {
@@ -30,7 +30,6 @@ pub fn avro_schema_to_column_descs(schema: &Schema) -> anyhow::Result<Vec<Column
     }
 }
 
-const RW_DECIMAL_MAX_PRECISION: usize = 28;
 const DBZ_VARIABLE_SCALE_DECIMAL_NAME: &str = "VariableScaleDecimal";
 const DBZ_VARIABLE_SCALE_DECIMAL_NAMESPACE: &str = "io.debezium.data";
 
@@ -81,10 +80,10 @@ fn avro_type_mapping(schema: &Schema) -> anyhow::Result<DataType> {
         Schema::Float => DataType::Float32,
         Schema::Double => DataType::Float64,
         Schema::Decimal { precision, .. } => {
-            if precision > &RW_DECIMAL_MAX_PRECISION {
+            if *precision > Decimal::MAX_PRECISION.into() {
                 tracing::warn!(
                     "RisingWave supports decimal precision up to {}, but got {}. Will truncate.",
-                    RW_DECIMAL_MAX_PRECISION,
+                    Decimal::MAX_PRECISION,
                     precision
                 );
             }

--- a/src/connector/src/parser/unified/avro.rs
+++ b/src/connector/src/parser/unified/avro.rs
@@ -320,7 +320,6 @@ where
     }
 }
 
-const RW_DECIMAL_MAX_PRECISION: usize = 28;
 pub(crate) fn avro_decimal_to_rust_decimal(
     avro_decimal: AvroDecimal,
     _precision: usize,

--- a/src/expr/src/vector_op/round.rs
+++ b/src/expr/src/vector_op/round.rs
@@ -12,18 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use num_traits::Zero;
 use risingwave_common::types::{Decimal, F64};
 use risingwave_expr_macro::function;
 
+use crate::{ExprError, Result};
+
 #[function("round_digit(decimal, int32) -> decimal")]
-pub fn round_digits<D: Into<i32>>(input: Decimal, digits: D) -> Decimal {
-    let digits = digits.into();
+pub fn round_digits(input: Decimal, digits: i32) -> Result<Decimal> {
     if digits < 0 {
-        Decimal::zero()
+        input
+            .round_left_ties_away(digits.unsigned_abs())
+            .ok_or(ExprError::NumericOverflow)
     } else {
         // rust_decimal can only handle up to 28 digits of scale
-        input.round_dp_ties_away(std::cmp::min(digits as u32, 28))
+        Ok(input.round_dp_ties_away((digits as u32).min(Decimal::MAX_PRECISION.into())))
     }
 }
 
@@ -78,22 +80,41 @@ mod tests {
     use super::ceil_f64;
     use crate::vector_op::round::*;
 
-    fn do_test(input: &str, digits: i32, expected_output: &str) {
+    fn do_test(input: &str, digits: i32, expected_output: Option<&str>) {
         let v = Decimal::from_str(input).unwrap();
-        let rounded_value = round_digits(v, digits);
-        assert_eq!(expected_output, rounded_value.to_string().as_str());
+        let rounded_value = round_digits(v, digits).ok();
+        assert_eq!(
+            expected_output,
+            rounded_value.as_ref().map(ToString::to_string).as_deref()
+        );
     }
 
     #[test]
     fn test_round_digits() {
-        do_test("21.666666666666666666666666667", 4, "21.6667");
-        do_test("84818.33333333333333333333333", 4, "84818.3333");
-        do_test("84818.15", 1, "84818.2");
-        do_test("21.372736", -1, "0");
+        do_test("21.666666666666666666666666667", 4, Some("21.6667"));
+        do_test("84818.33333333333333333333333", 4, Some("84818.3333"));
+        do_test("84818.15", 1, Some("84818.2"));
+        do_test("21.372736", -1, Some("20"));
+        do_test("-79228162514264337593543950335", -30, Some("0"));
+        do_test("-79228162514264337593543950335", -29, None);
+        do_test("-79228162514264337593543950335", -28, None);
+        do_test(
+            "-79228162514264337593543950335",
+            -27,
+            Some("-79000000000000000000000000000"),
+        );
+        do_test("-792.28162514264337593543950335", -4, Some("0"));
+        do_test("-792.28162514264337593543950335", -3, Some("-1000"));
+        do_test("-792.28162514264337593543950335", -2, Some("-800"));
+        do_test("-792.28162514264337593543950335", -1, Some("-790"));
+        do_test("-50000000000000000000000000000", -29, None);
+        do_test("-49999999999999999999999999999", -29, Some("0"));
+        do_test("-500.00000000000000000000000000", -3, Some("-1000"));
+        do_test("-499.99999999999999999999999999", -3, Some("0"));
         // When digit extends past original scale, it should just return original scale.
         // Intuitively, it does not make sense after rounding `0` it becomes `0.000`. Precision
         // should always be less or equal, not more.
-        do_test("0", 340, "0");
+        do_test("0", 340, Some("0"));
     }
 
     #[test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #9417

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

Just like in PostgreSQL, the 2nd arg of `round` can now be negative, which means to round to the left of the decimal point.