### PR TITLE
fix(test): enable deterministic integration tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ opt-level = 3
 inherits = "dev"
 opt-level = 2
 incremental = false
-debug = "line-tables-only"
+debug = 1
 
 # Patch third-party crates for deterministic simulation.
 [patch.crates-io]

--- a/src/tests/simulation/tests/integration_tests/scale/nexmark_q4.rs
+++ b/src/tests/simulation/tests/integration_tests/scale/nexmark_q4.rs
@@ -104,7 +104,7 @@ async fn nexmark_q4_materialize_agg() -> Result<()> {
 
 #[madsim::test]
 async fn nexmark_q4_source() -> Result<()> {
-    nexmark_q4_common([identity_contains("source: \"bid\"")]).await
+    nexmark_q4_common([identity_contains("source: bid")]).await
 }
 
 #[madsim::test]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

`cargo nextest` has been [failing to detect](https://buildkite.com/risingwavelabs/main/builds/4321#01885d6e-de8e-450e-a867-46c9d3794c74) the deterministic integration tests after #10029. It turns out that `debug="line-tables-only"` is not compatible. Switch to `debug=1` for `ci-sim` profile as a workaround.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
