### PR TITLE
refactor(meta): enable periodic full GC

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -161,12 +161,16 @@ pub enum MetaBackend {
 /// The section `[meta]` in `risingwave.toml`.
 #[derive(Clone, Debug, Serialize, Deserialize, DefaultFromSerde)]
 pub struct MetaConfig {
-    /// Threshold used by worker node to filter out new SSTs when scanning object store, during
-    /// full SST GC.
+    /// Objects within `min_sst_retention_time_sec` won't be deleted by hummock full GC, even they
+    /// are dangling.
     #[serde(default = "default::meta::min_sst_retention_time_sec")]
     pub min_sst_retention_time_sec: u64,
 
-    /// The spin interval when collecting global GC watermark in hummock
+    /// Interval of automatic hummock full GC.
+    #[serde(default = "default::meta::full_gc_interval_sec")]
+    pub full_gc_interval_sec: u64,
+
+    /// The spin interval when collecting global GC watermark in hummock.
     #[serde(default = "default::meta::collect_gc_watermark_spin_interval_sec")]
     pub collect_gc_watermark_spin_interval_sec: u64,
 
@@ -660,7 +664,11 @@ pub mod default {
         use crate::config::{DefaultParallelism, MetaBackend};
 
         pub fn min_sst_retention_time_sec() -> u64 {
-            604800
+            86400
+        }
+
+        pub fn full_gc_interval_sec() -> u64 {
+            86400
         }
 
         pub fn collect_gc_watermark_spin_interval_sec() -> u64 {

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -7,7 +7,8 @@ metrics_level = 0
 telemetry_enabled = true
 
 [meta]
-min_sst_retention_time_sec = 604800
+min_sst_retention_time_sec = 86400
+full_gc_interval_sec = 86400
 collect_gc_watermark_spin_interval_sec = 5
 periodic_compaction_interval_sec = 60
 vacuum_interval_sec = 30

--- a/src/meta/src/hummock/manager/gc.rs
+++ b/src/meta/src/hummock/manager/gc.rs
@@ -12,17 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cmp;
 use std::collections::HashSet;
 use std::ops::DerefMut;
+use std::time::Duration;
 
 use function_name::named;
+use futures::{stream, StreamExt};
 use itertools::Itertools;
 use risingwave_hummock_sdk::compaction_group::hummock_version_ext::HummockVersionExt;
 use risingwave_hummock_sdk::HummockSstableObjectId;
+use risingwave_pb::common::worker_node::State::Running;
+use risingwave_pb::common::WorkerType;
+use risingwave_pb::hummock::FullScanTask;
 
-use crate::hummock::error::Result;
-use crate::hummock::manager::{commit_multi_var, read_lock, write_lock};
+use crate::hummock::error::{Error, Result};
+use crate::hummock::manager::{commit_multi_var, read_lock, write_lock, ResponseEvent};
 use crate::hummock::HummockManager;
+use crate::manager::ClusterManagerRef;
 use crate::model::{BTreeMapTransaction, ValTransaction};
 use crate::storage::{MetaStore, Transaction};
 
@@ -123,5 +130,259 @@ where
         versioning_guard.objects_to_delete.extend(to_delete.clone());
         drop(versioning_guard);
         to_delete.count()
+    }
+
+    /// Starts a full GC.
+    /// 1. Meta node sends a `FullScanTask` to a compactor in this method.
+    /// 2. The compactor returns scan result of object store to meta node. See
+    /// `HummockManager::full_scan_inner` in storage crate.
+    /// 3. Meta node decides which SSTs to delete. See `HummockManager::complete_full_gc`.
+    ///
+    /// Returns Ok(false) if there is no worker available.
+    pub fn start_full_gc(&self, sst_retention_time: Duration) -> Result<bool> {
+        self.metrics.full_gc_trigger_count.inc();
+        // Set a minimum sst_retention_time to avoid deleting SSTs of on-going write op.
+        let sst_retention_time = cmp::max(
+            sst_retention_time,
+            Duration::from_secs(self.env.opts.min_sst_retention_time_sec),
+        );
+        tracing::info!(
+            "run full GC with sst_retention_time = {} secs",
+            sst_retention_time.as_secs()
+        );
+        let compactor = match self.compactor_manager.next_compactor() {
+            None => {
+                tracing::warn!("Try full GC but no available idle worker.");
+                return Ok(false);
+            }
+            Some(compactor) => compactor,
+        };
+        compactor
+            .send_event(ResponseEvent::FullScanTask(FullScanTask {
+                sst_retention_time_sec: sst_retention_time.as_secs(),
+            }))
+            .map_err(|_| Error::CompactorUnreachable(compactor.context_id()))?;
+        Ok(true)
+    }
+
+    /// Given candidate SSTs to GC, filter out false positive.
+    /// Returns number of SSTs to GC.
+    pub async fn complete_full_gc(&self, object_ids: Vec<HummockSstableObjectId>) -> Result<usize> {
+        if object_ids.is_empty() {
+            tracing::info!("SST full scan returns no SSTs.");
+            return Ok(0);
+        }
+        let metrics = &self.metrics;
+        let spin_interval =
+            Duration::from_secs(self.env.opts.collect_gc_watermark_spin_interval_sec);
+        let watermark =
+            collect_global_gc_watermark(self.cluster_manager().clone(), spin_interval).await?;
+        metrics.full_gc_last_object_id_watermark.set(watermark as _);
+        let candidate_sst_number = object_ids.len();
+        metrics
+            .full_gc_candidate_object_count
+            .observe(candidate_sst_number as _);
+        // 1. filter by watermark
+        let object_ids = object_ids
+            .into_iter()
+            .filter(|s| *s < watermark)
+            .collect_vec();
+        // 2. filter by version
+        let selected_sst_number = self.extend_objects_to_delete_from_scan(&object_ids).await;
+        metrics
+            .full_gc_selected_object_count
+            .observe(selected_sst_number as _);
+        tracing::info!("GC watermark is {}. SST full scan returns {} SSTs. {} remains after filtered by GC watermark. {} remains after filtered by hummock version.",
+            watermark, candidate_sst_number, object_ids.len(), selected_sst_number);
+        Ok(selected_sst_number)
+    }
+}
+
+/// Collects SST GC watermark from related cluster nodes and calculates a global one.
+///
+/// It must wait enough heartbeats first. This precondition is checked at `spin_interval`.
+///
+/// Returns a global GC watermark. The watermark only guards SSTs created before this
+/// invocation.
+pub async fn collect_global_gc_watermark<S>(
+    cluster_manager: ClusterManagerRef<S>,
+    spin_interval: Duration,
+) -> Result<HummockSstableObjectId>
+where
+    S: MetaStore,
+{
+    let mut global_watermark = HummockSstableObjectId::MAX;
+    let workers = vec![
+        cluster_manager.list_active_streaming_compute_nodes().await,
+        cluster_manager
+            .list_worker_node(WorkerType::Compactor, Some(Running))
+            .await,
+    ]
+    .concat();
+
+    if workers.is_empty() {
+        return Ok(global_watermark);
+    }
+
+    let mut worker_futures = vec![];
+    for worker in &workers {
+        // For each cluster node, its watermark is collected after waiting for 2 heartbeats.
+        // The first heartbeat may carry watermark took before the start of this method,
+        // which doesn't correctly guard target SSTs.
+        // The second heartbeat guarantees its watermark is took after the start of this method.
+        let worker_id = worker.id;
+        let cluster_manager_clone = cluster_manager.clone();
+        worker_futures.push(tokio::spawn(async move {
+            let mut init_version_id: Option<u64> = None;
+            loop {
+                let worker_info = match cluster_manager_clone.get_worker_by_id(worker_id).await {
+                    None => {
+                        return None;
+                    }
+                    Some(worker_info) => worker_info,
+                };
+                match init_version_id.as_ref() {
+                    None => {
+                        init_version_id = Some(worker_info.info_version_id());
+                    }
+                    Some(init_version_id) => {
+                        if worker_info.info_version_id() >= *init_version_id + 2 {
+                            return worker_info.hummock_gc_watermark();
+                        }
+                    }
+                }
+                tokio::time::sleep(spin_interval).await;
+            }
+        }));
+    }
+    let mut buffered = stream::iter(worker_futures).buffer_unordered(workers.len());
+    while let Some(worker_result) = buffered.next().await {
+        let worker_watermark = worker_result
+            .map_err(|e| anyhow::anyhow!("Failed to collect GC watermark: {:#?}", e))?;
+        // None means either the worker has gone or the worker has not set a watermark.
+        global_watermark = cmp::min(
+            global_watermark,
+            worker_watermark.unwrap_or(HummockSstableObjectId::MAX),
+        );
+    }
+    Ok(global_watermark)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use itertools::Itertools;
+    use risingwave_hummock_sdk::HummockSstableObjectId;
+
+    use crate::hummock::manager::ResponseEvent;
+    use crate::hummock::test_utils::{add_test_tables, setup_compute_env};
+    use crate::MetaOpts;
+
+    #[tokio::test]
+    async fn test_full_gc() {
+        let (mut env, hummock_manager, cluster_manager, worker_node) = setup_compute_env(80).await;
+        let context_id = worker_node.id;
+        let compactor_manager = hummock_manager.compactor_manager_ref_for_test();
+        // Use smaller spin interval to accelerate test.
+        env.opts = Arc::new(MetaOpts {
+            collect_gc_watermark_spin_interval_sec: 1,
+            ..(*env.opts).clone()
+        });
+
+        // No task scheduled because no available worker.
+        assert!(!hummock_manager
+            .start_full_gc(Duration::from_secs(
+                hummock_manager.env.opts.min_sst_retention_time_sec - 1
+            ))
+            .unwrap());
+
+        let mut receiver = compactor_manager.add_compactor(context_id);
+
+        assert!(hummock_manager
+            .start_full_gc(Duration::from_secs(
+                hummock_manager.env.opts.min_sst_retention_time_sec - 1
+            ))
+            .unwrap());
+        let full_scan_task = match receiver.recv().await.unwrap().unwrap().event.unwrap() {
+            ResponseEvent::FullScanTask(task) => task,
+            _ => {
+                panic!()
+            }
+        };
+        // min_sst_retention_time_sec override user provided value.
+        assert_eq!(
+            hummock_manager.env.opts.min_sst_retention_time_sec,
+            full_scan_task.sst_retention_time_sec
+        );
+
+        assert!(hummock_manager
+            .start_full_gc(Duration::from_secs(
+                hummock_manager.env.opts.min_sst_retention_time_sec + 1
+            ))
+            .unwrap());
+        let full_scan_task = match receiver.recv().await.unwrap().unwrap().event.unwrap() {
+            ResponseEvent::FullScanTask(task) => task,
+            _ => {
+                panic!()
+            }
+        };
+        // min_sst_retention_time_sec doesn't override user provided value.
+        assert_eq!(
+            hummock_manager.env.opts.min_sst_retention_time_sec + 1,
+            full_scan_task.sst_retention_time_sec
+        );
+
+        // Empty input results immediate return, without waiting heartbeat.
+        hummock_manager.complete_full_gc(vec![]).await.unwrap();
+
+        // mimic CN heartbeat
+        use risingwave_pb::meta::heartbeat_request::extra_info::Info;
+        let heartbeat_interval = hummock_manager
+            .env
+            .opts
+            .collect_gc_watermark_spin_interval_sec;
+        tokio::spawn(async move {
+            loop {
+                cluster_manager
+                    .heartbeat(
+                        context_id,
+                        vec![Info::HummockGcWatermark(HummockSstableObjectId::MAX)],
+                    )
+                    .await
+                    .unwrap();
+                tokio::time::sleep(Duration::from_secs(heartbeat_interval)).await;
+            }
+        });
+
+        // LSMtree is empty. All input SST ids should be treated as garbage.
+        assert_eq!(
+            3,
+            hummock_manager
+                .complete_full_gc(vec![1, 2, 3])
+                .await
+                .unwrap()
+        );
+
+        // All committed SST ids should be excluded from GC.
+        let sst_infos = add_test_tables(hummock_manager.as_ref(), context_id).await;
+        let committed_object_ids = sst_infos
+            .into_iter()
+            .flatten()
+            .map(|s| s.get_object_id())
+            .sorted()
+            .collect_vec();
+        assert!(!committed_object_ids.is_empty());
+        let max_committed_object_id = *committed_object_ids.iter().max().unwrap();
+        assert_eq!(
+            1,
+            hummock_manager
+                .complete_full_gc(
+                    [committed_object_ids, vec![max_committed_object_id + 1]].concat()
+                )
+                .await
+                .unwrap()
+        );
     }
 }

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -1956,6 +1956,8 @@ where
                 DynamicCompactionTrigger,
                 SpaceReclaimCompactionTrigger,
                 TtlCompactionTrigger,
+
+                FullGc,
             }
             let mut check_compact_trigger_interval =
                 tokio::time::interval(Duration::from_secs(CHECK_PENDING_TASK_PERIOD_SEC));
@@ -2015,6 +2017,14 @@ where
             let ttl_reclaim_trigger = IntervalStream::new(min_ttl_reclaim_trigger_interval)
                 .map(|_| HummockTimerEvent::TtlCompactionTrigger);
 
+            let mut full_gc_interval = tokio::time::interval(Duration::from_secs(
+                hummock_manager.env.opts.full_gc_interval_sec,
+            ));
+            full_gc_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            full_gc_interval.reset();
+            let full_gc_trigger =
+                IntervalStream::new(full_gc_interval).map(|_| HummockTimerEvent::FullGc);
+
             let mut triggers: Vec<BoxStream<'static, HummockTimerEvent>> = vec![
                 Box::pin(check_compact_trigger),
                 Box::pin(stat_report_trigger),
@@ -2022,6 +2032,7 @@ where
                 Box::pin(dynamic_tick_trigger),
                 Box::pin(space_reclaim_trigger),
                 Box::pin(ttl_reclaim_trigger),
+                Box::pin(full_gc_trigger),
             ];
 
             let periodic_check_split_group_interval_sec = hummock_manager
