### PR TITLE
fix(meta): fix split  group

### DIFF
--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -832,7 +832,7 @@ pub mod default {
         }
 
         pub fn move_table_size_limit() -> u64 {
-            8 * 1024 * 1024 * 1024 // 10GB
+            10 * 1024 * 1024 * 1024 // 10GB
         }
 
         pub fn split_group_size_limit() -> u64 {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -844,11 +844,11 @@ pub mod default {
         }
 
         pub fn table_write_throughput_threshold() -> u64 {
-            128 * 1024 * 1024 // 128MB
+            16 * 1024 * 1024 // 16MB
         }
 
         pub fn min_table_split_write_throughput() -> u64 {
-            32 * 1024 * 1024 // 32MB
+            4 * 1024 * 1024 // 4MB
         }
 
         pub fn compaction_task_max_heartbeat_interval_secs() -> u64 {

--- a/src/common/src/config.rs
+++ b/src/common/src/config.rs
@@ -832,7 +832,7 @@ pub mod default {
         }
 
         pub fn move_table_size_limit() -> u64 {
-            4 * 1024 * 1024 * 1024 // 4GB
+            8 * 1024 * 1024 * 1024 // 10GB
         }
 
         pub fn split_group_size_limit() -> u64 {

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -34,8 +34,8 @@ move_table_size_limit = 10737418240
 split_group_size_limit = 68719476736
 do_not_config_object_storage_lifecycle = false
 partition_vnode_count = 64
-table_write_throughput_threshold = 134217728
-min_table_split_write_throughput = 33554432
+table_write_throughput_threshold = 16777216
+min_table_split_write_throughput = 4194304
 compaction_task_max_heartbeat_interval_secs = 60
 
 [meta.compaction_config]

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -30,12 +30,12 @@ backend = "Mem"
 periodic_space_reclaim_compaction_interval_sec = 3600
 periodic_ttl_reclaim_compaction_interval_sec = 1800
 periodic_split_compact_group_interval_sec = 180
-move_table_size_limit = 4294967296
+move_table_size_limit = 8589934592
 split_group_size_limit = 68719476736
 do_not_config_object_storage_lifecycle = false
 partition_vnode_count = 64
 table_write_throughput_threshold = 134217728
-min_table_split_write_throughput = 33554432
+min_table_split_write_throughput = 16777216
 compaction_task_max_heartbeat_interval_secs = 60
 
 [meta.compaction_config]

--- a/src/config/example.toml
+++ b/src/config/example.toml
@@ -30,12 +30,12 @@ backend = "Mem"
 periodic_space_reclaim_compaction_interval_sec = 3600
 periodic_ttl_reclaim_compaction_interval_sec = 1800
 periodic_split_compact_group_interval_sec = 180
-move_table_size_limit = 8589934592
+move_table_size_limit = 10737418240
 split_group_size_limit = 68719476736
 do_not_config_object_storage_lifecycle = false
 partition_vnode_count = 64
 table_write_throughput_threshold = 134217728
-min_table_split_write_throughput = 16777216
+min_table_split_write_throughput = 33554432
 compaction_task_max_heartbeat_interval_secs = 60
 
 [meta.compaction_config]

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -593,6 +593,8 @@ impl<S: MetaStore> HummockManager<S> {
                 new_compaction_group_id
             }
         };
+        let mut current_version = versioning.current_version.clone();
+        let sst_split_info = current_version.apply_version_delta(&new_version_delta);
         let mut branched_ssts = BTreeMapTransaction::new(&mut versioning.branched_ssts);
         let mut trx = Transaction::default();
         new_version_delta.apply_to_txn(&mut trx)?;
@@ -612,9 +614,7 @@ impl<S: MetaStore> HummockManager<S> {
         } else {
             self.env.meta_store().txn(trx).await?;
         }
-        let sst_split_info = versioning
-            .current_version
-            .apply_version_delta(&new_version_delta);
+        versioning.current_version = current_version;
         // Updates SST split info
         let mut changed_sst_ids: HashSet<u64> = HashSet::default();
         for (object_id, sst_id, parent_old_sst_id, parent_new_sst_id) in sst_split_info {

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -560,11 +560,7 @@ impl<S: MetaStore> HummockManager<S> {
                     .await
                     .default_compaction_config();
                 config.split_by_state_table = allow_split_by_table;
-                if !allow_split_by_table {
-                    // TODO: remove it after we increase `max_bytes_for_level_base` for all group.
-                    config.max_bytes_for_level_base *= 4;
-                    config.split_weight_by_vnode = weight_split_by_vnode;
-                }
+                config.split_weight_by_vnode = weight_split_by_vnode;
 
                 new_version_delta.group_deltas.insert(
                     new_compaction_group_id,

--- a/src/meta/src/hummock/manager/compaction_group_manager.rs
+++ b/src/meta/src/hummock/manager/compaction_group_manager.rs
@@ -250,14 +250,14 @@ impl<S: MetaStore> HummockManager<S> {
                 })),
             });
         }
+        let mut current_version = versioning.current_version.clone();
+        let sst_split_info = current_version.apply_version_delta(&new_version_delta);
+        assert!(sst_split_info.is_empty());
 
         let mut trx = Transaction::default();
         new_version_delta.apply_to_txn(&mut trx)?;
         self.env.meta_store().txn(trx).await?;
-        let sst_split_info = versioning
-            .current_version
-            .apply_version_delta(&new_version_delta);
-        assert!(sst_split_info.is_empty());
+        versioning.current_version = current_version;
         new_version_delta.commit();
 
         self.notify_last_version_delta(versioning);
