### PR TITLE
chore: unify docker compose from integration test to unified settings

### DIFF
--- a/integration_tests/debezium-mongo/docker-compose.yaml
+++ b/integration_tests/debezium-mongo/docker-compose.yaml
@@ -1,14 +1,43 @@
 version: '3.1'
 
 services:
-  risingwave:
-    image: ghcr.io/risingwavelabs/risingwave:latest
-    ports:
-      - 4566:4566
-      - 5691:5691
-    command:
-      - playground
-    container_name: risingwave
+  compactor-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compactor-0
+  compute-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compute-node-0
+  etcd-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: etcd-0
+  frontend-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: frontend-node-0
+  grafana-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: grafana-0
+  meta-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: meta-node-0
+  minio-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: minio-0
+  prometheus-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: prometheus-0
+
+  message_queue:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: message_queue
 
   mongodb:
     image: mongo:4.4
@@ -71,11 +100,6 @@ services:
       MONGO_HOST: mongodb
       MONGO_PORT: 27017
       MONGO_DB_NAME: random_data
-
-  message_queue:
-    extends:
-      file: ../../docker/docker-compose.yml
-      service: message_queue
 
   register-mongodb-connector:
     image: curlimages/curl:7.79.1

--- a/integration_tests/debezium-mysql/docker-compose.yml
+++ b/integration_tests/debezium-mysql/docker-compose.yml
@@ -1,14 +1,42 @@
 ---
 version: "3"
 services:
-  risingwave:
-    image: ghcr.io/risingwavelabs/risingwave:latest
-    ports:
-      - 4566:4566
-      - 5691:5691
-    command:
-      - playground
-    container_name: risingwave
+  compactor-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compactor-0
+  compute-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compute-node-0
+  etcd-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: etcd-0
+  frontend-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: frontend-node-0
+  grafana-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: grafana-0
+  meta-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: meta-node-0
+  minio-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: minio-0
+  prometheus-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: prometheus-0
+  message_queue:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: message_queue
   mysql:
     image: mysql:8.0
     ports:
@@ -31,10 +59,6 @@ services:
       timeout: 5s
       retries: 5
     container_name: mysql
-  message_queue:
-    extends:
-      file: ../../docker/docker-compose.yml
-      service: message_queue
   debezium:
     image: debezium/connect:1.9
     environment:

--- a/integration_tests/debezium-postgres/docker-compose.yml
+++ b/integration_tests/debezium-postgres/docker-compose.yml
@@ -1,14 +1,42 @@
 ---
 version: "3"
 services:
-  risingwave:
-    image: ghcr.io/risingwavelabs/risingwave:latest
-    ports:
-      - 4566:4566
-      - 5691:5691
-    command:
-      - playground
-    container_name: risingwave
+  compactor-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compactor-0
+  compute-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compute-node-0
+  etcd-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: etcd-0
+  frontend-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: frontend-node-0
+  grafana-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: grafana-0
+  meta-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: meta-node-0
+  minio-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: minio-0
+  prometheus-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: prometheus-0
+  message_queue:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: message_queue
 
   postgres:
     image: debezium/postgres:13
@@ -30,11 +58,6 @@ services:
     container_name: postgres
     volumes:
       - ./postgres/postgres_bootstrap.sql:/docker-entrypoint-initdb.d/postgres_bootstrap.sql
-
-  message_queue:
-    extends:
-      file: ../../docker/docker-compose.yml
-      service: message_queue
 
   debezium:
     image: debezium/connect:1.9

--- a/integration_tests/debezium-sqlserver/docker-compose.yml
+++ b/integration_tests/debezium-sqlserver/docker-compose.yml
@@ -1,14 +1,42 @@
 ---
 version: "3"
 services:
-  risingwave:
-    image: ghcr.io/risingwavelabs/risingwave:latest
-    ports:
-      - 4566:4566
-      - 5691:5691
-    command:
-      - playground
-    container_name: risingwave
+  compactor-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compactor-0
+  compute-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compute-node-0
+  etcd-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: etcd-0
+  frontend-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: frontend-node-0
+  grafana-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: grafana-0
+  meta-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: meta-node-0
+  minio-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: minio-0
+  prometheus-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: prometheus-0
+  message_queue:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: message_queue
 
   sqlserver:
     image: mcr.microsoft.com/mssql/server:2017-latest
@@ -28,11 +56,6 @@ services:
       timeout: 5s
       retries: 5
     container_name: sqlserver
-
-  message_queue:
-    extends:
-      file: ../../docker/docker-compose.yml
-      service: message_queue
 
   debezium:
     image: debezium/connect:1.9


### PR DESCRIPTION
- Modify the docker-compose files in the `integration_tests/debezium-mysql`, `integration_tests/debezium-postgres`, `integration_tests/debezium-mongo`, and `integration_tests/debezium-sqlserver` directories
- Add and remove various services, such as `compactor-0`, `compute-node-0`, `etcd-0`, `frontend-node-0`, `grafana-0`, `meta-node-0`, `minio-0`, `prometheus-0`, `message_queue`, `datagen`, `register-mongodb-connector`, and `kafka-connect-ui`
- Update environment variables, ports, volumes, and healthcheck configurations for the services
- Remove the `risingwave` service from the Docker compose files
- Adjust service dependencies and volumes

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

related #11626

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

<!--

You can ignore or delete the section below if your PR does not contain user-facing changes.

Otherwise, please write a release note below.

-->

<details><summary>Click here for Documentation</summary>

### Types of user-facing changes

Please keep the types that apply to your changes, and remove the others.

- Installation and deployment
- Connector (sources & sinks)
- SQL commands, functions, and operators
- RisingWave cluster configuration changes
- Other (please specify in the release note below)

### Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
