### PR TITLE
refactor(common): unified macro for pg-compatible data type info

### DIFF
--- a/e2e_test/batch/catalog/pg_type.slt.part
+++ b/e2e_test/batch/catalog/pg_type.slt.part
@@ -1,5 +1,5 @@
 query ITITT
-SELECT oid, typname, typelem, typnotnull, typtype FROM pg_catalog.pg_type;
+SELECT oid, typname, typelem, typnotnull, typtype FROM pg_catalog.pg_type order by oid;
 ----
 16	bool	0	f	b
 17	bytea	0	f	b

--- a/src/common/src/types/postgres_type.rs
+++ b/src/common/src/types/postgres_type.rs
@@ -15,7 +15,7 @@
 use super::DataType;
 use crate::error::ErrorCode;
 
-/// DataType information extracted from PostgreSQL `pg_type`
+/// `DataType` information extracted from PostgreSQL `pg_type`
 ///
 /// ```sql
 /// select oid, typarray, typname, typlen from pg_type
@@ -23,8 +23,8 @@ use crate::error::ErrorCode;
 /// ```
 ///
 /// See also:
-/// * https://www.postgresql.org/docs/15/catalog-pg-type.html
-/// * https://github.com/postgres/postgres/blob/REL_15_4/src/include/catalog/pg_type.dat
+/// * <https://www.postgresql.org/docs/15/catalog-pg-type.html>
+/// * <https://github.com/postgres/postgres/blob/REL_15_4/src/include/catalog/pg_type.dat>
 #[macro_export]
 macro_rules! for_all_base_types {
     ($macro:ident $(, $x:tt)*) => {

--- a/src/common/src/types/postgres_type.rs
+++ b/src/common/src/types/postgres_type.rs
@@ -15,28 +15,56 @@
 use super::DataType;
 use crate::error::ErrorCode;
 
+/// DataType information extracted from PostgreSQL `pg_type`
+///
+/// ```sql
+/// select oid, typarray, typname, typlen from pg_type
+/// where oid in (16, 21, 23, 20, 1700, 700, 701, 1043, 17, 1082, 1114, 1184, 1083, 1186, 3802);
+/// ```
+///
+/// See also:
+/// * https://www.postgresql.org/docs/15/catalog-pg-type.html
+/// * https://github.com/postgres/postgres/blob/REL_15_4/src/include/catalog/pg_type.dat
+#[macro_export]
+macro_rules! for_all_base_types {
+    ($macro:ident $(, $x:tt)*) => {
+        $macro! {
+            $($x, )*
+            { Boolean     |   16 |     1000 | bool        |      1 }
+            { Bytea       |   17 |     1001 | bytea       |     -1 }
+            { Int64       |   20 |     1016 | int8        |      8 }
+            { Int16       |   21 |     1005 | int2        |      2 }
+            { Int32       |   23 |     1007 | int4        |      4 }
+            { Float32     |  700 |     1021 | float4      |      4 }
+            { Float64     |  701 |     1022 | float8      |      8 }
+            { Varchar     | 1043 |     1015 | varchar     |     -1 }
+            { Date        | 1082 |     1182 | date        |      4 }
+            { Time        | 1083 |     1183 | time        |      8 }
+            { Timestamp   | 1114 |     1115 | timestamp   |      8 }
+            { Timestamptz | 1184 |     1185 | timestamptz |      8 }
+            { Interval    | 1186 |     1187 | interval    |     16 }
+            { Decimal     | 1700 |     1231 | numeric     |     -1 }
+            { Jsonb       | 3802 |     3807 | jsonb       |     -1 }
+        }
+    };
+}
+
 /// Get type information compatible with Postgres type, such as oid, type length.
 impl DataType {
     pub fn type_len(&self) -> i16 {
-        match self {
-            DataType::Boolean => 1,
-            DataType::Int16 => 2,
-            DataType::Int32 | DataType::Float32 | DataType::Date => 4,
-            DataType::Int64
-            | DataType::Serial
-            | DataType::Float64
-            | DataType::Timestamp
-            | DataType::Timestamptz
-            | DataType::Time => 8,
-            DataType::Decimal
-            | DataType::Varchar
-            | DataType::Int256
-            | DataType::Bytea
-            | DataType::Interval
-            | DataType::Jsonb
-            | DataType::Struct(_)
-            | DataType::List { .. } => -1,
+        macro_rules! impl_type_len {
+            ($( { $enum:ident | $oid:literal | $oid_array:literal | $name:ident | $len:literal } )*) => {
+                match self {
+                    $(
+                    DataType::$enum => $len,
+                    )*
+                    DataType::Serial => 8,
+                    DataType::Int256 => -1,
+                    DataType::List(_) | DataType::Struct(_) => -1,
+                }
+            }
         }
+        for_all_base_types! { impl_type_len }
     }
 
     // NOTE:
@@ -46,108 +74,65 @@ impl DataType {
     //  https://github.com/postgres/postgres/blob/master/src/include/catalog/pg_type.dat#L347
     //  For Numeric(aka Decimal): oid = 1700, array_type_oid = 1231
     pub fn from_oid(oid: i32) -> crate::error::Result<Self> {
-        match oid {
-            16 => Ok(DataType::Boolean),
-            17 => Ok(DataType::Bytea),
-            21 => Ok(DataType::Int16),
-            23 => Ok(DataType::Int32),
-            20 => Ok(DataType::Int64),
-            25 => Ok(DataType::Varchar), // workaround to support text in extended mode.
-            700 => Ok(DataType::Float32),
-            701 => Ok(DataType::Float64),
-            1700 => Ok(DataType::Decimal),
-            1082 => Ok(DataType::Date),
-            1043 => Ok(DataType::Varchar),
-            1083 => Ok(DataType::Time),
-            1114 => Ok(DataType::Timestamp),
-            1184 => Ok(DataType::Timestamptz),
-            1186 => Ok(DataType::Interval),
-            3802 => Ok(DataType::Jsonb),
-            1000 => Ok(DataType::List(Box::new(DataType::Boolean))),
-            1005 => Ok(DataType::List(Box::new(DataType::Int16))),
-            1007 => Ok(DataType::List(Box::new(DataType::Int32))),
-            1016 => Ok(DataType::List(Box::new(DataType::Int64))),
-            1021 => Ok(DataType::List(Box::new(DataType::Float32))),
-            1022 => Ok(DataType::List(Box::new(DataType::Float64))),
-            1231 => Ok(DataType::List(Box::new(DataType::Decimal))),
-            1182 => Ok(DataType::List(Box::new(DataType::Date))),
-            1015 => Ok(DataType::List(Box::new(DataType::Varchar))),
-            1266 => Ok(DataType::List(Box::new(DataType::Time))),
-            1115 => Ok(DataType::List(Box::new(DataType::Timestamp))),
-            1185 => Ok(DataType::List(Box::new(DataType::Timestamptz))),
-            1001 => Ok(DataType::List(Box::new(DataType::Bytea))),
-            1187 => Ok(DataType::List(Box::new(DataType::Interval))),
-            3807 => Ok(DataType::List(Box::new(DataType::Jsonb))),
-            _ => Err(ErrorCode::InternalError(format!("Unsupported oid {}", oid)).into()),
+        macro_rules! impl_from_oid {
+            ($( { $enum:ident | $oid:literal | $oid_array:literal | $name:ident | $len:literal } )*) => {
+                match oid {
+                    $(
+                    $oid => Ok(DataType::$enum),
+                    )*
+                    $(
+                    $oid_array => Ok(DataType::List(Box::new(DataType::$enum))),
+                    )*
+                    // workaround to support text in extended mode.
+                    25 => Ok(DataType::Varchar),
+                    1009 => Ok(DataType::List(Box::new(DataType::Varchar))),
+                    _ => Err(ErrorCode::InternalError(format!("Unsupported oid {}", oid)).into()),
+                }
+            }
         }
+        for_all_base_types! { impl_from_oid }
     }
 
     pub fn to_oid(&self) -> i32 {
-        match self {
-            DataType::Boolean => 16,
-            DataType::Int16 => 21,
-            DataType::Int32 => 23,
-            DataType::Int64 => 20,
-            DataType::Serial => 20,
-            DataType::Float32 => 700,
-            DataType::Float64 => 701,
-            DataType::Int256 => 1301,
-            DataType::Decimal => 1700,
-            DataType::Date => 1082,
-            DataType::Varchar => 1043,
-            DataType::Time => 1083,
-            DataType::Timestamp => 1114,
-            DataType::Timestamptz => 1184,
-            DataType::Interval => 1186,
-            // TODO: Support to give a new oid for custom struct type. #9434
-            DataType::Struct(_) => 1043,
-            DataType::Jsonb => 3802,
-            DataType::Bytea => 17,
-            DataType::List(inner) => match inner.unnest_list() {
-                DataType::Boolean => 1000,
-                DataType::Int16 => 1005,
-                DataType::Int32 => 1007,
-                DataType::Int64 => 1016,
-                DataType::Int256 => 1302,
-                DataType::Serial => 1016,
-                DataType::Float32 => 1021,
-                DataType::Float64 => 1022,
-                DataType::Decimal => 1231,
-                DataType::Date => 1182,
-                DataType::Varchar => 1015,
-                DataType::Bytea => 1001,
-                DataType::Time => 1183,
-                DataType::Timestamp => 1115,
-                DataType::Timestamptz => 1185,
-                DataType::Interval => 1187,
-                DataType::Jsonb => 3807,
-                DataType::Struct(_) => -1,
-                DataType::List { .. } => unreachable!("Never reach here!"),
-            },
+        macro_rules! impl_to_oid {
+            ($( { $enum:ident | $oid:literal | $oid_array:literal | $name:ident | $len:literal } )*) => {
+                match self {
+                    $(
+                    DataType::$enum => $oid,
+                    )*
+                    DataType::List(inner) => match inner.unnest_list() {
+                        $(
+                        DataType::$enum => $oid_array,
+                        )*
+                        DataType::Int256 => 1302,
+                        DataType::Serial => 1016,
+                        DataType::Struct(_) => -1,
+                        DataType::List { .. } => unreachable!("Never reach here!"),
+                    }
+                    DataType::Serial => 20,
+                    DataType::Int256 => 1301,
+                    // TODO: Support to give a new oid for custom struct type. #9434
+                    DataType::Struct(_) => 1043,
+                }
+            }
         }
+        for_all_base_types! { impl_to_oid }
     }
 
     pub fn pg_name(&self) -> &'static str {
-        match self {
-            DataType::Boolean => "bool",
-            DataType::Int16 => "int2",
-            DataType::Int32 => "int4",
-            DataType::Int64 => "int8",
-            DataType::Float32 => "float4",
-            DataType::Float64 => "float8",
-            DataType::Decimal => "numeric",
-            DataType::Date => "date",
-            DataType::Varchar => "varchar",
-            DataType::Time => "time",
-            DataType::Timestamp => "timestamp",
-            DataType::Timestamptz => "timestamptz",
-            DataType::Interval => "interval",
-            DataType::Struct(_) => "struct",
-            DataType::List(_) => "list",
-            DataType::Bytea => "bytea",
-            DataType::Jsonb => "jsonb",
-            DataType::Serial => "serial",
-            DataType::Int256 => "rw_int256",
+        macro_rules! impl_pg_name {
+            ($( { $enum:ident | $oid:literal | $oid_array:literal | $name:ident | $len:literal } )*) => {
+                match self {
+                    $(
+                    DataType::$enum => stringify!($name),
+                    )*
+                    DataType::Struct(_) => "struct",
+                    DataType::List(_) => "list",
+                    DataType::Serial => "serial",
+                    DataType::Int256 => "rw_int256",
+                }
+            }
         }
+        for_all_base_types! { impl_pg_name }
     }
 }

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_types.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_types.rs
@@ -17,33 +17,26 @@ use std::sync::LazyLock;
 use itertools::Itertools;
 use risingwave_common::catalog::RW_CATALOG_SCHEMA_NAME;
 use risingwave_common::error::Result;
+use risingwave_common::for_all_base_types;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, ScalarImpl};
 
 use crate::catalog::system_catalog::{BuiltinTable, SysCatalogReaderImpl};
 
-// TODO: uniform the default data with `TypeOid` under `pg_field_descriptor`.
-pub const RW_TYPE_DATA: &[(i32, &str)] = &[
-    (16, "bool"),
-    (17, "bytea"),
-    (20, "int8"),
-    (21, "int2"),
-    (23, "int4"),
-    // Note: rw doesn't support `text` type, returning it is just a workaround to be compatible
-    // with PostgreSQL.
-    (25, "text"),
-    (700, "float4"),
-    (701, "float8"),
-    (1043, "varchar"),
-    (1082, "date"),
-    (1083, "time"),
-    (1114, "timestamp"),
-    (1184, "timestamptz"),
-    (1186, "interval"),
-    (1301, "rw_int256"),
-    (1700, "numeric"),
-    (3802, "jsonb"),
-];
+macro_rules! impl_pg_type_data {
+    ($( { $enum:ident | $oid:literal | $oid_array:literal | $name:ident | $len:literal } )*) => {
+        &[
+            $(
+            ($oid, stringify!($name)),
+            )*
+            // Note: rw doesn't support `text` type, returning it is just a workaround to be compatible
+            // with PostgreSQL.
+            (25, "text"),
+            (1301, "rw_int256"),
+        ]
+    }
+}
+pub const RW_TYPE_DATA: &[(i32, &str)] = for_all_base_types! { impl_pg_type_data };
 
 /// `rw_types` stores all supported types in the database.
 pub static RW_TYPES: LazyLock<BuiltinTable> = LazyLock::new(|| BuiltinTable {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Generate the PostgreSQL-compatible DataType info functions from a single macro:
* `common::types::postgres_type`
  * `type_len`
  * `from_oid`
  * `to_oid`
  * `pg_name`
* `frontend::catalog::system_catalog::rw_catalog::rw_types`
  * `RW_TYPE_DATA`

Despite the intention of being an equivalent refactor, some minor logic fixes / changes are included:
* `type_len` of `Interval` fixed from `-1` to `16`, which is true in both PostgreSQL and RisingWave
* `from_oid` of `time[]` fixed from `1266` to `1183`, where `1266` is actually the discouraged `timetz`
* `from_oid` of `text[]` (`1009`) in addition to existing `text` (`25`)

More enhancements can be done after this, for example providing real data for `typlen`, `typarray` and `typelem` in `pg_type`.

The macro is a new one rather than adding more columns to #11270 because:
* This one only iterates over "base" types that are not composed of other types. In addition to `list` and `struct`, the types `serial` and `int256` are also excluded due to their incompatibility with PostgreSQL.
* `for_all_variants` originated from handling array / scalar variants (physical type), while this one handles DataType (logical type) and its compatibility with PostgreSQL. It is unlikely we would need to use an array / scalar and PostgreSQL type oid together.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
