### PR TITLE
fix: Fixed the potential assert failure that may occur when the source split changes in multiple mvs that depend on the same source.

### DIFF
--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -778,7 +778,7 @@ where
 
         if !diff.is_empty() {
             let command = Command::SourceSplitAssignment(diff);
-            tracing::debug!("pushing down command {:#?}", command);
+            tracing::info!(command = ?command, "pushing down split assignment command");
             self.barrier_scheduler.run_command(command).await?;
         }
 

--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -120,25 +120,31 @@ impl<S: StateStore> SourceExecutor<S> {
             .map_err(StreamExecutorError::connector_error)
     }
 
-    fn check_split_is_migration(&self, actor_splits: &HashMap<ActorId, Vec<SplitImpl>>) -> bool {
+    fn check_split_assignment_is_migration(
+        &self,
+        actor_splits: &HashMap<ActorId, Vec<SplitImpl>>,
+    ) -> bool {
         let core = self.stream_source_core.as_ref().unwrap();
 
-        let mut revert_index = HashMap::new();
+        let mut split_to_actors_index = HashMap::new();
 
         for (actor_id, splits) in actor_splits {
             for split in splits {
-                assert!(revert_index.insert(split.id(), actor_id).is_none());
+                split_to_actors_index
+                    .entry(split.id())
+                    .or_insert(vec![])
+                    .push(*actor_id);
             }
         }
 
         for split_id in core.state_cache.keys() {
-            if let Some(actor_id) = revert_index.remove(split_id) {
-                if self.actor_ctx.id != *actor_id {
+            if let Some(actor_ids) = split_to_actors_index.remove(split_id) {
+                if !actor_ids.contains(&self.actor_ctx.id) {
                     tracing::warn!(
-                        "split {} migration detected, from {} to {}",
+                        "split {} migration from {} detected, target might be {:?}",
                         split_id,
                         self.actor_ctx.id,
-                        actor_id
+                        actor_ids
                     );
                     return true;
                 }
@@ -444,11 +450,17 @@ impl<S: StateStore> SourceExecutor<S> {
                                 Mutation::Pause => stream.pause_stream(),
                                 Mutation::Resume => stream.resume_stream(),
                                 Mutation::SourceChangeSplit(actor_splits) => {
+                                    tracing::info!(
+                                        actor_id = self.actor_ctx.id,
+                                        actor_splits = ?actor_splits,
+                                        "source change split received"
+                                    );
+
                                     // In the context of split changes, we do not allow split
                                     // migration because it can lead to inconsistent states.
                                     // Therefore, all split migration must be done via update
                                     // mutation and pause/resume
-                                    assert!(!self.check_split_is_migration(actor_splits));
+                                    assert!(!self.check_split_assignment_is_migration(actor_splits));
 
                                     target_state = self
                                         .apply_split_change(&source_desc, &mut stream, actor_splits)


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title, fix #11324

This pull request introduces two code changes.

The first code change modifies a debug log statement in the `SourceManager` module to an info log statement. The log message now includes the split assignment command being pushed down. This change improves the clarity of the log statements related to split assignments.

The second code change adds a new function called `check_split_assignment_is_migration` in the `SourceExecutor` module. This function is responsible for checking if a split assignment is a migration, meaning if a split is being assigned to a different actor. If a migration is detected, a warning log message is logged. To enforce this check, the function is called in the `apply_split_change` function. This change ensures that split migrations are not allowed, providing a stricter validation in the code.

Additionally, an info log statement is added in the `apply_split_change` function. This log statement now logs the source change split received, including the actor ID and actor splits. This change enhances the log visibility for source change splits.

Overall, these code changes improve the logging functionality related to split assignments and migrations.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
