### PR TITLE
chore: refine log & timeout in SourceManager

### DIFF
--- a/src/meta/src/stream/scale.rs
+++ b/src/meta/src/stream/scale.rs
@@ -1102,7 +1102,7 @@ where
 
                 let actor_splits = self
                     .source_manager
-                    .reallocate_splits(&prev_actor_ids, &curr_actor_ids)
+                    .reallocate_splits(*fragment_id, &prev_actor_ids, &curr_actor_ids)
                     .await?;
 
                 fragment_stream_source_actor_splits.insert(*fragment_id, actor_splits);

--- a/src/meta/src/stream/source_manager.rs
+++ b/src/meta/src/stream/source_manager.rs
@@ -55,7 +55,6 @@ pub struct SourceManager<S: MetaStore> {
 }
 
 const MAX_FAIL_CNT: u32 = 10;
-const DEFAULT_TICK_TIMEOUT: Duration = Duration::from_secs(10);
 
 struct SharedSplitMap {
     splits: Option<BTreeMap<SplitId, SplitImpl>>,
@@ -76,6 +75,8 @@ struct ConnectorSourceWorker {
 }
 
 impl ConnectorSourceWorker {
+    const DEFAULT_SOURCE_WORKER_TICK_INTERVAL: Duration = Duration::from_secs(30);
+
     async fn refresh(&mut self) -> MetaResult<()> {
         let enumerator = SplitEnumeratorImpl::create(
             self.connector_properties.clone(),
@@ -299,8 +300,11 @@ where
                         })
                         .collect();
 
+                    if discovered_splits.is_empty() {
+                        tracing::warn!("No splits discovered for source {}", source_id);
+                    }
+
                     if let Some(change) = diff_splits(
-                        *source_id,
                         *fragment_id,
                         prev_actor_splits,
                         &discovered_splits,
@@ -422,7 +426,6 @@ impl Default for SplitDiffOptions {
 }
 
 fn diff_splits<T>(
-    source_id: SourceId,
     fragment_id: FragmentId,
     actor_splits: HashMap<ActorId, Vec<T>>,
     discovered_splits: &BTreeMap<SplitId, T>,
@@ -436,17 +439,13 @@ where
         return None;
     }
 
-    if discovered_splits.is_empty() {
-        tracing::warn!("no splits discovered for source {}", source_id);
-    }
-
     let prev_split_ids: HashSet<_> = actor_splits
         .values()
         .flat_map(|splits| splits.iter().map(SplitMetaData::id))
         .collect();
 
-    tracing::trace!(fragment_id, source_id, prev_split_ids = ?prev_split_ids, "previous splits");
-    tracing::trace!(fragment_id, source_id, prev_split_ids = ?discovered_splits.keys(), "discovered splits");
+    tracing::trace!(fragment_id, prev_split_ids = ?prev_split_ids, "previous splits");
+    tracing::trace!(fragment_id, prev_split_ids = ?discovered_splits.keys(), "discovered splits");
 
     let discovered_split_ids: HashSet<_> = discovered_splits.keys().cloned().collect();
 
@@ -457,9 +456,9 @@ where
 
     if !dropped_splits.is_empty() {
         if opts.enable_scale_in {
-            tracing::info!(fragment_id, source_id, dropped_spltis = ?dropped_splits, "new dropped splits");
+            tracing::info!(fragment_id, dropped_spltis = ?dropped_splits, "new dropped splits");
         } else {
-            tracing::warn!(fragment_id, source_id, dropped_spltis = ?dropped_splits, "split dropping happened, but it is not allowed");
+            tracing::warn!(fragment_id, dropped_spltis = ?dropped_splits, "split dropping happened, but it is not allowed");
         }
     }
 
@@ -467,8 +466,6 @@ where
         .into_iter()
         .filter(|split_id| !prev_split_ids.contains(split_id))
         .collect();
-
-    tracing::info!(new_discovered_splits = ?new_discovered_splits, "new discovered splits");
 
     if opts.enable_scale_in {
         // if we support scale in, no more splits are discovered, and no splits are dropped, return
@@ -486,6 +483,8 @@ where
             return None;
         }
     }
+
+    tracing::info!(fragment_id, new_discovered_splits = ?new_discovered_splits, "new discovered splits");
 
     let mut heap = BinaryHeap::with_capacity(actor_splits.len());
 
@@ -515,7 +514,8 @@ impl<S> SourceManager<S>
 where
     S: MetaStore,
 {
-    const SOURCE_TICK_INTERVAL: Duration = Duration::from_secs(10);
+    const DEFAULT_SOURCE_TICK_INTERVAL: Duration = Duration::from_secs(10);
+    const DEFAULT_SOURCE_TICK_TIMEOUT: Duration = Duration::from_secs(10);
 
     pub async fn new(
         env: MetaSrvEnv<S>,
@@ -606,6 +606,7 @@ where
     // command.
     pub async fn reallocate_splits(
         &self,
+        fragment_id: FragmentId,
         prev_actor_ids: &[ActorId],
         curr_actor_ids: &[ActorId],
     ) -> MetaResult<HashMap<ActorId, Vec<SplitImpl>>> {
@@ -628,6 +629,7 @@ where
             .collect();
 
         let diff = diff_splits(
+            fragment_id,
             empty_actor_splits,
             &prev_splits,
             SplitDiffOptions::default(),
@@ -681,9 +683,12 @@ where
                     .map(|actor| (actor.actor_id, vec![]))
                     .collect();
 
-                if let Some(diff) =
-                    diff_splits(empty_actor_splits, &splits, SplitDiffOptions::default())
-                {
+                if let Some(diff) = diff_splits(
+                    fragment_id,
+                    empty_actor_splits,
+                    &splits,
+                    SplitDiffOptions::default(),
+                ) {
                     assigned.insert(fragment_id, diff);
                 }
             }
@@ -725,7 +730,7 @@ where
         let source_id = source.id;
 
         let handle = tokio::spawn(async move {
-            let mut ticker = time::interval(Self::SOURCE_TICK_INTERVAL);
+            let mut ticker = time::interval(Self::DEFAULT_SOURCE_TICK_INTERVAL);
             ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
 
             let mut worker = loop {
@@ -734,7 +739,7 @@ where
                 match ConnectorSourceWorker::create(
                     &connector_client,
                     &source,
-                    Duration::from_secs(10),
+                    ConnectorSourceWorker::DEFAULT_SOURCE_WORKER_TICK_INTERVAL,
                     splits.clone(),
                     metrics.clone(),
                 )
@@ -773,7 +778,7 @@ where
         let mut worker = ConnectorSourceWorker::create(
             &connector_client,
             source,
-            Duration::from_secs(10),
+            ConnectorSourceWorker::DEFAULT_SOURCE_WORKER_TICK_INTERVAL,
             current_splits_ref.clone(),
             metrics,
         )
@@ -788,13 +793,13 @@ where
 
             // todo: make the timeout configurable, longer than `properties.sync.call.timeout` in
             // kafka
-            tokio::time::timeout(DEFAULT_TICK_TIMEOUT, worker.tick())
+            tokio::time::timeout(Self::DEFAULT_SOURCE_TICK_TIMEOUT, worker.tick())
                 .await
                 .map_err(|_e| {
                     anyhow!(
                         "failed to fetch meta info for source {}, error: timeout {}",
                         source.id,
-                        DEFAULT_TICK_TIMEOUT.as_secs()
+                        Self::DEFAULT_SOURCE_TICK_TIMEOUT.as_secs()
                     )
                 })??;
         }
@@ -846,7 +851,7 @@ where
     }
 
     pub async fn run(&self) -> MetaResult<()> {
-        let mut ticker = time::interval(Self::SOURCE_TICK_INTERVAL);
+        let mut ticker = time::interval(Self::DEFAULT_SOURCE_TICK_INTERVAL);
         ticker.set_missed_tick_behavior(MissedTickBehavior::Skip);
         loop {
             ticker.tick().await;
@@ -907,7 +912,7 @@ mod tests {
     use risingwave_connector::source::{SplitId, SplitMetaData};
     use serde::{Deserialize, Serialize};
 
-    use crate::model::ActorId;
+    use crate::model::{ActorId, FragmentId};
     use crate::stream::source_manager::{diff_splits, SplitDiffOptions};
 
     #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
@@ -974,7 +979,13 @@ mod tests {
             .flat_map(|splits| splits.iter().map(|split| split.id()))
             .collect();
 
-        let diff = diff_splits(actor_splits, &discovered_splits, opts).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            opts,
+        )
+        .unwrap();
         check_all_splits(&discovered_splits, &diff);
 
         let mut after_split_to_actor = HashMap::new();
@@ -1008,7 +1019,13 @@ mod tests {
             enable_scale_in: true,
         };
 
-        let diff = diff_splits(actor_splits, &discovered_splits, opts).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            opts,
+        )
+        .unwrap();
 
         assert!(!diff.is_empty())
     }
@@ -1017,11 +1034,23 @@ mod tests {
     fn test_diff_splits() {
         let actor_splits = HashMap::new();
         let discovered_splits: BTreeMap<SplitId, TestSplit> = BTreeMap::new();
-        assert!(diff_splits(actor_splits, &discovered_splits, Default::default()).is_none());
+        assert!(diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            Default::default()
+        )
+        .is_none());
 
         let actor_splits = (0..3).map(|i| (i, vec![])).collect();
         let discovered_splits: BTreeMap<SplitId, TestSplit> = BTreeMap::new();
-        let diff = diff_splits(actor_splits, &discovered_splits, Default::default()).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            Default::default(),
+        )
+        .unwrap();
         assert_eq!(diff.len(), 3);
         for splits in diff.values() {
             assert!(splits.is_empty())
@@ -1035,7 +1064,13 @@ mod tests {
             })
             .collect();
 
-        let diff = diff_splits(actor_splits, &discovered_splits, Default::default()).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            Default::default(),
+        )
+        .unwrap();
         assert_eq!(diff.len(), 3);
         for splits in diff.values() {
             assert_eq!(splits.len(), 1);
@@ -1051,7 +1086,13 @@ mod tests {
             })
             .collect();
 
-        let diff = diff_splits(actor_splits, &discovered_splits, Default::default()).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            Default::default(),
+        )
+        .unwrap();
         assert_eq!(diff.len(), 3);
         for splits in diff.values() {
             let len = splits.len();
@@ -1072,7 +1113,13 @@ mod tests {
             })
             .collect();
 
-        let diff = diff_splits(actor_splits, &discovered_splits, Default::default()).unwrap();
+        let diff = diff_splits(
+            FragmentId::default(),
+            actor_splits,
+            &discovered_splits,
+            Default::default(),
+        )
+        .unwrap();
         assert_eq!(diff.len(), 5);
         for splits in diff.values() {
             assert_eq!(splits.len(), 1);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title, made some adjustments to the annoying logs and extended the tick period of the source worker to 30 seconds.



----
#### generated by ai
Code changes in `scale.rs`, `source_manager.rs`, and `ConnectorSourceWorker`

**Summary:** This pull request introduces several code changes across multiple files. In the `scale.rs` file, the `reallocate_splits` function now accepts an additional parameter `fragment_id`. The `DEFAULT_TICK_TIMEOUT` constant has been removed from the `source_manager.rs` file. The `ConnectorSourceWorker` struct now includes a new constant `DEFAULT_SOURCE_WORKER_TICK_INTERVAL`. Additionally, the `diff_splits` function now includes the `fragment_id` parameter in the tracing messages. In the `SourceManager` struct, the `SOURCE_TICK_INTERVAL` constant has been renamed to `DEFAULT_SOURCE_TICK_INTERVAL`, and a new constant `DEFAULT_SOURCE_TICK_TIMEOUT` has been added. The `reallocate_splits` function in the `SourceManager` struct has also been updated to accept the `fragment_id` parameter. Lastly, the `run` function in the `SourceManager` struct now utilizes the `DEFAULT_SOURCE_TICK_INTERVAL` for the ticker interval. These changes aim to streamline and enhance the functionality of the codebase.

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
