### PR TITLE
fix(expr): `to_timestamp` should return timestamptz

### DIFF
--- a/e2e_test/batch/functions/to_timestamp.slt.part
+++ b/e2e_test/batch/functions/to_timestamp.slt.part
@@ -1,47 +1,47 @@
 query T
 select to_timestamp('2022 12 25', 'YYYY MM DD');
 ----
-2022-12-25 00:00:00
+2022-12-25 00:00:00+00:00
 
 query T
 select to_timestamp('2022/12/25 15:24:33', 'YYYY/MM/DD HH24:MI:SS');
 ----
-2022-12-25 15:24:33
+2022-12-25 15:24:33+00:00
 
 query T
 select to_timestamp('2022/12/25 10:24:33', 'YYYY/MM/DD HH12:MI:SS');
 ----
-2022-12-25 10:24:33
+2022-12-25 10:24:33+00:00
 
 query T
 select to_timestamp('2022/12/25 10:24:33', 'YYYY/MM/DD HH12:MI:SS');
 ----
-2022-12-25 10:24:33
+2022-12-25 10:24:33+00:00
 
 query T
 select to_timestamp('2022/12/25 15', 'YYYY/MM/DD HH24');
 ----
-2022-12-25 15:00:00
+2022-12-25 15:00:00+00:00
 
 query T
 select to_timestamp('2001-04-17 00:00:00.900006', 'YYYY-MM-DD HH24:MI:SS.US');
 ----
-2001-04-17 00:00:00.900006
+2001-04-17 00:00:00.900006+00:00
 
 query T
 select to_timestamp('2001-04-17 00:00:00.000000', 'YYYY-MM-DD HH24:MI:SS.US');
 ----
-2001-04-17 00:00:00
+2001-04-17 00:00:00+00:00
 
 query T
 select to_timestamp('2001-04-17 00:00:00.906', 'YYYY-MM-DD HH24:MI:SS.MS');
 ----
-2001-04-17 00:00:00.906
+2001-04-17 00:00:00.906+00:00
 
 query T
 select to_timestamp('2001-04-17 00:00:00.000', 'YYYY-MM-DD HH24:MI:SS.MS');
 ----
-2001-04-17 00:00:00
+2001-04-17 00:00:00+00:00
 
 # FIXME: false positive cases, but hard to handle in chrono.
 
@@ -52,17 +52,16 @@ statement error
 select to_timestamp('2001-04-17 00:00:00.9999', 'YYYY-MM-DD HH24:MI:SS.US');
 
 # Timezone
-# FIXME: We should return timestamptz here.
 
 query T
 SELECT to_timestamp('2021/12/30 14:52:49 +03:30', 'YYYY/MM/DD HH24:MI:SS TZH:TZM');
 ----
-2021-12-30 11:22:49
+2021-12-30 11:22:49+00:00
 
 query T
 SELECT to_timestamp('2021/12/30 14:52:49 +0330', 'YYYY/MM/DD HH24:MI:SS TZHTZM');
 ----
-2021-12-30 11:22:49
+2021-12-30 11:22:49+00:00
 
 statement error
 SELECT to_timestamp('2021/12/30 14:52:49 +330', 'YYYY/MM/DD HH24:MI:SS TZHTZM');
@@ -70,4 +69,4 @@ SELECT to_timestamp('2021/12/30 14:52:49 +330', 'YYYY/MM/DD HH24:MI:SS TZHTZM');
 query T
 SELECT to_timestamp('2021/12/30 14:52:49 +03', 'YYYY/MM/DD HH24:MI:SS TZH');
 ----
-2021-12-30 11:52:49
+2021-12-30 11:52:49+00:00

--- a/src/common/src/types/timestamptz.rs
+++ b/src/common/src/types/timestamptz.rs
@@ -127,8 +127,8 @@ impl Timestamptz {
     }
 }
 
