### PR TITLE
feat: add optional `created_at` and `initialized_at` for rw relations

### DIFF
--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -64,6 +64,9 @@ message Source {
   }
   string definition = 13;
   optional uint32 connection_id = 14;
+
+  optional uint64 initialized_at_epoch = 15;
+  optional uint64 created_at_epoch = 16;
 }
 
 enum SinkType {
@@ -94,6 +97,8 @@ message Sink {
   map<string, string> properties = 12;
   string definition = 13;
   optional uint32 connection_id = 14;
+  optional uint64 initialized_at_epoch = 15;
+  optional uint64 created_at_epoch = 16;
 }
 
 message Connection {
@@ -132,6 +137,9 @@ message Index {
   // The index of `InputRef` is the column index of the primary table.
   repeated expr.ExprNode index_item = 8;
   repeated int32 original_columns = 9;
+
+  optional uint64 initialized_at_epoch = 10;
+  optional uint64 created_at_epoch = 11;
 }
 
 message Function {
@@ -216,6 +224,10 @@ message Table {
   // The range of row count of the table.
   // This field is not always present due to backward compatibility. Use `Cardinality::unknown` in this case.
   plan_common.Cardinality cardinality = 27;
+
+  optional uint64 initialized_at_epoch = 28;
+  optional uint64 created_at_epoch = 29;
+
   // Per-table catalog version, used by schema change. `None` for internal tables and tests.
   // Not to be confused with the global catalog version for notification service.
   TableVersion version = 100;

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -18,7 +18,6 @@ use itertools::Itertools;
 use risingwave_common::catalog::{
     ColumnCatalog, ConnectionId, DatabaseId, SchemaId, TableId, UserId,
 };
-
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::stream_plan::PbSinkDesc;
 

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -18,6 +18,7 @@ use itertools::Itertools;
 use risingwave_common::catalog::{
     ColumnCatalog, ConnectionId, DatabaseId, SchemaId, TableId, UserId,
 };
+
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::stream_plan::PbSinkDesc;
 
@@ -80,6 +81,8 @@ impl SinkDesc {
             properties: self.properties.into_iter().collect(),
             sink_type: self.sink_type,
             connection_id,
+            created_at_epoch: None,
+            started_at_epoch: None,
         }
     }
 

--- a/src/connector/src/sink/catalog/desc.rs
+++ b/src/connector/src/sink/catalog/desc.rs
@@ -81,7 +81,7 @@ impl SinkDesc {
             sink_type: self.sink_type,
             connection_id,
             created_at_epoch: None,
-            started_at_epoch: None,
+            initialized_at_epoch: None,
         }
     }
 

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -149,7 +149,7 @@ pub struct SinkCatalog {
 
     pub created_at_epoch: Option<Epoch>,
 
-    pub started_at_epoch: Option<Epoch>,
+    pub initialized_at_epoch: Option<Epoch>,
 }
 
 impl SinkCatalog {
@@ -181,7 +181,7 @@ impl SinkCatalog {
             properties: self.properties.clone(),
             sink_type: self.sink_type.to_proto() as i32,
             connection_id: self.connection_id.map(|id| id.into()),
-            initialized_at_epoch: self.started_at_epoch.map(|e| e.0),
+            initialized_at_epoch: self.initialized_at_epoch.map(|e| e.0),
             created_at_epoch: self.created_at_epoch.map(|e| e.0),
         }
     }
@@ -256,7 +256,7 @@ impl From<PbSink> for SinkCatalog {
             sink_type: SinkType::from_proto(sink_type),
             connection_id: pb.connection_id.map(ConnectionId),
             created_at_epoch: pb.created_at_epoch.map(Epoch::from),
-            started_at_epoch: pb.initialized_at_epoch.map(Epoch::from),
+            initialized_at_epoch: pb.initialized_at_epoch.map(Epoch::from),
         }
     }
 }

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use risingwave_common::catalog::{
     ColumnCatalog, ConnectionId, DatabaseId, Field, Schema, SchemaId, TableId, UserId,
 };
+use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::catalog::{PbSink, PbSinkType};
 
