### PR TITLE
feat(binder): reserve system column names

### DIFF
--- a/e2e_test/ddl/system_columns.slt
+++ b/e2e_test/ddl/system_columns.slt
@@ -1,0 +1,23 @@
+statement error conflicts with a system column name
+create table t (v1 int, cmin int);
+
+statement error conflicts with a system column name
+create materialized view mv as select 1 as tableoid;
+
+statement error conflicts with a system column name
+create materialized view mv(ctid) as select 1 as x;
+
+# Unlike keywords, these are still reserved with quotes
+statement error conflicts with a system column name
+create table t (v1 int, "xmax" int);
+
+# But only reserved in lowercase
+statement ok
+create table t (v1 int, "xMin" int);
+
+statement ok
+drop table t;
+
+# Note that PostgreSQL folds to lowercase automatically without quotes
+statement error conflicts with a system column name
+create table t (v1 int, cMax int);

--- a/src/frontend/src/binder/expr/column.rs
+++ b/src/frontend/src/binder/expr/column.rs
@@ -101,7 +101,7 @@ impl Binder {
         // FIXME: The type of `CTID` should be `tid`.
         // FIXME: The `CTID` column should be unique, so literal may break something.
         // FIXME: At least we should add a notice here.
-        if let ErrorCode::ItemNotFound(_) = err && column_name.eq_ignore_ascii_case("ctid") {
+        if let ErrorCode::ItemNotFound(_) = err && column_name == "ctid" {
             return Ok(Literal::new(Some("".into()), DataType::Varchar).into())
         }
         Err(err.into())

--- a/src/frontend/src/catalog/mod.rs
+++ b/src/frontend/src/catalog/mod.rs
@@ -53,14 +53,20 @@ pub(crate) type FragmentId = u32;
 /// Check if the column name does not conflict with the internally reserved column name.
 pub fn check_valid_column_name(column_name: &str) -> Result<()> {
     if is_row_id_column_name(column_name) {
-        Err(ErrorCode::InternalError(format!(
+        return Err(ErrorCode::InternalError(format!(
             "column name prefixed with {:?} are reserved word.",
             ROWID_PREFIX
         ))
-        .into())
-    } else {
-        Ok(())
+        .into());
     }
+    if ["tableoid", "xmin", "cmin", "xmax", "cmax", "ctid"].contains(&column_name) {
+        return Err(ErrorCode::InvalidInputSyntax(format!(
+            "column name \"{column_name}\" conflicts with a system column name"
+        ))
+        .into());
+    }
+
+    Ok(())
 }
 
 /// Check if modifications happen to system catalog.

--- a/src/frontend/src/handler/create_mv.rs
+++ b/src/frontend/src/handler/create_mv.rs
@@ -23,7 +23,7 @@ use risingwave_sqlparser::ast::{EmitMode, Ident, ObjectName, Query};
 use super::privilege::resolve_relation_privileges;
 use super::RwPgResponse;
 use crate::binder::{Binder, BoundQuery, BoundSetExpr};
-use crate::catalog::CatalogError;
+use crate::catalog::{check_valid_column_name, CatalogError};
 use crate::handler::privilege::resolve_query_privileges;
 use crate::handler::HandlerArgs;
 use crate::optimizer::plan_node::Explain;
@@ -107,6 +107,9 @@ pub fn gen_create_mv_plan(
 
     let mut plan_root = Planner::new(context).plan_query(bound)?;
     if let Some(col_names) = col_names {
+        for name in &col_names {
+            check_valid_column_name(name)?;
+        }
         plan_root.set_out_names(col_names)?;
     }
     let materialize =


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolves #11242

https://www.postgresql.org/docs/current/ddl-system-columns.html
PostgreSQL reserves `tableoid`, `xmin`, `cmin`, `xmax`, `cmax`, `ctid` as column names.

|context|PostgreSQL|RisingWave|
|-|-|-|
|table column|err|err|
|mview column|err|err|
|composite type field|ok|ok|
|batch select alias|ok|err<sup>1</sup>|
|view column|ok|ok<sup>2</sup>|
|source column<sup>3</sup>||err|
|avro/proto source column||4|
|sink column||ok<sup>2</sup>|

1. Just a side effect of code reuse. No decision was made yet but being conservative.
2. Allowed but only when not using select alias. For example, `create view(ctid) as select 1` allowed but not `create view as select 1 as ctid`
3. Excludes avro or proto, where columns are not specified as part of SQL.
4. Not tested.

This is not a breaking change, as existing table, sources, and mview are not affected. We are just being stricter on new creations.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
