### PR TITLE
fix(sqlsmith): ban `Sum(Int64) -> Int64`

### DIFF
--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -206,16 +206,17 @@ pub(crate) static INVARIANT_FUNC_SET: LazyLock<HashSet<ExprType>> = LazyLock::ne
 
 /// Table which maps aggregate functions' return types to possible function signatures.
 // ENABLE: https://github.com/risingwavelabs/risingwave/issues/5826
-pub(crate) static AGG_FUNC_TABLE: LazyLock<HashMap<DataType, Vec<AggFuncSig>>> =
-    LazyLock::new(|| {
+pub(crate) static AGG_FUNC_TABLE: LazyLock<HashMap<DataType, Vec<AggFuncSig>>> = LazyLock::new(
+    || {
         let mut funcs = HashMap::<DataType, Vec<AggFuncSig>>::new();
         agg_func_sigs()
             .filter(|func| {
                 func.inputs_type
                     .iter()
                     .all(|t| *t != DataTypeName::Timestamptz)
+                    // Ignored functions
                     && ![
-                        AggKind::Sum0,
+                        AggKind::Sum0, // Used internally
                         AggKind::BitAnd,
                         AggKind::BitOr,
                         AggKind::BoolAnd,
@@ -225,13 +226,24 @@ pub(crate) static AGG_FUNC_TABLE: LazyLock<HashMap<DataType, Vec<AggFuncSig>>> =
                         AggKind::Mode,
                     ]
                     .contains(&func.func)
+                    // Exclude 2 phase agg global sum.
+                    // Sum(Int64) -> Int64.
+                    // Otherwise it conflicts with normal aggregation:
+                    // Sum(Int64) -> Decimal.
+                    // And sqlsmith will generate expressions with wrong types.
+                    && if func.func == AggKind::Sum {
+                       !(func.inputs_type[0] == DataTypeName::Int64 && func.ret_type == DataTypeName::Int64)
+                    } else {
+                       true
+                    }
             })
             .filter_map(|func| func.try_into().ok())
             .for_each(|func: AggFuncSig| {
                 funcs.entry(func.ret_type.clone()).or_default().push(func)
             });
         funcs
-    });
+    },
+);
 
 /// Build a cast map from return types to viable cast-signatures.
 /// NOTE: We avoid cast from varchar to other datatypes apart from itself.


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Recently fuzz test failed. Reason was that it treated a `Sum` expression as `Sum(Int64) -> Int64`, instead of `Sum(Int64) -> Numeric`, and subsequently the sql could not be bound.


We can just ban `Sum(Int64) -> Int64` since it is just used internally by 2phase agg.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
