### PR TITLE
feat(binder): support align types for set operation

### DIFF
--- a/e2e_test/batch/basic/union.slt.part
+++ b/e2e_test/batch/basic/union.slt.part
@@ -2,7 +2,7 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-create table t1 (v1 int, v2 int);
+create table t1 (v1 int, v2 bigint);
 
 statement ok
 create table t2 (v1 int, v3 int);
@@ -53,6 +53,22 @@ select 1 as a union all select 1 as b order by a;
 ----
 1
 1
+
+query I
+select 1 union all select null
+----
+1
+NULL
+
+query T
+select null union all select null
+----
+NULL
+NULL
+
+statement error
+select null union all select null select union 1
+
 
 statement ok
 drop table t1;

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -54,7 +54,7 @@ pub struct BoundSelect {
     pub where_clause: Option<ExprImpl>,
     pub group_by: GroupBy,
     pub having: Option<ExprImpl>,
-    schema: Schema,
+    pub schema: Schema,
 }
 
 impl RewriteExprsRecursive for BoundSelect {

--- a/src/frontend/src/binder/set_expr.rs
+++ b/src/frontend/src/binder/set_expr.rs
@@ -150,21 +150,19 @@ impl Binder {
 
                         // Handle type alignment for select union select
                         // E.g. Select 1 UNION ALL Select NULL
-                        match (&mut left, &mut right) {
-                            (BoundSetExpr::Select(l_select), BoundSetExpr::Select(r_select)) => {
-                                for (i, (l, r)) in l_select
-                                    .select_items
-                                    .iter_mut()
-                                    .zip_eq_fast(r_select.select_items.iter_mut())
-                                    .enumerate()
-                                {
-                                    let column_type = align_types(vec![l, r].into_iter())?;
-                                    l_select.schema.fields[i].data_type = column_type.clone();
-                                    r_select.schema.fields[i].data_type = column_type;
-                                }
+                        if let (BoundSetExpr::Select(l_select), BoundSetExpr::Select(r_select)) =
+                            (&mut left, &mut right)
+                        {
+                            for (i, (l, r)) in l_select
+                                .select_items
+                                .iter_mut()
+                                .zip_eq_fast(r_select.select_items.iter_mut())
+                                .enumerate()
+                            {
+                                let column_type = align_types(vec![l, r].into_iter())?;
+                                l_select.schema.fields[i].data_type = column_type.clone();
+                                r_select.schema.fields[i].data_type = column_type;
                             }
-                            // TODO: handle other cases
-                            _ => {}
                         }
 
                         for (a, b) in left


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Related issue https://github.com/risingwavelabs/risingwave/issues/7768 https://github.com/risingwavelabs/risingwave/issues/7577
- Currently only support type alignment between `Select` and `Select` for set operation.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