@@ -2206,6 +2217,15 @@ where
                                     hummock_manager
                                         .on_handle_trigger_multi_group(compact_task::TaskType::Ttl)
                                         .await;
+                                }
+
+                                HummockTimerEvent::FullGc => {
+                                    if hummock_manager
+                                        .start_full_gc(Duration::from_secs(3600))
+                                        .is_ok()
+                                    {
+                                        tracing::info!("Start full GC from meta node.");
+                                    }
                                 }
                             }
                         }

--- a/src/meta/src/hummock/vacuum.rs
+++ b/src/meta/src/hummock/vacuum.rs
@@ -12,30 +12,25 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::cmp;
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::time::Duration;
 
-use futures::{stream, StreamExt};
 use itertools::Itertools;
 use risingwave_hummock_sdk::HummockSstableObjectId;
-use risingwave_pb::common::worker_node::State::Running;
-use risingwave_pb::common::WorkerType;
 use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
-use risingwave_pb::hummock::{FullScanTask, VacuumTask};
+use risingwave_pb::hummock::VacuumTask;
 
 use super::CompactorManagerRef;
 use crate::backup_restore::BackupManagerRef;
-use crate::hummock::error::{Error, Result};
 use crate::hummock::HummockManagerRef;
-use crate::manager::{ClusterManagerRef, MetaSrvEnv};
+use crate::manager::MetaSrvEnv;
 use crate::storage::MetaStore;
 use crate::MetaResult;
 
 pub type VacuumManagerRef<S> = Arc<VacuumManager<S>>;
 
 pub struct VacuumManager<S: MetaStore> {
+    #[allow(dead_code)]
     env: MetaSrvEnv<S>,
     hummock_manager: HummockManagerRef<S>,
     backup_manager: BackupManagerRef<S>,
@@ -202,163 +197,19 @@ where
         tracing::info!("Finish vacuuming SSTs {:?}", vacuum_task.sstable_object_ids);
         Ok(())
     }