-impl From<chrono::DateTime<Utc>> for Timestamptz {
-    fn from(dt: chrono::DateTime<Utc>) -> Self {
+impl<Tz: TimeZone> From<chrono::DateTime<Tz>> for Timestamptz {
+    fn from(dt: chrono::DateTime<Tz>) -> Self {
         Self(dt.timestamp_micros())
     }
 }

--- a/src/expr/src/expr/build.rs
+++ b/src/expr/src/expr/build.rs
@@ -31,6 +31,7 @@ use super::expr_some_all::SomeAllExpression;
 use super::expr_udf::UdfExpression;
 use super::expr_vnode::VnodeExpression;
 use crate::expr::expr_proctime::ProcTimeExpression;
+use crate::expr::expr_to_timestamp_const_tmpl::build_to_timestamp_expr_legacy;
 use crate::expr::{
     BoxedExpression, Expression, InputRefExpression, LiteralExpression, TryFromExprNodeBoxed,
 };
@@ -79,6 +80,11 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
                 .iter()
                 .map(build_from_prost)
                 .try_collect()?;
+
+            // deprecated exprs not in signature map just for backward compatibility
+            if func_type == E::ToTimestamp1 && ret_type == DataType::Timestamp {
+                return build_to_timestamp_expr_legacy(ret_type, children);
+            }
 
             build_func(func_type, ret_type, children)
         }

--- a/src/expr/src/expr/expr_to_timestamp_const_tmpl.rs
+++ b/src/expr/src/expr/expr_to_timestamp_const_tmpl.rs
@@ -14,20 +14,22 @@
 
 use std::sync::Arc;
 
-use risingwave_common::array::{Array, ArrayBuilder, TimestampArrayBuilder, Utf8Array};
+use risingwave_common::array::{Array, ArrayBuilder, TimestamptzArrayBuilder, Utf8Array};
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, Datum, ScalarImpl};
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_expr_macro::build_function;
 
 use super::{BoxedExpression, Expression, Result};
-use crate::expr::template::BinaryExpression;
+use crate::expr::template::{BinaryExpression, TernaryExpression};
 use crate::vector_op::to_char::{compile_pattern_to_chrono, ChronoPattern};
-use crate::vector_op::to_timestamp::{to_timestamp, to_timestamp_const_tmpl};
+use crate::vector_op::to_timestamp::{to_timestamp, to_timestamp_const_tmpl, to_timestamp_legacy};
+use crate::ExprError;
 
 #[derive(Debug)]
 struct ExprToTimestampConstTmplContext {
     chrono_pattern: ChronoPattern,
+    time_zone: Box<str>,
 }
 
 #[derive(Debug)]
