### PR TITLE
perf(source): optimize op for `json_parser`

### DIFF
--- a/src/connector/src/parser/json_parser.rs
+++ b/src/connector/src/parser/json_parser.rs
@@ -19,7 +19,9 @@ use super::ByteStreamSourceParser;
 use crate::common::UpsertMessage;
 use crate::parser::unified::json::JsonAccess;
 use crate::parser::unified::upsert::UpsertChangeEvent;
-use crate::parser::unified::util::apply_row_operation_on_stream_chunk_writer_with_op;
+use crate::parser::unified::util::{
+    apply_row_operation_on_stream_chunk_writer_with_op, apply_upsert_on_stream_chunk_writer,
+};
 use crate::parser::unified::ChangeEventOperation;
 use crate::parser::{SourceStreamChunkRowWriter, WriteGuard};
 use crate::source::{SourceColumnDesc, SourceContext, SourceContextRef};
@@ -100,7 +102,6 @@ impl JsonParser {
                 change_event_op,
             )
         } else {
-            let change_event_op = ChangeEventOperation::Upsert;
             let value = simd_json::to_borrowed_value(&mut payload)
                 .map_err(|e| RwError::from(ProtocolError(e.to_string())))?;
             let values = if let simd_json::BorrowedValue::Array(arr) = value {
@@ -114,11 +115,7 @@ impl JsonParser {
                 let accessor: UpsertChangeEvent<JsonAccess<'_, '_>, JsonAccess<'_, '_>> =
                     UpsertChangeEvent::default().with_value(JsonAccess::new(value));
 
-                match apply_row_operation_on_stream_chunk_writer_with_op(
-                    accessor,
-                    &mut writer,
-                    change_event_op,
-                ) {
+                match apply_upsert_on_stream_chunk_writer(accessor, &mut writer) {
                     Ok(this_guard) => guard = Some(this_guard),
                     Err(err) => errors.push(err),
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/issues/10840

It is the newly introduced cost ~18%:

<img width="1060" alt="Screenshot 2023-07-17 at 2 12 03 PM" src="https://github.com/risingwavelabs/risingwave/assets/47273164/713b9bd3-cbf1-4cbc-ac18-9acfb4eae424">



<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
