### PR TITLE
ci: add back auto-retry for status 255

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -30,3 +30,6 @@ e7b7842826035b645bc4feddf5ef315d0935e35e
 
 # test: split input/output for planner test (#9902)
 f8266748dcb70541da944664552c1944ff8362e4
+
+# feat(risedev): add check for trailing spaces in `risedev check` (#11294)
+f2a3fd021059e680b35b24c63cff5f8dbe9f9d5f

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -340,7 +340,7 @@ steps:
     timeout_in_minutes: 5
     retry: *auto-retry
 
-  # The following jobs are triggerd only when PR has corresponding labels.
+  # The following jobs are triggered only when PR has corresponding labels.
 
   # Generates cpu flamegraph env
   - label: "flamegraph-env-build"

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -1,3 +1,10 @@
+auto-retry: &auto-retry
+  automatic:
+    # Agent terminated because the AWS EC2 spot instance killed by AWS.
+    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
+    - exit_status: 255
+      limit: 2
+
 steps:
   - label: "check ci image rebuild"
     plugins:
@@ -19,6 +26,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -34,6 +42,7 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -44,6 +53,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -54,6 +64,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test"
     command: "ci/scripts/e2e-test.sh -p ci-dev"
@@ -68,6 +79,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "end-to-end test (parallel)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
@@ -81,6 +93,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "end-to-end test for opendal (parallel)"
     command: "ci/scripts/e2e-test-parallel-for-opendal.sh -p ci-dev"
@@ -94,6 +107,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 14
+    retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-dev"
@@ -105,6 +119,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 12
+    retry: *auto-retry
 
   - label: "end-to-end source test"
     command: "ci/scripts/e2e-source-test.sh -p ci-dev"
@@ -118,6 +133,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 18
+    retry: *auto-retry
 
   - label: "end-to-end sink test"
     command: "ci/scripts/e2e-sink-test.sh -p ci-dev"
@@ -132,6 +148,7 @@ steps:
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 18
     cancel_on_build_failing: true
+    retry: *auto-retry
 
   - label: "connector node integration test Java {{matrix.java_version}}"
     command: "ci/scripts/connector-node-integration-test.sh -p ci-dev -v {{matrix.java_version}}"
@@ -150,6 +167,7 @@ steps:
           - "11"
           - "17"
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end iceberg sink test"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-dev"
@@ -163,6 +181,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
+    retry: *auto-retry
 
   - label: "e2e java-binding test"
     command: "ci/scripts/java-binding-test.sh -p ci-dev"
@@ -176,6 +195,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "regress test"
     command: "ci/scripts/regress-test.sh -p ci-dev"
@@ -187,6 +207,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
+    retry: *auto-retry
 
   # The timeout should be strictly less than timeout in `main-cron.yml`.
   # It should be as conservative as possible.
@@ -204,6 +225,7 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 14
+    retry: *auto-retry
 
   - label: "check"
     command: "ci/scripts/check.sh"
@@ -224,6 +246,7 @@ steps:
           run: rw-build-env
           config: ci/docker-compose.yml
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "ci/scripts/deterministic-unit-test.sh"
@@ -234,6 +257,7 @@ steps:
           mount-buildkite-agent: true
     timeout_in_minutes: 10
     cancel_on_build_failing: true
+    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh scale::"
@@ -244,6 +268,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "recovery integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh recovery::"
@@ -254,6 +279,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "backfill integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh backfill_tests::"
@@ -264,6 +290,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=16 ci/scripts/deterministic-e2e-test.sh"
@@ -281,6 +308,7 @@ steps:
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 21
     cancel_on_build_failing: true
+    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=8 KILL_RATE=0.5 ci/scripts/deterministic-recovery-test.sh"
@@ -299,6 +327,7 @@ steps:
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 25
     cancel_on_build_failing: true
+    retry: *auto-retry
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
@@ -309,6 +338,9 @@ steps:
       - shellcheck#v1.2.0:
           files: ./**/*.sh
     timeout_in_minutes: 5
+    retry: *auto-retry
+
+  # The following jobs are triggerd only when PR has corresponding labels.
 
   # Generates cpu flamegraph env
   - label: "flamegraph-env-build"


### PR DESCRIPTION
It was removed in #8852. Add back because it's too frequent and thus manual retry isn't friendly. I've checked some failures on recent PRs and only found 255, so did not add -1.

It *might be possible* that 255 is not "agent terminated", but I've never met it.

Only added retry for PRs first, because it caused most troubles. For other pipelines, maybe it's worth checking errors and retrying manually.

> Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).
