### PR TITLE
feat(expr): introduce `deprecated` to `#[function]` macro

### DIFF
--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -70,6 +70,7 @@ impl FunctionAttr {
         } else {
             self.generate_build_fn()?
         };
+        let deprecated = self.deprecated;
         Ok(quote! {
             #[ctor::ctor]
             fn #ctor_name() {
@@ -79,6 +80,7 @@ impl FunctionAttr {
                     inputs_type: &[#(#args),*],
                     ret_type: #ret,
                     build: #build_fn,
+                    deprecated: #deprecated,
                 }) };
             }
         })

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -422,6 +422,7 @@ struct FunctionAttr {
     init_state: Option<String>,
     prebuild: Option<String>,
     type_infer: Option<String>,
+    deprecated: bool,
     user_fn: UserFunctionAttr,
 }
 

--- a/src/expr/macro/src/parse.rs
+++ b/src/expr/macro/src/parse.rs
@@ -62,6 +62,7 @@ impl FunctionAttr {
             init_state: find_argument(attr, "init_state"),
             prebuild: find_argument(attr, "prebuild"),
             type_infer: find_argument(attr, "type_infer"),
+            deprecated: find_name(attr, "deprecated"),
             user_fn,
         })
     }
@@ -177,5 +178,13 @@ fn find_argument(attr: &syn::AttributeArgs, name: &str) -> Option<String> {
         }
         let syn::Lit::Str(ref lit_str) = nv.lit else { return None };
         Some(lit_str.value())
+    })
+}
+
+/// Find name `#[xxx(.., name)]`.
+fn find_name(attr: &syn::AttributeArgs, name: &str) -> bool {
+    attr.iter().any(|n| {
+        let syn::NestedMeta::Meta(syn::Meta::Path(path)) = n else { return false };
+        path.is_ident(name)
     })
 }

--- a/src/expr/src/agg/mod.rs
+++ b/src/expr/src/agg/mod.rs
@@ -93,7 +93,8 @@ pub fn build(agg: AggCall) -> Result<BoxedAggState> {
                     func: agg.kind,
                     inputs_type: &args,
                     ret_type,
-                    set_returning: false
+                    set_returning: false,
+                    deprecated: false,
                 }
             ))
         })?;

--- a/src/expr/src/expr/build.rs
+++ b/src/expr/src/expr/build.rs
@@ -31,7 +31,6 @@ use super::expr_some_all::SomeAllExpression;
 use super::expr_udf::UdfExpression;
 use super::expr_vnode::VnodeExpression;
 use crate::expr::expr_proctime::ProcTimeExpression;
-use crate::expr::expr_to_timestamp_const_tmpl::build_to_timestamp_expr_legacy;
 use crate::expr::{
     BoxedExpression, Expression, InputRefExpression, LiteralExpression, TryFromExprNodeBoxed,
 };
@@ -81,11 +80,6 @@ pub fn build_from_prost(prost: &ExprNode) -> Result<BoxedExpression> {
                 .map(build_from_prost)
                 .try_collect()?;
 
-            // deprecated exprs not in signature map just for backward compatibility
-            if func_type == E::ToTimestamp1 && ret_type == DataType::Timestamp {
-                return build_to_timestamp_expr_legacy(ret_type, children);
-            }
-
             build_func(func_type, ret_type, children)
         }
     }
@@ -111,6 +105,7 @@ pub fn build_func(
                     inputs_type: &args,
                     ret_type: (&ret_type).into(),
                     set_returning: false,
+                    deprecated: false,
                 }
             ))
         })?;

--- a/src/expr/src/expr/expr_to_timestamp_const_tmpl.rs
+++ b/src/expr/src/expr/expr_to_timestamp_const_tmpl.rs
@@ -121,6 +121,7 @@ fn build_to_timestamp_expr(
 }
 
 /// Support building the variant returning timestamp without time zone for backward compatibility.
