### PR TITLE
feat(udf): print CREATE FUNCTION in the py server's log

### DIFF
--- a/src/udf/python/risingwave/udf.py
+++ b/src/udf/python/risingwave/udf.py
@@ -360,7 +360,7 @@ class UdfServer(pa.flight.FlightServerBase):
         else:
             output_type = _data_type_to_string(udf._result_schema.types[-1])
 
-        sql = f"CREATE FUNCTION udf_{name}({input_types}) RETURNS {output_type} AS '{name}' USING LINK 'http://{self._location}';"
+        sql = f"CREATE FUNCTION {name}({input_types}) RETURNS {output_type} AS '{name}' USING LINK 'http://{self._location}';"
         print(f"added function: {name}, corresponding SQL:\n{sql}\n")
         self._functions[name] = udf
 

--- a/src/udf/python/risingwave/udf.py
+++ b/src/udf/python/risingwave/udf.py
@@ -470,8 +470,6 @@ def _data_type_to_string(t: pa.DataType) -> str:
         return "FLOAT8"
     elif t.equals(pa.decimal128(38)):
         return "DECIMAL"
-    elif t.equals(pa.decimal128(38, 0)):
-        return "DECIMAL"
     elif t.equals(pa.date32()):
         return "DATE"
     elif t.equals(pa.time64("us")):

--- a/src/udf/python/risingwave/udf.py
+++ b/src/udf/python/risingwave/udf.py
@@ -342,7 +342,26 @@ class UdfServer(pa.flight.FlightServerBase):
         name = udf._name
         if name in self._functions:
             raise ValueError("Function already exists: " + name)
-        print("added function:", name)
+
+        input_types = ",".join(
+            [_data_type_to_string(t) for t in udf._input_schema.types]
+        )
+        if isinstance(udf, TableFunction):
+            output_type = udf._result_schema.types[-1]
+            if isinstance(output_type, pa.StructType):
+                output_type = ",".join(
+                    f"field_{i} {_data_type_to_string(field.type)}"
+                    for i, field in enumerate(output_type)
+                )
+                output_type = f"TABLE({output_type})"
+            else:
+                output_type = _data_type_to_string(output_type)
+                output_type = f"TABLE(output {output_type})"
+        else:
+            output_type = _data_type_to_string(udf._result_schema.types[-1])
+
+        sql = f"CREATE FUNCTION udf_{name}({input_types}) RETURNS {output_type} AS '{name}' USING LINK 'http://{self._location}';"
+        print(f"added function: {name}, corresponding SQL:\n{sql}\n")
         self._functions[name] = udf
 
     def do_exchange(self, context, descriptor, reader, writer):
@@ -360,13 +379,16 @@ class UdfServer(pa.flight.FlightServerBase):
 
     def serve(self):
         """Start the server."""
-        print(f"listening on {self._location}")
+        print(
+            "Note: You can use arbitrary function names and struct field names in CREATE FUNCTION statements."
+            f"\n\nlistening on {self._location}"
+        )
         super(UdfServer, self).serve()
 
 
 def _to_data_type(t: Union[str, pa.DataType]) -> pa.DataType:
     """
-    Convert a string or pyarrow.DataType to pyarrow.DataType.
+    Convert a SQL data type string or `pyarrow.DataType` to `pyarrow.DataType`.
     """
     if isinstance(t, str):
         return _string_to_data_type(t)
@@ -375,6 +397,9 @@ def _to_data_type(t: Union[str, pa.DataType]) -> pa.DataType:
 
 
 def _string_to_data_type(type_str: str):
+    """
+    Convert a SQL data type string to `pyarrow.DataType`.
+    """
     type_str = type_str.upper()
     if type_str.endswith("[]"):
         return pa.list_(_string_to_data_type(type_str[:-2]))
@@ -423,3 +448,52 @@ def _string_to_data_type(type_str: str):
         return pa.struct(fields)
 
     raise ValueError(f"Unsupported type: {type_str}")
