### PR TITLE
feat(parser): parse `create aggregate`

### DIFF
--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1050,6 +1050,17 @@ pub enum Statement {
         /// Optional parameters.
         params: CreateFunctionBody,
     },
+    /// CREATE AGGREGATE
+    ///
+    /// Postgres: <https://www.postgresql.org/docs/15/sql-createaggregate.html>
+    CreateAggregate {
+        or_replace: bool,
+        name: ObjectName,
+        args: Vec<OperateFunctionArg>,
+        returns: Option<DataType>,
+        /// Optional parameters.
+        params: CreateFunctionBody,
+    },
     /// ALTER TABLE
     AlterTable {
         /// Table name
@@ -1359,6 +1370,25 @@ impl fmt::Display for Statement {
                 }
                 if let Some(return_type) = returns {
                     write!(f, " {}", return_type)?;
+                }
+                write!(f, "{params}")?;
+                Ok(())
+            }
+            Statement::CreateAggregate {
+                or_replace,
+                name,
+                args,
+                returns,
+                params,
+            } => {
+                write!(
+                    f,
+                    "CREATE {or_replace}AGGREGATE {name}",
+                    or_replace = if *or_replace { "OR REPLACE " } else { "" },
+                )?;
+                write!(f, "({})", display_comma_separated(args))?;
+                if let Some(return_type) = returns {
+                    write!(f, " RETURNS {}", return_type)?;
                 }
                 write!(f, "{params}")?;
                 Ok(())

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -1057,8 +1057,9 @@ pub enum Statement {
         or_replace: bool,
         name: ObjectName,
         args: Vec<OperateFunctionArg>,
-        returns: Option<DataType>,
         /// Optional parameters.
+        returns: Option<DataType>,
+        append_only: bool,
         params: CreateFunctionBody,
     },
     /// ALTER TABLE
@@ -1379,6 +1380,7 @@ impl fmt::Display for Statement {
                 name,
                 args,
                 returns,
+                append_only,
                 params,
             } => {
                 write!(
@@ -1389,6 +1391,9 @@ impl fmt::Display for Statement {
                 write!(f, "({})", display_comma_separated(args))?;
                 if let Some(return_type) = returns {
                     write!(f, " RETURNS {}", return_type)?;
+                }
+                if *append_only {
+                    write!(f, " APPEND ONLY")?;
                 }
                 write!(f, "{params}")?;
                 Ok(())

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -71,6 +71,7 @@ define_keywords!(
     ABS,
     ACTION,
     ADD,
+    AGGREGATE,
     ALL,
     ALLOCATE,
     ALTER,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2045,6 +2045,7 @@ impl Parser {
             None
         };
 
+        let append_only = self.parse_keywords(&[Keyword::APPEND, Keyword::ONLY]);
         let params = self.parse_create_function_body()?;
 
         Ok(Statement::CreateAggregate {
@@ -2052,6 +2053,7 @@ impl Parser {
             name,
             args,
             returns: return_type,
+            append_only,
             params,
         })
     }

--- a/src/sqlparser/tests/sqlparser_postgres.rs
+++ b/src/sqlparser/tests/sqlparser_postgres.rs
@@ -825,6 +825,26 @@ fn parse_create_function() {
 }
 
 #[test]
+fn parse_create_aggregate() {
+    let sql =
+        "CREATE OR REPLACE AGGREGATE sum(INT) RETURNS BIGINT LANGUAGE python USING LINK 'xxx'";
+    assert_eq!(
+        verified_stmt(sql),
+        Statement::CreateAggregate {
+            or_replace: true,
+            name: ObjectName(vec![Ident::new_unchecked("sum")]),
+            args: vec![OperateFunctionArg::unnamed(DataType::Int)],
+            returns: Some(DataType::BigInt),
+            params: CreateFunctionBody {
+                language: Some("python".into()),
+                using: Some(CreateFunctionUsing::Link("xxx".into())),
+                ..Default::default()
+            },
+        }
+    );
+}
+
+#[test]
 fn parse_drop_function() {
     let sql = "DROP FUNCTION IF EXISTS test_func";
     assert_eq!(

--- a/src/sqlparser/tests/sqlparser_postgres.rs
+++ b/src/sqlparser/tests/sqlparser_postgres.rs
@@ -827,7 +827,7 @@ fn parse_create_function() {
 #[test]
 fn parse_create_aggregate() {
     let sql =
-        "CREATE OR REPLACE AGGREGATE sum(INT) RETURNS BIGINT LANGUAGE python USING LINK 'xxx'";
+        "CREATE OR REPLACE AGGREGATE sum(INT) RETURNS BIGINT APPEND ONLY LANGUAGE python AS 'sum' USING LINK 'xxx'";
     assert_eq!(
         verified_stmt(sql),
         Statement::CreateAggregate {
@@ -835,8 +835,10 @@ fn parse_create_aggregate() {
             name: ObjectName(vec![Ident::new_unchecked("sum")]),
             args: vec![OperateFunctionArg::unnamed(DataType::Int)],
             returns: Some(DataType::BigInt),
+            append_only: true,
             params: CreateFunctionBody {
                 language: Some("python".into()),
+                as_: Some(FunctionDefinition::SingleQuotedDef("sum".into())),
                 using: Some(CreateFunctionUsing::Link("xxx".into())),
                 ..Default::default()
             },


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds `create aggregate` syntax for user-defined aggregate functions.

The syntax is a mix of current `create function` and [postgres `create aggregate`](https://www.postgresql.org/docs/15/sql-createaggregate.html):
```sql
CREATE [ OR REPLACE ] AGGREGATE name ( [ argmode ] [ argname ] arg_data_type [ , ... ] ) # same as pg
[ RETURNS return_data_type ] [ APPEND ONLY ]
[ LANGUAGE language ] [ AS identifier ] [ USING LINK link ]; # same as function
```

Examples:
```sql
create aggregate sum(int) returns bigint
as sum using link 'http://localhost:8815';

# "returns" is omitted as the return type is same as the only argument
create aggregate max(int) append only
as max using link 'http://localhost:8815';

create aggregate string_agg(varchar, varchar) returns varchar append only
as string_agg using link 'http://localhost:8815';
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.
