### PR TITLE
fix(binder): cast of empty array literal

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/array.yaml
@@ -35,6 +35,18 @@
   expected_outputs:
   - binder_error
 - sql: |
+    select ARRAY[]::timestamptz[];
+  expected_outputs:
+  - logical_plan
+  - batch_plan
+  - stream_plan
+- sql: |
+    select ARRAY[]::STRUCT<f1 INT>[];
+  expected_outputs:
+  - logical_plan
+  - batch_plan
+  - stream_plan
+- sql: |
     select array_cat(array[66], array[123]);
   expected_outputs:
   - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/array.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/array.yaml
@@ -33,12 +33,12 @@
 - sql: |
     select ARRAY[]::int[];
   logical_plan: |-
-    LogicalProject { exprs: [Array::List(Int32) as $expr1] }
+    LogicalProject { exprs: [Array as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int[][];
   logical_plan: |-
-    LogicalProject { exprs: [Array::List(List(Int32)) as $expr1] }
+    LogicalProject { exprs: [Array as $expr1] }
     └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
 - sql: |
     select ARRAY[]::int;
@@ -48,6 +48,24 @@
     Caused by:
       Bind error: cannot determine type of empty array
     HINT:  Explicitly cast to the desired type, for example ARRAY[]::integer[].
+- sql: |
+    select ARRAY[]::timestamptz[];
+  logical_plan: |-
+    LogicalProject { exprs: [Array as $expr1] }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  batch_plan: 'BatchValues { rows: [[ARRAY[]:List(Timestamptz)]] }'
+  stream_plan: |-
+    StreamMaterialize { columns: [array, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck }
+    └─StreamValues { rows: [[Array, 0:Int64]] }
+- sql: |
+    select ARRAY[]::STRUCT<f1 INT>[];
+  logical_plan: |-
+    LogicalProject { exprs: [Array as $expr1] }
+    └─LogicalValues { rows: [[]], schema: Schema { fields: [] } }
+  batch_plan: 'BatchValues { rows: [[ARRAY[]:List(Struct(StructType { field_names: ["f1"], field_types: [Int32] }))]] }'
+  stream_plan: |-
+    StreamMaterialize { columns: [array, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck }
+    └─StreamValues { rows: [[Array, 0:Int64]] }
 - sql: |
     select array_cat(array[66], array[123]);
   logical_plan: |-

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -115,16 +115,6 @@ impl Binder {
     }
 
     pub(super) fn bind_array_cast(&mut self, exprs: Vec<Expr>, ty: DataType) -> Result<ExprImpl> {
-        if exprs.is_empty() {
-            let lhs: ExprImpl = FunctionCall::new_unchecked(
-                ExprType::Array,
-                vec![],
-                // Treat `array[]` as `varchar[]` temporarily before applying cast.
-                DataType::List(Box::new(DataType::Varchar)),
-            )
-            .into();
-            return lhs.cast_explicit(ty).map_err(Into::into);
-        }
         let inner_type = if let DataType::List(datatype) = &ty {
             *datatype.clone()
         } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fixes #11351 `array[]::timestamptz[]`
Fixes #11352 `array[]::STRUCT<s1_c1_integer INT>[]`

The problem originated from this line:
https://github.com/risingwavelabs/risingwave/blob/9f73f907fcc8fce275332e070001ecc88043e3ac/src/frontend/src/binder/expr/value.rs#L119

Casting from a dummy `varchar[]` does not work for timestamptz https://github.com/risingwavelabs/risingwave/issues/7175#issuecomment-1381314486 or struct #7369 currently.

The offending assumption was introduced by #5402 but a later enhancement #6096 can actually handle it without the assumption. So the issues are fixed simply by removing the special handling logic for empty array.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
