### PR TITLE
feat(optimizer, stream): support index selection for temporal join

### DIFF
--- a/e2e_test/streaming/temporal_join/temporal_join_with_index.slt
+++ b/e2e_test/streaming/temporal_join/temporal_join_with_index.slt
@@ -11,7 +11,7 @@ statement ok
 create index idx on version (a2);
 
 statement ok
-create materialized view v as select id1, a1, id2, a2 from stream left join idx FOR SYSTEM_TIME AS OF PROCTIME() on b1 = b2 and a1 = a2;
+create materialized view v as select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on b1 = b2 and a1 = a2;
 
 statement ok
 insert into stream values(1, 11, 111);

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -64,6 +64,7 @@ message StorageTableDesc {
   // Whether the table is versioned. If `true`, column-aware row encoding will
   // be used to be compatible with schema changes.
   bool versioned = 8;
+  repeated uint32 stream_key = 9;
 }
 
 enum JoinType {

--- a/src/common/src/catalog/physical_table.rs
+++ b/src/common/src/catalog/physical_table.rs
@@ -108,6 +108,7 @@ impl TableDesc {
             value_indices: self.value_indices.iter().map(|&v| v as u32).collect(),
             read_prefix_len_hint: self.read_prefix_len_hint as u32,
             versioned: self.versioned,
+            stream_key: self.stream_key.iter().map(|&x| x as u32).collect(),
         }
     }
 

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -119,7 +119,7 @@
     select * from t left join v FOR SYSTEM_TIME AS OF PROCTIME() on a = count;
   expected_outputs:
   - stream_plan
-- name: index selection for temporal join (one index).
+- name: index selection for temporal join (with one index).
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -127,7 +127,7 @@
     select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
   expected_outputs:
     - stream_plan
-- name: index selection for temporal join (two index) and should choose the index with a longer prefix..
+- name: index selection for temporal join (with two indexes) and should choose the index with a longer prefix..
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -136,7 +136,7 @@
     select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
   expected_outputs:
     - stream_plan
-- name: index selection for temporal join (three index) and should choose the index matched primary table pk.
+- name: index selection for temporal join (with three indexes) and should choose primary table.
   sql: |
     create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));

--- a/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/temporal_join.yaml
@@ -119,4 +119,39 @@
     select * from t left join v FOR SYSTEM_TIME AS OF PROCTIME() on a = count;
   expected_outputs:
   - stream_plan
-
+- name: index selection for temporal join (one index).
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    create index idx on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
+  expected_outputs:
+    - stream_plan
+- name: index selection for temporal join (two index) and should choose the index with a longer prefix..
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
+  expected_outputs:
+    - stream_plan
+- name: index selection for temporal join (three index) and should choose the index matched primary table pk.
+  sql: |
+    create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (b2);
+    create index idx3 on version (c2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2 and c1 = c2 and id1 = id2;
+  expected_outputs:
+    - stream_plan
+- name: index selection for temporal join (two index) and no one matches.
+  sql: |
+    create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on c1 = c2;
+  expected_outputs:
+    - stream_error

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -204,7 +204,7 @@
       │   └─StreamTableScan { table: t, columns: [t.a, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange [no_shuffle] { dist: Single }
         └─StreamTableScan { table: v, columns: [v.count], pk: [], dist: Single }
-- name: index selection for temporal join (one index).
+- name: index selection for temporal join (with one index).
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -217,7 +217,7 @@
       │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
       └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(idx.a2, idx.b2) }
         └─StreamTableScan { table: idx, columns: [idx.id2, idx.a2, idx.b2], pk: [idx.id2], dist: UpstreamHashShard(idx.a2, idx.b2) }
-- name: index selection for temporal join (two index) and should choose the index with a longer prefix..
+- name: index selection for temporal join (with two indexes) and should choose the index with a longer prefix..
   sql: |
     create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, primary key (id2));
@@ -231,7 +231,7 @@
       │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
       └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(idx2.a2, idx2.b2) }
         └─StreamTableScan { table: idx2, columns: [idx2.id2, idx2.a2, idx2.b2], pk: [idx2.id2], dist: UpstreamHashShard(idx2.a2, idx2.b2) }
-- name: index selection for temporal join (three index) and should choose the index matched primary table pk.
+- name: index selection for temporal join (with three indexes) and should choose primary table.
   sql: |
     create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
     create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));