@@ -345,6 +345,9 @@ impl<S: MetaStore> HummockManager<S> {
                 delta_type: Some(DeltaType::GroupDestroy(GroupDestroy {})),
             });
         }
+        let mut current_version = versioning.current_version.clone();
+        let sst_split_info = current_version.apply_version_delta(&new_version_delta);
+        assert!(sst_split_info.is_empty());
 
         let mut trx = Transaction::default();
         new_version_delta.apply_to_txn(&mut trx)?;
@@ -358,10 +361,7 @@ impl<S: MetaStore> HummockManager<S> {
             remove_compaction_group_in_sst_stat(&self.metrics, *group_id, max_level);
         }
 
-        let sst_split_info = versioning
-            .current_version
-            .apply_version_delta(&new_version_delta);
-        assert!(sst_split_info.is_empty());
+        versioning.current_version = current_version;
         new_version_delta.commit();
         branched_ssts.commit_memory();
 

--- a/src/meta/src/hummock/manager/mod.rs
+++ b/src/meta/src/hummock/manager/mod.rs
@@ -2359,7 +2359,7 @@ where
                         is_low_write_throughput = history.iter().any(|throughput| {
                             *throughput < self.env.opts.min_table_split_write_throughput
                         });
-                        do_not_split = history.iter().all(|throughput| {
+                        do_not_split = history.iter().any(|throughput| {
                             *throughput < self.env.opts.min_table_split_write_throughput / 2
                         });
                     }

--- a/src/meta/src/hummock/manager/tests.rs
+++ b/src/meta/src/hummock/manager/tests.rs
@@ -2020,12 +2020,7 @@ async fn test_move_tables_between_compaction_group() {
     let info = branched_ssts.get(&12).unwrap();
     let groups = info.keys().sorted().cloned().collect_vec();
     assert_eq!(groups, vec![2, new_group_id]);
-    let ret = hummock_manager
-        .move_state_table_to_compaction_group(2, &[101], Some(new_group_id), false, 0)
-        .await;
-    // we can not move table-101 since sst-12 has been moved to new-group. If we move sst-12 to
-    // new-group, some of its data may be expired and it would return error result.
-    assert!(ret.is_err());
+
     let mut selector: Box<dyn LevelSelector> = Box::<SpaceReclaimCompactionSelector>::default();
 
     let mut compaction_task = hummock_manager
@@ -2047,33 +2042,6 @@ async fn test_move_tables_between_compaction_group() {
     let branched_ssts = hummock_manager.get_branched_ssts_info().await;
     // there is still left one sst for object-12 in branched-sst.
     assert_eq!(branched_ssts.len(), 2);
-
-    hummock_manager
-        .move_state_table_to_compaction_group(2, &[101], Some(new_group_id), false, 0)
-        .await
-        .unwrap();
-    let current_version = hummock_manager.get_current_version().await;
-    assert_eq!(
-        current_version
-            .get_compaction_group_levels(new_group_id)
-            .levels[base_level - 1]
-            .table_infos
-            .len(),
-        4
-    );
-    assert_eq!(
-        current_version.get_compaction_group_levels(2).levels[base_level - 1]
-            .table_infos
-            .len(),
-        2
-    );
-    let branched_ssts = hummock_manager.get_branched_ssts_info().await;
-    assert_eq!(branched_ssts.len(), 5);
-    let info = branched_ssts.get(&14).unwrap();
-    assert_eq!(
-        info.keys().cloned().sorted().collect_vec(),
-        vec![2, new_group_id]
-    );
 }
 
 #[tokio::test]

--- a/src/meta/src/manager/env.rs
+++ b/src/meta/src/manager/env.rs
@@ -149,7 +149,10 @@ pub struct MetaOpts {
     pub do_not_config_object_storage_lifecycle: bool,
 
     pub partition_vnode_count: u32,
+
+    /// threshold of high write throughput of state-table, unit: B/sec
     pub table_write_throughput_threshold: u64,
+    /// threshold of low write throughput of state-table, unit: B/sec
     pub min_table_split_write_throughput: u64,
 
     pub compaction_task_max_heartbeat_interval_secs: u64,

--- a/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
+++ b/src/storage/hummock_sdk/src/compaction_group/hummock_version_ext.rs
@@ -370,6 +370,7 @@ impl HummockVersionUpdateExt for HummockVersion {
                 let b = sst2.key_range.as_ref().unwrap();
                 a.compare(b)
             });
+            assert!(can_concat(&cur_levels.levels[z].table_infos));
             level
                 .table_infos
                 .drain_filter(|sst_info| sst_info.table_ids.is_empty())
@@ -917,6 +918,7 @@ pub fn add_ssts_to_sub_level(
                 let b = sst2.key_range.as_ref().unwrap();
                 a.compare(b)
             });
+        assert!(can_concat(&l0.sub_levels[sub_level_idx].table_infos));
     }
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Fix two problem

* split several small group
* split several state-table to one group. For example: we split state-table 1 and 5 to group-4. And then we split state-table 3 to group-4. There may exist a sstable with table-id [1, 5] and the new sstable with table-id 3 would overlap with it. This problem may cause iterator can not read the correct data

We check whether need to split a small group by these code:

```rust
is_low_write_throughput = window_total_size
                            < (HISTORY_TABLE_INFO_WINDOW_SIZE as u64)
                                * self.env.opts.min_table_split_write_throughput;
```

But there may be some empty write between we just create the table and really write data to risingwave.
So this check may return false and it would cause meta-service split a state-table larger than 4GB even if it does not have much write throughput.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