@@ -145,6 +146,10 @@ pub struct SinkCatalog {
 
     /// Sink may use a privatelink connection to connect to the downstream system.
     pub connection_id: Option<ConnectionId>,
+
+    pub created_at_epoch: Option<Epoch>,
+
+    pub started_at_epoch: Option<Epoch>,
 }
 
 impl SinkCatalog {
@@ -176,6 +181,8 @@ impl SinkCatalog {
             properties: self.properties.clone(),
             sink_type: self.sink_type.to_proto() as i32,
             connection_id: self.connection_id.map(|id| id.into()),
+            initialized_at_epoch: self.started_at_epoch.map(|e| e.0),
+            created_at_epoch: self.created_at_epoch.map(|e| e.0),
         }
     }
 
@@ -248,6 +255,8 @@ impl From<PbSink> for SinkCatalog {
                 .collect_vec(),
             sink_type: SinkType::from_proto(sink_type),
             connection_id: pb.connection_id.map(ConnectionId),
+            created_at_epoch: pb.created_at_epoch.map(Epoch::from),
+            started_at_epoch: pb.initialized_at_epoch.map(Epoch::from),
         }
     }
 }

--- a/src/frontend/src/catalog/index_catalog.rs
+++ b/src/frontend/src/catalog/index_catalog.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use educe::Educe;
 use itertools::Itertools;
 use risingwave_common::catalog::IndexId;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_common::util::sort_util::ColumnOrder;
 use risingwave_pb::catalog::PbIndex;
 
@@ -58,6 +59,10 @@ pub struct IndexCatalog {
     pub function_mapping: HashMap<FunctionCall, usize>,
 
     pub original_columns: Vec<ColumnId>,
+
+    pub created_at_epoch: Option<Epoch>,
+
+    pub started_at_epoch: Option<Epoch>,
 }
 
 impl IndexCatalog {
@@ -117,6 +122,8 @@ impl IndexCatalog {
             secondary_to_primary_mapping,
             function_mapping,
             original_columns,
+            created_at_epoch: index_prost.created_at_epoch.map(Epoch::from),
+            started_at_epoch: index_prost.initialized_at_epoch.map(Epoch::from),
         }
     }
 
@@ -175,6 +182,8 @@ impl IndexCatalog {
                 .map(|expr| expr.to_expr_proto())
                 .collect_vec(),
             original_columns: self.original_columns.iter().map(Into::into).collect_vec(),
+            initialized_at_epoch: self.started_at_epoch.map(|e| e.0),
+            created_at_epoch: self.created_at_epoch.map(|e| e.0),
         }
     }
 

--- a/src/frontend/src/catalog/index_catalog.rs
+++ b/src/frontend/src/catalog/index_catalog.rs
@@ -62,7 +62,7 @@ pub struct IndexCatalog {
 
     pub created_at_epoch: Option<Epoch>,
 
-    pub started_at_epoch: Option<Epoch>,
+    pub initialized_at_epoch: Option<Epoch>,
 }
 
 impl IndexCatalog {
@@ -123,7 +123,7 @@ impl IndexCatalog {
             function_mapping,
             original_columns,
             created_at_epoch: index_prost.created_at_epoch.map(Epoch::from),
-            started_at_epoch: index_prost.initialized_at_epoch.map(Epoch::from),
+            initialized_at_epoch: index_prost.initialized_at_epoch.map(Epoch::from),
         }
     }
 
@@ -182,7 +182,7 @@ impl IndexCatalog {
                 .map(|expr| expr.to_expr_proto())
                 .collect_vec(),
             original_columns: self.original_columns.iter().map(Into::into).collect_vec(),
-            initialized_at_epoch: self.started_at_epoch.map(|e| e.0),
+            initialized_at_epoch: self.initialized_at_epoch.map(|e| e.0),
             created_at_epoch: self.created_at_epoch.map(|e| e.0),
         }
     }

