### PR TITLE
feat(config): support dummy synchronize_seqscans,statement_timeout,lock_timeout,row_security

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -799,7 +799,7 @@ impl ConfigMap {
             VariableInfo{
                 name: StatementTimeout::entry_name().to_lowercase(),
                 setting: self.statement_timeout.to_string(),
-                description: String::from("Sets the maximum allowed duration of any statement."),
+                description: String::from("Sets the maximum allowed duration of any statement, currently just a mock varible and not adopted in RW"),
             },
             VariableInfo{
                 name: LockTimeout::entry_name().to_lowercase(),

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -799,7 +799,7 @@ impl ConfigMap {
             VariableInfo{
                 name: StatementTimeout::entry_name().to_lowercase(),
                 setting: self.statement_timeout.to_string(),
-                description: String::from("Sets the maximum allowed duration of any statement, currently just a mock varible and not adopted in RW"),
+                description: String::from("Sets the maximum allowed duration of any statement, currently just a mock variable and not adopted in RW"),
             },
             VariableInfo{
                 name: LockTimeout::entry_name().to_lowercase(),

--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -34,7 +34,7 @@ use crate::util::epoch::Epoch;
 
 // This is a hack, &'static str is not allowed as a const generics argument.
 // TODO: refine this using the adt_const_params feature.
-const CONFIG_KEYS: [&str; 29] = [
+const CONFIG_KEYS: [&str; 33] = [
     "RW_IMPLICIT_FLUSH",
     "CREATE_COMPACTION_GROUP_FOR_MV",
     "QUERY_MODE",
@@ -64,6 +64,10 @@ const CONFIG_KEYS: [&str; 29] = [
     "CLIENT_MIN_MESSAGES",
     "CLIENT_ENCODING",
     "SINK_DECOUPLE",
+    "SYNCHRONIZE_SEQSCANS",
+    "STATEMENT_TIMEOUT",
+    "LOCK_TIMEOUT",
+    "ROW_SECURITY",
 ];
 
 // MUST HAVE 1v1 relationship to CONFIG_KEYS. e.g. CONFIG_KEYS[IMPLICIT_FLUSH] =
@@ -97,6 +101,10 @@ const FORCE_SPLIT_DISTINCT_AGG: usize = 25;
 const CLIENT_MIN_MESSAGES: usize = 26;
 const CLIENT_ENCODING: usize = 27;
 const SINK_DECOUPLE: usize = 28;
+const SYNCHRONIZE_SEQSCANS: usize = 29;
+const STATEMENT_TIMEOUT: usize = 30;
+const LOCK_TIMEOUT: usize = 31;
+const ROW_SECURITY: usize = 32;
 
 trait ConfigEntry: Default + for<'a> TryFrom<&'a [&'a str], Error = RwError> {
     fn entry_name() -> &'static str;
@@ -306,6 +314,10 @@ type ForceSplitDistinctAgg = ConfigBool<FORCE_SPLIT_DISTINCT_AGG, false>;
 type ClientMinMessages = ConfigString<CLIENT_MIN_MESSAGES>;
 type ClientEncoding = ConfigString<CLIENT_ENCODING>;
 type SinkDecouple = ConfigBool<SINK_DECOUPLE, false>;
+type SynchronizeSeqscans = ConfigBool<SYNCHRONIZE_SEQSCANS, false>;
+type StatementTimeout = ConfigI32<STATEMENT_TIMEOUT, 0>;
+type LockTimeout = ConfigI32<LOCK_TIMEOUT, 0>;
+type RowSecurity = ConfigBool<ROW_SECURITY, true>;
 
 /// Report status or notice to caller.
 pub trait ConfigReporter {
@@ -421,6 +433,24 @@ pub struct ConfigMap {
 
     /// Enable decoupling sink and internal streaming graph or not
     sink_decouple: SinkDecouple,
+
+    /// See <https://www.postgresql.org/docs/current/runtime-config-compatible.html#RUNTIME-CONFIG-COMPATIBLE-VERSION>
+    /// Unused in RisingWave, support for compatibility.
+    synchronize_seqscans: SynchronizeSeqscans,
+
+    /// Abort any statement that takes more than the specified amount of time. If
+    /// log_min_error_statement is set to ERROR or lower, the statement that timed out will also be
+    /// logged. If this value is specified without units, it is taken as milliseconds. A value of
+    /// zero (the default) disables the timeout.
+    statement_timeout: StatementTimeout,
+
+    /// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-LOCK-TIMEOUT>
+    /// Unused in RisingWave, support for compatibility.
+    lock_timeout: LockTimeout,
+
+    /// see <https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-ROW-SECURITY>.
+    /// Unused in RisingWave, support for compatibility.
+    row_security: RowSecurity,
 }
 
 impl ConfigMap {
@@ -522,6 +552,14 @@ impl ConfigMap {
             }
         } else if key.eq_ignore_ascii_case(SinkDecouple::entry_name()) {
             self.sink_decouple = val.as_slice().try_into()?;
+        } else if key.eq_ignore_ascii_case(SynchronizeSeqscans::entry_name()) {
+            self.synchronize_seqscans = val.as_slice().try_into()?;
+        } else if key.eq_ignore_ascii_case(StatementTimeout::entry_name()) {
+            self.statement_timeout = val.as_slice().try_into()?;
+        } else if key.eq_ignore_ascii_case(LockTimeout::entry_name()) {
+            self.lock_timeout = val.as_slice().try_into()?;
+        } else if key.eq_ignore_ascii_case(RowSecurity::entry_name()) {
+            self.row_security = val.as_slice().try_into()?;
         } else {
             return Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into());
         }
@@ -593,6 +631,14 @@ impl ConfigMap {
             Ok("hex".to_string())
         } else if key.eq_ignore_ascii_case(SinkDecouple::entry_name()) {
             Ok(self.sink_decouple.to_string())
+        } else if key.eq_ignore_ascii_case(SynchronizeSeqscans::entry_name()) {
+            Ok(self.synchronize_seqscans.to_string())
+        } else if key.eq_ignore_ascii_case(StatementTimeout::entry_name()) {
+            Ok(self.statement_timeout.to_string())
+        } else if key.eq_ignore_ascii_case(LockTimeout::entry_name()) {
+            Ok(self.lock_timeout.to_string())
+        } else if key.eq_ignore_ascii_case(RowSecurity::entry_name()) {
+            Ok(self.row_security.to_string())
         } else {
             Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into())
         }
@@ -744,7 +790,27 @@ impl ConfigMap {
                 name: SinkDecouple::entry_name().to_lowercase(),
                 setting: self.sink_decouple.to_string(),
                 description: String::from("Enable decoupling sink and internal streaming graph or not")
-            }
+            },
+            VariableInfo{
+                name: SynchronizeSeqscans::entry_name().to_lowercase(),
+                setting: self.synchronize_seqscans.to_string(),
+                description: String::from("Unused in RisingWave")
+            },
+            VariableInfo{
+                name: StatementTimeout::entry_name().to_lowercase(),
+                setting: self.statement_timeout.to_string(),
+                description: String::from("Sets the maximum allowed duration of any statement."),
+            },
+            VariableInfo{
+                name: LockTimeout::entry_name().to_lowercase(),
+                setting: self.lock_timeout.to_string(),
+                description: String::from("Unused in RisingWave"),
+            },
+            VariableInfo{
+                name: RowSecurity::entry_name().to_lowercase(),
+                setting: self.row_security.to_string(),
+                description: String::from("Unused in RisingWave"),
+            },
         ]
     }
 


### PR DESCRIPTION


I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

configs for pg_dump

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
