### PR TITLE
fix(stream): clear upstream buffer if no snapshot progress

### DIFF
--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -361,7 +361,7 @@ where
                 // Consume upstream buffer chunk
                 // If no current_pos, means we did not process any snapshot
                 // yet. In that case
-                // we can just ignore the upstream buffer chunk.
+                // we can just ignore the upstream buffer chunk, but still need to clean it.
                 if let Some(current_pos) = &current_pos {
                     for chunk in upstream_chunk_buffer.drain(..) {
                         cur_barrier_upstream_processed_rows += chunk.cardinality() as u64;
@@ -370,6 +370,8 @@ where
                             &self.output_indices,
                         ));
                     }
+                } else {
+                    upstream_chunk_buffer.clear()
                 }
 
                 self.metrics


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As per title. Thanks to @Little-Wallace for discovering and reporting this bug. Found in https://github.com/risingwavelabs/risingwave/pull/11398.

The observation was that multiple rows with the same PK were inserted into upstream mview.
Consider the following sequence of events:
1. Upstream update for row with `pk=123`. -------> Upstream buffer contains `pk=123`
2. Snapshot read no progress in this epoch.
3. Barrier (and upstream buffer not cleaned)
4. new snapshot with current_pos=None. Pk will be at least `123`.
5. snapshot read with 123, flush `pk=123` to downstream.
6. No more snapshot. 
7. Flush remaining rows in upstream buffer. ---------> Upstream buffer contains 123, so we flush it twice.

Then we will have inconsistent table.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
