### PR TITLE
refactor(config): support setting default compaction config in config file

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -268,6 +268,9 @@ pub struct MetaConfig {
     // If the compaction task does not change in progress beyond the
     // `compaction_task_max_heartbeat_interval_secs` interval, we will cancel the task
     pub compaction_task_max_heartbeat_interval_secs: u64,
+
+    #[serde(default)]
+    pub compaction_config: CompactionConfig,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -656,7 +659,7 @@ impl SystemConfig {
     }
 }
 
-mod default {
+pub mod default {
     pub mod meta {
         use crate::config::{DefaultParallelism, MetaBackend};
 
@@ -985,6 +988,65 @@ mod default {
             true
         }
     }
+
+    pub mod compaction_config {
+        const DEFAULT_MAX_COMPACTION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2GB
+        const DEFAULT_MIN_COMPACTION_BYTES: u64 = 128 * 1024 * 1024; // 128MB
+        const DEFAULT_MAX_BYTES_FOR_LEVEL_BASE: u64 = 512 * 1024 * 1024; // 512MB
+
+        // decrease this configure when the generation of checkpoint barrier is not frequent.
+        const DEFAULT_TIER_COMPACT_TRIGGER_NUMBER: u64 = 6;
+        const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 32 * 1024 * 1024; // 32MB
+        const DEFAULT_MAX_SUB_COMPACTION: u32 = 4;
+        const DEFAULT_LEVEL_MULTIPLIER: u64 = 5;
+        const DEFAULT_MAX_SPACE_RECLAIM_BYTES: u64 = 512 * 1024 * 1024; // 512MB;
+        const DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER: u64 = 1000;
+        const DEFAULT_MAX_COMPACTION_FILE_COUNT: u64 = 96;
+        const DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 3;
+        const DEFAULT_MIN_OVERLAPPING_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 6;
+
+        use crate::catalog::hummock::CompactionFilterFlag;
+
+        pub fn max_bytes_for_level_base() -> u64 {
+            DEFAULT_MAX_BYTES_FOR_LEVEL_BASE
+        }
+        pub fn max_bytes_for_level_multiplier() -> u64 {
+            DEFAULT_LEVEL_MULTIPLIER
+        }
+        pub fn max_compaction_bytes() -> u64 {
+            DEFAULT_MAX_COMPACTION_BYTES
+        }
+        pub fn sub_level_max_compaction_bytes() -> u64 {
+            DEFAULT_MIN_COMPACTION_BYTES
+        }
+        pub fn level0_tier_compact_file_number() -> u64 {
+            DEFAULT_TIER_COMPACT_TRIGGER_NUMBER
+        }
+        pub fn target_file_size_base() -> u64 {
+            DEFAULT_TARGET_FILE_SIZE_BASE
+        }
+        pub fn compaction_filter_mask() -> u32 {
+            (CompactionFilterFlag::STATE_CLEAN | CompactionFilterFlag::TTL).into()
+        }
+        pub fn max_sub_compaction() -> u32 {
+            DEFAULT_MAX_SUB_COMPACTION
+        }
+        pub fn level0_stop_write_threshold_sub_level_number() -> u64 {
+            DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER
+        }
+        pub fn level0_sub_level_compact_level_count() -> u32 {
+            DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT
+        }
+        pub fn level0_overlapping_sub_level_compact_level_count() -> u32 {
+            DEFAULT_MIN_OVERLAPPING_SUB_LEVEL_COMPACT_LEVEL_COUNT
+        }
+        pub fn max_space_reclaim_bytes() -> u64 {
+            DEFAULT_MAX_SPACE_RECLAIM_BYTES
+        }
+        pub fn level0_max_compact_file_number() -> u64 {
+            DEFAULT_MAX_COMPACTION_FILE_COUNT
+        }
+    }
 }
 
 pub struct StorageMemoryConfig {
@@ -1031,6 +1093,38 @@ pub fn extract_storage_memory_config(s: &RwConfig) -> StorageMemoryConfig {
         compactor_memory_limit_mb,
         high_priority_ratio_in_percent,
     }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, DefaultFromSerde)]