--- a/src/frontend/src/catalog/source_catalog.rs
+++ b/src/frontend/src/catalog/source_catalog.rs
@@ -15,6 +15,7 @@
 use std::collections::BTreeMap;
 
 use risingwave_common::catalog::ColumnCatalog;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::catalog::source::OptionalAssociatedTableId;
 use risingwave_pb::catalog::{PbSource, StreamSourceInfo, WatermarkDesc};
 
@@ -40,6 +41,8 @@ pub struct SourceCatalog {
     pub associated_table_id: Option<TableId>,
     pub definition: String,
     pub connection_id: Option<ConnectionId>,
+    pub created_at_epoch: Option<Epoch>,
+    pub initialized_at_epoch: Option<Epoch>,
 }
 
 impl SourceCatalog {
@@ -91,6 +94,8 @@ impl From<&PbSource> for SourceCatalog {
             associated_table_id: associated_table_id.map(|x| x.into()),
             definition: prost.definition.clone(),
             connection_id,
+            created_at_epoch: prost.created_at_epoch.map(Epoch::from),
+            initialized_at_epoch: prost.initialized_at_epoch.map(Epoch::from),
         }
     }
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
@@ -47,7 +47,7 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Int32(index.index_table.owner as i32)),
                         Some(ScalarImpl::Utf8(index.index_table.create_sql().into())),
                         Some(ScalarImpl::Utf8("".into())),
-                        index.started_at_epoch.map(|e| e.as_scalar()),
+                        index.initialized_at_epoch.map(|e| e.as_scalar()),
                         index.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_indexes.rs
@@ -28,6 +28,8 @@ pub const RW_INDEXES_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "owner"),
     (DataType::Varchar, "definition"),
     (DataType::Varchar, "acl"),
+    (DataType::Timestamptz, "initialized_at"),
+    (DataType::Timestamptz, "created_at"),
 ];
 
 impl SysCatalogReaderImpl {
@@ -45,6 +47,8 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Int32(index.index_table.owner as i32)),
                         Some(ScalarImpl::Utf8(index.index_table.create_sql().into())),
                         Some(ScalarImpl::Utf8("".into())),
+                        index.started_at_epoch.map(|e| e.as_scalar()),
+                        index.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
@@ -58,9 +58,9 @@ impl SysCatalogReaderImpl {
                                 &users,
                                 username_map,
                             )
-                                .into(),
+                            .into(),
                         )),
-                        table.started_at_epoch.map(|e| e.as_scalar()),
+                        table.initialized_at_epoch.map(|e| e.as_scalar()),
                         table.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_materialized_views.rs
@@ -31,6 +31,8 @@ pub const RW_MATERIALIZED_VIEWS_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "owner"),
     (DataType::Varchar, "definition"),
     (DataType::Varchar, "acl"),
+    (DataType::Timestamptz, "initialized_at"),
+    (DataType::Timestamptz, "created_at"),
 ];
 
 impl SysCatalogReaderImpl {
@@ -56,8 +58,10 @@ impl SysCatalogReaderImpl {
                                 &users,
                                 username_map,
                             )
-                            .into(),
+                                .into(),
                         )),
+                        table.started_at_epoch.map(|e| e.as_scalar()),
+                        table.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -84,7 +84,7 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
-                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.initialized_at_epoch.map(|e| e.as_scalar()),
                         t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
@@ -105,7 +105,7 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
-                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.initialized_at_epoch.map(|e| e.as_scalar()),
                         t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
@@ -126,7 +126,7 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
-                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.initialized_at_epoch.map(|e| e.as_scalar()),
                         t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
@@ -147,7 +147,7 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
-                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.initialized_at_epoch.map(|e| e.as_scalar()),
                         t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_relation_info.rs
@@ -31,6 +31,8 @@ pub const RW_RELATION_INFO_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Varchar, "relationtimezone"), /* The timezone used to interpret ambiguous
                                               * dates/timestamps as tstz */
     (DataType::Varchar, "fragments"), // fragments is json encoded fragment infos.
+    (DataType::Timestamptz, "initialized_at"),
+    (DataType::Timestamptz, "created_at"),
 ];
 
 impl SysCatalogReaderImpl {
@@ -82,6 +84,8 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
+                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
             });
