### PR TITLE
feat(risedev): generate `env` file also for playground

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -46,8 +46,10 @@ end
 
 if ${is_all_in_one_enabled}
   set_env RISEDEV_CARGO_BUILD_CRATE "risingwave_cmd_all"
+  set_env RISEDEV_CTL_RUN_CMD "-- risectl"
 else
   set_env RISEDEV_CARGO_BUILD_CRATE "risingwave_cmd"
+  set_env RISEDEV_CTL_RUN_CMD "--bin risectl --"
 end
 
 if ${is_hdfs_backend}
@@ -251,10 +253,12 @@ rm -f "${PREFIX_BIN}/compute-node"
 rm -f "${PREFIX_BIN}/meta-node"
 rm -f "${PREFIX_BIN}/frontend"
 rm -f "${PREFIX_BIN}/compactor"
+rm -f "${PREFIX_BIN}/risectl"
 ln -s "$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}/compute-node" "${PREFIX_BIN}/compute-node"
 ln -s "$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}/meta-node" "${PREFIX_BIN}/meta-node"
 ln -s "$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}/frontend" "${PREFIX_BIN}/frontend"
 ln -s "$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}/compactor" "${PREFIX_BIN}/compactor"
+ln -s "$(pwd)/target/${RISEDEV_BUILD_TARGET_DIR}${BUILD_MODE_DIR}/risectl" "${PREFIX_BIN}/risectl"
 '''
 
 [tasks.link-all-in-one-binaries]
@@ -473,6 +477,43 @@ dependencies = [
   "download-redis",
 ]
 
+[tasks.check-risedev-env-file]
+private = true
+category = "RiseDev - Prepare"
+description = "Check if risedev-env file exists"
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+RC_ENV_FILE="${PREFIX_CONFIG}/risedev-env"
+
+if [ ! -f "${RC_ENV_FILE}" ]; then
+  echo "risedev-env file not found. Did you start cluster using $(tput setaf 4)\`./risedev d\`$(tput sgr0) or $(tput setaf 4)\`./risedev p\`$(tput sgr0)?"
+  exit 1
+fi
+'''
+
+[tasks.psql]
+category = "RiseDev - Start/Stop"
+description = "Run local psql client with default connection parameters. You can pass extra arguments to psql."
+dependencies = ["check-risedev-env-file"]
+env_files = ["${PREFIX_CONFIG}/risedev-env"]
+script = '''
+#!/usr/bin/env bash
+psql -h $RW_FRONTEND_LISTEN_ADDRESS -p $RW_FRONTEND_PORT -U root -d dev "$@"
+'''
+
+[tasks.ctl]
+category = "RiseDev - Start/Stop"
+description = "Start RiseCtl"
+dependencies = ["check-risedev-env-file"]
+env_files = ["${PREFIX_CONFIG}/risedev-env"]
+script = '''
+#!/usr/bin/env bash
+cargo run -p ${RISEDEV_CARGO_BUILD_CRATE} --profile "${RISINGWAVE_BUILD_PROFILE}" ${RISEDEV_CTL_RUN_CMD} "$@"
+test $? -eq 0 || exit 1
+'''
+
 [tasks.p]
 alias = "playground"
 
@@ -490,25 +531,6 @@ cargo run -p risingwave_cmd_all \
           --profile "${RISINGWAVE_BUILD_PROFILE}" \
           ${RISINGWAVE_FEATURE_FLAGS} \
           -- playground
