### PR TITLE
ci: add back auto-retry for main and docker pipeline

### DIFF
--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -1,3 +1,13 @@
+auto-retry: &auto-retry
+  automatic:
+    # Agent terminated because the AWS EC2 spot instance killed by AWS.
+    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
+    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    - exit_status: 255
+      limit: 2
+    - exit_status: -1
+      limit: 2
+
 steps:
   - label: "docker-build-push: amd64"
     command: "ci/scripts/docker.sh"
@@ -9,6 +19,7 @@ steps:
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
+    retry: *auto-retry
 
   - label: "docker-build-push: aarch64"
     command: "ci/scripts/docker.sh"
@@ -22,6 +33,7 @@ steps:
             GITHUB_TOKEN: github-token
     agents:
       queue: "linux-arm64"
+      retry: *auto-retry
 
   - label: "multi-arch-image-create-push"
     command: "ci/scripts/multi-arch-docker.sh"
@@ -34,6 +46,7 @@ steps:
             GHCR_USERNAME: ghcr-username
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
+    retry: *auto-retry
 
   - label: "pre build binary"
     command: "ci/scripts/release.sh"
@@ -50,3 +63,4 @@ steps:
             - GITHUB_TOKEN
             - BUILDKITE_COMMIT
             - BUILDKITE_TAG
+    retry: *auto-retry

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -1,10 +1,6 @@
 auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
-    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
-    - exit_status: 255
-      limit: 2
     - signal_reason: agent_stop
       limit: 2
 

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -2,10 +2,10 @@ auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
     - exit_status: 255
       limit: 2
-    - exit_status: -1
+    - signal_reason: agent_stop
       limit: 2
 
 steps:

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -1,10 +1,6 @@
 auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
-    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
-    - exit_status: 255
-      limit: 2
     - signal_reason: agent_stop
       limit: 2
 

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -1,3 +1,13 @@
+auto-retry: &auto-retry
+  automatic:
+    # Agent terminated because the AWS EC2 spot instance killed by AWS.
+    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
+    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    - exit_status: 255
+      limit: 2
+    - exit_status: -1
+      limit: 2
+
 steps:
   - label: "build"
     command: "ci/scripts/build.sh -p ci-release"
@@ -8,6 +18,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -23,6 +34,7 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -33,6 +45,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -43,6 +56,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (release)"
     command: "ci/scripts/cron-e2e-test.sh -p ci-release"
@@ -56,6 +70,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "end-to-end source test (release)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
@@ -69,6 +84,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "fuzz test"
     command: "ci/scripts/cron-fuzz-test.sh -p ci-release"
@@ -83,6 +99,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   # The timeout should be strictly more than timeout in `pull-request.yml`.
   # This ensures our `main-cron` workflow will be stable.
@@ -99,6 +116,7 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 16
+    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=100 timeout 15m ci/scripts/deterministic-unit-test.sh"
@@ -108,6 +126,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=60 timeout 70m ci/scripts/deterministic-it-test.sh scale::"
@@ -118,6 +137,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 70
+    retry: *auto-retry
 
   - label: "recovery integration test (deterministic simulation)"
     command: "TEST_NUM=60 timeout 70m ci/scripts/deterministic-it-test.sh recovery::"
@@ -128,6 +148,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 70
+    retry: *auto-retry
 
   - label: "backfill integration test (deterministic simulation)"
     command: "TEST_NUM=10 ci/scripts/deterministic-it-test.sh backfill_tests::"
@@ -138,6 +159,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 30
+    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=64 timeout 55m ci/scripts/deterministic-e2e-test.sh"
@@ -154,6 +176,7 @@ steps:
             - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=12 KILL_RATE=1.0 timeout 55m ci/scripts/deterministic-recovery-test.sh"
@@ -165,6 +188,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "misc check"
     command: "ci/scripts/misc-check.sh"
@@ -175,6 +199,7 @@ steps:
       - shellcheck#v1.2.0:
           files: ./**/*.sh
     timeout_in_minutes: 5
+    retry: *auto-retry
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run"
@@ -191,6 +216,7 @@ steps:
             - S3_SOURCE_TEST_CONF
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "S3 source check on AWS (json parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s json_file"
@@ -207,6 +233,7 @@ steps:
             - S3_SOURCE_TEST_CONF
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 25
+    retry: *auto-retry
 
   - label: "S3 source check on AWS (csv parser)"
     command: "ci/scripts/s3-source-test.sh -p ci-release -s run_csv"