@@ -101,6 +105,8 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
+                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
             });
@@ -120,6 +126,8 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
+                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
             });
@@ -139,6 +147,8 @@ impl SysCatalogReaderImpl {
                         Some(ScalarImpl::Utf8(
                             json!(fragments.get_fragments()).to_string().into(),
                         )),
+                        t.started_at_epoch.map(|e| e.as_scalar()),
+                        t.created_at_epoch.map(|e| e.as_scalar()),
                     ]));
                 }
             });
@@ -154,6 +164,8 @@ impl SysCatalogReaderImpl {
                     Some(ScalarImpl::Int32(t.id as i32)),
                     Some(ScalarImpl::Utf8("".into())),
                     None,
+                    t.initialized_at_epoch.map(|e| e.as_scalar()),
+                    t.created_at_epoch.map(|e| e.as_scalar()),
                 ]));
             });
         }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
@@ -73,7 +73,7 @@ impl SysCatalogReaderImpl {
                             get_acl_items(&Object::SinkId(sink.id.sink_id), &users, username_map)
                                 .into(),
                         ),
-                        sink.started_at_epoch.map(|e| e.as_scalar()),
+                        sink.initialized_at_epoch.map(|e| e.as_scalar()),
                         sink.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sinks.rs
@@ -35,6 +35,8 @@ pub const RW_SINKS_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "connection_id"),
     (DataType::Varchar, "definition"),
     (DataType::Varchar, "acl"),
+    (DataType::Timestamptz, "initialized_at"),
+    (DataType::Timestamptz, "created_at"),
 ];
 
 impl SysCatalogReaderImpl {
@@ -71,6 +73,8 @@ impl SysCatalogReaderImpl {
                             get_acl_items(&Object::SinkId(sink.id.sink_id), &users, username_map)
                                 .into(),
                         ),
+                        sink.started_at_epoch.map(|e| e.as_scalar()),
+                        sink.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_sources.rs
@@ -42,6 +42,8 @@ pub static RW_SOURCES_COLUMNS: LazyLock<Vec<SystemCatalogColumnsDef<'_>>> = Lazy
         (DataType::Int32, "connection_id"),
         (DataType::Varchar, "definition"),
         (DataType::Varchar, "acl"),
+        (DataType::Timestamptz, "initialized_at"),
+        (DataType::Timestamptz, "created_at"),
     ]
 });
 
@@ -90,6 +92,8 @@ impl SysCatalogReaderImpl {
                                 get_acl_items(&Object::SourceId(source.id), &users, username_map)
                                     .into(),
                             ),
+                            source.initialized_at_epoch.map(|e| e.as_scalar()),
+                            source.created_at_epoch.map(|e| e.as_scalar()),
                         ])
                     })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
@@ -31,6 +31,8 @@ pub const RW_TABLES_COLUMNS: &[SystemCatalogColumnsDef<'_>] = &[
     (DataType::Int32, "owner"),
     (DataType::Varchar, "definition"),
     (DataType::Varchar, "acl"),
+    (DataType::Timestamptz, "initialized_at"),
+    (DataType::Timestamptz, "created_at"),
 ];
 
 impl SysCatalogReaderImpl {
@@ -58,6 +60,8 @@ impl SysCatalogReaderImpl {
                             )
                             .into(),
                         )),
+                        table.started_at_epoch.map(|e| e.as_scalar()),
+                        table.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })
             })

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_tables.rs
@@ -60,7 +60,7 @@ impl SysCatalogReaderImpl {
                             )
                             .into(),
                         )),
-                        table.started_at_epoch.map(|e| e.as_scalar()),
+                        table.initialized_at_epoch.map(|e| e.as_scalar()),
                         table.created_at_epoch.map(|e| e.as_scalar()),
                     ])
                 })

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -145,7 +145,7 @@ pub struct TableCatalog {
 
     pub created_at_epoch: Option<Epoch>,
 
-    pub started_at_epoch: Option<Epoch>,
+    pub initialized_at_epoch: Option<Epoch>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -391,7 +391,7 @@ impl TableCatalog {
             dist_key_in_pk: self.dist_key_in_pk.iter().map(|x| *x as _).collect(),
             handle_pk_conflict_behavior: self.conflict_behavior.to_protobuf().into(),
             cardinality: Some(self.cardinality.to_protobuf()),
-            initialized_at_epoch: self.started_at_epoch.map(|epoch| epoch.0),
+            initialized_at_epoch: self.initialized_at_epoch.map(|epoch| epoch.0),
             created_at_epoch: self.created_at_epoch.map(|epoch| epoch.0),
         }
     }
