### PR TITLE
feat: add `initialized_at` to ddl_progress

### DIFF
--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_ddl_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_ddl_progress.rs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::result;
-
 use itertools::Itertools;
 use risingwave_common::catalog::RW_CATALOG_SCHEMA_NAME;
 use risingwave_common::error::Result;
@@ -22,7 +20,6 @@ use risingwave_common::types::{DataType, ScalarImpl};
 use risingwave_common::util::epoch::Epoch;
 
 use crate::catalog::system_catalog::{BuiltinTable, SysCatalogReaderImpl};
-use crate::catalog::TableId;
 
 pub const RW_DDL_PROGRESS: BuiltinTable = BuiltinTable {
     name: "rw_ddl_progress",
@@ -52,7 +49,7 @@ impl SysCatalogReaderImpl {
             .map(|s| {
                 let initialized_at = tables
                     .get(&(s.id as u32))
-                    .and_then(|table| table.initialized_at_epoch.map(|e| Epoch::from(e)));
+                    .and_then(|table| table.initialized_at_epoch.map(Epoch::from));
 
                 OwnedRow::new(vec![
                     Some(ScalarImpl::Int64(s.id as i64)),

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_ddl_progress.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_ddl_progress.rs
@@ -12,13 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::result;
+
 use itertools::Itertools;
 use risingwave_common::catalog::RW_CATALOG_SCHEMA_NAME;
 use risingwave_common::error::Result;
 use risingwave_common::row::OwnedRow;
 use risingwave_common::types::{DataType, ScalarImpl};
+use risingwave_common::util::epoch::Epoch;
 
 use crate::catalog::system_catalog::{BuiltinTable, SysCatalogReaderImpl};
+use crate::catalog::TableId;
 
 pub const RW_DDL_PROGRESS: BuiltinTable = BuiltinTable {
     name: "rw_ddl_progress",
@@ -27,22 +31,34 @@ pub const RW_DDL_PROGRESS: BuiltinTable = BuiltinTable {
         (DataType::Int64, "ddl_id"),
         (DataType::Varchar, "ddl_statement"),
         (DataType::Varchar, "progress"),
+        (DataType::Timestamptz, "initialized_at"),
     ],
     pk: &[0],
 };
 
 impl SysCatalogReaderImpl {
     pub async fn read_ddl_progress(&self) -> Result<Vec<OwnedRow>> {
-        let ddl_progress = self
-            .meta_client
-            .list_ddl_progress()
-            .await?
+        let ddl_progresses = self.meta_client.list_ddl_progress().await?;
+
+        let table_ids = ddl_progresses
+            .iter()
+            .map(|progress| progress.id as u32)
+            .collect_vec();
+
+        let tables = self.meta_client.get_tables(&table_ids).await?;
+
+        let ddl_progress = ddl_progresses
             .into_iter()
             .map(|s| {
+                let initialized_at = tables
+                    .get(&(s.id as u32))
+                    .and_then(|table| table.initialized_at_epoch.map(|e| Epoch::from(e)));
+
                 OwnedRow::new(vec![
                     Some(ScalarImpl::Int64(s.id as i64)),
                     Some(ScalarImpl::Utf8(s.statement.into())),
                     Some(ScalarImpl::Utf8(s.progress.into())),
+                    initialized_at.map(|e| e.as_scalar()),
                 ])
             })
             .collect_vec();

--- a/src/frontend/src/meta_client.rs
+++ b/src/frontend/src/meta_client.rs
@@ -16,6 +16,7 @@ use std::collections::HashMap;
 
 use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_pb::backup_service::MetaSnapshotMetadata;
+use risingwave_pb::catalog::Table;
 use risingwave_pb::ddl_service::DdlProgress;
 use risingwave_pb::hummock::HummockSnapshot;
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
@@ -67,6 +68,8 @@ pub trait FrontendMetaClient: Send + Sync {
     ) -> Result<Option<SystemParamsReader>>;
 
     async fn list_ddl_progress(&self) -> Result<Vec<DdlProgress>>;
+
+    async fn get_tables(&self, table_ids: &[u32]) -> Result<HashMap<u32, Table>>;
 }
 
 pub struct FrontendMetaClientImpl(pub MetaClient);
@@ -136,5 +139,10 @@ impl FrontendMetaClient for FrontendMetaClientImpl {
     async fn list_ddl_progress(&self) -> Result<Vec<DdlProgress>> {
         let ddl_progress = self.0.get_ddl_progress().await?;
         Ok(ddl_progress)
+    }
+
+    async fn get_tables(&self, table_ids: &[u32]) -> Result<HashMap<u32, Table>> {
+        let tables = self.0.get_tables(table_ids).await?;
+        Ok(tables)
     }
 }

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -31,7 +31,9 @@ use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::backup_service::MetaSnapshotMetadata;
 use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
-use risingwave_pb::catalog::{PbDatabase, PbFunction, PbIndex, PbSchema, PbSink, PbSource, PbTable, PbView, Table};
+use risingwave_pb::catalog::{
+    PbDatabase, PbFunction, PbIndex, PbSchema, PbSink, PbSource, PbTable, PbView, Table,
+};
 use risingwave_pb::ddl_service::{create_connection_request, DdlProgress};
 use risingwave_pb::hummock::HummockSnapshot;
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;

--- a/src/frontend/src/test_utils.rs
+++ b/src/frontend/src/test_utils.rs
@@ -31,9 +31,7 @@ use risingwave_common::system_param::reader::SystemParamsReader;
 use risingwave_common::util::column_index_mapping::ColIndexMapping;
 use risingwave_pb::backup_service::MetaSnapshotMetadata;
 use risingwave_pb::catalog::table::OptionalAssociatedSourceId;
-use risingwave_pb::catalog::{
-    PbDatabase, PbFunction, PbIndex, PbSchema, PbSink, PbSource, PbTable, PbView,
-};
+use risingwave_pb::catalog::{PbDatabase, PbFunction, PbIndex, PbSchema, PbSink, PbSource, PbTable, PbView, Table};
 use risingwave_pb::ddl_service::{create_connection_request, DdlProgress};
 use risingwave_pb::hummock::HummockSnapshot;
 use risingwave_pb::meta::cancel_creating_jobs_request::PbJobs;
@@ -818,6 +816,10 @@ impl FrontendMetaClient for MockFrontendMetaClient {
 
     async fn list_ddl_progress(&self) -> RpcResult<Vec<DdlProgress>> {
         Ok(vec![])
+    }
+
+    async fn get_tables(&self, _table_ids: &[u32]) -> RpcResult<HashMap<u32, Table>> {
+        Ok(HashMap::new())
     }
 }
 

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -15,7 +15,6 @@
 use std::collections::HashMap;
 use std::pin::pin;
 use std::sync::Arc;
-use std::time::Duration;
 
 use either::Either;
 use futures::stream::select_with_strategy;
@@ -31,7 +30,6 @@ use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::select_all;
 use risingwave_storage::StateStore;
-use tokio::time;
 
 use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::backfill::utils::{

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -15,6 +15,7 @@
 use std::collections::HashMap;
 use std::pin::pin;
 use std::sync::Arc;
+use std::time::Duration;
 
 use either::Either;
 use futures::stream::select_with_strategy;
@@ -30,6 +31,7 @@ use risingwave_common::util::chunk_coalesce::DataChunkBuilder;
 use risingwave_common::util::iter_util::ZipEqDebug;
 use risingwave_common::util::select_all;
 use risingwave_storage::StateStore;
+use tokio::time;
 
 use crate::common::table::state_table::ReplicatedStateTable;
 use crate::executor::backfill::utils::{


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

```
 ddl_id |                 ddl_statement                 | progress |        initialized_at
--------+-----------------------------------------------+----------+-------------------------------
   1002 | CREATE MATERIALIZED VIEW m AS SELECT * FROM t | 0.00%    | 2023-08-29 11:30:12.623+00:00
(1 row)
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
