### PR TITLE
refactor: reuse logger initialization in file-cache bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,12 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "castaway"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2698f953def977c68f935bb0dfa959375ad4638570e969e2f1e9f433cbf1af6"
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,36 +1741,6 @@ checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
 dependencies = [
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "curl"
-version = "0.4.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "509bd11746c7ac09ebd19f0b17782eae80aadee26237658a6b4808afb5c11a22"
-dependencies = [
- "curl-sys",
- "libc",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "socket2 0.4.9",
- "winapi",
-]
-
-[[package]]
-name = "curl-sys"
-version = "0.4.61+curl-8.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d05c10f541ae6f3bc5b3d923c20001f47db7d5f0b2bc6ad16490133842db79"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "openssl-sys",
- "pkg-config",
- "vcpkg",
- "winapi",
 ]
 
 [[package]]
@@ -3072,12 +3036,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3104,31 +3062,6 @@ dependencies = [
  "io-lifetimes",
  "rustix 0.37.19",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "isahc"
-version = "1.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "334e04b4d781f436dc315cb1e7515bd96826426345d498149e4bde36b67f8ee9"
-dependencies = [
- "async-channel",
- "castaway",
- "crossbeam-utils",
- "curl",
- "curl-sys",
- "event-listener",
- "futures-lite",
- "http",
- "log",
- "once_cell",
- "polling",
- "slab",
- "sluice",
- "tracing",
- "tracing-futures",
- "url",
- "waker-fn",
 ]
 
 [[package]]
@@ -4239,64 +4172,12 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6105e89802af13fdf48c49d7646d3b533a70e536d818aae7e78ba0433d01acb8"
-dependencies = [
- "async-trait",
- "crossbeam-channel",
- "futures-channel",
- "futures-executor",
- "futures-util",
- "js-sys",
- "lazy_static",
- "percent-encoding",
- "pin-project",
- "rand",
- "thiserror",
- "tokio",
- "tokio-stream",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
-]
-
-[[package]]
-name = "opentelemetry-http"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449048140ee61e28f57abe6e9975eedc1f3a29855c7407bd6c12b18578863379"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "isahc",
- "opentelemetry 0.17.0",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c0b12cd9e3f9b35b52f6e0dac66866c519b26f424f4bbf96e3fe8bfbdc5229"
-dependencies = [
- "async-trait",
- "http",
- "isahc",
- "lazy_static",
- "opentelemetry 0.17.0",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions 0.9.0",
- "thiserror",
- "thrift",
- "tokio",
 ]
 
 [[package]]
@@ -4309,7 +4190,7 @@ dependencies = [
  "futures",
  "futures-util",
  "http",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "opentelemetry-proto",
  "prost",
  "thiserror",
@@ -4325,18 +4206,9 @@ checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
 dependencies = [
  "futures",
  "futures-util",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "prost",
  "tonic",
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985cc35d832d412224b2cffe2f9194b1b89b6aa5d0bef76d080dce09d90e62bd"
-dependencies = [
- "opentelemetry 0.17.0",
 ]
 
 [[package]]
@@ -4345,7 +4217,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24e33428e6bf08c6f7fcea4ddb8e358fab0fe48ab877a87c70c6ebe20f673ce5"
 dependencies = [
- "opentelemetry 0.19.0",
+ "opentelemetry",
 ]
 
 [[package]]
@@ -4384,15 +4256,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
 ]
 
 [[package]]
@@ -5698,23 +5561,20 @@ dependencies = [
  "clap",
  "futures",
  "hdrhistogram",
- "isahc",
  "itertools 0.10.5",
  "libc",
  "madsim-tokio",
  "nix 0.25.1",
- "opentelemetry 0.17.0",
- "opentelemetry-jaeger",
  "parking_lot 0.12.1",
  "prometheus",
  "rand",
  "risingwave_common",
+ "risingwave_rt",
  "risingwave_storage",
  "serde",
  "tokio-stream",
  "toml 0.7.3",
  "tracing",
- "tracing-opentelemetry 0.17.4",
  "tracing-subscriber",
  "workspace-hack",
 ]
@@ -5812,7 +5672,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "number_prefix",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "parking_lot 0.12.1",
  "parse-display",
  "paste",
@@ -5845,7 +5705,7 @@ dependencies = [
  "tinyvec",
  "toml 0.7.3",
  "tracing",
- "tracing-opentelemetry 0.19.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "twox-hash",
  "url",
@@ -6477,16 +6337,16 @@ dependencies = [
  "futures",
  "hostname",
  "madsim-tokio",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "opentelemetry-otlp",
- "opentelemetry-semantic-conventions 0.11.0",
+ "opentelemetry-semantic-conventions",
  "parking_lot 0.12.1",
  "pprof",
  "prometheus",
  "risingwave_common",
  "time 0.3.21",
  "tracing",
- "tracing-opentelemetry 0.19.0",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "workspace-hack",
 ]
@@ -7106,7 +6966,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -7465,17 +7325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sluice"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d7400c0eff44aa2fcb5e31a5f24ba9716ed90138769e4977a2ba6014ae63eb5"
-dependencies = [
- "async-channel",
- "futures-core",
- "futures-io",
-]
-
-[[package]]
 name = "smallbitset"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7828,19 +7677,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
 ]
 
 [[package]]
@@ -8306,26 +8142,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.17.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbbe89715c1dbbb790059e2565353978564924ee85017b5fff365c872ff6721f"
-dependencies = [
- "once_cell",
- "opentelemetry 0.17.0",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "tracing-opentelemetry"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00a39dcf9bfc1742fa4d6215253b33a6e474be78275884c216fc2a06267b3600"
 dependencies = [
  "once_cell",
- "opentelemetry 0.19.0",
+ "opentelemetry",
  "tracing",
  "tracing-core",
  "tracing-log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5565,6 +5565,7 @@ dependencies = [
  "libc",
  "madsim-tokio",
  "nix 0.25.1",
+ "opentelemetry",
  "parking_lot 0.12.1",
  "prometheus",
  "rand",

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -20,6 +20,7 @@ futures = { version = "0.3", default-features = false, features = ["alloc"] }
 hdrhistogram = "7"
 itertools = "0.10"
 libc = "0.2"
+opentelemetry = { version = "0.19", default-features = false, features = ["rt-tokio"], optional = true }
 parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
@@ -57,4 +58,4 @@ path = "s3_bench/main.rs"
 
 [features]
 bpf = ["bcc", "risingwave_storage/bpf"]
-trace = ["risingwave_rt", "tracing/release_max_level_trace"]
+trace = ["opentelemetry", "risingwave_rt", "tracing/release_max_level_trace"]

--- a/src/bench/Cargo.toml
+++ b/src/bench/Cargo.toml
@@ -18,20 +18,13 @@ bytesize = { version = "1", features = ["serde"] }
 clap = { version = "4", features = ["derive"] }
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 hdrhistogram = "7"
-isahc = { version = "1", default-features = false }
 itertools = "0.10"
 libc = "0.2"
-opentelemetry = { version = "0.17", optional = true, features = ["rt-tokio"] }
-opentelemetry-jaeger = { version = "0.16", optional = true, features = [
-    "rt-tokio",
-    "collector_client",
-    "isahc",
-    "isahc_collector_client",
-] }
 parking_lot = "0.12"
 prometheus = { version = "0.13", features = ["process"] }
 rand = "0.8"
 risingwave_common = { path = "../common" }
+risingwave_rt = { path = "../utils/runtime", optional = true }
 risingwave_storage = { path = "../storage" }
 serde = { version = "1", features = ["derive"] }
 tokio = { version = "0.2", package = "madsim-tokio", features = [
@@ -46,7 +39,6 @@ tokio = { version = "0.2", package = "madsim-tokio", features = [
 tokio-stream = "0.1"
 toml = "0.7"
 tracing = "0.1"
-tracing-opentelemetry = { version = "0.17", optional = true }
 tracing-subscriber = "0.3.16"
 
 [target.'cfg(not(madsim))'.dependencies]
@@ -65,4 +57,4 @@ path = "s3_bench/main.rs"
 
 [features]
 bpf = ["bcc", "risingwave_storage/bpf"]
-trace = ["opentelemetry", "opentelemetry-jaeger", "tracing-opentelemetry", "tracing/release_max_level_trace"]
+trace = ["risingwave_rt", "tracing/release_max_level_trace"]

--- a/src/bench/file_cache_bench/main.rs
+++ b/src/bench/file_cache_bench/main.rs
@@ -116,10 +116,7 @@ async fn main_okk() {
     #[cfg(feature = "bpf")]
     tokio::spawn(bpf::bpf(args.clone(), bpf_stop_rx));
 
-    bench::run(args.clone(), bench_stop_rx).await;
-
-    #[cfg(feature = "trace")]
-    opentelemetry::global::shutdown_tracer_provider();
+    bench::run(args.clone(), bench_stop_rx).await;s
 }
 
 #[tokio::main]

--- a/src/bench/file_cache_bench/main.rs
+++ b/src/bench/file_cache_bench/main.rs
@@ -116,7 +116,10 @@ async fn main_okk() {
     #[cfg(feature = "bpf")]
     tokio::spawn(bpf::bpf(args.clone(), bpf_stop_rx));
 
-    bench::run(args.clone(), bench_stop_rx).await;s
+    bench::run(args.clone(), bench_stop_rx).await;
+
+    #[cfg(feature = "trace")]
+    opentelemetry::global::shutdown_tracer_provider();
 }
 
 #[tokio::main]

--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -66,8 +66,10 @@ pub struct LoggerSettings {
     colorful: bool,
     /// Output to `stderr` instead of `stdout`.
     stderr: bool,
-    /// Override default target settings.
+    /// Override target settings.
     targets: Vec<(String, tracing::metadata::LevelFilter)>,
+    /// Override the default level.
+    default_level: Option<tracing::metadata::LevelFilter>,
 }
 
 impl Default for LoggerSettings {
@@ -84,6 +86,7 @@ impl LoggerSettings {
             colorful: console::colors_enabled_stderr() && console::colors_enabled(),
             stderr: false,
             targets: vec![],
+            default_level: None,
         }
     }
 
@@ -106,6 +109,12 @@ impl LoggerSettings {
         level: impl Into<tracing::metadata::LevelFilter>,
     ) -> Self {
         self.targets.push((target.into(), level.into()));
+        self
+    }
+
+    /// Overrides the default level.
+    pub fn with_default(mut self, level: impl Into<tracing::metadata::LevelFilter>) -> Self {
+        self.default_level = Some(level.into());
         self
     }
 }
@@ -205,6 +214,9 @@ pub fn init_risingwave_logger(settings: LoggerSettings, registry: prometheus::Re
 
         // Overrides from settings
         filter = filter.with_targets(settings.targets);
+        if let Some(default_level) = settings.default_level {
+            filter = filter.with_default(default_level);
+        }
 
         // Overrides from env var
         if let Ok(rust_log) = std::env::var(EnvFilter::DEFAULT_ENV) && !rust_log.is_empty() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

So that we don't need to depend on `opentelemetry-jaeger`.

- Close #11062
- Close #11066

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