@@ -497,7 +497,7 @@ impl From<PbTable> for TableCatalog {
                 .map(|c| Cardinality::from_protobuf(&c))
                 .unwrap_or_else(Cardinality::unknown),
             created_at_epoch: tb.created_at_epoch.map(Epoch::from),
-            started_at_epoch: tb.initialized_at_epoch.map(Epoch::from),
+            initialized_at_epoch: tb.initialized_at_epoch.map(Epoch::from),
         }
     }
 }
@@ -639,7 +639,7 @@ mod tests {
                 dist_key_in_pk: vec![],
                 cardinality: Cardinality::unknown(),
                 created_at_epoch: None,
-                started_at_epoch: None,
+                initialized_at_epoch: None,
             }
         );
         assert_eq!(table, TableCatalog::from(table.to_prost(0, 0)));

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -380,7 +380,6 @@ impl TableCatalog {
             properties: self.properties.inner().clone().into_iter().collect(),
             fragment_id: self.fragment_id,
             dml_fragment_id: self.dml_fragment_id,
-
             vnode_col_index: self.vnode_col_index.map(|i| i as _),
             row_id_index: self.row_id_index.map(|i| i as _),
             value_indices: self.value_indices.iter().map(|x| *x as _).collect(),

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -20,7 +20,6 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{IndexId, TableDesc, TableId};
 use risingwave_common::error::{ErrorCode, Result};
-
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_pb::catalog::{PbIndex, PbTable};
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;

--- a/src/frontend/src/handler/create_index.rs
+++ b/src/frontend/src/handler/create_index.rs
@@ -20,6 +20,7 @@ use itertools::Itertools;
 use pgwire::pg_response::{PgResponse, StatementType};
 use risingwave_common::catalog::{IndexId, TableDesc, TableId};
 use risingwave_common::error::{ErrorCode, Result};
+
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_pb::catalog::{PbIndex, PbTable};
 use risingwave_pb::stream_plan::stream_fragment_graph::Parallelism;
@@ -240,6 +241,8 @@ pub(crate) fn gen_create_index_plan(
         primary_table_id: table.id.table_id,
         index_item,
         original_columns,
+        initialized_at_epoch: None,
+        created_at_epoch: None,
     };
 
     let plan: PlanRef = materialize.into();

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -25,7 +25,6 @@ use risingwave_common::catalog::{
 use risingwave_common::error::ErrorCode::{self, InvalidInputSyntax, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
-
 use risingwave_connector::parser::{
     AvroParserConfig, DebeziumAvroParserConfig, ParserProperties, ProtobufParserConfig,
 };

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -25,6 +25,7 @@ use risingwave_common::catalog::{
 use risingwave_common::error::ErrorCode::{self, InvalidInputSyntax, ProtocolError};
 use risingwave_common::error::{Result, RwError};
 use risingwave_common::types::DataType;
+
 use risingwave_connector::parser::{
     AvroParserConfig, DebeziumAvroParserConfig, ParserProperties, ProtobufParserConfig,
 };
@@ -948,6 +949,8 @@ pub async fn handle_create_source(
         watermark_descs,
         definition,
         connection_id,
+        initialized_at_epoch: None,
+        created_at_epoch: None,
         optional_associated_table_id: None,
     };
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -23,6 +23,7 @@ use risingwave_common::catalog::{
     USER_COLUMN_ID_OFFSET,
 };
 use risingwave_common::error::{ErrorCode, Result, RwError};
+
 use risingwave_pb::catalog::source::OptionalAssociatedTableId;
 use risingwave_pb::catalog::{PbSource, PbTable, StreamSourceInfo, WatermarkDesc};
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
@@ -593,6 +594,8 @@ fn gen_table_plan_inner(
         watermark_descs: watermark_descs.clone(),
         definition: "".to_string(),
         connection_id,
+        initialized_at_epoch: None,
+        created_at_epoch: None,
         optional_associated_table_id: Some(OptionalAssociatedTableId::AssociatedTableId(
             TableId::placeholder().table_id,
         )),

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -23,7 +23,6 @@ use risingwave_common::catalog::{
     USER_COLUMN_ID_OFFSET,
 };
 use risingwave_common::error::{ErrorCode, Result, RwError};
-
 use risingwave_pb::catalog::source::OptionalAssociatedTableId;
 use risingwave_pb::catalog::{PbSource, PbTable, StreamSourceInfo, WatermarkDesc};
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -19,7 +19,6 @@ use itertools::Itertools;
 use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnCatalog, ConflictBehavior, TableId};
 use risingwave_common::error::Result;
-
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -220,7 +220,7 @@ impl StreamMaterialize {
             dist_key_in_pk: vec![],
             cardinality,
             created_at_epoch: None,
-            started_at_epoch: None,
+            initialized_at_epoch: None,
         })
     }
 

--- a/src/frontend/src/optimizer/plan_node/stream_materialize.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_materialize.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use pretty_xmlish::{Pretty, XmlNode};
 use risingwave_common::catalog::{ColumnCatalog, ConflictBehavior, TableId};
 use risingwave_common::error::Result;
+
 use risingwave_common::util::iter_util::ZipEqFast;
 use risingwave_common::util::sort_util::{ColumnOrder, OrderType};
 use risingwave_pb::stream_plan::stream_node::PbNodeBody;
@@ -219,6 +220,8 @@ impl StreamMaterialize {
             watermark_columns,
             dist_key_in_pk: vec![],
             cardinality,
+            created_at_epoch: None,
+            started_at_epoch: None,
         })
     }
 

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -174,6 +174,8 @@ impl TableCatalogBuilder {
             watermark_columns,
             dist_key_in_pk: self.dist_key_in_pk.unwrap_or(vec![]),
             cardinality: Cardinality::unknown(), // TODO(card): cardinality of internal table
+            created_at_epoch: None,
+            started_at_epoch: None,
         }
     }
 
