### PR TITLE
feat(optimizer): support streaming query with limit clause

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/limit.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/limit.yaml
@@ -49,33 +49,40 @@
   expected_outputs:
   - planner_error
 - sql: |
-    select 1 limit 1
+    select 1 c limit 1
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
-    select 1 order by 1 limit 1
+    select 1 c order by 1 limit 1
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
-    select 1 union all select 1 limit 10
+    select 1 c union all select 1 c limit 10
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
-    select 1 union all select 1 order by 1 limit 10
+    select 1 c union all select 1 c order by 1 limit 10
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
     create table t (a int);
     select count(*) from t limit 1;
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
     create table t (a int);
     select count(*) from t order by 1 limit 1;
   expected_outputs:
   - batch_plan
+  - stream_plan
 - sql: |
     create table t (a int primary key);
     select * from t limit 1;
   expected_outputs:
   - batch_plan
+  - stream_plan

--- a/src/frontend/planner_test/tests/testdata/output/limit.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/limit.yaml
@@ -75,25 +75,41 @@
     Feature is not yet implemented: WITH TIES is not supported with OFFSET
     No tracking issue yet. Feel free to submit a feature request at https://github.com/risingwavelabs/risingwave/issues/new?labels=type%2Ffeature&template=feature_request.yml
 - sql: |
-    select 1 limit 1
+    select 1 c limit 1
   batch_plan: |-
     BatchLimit { limit: 1, offset: 0 }
     └─BatchValues { rows: [[1:Int32]] }
+  stream_plan: |-
+    StreamMaterialize { columns: [c, _row_id(hidden)], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamTopN [append_only] { order: [1:Int32 ASC], limit: 1, offset: 0 }
+      └─StreamValues { rows: [[1:Int32, 0:Int64]] }
 - sql: |
-    select 1 order by 1 limit 1
+    select 1 c order by 1 limit 1
   batch_plan: |-
     BatchTopN { order: [1:Int32 ASC], limit: 1, offset: 0 }
     └─BatchValues { rows: [[1:Int32]] }
+  stream_plan: |-
+    StreamMaterialize { columns: [c, _row_id(hidden)], stream_key: [], pk_columns: [c], pk_conflict: NoCheck }
+    └─StreamTopN [append_only] { order: [1:Int32 ASC], limit: 1, offset: 0 }
+      └─StreamValues { rows: [[1:Int32, 0:Int64]] }
 - sql: |
-    select 1 union all select 1 limit 10
+    select 1 c union all select 1 c limit 10
   batch_plan: |-
     BatchLimit { limit: 10, offset: 0 }
     └─BatchValues { rows: [[1:Int32], [1:Int32]] }
+  stream_plan: |-
+    StreamMaterialize { columns: [c, _row_id(hidden)], stream_key: [_row_id], pk_columns: [_row_id], pk_conflict: NoCheck }
+    └─StreamTopN [append_only] { order: [1:Int32 ASC], limit: 10, offset: 0 }
+      └─StreamValues { rows: [[1:Int32, 0:Int64], [1:Int32, 1:Int64]] }
 - sql: |
-    select 1 union all select 1 order by 1 limit 10
+    select 1 c union all select 1 c order by 1 limit 10
   batch_plan: |-
     BatchTopN { order: [1:Int32 ASC], limit: 10, offset: 0 }
     └─BatchValues { rows: [[1:Int32], [1:Int32]] }
+  stream_plan: |-
+    StreamMaterialize { columns: [c, _row_id(hidden)], stream_key: [_row_id], pk_columns: [c, _row_id], pk_conflict: NoCheck }
+    └─StreamTopN [append_only] { order: [1:Int32 ASC], limit: 10, offset: 0 }
+      └─StreamValues { rows: [[1:Int32, 0:Int64], [1:Int32, 1:Int64]] }
 - sql: |
     create table t (a int);
     select count(*) from t limit 1;
@@ -103,6 +119,14 @@
       └─BatchExchange { order: [], dist: Single }
         └─BatchSimpleAgg { aggs: [count] }
           └─BatchScan { table: t, columns: [], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [count], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamTopN { order: [sum0(count) ASC], limit: 1, offset: 0 }
+      └─StreamProject { exprs: [sum0(count)] }
+        └─StreamSimpleAgg { aggs: [sum0(count), count] }
+          └─StreamExchange { dist: Single }
+            └─StreamStatelessSimpleAgg { aggs: [count] }
+              └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (a int);
     select count(*) from t order by 1 limit 1;
@@ -112,6 +136,14 @@
       └─BatchExchange { order: [], dist: Single }
         └─BatchSimpleAgg { aggs: [count] }
           └─BatchScan { table: t, columns: [], distribution: SomeShard }
+  stream_plan: |-
+    StreamMaterialize { columns: [count], stream_key: [], pk_columns: [count], pk_conflict: NoCheck }
+    └─StreamTopN { order: [sum0(count) ASC], limit: 1, offset: 0 }
+      └─StreamProject { exprs: [sum0(count)] }
+        └─StreamSimpleAgg { aggs: [sum0(count), count] }
+          └─StreamExchange { dist: Single }
+            └─StreamStatelessSimpleAgg { aggs: [count] }
+              └─StreamTableScan { table: t, columns: [t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
 - sql: |
     create table t (a int primary key);
     select * from t limit 1;
@@ -120,3 +152,11 @@
     └─BatchExchange { order: [], dist: Single }
       └─BatchLimit { limit: 1, offset: 0 }
         └─BatchScan { table: t, columns: [t.a], distribution: UpstreamHashShard(t.a) }
+  stream_plan: |-
+    StreamMaterialize { columns: [a], stream_key: [], pk_columns: [], pk_conflict: NoCheck }
+    └─StreamProject { exprs: [t.a] }
+      └─StreamTopN { order: [t.a ASC], limit: 1, offset: 0 }
+        └─StreamExchange { dist: Single }
+          └─StreamGroupTopN { order: [t.a ASC], limit: 1, offset: 0, group_key: [$expr1] }
+            └─StreamProject { exprs: [t.a, Vnode(t.a) as $expr1] }
+              └─StreamTableScan { table: t, columns: [t.a], pk: [t.a], dist: UpstreamHashShard(t.a) }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Convert `LogicalLimit` into `StreamTopN` for streaming queries instead of throwing an error.

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

- Support using limit clauses in streaming queries.

</details>
