### PR TITLE
feat: Add the functionality of resolving NO_SHUFFLE upstream to the reschedule API

### DIFF
--- a/proto/meta.proto
+++ b/proto/meta.proto
@@ -404,6 +404,7 @@ message RescheduleRequest {
   // reschedule plan for each fragment
   map<uint32, Reschedule> reschedules = 1;
   uint64 revision = 2;
+  bool resolve_no_shuffle_upstream = 3;
 }
 
 message RescheduleResponse {

--- a/src/ctl/src/cmd_impl/meta/reschedule.rs
+++ b/src/ctl/src/cmd_impl/meta/reschedule.rs
@@ -118,6 +118,7 @@ pub async fn reschedule(
     revision: Option<u64>,
     from: Option<String>,
     dry_run: bool,
+    resolve_no_shuffle: bool,
 ) -> Result<()> {
     let meta_client = context.meta_client().await?;
 
@@ -157,7 +158,9 @@ pub async fn reschedule(
 
     if !dry_run {
         println!("---------------------------");
-        let (success, revision) = meta_client.reschedule(reschedules, revision).await?;
+        let (success, revision) = meta_client
+            .reschedule(reschedules, revision, resolve_no_shuffle)
+            .await?;
 
         if !success {
             println!(

--- a/src/ctl/src/cmd_impl/scale/resize.rs
+++ b/src/ctl/src/cmd_impl/scale/resize.rs
@@ -264,13 +264,14 @@ pub async fn resize(context: &CtlContext, resize: ScaleResizeCommands) -> anyhow
             }
         }
 
-        let (success, next_revision) = match meta_client.reschedule(reschedules, revision).await {
-            Ok(response) => response,
-            Err(e) => {
-                println!("Failed to execute plan: {:?}", e);
-                exit(1);
-            }
-        };
+        let (success, next_revision) =
+            match meta_client.reschedule(reschedules, revision, false).await {
+                Ok(response) => response,
+                Err(e) => {
+                    println!("Failed to execute plan: {:?}", e);
+                    exit(1);
+                }
+            };
 
         if !success {
             println!("Failed to execute plan, current revision is {}", revision);

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -366,6 +366,9 @@ enum MetaCommands {
         /// Show the plan only, no actual operation
         #[clap(long, default_value = "false")]
         dry_run: bool,
+        /// Resolve NO_SHUFFLE upstream
+        #[clap(long, default_value = "false")]
+        resolve_no_shuffle: bool,
     },
     /// backup meta by taking a meta snapshot
     BackupMeta,
@@ -533,7 +536,11 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
             dry_run,
             plan,
             revision,
-        }) => cmd_impl::meta::reschedule(context, plan, revision, from, dry_run).await?,
+            resolve_no_shuffle,
+        }) => {
+            cmd_impl::meta::reschedule(context, plan, revision, from, dry_run, resolve_no_shuffle)
+                .await?
+        }
         Commands::Meta(MetaCommands::BackupMeta) => cmd_impl::meta::backup_meta(context).await?,
         Commands::Meta(MetaCommands::DeleteMetaSnapshots { snapshot_ids }) => {
             cmd_impl::meta::delete_meta_snapshots(context, &snapshot_ids).await?

--- a/src/meta/src/rpc/service/scale_service.rs
+++ b/src/meta/src/rpc/service/scale_service.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use itertools::Itertools;
 use risingwave_pb::common::WorkerType;
 use risingwave_pb::meta::scale_service_server::ScaleService;
 use risingwave_pb::meta::{
@@ -27,7 +26,9 @@ use crate::barrier::{BarrierScheduler, Command};
 use crate::manager::{CatalogManagerRef, ClusterManagerRef, FragmentManagerRef};
 use crate::model::MetadataModel;
 use crate::storage::MetaStore;
-use crate::stream::{GlobalStreamManagerRef, ParallelUnitReschedule, SourceManagerRef};
+use crate::stream::{
+    GlobalStreamManagerRef, ParallelUnitReschedule, RescheduleOptions, SourceManagerRef,
+};
 
 pub struct ScaleServiceImpl<S: MetaStore> {
     barrier_scheduler: BarrierScheduler<S>,
@@ -135,13 +136,17 @@ where
         &self,
         request: Request<RescheduleRequest>,
     ) -> Result<Response<RescheduleResponse>, Status> {
-        let req = request.into_inner();
+        let RescheduleRequest {
+            reschedules,
+            revision,
+            resolve_no_shuffle_upstream,
+        } = request.into_inner();
 
         let _reschedule_job_lock = self.stream_manager.reschedule_lock.write().await;
 
         let current_revision = self.fragment_manager.get_revision().await;
 
-        if req.revision != current_revision.inner() {
+        if revision != current_revision.inner() {
             return Ok(Response::new(RescheduleResponse {
                 success: false,
                 revision: current_revision.inner(),
@@ -150,7 +155,7 @@ where
 
         self.stream_manager
             .reschedule_actors(
-                req.reschedules
+                reschedules
                     .into_iter()
                     .map(|(fragment_id, reschedule)| {
                         let Reschedule {
@@ -158,23 +163,21 @@ where
                             removed_parallel_units,
                         } = reschedule;
 
+                        let added_parallel_units = added_parallel_units.into_iter().collect();
+                        let removed_parallel_units = removed_parallel_units.into_iter().collect();
+
                         (
                             fragment_id,
                             ParallelUnitReschedule {
-                                added_parallel_units: added_parallel_units
-                                    .into_iter()
-                                    .sorted()
-                                    .dedup()
-                                    .collect(),
-                                removed_parallel_units: removed_parallel_units
-                                    .into_iter()
-                                    .sorted()
-                                    .dedup()
-                                    .collect(),
+                                added_parallel_units,
+                                removed_parallel_units,
                             },
                         )
                     })
                     .collect(),
+                RescheduleOptions {
+                    resolve_no_shuffle_upstream,
+                },
             )
             .await?;
 

--- a/src/rpc_client/src/meta_client.rs
+++ b/src/rpc_client/src/meta_client.rs
@@ -735,10 +735,12 @@ impl MetaClient {
         &self,
         reschedules: HashMap<u32, PbReschedule>,
         revision: u64,
+        resolve_no_shuffle_upstream: bool,
     ) -> Result<(bool, u64)> {
         let request = RescheduleRequest {
             reschedules,
             revision,
+            resolve_no_shuffle_upstream,
         };
         let resp = self.inner.reschedule(request).await?;
         Ok((resp.success, resp.revision))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Currently, our reschedule API will bluntly check whether the involved fragment id is downstream in the no_shuffle relationship. If it is, it will directly reject it. This could cause problems in some situations, as it's not always clear where the root of a group of no_shuffle relationship forests is. Therefore, this PR aims to add a resolve no_shuffle upstream functionality to automatically resolve this relationship.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