+pub struct CompactionConfig {
+    #[serde(default = "default::compaction_config::max_bytes_for_level_base")]
+    pub max_bytes_for_level_base: u64,
+    #[serde(default = "default::compaction_config::max_bytes_for_level_multiplier")]
+    pub max_bytes_for_level_multiplier: u64,
+    #[serde(default = "default::compaction_config::max_compaction_bytes")]
+    pub max_compaction_bytes: u64,
+    #[serde(default = "default::compaction_config::sub_level_max_compaction_bytes")]
+    pub sub_level_max_compaction_bytes: u64,
+    #[serde(default = "default::compaction_config::level0_tier_compact_file_number")]
+    pub level0_tier_compact_file_number: u64,
+    #[serde(default = "default::compaction_config::target_file_size_base")]
+    pub target_file_size_base: u64,
+    #[serde(default = "default::compaction_config::compaction_filter_mask")]
+    pub compaction_filter_mask: u32,
+    #[serde(default = "default::compaction_config::max_sub_compaction")]
+    pub max_sub_compaction: u32,
+    #[serde(default = "default::compaction_config::level0_stop_write_threshold_sub_level_number")]
+    pub level0_stop_write_threshold_sub_level_number: u64,
+    #[serde(default = "default::compaction_config::level0_sub_level_compact_level_count")]
+    pub level0_sub_level_compact_level_count: u32,
+    #[serde(
+        default = "default::compaction_config::level0_overlapping_sub_level_compact_level_count"
+    )]
+    pub level0_overlapping_sub_level_compact_level_count: u32,
+    #[serde(default = "default::compaction_config::max_space_reclaim_bytes")]
+    pub max_space_reclaim_bytes: u64,
+    #[serde(default = "default::compaction_config::level0_max_compact_file_number")]
+    pub level0_max_compact_file_number: u64,
 }
 
 #[cfg(test)]

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -33,6 +33,21 @@ table_write_throughput_threshold = 134217728
 min_table_split_write_throughput = 33554432
 compaction_task_max_heartbeat_interval_secs = 60
 
+[meta.compaction_config]
+max_bytes_for_level_base = 536870912
+max_bytes_for_level_multiplier = 5
+max_compaction_bytes = 2147483648
+sub_level_max_compaction_bytes = 134217728
+level0_tier_compact_file_number = 6
+target_file_size_base = 33554432
+compaction_filter_mask = 6
+max_sub_compaction = 4
+level0_stop_write_threshold_sub_level_number = 1000
+level0_sub_level_compact_level_count = 3
+level0_overlapping_sub_level_compact_level_count = 6
+max_space_reclaim_bytes = 536870912
+level0_max_compact_file_number = 96
+
 [batch]
 enable_barrier_read = true
 

--- a/src/meta/src/hummock/compaction/compaction_config.rs
+++ b/src/meta/src/hummock/compaction/compaction_config.rs
@@ -12,25 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use risingwave_common::constants::hummock::CompactionFilterFlag;
+use risingwave_common::config::default::compaction_config;
+use risingwave_common::config::CompactionConfig as CompactionConfigOpt;
 use risingwave_pb::hummock::compaction_config::CompactionMode;
 use risingwave_pb::hummock::CompactionConfig;
 
-const DEFAULT_MAX_COMPACTION_BYTES: u64 = 2 * 1024 * 1024 * 1024; // 2GB
-const DEFAULT_MIN_COMPACTION_BYTES: u64 = 128 * 1024 * 1024; // 128MB
-const DEFAULT_MAX_BYTES_FOR_LEVEL_BASE: u64 = 512 * 1024 * 1024; // 512MB
-
-// decrease this configure when the generation of checkpoint barrier is not frequent.
-const DEFAULT_TIER_COMPACT_TRIGGER_NUMBER: u64 = 6;
-const DEFAULT_TARGET_FILE_SIZE_BASE: u64 = 32 * 1024 * 1024; // 32MB
-const DEFAULT_MAX_SUB_COMPACTION: u32 = 4;
 const MAX_LEVEL: u64 = 6;
