### PR TITLE
fix(sqlsmith): do not generate `sum0`

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -215,6 +215,7 @@ pub(crate) static AGG_FUNC_TABLE: LazyLock<HashMap<DataType, Vec<AggFuncSig>>> =
                     .iter()
                     .all(|t| *t != DataTypeName::Timestamptz)
                     && ![
+                        AggKind::Sum0,
                         AggKind::BitAnd,
                         AggKind::BitOr,
                         AggKind::BoolAnd,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

```
-- Failing SQL query:
--
  | CREATE MATERIALIZED VIEW m13 AS WITH with_0 AS (WITH with_1 AS (SELECT max(DISTINCT t_4.col_2) FILTER(WHERE false) AS col_0, sum0(DISTINCT t_4.col_1 ORDER BY t_4.col_1 DESC) FILTER(WHERE true) AS col_1 FROM m4 AS t_4 WHERE false GROUP BY t_4.col_2, t_4.col_1) SELECT (INT '-1909674191') AS col_0, CAST(NULL AS STRUCT<a DATE, b TIME>) AS col_1 FROM with_1 WHERE true) SELECT TIMESTAMP '2023-07-18 04:43:58' AS col_0, 'ZL8jMtunt8' AS col_1 FROM with_0;
  |  
  | ---- END
  |  
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Failed { msg: Some("Error Reason:\nBind error: failed to bind expression: sum0(DISTINCT t_4.col_1 ORDER BY t_4.col_1 DESC) FILTER(WHERE true)\n\nCaused by:\n  Invalid input syntax: Invalid aggregation: sum0(numeric)") }', src/tests/sqlsmith/tests/frontend/mod.rs:280:52
  | stack backtrace:
  | 0: rust_begin_unwind
  | at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/std/src/panicking.rs:593:5
  | 1: core::panicking::panic_fmt
  | at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/panicking.rs:67:14
  | 2: core::result::unwrap_failed
  | at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/result.rs:1651:5
  | 3: core::result::Result<T,E>::unwrap
  | at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/result.rs:1076:23
  | 4: test_runner::frontend::run
  | at ./tests/frontend/mod.rs:280:24
  | 5: test_runner::main
  | at ./tests/test_runner.rs:22:5
  | 6: core::ops::function::FnOnce::call_once
  | at /rustc/f0411ffcebcd7f75ac02ed45feb53ffd07b75398/library/core/src/ops/function.rs:250:5
  | note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

I've encountered `Invalid aggregation: sum0(numeric)` in [fuzz test](https://buildkite.com/risingwavelabs/pull-request/builds/27497#01896746-aa55-4329-b4e3-a8c921d12755). It seems `sum0` is only used internally by the optimizer and is not a user-facing aggregation kind for now.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