@@ -223,6 +250,7 @@ steps:
             - S3_SOURCE_TEST_CONF
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 25
+    retry: *auto-retry
 
   - label: "S3 source on OpenDAL fs engine"
     command: "ci/scripts/s3-source-test-for-opendal-fs-engine.sh -p ci-release -s run"
@@ -239,6 +267,7 @@ steps:
             - S3_SOURCE_TEST_CONF
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "pulsar source check"
     command: "ci/scripts/pulsar-source-test.sh -p ci-release"
@@ -258,6 +287,7 @@ steps:
             - ASTRA_STREAMING_TEST_TOKEN
             - STREAMNATIVE_CLOUD_TEST_CONF
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "micro benchmark"
     command: "ci/scripts/run-micro-benchmarks.sh"
@@ -268,6 +298,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "upload micro-benchmark"
     if: build.branch == "main" || build.pull_request.labels includes "ci/upload-micro-benchmark"
@@ -300,6 +331,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 30
+    retry: *auto-retry
 
   # Sqlsmith differential testing
   - label: "Sqlsmith Differential Testing"
@@ -325,3 +357,4 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
+    retry: *auto-retry

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -2,10 +2,10 @@ auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
     - exit_status: 255
       limit: 2
-    - exit_status: -1
+    - signal_reason: agent_stop
       limit: 2
 
 steps:

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -1,3 +1,13 @@
+auto-retry: &auto-retry
+  automatic:
+    # Agent terminated because the AWS EC2 spot instance killed by AWS.
+    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
+    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    - exit_status: 255
+      limit: 2
+    - exit_status: -1
+      limit: 2
+
 steps:
   - label: "build (dev mode)"
     command: "ci/scripts/build.sh -p ci-dev"
@@ -8,6 +18,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "build (release mode)"
     command: "ci/scripts/build.sh -p ci-release"
@@ -20,6 +31,7 @@ steps:
           env:
             - BUILDKITE_COMMIT
     timeout_in_minutes: 20
+    retry: *auto-retry
 
   - label: "build other components"
     command: "ci/scripts/build-other.sh"
@@ -35,6 +47,7 @@ steps:
           environment:
             - GITHUB_TOKEN
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "build (deterministic simulation)"
     command: "ci/scripts/build-simulation.sh"
@@ -45,6 +58,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "docslt"
     command: "ci/scripts/docslt.sh"
@@ -55,6 +69,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (dev mode)"
     command: "ci/scripts/e2e-test.sh -p ci-dev"
@@ -75,6 +90,7 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "end-to-end test (release mode)"
     command: "ci/scripts/e2e-test.sh -p ci-release"
@@ -95,6 +111,7 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (parallel) (dev mode)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-dev"
@@ -114,6 +131,7 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "end-to-end test (parallel) (release mode)"
     command: "ci/scripts/e2e-test-parallel.sh -p ci-release"
@@ -133,6 +151,7 @@ steps:
           format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (parallel, in-memory) (release mode)"
     command: "ci/scripts/e2e-test-parallel-in-memory.sh -p ci-release"
@@ -146,6 +165,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end source test (release mode)"
     command: "ci/scripts/e2e-source-test.sh -p ci-release"
@@ -159,6 +179,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "unit test"
     command: "ci/scripts/pr-unit-test.sh"
@@ -173,6 +194,7 @@ steps:
           environment:
             - CODECOV_TOKEN
     timeout_in_minutes: 13
+    retry: *auto-retry
 
   - label: "unit test (deterministic simulation)"
     command: "MADSIM_TEST_NUM=50 ci/scripts/deterministic-unit-test.sh"
@@ -182,6 +204,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 15
+    retry: *auto-retry
 
   - label: "scaling test (deterministic simulation)"
     command: "TEST_NUM=30 ci/scripts/deterministic-it-test.sh scale::"
@@ -192,6 +215,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 40
+    retry: *auto-retry
 
   - label: "recovery integration test (deterministic simulation)"
     command: "TEST_NUM=30 ci/scripts/deterministic-it-test.sh recovery::"
@@ -202,6 +226,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 40
+    retry: *auto-retry
 
   - label: "backfill integration test (deterministic simulation)"
     command: "TEST_NUM=5 ci/scripts/deterministic-it-test.sh backfill_tests::"
