### PR TITLE
chore: rename `primary_key` to `key` in kafka sink

### DIFF
--- a/e2e_test/sink/kafka/create_sink.slt
+++ b/e2e_test/sink/kafka/create_sink.slt
@@ -85,7 +85,7 @@ create sink si_kafka_upsert from t_kafka with (
     properties.bootstrap.server = '127.0.0.1:29092',
     topic = 'test-rw-sink-upsert',
     type = 'upsert',
-    primary_key = 'id',
+    key = 'id',
 );
 
 statement ok
@@ -94,7 +94,7 @@ create sink si_kafka_debezium from t_kafka with (
     properties.bootstrap.server = '127.0.0.1:29092',
     topic = 'test-rw-sink-debezium',
     type = 'debezium',
-    primary_key = 'id',
+    key = 'id',
 );
 
 statement error primary key not defined for debezium kafka sink

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -35,6 +35,7 @@ use super::{
     Sink, SinkError, SINK_TYPE_APPEND_ONLY, SINK_TYPE_DEBEZIUM, SINK_TYPE_OPTION, SINK_TYPE_UPSERT,
 };
 use crate::common::KafkaCommon;
+use crate::deserialize_duration_from_string;
 use crate::sink::utils::{
     gen_append_only_message_stream, gen_debezium_message_stream, gen_upsert_message_stream,
     AppendOnlyAdapterOpts, DebeziumAdapterOpts, UpsertAdapterOpts,
@@ -43,9 +44,6 @@ use crate::sink::{
     DummySinkCommitCoordinator, Result, SinkWriterParam, SinkWriterV1, SinkWriterV1Adapter,
 };
 use crate::source::kafka::PrivateLinkProducerContext;
-use crate::{
-    deserialize_bool_from_string, deserialize_duration_from_string, deserialize_u32_from_string,
-};
 
 pub const KAFKA_SINK: &str = "kafka";
 
@@ -168,10 +166,8 @@ pub struct KafkaConfig {
 
     pub r#type: String, // accept "append-only", "debezium", or "upsert"
 
-    #[serde(
-        default = "_default_force_append_only",
-        deserialize_with = "deserialize_bool_from_string"
-    )]
+    #[serde(default = "_default_force_append_only")]
+    #[serde_as(as = "DisplayFromStr")]
     pub force_append_only: bool,
 
     #[serde(
@@ -181,11 +177,8 @@ pub struct KafkaConfig {
     )]
     pub timeout: Duration,
 
-    #[serde(
-        rename = "properties.retry.max",
-        default = "_default_max_retries",
-        deserialize_with = "deserialize_u32_from_string"
-    )]
+    #[serde(rename = "properties.retry.max", default = "_default_max_retries")]
+    #[serde_as(as = "DisplayFromStr")]
     pub max_retry_num: u32,
 
     #[serde(
@@ -195,15 +188,14 @@ pub struct KafkaConfig {
     )]
     pub retry_interval: Duration,
 
-    #[serde(
-        default = "_default_use_transaction",
-        deserialize_with = "deserialize_bool_from_string"
-    )]
+    #[serde(default = "_default_use_transaction")]
+    #[serde_as(as = "DisplayFromStr")]
     pub use_transaction: bool,
 
     /// We have parsed the primary key for an upsert kafka sink into a `usize` vector representing
     /// the indices of the pk columns in the frontend, so we simply store the primary key here
     /// as a string.
+    #[serde(rename = "key")]
     pub primary_key: Option<String>,
 
     #[serde(flatten)]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

resolve #9768

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

as title. the old syntax is still acceptable. 

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
