### PR TITLE
feat(kafka source): expose rdkafka fetch params

### DIFF
--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -777,8 +777,8 @@ create table s25 (v1 int, v2 varchar) with (
   topic = 'kafka_1_partition_topic',
   properties.bootstrap.server = 'message_queue:29092',
   scan.startup.mode = 'earliest',
-  properties.fetch.queue.backoff.ms = 250,
-  properties.queued.min.messages = 10000
+  properties.queued.min.messages = 10000,
+  properties.queued.max.messages.kbytes = 65536
 ) FORMAT PLAIN ENCODE JSON
 
 query I

--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -425,6 +425,16 @@ CREATE TABLE dbz_ignore_case_json (
     topic = 'debezium_ignore_case_json'
 ) FORMAT DEBEZIUM ENCODE JSON
 
+# create kafka source with additional rdkafka properties
+statement ok
+create table source_with_rdkafka_props (v1 int, v2 varchar) with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = 'message_queue:29092',
+  scan.startup.mode = 'earliest',
+  properties.queued.min.messages = 10000,
+  properties.queued.max.messages.kbytes = 65536
+) FORMAT PLAIN ENCODE JSON
 
 statement ok
 flush;
@@ -698,6 +708,11 @@ SELECT * FROM source_mv3 ORDER BY id;
 \x6b6b
 \x776561776566776566
 
+query I
+select count(*) from source_with_rdkafka_props
+----
+100
+
 statement ok
 drop materialized view source_mv1
 
@@ -770,21 +785,5 @@ DROP TABLE upsert_students;
 statement ok
 drop table dbz_ignore_case_json;
 
-# create kafka source with additional rdkafka properties
 statement ok
-create table s25 (v1 int, v2 varchar) with (
-  connector = 'kafka',
-  topic = 'kafka_1_partition_topic',
-  properties.bootstrap.server = 'message_queue:29092',
-  scan.startup.mode = 'earliest',
-  properties.queued.min.messages = 10000,
-  properties.queued.max.messages.kbytes = 65536
-) FORMAT PLAIN ENCODE JSON
-
-query I
-select count(*) from s25
-----
-100
-
-statement ok
-drop table s25;
+drop table source_with_rdkafka_props;

--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -769,3 +769,22 @@ DROP TABLE upsert_students;
 
 statement ok
 drop table dbz_ignore_case_json;
+
+# create kafka source with additional rdkafka properties
+statement ok
+create table s25 (v1 int, v2 varchar) with (
+  connector = 'kafka',
+  topic = 'kafka_1_partition_topic',
+  properties.bootstrap.server = 'message_queue:29092',
+  scan.startup.mode = 'earliest',
+  properties.fetch.queue.backoff.ms = 250,
+  properties.queued.min.messages = 10000
+) FORMAT PLAIN ENCODE JSON
+
+query I
+select count(*) from s25
+----
+100
+
+statement ok
+drop table s25;

--- a/e2e_test/source/basic/kafka.slt
+++ b/e2e_test/source/basic/kafka.slt
@@ -711,7 +711,7 @@ SELECT * FROM source_mv3 ORDER BY id;
 query I
 select count(*) from source_with_rdkafka_props
 ----
-100
+4
 
 statement ok
 drop materialized view source_mv1

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -106,7 +106,7 @@ pub struct KafkaCommon {
     sasl_oathbearer_config: Option<String>,
 
     #[serde(flatten)]
-    rdkafka_properties: RdKafkaPropertiesCommon,
+    pub rdkafka_properties: RdKafkaPropertiesCommon,
 }
 
 #[serde_as]

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -21,7 +21,7 @@ use clickhouse::Client;
 use rdkafka::ClientConfig;
 use serde_derive::{Deserialize, Serialize};
 use serde_with::json::JsonString;
-use serde_with::serde_as;
+use serde_with::{serde_as, DisplayFromStr};
 
 use crate::aws_auth::AwsAuthProps;
 
