### PR TITLE
fix(optimizer): common sub-expression extraction on special exprs

### DIFF
--- a/src/expr/src/expr/expr_binary_nullable.rs
+++ b/src/expr/src/expr/expr_binary_nullable.rs
@@ -27,6 +27,8 @@ use super::{BoxedExpression, Expression};
 use crate::vector_op::conjunction::{and, or};
 use crate::Result;
 
+/// This is just an implementation detail. The semantic is not guaranteed at SQL level because
+/// optimizer may have rearranged the boolean expressions. #6202
 #[derive(Debug)]
 pub struct BinaryShortCircuitExpression {
     expr_ia1: BoxedExpression,

--- a/src/frontend/planner_test/tests/testdata/input/cse_expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/cse_expr.yaml
@@ -37,4 +37,9 @@
   expected_outputs:
     - batch_plan
     - stream_plan
+- name:  Common sub expression shouldn't extract partial expression of `some`/`all`. See 11766
+  sql: |
+    with t(v, arr) as (select 1, array[2, 3]) select v < all(arr), v < some(arr) from t;
+  expected_outputs:
+    - batch_plan
 

--- a/src/frontend/planner_test/tests/testdata/output/cse_expr.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/cse_expr.yaml
@@ -80,3 +80,9 @@
                 └─StreamStatelessSimpleAgg { aggs: [sum($expr1), sum(t.v), count(t.v)] }
                   └─StreamProject { exprs: [t.v, (t.v * t.v) as $expr1, t._row_id] }
                     └─StreamTableScan { table: t, columns: [t.v, t._row_id], pk: [t._row_id], dist: UpstreamHashShard(t._row_id) }
+- name: Common sub expression shouldn't extract partial expression of `some`/`all`. See 11766
+  sql: |
+    with t(v, arr) as (select 1, array[2, 3]) select v < all(arr), v < some(arr) from t;
+  batch_plan: |-
+    BatchProject { exprs: [All((1:Int32 < $expr10060)) as $expr1, Some((1:Int32 < $expr10060)) as $expr2] }
+    └─BatchValues { rows: [[1:Int32, ARRAY[2, 3]:List(Int32)]] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix / improve:
* SomeAllExpression are no longer broken up in the middle. Fixes #11766
* `coalesce` is also a short-circuit expr that should not have children extracted, just like `case when`
* `and` / `or` are not guaranteed to have short-circuit behavior. Actually other optimizer rules already break it (in both PostgreSQL and RisingWave).
* Allows `coalesce` and `case when` to be extracted as sub-expression in whole.

Limitation:
* In SomeAllExpression `v op SOME(arr)`, we could attempt to extract lhs `v` or rhs `arr`. But this is not done. It is [a little bit clumsy](https://github.com/risingwavelabs/risingwave/blob/main/src/expr/src/expr/expr_some_all.rs#L217-L228) to find the real rhs and rhs inside a bound SomeAllExpression.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
