### PR TITLE
fix: fix panic when visit predicate meet empty output col idx in pg_namespace

### DIFF
--- a/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
+++ b/src/frontend/src/optimizer/plan_visitor/cardinality_visitor.rs
@@ -45,12 +45,12 @@ impl CardinalityVisitor {
             && scan.is_sys_table()
             && scan.table_name() == PG_NAMESPACE_TABLE_NAME
         {
-            let nspname = scan
+            if let Some(nspname) = scan
                 .output_col_idx()
                 .iter()
-                .find(|i| scan.table_desc().columns[**i].name == "nspname")
-                .unwrap();
-            unique_keys.push([*nspname].into_iter().collect());
+                .find(|i| scan.table_desc().columns[**i].name == "nspname") {
+                unique_keys.push([*nspname].into_iter().collect());
+            }
         }
 
         if unique_keys


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title, previously table completion in psql will cause panic in frontend. It generates a sql as follows:
```sql
SELECT pg_catalog.quote_ident(c.relname) FROM pg_catalog.pg_class AS c WHERE c.relkind IN ('r', 'S', 'v', 'm', 'f', 'p') AND SUBSTRING(pg_catalog.quote_ident(c.relname) FROM 1 FOR 3) = 'xxx' AND pg_catalog.pg_table_is_visible(c.oid) AND c.relnamespace <> (SELECT oid FROM pg_catalog.pg_namespace WHERE nspname = 'pg_catalog') UNION SELECT pg_catalog.quote_ident(n.nspname) || '.' FROM pg_catalog.pg_namespace AS n WHERE SUBSTRING(pg_catalog.quote_ident(n.nspname) || '.' FROM 1 FOR 3) = 'xxx' AND (SELECT pg_catalog.count(*) FROM pg_catalog.pg_namespace WHERE SUBSTRING(pg_catalog.quote_ident(nspname) || '.' FROM 1 FOR 3) = SUBSTRING('xxx' FROM 1 FOR pg_catalog.length(pg_catalog.quote_ident(nspname)) + 1)) > 1 UNION SELECT pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) FROM pg_catalog.pg_class AS c, pg_catalog.pg_namespace AS n WHERE c.relnamespace = n.oid AND c.relkind IN ('r', 'S', 'v', 'm', 'f', 'p') AND SUBSTRING(pg_catalog.quote_ident(n.nspname) || '.' || pg_catalog.quote_ident(c.relname) FROM 1 FOR 3) = 'xxx' AND SUBSTRING(pg_catalog.quote_ident(n.nspname) || '.' FROM 1 FOR 3) = SUBSTRING('xxx' FROM 1 FOR pg_catalog.length(pg_catalog.quote_ident(n.nspname)) + 1) AND (SELECT pg_catalog.count(*) FROM pg_catalog.pg_namespace WHERE SUBSTRING(pg_catalog.quote_ident(nspname) || '.' FROM 1 FOR 3) = SUBSTRING('xxx' FROM 1 FOR pg_catalog.length(pg_catalog.quote_ident(nspname)) + 1)) = 1 LIMIT 1000;
```
And you can use the following sql to reproduce it:
```sql
select n.nspname from pg_catalog.pg_namespace AS n where n.nspname = 'xx' and (select count(*) from pg_catalog.pg_namespace ) > 1;
```
This PR will fix this corner case.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!-- 

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes. 

Discuss technical details in the "What's changed" section, and 
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