@@ -298,6 +300,7 @@ macro_rules! plan_node_name {
     };
 }
 pub(crate) use plan_node_name;
+
 
 use super::generic::{self, GenericPlanRef};
 use super::pretty_config;

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -301,6 +301,5 @@ macro_rules! plan_node_name {
 }
 pub(crate) use plan_node_name;
 
-
 use super::generic::{self, GenericPlanRef};
 use super::pretty_config;

--- a/src/frontend/src/optimizer/plan_node/utils.rs
+++ b/src/frontend/src/optimizer/plan_node/utils.rs
@@ -175,7 +175,7 @@ impl TableCatalogBuilder {
             dist_key_in_pk: self.dist_key_in_pk.unwrap_or(vec![]),
             cardinality: Cardinality::unknown(), // TODO(card): cardinality of internal table
             created_at_epoch: None,
-            started_at_epoch: None,
+            initialized_at_epoch: None,
         }
     }
 

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -47,9 +47,7 @@ impl StreamingJob {
             }
         }
     }
-}
 
-impl StreamingJob {
     pub(crate) fn mark_initialized(&mut self) {
         let initialized_at_epoch = Some(Epoch::now().0);
         match self {

--- a/src/meta/src/manager/streaming_job.rs
+++ b/src/meta/src/manager/streaming_job.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 
 use risingwave_common::catalog::TableVersionId;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::catalog::{Index, Sink, Source, Table};
 
 use crate::model::FragmentId;
@@ -27,6 +28,46 @@ pub enum StreamingJob {
     Sink(Sink),
     Table(Option<Source>, Table),
     Index(Index, Table),
+}
+
+impl StreamingJob {
+    pub(crate) fn mark_created(&mut self) {
+        let created_at_epoch = Some(Epoch::now().0);
+        match self {
+            StreamingJob::MaterializedView(table) => table.created_at_epoch = created_at_epoch,
+            StreamingJob::Sink(table) => table.created_at_epoch = created_at_epoch,
+            StreamingJob::Table(source, table) => {
+                table.created_at_epoch = created_at_epoch;
+                if let Some(source) = source {
+                    source.created_at_epoch = created_at_epoch;
+                }
+            }
+            StreamingJob::Index(index, _) => {
+                index.created_at_epoch = created_at_epoch;
+            }
+        }
+    }
+}
+
+impl StreamingJob {
+    pub(crate) fn mark_initialized(&mut self) {
+        let initialized_at_epoch = Some(Epoch::now().0);
+        match self {
+            StreamingJob::MaterializedView(table) => {
+                table.initialized_at_epoch = initialized_at_epoch
+            }
+            StreamingJob::Sink(table) => table.initialized_at_epoch = initialized_at_epoch,
+            StreamingJob::Table(source, table) => {
+                table.initialized_at_epoch = initialized_at_epoch;
+                if let Some(source) = source {
+                    source.initialized_at_epoch = initialized_at_epoch;
+                }
+            }
+            StreamingJob::Index(index, _) => {
+                index.initialized_at_epoch = initialized_at_epoch;
+            }
+        }
+    }
 }
 
 impl StreamingJob {

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -210,7 +210,7 @@ where
     }
 
     async fn create_source(&self, mut source: Source) -> MetaResult<NotificationVersion> {
-        // set the started_at_epoch to the current epoch.
+        // set the initialized_at_epoch to the current epoch.
         source.initialized_at_epoch = Some(Epoch::now().0);
 
         self.catalog_manager

--- a/src/meta/src/rpc/ddl_controller.rs
+++ b/src/meta/src/rpc/ddl_controller.rs
@@ -18,6 +18,7 @@ use std::sync::Arc;
 use itertools::Itertools;
 use risingwave_common::config::DefaultParallelism;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
+use risingwave_common::util::epoch::Epoch;
 use risingwave_pb::catalog::connection::private_link_service::PbPrivateLinkProvider;
 use risingwave_pb::catalog::{
     connection, Connection, Database, Function, Schema, Source, Table, View,
@@ -208,7 +209,10 @@ where
         self.catalog_manager.drop_schema(schema_id).await
     }
 
-    async fn create_source(&self, source: Source) -> MetaResult<NotificationVersion> {
+    async fn create_source(&self, mut source: Source) -> MetaResult<NotificationVersion> {
+        // set the started_at_epoch to the current epoch.
+        source.initialized_at_epoch = Some(Epoch::now().0);
+
         self.catalog_manager
             .start_create_source_procedure(&source)
             .await?;
@@ -221,7 +225,7 @@ where
         }
 
         self.catalog_manager
-            .finish_create_source_procedure(&source)
+            .finish_create_source_procedure(source)
             .await
     }
 
@@ -290,6 +294,9 @@ where
             .prepare_stream_job(&mut stream_job, fragment_graph)
             .await?;
 
+        // Update the corresponding 'initiated_at' field.
+        stream_job.mark_initialized();
+
         let mut internal_tables = vec![];
         let result = try {
             let (ctx, table_fragments) = self
@@ -316,7 +323,7 @@ where
         };
 
         match result {
-            Ok(_) => self.finish_stream_job(&stream_job, internal_tables).await,
+            Ok(_) => self.finish_stream_job(stream_job, internal_tables).await,
             Err(err) => {
                 self.cancel_stream_job(&stream_job, internal_tables).await;
                 Err(err)
@@ -547,11 +554,15 @@ where
     /// `finish_stream_job` finishes a stream job and clean some states.
     async fn finish_stream_job(
         &self,
-        stream_job: &StreamingJob,
+        mut stream_job: StreamingJob,
         internal_tables: Vec<Table>,
     ) -> MetaResult<u64> {
         // 1. finish procedure.
         let mut creating_internal_table_ids = internal_tables.iter().map(|t| t.id).collect_vec();
+
+        // Update the corresponding 'created_at' field.
+        stream_job.mark_created();
+
         let version = match stream_job {
             StreamingJob::MaterializedView(table) => {
                 creating_internal_table_ids.push(table.id);

--- a/src/meta/src/stream/stream_manager.rs
+++ b/src/meta/src/stream/stream_manager.rs
@@ -856,7 +856,7 @@ mod tests {
                 .create_streaming_job(table_fragments, ctx)
                 .await?;
             self.catalog_manager
-                .finish_create_table_procedure(vec![], &table)
+                .finish_create_table_procedure(vec![], table)
                 .await?;
             Ok(())
         }

--- a/src/storage/src/filter_key_extractor.rs
+++ b/src/storage/src/filter_key_extractor.rs
@@ -493,6 +493,7 @@ mod tests {
             )]),
             fragment_id: 0,
             dml_fragment_id: None,
+            initialized_at_epoch: None,
             vnode_col_index: None,
             row_id_index: Some(0),
             value_indices: vec![0],
@@ -503,6 +504,7 @@ mod tests {
             watermark_indices: vec![],
             dist_key_in_pk: vec![],
             cardinality: None,
+            created_at_epoch: None,
         }
     }
 

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -123,6 +123,7 @@ async fn compaction_test(
         )]),
         fragment_id: 0,
         dml_fragment_id: None,
+        initialized_at_epoch: None,
         vnode_col_index: None,
         value_indices: vec![],
         definition: "".to_string(),
@@ -136,6 +137,7 @@ async fn compaction_test(
         watermark_indices: vec![],
         dist_key_in_pk: vec![],
         cardinality: None,
+        created_at_epoch: None,
     };
     let mut delete_range_table = delete_key_table.clone();
     delete_range_table.id = 2;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

```
dev=> select name,initialized_at,created_at from rw_sources;
 name |        initialized_at         |          created_at
------+-------------------------------+-------------------------------
 s    | 2023-07-25 10:53:30.128+00:00 | 2023-07-25 10:53:30.130+00:00
(1 row)

dev=> select name,initialized_at,created_at from rw_sinks;
 name |        initialized_at         |          created_at
------+-------------------------------+-------------------------------
 ss   | 2023-07-25 10:53:32.176+00:00 | 2023-07-25 10:53:43.238+00:00
(1 row)

dev=> select name,initialized_at,created_at from rw_tables;
 name |        initialized_at         |          created_at
------+-------------------------------+-------------------------------
 t    | 2023-07-25 10:53:28.030+00:00 | 2023-07-25 10:53:28.052+00:00
(1 row)

dev=> select name,initialized_at,created_at from rw_indexes;
 name |        initialized_at         |          created_at
------+-------------------------------+-------------------------------
 x    | 2023-07-25 10:53:30.135+00:00 | 2023-07-25 10:53:32.171+00:00
(1 row)

dev=> select name,initialized_at,created_at from rw_materialized_views;
 name |        initialized_at         |          created_at
------+-------------------------------+-------------------------------
 m    | 2023-07-25 10:53:28.089+00:00 | 2023-07-25 10:53:30.123+00:00
(1 row)

dev=> select relationname, relationtype , initialized_at, created_at from rw_relation_info ;
 relationname |   relationtype    |        initialized_at         |          created_at
--------------+-------------------+-------------------------------+-------------------------------
 m            | MATERIALIZED VIEW | 2023-07-25 10:53:28.089+00:00 | 2023-07-25 10:53:30.123+00:00
 t            | TABLE             | 2023-07-25 10:53:28.030+00:00 | 2023-07-25 10:53:28.052+00:00
 ss           | SINK              | 2023-07-25 10:53:32.176+00:00 | 2023-07-25 10:53:43.238+00:00
 x            | INDEX             | 2023-07-25 10:53:30.135+00:00 | 2023-07-25 10:53:32.171+00:00
 s            | SOURCE            | 2023-07-25 10:53:30.128+00:00 | 2023-07-25 10:53:30.130+00:00
(5 rows)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation


