### PR TITLE
refactor(frontend): escape `E'..'` in tokenizer

### DIFF
--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -12,11 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::iter::Peekable;
-use std::str::{from_utf8, Chars};
-
 use itertools::Itertools;
-use risingwave_common::error::{ErrorCode, Result, RwError};
+use risingwave_common::error::{ErrorCode, Result};
 use risingwave_common::types::{DataType, DateTimeField, Decimal, Interval, ScalarImpl};
 use risingwave_sqlparser::ast::{DateTimeField as AstDateTimeField, Expr, Value};
 
@@ -28,7 +25,7 @@ impl Binder {
         match value {
             Value::Number(s) => self.bind_number(s),
             Value::SingleQuotedString(s) => self.bind_string(s),
-            Value::CstyleEscapesString(s) => self.bind_string(unescape_c_style(&s)?),
+            Value::CstyleEscapedString(s) => self.bind_string(s.value),
             Value::Boolean(b) => self.bind_bool(b),
             // Both null and string literal will be treated as `unknown` during type inference.
             // See [`ExprImpl::is_unknown`].
@@ -208,113 +205,6 @@ impl Binder {
         let expr: ExprImpl = FunctionCall::new_unchecked(ExprType::Row, exprs, data_type).into();
         Ok(expr)
     }
-}
-
-/// Helper function used to convert string with c-style escapes into a normal string
-/// e.g. 'hello\x3fworld' -> 'hello?world'
-///
-/// Detail of c-style escapes refer from:
-/// <https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-STRINGS-UESCAPE:~:text=4.1.2.2.%C2%A0String%20Constants%20With%20C%2DStyle%20Escapes>
-fn unescape_c_style(s: &str) -> Result<String> {
-    let mut chars = s.chars().peekable();
-
-    let mut res = String::with_capacity(s.len());
-
-    let hex_byte_process = |chars: &mut Peekable<Chars<'_>>,
-                            res: &mut String,
-                            len: usize,
-                            default_char: char| {
-        let mut unicode_seq: String = String::with_capacity(len);
-        for _ in 0..len {
-            if let Some(c) = chars.peek() && c.is_ascii_hexdigit() {
-                unicode_seq.push(chars.next().unwrap());
-            } else {
-                break;
-            }
-        }
-
-        if unicode_seq.is_empty() && len == 2 {
-            res.push(default_char);
-            return Ok::<(), RwError>(());
-        } else if unicode_seq.len() < len && len != 2 {
-            return Err(ErrorCode::BindError(
-                "invalid unicode sequence: must be \\uXXXX or \\UXXXXXXXX".to_string(),
-            )
-            .into());
-        }
-
-        if len == 2 {
-            let number = [u8::from_str_radix(&unicode_seq, 16)
-                .map_err(|e| ErrorCode::BindError(format!("invalid unicode sequence: {}", e)))?];
-
-            res.push(
-                from_utf8(&number)
-                    .map_err(|err| {
-                        ErrorCode::BindError(format!("invalid unicode sequence: {}", err))
-                    })?
-                    .chars()
-                    .next()
-                    .unwrap(),
-            );
-        } else {
-            let number = u32::from_str_radix(&unicode_seq, 16)
-                .map_err(|e| ErrorCode::BindError(format!("invalid unicode sequence: {}", e)))?;
-            res.push(char::from_u32(number).ok_or_else(|| {
-                ErrorCode::BindError(format!("invalid unicode sequence: {}", unicode_seq))
-            })?);
-        }
-        Ok(())
-    };
-
-    let octal_byte_process = |chars: &mut Peekable<Chars<'_>>, res: &mut String, digit: char| {
-        let mut unicode_seq: String = String::with_capacity(3);
-        unicode_seq.push(digit);
-        for _ in 0..2 {
-            if let Some(c) = chars.peek() && matches!(*c, '0'..='7') {
-                unicode_seq.push(chars.next().unwrap());
-            } else {
-                break;
-            }
-        }
-
-        let number = [u8::from_str_radix(&unicode_seq, 8)
-            .map_err(|e| ErrorCode::BindError(format!("invalid unicode sequence: {}", e)))?];
-
-        res.push(
-            from_utf8(&number)
-                .map_err(|err| ErrorCode::BindError(format!("invalid unicode sequence: {}", err)))?
-                .chars()
-                .next()
-                .unwrap(),
-        );
-        Ok::<(), RwError>(())
-    };
-
-    while let Some(c) = chars.next() {
-        if c == '\\' {
-            match chars.next() {
-                None => {
-                    return Err(ErrorCode::BindError("unterminated escape sequence".into()).into());
-                }
-                Some(next_c) => match next_c {
-                    'b' => res.push('\u{08}'),
-                    'f' => res.push('\u{0C}'),
-                    'n' => res.push('\n'),
-                    'r' => res.push('\r'),
-                    't' => res.push('\t'),
-                    'x' => hex_byte_process(&mut chars, &mut res, 2, 'x')?,
-                    'u' => hex_byte_process(&mut chars, &mut res, 4, 'u')?,
-                    'U' => hex_byte_process(&mut chars, &mut res, 8, 'U')?,
-                    digit @ '0'..='7' => octal_byte_process(&mut chars, &mut res, digit)?,
-                    _ => res.push(next_c),
-                },
-            }
-        } else {
-            res.push(c);
-        }
-    }
-
-    Ok(res)
 }
 
 #[cfg(test)]