-const DEFAULT_LEVEL_MULTIPLIER: u64 = 5;
-const DEFAULT_MAX_SPACE_RECLAIM_BYTES: u64 = 512 * 1024 * 1024; // 512MB;
-const DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER: u64 = 1000;
-const DEFAULT_MAX_COMPACTION_FILE_COUNT: u64 = 96;
-const DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 3;
-const DEFAULT_MIN_OVERLAPPING_SUB_LEVEL_COMPACT_LEVEL_COUNT: u32 = 6;
 
 pub struct CompactionConfigBuilder {
     config: CompactionConfig,
@@ -40,13 +27,14 @@ impl CompactionConfigBuilder {
     pub fn new() -> Self {
         Self {
             config: CompactionConfig {
-                max_bytes_for_level_base: DEFAULT_MAX_BYTES_FOR_LEVEL_BASE,
-                max_bytes_for_level_multiplier: DEFAULT_LEVEL_MULTIPLIER,
+                max_bytes_for_level_base: compaction_config::max_bytes_for_level_base(),
+                max_bytes_for_level_multiplier: compaction_config::max_bytes_for_level_multiplier(),
                 max_level: MAX_LEVEL,
-                max_compaction_bytes: DEFAULT_MAX_COMPACTION_BYTES,
-                sub_level_max_compaction_bytes: DEFAULT_MIN_COMPACTION_BYTES,
-                level0_tier_compact_file_number: DEFAULT_TIER_COMPACT_TRIGGER_NUMBER,
-                target_file_size_base: DEFAULT_TARGET_FILE_SIZE_BASE,
+                max_compaction_bytes: compaction_config::max_compaction_bytes(),
+                sub_level_max_compaction_bytes: compaction_config::sub_level_max_compaction_bytes(),
+                level0_tier_compact_file_number: compaction_config::level0_tier_compact_file_number(
+                ),
+                target_file_size_base: compaction_config::target_file_size_base(),
                 compaction_mode: CompactionMode::Range as i32,
                 // support compression setting per level
                 // L0/L1 and L2 do not use compression algorithms
@@ -60,29 +48,49 @@ impl CompactionConfigBuilder {
                     "Zstd".to_string(),
                     "Zstd".to_string(),
                 ],
-                compaction_filter_mask: (CompactionFilterFlag::STATE_CLEAN
-                    | CompactionFilterFlag::TTL)
-                    .into(),
-                max_sub_compaction: DEFAULT_MAX_SUB_COMPACTION,
-                max_space_reclaim_bytes: DEFAULT_MAX_SPACE_RECLAIM_BYTES,
+                compaction_filter_mask: compaction_config::compaction_filter_mask(),
+                max_sub_compaction: compaction_config::max_sub_compaction(),
+                max_space_reclaim_bytes: compaction_config::max_space_reclaim_bytes(),
                 split_by_state_table: false,
                 split_weight_by_vnode: 0,
                 level0_stop_write_threshold_sub_level_number:
-                    DEFAULT_LEVEL0_STOP_WRITE_THRESHOLD_SUB_LEVEL_NUMBER,
+                    compaction_config::level0_stop_write_threshold_sub_level_number(),
                 // This configure variable shall be larger than level0_tier_compact_file_number, and
                 // it shall meet the following condition:
                 //    level0_max_compact_file_number * target_file_size_base >
                 // max_bytes_for_level_base
-                level0_max_compact_file_number: DEFAULT_MAX_COMPACTION_FILE_COUNT,
-                level0_sub_level_compact_level_count: DEFAULT_MIN_SUB_LEVEL_COMPACT_LEVEL_COUNT,
+                level0_max_compact_file_number: compaction_config::level0_max_compact_file_number(),
+                level0_sub_level_compact_level_count:
+                    compaction_config::level0_sub_level_compact_level_count(),
                 level0_overlapping_sub_level_compact_level_count:
-                    DEFAULT_MIN_OVERLAPPING_SUB_LEVEL_COMPACT_LEVEL_COUNT,
+                    compaction_config::level0_overlapping_sub_level_compact_level_count(),
             },
         }
     }
 
     pub fn with_config(config: CompactionConfig) -> Self {
         Self { config }
+    }
+
+    pub fn with_opt(opt: &CompactionConfigOpt) -> Self {
+        Self::new()
+            .max_bytes_for_level_base(opt.max_bytes_for_level_base)
+            .max_bytes_for_level_multiplier(opt.max_bytes_for_level_multiplier)
+            .max_compaction_bytes(opt.max_compaction_bytes)
+            .sub_level_max_compaction_bytes(opt.sub_level_max_compaction_bytes)
+            .level0_tier_compact_file_number(opt.level0_tier_compact_file_number)
+            .target_file_size_base(opt.target_file_size_base)
+            .compaction_filter_mask(opt.compaction_filter_mask)
+            .max_sub_compaction(opt.max_sub_compaction)
+            .level0_stop_write_threshold_sub_level_number(
+                opt.level0_stop_write_threshold_sub_level_number,
+            )
+            .level0_sub_level_compact_level_count(opt.level0_sub_level_compact_level_count)
+            .level0_overlapping_sub_level_compact_level_count(
+                opt.level0_overlapping_sub_level_compact_level_count,
+            )
+            .max_space_reclaim_bytes(opt.max_space_reclaim_bytes)
+            .level0_max_compact_file_number(opt.level0_max_compact_file_number)
     }
 
     pub fn build(self) -> CompactionConfig {

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -54,17 +54,20 @@ impl<S: MetaStore> HummockManager<S> {
     pub(super) async fn build_compaction_group_manager(
         env: &MetaSrvEnv<S>,
     ) -> Result<RwLock<CompactionGroupManager>> {
-        let config = CompactionConfigBuilder::new().build();
-        Self::build_compaction_group_manager_with_config(env, config).await
+        let default_config = match env.opts.compaction_config.as_ref() {
+            None => CompactionConfigBuilder::new().build(),
+            Some(opt) => CompactionConfigBuilder::with_opt(opt).build(),
+        };
+        Self::build_compaction_group_manager_with_config(env, default_config).await
     }
 
     pub(super) async fn build_compaction_group_manager_with_config(
         env: &MetaSrvEnv<S>,
-        config: CompactionConfig,
+        default_config: CompactionConfig,
     ) -> Result<RwLock<CompactionGroupManager>> {
         let compaction_group_manager = RwLock::new(CompactionGroupManager {
             compaction_groups: BTreeMap::new(),
-            default_config: config,
+            default_config,
         });
         compaction_group_manager
             .write()

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -306,6 +306,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
                 compaction_task_max_heartbeat_interval_secs: config
                     .meta
                     .compaction_task_max_heartbeat_interval_secs,
+                compaction_config: Some(config.meta.compaction_config),
             },
             config.system.into_init_system_params(),
         )

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -15,7 +15,7 @@
 use std::ops::Deref;
 use std::sync::Arc;
 
-use risingwave_common::config::DefaultParallelism;
+use risingwave_common::config::{CompactionConfig, DefaultParallelism};
 use risingwave_pb::meta::SystemParams;
 use risingwave_rpc_client::{ConnectorClient, StreamClientPool, StreamClientPoolRef};
 
@@ -149,6 +149,7 @@ pub struct MetaOpts {
     pub min_table_split_write_throughput: u64,
 
     pub compaction_task_max_heartbeat_interval_secs: u64,
+    pub compaction_config: Option<CompactionConfig>,
 }
 
 impl MetaOpts {
@@ -185,6 +186,7 @@ impl MetaOpts {
             do_not_config_object_storage_lifecycle: true,
             partition_vnode_count: 32,
             compaction_task_max_heartbeat_interval_secs: 0,
+            compaction_config: None,
         }
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously default compaction config used by meta node is hard-coded, and can only be updated by risectl afterwards. Thus it is inconvenient for setting compaction config for new compaction group created by group splitting.
This PR allows setting default compaction config via config file. Each new compaction group will use this config.

**Note that below compaction configs are not available in config file, i.e. they are still hard-coded only.** Because I've not verified whether it's correct or necessary for those configs to have different values across compaction groups.
- max_level
- compression_algorithm
- split_by_state_table
- split_weight_by_vnode

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