--- a/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/temporal_join.yaml
@@ -204,3 +204,55 @@
       │   └─StreamTableScan { table: t, columns: [t.a, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
       └─StreamExchange [no_shuffle] { dist: Single }
         └─StreamTableScan { table: v, columns: [v.count], pk: [], dist: Single }
+- name: index selection for temporal join (one index).
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    create index idx on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden), stream.b1(hidden)], stream_key: [stream._row_id, id2, a1, stream.b1], pk_columns: [stream._row_id, id2, a1, stream.b1], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: LeftOuter, predicate: stream.a1 = idx.a2 AND stream.b1 = idx.b2, output: [stream.id1, stream.a1, idx.id2, idx.a2, stream._row_id, stream.b1] }
+      ├─StreamExchange { dist: HashShard(stream.a1, stream.b1) }
+      │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(idx.a2, idx.b2) }
+        └─StreamTableScan { table: idx, columns: [idx.id2, idx.a2, idx.b2], pk: [idx.id2], dist: UpstreamHashShard(idx.a2, idx.b2) }
+- name: index selection for temporal join (two index) and should choose the index with a longer prefix..
+  sql: |
+    create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden), stream.b1(hidden)], stream_key: [stream._row_id, id2, a1, stream.b1], pk_columns: [stream._row_id, id2, a1, stream.b1], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: LeftOuter, predicate: stream.a1 = idx2.a2 AND stream.b1 = idx2.b2, output: [stream.id1, stream.a1, idx2.id2, idx2.a2, stream._row_id, stream.b1] }
+      ├─StreamExchange { dist: HashShard(stream.a1, stream.b1) }
+      │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.b1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(idx2.a2, idx2.b2) }
+        └─StreamTableScan { table: idx2, columns: [idx2.id2, idx2.a2, idx2.b2], pk: [idx2.id2], dist: UpstreamHashShard(idx2.a2, idx2.b2) }
+- name: index selection for temporal join (three index) and should choose the index matched primary table pk.
+  sql: |
+    create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (b2);
+    create index idx3 on version (c2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on a1 = a2 and b1 = b2 and c1 = c2 and id1 = id2;
+  stream_plan: |-
+    StreamMaterialize { columns: [id1, a1, id2, a2, stream._row_id(hidden), stream.b1(hidden), stream.c1(hidden)], stream_key: [stream._row_id, id2, id1, a1, stream.b1, stream.c1], pk_columns: [stream._row_id, id2, id1, a1, stream.b1, stream.c1], pk_conflict: NoCheck }
+    └─StreamTemporalJoin { type: LeftOuter, predicate: stream.id1 = version.id2 AND (stream.a1 = version.a2) AND (stream.b1 = version.b2) AND (stream.c1 = version.c2), output: [stream.id1, stream.a1, version.id2, version.a2, stream._row_id, stream.b1, stream.c1] }
+      ├─StreamExchange { dist: HashShard(stream.id1) }
+      │ └─StreamTableScan { table: stream, columns: [stream.id1, stream.a1, stream.b1, stream.c1, stream._row_id], pk: [stream._row_id], dist: UpstreamHashShard(stream._row_id) }
+      └─StreamExchange [no_shuffle] { dist: UpstreamHashShard(version.id2) }
+        └─StreamTableScan { table: version, columns: [version.id2, version.a2, version.b2, version.c2], pk: [version.id2], dist: UpstreamHashShard(version.id2) }
+- name: index selection for temporal join (two index) and no one matches.
+  sql: |
+    create table stream(id1 int, a1 int, b1 int, c1 int) APPEND ONLY;
+    create table version(id2 int, a2 int, b2 int, c2 int, primary key (id2));
+    create index idx1 on version (a2);
+    create index idx2 on version (a2, b2);
+    select id1, a1, id2, a2 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on c1 = c2;
+  stream_error: |-
+    Not supported: Temporal join requires the lookup table's primary key contained exactly in the equivalence condition
+    HINT: Please add the primary key of the lookup table to the join condition and remove any other conditions

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -985,7 +985,7 @@ impl LogicalJoin {
                     match &result_plan {
                         Err(_) => result_plan = Ok(temporal_join),
                         Ok(prev_temporal_join) => {
-                            // Prefer to choose temporal join with longer lookup prefix len.
+                            // Prefer to the temporal join with a longer lookup prefix len.
                             if prev_temporal_join.eq_join_predicate().eq_indexes().len()
                                 < temporal_join.eq_join_predicate().eq_indexes().len()
                             {

--- a/src/frontend/src/optimizer/plan_node/logical_join.rs
+++ b/src/frontend/src/optimizer/plan_node/logical_join.rs
@@ -959,11 +959,52 @@ impl LogicalJoin {
         }
     }
 
+    fn to_stream_temporal_join_with_index_selection(
+        &self,
+        predicate: EqJoinPredicate,
+        ctx: &mut ToStreamContext,
+    ) -> Result<StreamTemporalJoin> {
+        // Index selection for temporal join.
+        let right = self.right();
+        // `should_be_temporal_join()` has already check right input for us.
+        let logical_scan: &LogicalScan = right.as_logical_scan().unwrap();
+
+        // Use primary table.
+        let mut result_plan = self.to_stream_temporal_join(predicate.clone(), ctx);
+        // Return directly if this temporal join can match the pk of its right table.
+        if let Ok(temporal_join) = &result_plan && temporal_join.eq_join_predicate().eq_indexes().len() == logical_scan.primary_key().len() {
+            return result_plan;
+        }
+        let indexes = logical_scan.indexes();
+        for index in indexes {
+            // Use index table
+            if let Some(index_scan) = logical_scan.to_index_scan_if_index_covered(index) {
+                let index_scan: PlanRef = index_scan.into();
+                let that = self.clone_with_left_right(self.left(), index_scan.clone());
+                if let Ok(temporal_join) = that.to_stream_temporal_join(predicate.clone(), ctx) {
+                    match &result_plan {
+                        Err(_) => result_plan = Ok(temporal_join),
+                        Ok(prev_temporal_join) => {
+                            // Prefer to choose temporal join with longer lookup prefix len.
+                            if prev_temporal_join.eq_join_predicate().eq_indexes().len()
+                                < temporal_join.eq_join_predicate().eq_indexes().len()
+                            {
+                                result_plan = Ok(temporal_join)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        result_plan
+    }
+
     fn to_stream_temporal_join(
         &self,
         predicate: EqJoinPredicate,
         ctx: &mut ToStreamContext,
-    ) -> Result<PlanRef> {
+    ) -> Result<StreamTemporalJoin> {
         assert!(predicate.has_eq());
 
         let right = self.right();
@@ -1126,7 +1167,7 @@ impl LogicalJoin {
 
         let new_predicate = new_predicate.retain_prefix_eq_key(lookup_prefix_len);
 
-        Ok(StreamTemporalJoin::new(new_logical_join, new_predicate).into())
+        Ok(StreamTemporalJoin::new(new_logical_join, new_predicate))
     }
 
     fn to_stream_dynamic_filter(
@@ -1305,7 +1346,8 @@ impl ToStream for LogicalJoin {
             }
 
             if self.should_be_temporal_join() {
-                self.to_stream_temporal_join(predicate, ctx)
+                self.to_stream_temporal_join_with_index_selection(predicate, ctx)
+                    .map(|x| x.into())
             } else {
                 self.to_stream_hash_join(predicate, ctx)
             }

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -88,11 +88,11 @@ impl JoinEntry {
     }
 
     /// Delete from the cache.
-    pub fn remove(&mut self, pk: &OwnedRow) {
-        if let Some(value) = self.cached.remove(pk) {
-            self.kv_heap_size.sub(pk, &value);
+    pub fn remove(&mut self, key: &OwnedRow) {
+        if let Some(value) = self.cached.remove(key) {
+            self.kv_heap_size.sub(key, &value);
         } else {
-            panic!("pk {:?} should be in the cache", pk);
+            panic!("key {:?} should be in the cache", key);
         }
     }
 
@@ -134,7 +134,7 @@ impl DerefMut for JoinEntryWrapper {
 
 struct TemporalSide<K: HashKey, S: StateStore> {
     source: StorageTable<S>,
-    pk: Vec<usize>,
+    table_stream_key_indices: Vec<usize>,
     table_output_indices: Vec<usize>,
     cache: ManagedLruCache<K, JoinEntryWrapper, DefaultHasher, SharedStatsAlloc<Global>>,
     ctx: ActorContextRef,
@@ -182,7 +182,7 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
             pin_mut!(iter);
             while let Some(row) = iter.next_row().await? {
                 entry.insert(
-                    row.as_ref().project(&self.pk).into_owned_row(),
+                    row.as_ref().project(&self.table_stream_key_indices).into_owned_row(),
                     row.project(&self.table_output_indices).into_owned_row(),
                 );
             }
@@ -197,17 +197,20 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
         &mut self,
         chunks: Vec<StreamChunk>,
         join_keys: &[usize],
+        right_stream_key_indices: &[usize],
     ) -> StreamExecutorResult<()> {
         for chunk in chunks {
+            // Compact chunk, otherwise the following keys and chunk rows might fail to zip.
+            let chunk = chunk.compact();
             let keys = K::build(join_keys, chunk.data_chunk())?;
             for ((op, row), key) in chunk.rows().zip_eq_debug(keys.into_iter()) {
                 if self.cache.contains(&key) {
                     // Update cache
                     let mut entry = self.cache.get_mut(&key).unwrap();
-                    let pk = row.project(&self.pk).into_owned_row();
+                    let stream_key = row.project(right_stream_key_indices).into_owned_row();
                     match op {
-                        Op::Insert | Op::UpdateInsert => entry.insert(pk, row.into_owned_row()),
-                        Op::Delete | Op::UpdateDelete => entry.remove(&pk),
+                        Op::Insert | Op::UpdateInsert => entry.insert(stream_key, row.into_owned_row()),
+                        Op::Delete | Op::UpdateDelete => entry.remove(&stream_key),
                     };
                 }
             }
@@ -306,6 +309,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
         pk_indices: PkIndices,
         output_indices: Vec<usize>,
         table_output_indices: Vec<usize>,
+        table_stream_key_indices: Vec<usize>,
         executor_id: u64,
         watermark_epoch: AtomicU64Ref,
         metrics: Arc<StreamingMetrics>,
@@ -335,15 +339,13 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
             alloc,
         );
 
-        let pk = table.pk_in_output_indices().unwrap();
-
         Self {
             ctx: ctx.clone(),
             left,
             right,
             right_table: TemporalSide {
                 source: table,
-                pk,
+                table_stream_key_indices,
                 table_output_indices,
                 cache,
                 ctx,
@@ -369,6 +371,8 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
             self.left.schema().len(),
             self.right.schema().len(),
         );
+
+        let right_stream_key_indices = self.right.pk_indices().to_vec();
 
         let null_matched = K::Bitmap::from_bool_vec(self.null_safe);
 
@@ -441,7 +445,7 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
                         }
                     }
                     self.right_table.cache.update_epoch(barrier.epoch.curr);
-                    self.right_table.update(updates, &self.right_join_keys)?;
+                    self.right_table.update(updates, &self.right_join_keys, &right_stream_key_indices)?;
                     prev_epoch = Some(barrier.epoch.curr);
                     yield Message::Barrier(barrier)
                 }

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -182,7 +182,9 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
             pin_mut!(iter);
             while let Some(row) = iter.next_row().await? {
                 entry.insert(
-                    row.as_ref().project(&self.table_stream_key_indices).into_owned_row(),
+                    row.as_ref()
+                        .project(&self.table_stream_key_indices)
+                        .into_owned_row(),
                     row.project(&self.table_output_indices).into_owned_row(),
                 );
             }
@@ -209,7 +211,9 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
                     let mut entry = self.cache.get_mut(&key).unwrap();
                     let stream_key = row.project(right_stream_key_indices).into_owned_row();
                     match op {
-                        Op::Insert | Op::UpdateInsert => entry.insert(stream_key, row.into_owned_row()),
+                        Op::Insert | Op::UpdateInsert => {
+                            entry.insert(stream_key, row.into_owned_row())
+                        }
                         Op::Delete | Op::UpdateDelete => entry.remove(&stream_key),
                     };
                 }
@@ -445,7 +449,11 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
                         }
                     }
                     self.right_table.cache.update_epoch(barrier.epoch.curr);
-                    self.right_table.update(updates, &self.right_join_keys, &right_stream_key_indices)?;
+                    self.right_table.update(
+                        updates,
+                        &self.right_join_keys,
+                        &right_stream_key_indices,
+                    )?;
                     prev_epoch = Some(barrier.epoch.curr);
                     yield Message::Barrier(barrier)
                 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Support index selection for temporal join. Related issue. https://github.com/risingwavelabs/risingwave/issues/8123

## Example:
```sql
create table stream(id1 int, a1 int, b1 int) APPEND ONLY;
create table version(id2 int, a2 int, b2 int, primary key (id2));
create index idx on version (a2);
CREATE materialized VIEW v AS
SELECT id1,
       a1,
       id2,
       a2
FROM stream
LEFT JOIN idx
FOR SYSTEM_TIME AS OF PROCTIME() ON b1 = b2
AND a1 = a2;
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- SQL commands, functions, and operators


### Release note

- Support index selection for temporal join. 

</details>
