### PR TITLE
fix(optimizer): ban subquery in project set and table function

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/subquery.yaml
@@ -199,3 +199,15 @@
     select 1 from a where exists ( select 1 from b having exists ( select a1 from c ));
   expected_outputs:
   - optimized_logical_plan_for_stream
+- name: test subquery in table function
+  sql: |
+    create table t(x int[], y int[], k int primary key);
+    select *, (select sum(i) from unnest(x) i) as sum_x from t;
+  expected_outputs:
+    - batch_error
+- name: test subquery in project set
+  sql: |
+    create table t(x int[], y int[], k int primary key);
+    select *, (select sum(i) from (select unnest(x) i ) i) as sum_x from t;
+  expected_outputs:
+    - batch_error

--- a/src/frontend/planner_test/tests/testdata/output/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery.yaml
@@ -464,3 +464,13 @@
           │   └─LogicalProject { exprs: [a1] }
           │     └─LogicalSource { source: a, columns: [a1, a2, _row_id], time_range: (Unbounded, Unbounded) }
           └─LogicalSource { source: c, columns: [c1, c2, _row_id], time_range: (Unbounded, Unbounded) }
+- name: test subquery in table function
+  sql: |
+    create table t(x int[], y int[], k int primary key);
+    select *, (select sum(i) from unnest(x) i) as sum_x from t;
+  batch_error: 'internal error: Subquery can not be unnested.'
+- name: test subquery in project set
+  sql: |
+    create table t(x int[], y int[], k int primary key);
+    select *, (select sum(i) from (select unnest(x) i ) i) as sum_x from t;
+  batch_error: 'internal error: Subquery can not be unnested.'

--- a/src/frontend/src/binder/relation/mod.rs
+++ b/src/frontend/src/binder/relation/mod.rs
@@ -111,6 +111,8 @@ impl Relation {
                 );
                 correlated_indices
             }
+            Relation::TableFunction(table_function) => table_function
+                .collect_correlated_indices_by_depth_and_assign_id(depth, correlated_id),
             _ => vec![],
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Ban correlated input ref in project set or table function.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
