### PR TITLE
feat: allow decoding of Avro encoded payloads without included header/schema via config option

### DIFF
--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -576,6 +576,7 @@ pub struct AvroProperties {
     pub aws_auth_props: Option<AwsAuthProps>,
     pub topic: String,
     pub enable_upsert: bool,
+    pub payload_no_header: bool,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -659,6 +660,11 @@ impl ParserProperties {
                 if let SourceFormat::UpsertAvro = format {
                     config.enable_upsert = true;
                 }
+
+                if let Some(pnh) = props.get("payload_no_header") {
+                    config.payload_no_header = pnh.parse().unwrap_or(false);
+                }
+
                 if info.use_schema_registry {
                     config.topic = get_kafka_topic(props)?.clone();
                     config.client_config = SchemaRegistryAuth::from(props);


### PR DESCRIPTION
Added "payload_no_header" to the Avro parser, to allow decoding of Avro messages without header/included schema.

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In some environments messages/payloads are sent without included schema to save space on transmission. An option has been added to parse Avro payloads without headers, including the different logic when parsing the payload. 

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [X] My PR contains user-facing changes.

The Avro parser got an additional option "payload_no_header" which defaults to false. To switch the parser to "no included header/schema" set it to true.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Connector (sources & sinks)

### Release note

Added "payload_no_header" option to the Avro parser
<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
