### PR TITLE
feat(expr): `scale`, `min_scale` and `trim_scale` for decimal

### DIFF
--- a/e2e_test/batch/functions/pow.slt.part
+++ b/e2e_test/batch/functions/pow.slt.part
@@ -242,7 +242,7 @@ with t(v) as (
 	values ('nan'), ('inf'), ('-inf'), ('-0')
 ) select
 	v,
-	exp(v::decimal)::float8, -- display with trailing zeros, use `trim_scale` later
+	trim_scale(exp(v::decimal)),
 	exp(v::float8)
 from t;
 ----

--- a/e2e_test/batch/functions/scale.slt.part
+++ b/e2e_test/batch/functions/scale.slt.part
@@ -1,0 +1,23 @@
+query RIIR
+with t(v) as (values
+	(8.4100),
+	(0),
+	(10),
+	(10.0),
+	('-inf'),
+	('inf'),
+	('nan')
+) select
+	v,
+	scale(v),
+	min_scale(v),
+	trim_scale(v)
+from t;
+----
+   8.4100    4    2      8.41
+        0    0    0         0
+       10    0    0        10
+     10.0    1    0        10
+-Infinity NULL NULL -Infinity
+ Infinity NULL NULL  Infinity
+      NaN NULL NULL       NaN

--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -142,6 +142,9 @@ message ExprNode {
     LOG10 = 273;
     CBRT = 274;
     SIGN = 275;
+    SCALE = 276;
+    MIN_SCALE = 277;
+    TRIM_SCALE = 278;
 
     // Boolean comparison
     IS_TRUE = 301;

--- a/src/common/src/array/arrow.rs
+++ b/src/common/src/array/arrow.rs
@@ -415,7 +415,7 @@ impl From<&DecimalArray> for arrow_array::Decimal128Array {
     fn from(array: &DecimalArray) -> Self {
         let max_scale = array
             .iter()
-            .filter_map(|o| o.map(|v| v.scale()))
+            .filter_map(|o| o.map(|v| v.scale().unwrap_or(0)))
             .max()
             .unwrap_or(0) as u32;
         let mut builder = arrow_array::builder::Decimal128Builder::with_capacity(array.len())
@@ -578,7 +578,7 @@ impl From<&ListArray> for arrow_array::ListArray {
             ArrayImpl::Decimal(a) => {
                 let max_scale = a
                     .iter()
-                    .filter_map(|o| o.map(|v| v.scale()))
+                    .filter_map(|o| o.map(|v| v.scale().unwrap_or(0)))
                     .max()
                     .unwrap_or(0) as u32;
                 build(

--- a/src/common/src/types/decimal.rs
+++ b/src/common/src/types/decimal.rs
@@ -409,43 +409,9 @@ impl Sub for Decimal {
 impl Decimal {
     pub const MAX_PRECISION: u8 = 28;
 
-    /// TODO: handle nan and inf
-    pub fn mantissa(&self) -> i128 {
-        match self {
-            Self::Normalized(d) => d.mantissa(),
-            _ => 0,
-        }
-    }
-
-    /// TODO: handle nan and inf
-    pub fn scale(&self) -> i32 {
-        match self {
-            Self::Normalized(d) => d.scale() as i32,
-            _ => 0,
-        }
-    }
-
-    /// TODO: handle nan and inf
-    /// There are maybe better solution here.
-    pub fn precision(&self) -> u32 {
-        match &self {
-            Decimal::Normalized(decimal) => {
-                let s = decimal.to_string();
-                let mut res = s.len();
-                if s.find('.').is_some() {
-                    res -= 1;
-                }
-                if s.find('-').is_some() {
-                    res -= 1;
-                }
-                res as u32
-            }
-            _ => 0,
-        }
-    }
-
-    pub fn new(num: i64, scale: u32) -> Self {
-        Self::Normalized(RustDecimal::new(num, scale))
+    pub fn scale(&self) -> Option<i32> {
+        let Decimal::Normalized(d) = self else { return None };
+        Some(d.scale() as _)
     }
 
     #[must_use]

--- a/src/expr/src/expr/expr_literal.rs
+++ b/src/expr/src/expr/expr_literal.rs
@@ -188,7 +188,7 @@ mod tests {
         let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();
         assert_eq!(v.to_scalar_value(), expr.literal().unwrap());
 
-        let v = Decimal::new(3141, 3);
+        let v = Decimal::from_i128_with_scale(3141, 3);
         let t = TypeName::Decimal;
         let bytes = serialize_datum(Some(v.to_scalar_value()).as_ref());
         let expr = LiteralExpression::try_from(&make_expression(bytes, t)).unwrap();

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -424,6 +424,25 @@ pub fn sign_dec(input: Decimal) -> Decimal {
     input.sign()
 }
 
+#[function("scale(decimal) -> int32")]
+pub fn decimal_scale(d: Decimal) -> Option<i32> {
+    let Decimal::Normalized(d) = d else { return None };
+    Some(d.scale() as _)
+}
+
+#[function("min_scale(decimal) -> int32")]
+pub fn decimal_min_scale(d: Decimal) -> Option<i32> {
+    let Decimal::Normalized(d) = d else { return None };
+    let d_shortest = d.normalize();
+    Some(d_shortest.scale() as _)
+}
+
+#[function("trim_scale(decimal) -> decimal")]
+pub fn decimal_trim_scale(d: Decimal) -> Decimal {
+    let Decimal::Normalized(d) = d else { return d };
+    d.normalize().into()
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;

--- a/src/expr/src/vector_op/arithmetic_op.rs
+++ b/src/expr/src/vector_op/arithmetic_op.rs
@@ -426,21 +426,17 @@ pub fn sign_dec(input: Decimal) -> Decimal {
 
 #[function("scale(decimal) -> int32")]
 pub fn decimal_scale(d: Decimal) -> Option<i32> {
-    let Decimal::Normalized(d) = d else { return None };
-    Some(d.scale() as _)
+    d.scale()
 }
 
 #[function("min_scale(decimal) -> int32")]
 pub fn decimal_min_scale(d: Decimal) -> Option<i32> {
-    let Decimal::Normalized(d) = d else { return None };
-    let d_shortest = d.normalize();
-    Some(d_shortest.scale() as _)
+    d.normalize().scale()
 }
 
 #[function("trim_scale(decimal) -> decimal")]
 pub fn decimal_trim_scale(d: Decimal) -> Decimal {
-    let Decimal::Normalized(d) = d else { return d };
-    d.normalize().into()
+    d.normalize()
 }
 
 #[cfg(test)]

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -638,6 +638,9 @@ impl Binder {
                 ("sqrt", raw_call(ExprType::Sqrt)),
                 ("cbrt", raw_call(ExprType::Cbrt)),
                 ("sign", raw_call(ExprType::Sign)),
+                ("scale", raw_call(ExprType::Scale)),
+                ("min_scale", raw_call(ExprType::MinScale)),
+                ("trim_scale", raw_call(ExprType::TrimScale)),
 
                 (
                     "to_timestamp",

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -127,6 +127,9 @@ impl ExprVisitor<bool> for ImpureAnalyzer {
             | expr_node::Type::Sqrt
             | expr_node::Type::Cbrt
             | expr_node::Type::Sign
+            | expr_node::Type::Scale
+            | expr_node::Type::MinScale
+            | expr_node::Type::TrimScale
             | expr_node::Type::Left
             | expr_node::Type::Right
             | expr_node::Type::Degrees


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://www.postgresql.org/docs/15/functions-math.html
`trim_scale` enables the `1.20` -> `1.2` normalization.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Support decimal expressions: `scale`, `min_scale` and `trim_scale`.

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
