### PR TITLE
fix: warnings on naming from rust analyzer in generated code

### DIFF
--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -656,6 +656,7 @@ impl FunctionAttr {
                 #(let #const_child = #const_child.eval_const()?;)*
 
                 #[derive(Debug)]
+                #[allow(non_camel_case_types)]
                 struct #struct_name {
                     return_type: DataType,
                     chunk_size: usize,

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #![allow(rustdoc::private_intra_doc_links)]
+#![allow(non_snake_case)] // for `ctor` generated code
 #![feature(let_chains)]
 #![feature(assert_matches)]
 #![feature(lint_reasons)]

--- a/src/prost/src/lib.rs
+++ b/src/prost/src/lib.rs
@@ -15,6 +15,7 @@
 #![expect(clippy::all)]
 #![expect(rustdoc::bare_urls)]
 #![expect(clippy::doc_markdown)]
+#![allow(non_snake_case)] // for derived code of `Message`
 #![feature(lint_reasons)]
 
 use std::str::FromStr;

--- a/src/storage/src/store_impl.rs
+++ b/src/storage/src/store_impl.rs
@@ -529,7 +529,7 @@ pub mod verify {
 }
 
 impl StateStoreImpl {
-    #[cfg_attr(not(target_os = "linux"), expect(unused_variables))]
+    #[cfg_attr(not(target_os = "linux"), allow(unused_variables))]
     #[allow(clippy::too_many_arguments)]
     pub async fn new(
         s: &str,


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

It's annoying when developing. Not sure why it did not happen previously.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