@@ -39,7 +41,7 @@ struct ExprToTimestampConstTmpl {
 #[async_trait::async_trait]
 impl Expression for ExprToTimestampConstTmpl {
     fn return_type(&self) -> DataType {
-        DataType::Timestamp
+        DataType::Timestamptz
     }
 
     async fn eval(
@@ -48,12 +50,13 @@ impl Expression for ExprToTimestampConstTmpl {
     ) -> crate::Result<risingwave_common::array::ArrayRef> {
         let data_arr = self.child.eval_checked(input).await?;
         let data_arr: &Utf8Array = data_arr.as_ref().into();
-        let mut output = TimestampArrayBuilder::new(input.capacity());
+        let mut output = TimestamptzArrayBuilder::new(input.capacity());
         for (data, vis) in data_arr.iter().zip_eq_fast(input.vis().iter()) {
             if !vis {
                 output.append_null();
             } else if let Some(data) = data {
-                let res = to_timestamp_const_tmpl(data, &self.ctx.chrono_pattern)?;
+                let res =
+                    to_timestamp_const_tmpl(data, &self.ctx.chrono_pattern, &self.ctx.time_zone)?;
                 output.append(Some(res));
             } else {
                 output.append_null();
@@ -66,7 +69,8 @@ impl Expression for ExprToTimestampConstTmpl {
     async fn eval_row(&self, input: &OwnedRow) -> crate::Result<Datum> {
         let data = self.child.eval_row(input).await?;
         Ok(if let Some(ScalarImpl::Utf8(data)) = data {
-            let res = to_timestamp_const_tmpl(&data, &self.ctx.chrono_pattern)?;
+            let res =
+                to_timestamp_const_tmpl(&data, &self.ctx.chrono_pattern, &self.ctx.time_zone)?;
             Some(res.into())
         } else {
             None
@@ -74,7 +78,15 @@ impl Expression for ExprToTimestampConstTmpl {
     }
 }
 
-#[build_function("to_timestamp1(varchar, varchar) -> timestamp")]
+// Only to register this signature to function signature map.
+#[build_function("to_timestamp1(varchar, varchar) -> timestamptz")]
+fn build_dummy(_return_type: DataType, _children: Vec<BoxedExpression>) -> Result<BoxedExpression> {
+    Err(ExprError::UnsupportedFunction(
+        "to_timestamp should have been rewritten to include timezone".into(),
+    ))
+}
+
+#[build_function("to_timestamp1(varchar, varchar, varchar) -> timestamptz")]
 fn build_to_timestamp_expr(
     return_type: DataType,
     children: Vec<BoxedExpression>,
@@ -84,22 +96,48 @@ fn build_to_timestamp_expr(
     let mut iter = children.into_iter();
     let data_expr = iter.next().unwrap();
     let tmpl_expr = iter.next().unwrap();
+    let zone_expr = iter.next().unwrap();
 
-    Ok(if let Ok(Some(tmpl)) = tmpl_expr.eval_const() {
+    Ok(if let Ok(Some(tmpl)) = tmpl_expr.eval_const()
+        && let Ok(Some(zone)) = zone_expr.eval_const() {
         ExprToTimestampConstTmpl {
             ctx: ExprToTimestampConstTmplContext {
                 chrono_pattern: compile_pattern_to_chrono(tmpl.as_utf8()),
+                time_zone: zone.into_utf8(),
             },
             child: data_expr,
         }
         .boxed()
     } else {
-        BinaryExpression::<Utf8Array, Utf8Array, TimestampArray, _>::new(
+        TernaryExpression::<Utf8Array, Utf8Array, Utf8Array, TimestamptzArray, _>::new(
             data_expr,
             tmpl_expr,
+            zone_expr,
             return_type,
             to_timestamp,
         )
         .boxed()
     })
+}
+
+/// Support building the variant returning timestamp without time zone for backward compatibility.
+pub fn build_to_timestamp_expr_legacy(
+    return_type: DataType,
+    children: Vec<BoxedExpression>,
+) -> Result<BoxedExpression> {
+    use risingwave_common::array::*;
+
+    let mut iter = children.into_iter();
+    let data_expr = iter.next().unwrap();
+    let tmpl_expr = iter.next().unwrap();
+
+    Ok(
+        BinaryExpression::<Utf8Array, Utf8Array, TimestampArray, _>::new(
+            data_expr,
+            tmpl_expr,
+            return_type,
+            to_timestamp_legacy,
+        )
+        .boxed(),
+    )
 }

--- a/src/expr/src/vector_op/to_timestamp.rs
+++ b/src/expr/src/vector_op/to_timestamp.rs
@@ -13,14 +13,19 @@
 // limitations under the License.
 
 use chrono::format::Parsed;
-use risingwave_common::types::Timestamp;
+use either::Either;
+use risingwave_common::types::{Timestamp, Timestamptz};
 
 // use risingwave_expr_macro::function;
+use super::timestamptz::{timestamp_at_time_zone, timestamptz_at_time_zone};
 use super::to_char::{compile_pattern_to_chrono, ChronoPattern};
 use crate::Result;
 
 #[inline(always)]
-pub fn to_timestamp_const_tmpl(s: &str, tmpl: &ChronoPattern) -> Result<Timestamp> {
+pub fn to_timestamp_common(
+    s: &str,
+    tmpl: &ChronoPattern,
+) -> Result<Either<Timestamp, Timestamptz>> {
     let mut parsed = Parsed::new();
     chrono::format::parse(&mut parsed, s, tmpl.borrow_dependent().iter())?;
 
@@ -61,13 +66,70 @@ pub fn to_timestamp_const_tmpl(s: &str, tmpl: &ChronoPattern) -> Result<Timestam
 
     // Seconds and nanoseconds can be omitted, so we don't need to assign default value for them.
 
-    // FIXME: We should return `TimestampTz` here.
-    parsed.offset.get_or_insert(0);
-    Ok(Timestamp(parsed.to_datetime()?.naive_utc()))
+    // The parsed result may or may not contain an offset.
+    Ok(match parsed.offset {
+        None => Either::Left(parsed.to_naive_datetime_with_offset(0)?.into()),
+        Some(_) => Either::Right(parsed.to_datetime()?.into()),
+    })
 }
 
-// #[function("to_timestamp(varchar, varchar) -> timestamp")]
-pub fn to_timestamp(s: &str, tmpl: &str) -> Result<Timestamp> {
+#[inline(always)]
+pub fn to_timestamp_const_tmpl_legacy(s: &str, tmpl: &ChronoPattern) -> Result<Timestamp> {
+    match to_timestamp_common(s, tmpl)? {
+        Either::Left(ts) => Ok(ts),
+        // If the parsed result is a physical instant, return its reading in UTC.
+        // This decision was arbitrary and we are just being backward compatible here.
+        Either::Right(tsz) => timestamptz_at_time_zone(tsz, "UTC"),
+    }
+}
+
+#[inline(always)]
+pub fn to_timestamp_const_tmpl(
+    s: &str,
+    tmpl: &ChronoPattern,
+    timezone: &str,
+) -> Result<Timestamptz> {
+    Ok(match to_timestamp_common(s, tmpl)? {
+        Either::Right(tsz) => tsz,
+        // If the parsed result lacks offset info, interpret it in the implicit session time zone.
+        Either::Left(ts) => timestamp_at_time_zone(ts, timezone)?,
+    })
+}
+
+// #[function("to_timestamp1(varchar, varchar) -> timestamp")]
+pub fn to_timestamp_legacy(s: &str, tmpl: &str) -> Result<Timestamp> {
     let pattern = compile_pattern_to_chrono(tmpl);
-    to_timestamp_const_tmpl(s, &pattern)
+    to_timestamp_const_tmpl_legacy(s, &pattern)
+}
+
+// #[function("to_timestamp1(varchar, varchar, varchar) -> timestamptz")]
+pub fn to_timestamp(s: &str, tmpl: &str, timezone: &str) -> Result<Timestamptz> {
+    let pattern = compile_pattern_to_chrono(tmpl);
+    to_timestamp_const_tmpl(s, &pattern, timezone)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_to_timestamp_legacy() {
+        // This legacy expr can no longer be build by frontend, so we test its backward compatible
+        // behavior in unit tests rather than e2e slt.
+        for (input, format, expected) in [
+            (
+                "2020-02-03 12:34:56",
+                "yyyy-mm-dd hh24:mi:ss",
+                "2020-02-03 12:34:56",
+            ),
+            (
+                "2020-02-03 12:34:56+03:00",
+                "yyyy-mm-dd hh24:mi:ss tzh:tzm",
+                "2020-02-03 09:34:56",
+            ),
+        ] {
+            let actual = to_timestamp_legacy(input, format).unwrap();
+            assert_eq!(actual.to_string(), expected);
+        }
+    }
 }

--- a/src/frontend/src/expr/session_timezone.rs
+++ b/src/frontend/src/expr/session_timezone.rs
@@ -216,6 +216,19 @@ impl SessionTimezone {
                 new_inputs.push(ExprImpl::literal_varchar(self.timezone()));
                 Some(FunctionCall::new(func_type, new_inputs).unwrap().into())
             }
+            // `to_timestamp1(input_string, format_string)`
+            // => `to_timestamp1(input_string, format_string, zone_string)`
+            ExprType::ToTimestamp1 => {
+                if !(inputs.len() == 2
+                    && inputs[0].return_type() == DataType::Varchar
+                    && inputs[1].return_type() == DataType::Varchar)
+                {
+                    return None;
+                }
+                let mut new_inputs = inputs.clone();
+                new_inputs.push(ExprImpl::literal_varchar(self.timezone()));
+                Some(FunctionCall::new(func_type, new_inputs).unwrap().into())
+            }
             _ => None,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #7780 

Backward compatibility: The old `to_timestamp(varchar, varchar) -> timestamp` would not be generated by frontend, but is still accepted by backend, despite lacking the constant template optimization.

Tested locally: (1) create a mview with `to_timestamp` on main branch; (2) kill the cluster, switch to PR branch, and start cluster; (3) query the mview, insert new rows to its upstream and query again

Given the initial request to support `to_timestamp` comes from superset, it is likely this expr is not used in a mview yet. If we do find it is necessary to optimize this legacy variant with constant template as well, we can refactor `ExprToTimestampConstTmpl` with generic.

The following styling issues will be handled in a followup PR:
* `timezone` vs `time_zone`
* `to_timestamp1` -> `char_to_timestamptz`
* `to_timestamp` -> `sec_to_timestamptz`

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

### Types of user-facing changes

- SQL commands, functions, and operators

### Release note

`to_timestamp(input_string, format)` returns `timestamptz`, aligning with PostgreSQL.