+#[build_function("to_timestamp1(varchar, varchar) -> timestamp", deprecated)]
 pub fn build_to_timestamp_expr_legacy(
     return_type: DataType,
     children: Vec<BoxedExpression>,

--- a/src/expr/src/sig/agg.rs
+++ b/src/expr/src/sig/agg.rs
@@ -47,6 +47,7 @@ impl fmt::Debug for AggFuncSig {
             inputs_type: self.inputs_type,
             ret_type: self.ret_type,
             set_returning: false,
+            deprecated: false,
         }
         .fmt(f)
     }

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -132,6 +132,10 @@ mod tests {
                 // validate the FUNC_SIG_MAP is consistent
                 assert_eq!(func, &sig.func);
                 assert_eq!(num_args, &sig.inputs_type.len());
+                // exclude deprecated functions
+                if sig.deprecated {
+                    continue;
+                }
 
                 new_map
                     .entry(*func)
@@ -175,9 +179,6 @@ mod tests {
         // handle them specially without relying on FuncSigMap.
         let expected = expect_test::expect![[r#"
             {
-                ToTimestamp1: [
-                    "to_timestamp1(varchar, varchar) -> timestamptz/timestamp",
-                ],
                 Cast: [
                     "cast(boolean) -> int32/varchar",
                     "cast(int16) -> int256/decimal/float64/float32/int64/int32/varchar",
@@ -197,12 +198,6 @@ mod tests {
                 ],
                 ArrayAccess: [
                     "array_access(list, int32) -> boolean/int16/int32/int64/int256/float32/float64/decimal/serial/date/time/timestamp/timestamptz/interval/varchar/bytea/jsonb/list/struct",
-                ],
-                ArrayLength: [
-                    "array_length(list) -> int64/int32",
-                ],
-                Cardinality: [
-                    "cardinality(list) -> int64/int32",
                 ],
             }
         "#]];

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -16,7 +16,6 @@
 
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::Deref;
 use std::sync::LazyLock;
 
 use risingwave_common::types::{DataType, DataTypeName};
@@ -53,6 +52,7 @@ impl FuncSigMap {
     }
 
     /// Returns a function signature with the same type, argument types and return type.
+    /// Deprecated functions are included.
     pub fn get(&self, ty: PbType, args: &[DataTypeName], ret: DataTypeName) -> Option<&FuncSign> {
         let v = self.0.get(&(ty, args.len()))?;
         v.iter()
@@ -60,8 +60,12 @@ impl FuncSigMap {
     }
 
     /// Returns all function signatures with the same type and number of arguments.
-    pub fn get_with_arg_nums(&self, ty: PbType, nargs: usize) -> &[FuncSign] {
-        self.0.get(&(ty, nargs)).map_or(&[], Deref::deref)
+    /// Deprecated functions are excluded.
+    pub fn get_with_arg_nums(&self, ty: PbType, nargs: usize) -> Vec<&FuncSign> {
+        match self.0.get(&(ty, nargs)) {
+            Some(v) => v.iter().filter(|d| !d.deprecated).collect(),
+            None => vec![],
+        }
     }
 }
 

--- a/src/expr/src/sig/func.rs
+++ b/src/expr/src/sig/func.rs
@@ -72,6 +72,9 @@ pub struct FuncSign {
     pub inputs_type: &'static [DataTypeName],
     pub ret_type: DataTypeName,
     pub build: fn(return_type: DataType, children: Vec<BoxedExpression>) -> Result<BoxedExpression>,
+    /// Whether the function is deprecated and should not be used in the frontend.
+    /// For backward compatibility, it is still available in the backend.
+    pub deprecated: bool,
 }
 
 impl fmt::Debug for FuncSign {
@@ -81,6 +84,7 @@ impl fmt::Debug for FuncSign {
             inputs_type: self.inputs_type,
             ret_type: self.ret_type,
             set_returning: false,
+            deprecated: self.deprecated,
         }
         .fmt(f)
     }
@@ -167,6 +171,9 @@ mod tests {
         // handle them specially without relying on FuncSigMap.
         let expected = expect_test::expect![[r#"
             {
+                ToTimestamp1: [
+                    "to_timestamp1(varchar, varchar) -> timestamptz/timestamp",
+                ],
                 Cast: [
                     "cast(boolean) -> int32/varchar",
                     "cast(int16) -> int256/decimal/float64/float32/int64/int32/varchar",

--- a/src/expr/src/sig/mod.rs
+++ b/src/expr/src/sig/mod.rs
@@ -28,16 +28,18 @@ pub(crate) struct FuncSigDebug<'a, T> {
     pub inputs_type: &'a [DataTypeName],
     pub ret_type: DataTypeName,
     pub set_returning: bool,
+    pub deprecated: bool,
 }
 
 impl<'a, T: std::fmt::Display> std::fmt::Debug for FuncSigDebug<'a, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let s = format!(
-            "{}({:?}) -> {}{:?}",
+            "{}({:?}) -> {}{:?}{}",
             self.func,
             self.inputs_type.iter().format(", "),
             if self.set_returning { "setof " } else { "" },
-            self.ret_type
+            self.ret_type,
+            if self.deprecated { " [deprecated]" } else { "" },
         )
         .to_ascii_lowercase();
 

--- a/src/expr/src/sig/table_function.rs
+++ b/src/expr/src/sig/table_function.rs
@@ -90,6 +90,7 @@ impl fmt::Debug for FuncSign {
             inputs_type: self.inputs_type,
             ret_type: self.ret_type,
             set_returning: true,
+            deprecated: false,
         }
         .fmt(f)
     }

--- a/src/expr/src/table_function/mod.rs
+++ b/src/expr/src/table_function/mod.rs
@@ -146,6 +146,7 @@ pub fn build(
                     inputs_type: &args,
                     ret_type: (&return_type).into(),
                     set_returning: true,
+                    deprecated: false,
                 }
             ))
         })?;

--- a/src/expr/src/vector_op/array_length.rs
+++ b/src/expr/src/vector_op/array_length.rs
@@ -56,7 +56,7 @@ use crate::ExprError;
 /// ----
 /// 1
 ///
-/// query error type unknown
+/// query error Cannot implicitly cast
 /// select array_length(null);
 /// ```
 #[function("array_length(list) -> int32")]

--- a/src/expr/src/vector_op/array_length.rs
+++ b/src/expr/src/vector_op/array_length.rs
@@ -60,7 +60,7 @@ use crate::ExprError;
 /// select array_length(null);
 /// ```
 #[function("array_length(list) -> int32")]
-#[function("array_length(list) -> int64")] // for compatibility with plans from old version
+#[function("array_length(list) -> int64", deprecated)]
 fn array_length<T: TryFrom<usize>>(array: ListRef<'_>) -> Result<T, ExprError> {
     array
         .len()

--- a/src/expr/src/vector_op/cardinality.rs
+++ b/src/expr/src/vector_op/cardinality.rs
@@ -60,7 +60,7 @@ use crate::ExprError;
 /// select cardinality(null);
 /// ```
 #[function("cardinality(list) -> int32")]
-#[function("cardinality(list) -> int64")] // for compatibility with plans from old version
+#[function("cardinality(list) -> int64", deprecated)]
 fn cardinality<T: TryFrom<usize>>(array: ListRef<'_>) -> Result<T, ExprError> {
     array
         .flatten()

--- a/src/expr/src/vector_op/cardinality.rs
+++ b/src/expr/src/vector_op/cardinality.rs
@@ -56,7 +56,7 @@ use crate::ExprError;
 /// ----
 /// 1
 ///
-/// query error type unknown
+/// query error Cannot implicitly cast
 /// select cardinality(null);
 /// ```
 #[function("cardinality(list) -> int32")]

--- a/src/expr/src/vector_op/position.rs
+++ b/src/expr/src/vector_op/position.rs
@@ -45,7 +45,7 @@ use risingwave_expr_macro::function;
 /// ----
 /// 4
 /// ```
-#[function("strpos(varchar, varchar) -> int32")] // backward compatibility with old proto
+#[function("strpos(varchar, varchar) -> int32", deprecated)]
 #[function("position(varchar, varchar) -> int32")]
 pub fn position(str: &str, sub_str: &str) -> i32 {
     match str.find(sub_str) {

--- a/src/expr/src/window_function/state/mod.rs
+++ b/src/expr/src/window_function/state/mod.rs
@@ -126,7 +126,8 @@ pub fn create_window_state(call: &WindowFuncCall) -> Result<Box<dyn WindowState 
                     func: kind,
                     inputs_type: &args,
                     ret_type: call.return_type.clone().into(),
-                    set_returning: false
+                    set_returning: false,
+                    deprecated: false,
                 }
             )));
         }

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -596,16 +596,6 @@ fn infer_type_for_special(
             }
             Ok(Some(DataType::Varchar))
         }
-        ExprType::ArrayLength => {
-            ensure_arity!("array_length", 1 <= | inputs | <= 2);
-            inputs[0].ensure_array_type()?;
-
-            if let Some(arg1) = inputs.get_mut(1) {
-                arg1.cast_implicit_mut(DataType::Int32)?;
-            }
-
-            Ok(Some(DataType::Int32))
-        }
         ExprType::StringToArray => {
             ensure_arity!("string_to_array", 2 <= | inputs | <= 3);
 
@@ -614,12 +604,6 @@ fn infer_type_for_special(
             }
 
             Ok(Some(DataType::List(Box::new(DataType::Varchar))))
-        }
-        ExprType::Cardinality => {
-            ensure_arity!("cardinality", | inputs | == 1);
-            inputs[0].ensure_array_type()?;
-
-            Ok(Some(DataType::Int32))
         }
         ExprType::TrimArray => {
             ensure_arity!("trim_array", | inputs | == 2);

--- a/src/frontend/src/expr/type_inference/func.rs
+++ b/src/frontend/src/expr/type_inference/func.rs
@@ -676,7 +676,9 @@ fn infer_type_name<'a>(
             (Some(_), Some(_)) => Err(()),
         };
         if let Ok(Some(t)) = t {
-            let exact = candidates.iter().find(|sig| sig.inputs_type == [t, t]);
+            let exact = candidates
+                .iter()
+                .find(|sig| sig.inputs_type == [t, t] && !sig.deprecated);
             if let Some(sig) = exact {
                 return Ok(sig);
             }
@@ -771,6 +773,9 @@ fn top_matches<'a>(
     let mut best_candidates = Vec::new();
 
     for sig in candidates {
+        if sig.deprecated {
+            continue;
+        }
         let mut n_exact = 0;
         let mut n_preferred = 0;
         let mut castable = true;
@@ -1226,6 +1231,7 @@ mod tests {
                     inputs_type: formals,
                     ret_type: DUMMY_RET,
                     build: |_, _| unreachable!(),
+                    deprecated: false,
                 });
             }
             let result = infer_type_name(&sig_map, DUMMY_FUNC, inputs);

--- a/src/tests/sqlsmith/src/sql_gen/types.rs
+++ b/src/tests/sqlsmith/src/sql_gen/types.rs
@@ -24,7 +24,6 @@ use risingwave_expr::sig::agg::{agg_func_sigs, AggFuncSig as RwAggFuncSig};
 use risingwave_expr::sig::cast::{cast_sigs, CastContext, CastSig as RwCastSig};
 use risingwave_expr::sig::func::{func_sigs, FuncSign as RwFuncSig};
 use risingwave_frontend::expr::ExprType;
-use risingwave_pb::expr::expr_node::PbType;
 use risingwave_sqlparser::ast::{BinaryOperator, DataType as AstDataType, StructField};
 
 pub(super) fn data_type_to_ast_data_type(data_type: &DataType) -> AstDataType {
@@ -187,12 +186,7 @@ pub(crate) static FUNC_TABLE: LazyLock<HashMap<DataType, Vec<FuncSig>>> = LazyLo
                 .iter()
                 .all(|t| *t != DataTypeName::Timestamptz)
                 && !FUNC_BAN_LIST.contains(&func.func)
-                && (func.func != PbType::Cardinality
-                    || !(func.inputs_type[0] == DataTypeName::List
-                        && func.ret_type == DataTypeName::Int64))
-                && (func.func != PbType::ArrayLength
-                    || !(func.inputs_type[0] == DataTypeName::List
-                        && func.ret_type == DataTypeName::Int64))
+                && !func.deprecated // deprecated functions are not accepted by frontend
         })
         .filter_map(|func| func.try_into().ok())
         .for_each(|func: FuncSig| funcs.entry(func.ret_type.clone()).or_default().push(func));


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR introduces `deprecated` attribute to `#[function]` macro. Deprecated functions should not be used in the frontend, but for backward compatibility, they are still in the signature map and are available in the backend.

Current deprecated functions:
- to_timestamp1(varchar, varchar) -> timestamp
- array_length(list) -> int64
- cardinality(list) -> int64
- strpos(varchar, varchar) -> int32

With this feature, can we remove these cases from `infer_type_for_special`? @xiangjinwu 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.
