### PR TITLE
feat(connector): support parsing "string containing JSON" as a struct type

### DIFF
--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -79,13 +79,23 @@ pub enum VarcharHandling {
 }
 
 #[derive(Clone, Debug)]
+pub enum StructHandling {
+    // only allow object parsed to struct
+    Strict,
+    // allow string containing a serialized json object (like "{\"a\": 1, \"b\": 2}") parsed to
+    // struct
+    AllowJsonString,
+}
+
+#[derive(Clone, Debug)]
 pub struct JsonParseOptions {
     pub bytea_handling: ByteaHandling,
     pub time_handling: TimeHandling,
     pub json_value_handling: JsonValueHandling,
     pub numeric_handling: NumericHandling,
-    pub boolean_handing: BooleanHandling,
-    pub varchar_handing: VarcharHandling,
+    pub boolean_handling: BooleanHandling,
+    pub varchar_handling: VarcharHandling,
+    pub struct_handling: StructHandling,
     pub ignoring_keycase: bool,
 }
 
@@ -103,11 +113,12 @@ impl JsonParseOptions {
         numeric_handling: NumericHandling::Relax {
             string_parsing: true,
         },
-        boolean_handing: BooleanHandling::Relax {
+        boolean_handling: BooleanHandling::Relax {
             string_parsing: true,
             string_integer_parsing: true,
         },
-        varchar_handing: VarcharHandling::Strict,
+        varchar_handling: VarcharHandling::Strict,
+        struct_handling: StructHandling::Strict,
         ignoring_keycase: true,
     };
     pub const DEBEZIUM: JsonParseOptions = JsonParseOptions {
@@ -117,11 +128,12 @@ impl JsonParseOptions {
         numeric_handling: NumericHandling::Relax {
             string_parsing: false,
         },
-        boolean_handing: BooleanHandling::Relax {
+        boolean_handling: BooleanHandling::Relax {
             string_parsing: false,
             string_integer_parsing: false,
         },
-        varchar_handing: VarcharHandling::Strict,
+        varchar_handling: VarcharHandling::Strict,
+        struct_handling: StructHandling::Strict,
         ignoring_keycase: true,
     };
     pub const DEFAULT: JsonParseOptions = JsonParseOptions {
@@ -131,8 +143,9 @@ impl JsonParseOptions {
         numeric_handling: NumericHandling::Relax {
             string_parsing: true,
         },
-        boolean_handing: BooleanHandling::Strict,
-        varchar_handing: VarcharHandling::OnlyPrimaryTypes,
+        boolean_handling: BooleanHandling::Strict,
+        varchar_handling: VarcharHandling::OnlyPrimaryTypes,
+        struct_handling: StructHandling::AllowJsonString,
         ignoring_keycase: true,
     };
 
@@ -154,7 +167,7 @@ impl JsonParseOptions {
             (
                 Some(DataType::Boolean),
                 ValueType::I64 | ValueType::I128 | ValueType::U64 | ValueType::U128,
-            ) if matches!(self.boolean_handing, BooleanHandling::Relax { .. })
+            ) if matches!(self.boolean_handling, BooleanHandling::Relax { .. })
                 && matches!(value.as_i64(), Some(0i64) | Some(1i64)) =>
             {
                 (value.as_i64() == Some(1i64)).into()
@@ -162,7 +175,7 @@ impl JsonParseOptions {
 
             (Some(DataType::Boolean), ValueType::String)
                 if matches!(
-                    self.boolean_handing,
+                    self.boolean_handling,
                     BooleanHandling::Relax {
                         string_parsing: true,
                         ..
@@ -174,7 +187,7 @@ impl JsonParseOptions {
                     "false" => false.into(),
                     c @ ("1" | "0")
                         if matches!(
-                            self.boolean_handing,
+                            self.boolean_handling,
                             BooleanHandling::Relax {
                                 string_parsing: true,
                                 string_integer_parsing: true
@@ -358,7 +371,7 @@ impl JsonParseOptions {
                 | ValueType::U64
                 | ValueType::U128
                 | ValueType::F64,
-            ) if matches!(self.varchar_handing, VarcharHandling::OnlyPrimaryTypes) => {
+            ) if matches!(self.varchar_handling, VarcharHandling::OnlyPrimaryTypes) => {
                 value.to_string().into()
             }
             (
@@ -371,7 +384,7 @@ impl JsonParseOptions {
                 | ValueType::F64
                 | ValueType::Array
                 | ValueType::Object,
-            ) if matches!(self.varchar_handing, VarcharHandling::AllTypes) => {
+            ) if matches!(self.varchar_handling, VarcharHandling::AllTypes) => {
                 value.to_string().into()
             }
             // ---- Time -----
@@ -449,7 +462,9 @@ impl JsonParseOptions {
 
             // String containing json object, e.g. "{\"a\": 1, \"b\": 2}"
             // Try to parse it as json object.
-            (Some(DataType::Struct(_)), ValueType::String) => {
+            (Some(DataType::Struct(_)), ValueType::String)
+                if matches!(self.struct_handling, StructHandling::AllowJsonString) =>
+            {
                 // TODO: avoid copy by accepting `&mut BorrowedValue` in `parse` method.
                 let mut value = value.as_str().unwrap().as_bytes().to_vec();
                 let value =

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -446,6 +446,14 @@ impl JsonParseOptions {
                     .collect::<Result<_, _>>()?,
             )
             .into(),
+
+            (Some(DataType::Struct(_)), ValueType::String) => {
+                let mut value = value.as_str().unwrap().as_bytes().to_vec();
+                let value =
+                    simd_json::to_borrowed_value(&mut value[..]).map_err(|_| create_error())?;
+                return self.parse(&value, type_expected);
+            }
+
             // ---- List -----
             (Some(DataType::List(item_type)), ValueType::Array) => ListValue::new(
                 value

--- a/src/connector/src/parser/unified/json.rs
+++ b/src/connector/src/parser/unified/json.rs
@@ -447,7 +447,10 @@ impl JsonParseOptions {
             )
             .into(),
 
+            // String containing json object, e.g. "{\"a\": 1, \"b\": 2}"
+            // Try to parse it as json object.
             (Some(DataType::Struct(_)), ValueType::String) => {
+                // TODO: avoid copy by accepting `&mut BorrowedValue` in `parse` method.
                 let mut value = value.as_str().unwrap().as_bytes().to_vec();
                 let value =
                     simd_json::to_borrowed_value(&mut value[..]).map_err(|_| create_error())?;


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As explained in #10772. Now we can parse
```json
{
  "nested": "{\"v1\": 10, \"v2\": \"hello\"}"
}
```
as `CREATE SOURCE .. (nested struct<v1 int, v2 varchar>) FORMAT JSON`.

Close #10772.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Support parsing "string containing JSON" as a struct type.
