### PR TITLE
fix: failed source should not block the startup of the meta

### DIFF
--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -95,9 +95,10 @@ impl ConnectorSourceWorker {
     }
 
     pub async fn create(
-        connector_client: Option<ConnectorClient>,
+        connector_client: &Option<ConnectorClient>,
         source: &Source,
         period: Duration,
+        splits: Arc<Mutex<SharedSplitMap>>,
         metrics: Arc<MetaMetrics>,
     ) -> MetaResult<Self> {
         let mut properties = ConnectorProperties::extract(source.properties.clone())?;
@@ -116,7 +117,7 @@ impl ConnectorSourceWorker {
             }),
         )
         .await?;
-        let splits = Arc::new(Mutex::new(SharedSplitMap { splits: None }));
+
         Ok(Self {
             source_id: source.id,
             source_name: source.name.clone(),
@@ -125,7 +126,7 @@ impl ConnectorSourceWorker {
             period,
             metrics,
             connector_properties: properties,
-            connector_client,
+            connector_client: connector_client.clone(),
             fail_cnt: 0,
         })
     }
@@ -526,14 +527,13 @@ where
         {
             let sources = catalog_manager.list_sources().await;
             for source in sources {
-                Self::create_source_worker(
+                Self::create_source_worker_async(
                     env.connector_client(),
-                    &source,
+                    source,
                     &mut managed_sources,
-                    false,
                     metrics.clone(),
                 )
-                .await?
+                .await
             }
         }
 
@@ -704,6 +704,58 @@ where
         Ok(())
     }
 
+    async fn create_source_worker_async(
+        connector_client: Option<ConnectorClient>,
+        source: Source,
+        managed_sources: &mut HashMap<SourceId, ConnectorSourceWorkerHandle>,
+        metrics: Arc<MetaMetrics>,
+    ) {
+        tracing::info!("spawning new watcher for source {}", source.id);
+
+        let (sync_call_tx, sync_call_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let splits = Arc::new(Mutex::new(SharedSplitMap { splits: None }));
+        let current_splits_ref = splits.clone();
+        let source_id = source.id;
+
+        let handle = tokio::spawn(async move {
+            let mut ticker = time::interval(Self::SOURCE_TICK_INTERVAL);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+            let mut worker = loop {
+                ticker.tick().await;
+
+                match ConnectorSourceWorker::create(
+                    &connector_client,
+                    &source,
+                    Duration::from_secs(10),
+                    splits.clone(),
+                    metrics.clone(),
+                )
+                .await
+                {
+                    Ok(worker) => {
+                        break worker;
+                    }
+                    Err(e) => {
+                        tracing::warn!("failed to create source worker: {}", e);
+                    }
+                }
+            };
+
+            worker.run(sync_call_rx).await
+        });
+
+        managed_sources.insert(
+            source_id,
+            ConnectorSourceWorkerHandle {
+                handle,
+                sync_call_tx,
+                splits: current_splits_ref,
+            },
+        );
+    }
+
     async fn create_source_worker(
         connector_client: Option<ConnectorClient>,
         source: &Source,
@@ -711,14 +763,16 @@ where
         force_tick: bool,
         metrics: Arc<MetaMetrics>,
     ) -> MetaResult<()> {
+        let current_splits_ref = Arc::new(Mutex::new(SharedSplitMap { splits: None }));
         let mut worker = ConnectorSourceWorker::create(
-            connector_client,
+            &connector_client,
             source,
             Duration::from_secs(10),
+            current_splits_ref.clone(),
             metrics,
         )
         .await?;
-        let current_splits_ref = worker.current_splits.clone();
+
         tracing::info!("spawning new watcher for source {}", source.id);
 
         // don't force tick in process of recovery. One source down should not lead to meta recovery


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

cherry-pick to v1.1 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