@@ -104,6 +104,40 @@ pub struct KafkaCommon {
     /// Configurations for SASL/OAUTHBEARER.
     #[serde(rename = "properties.sasl.oauthbearer.config")]
     sasl_oathbearer_config: Option<String>,
+
+    #[serde(flatten)]
+    rdkafka_properties: RdKafkaPropertiesCommon,
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RdKafkaPropertiesCommon {
+    /// Maximum Kafka protocol request message size. Due to differing framing overhead between
+    /// protocol versions the producer is unable to reliably enforce a strict max message limit at
+    /// produce time and may exceed the maximum size by one message in protocol ProduceRequests,
+    /// the broker will enforce the the topic's max.message.bytes limit
+    #[serde(rename = "properties.message.max.bytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub message_max_bytes: Option<usize>,
+
+    /// Maximum Kafka protocol response message size. This serves as a safety precaution to avoid
+    /// memory exhaustion in case of protocol hickups. This value must be at least fetch.max.bytes
+    /// + 512 to allow for protocol overhead; the value is adjusted automatically unless the
+    /// configuration property is explicitly set.
+    #[serde(rename = "properties.receive.message.max.bytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub receive_message_max_bytes: Option<usize>,
+}
+
+impl RdKafkaPropertiesCommon {
+    pub(crate) fn set_client(&self, c: &mut rdkafka::ClientConfig) {
+        if let Some(v) = self.message_max_bytes {
+            c.set("message.max.bytes", v.to_string());
+        }
+        if let Some(v) = self.message_max_bytes {
+            c.set("receive.message.max.bytes", v.to_string());
+        }
+    }
 }
 
 impl KafkaCommon {
@@ -168,6 +202,10 @@ impl KafkaCommon {
         }
         // Currently, we only support unsecured OAUTH.
         config.set("enable.sasl.oauthbearer.unsecure.jwt", "true");
+    }
+
+    pub(crate) fn set_client(&self, c: &mut rdkafka::ClientConfig) {
+        self.rdkafka_properties.set_client(c);
     }
 }
 

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -528,6 +528,7 @@ impl KafkaTransactionConductor {
         let inner: ThreadedProducer<PrivateLinkProducerContext> = {
             let mut c = ClientConfig::new();
             config.common.set_security_properties(&mut c);
+            config.set_client(&mut c);
             c.set("bootstrap.servers", &config.common.brokers)
                 .set("message.timeout.ms", "5000");
             config.use_transaction = false;

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -155,8 +155,8 @@ impl RdKafkaPropertiesProducer {
     }
 }
 
+#[serde_as]
 #[derive(Debug, Clone, Deserialize)]
-#[serde(deny_unknown_fields)]
 pub struct KafkaConfig {
     #[serde(skip_serializing)]
     pub connector: String, // Must be "kafka" here.

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -27,8 +27,9 @@ use rdkafka::ClientConfig;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::catalog::Schema;
 use risingwave_rpc_client::ConnectorClient;
-use serde_derive::Deserialize;
+use serde_derive::{Deserialize, Serialize};
 use serde_json::Value;
+use serde_with::{serde_as, DisplayFromStr};
 
 use super::{
     Sink, SinkError, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION, SINK_TYPE_UPSERT,
@@ -66,6 +67,24 @@ const fn _default_use_transaction() -> bool {
 
 const fn _default_force_append_only() -> bool {
     false
+}
+
+#[serde_as]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RdKafkaPropertiesProducer {
+    /// Maximum number of messages allowed on the producer queue. This queue is shared by all
+    /// topics and partitions. A value of 0 disables this limit.
+    #[serde(rename = "properties.queue.buffering.max.messages")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub queue_buffering_max_messages: Option<usize>,
+
+    #[serde(rename = "properties.queue.buffering.max.kbytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    queue_buffering_max_kbytes: Option<usize>,
+
+    #[serde(rename = "properties.queue.buffering.max.ms")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    queue_buffering_max_ms: Option<usize>,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -206,6 +206,7 @@ pub struct KafkaConfig {
     /// as a string.
     pub primary_key: Option<String>,
 
+    #[serde(flatten)]
     pub rdkafka_properties: RdKafkaPropertiesProducer,
 }
 

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -653,7 +653,7 @@ mod test {
 
             "properties.enable.idempotence".to_string() => "True".to_string(), // can only be 'true' or 'false'
         };
-        assert_eq!(KafkaConfig::from_hashmap(props).is_err(), true);
+        assert!(KafkaConfig::from_hashmap(props).is_err());
 
         let props: HashMap<String, String> = hashmap! {
             // basic
@@ -663,7 +663,7 @@ mod test {
             "type".to_string() => "append-only".to_string(),
             "properties.queue.buffering.max.kbytes".to_string() => "-114514".to_string(), // usize cannot be negative
         };
-        assert_eq!(KafkaConfig::from_hashmap(props).is_err(), true);
+        assert!(KafkaConfig::from_hashmap(props).is_err());
     }
 
     #[test]
@@ -682,10 +682,10 @@ mod test {
             "properties.timeout".to_string() => "10s".to_string(),
             "properties.retry.max".to_string() => "20".to_string(),
             "properties.retry.interval".to_string() => "500ms".to_string(),
-            "aaa".to_string() => "bbb".to_string().to_string(),
+            "aaa".to_string() => "bbb".to_string(),
         };
         let config = KafkaConfig::from_hashmap(properties).unwrap();
-        assert_eq!(config.reject_unknown_fields().is_err(), true);
+        assert!(config.reject_unknown_fields().is_err());
         assert_eq!(config.common.brokers, "localhost:9092");
         assert_eq!(config.common.topic, "test");
         assert_eq!(config.r#type, "append-only");

--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -67,6 +67,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
         config.set("bootstrap.servers", &broker_address);
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         common_props.set_security_properties(&mut config);
+        properties.set_client(&mut config);
         let mut scan_start_offset = match properties
             .scan_startup_mode
             .as_ref()

--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -67,6 +67,7 @@ impl SplitEnumerator for KafkaSplitEnumerator {
         config.set("bootstrap.servers", &broker_address);
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         common_props.set_security_properties(&mut config);
+        properties.reject_unknown_fields()?;
         properties.set_client(&mut config);
         let mut scan_start_offset = match properties
             .scan_startup_mode

--- a/src/connector/src/source/kafka/enumerator/client.rs
+++ b/src/connector/src/source/kafka/enumerator/client.rs
@@ -67,7 +67,6 @@ impl SplitEnumerator for KafkaSplitEnumerator {
         config.set("bootstrap.servers", &broker_address);
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         common_props.set_security_properties(&mut config);
-        properties.reject_unknown_fields()?;
         properties.set_client(&mut config);
         let mut scan_start_offset = match properties
             .scan_startup_mode

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -12,10 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::time::Duration;
 
-use anyhow::anyhow;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr};
 

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -124,9 +124,6 @@ pub struct KafkaProperties {
 
     #[serde(flatten)]
     pub rdkafka_properties: RdKafkaPropertiesConsumer,
-
-    #[serde(flatten)]
-    unknown_fields: HashMap<String, String>,
 }
 
 impl KafkaProperties {
@@ -135,17 +132,6 @@ impl KafkaProperties {
         self.rdkafka_properties.set_client(c);
 
         tracing::info!("kafka client starts with: {:?}", c);
-    }
-
-    pub fn reject_unknown_fields(&self) -> anyhow::Result<()> {
-        if self.unknown_fields.is_empty() {
-            Ok(())
-        } else {
-            Err(anyhow!(
-                "got known fields: {:?}",
-                self.unknown_fields.keys()
-            ))
-        }
     }
 }
 
@@ -198,14 +184,12 @@ mod test {
             "properties.queued.max.messages.kbytes".to_string() => "114514".to_string(),
             "properties.fetch.wait.max.ms".to_string() => "114514".to_string(),
             "properties.fetch.max.bytes".to_string() => "114514".to_string(),
-            "aaa".to_string() => "bbb".to_string(),
         };
 
         let props: KafkaProperties =
             serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();
 
         assert_eq!(props.scan_startup_mode, Some("earliest".to_string()));
-        assert!(props.reject_unknown_fields().is_err());
         assert_eq!(
             props.common.rdkafka_properties.receive_message_max_bytes,
             Some(54321)

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -62,6 +62,7 @@ pub struct RdKafkaProperties {
     /// exceeded. This property may need to be decreased if the queue thresholds are set low
     /// and the application is experiencing long (~1s) delays between messages. Low values may
     /// increase CPU utilization.
+    // FIXME: need to upgrade rdkafka to v2.2.0 to use this property
     #[serde(rename = "properties.fetch.queue.backoff.ms")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_queue_backoff_ms: Option<usize>,

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -205,7 +205,7 @@ mod test {
             serde_json::from_value(serde_json::to_value(config).unwrap()).unwrap();
 
         assert_eq!(props.scan_startup_mode, Some("earliest".to_string()));
-        assert_eq!(props.reject_unknown_fields().is_err(), true);
+        assert!(props.reject_unknown_fields().is_err());
         assert_eq!(
             props.common.rdkafka_properties.receive_message_max_bytes,
             Some(54321)

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -36,7 +36,7 @@ pub const PRIVATELINK_CONNECTION: &str = "privatelink";
 /// Properties for the rdkafka library. Leave a field as `None` to use the default value.
 /// These properties are not intended to be exposed to users in the majority of cases.
 ///
-/// See also https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+/// See also <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
 #[derive(Clone, Debug, Deserialize)]
 pub struct RdKafkaProperties {
     /// Minimum number of messages per topic+partition librdkafka tries to maintain in the local

--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -15,6 +15,7 @@
 use std::time::Duration;
 
 use serde::Deserialize;
+use serde_with::{serde_as, DisplayFromStr};
 
 pub mod enumerator;
 pub mod private_link;
@@ -37,19 +38,23 @@ pub const PRIVATELINK_CONNECTION: &str = "privatelink";
 /// These properties are not intended to be exposed to users in the majority of cases.
 ///
 /// See also <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
+#[serde_as]
 #[derive(Clone, Debug, Deserialize)]
 pub struct RdKafkaProperties {
     /// Minimum number of messages per topic+partition librdkafka tries to maintain in the local
     /// consumer queue.
     #[serde(rename = "properties.queued.min.messages")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub queued_min_messages: Option<usize>,
 
     #[serde(rename = "properties.queued.max.messages.kbytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub queued_max_messages_kbytes: Option<usize>,
 
     /// Maximum time the broker may wait to fill the Fetch response with `fetch.min.`bytes of
     /// messages.
     #[serde(rename = "properties.fetch.wait.max.ms")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_wait_max_ms: Option<usize>,
 
     /// How long to postpone the next fetch request for a topic+partition in case the current fetch
@@ -58,6 +63,7 @@ pub struct RdKafkaProperties {
     /// and the application is experiencing long (~1s) delays between messages. Low values may
     /// increase CPU utilization.
     #[serde(rename = "properties.fetch.queue.backoff.ms")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_queue_backoff_ms: Option<usize>,
 
     /// Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in
@@ -68,6 +74,7 @@ pub struct RdKafkaProperties {
     /// topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least
     /// `message.max.bytes` (consumer config).
     #[serde(rename = "properties.fetch.max.bytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_max_bytes: Option<usize>,
 
     /// Maximum Kafka protocol response message size. This serves as a safety precaution to avoid
@@ -75,6 +82,7 @@ pub struct RdKafkaProperties {
     /// `fetch.max.bytes` + 512 to allow for protocol overhead; the value is adjusted automatically
     /// unless the configuration property is explicitly set.
     #[serde(rename = "properties.receive.message.max.bytes")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
     pub receive_message_max_bytes: Option<usize>,
 }
 

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -70,7 +70,6 @@ impl SplitReader for KafkaSplitReader {
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         config.set("bootstrap.servers", bootstrap_servers);
 
-        properties.reject_unknown_fields()?;
         properties.common.set_security_properties(&mut config);
         properties.set_client(&mut config);
 

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -73,8 +73,6 @@ impl SplitReader for KafkaSplitReader {
         properties.common.set_security_properties(&mut config);
 
         // rdkafka fetching config
-        config.set("fetch.max.bytes", "10485760"); // default: 52428800 (50 MB)
-        config.set("queued.min.messages", "2048"); // default: 100000
         properties.rdkafka_properties.set_client(&mut config);
 
         if config.get("group.id").is_none() {

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -71,6 +71,7 @@ impl SplitReader for KafkaSplitReader {
         config.set("bootstrap.servers", bootstrap_servers);
 
         properties.common.set_security_properties(&mut config);
+        properties.set_client(&mut config);
 
         // rdkafka fetching config
         properties.rdkafka_properties.set_client(&mut config);

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -70,6 +70,7 @@ impl SplitReader for KafkaSplitReader {
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         config.set("bootstrap.servers", bootstrap_servers);
 
+        properties.reject_unknown_fields()?;
         properties.common.set_security_properties(&mut config);
         properties.set_client(&mut config);
 

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -72,6 +72,8 @@ impl SplitReader for KafkaSplitReader {
 
         properties.common.set_security_properties(&mut config);
 
+        properties.rdkafka_properties.set_client(&mut config);
+
         if config.get("group.id").is_none() {
             config.set(
                 "group.id",

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -72,6 +72,9 @@ impl SplitReader for KafkaSplitReader {
 
         properties.common.set_security_properties(&mut config);
 
+        // rdkafka fetching config
+        config.set("fetch.max.bytes", "10485760"); // default: 52428800 (50 MB)
+        config.set("queued.min.messages", "2048"); // default: 100000
         properties.rdkafka_properties.set_client(&mut config);
 
         if config.get("group.id").is_none() {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Expose these configurations for the convenience of debugging in the future.

I'll set better parameters in a separate PR, after sufficient performance test, etc. 

related #10888 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Connector (sources & sinks)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

allow user specify kafka params in rw SQL (description in details available [here](https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md))

valid for both source and sink

| config name in RW | config name in Kafka | type |
|--|--|--|
| `properties.message.max.bytes` | `message.max.bytes` | int |
| `properties.receive.message.max.bytes` | `receive.message.max.bytes` | int |

only valid in source

| config name in RW | config name in Kafka | type |
|--|--|--|
| `properties.queued.min.messages` | `queued.min.messages` | int |
| `properties.queued.max.messages.kbytes` | `queued.max.messages.kbytes` | int |
| `properties.fetch.wait.max.ms` | `fetch.wait.max.ms` | int |
| `properties.fetch.max.bytes` | `fetch.max.bytes` | int |

only valid for sink

| config name in RW | config name in Kafka | type |
|--|--|--|
|`properties.queue.buffering.max.messages`|`queue.buffering.max.messages`| int |
|`properties.queue.buffering.max.kbytes`|`queue.buffering.max.kbytes`| int |
|`properties.queue.buffering.max.ms`|`queue.buffering.max.ms`| float |
|`properties.enable.idempotence`|`enable.idempotence`| bool (only accept `'true'` and `'false'`) |
|`properties.message.send.max.retries`|`message.send.max.retries`| int |
|`properties.retry.backoff.ms`|`retry.backoff.ms`| int |
|`properties.batch.num.messages`|`batch.num.messages`| int |
|`properties.batch.size`|`batch.size`| int |

</details>
