### PR TITLE
chore(runtime): replace `Pretty` with `Full` format

### DIFF
--- a/src/utils/runtime/src/lib.rs
+++ b/src/utils/runtime/src/lib.rs
@@ -251,7 +251,7 @@ pub fn init_risingwave_logger(settings: LoggerSettings, registry: prometheus::Re
                 .with_filter(FilterFn::new(|metadata| metadata.is_event())) // filter-out all span-related info
                 .boxed(),
             Deployment::Cloud => fmt_layer.json().boxed(),
-            Deployment::Other => fmt_layer.pretty().boxed(),
+            Deployment::Other => fmt_layer.boxed(),
         };
 
         layers.push(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Use [`Full` format](https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/fmt/format/struct.Full.html) instead of `Pretty` (#10633) for logs in local deployments to make it less verbose.

> This formatter shows the span context before printing event data. Spans are displayed including their names and fields.

```
2023-07-24T11:11:22.642603+08:00 DEBUG actor{otel.name="Actor 29" actor_id=29 prev_epoch=4779742372823040 curr_epoch=4779742438359040}:executor{otel.name="RowIdGenExecutor 1D00000003 (actor 29, operator 3)" actor_id=29}:executor{otel.name="SourceExecutor 1D000027A7 (actor 29, operator 10151)" actor_id=29}: risingwave_stream::executor::source::source_executor: take snapshot actor_id=29 state=[Nexmark(NexmarkSplit { split_index: 0, split_num: 1, start_offset: Some(984064) })]
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
