### PR TITLE
perf(source): compare key once for `json_object_smart_get_value`

### DIFF
--- a/src/connector/src/parser/common.rs
+++ b/src/connector/src/parser/common.rs
@@ -21,8 +21,9 @@ pub(crate) fn json_object_smart_get_value<'a, 'b>(
     key: Cow<'b, str>,
 ) -> Option<&'b BorrowedValue<'a>> {
     let obj = v.as_object()?;
-    if obj.contains_key(key.as_ref()) {
-        return obj.get(key.as_ref());
+    let value = obj.get(key.as_ref());
+    if value.is_some() {
+        return value;
     }
     for (k, v) in obj {
         if k.eq_ignore_ascii_case(key.as_ref()) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

```
json_parser             time:   [297.47 ms 298.17 ms 298.88 ms]
                        change: [-11.671% -10.436% -9.4821%] (p = 0.00 < 0.05)
                        Performance has improved.
```

As shown from flamegraph this happens twice:
![Screenshot 2023-07-18 at 10 42 19 AM](https://github.com/risingwavelabs/risingwave/assets/47273164/c0a6f4ff-42b1-4fbd-9ea0-02d03c7cfb5b)

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