@@ -212,6 +237,7 @@ steps:
           config: ci/docker-compose.yml
           mount-buildkite-agent: true
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end test (deterministic simulation)"
     command: "TEST_NUM=32 ci/scripts/deterministic-e2e-test.sh"
@@ -228,6 +254,7 @@ steps:
             - GITHUB_TOKEN
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 30
+    retry: *auto-retry
 
   - label: "recovery test (deterministic simulation)"
     command: "TEST_NUM=16 KILL_RATE=0.5 ci/scripts/deterministic-recovery-test.sh"
@@ -245,6 +272,7 @@ steps:
       #     format: "junit"
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 30
+    retry: *auto-retry
 
   - label: "end-to-end sink test (release mode)"
     command: "ci/scripts/e2e-sink-test.sh -p ci-release"
@@ -258,6 +286,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 35
+    retry: *auto-retry
 
   - label: "connector node integration test Java {{matrix.java_version}}"
     command: "ci/scripts/connector-node-integration-test.sh -p ci-release -v {{matrix.java_version}}"
@@ -276,6 +305,7 @@ steps:
           - "11"
           - "17"
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "end-to-end iceberg sink test (release mode)"
     command: "ci/scripts/e2e-iceberg-sink-test.sh -p ci-release"
@@ -289,6 +319,7 @@ steps:
           mount-buildkite-agent: true
       - ./ci/plugins/upload-failure-logs
     timeout_in_minutes: 5
+    retry: *auto-retry
 
   - label: "e2e java-binding test (at release)"
     command: "ci/scripts/java-binding-test.sh -p ci-release"
@@ -304,6 +335,7 @@ steps:
     # Extra 2 minutes to account for docker-compose latency.
     # See: https://github.com/risingwavelabs/risingwave/issues/9423#issuecomment-1521222169
     timeout_in_minutes: 10
+    retry: *auto-retry
 
   - label: "release"
     command: "ci/scripts/release.sh"
@@ -321,6 +353,7 @@ steps:
             - BUILDKITE_TAG
             - BUILDKITE_SOURCE
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "release docker image: amd64"
     command: "ci/scripts/docker.sh"
@@ -336,6 +369,7 @@ steps:
             DOCKER_TOKEN: docker-token
             GITHUB_TOKEN: github-token
     timeout_in_minutes: 60
+    retry: *auto-retry
 
   - label: "docker-build-push: aarch64"
     command: "ci/scripts/docker.sh"
@@ -353,6 +387,7 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: "linux-arm64"
+    retry: *auto-retry
 
   - label: "multi arch image create push"
     command: "ci/scripts/multi-arch-docker.sh"
@@ -367,3 +402,4 @@ steps:
             GHCR_TOKEN: ghcr-token
             DOCKER_TOKEN: docker-token
     timeout_in_minutes: 10
+    retry: *auto-retry

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -1,10 +1,6 @@
 auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
-    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
-    - exit_status: 255
-      limit: 2
     - signal_reason: agent_stop
       limit: 2
 

--- a/ci/workflows/main.yml
+++ b/ci/workflows/main.yml
@@ -2,10 +2,10 @@ auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
     - exit_status: 255
       limit: 2
-    - exit_status: -1
+    - signal_reason: agent_stop
       limit: 2
 
 steps:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -1,10 +1,6 @@
 auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
-    # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
-    - exit_status: 255
-      limit: 2
     - signal_reason: agent_stop
       limit: 2
 

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -2,10 +2,10 @@ auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
-    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
+    # "Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1"
     - exit_status: 255
       limit: 2
-    - exit_status: -1
+    - signal_reason: agent_stop
       limit: 2
 
 steps:

--- a/ci/workflows/pull-request.yml
+++ b/ci/workflows/pull-request.yml
@@ -2,7 +2,10 @@ auto-retry: &auto-retry
   automatic:
     # Agent terminated because the AWS EC2 spot instance killed by AWS.
     # "Exited with status 255 (after intercepting the agent’s termination signal, sent because the agent was stopped)"
+    # Terminated with signal SIGKILL (from the agent because the agent was stopped). Exit status -1
     - exit_status: 255
+      limit: 2
+    - exit_status: -1
       limit: 2
 
 steps:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

In #11304 , the auto-retry(exit code 255) of pull-request workflow was added back.

Here I add back the retry of main, main-cron and docker workflows, and also retry when the exit code is -1.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.