--- a/src/frontend/src/utils/with_options.rs
+++ b/src/frontend/src/utils/with_options.rs
@@ -151,7 +151,7 @@ impl TryFrom<&[SqlOption]> for WithOptions {
             .iter()
             .cloned()
             .map(|x| match x.value {
-                Value::CstyleEscapesString(s) => Ok((x.name.real_value(), s)),
+                Value::CstyleEscapedString(s) => Ok((x.name.real_value(), s.value)),
                 Value::SingleQuotedString(s) => Ok((x.name.real_value(), s)),
                 Value::Number(n) => Ok((x.name.real_value(), n)),
                 Value::Boolean(b) => Ok((x.name.real_value(), b.to_string())),

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -42,7 +42,9 @@ pub use self::query::{
     With,
 };
 pub use self::statement::*;
-pub use self::value::{DateTimeField, DollarQuotedString, TrimWhereField, Value};
+pub use self::value::{
+    CstyleEscapedString, DateTimeField, DollarQuotedString, TrimWhereField, Value,
+};
 pub use crate::ast::ddl::{
     AlterIndexOperation, AlterSinkOperation, AlterSourceOperation, AlterViewOperation,
 };

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -583,7 +583,7 @@ impl SourceSchemaV2 {
             .iter()
             .cloned()
             .map(|x| match x.value {
-                Value::CstyleEscapesString(s) => Ok((x.name.real_value(), s)),
+                Value::CstyleEscapedString(s) => Ok((x.name.real_value(), s.value)),
                 Value::SingleQuotedString(s) => Ok((x.name.real_value(), s)),
                 Value::Number(n) => Ok((x.name.real_value(), n)),
                 Value::Boolean(b) => Ok((x.name.real_value(), b.to_string())),
@@ -844,8 +844,8 @@ pub struct CsvInfo {
 
 pub fn get_delimiter(chars: &str) -> Result<u8, ParserError> {
     match chars {
-        "," => Ok(b','),    // comma
-        "\\t" => Ok(b'\t'), // tab
+        "," => Ok(b','),   // comma
+        "\t" => Ok(b'\t'), // tab
         other => Err(ParserError::ParserError(format!(
             "The delimiter should be one of ',', E'\\t', but got {:?}",
             other

--- a/src/sqlparser/src/ast/value.rs
+++ b/src/sqlparser/src/ast/value.rs
@@ -28,7 +28,7 @@ pub enum Value {
     // $<tag_name>$string value$<tag_name>$ (postgres syntax)
     DollarQuotedString(DollarQuotedString),
     /// String Constants With C-Style Escapes
-    CstyleEscapesString(String),
+    CstyleEscapedString(CstyleEscapedString),
     /// N'string value'
     NationalStringLiteral(String),
     /// X'hex value'
@@ -68,7 +68,7 @@ impl fmt::Display for Value {
             Value::DollarQuotedString(v) => write!(f, "{}", v),
             Value::NationalStringLiteral(v) => write!(f, "N'{}'", v),
             Value::HexStringLiteral(v) => write!(f, "X'{}'", v),
-            Value::CstyleEscapesString(v) => write!(f, "E'{}'", v),
+            Value::CstyleEscapedString(v) => write!(f, "E'{}'", v),
             Value::Boolean(v) => write!(f, "{}", v),
             Value::Interval {
                 value,
@@ -132,6 +132,21 @@ impl fmt::Display for DollarQuotedString {
                 write!(f, "$${}$$", self.value)
             }
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct CstyleEscapedString {
+    /// The unescaped string.
+    pub value: String,
+    /// The raw string used for simplifying `fmt::Display` (unparsing) implementation.
+    pub raw: String,
+}
+
+impl fmt::Display for CstyleEscapedString {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.raw)
     }
 }
 

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -2967,7 +2967,7 @@ impl Parser {
             Token::Number(ref n) => Ok(Value::Number(n.clone())),
             Token::SingleQuotedString(ref s) => Ok(Value::SingleQuotedString(s.to_string())),
             Token::DollarQuotedString(ref s) => Ok(Value::DollarQuotedString(s.clone())),
-            Token::CstyleEscapesString(ref s) => Ok(Value::CstyleEscapesString(s.to_string())),
+            Token::CstyleEscapesString(ref s) => Ok(Value::CstyleEscapedString(s.clone())),
             Token::NationalStringLiteral(ref s) => Ok(Value::NationalStringLiteral(s.to_string())),
             Token::HexStringLiteral(ref s) => Ok(Value::HexStringLiteral(s.to_string())),
             unexpected => self.expected("a value", unexpected.with_location(token.location)),

--- a/src/sqlparser/tests/sqlparser_common.rs
+++ b/src/sqlparser/tests/sqlparser_common.rs
@@ -1995,9 +1995,10 @@ fn parse_literal_string() {
         expr_from_projection(&select.projection[2])
     );
     assert_eq!(
-        &Expr::Value(Value::CstyleEscapesString(
-            r"c style escape string \x3f".to_string()
-        )),
+        &Expr::Value(Value::CstyleEscapedString(CstyleEscapedString {
+            value: "c style escape string \x3f".to_string(),
+            raw: r"c style escape string \x3f".to_string(),
+        })),
         expr_from_projection(&select.projection[3])
     );
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As explained in #11260 and https://github.com/risingwavelabs/risingwave/pull/11195#discussion_r1274553446.

Close #11260.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