+
+
+def _data_type_to_string(t: pa.DataType) -> str:
+    """
+    Convert a `pyarrow.DataType` to a SQL data type string.
+    """
+    if isinstance(t, pa.ListType):
+        return _data_type_to_string(t.value_type) + "[]"
+    elif t.equals(pa.bool_()):
+        return "BOOLEAN"
+    elif t.equals(pa.int16()):
+        return "SMALLINT"
+    elif t.equals(pa.int32()):
+        return "INT"
+    elif t.equals(pa.int64()):
+        return "BIGINT"
+    elif t.equals(pa.float32()):
+        return "FLOAT4"
+    elif t.equals(pa.float64()):
+        return "FLOAT8"
+    elif t.equals(pa.decimal128(38)):
+        return "DECIMAL"
+    elif t.equals(pa.decimal128(38, 0)):
+        return "DECIMAL"
+    elif t.equals(pa.date32()):
+        return "DATE"
+    elif t.equals(pa.time64("us")):
+        return "TIME"
+    elif t.equals(pa.timestamp("us")):
+        return "TIMESTAMP"
+    elif t.equals(pa.month_day_nano_interval()):
+        return "INTERVAL"
+    elif t.equals(pa.string()):
+        return "VARCHAR"
+    elif t.equals(pa.large_string()):
+        return "JSONB"
+    elif t.equals(pa.binary()):
+        return "BYTEA"
+    elif isinstance(t, pa.StructType):
+        return (
+            "STRUCT<"
+            + ",".join(
+                f"field_{i} {_data_type_to_string(field.type)}"
+                for i, field in enumerate(t)
+            )
+            + ">"
+        )
+    else:
+        raise ValueError(f"Unsupported type: {t}")


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
```
> python3 e2e_test/udf/test.py
added function: int_42, corresponding SQL:
CREATE FUNCTION int_42() RETURNS INT AS 'int_42' USING LINK 'http://0.0.0.0:8815';

added function: gcd, corresponding SQL:
CREATE FUNCTION gcd(INT,INT) RETURNS INT AS 'gcd' USING LINK 'http://0.0.0.0:8815';

added function: gcd3, corresponding SQL:
CREATE FUNCTION gcd3(INT,INT,INT) RETURNS INT AS 'gcd3' USING LINK 'http://0.0.0.0:8815';

added function: series, corresponding SQL:
CREATE FUNCTION series(INT) RETURNS TABLE(output INT) AS 'series' USING LINK 'http://0.0.0.0:8815';

added function: split, corresponding SQL:
CREATE FUNCTION split(VARCHAR) RETURNS TABLE(field_0 VARCHAR,field_1 INT) AS 'split' USING LINK 'http://0.0.0.0:8815';

added function: extract_tcp_info, corresponding SQL:
CREATE FUNCTION extract_tcp_info(BYTEA) RETURNS STRUCT<field_0 VARCHAR,field_1 VARCHAR,field_2 SMALLINT,field_3 SMALLINT> AS 'extract_tcp_info' USING LINK 'http://0.0.0.0:8815';

added function: hex_to_dec, corresponding SQL:
CREATE FUNCTION hex_to_dec(VARCHAR) RETURNS DECIMAL AS 'hex_to_dec' USING LINK 'http://0.0.0.0:8815';

added function: array_access, corresponding SQL:
CREATE FUNCTION array_access(VARCHAR[],INT) RETURNS VARCHAR AS 'array_access' USING LINK 'http://0.0.0.0:8815';

added function: jsonb_access, corresponding SQL:
CREATE FUNCTION jsonb_access(JSONB,INT) RETURNS JSONB AS 'jsonb_access' USING LINK 'http://0.0.0.0:8815';

added function: jsonb_concat, corresponding SQL:
CREATE FUNCTION jsonb_concat(JSONB[]) RETURNS JSONB AS 'jsonb_concat' USING LINK 'http://0.0.0.0:8815';

added function: jsonb_array_identity, corresponding SQL:
CREATE FUNCTION jsonb_array_identity(JSONB[]) RETURNS JSONB[] AS 'jsonb_array_identity' USING LINK 'http://0.0.0.0:8815';

added function: jsonb_array_struct_identity, corresponding SQL:
CREATE FUNCTION jsonb_array_struct_identity(STRUCT<field_0 JSONB[],field_1 INT>) RETURNS STRUCT<field_0 JSONB[],field_1 INT> AS 'jsonb_array_struct_identity' USING LINK 'http://0.0.0.0:8815';

added function: return_all, corresponding SQL:
CREATE FUNCTION return_all(BOOLEAN,SMALLINT,INT,BIGINT,FLOAT4,FLOAT8,DECIMAL,DATE,TIME,TIMESTAMP,INTERVAL,VARCHAR,BYTEA,JSONB) RETURNS STRUCT<field_0 BOOLEAN,field_1 SMALLINT,field_2 INT,field_3 BIGINT,field_4 FLOAT4,field_5 FLOAT8,field_6 DECIMAL,field_7 DATE,field_8 TIME,field_9 TIMESTAMP,field_10 INTERVAL,field_11 VARCHAR,field_12 BYTEA,field_13 JSONB> AS 'return_all' USING LINK 'http://0.0.0.0:8815';

added function: return_all_arrays, corresponding SQL:
CREATE FUNCTION return_all_arrays(BOOLEAN[],SMALLINT[],INT[],BIGINT[],FLOAT4[],FLOAT8[],DECIMAL[],DATE[],TIME[],TIMESTAMP[],INTERVAL[],VARCHAR[],BYTEA[],JSONB[]) RETURNS STRUCT<field_0 BOOLEAN[],field_1 SMALLINT[],field_2 INT[],field_3 BIGINT[],field_4 FLOAT4[],field_5 FLOAT8[],field_6 DECIMAL[],field_7 DATE[],field_8 TIME[],field_9 TIMESTAMP[],field_10 INTERVAL[],field_11 VARCHAR[],field_12 BYTEA[],field_13 JSONB[]> AS 'return_all_arrays' USING LINK 'http://0.0.0.0:8815';

Note: You can use arbitrary function names and struct field names in CREATE FUNCTION statements.

listening on 0.0.0.0:8815
```
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
