### PR TITLE
fix(delete range): fix key range mistake cause concat check panic

### DIFF
--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -386,6 +386,7 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
                     &monotonic_delete.event_key.left_user_key,
                 )
             {
+                assert!(!monotonic_delete.event_key.is_exclude_left_key);
                 smallest_key = FullKey::from_user_key(
                     monotonic_delete.event_key.left_user_key.clone(),
                     HummockEpoch::MAX,

--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -386,7 +386,6 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
                     &monotonic_delete.event_key.left_user_key,
                 )
             {
-                assert!(!monotonic_delete.event_key.is_exclude_left_key);
                 smallest_key = FullKey::from_user_key(
                     monotonic_delete.event_key.left_user_key.clone(),
                     HummockEpoch::MAX,

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -750,7 +750,7 @@ mod tests {
             .add_monotonic_delete(MonotonicDeleteEvent {
                 event_key: PointRange::from_user_key(
                     UserKey::for_test(table_id, b"eeee".to_vec()),
-                    false,
+                    true,
                 ),
                 new_epoch: 11,
             })

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -271,15 +271,16 @@ where
     /// Add kv pair to sstable.
     pub async fn add_monotonic_delete(&mut self, event: MonotonicDeleteEvent) -> HummockResult<()> {
         if let Some(builder) = self.current_builder.as_mut() && builder.reach_capacity() &&
-            !event.event_key.is_exclude_left_key
             && event.new_epoch != HummockEpoch::MAX {
-            if builder.last_range_tombstone_epoch() != HummockEpoch::MAX {
+            if builder.last_range_tombstone_epoch() == HummockEpoch::MAX {
+                self.seal_current().await?;
+            } else if !event.event_key.is_exclude_left_key {
                 builder.add_monotonic_delete(MonotonicDeleteEvent {
                     event_key: event.event_key.clone(),
                     new_epoch: HummockEpoch::MAX,
                 });
+                self.seal_current().await?;
             }
-            self.seal_current().await?;
         }
 
         if self.current_builder.is_none() {

--- a/src/storage/src/hummock/sstable/multi_builder.rs
+++ b/src/storage/src/hummock/sstable/multi_builder.rs
@@ -270,7 +270,9 @@ where
 
     /// Add kv pair to sstable.
     pub async fn add_monotonic_delete(&mut self, event: MonotonicDeleteEvent) -> HummockResult<()> {
-        if let Some(builder) = self.current_builder.as_mut() && builder.reach_capacity() && event.new_epoch != HummockEpoch::MAX {
+        if let Some(builder) = self.current_builder.as_mut() && builder.reach_capacity() &&
+            !event.event_key.is_exclude_left_key
+            && event.new_epoch != HummockEpoch::MAX {
             if builder.last_range_tombstone_epoch() != HummockEpoch::MAX {
                 builder.add_monotonic_delete(MonotonicDeleteEvent {
                     event_key: event.event_key.clone(),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

close https://github.com/risingwavelabs/risingwave/issues/11864

This Bug is caused by an open interval delete-range.

We used to delete range of data by insert such data:  [a,  c), it means that RisingWave shall delete all data no less than "a" and less than "c". For example: "a", "ab",  "b", "bc" will be all deleted, but "c" will keep alive.

But this case delete a range with open interval. For example, it deletes (a, ∞) and  (d, f). When Compactor Node try to add (d, f) to Builder, it finds that this builder meet `reach_capacity` and will switch to a new sstable. So key-range of the previous sstable will be (a, d]. But how shall key-range of the next ssable be? Exactly, we do not support the left bound of key-range of a sstable to be `Exclude`, so the key-range of next sstable will still be [d, f) rather than (d, f). 

This problem cause these two sstable files generated by compaction task overlap with each other.  So it can not pass the assertion check in `apply_version_delta`.






## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
