### PR TITLE
fix(pgwire): terminate connection rather than panic when write fails

### DIFF
--- a/src/utils/pgwire/src/pg_message.rs
+++ b/src/utils/pgwire/src/pg_message.rs
@@ -495,7 +495,7 @@ impl<'a> BeMessage<'a> {
             // https://www.postgresql.org/docs/current/protocol-error-fields.html
             BeMessage::NoticeResponse(notice) => {
                 buf.put_u8(b'N');
-                write_err_or_notice(buf, &ErrorOrNoticeMessage::notice(notice));
+                write_err_or_notice(buf, &ErrorOrNoticeMessage::notice(notice))?;
             }
 
             // DataRow
@@ -630,7 +630,7 @@ impl<'a> BeMessage<'a> {
                 // 'E' signalizes ErrorResponse messages
                 buf.put_u8(b'E');
                 let msg = error.to_string();
-                write_err_or_notice(buf, &ErrorOrNoticeMessage::internal_error(&msg));
+                write_err_or_notice(buf, &ErrorOrNoticeMessage::internal_error(&msg))?;
             }
 
             BeMessage::BackendKeyData((process_id, secret_key)) => {
@@ -700,7 +700,7 @@ fn write_cstr(buf: &mut BytesMut, s: &[u8]) -> Result<()> {
 }
 
 /// Safe write error or notice message.
-fn write_err_or_notice(buf: &mut BytesMut, msg: &ErrorOrNoticeMessage<'_>) {
+fn write_err_or_notice(buf: &mut BytesMut, msg: &ErrorOrNoticeMessage<'_>) -> Result<()> {
     write_body(buf, |buf| {
         buf.put_u8(b'S'); // severity
         write_cstr(buf, msg.severity.as_str().as_bytes())?;
@@ -714,7 +714,6 @@ fn write_err_or_notice(buf: &mut BytesMut, msg: &ErrorOrNoticeMessage<'_>) {
         buf.put_u8(0); // terminator
         Ok(())
     })
-    .unwrap();
 }
 
 #[cfg(test)]

--- a/src/utils/pgwire/src/pg_protocol.rs
+++ b/src/utils/pgwire/src/pg_protocol.rs
@@ -174,10 +174,13 @@ where
 
     /// Processes one message. Returns true if the connection is terminated.
     pub async fn process(&mut self, msg: FeMessage) -> bool {
-        self.do_process(msg).await || self.is_terminate
+        self.do_process(msg).await.is_none() || self.is_terminate
     }
 
-    async fn do_process(&mut self, msg: FeMessage) -> bool {
+    /// Return type `Option<()>` is essentially a bool, but allows `?` for early return.
+    /// - `None` means to terminate the current connection
+    /// - `Some(())` means to continue processing the next message
+    async fn do_process(&mut self, msg: FeMessage) -> Option<()> {
         let result = AssertUnwindSafe(self.do_process_inner(msg))
             .rw_catch_unwind()
             .await
@@ -189,47 +192,46 @@ where
             .inspect_err(|error| error!(%error, "error when process message"));
 
         match result {
-            Ok(v) => v,
+            Ok(()) => Some(()),
             Err(e) => {
                 match e {
                     PsqlError::IoError(io_err) => {
                         if io_err.kind() == std::io::ErrorKind::UnexpectedEof {
-                            return true;
+                            return None;
                         }
                     }
 
                     PsqlError::SslError(_) => {
                         // For ssl error, because the stream has already been consumed, so there is
                         // no way to write more message.
-                        return true;
+                        return None;
                     }
 
                     PsqlError::StartupError(_) | PsqlError::PasswordError(_) => {
-                        // TODO: Fix the unwrap in this stream.
                         self.stream
                             .write_no_flush(&BeMessage::ErrorResponse(Box::new(e)))
-                            .unwrap();
+                            .ok()?;
                         let _ = self.stream.flush().await;
-                        return true;
+                        return None;
                     }
 
                     PsqlError::QueryError(_) => {
                         self.stream
                             .write_no_flush(&BeMessage::ErrorResponse(Box::new(e)))
-                            .unwrap();
-                        self.ready_for_query().unwrap();
+                            .ok()?;
+                        self.ready_for_query().ok()?;
                     }
 
                     PsqlError::Panic(_) => {
                         self.stream
                             .write_no_flush(&BeMessage::ErrorResponse(Box::new(e)))
-                            .unwrap();
+                            .ok()?;
                         let _ = self.stream.flush().await;
 
                         // Catching the panic during message processing may leave the session in an
                         // inconsistent state. We forcefully close the connection (then end the
                         // session) here for safety.
-                        return true;
+                        return None;
                     }
 
                     PsqlError::Internal(_)
@@ -237,16 +239,16 @@ where
                     | PsqlError::ExecuteError(_) => {
                         self.stream
                             .write_no_flush(&BeMessage::ErrorResponse(Box::new(e)))
-                            .unwrap();
+                            .ok()?;
                     }
                 }
                 let _ = self.stream.flush().await;
-                false
+                Some(())
             }
         }
     }
 
-    async fn do_process_inner(&mut self, msg: FeMessage) -> PsqlResult<bool> {
+    async fn do_process_inner(&mut self, msg: FeMessage) -> PsqlResult<()> {
         match msg {
             FeMessage::Ssl => self.process_ssl_msg().await?,
             FeMessage::Startup(msg) => self.process_startup_msg(msg)?,
@@ -263,7 +265,7 @@ where
             FeMessage::Flush => self.stream.flush().await?,
         }
         self.stream.flush().await?;
-        Ok(false)
+        Ok(())
     }
 
     pub async fn read_message(&mut self) -> io::Result<FeMessage> {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Avoid panic mentioned in #10827.

Note this PR does not intend to resolve the root cause of failed writes. It just fails the offending connection gracefully rather than kills the whole frontend node. Details are discussed in that issue.

Implementation is mostly substitution:
* `return true` -> `return None` for early termination
* `.unwrap()` -> `.ok()?` to terminate on `Err`/`None`

E2E test to demonstrate the expected behavior after fix is not included because a good client library refuses to send such invalid request. The PR was tested by returning a dummy error containing `\0` on simple queries like `select 1 + 1;`

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