-
-    /// Starts a full GC.
-    /// 1. Meta node sends a `FullScanTask` to a compactor in this method.
-    /// 2. The compactor returns scan result of object store to meta node. See
-    /// `Vacuum::full_scan_inner` in storage crate.
-    /// 3. Meta node decides which SSTs to delete. See `VacuumManager::complete_full_gc`.
-    ///
-    /// Returns Ok(false) if there is no worker available.
-    pub fn start_full_gc(&self, sst_retention_time: Duration) -> Result<bool> {
-        self.hummock_manager.metrics.full_gc_trigger_count.inc();
-        // Set a minimum sst_retention_time to avoid deleting SSTs of on-going write op.
-        let sst_retention_time = cmp::max(
-            sst_retention_time,
-            Duration::from_secs(self.env.opts.min_sst_retention_time_sec),
-        );
-        tracing::info!(
-            "run full GC with sst_retention_time = {} secs",
-            sst_retention_time.as_secs()
-        );
-        let compactor = match self.compactor_manager.next_compactor() {
-            None => {
-                tracing::warn!("Try full GC but no available idle worker.");
-                return Ok(false);
-            }
-            Some(compactor) => compactor,
-        };
-        compactor
-            .send_event(ResponseEvent::FullScanTask(FullScanTask {
-                sst_retention_time_sec: sst_retention_time.as_secs(),
-            }))
-            .map_err(|_| Error::CompactorUnreachable(compactor.context_id()))?;
-        Ok(true)
-    }
-
-    /// Given candidate SSTs to GC, filter out false positive.
-    /// Returns number of SSTs to GC.
-    pub async fn complete_full_gc(&self, object_ids: Vec<HummockSstableObjectId>) -> Result<usize> {
-        if object_ids.is_empty() {
-            tracing::info!("SST full scan returns no SSTs.");
-            return Ok(0);
-        }
-        let metrics = &self.hummock_manager.metrics;
-        let spin_interval =
-            Duration::from_secs(self.env.opts.collect_gc_watermark_spin_interval_sec);
-        let watermark = collect_global_gc_watermark(
-            self.hummock_manager.cluster_manager().clone(),
-            spin_interval,
-        )
-        .await?;
-        metrics.full_gc_last_object_id_watermark.set(watermark as _);
-        let candidate_sst_number = object_ids.len();
-        metrics
-            .full_gc_candidate_object_count
-            .observe(candidate_sst_number as _);
-        // 1. filter by watermark
-        let object_ids = object_ids
-            .into_iter()
-            .filter(|s| *s < watermark)
-            .collect_vec();
-        // 2. filter by version
-        let selected_sst_number = self
-            .hummock_manager
-            .extend_objects_to_delete_from_scan(&object_ids)
-            .await;
-        metrics
-            .full_gc_selected_object_count
-            .observe(selected_sst_number as _);
-        tracing::info!("GC watermark is {}. SST full scan returns {} SSTs. {} remains after filtered by GC watermark. {} remains after filtered by hummock version.",
-            watermark, candidate_sst_number, object_ids.len(), selected_sst_number);
-        Ok(selected_sst_number)
-    }
-}
-
-/// Collects SST GC watermark from related cluster nodes and calculates a global one.
-///
-/// It must wait enough heartbeats first. This precondition is checked at `spin_interval`.
-///
-/// Returns a global GC watermark. The watermark only guards SSTs created before this
-/// invocation.
-pub async fn collect_global_gc_watermark<S>(
-    cluster_manager: ClusterManagerRef<S>,
-    spin_interval: Duration,
-) -> Result<HummockSstableObjectId>
-where
-    S: MetaStore,
-{
-    let mut global_watermark = HummockSstableObjectId::MAX;
-    let workers = vec![
-        cluster_manager.list_active_streaming_compute_nodes().await,
-        cluster_manager
-            .list_worker_node(WorkerType::Compactor, Some(Running))
-            .await,
-    ]
-    .concat();
-
-    if workers.is_empty() {
-        return Ok(global_watermark);
-    }
-
-    let mut worker_futures = vec![];
-    for worker in &workers {
-        // For each cluster node, its watermark is collected after waiting for 2 heartbeats.
-        // The first heartbeat may carry watermark took before the start of this method,
-        // which doesn't correctly guard target SSTs.
-        // The second heartbeat guarantees its watermark is took after the start of this method.
-        let worker_id = worker.id;
-        let cluster_manager_clone = cluster_manager.clone();
-        worker_futures.push(tokio::spawn(async move {
-            let mut init_version_id: Option<u64> = None;
-            loop {
-                let worker_info = match cluster_manager_clone.get_worker_by_id(worker_id).await {
-                    None => {
-                        return None;
-                    }
-                    Some(worker_info) => worker_info,
-                };
-                match init_version_id.as_ref() {
-                    None => {
-                        init_version_id = Some(worker_info.info_version_id());
-                    }
-                    Some(init_version_id) => {
-                        if worker_info.info_version_id() >= *init_version_id + 2 {
-                            return worker_info.hummock_gc_watermark();
-                        }
-                    }
-                }
-                tokio::time::sleep(spin_interval).await;
-            }
-        }));
-    }
-    let mut buffered = stream::iter(worker_futures).buffer_unordered(workers.len());
-    while let Some(worker_result) = buffered.next().await {
-        let worker_watermark = worker_result
-            .map_err(|e| anyhow::anyhow!("Failed to collect GC watermark: {:#?}", e))?;
-        // None means either the worker has gone or the worker has not set a watermark.
-        global_watermark = cmp::min(
-            global_watermark,
-            worker_watermark.unwrap_or(HummockSstableObjectId::MAX),
-        );
-    }
-    Ok(global_watermark)
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::time::Duration;
 
     use itertools::Itertools;
-    use risingwave_hummock_sdk::{HummockSstableObjectId, HummockVersionId};
-    use risingwave_pb::hummock::subscribe_compaction_event_response::Event as ResponseEvent;
+    use risingwave_hummock_sdk::HummockVersionId;
     use risingwave_pb::hummock::VacuumTask;
 
     use crate::backup_restore::BackupManager;
     use crate::hummock::test_utils::{add_test_tables, setup_compute_env};
     use crate::hummock::VacuumManager;
-    use crate::MetaOpts;
 
     #[tokio::test]
     async fn test_vacuum() {
@@ -425,113 +276,6 @@ mod tests {
         assert_eq!(
             VacuumManager::vacuum_sst_data(&vacuum).await.unwrap().len(),
             0
-        );
-    }
-
-    #[tokio::test]
-    async fn test_full_gc() {
-        let (mut env, hummock_manager, cluster_manager, worker_node) = setup_compute_env(80).await;
-        let context_id = worker_node.id;
-        let compactor_manager = hummock_manager.compactor_manager_ref_for_test();
-        let backup_manager = Arc::new(BackupManager::for_test(
-            env.clone(),
-            hummock_manager.clone(),
-        ));
-        // Use smaller spin interval to accelerate test.
-        env.opts = Arc::new(MetaOpts {
-            collect_gc_watermark_spin_interval_sec: 1,
-            ..(*env.opts).clone()
-        });
-        let vacuum = Arc::new(VacuumManager::new(
-            env,
-            hummock_manager.clone(),
-            backup_manager,
-            compactor_manager.clone(),
-        ));
-
-        // No task scheduled because no available worker.
-        assert!(!vacuum
-            .start_full_gc(Duration::from_secs(
-                vacuum.env.opts.min_sst_retention_time_sec - 1
-            ))
-            .unwrap());
-
-        let mut receiver = compactor_manager.add_compactor(context_id);
-
-        assert!(vacuum
-            .start_full_gc(Duration::from_secs(
-                vacuum.env.opts.min_sst_retention_time_sec - 1
-            ))
-            .unwrap());
-        let full_scan_task = match receiver.recv().await.unwrap().unwrap().event.unwrap() {
-            ResponseEvent::FullScanTask(task) => task,
-            _ => {
-                panic!()
-            }
-        };
-        // min_sst_retention_time_sec override user provided value.
-        assert_eq!(
-            vacuum.env.opts.min_sst_retention_time_sec,
-            full_scan_task.sst_retention_time_sec
-        );
-
-        assert!(vacuum
-            .start_full_gc(Duration::from_secs(
-                vacuum.env.opts.min_sst_retention_time_sec + 1
-            ))
-            .unwrap());
-        let full_scan_task = match receiver.recv().await.unwrap().unwrap().event.unwrap() {
-            ResponseEvent::FullScanTask(task) => task,
-            _ => {
-                panic!()
-            }
-        };
-        // min_sst_retention_time_sec doesn't override user provided value.
-        assert_eq!(
-            vacuum.env.opts.min_sst_retention_time_sec + 1,
-            full_scan_task.sst_retention_time_sec
-        );
-
-        // Empty input results immediate return, without waiting heartbeat.
-        vacuum.complete_full_gc(vec![]).await.unwrap();
-
-        // mimic CN heartbeat
-        use risingwave_pb::meta::heartbeat_request::extra_info::Info;
-        let heartbeat_interval = vacuum.env.opts.collect_gc_watermark_spin_interval_sec;
-        tokio::spawn(async move {
-            loop {
-                cluster_manager
-                    .heartbeat(
-                        context_id,
-                        vec![Info::HummockGcWatermark(HummockSstableObjectId::MAX)],
-                    )
-                    .await
-                    .unwrap();
-                tokio::time::sleep(Duration::from_secs(heartbeat_interval)).await;
-            }
-        });
-
-        // LSMtree is empty. All input SST ids should be treated as garbage.
-        assert_eq!(3, vacuum.complete_full_gc(vec![1, 2, 3]).await.unwrap());
-
-        // All committed SST ids should be excluded from GC.
-        let sst_infos = add_test_tables(hummock_manager.as_ref(), context_id).await;
-        let committed_object_ids = sst_infos
-            .into_iter()
-            .flatten()
-            .map(|s| s.get_object_id())
-            .sorted()
-            .collect_vec();
-        assert!(!committed_object_ids.is_empty());
-        let max_committed_object_id = *committed_object_ids.iter().max().unwrap();
-        assert_eq!(
-            1,
-            vacuum
-                .complete_full_gc(
-                    [committed_object_ids, vec![max_committed_object_id + 1]].concat()
-                )
-                .await
-                .unwrap()
         );
     }
 }

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -266,6 +266,7 @@ pub fn start(opts: MetaNodeOpts) -> Pin<Box<dyn Future<Output = ()> + Send>> {
                     .meta
                     .min_delta_log_num_for_hummock_version_checkpoint,
                 min_sst_retention_time_sec: config.meta.min_sst_retention_time_sec,
+                full_gc_interval_sec: config.meta.full_gc_interval_sec,
                 collect_gc_watermark_spin_interval_sec: config
                     .meta
                     .collect_gc_watermark_spin_interval_sec,

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -93,8 +93,11 @@ pub struct MetaOpts {
     /// more loss of in memory `HummockVersionCheckpoint::stale_objects` state when meta node is
     /// restarted.
     pub min_delta_log_num_for_hummock_version_checkpoint: u64,
-    /// Threshold used by worker node to filter out new SSTs when scanning object store.
+    /// Objects within `min_sst_retention_time_sec` won't be deleted by hummock full GC, even they
+    /// are dangling.
     pub min_sst_retention_time_sec: u64,
+    /// Interval of automatic hummock full GC.
+    pub full_gc_interval_sec: u64,
     /// The spin interval when collecting global GC watermark in hummock
     pub collect_gc_watermark_spin_interval_sec: u64,
     /// Enable sanity check when SSTs are committed
@@ -162,6 +165,7 @@ impl MetaOpts {
             hummock_version_checkpoint_interval_sec: 30,
             min_delta_log_num_for_hummock_version_checkpoint: 1,
             min_sst_retention_time_sec: 3600 * 24 * 7,
+            full_gc_interval_sec: 3600 * 24 * 7,
             collect_gc_watermark_spin_interval_sec: 5,
             enable_committed_sst_sanity_check: false,
             periodic_compaction_interval_sec: 60,

--- a/src/meta/src/rpc/service/hummock_service.rs
+++ b/src/meta/src/rpc/service/hummock_service.rs
@@ -279,11 +279,11 @@ where
         &self,
         request: Request<ReportFullScanTaskRequest>,
     ) -> Result<Response<ReportFullScanTaskResponse>, Status> {
-        let vacuum_manager = self.vacuum_manager.clone();
+        let hummock_manager = self.hummock_manager.clone();
         // The following operation takes some time, so we do it in dedicated task and responds the
         // RPC immediately.
         tokio::spawn(async move {
-            match vacuum_manager
+            match hummock_manager
                 .complete_full_gc(request.into_inner().object_ids)
                 .await
             {
@@ -302,7 +302,7 @@ where
         &self,
         request: Request<TriggerFullGcRequest>,
     ) -> Result<Response<TriggerFullGcResponse>, Status> {
-        self.vacuum_manager.start_full_gc(Duration::from_secs(
+        self.hummock_manager.start_full_gc(Duration::from_secs(
             request.into_inner().sst_retention_time_sec,
         ))?;
         Ok(Response::new(TriggerFullGcResponse { status: None }))


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR enables automatic hummock full GC. Previously user need to trigger full GC via risectl manually. 

Detailed changes are
- Move GC code from VacuumManager to HummockManager, so that hummock timer can invoke full GC easily.
- Add `full_gc_interval_sec` config.
- Reduce `min_sst_retention_time_sec` from 7 days to 1 days.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