-'''
-
-[tasks.ctl]
-category = "RiseDev - Start/Stop"
-description = "Start RiseCtl"
-script = '''
-#!/usr/bin/env bash
-
-RC_ENV_FILE="${PREFIX_CONFIG}/risectl-env"
-
-if [ ! -f "${RC_ENV_FILE}" ]; then
-  echo "risectl-env file not found. Did you start cluster using $(tput setaf 4)\`./risedev d\`$(tput sgr0)?"
-  exit 1
-fi
-
-source "${RC_ENV_FILE}"
-
-cargo run -p risingwave_cmd --bin risectl --profile "${RISINGWAVE_BUILD_PROFILE}" -- "$@"
-test $? -eq 0 || exit 1
 '''
 
 [tasks.d]
@@ -1184,23 +1206,4 @@ cat << EOF > src/config/example.toml
 # Check detailed comments in src/common/src/config.rs
 EOF
 cargo run -p risingwave_common --bin example-config >> src/config/example.toml
-'''
-
-[tasks.psql]
-category = "RiseDev - PSQL Client"
-description = "Run local psql client with default connection parameters. You can pass extra arguments to psql."
-script = '''
-#!/usr/bin/env bash
-set -euo pipefail
-
-RC_ENV_FILE="${PREFIX_CONFIG}/risectl-env"
-
-if [ ! -f "${RC_ENV_FILE}" ]; then
-  echo "risectl-env file not found. Did you start cluster using $(tput setaf 4)\`./risedev d\`$(tput sgr0)?"
-  exit 1
-fi
-
-source "${RC_ENV_FILE}"
-
-psql -h $RW_FRONTEND_LISTEN_ADDRESS -p $RW_FRONTEND_PORT -U root -d dev "$@"
 '''

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -54,7 +54,7 @@ pub struct ComputeNodeOpts {
     /// This would be synonymous with the service's "public address"
     /// or "identifying address".
     /// Optional, we will use listen_addr if not specified.
-    #[clap(long, env = "RW_ADVERTISE_ADDR", long)]
+    #[clap(long, env = "RW_ADVERTISE_ADDR")]
     pub advertise_addr: Option<String>,
 
     #[clap(

--- a/src/meta/src/lib.rs
+++ b/src/meta/src/lib.rs
@@ -69,7 +69,6 @@ pub struct MetaNodeOpts {
     #[clap(long, env = "RW_VPC_SECURITY_GROUP_ID")]
     security_group_id: Option<String>,
 
-    // TODO: rename to listen_address and separate out the port.
     #[clap(long, env = "RW_LISTEN_ADDR", default_value = "127.0.0.1:5690")]
     listen_addr: String,
 

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -733,7 +733,8 @@ pub async fn start_service_as_election_leader<S: MetaStore>(
 
     #[cfg(not(madsim))]
     if let Some(dashboard_task) = dashboard_task {
-        dashboard_task.await.unwrap().unwrap();
+        // Join the task while ignoring the cancellation error.
+        let _ = dashboard_task.await;
     }
     Ok(())
 }

--- a/src/risedevtool/common.toml
+++ b/src/risedevtool/common.toml
@@ -1,4 +1,5 @@
 [env]
+RISEDEV = "1"
 OS = { source = "${CARGO_MAKE_RUST_TARGET_OS}", mapping = { linux = "linux", macos = "darwin" } }
 ARCH = { source = "${CARGO_MAKE_RUST_TARGET_ARCH}", mapping = { x86_64 = "amd64", aarch64 = "arm64" } }
 SYSTEM = "${OS}-${ARCH}"

--- a/src/risedevtool/src/bin/risedev-compose.rs
+++ b/src/risedevtool/src/bin/risedev-compose.rs
@@ -22,7 +22,7 @@ use console::style;
 use fs_err::{self, File};
 use itertools::Itertools;
 use risedev::{
-    compose_deploy, compute_risectl_env, Compose, ComposeConfig, ComposeDeployConfig, ComposeFile,
+    compose_deploy, generate_risedev_env, Compose, ComposeConfig, ComposeDeployConfig, ComposeFile,
     ComposeService, ComposeVolume, ConfigExpander, DockerImageConfig, ServiceConfig,
     RISEDEV_CONFIG_FILE,
 };
@@ -277,8 +277,9 @@ fn main() -> Result<()> {
             )?;
         }
 
-        let env = compute_risectl_env(&services)?;
-        writeln!(log_buffer, "-- risectl --\n{}\n", style(env).green())?;
+        if let Some(env) = Some(generate_risedev_env(&services)).filter(|x| !x.is_empty()) {
+            writeln!(log_buffer, "-- risedev-env --\n{}\n", style(env).green())?;
+        }
 
         compose_deploy(
             Path::new(&opts.directory),

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -24,7 +24,7 @@ use fs_err::OpenOptions;
 use indicatif::ProgressBar;
 use risedev::util::{complete_spin, fail_spin};
 use risedev::{
-    compute_risectl_env, preflight_check, AwsS3Config, CompactorService, ComputeNodeService,
+    generate_risedev_env, preflight_check, AwsS3Config, CompactorService, ComputeNodeService,
     ConfigExpander, ConfigureTmuxTask, ConnectorNodeService, EnsureStopService, ExecuteContext,
     FrontendService, GrafanaService, KafkaService, MetaNodeService, MinioService, OpendalConfig,
     PrometheusService, PubsubService, RedisService, ServiceConfig, Task, TempoService,
@@ -424,14 +424,9 @@ fn main() -> Result<()> {
             println!("-------------------------------");
             println!();
 
-            let risectl_env = match compute_risectl_env(&services) {
-                Ok(x) => x,
-                Err(_) => "".into(),
-            };
-
             fs_err::write(
-                Path::new(&env::var("PREFIX_CONFIG")?).join("risectl-env"),
-                risectl_env,
+                Path::new(&env::var("PREFIX_CONFIG")?).join("risedev-env"),
+                generate_risedev_env(&services),
             )?;
 
             println!("All services started successfully.");

--- a/src/risedevtool/src/lib.rs
+++ b/src/risedevtool/src/lib.rs
@@ -29,8 +29,8 @@ mod compose;
 pub use compose::*;
 mod compose_deploy;
 pub use compose_deploy::*;
-mod risectl_env;
-pub use risectl_env::*;
+mod risedev_env;
+pub use risedev_env::*;
 
 mod task;
 pub mod util;

--- a/src/risedevtool/src/risedev_env.rs
+++ b/src/risedevtool/src/risedev_env.rs
@@ -15,12 +15,11 @@
 use std::fmt::Write;
 use std::process::Command;
 
-use anyhow::Result;
-
 use crate::{add_hummock_backend, HummockInMemoryStrategy, ServiceConfig};
 
-pub fn compute_risectl_env(services: &Vec<ServiceConfig>) -> Result<String> {
-    // Pick one of the compute node and generate risectl config
+/// Generate environment variables from the given service configurations to be used by future
+/// RiseDev commands, like `risedev ctl` or `risedev psql`.
+pub fn generate_risedev_env(services: &Vec<ServiceConfig>) -> String {
     let mut env = String::new();
     for item in services {
         if let ServiceConfig::ComputeNode(c) = item {
@@ -29,7 +28,7 @@ pub fn compute_risectl_env(services: &Vec<ServiceConfig>) -> Result<String> {
             {
                 let mut cmd = Command::new("compute-node");
                 if add_hummock_backend(
-                    "risectl",
+                    "dummy",
                     c.provide_opendal.as_ref().unwrap(),
                     c.provide_minio.as_ref().unwrap(),
                     c.provide_aws_s3.as_ref().unwrap(),
@@ -40,7 +39,7 @@ pub fn compute_risectl_env(services: &Vec<ServiceConfig>) -> Result<String> {
                 {
                     writeln!(
                         env,
-                        "export RW_HUMMOCK_URL=\"{}\"",
+                        "RW_HUMMOCK_URL=\"{}\"",
                         cmd.get_args().nth(1).unwrap().to_str().unwrap()
                     )
                     .unwrap();
@@ -52,7 +51,7 @@ pub fn compute_risectl_env(services: &Vec<ServiceConfig>) -> Result<String> {
                 let meta_node = &c.provide_meta_node.as_ref().unwrap()[0];
                 writeln!(
                     env,
-                    "export RW_META_ADDR=\"http://{}:{}\"",
+                    "RW_META_ADDR=\"http://{}:{}\"",
                     meta_node.address, meta_node.port
                 )
                 .unwrap();
@@ -63,15 +62,11 @@ pub fn compute_risectl_env(services: &Vec<ServiceConfig>) -> Result<String> {
     for item in services {
         if let ServiceConfig::Frontend(c) = item {
             let listen_address = &c.listen_address;
-            writeln!(
-                env,
-                "export RW_FRONTEND_LISTEN_ADDRESS=\"{listen_address}\"",
-            )
-            .unwrap();
+            writeln!(env, "RW_FRONTEND_LISTEN_ADDRESS=\"{listen_address}\"",).unwrap();
             let port = &c.port;
-            writeln!(env, "export RW_FRONTEND_PORT=\"{port}\"",).unwrap();
+            writeln!(env, "RW_FRONTEND_PORT=\"{port}\"",).unwrap();
             break;
         }
     }
-    Ok(env)
+    env
 }

--- a/src/risedevtool/src/risedev_env.rs
+++ b/src/risedevtool/src/risedev_env.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![allow(clippy::doc_markdown)] // RiseDev
+
 use std::fmt::Write;
 use std::process::Command;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Also generate `risedev-env` for playground launches, so that we can leverage `risedev ctl` or `risedev psql` for it. 

Also some minor fixes:
- Reuse the logic for sourcing env vars for `ctl` and `psql`.
- Do not `unwrap` the joining result of the dashboard task.
- Suggest users about other `risedev` commands only if launched with RiseDev.
- Follows the configuration of all-in-one binary when launching risectl.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
