### PR TITLE
Revert "chore(stream): cherry pick #11625 into v1.1-rc"

### DIFF
--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -284,8 +284,6 @@ where
                                                 &self.output_indices,
                                             ));
                                         }
-                                    } else {
-                                        upstream_chunk_buffer.clear();
                                     }
 
                                     self.metrics


### PR DESCRIPTION
Reverts risingwavelabs/risingwave#11633

Realize it's not actually needed. The bug was caused by a refactoring, that is not present in `v1.1`. So we can leave it out.