### PR TITLE
fix: auto doc create-pr actions

### DIFF
--- a/.github/workflows/auto-create-docs-pr.yml
+++ b/.github/workflows/auto-create-docs-pr.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # - name: Check if PR is merged
-      #   id: check_merged
-      #   run: echo "merged=$(echo ${{ github.event.pull_request.merged }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+      - name: Check if PR is merged
+        id: check_merged
+        run: echo "merged=$(echo ${{ github.event.pull_request.merged }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
 
       - name: Retrieve PR information
         uses: 8BitJonny/gh-get-current-pr@2.2.0


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The new fix allows us to trigger the create-doc-issue action even when the PR has been merged, as we add "user-facing-changes".
