### PR TITLE
refactor(common): Use safe interfaces for `DataChunkBuilder`

### DIFF
--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -165,14 +165,7 @@ impl DataChunkBuilder {
         }
     }
 
-    /// Append one row from the given [`Row`].
-    /// The caller is responsible to build the data chunk,
-    /// i.e. call the `build_data_chunk` function.
-    /// Used when caller wants to decide when to `build_data_chunk`.
-    /// For instance, in backfill, we want to build data chunk when:
-    /// 1. Buffer is full (typical case)
-    /// 2. On barrier, to flush the remaining data in `data_chunk_builder`.
-    pub fn append_one_row_no_finish(&mut self, row: impl Row) {
+    fn append_one_row_no_finish(&mut self, row: impl Row) {
         assert!(self.buffered_count < self.batch_size);
         self.ensure_builders();
         self.do_append_one_row_from_datums(row.iter());
@@ -212,7 +205,7 @@ impl DataChunkBuilder {
         }
     }
 
-    pub fn build_data_chunk(&mut self) -> DataChunk {
+    fn build_data_chunk(&mut self) -> DataChunk {
         let mut finished_array_builders = vec![];
         swap(&mut finished_array_builders, &mut self.array_builders);
         let cardinality = self.buffered_count;

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -241,7 +241,6 @@ impl DataChunkBuilder {
         self.buffered_count == 0
     }
 
-    /// Clears the buffer and returns all data in current buffer.
     pub fn clear(&mut self) {
         if !self.is_empty() {
             self.array_builders.clear()

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -237,9 +237,14 @@ impl DataChunkBuilder {
         self.data_types.clone()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.buffered_count == 0
+    }
+
+    /// Clears the buffer and returns all data in current buffer.
     pub fn clear(&mut self) {
-        if !self.array_builders.is_empty() {
-            self.array_builders.clear();
+        if !self.is_empty() {
+            self.array_builders.clear()
         }
         self.buffered_count = 0;
     }

--- a/src/common/src/util/chunk_coalesce.rs
+++ b/src/common/src/util/chunk_coalesce.rs
@@ -236,6 +236,13 @@ impl DataChunkBuilder {
     pub fn data_types(&self) -> Vec<DataType> {
         self.data_types.clone()
     }
+
+    pub fn clear(&mut self) {
+        if !self.array_builders.is_empty() {
+            self.array_builders.clear();
+        }
+        self.buffered_count = 0;
+    }
 }
 
 impl Drop for DataChunkBuilder {

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -130,28 +130,22 @@ where
 /// Collects data chunks from stream of rows.
 pub async fn collect_data_chunk_with_builder<E, S>(
     stream: &mut S,
-    chunk_size: Option<usize>,
     builder: &mut DataChunkBuilder,
 ) -> Result<Option<DataChunk>, E>
 where
     S: Stream<Item = Result<OwnedRow, E>> + Unpin,
 {
-    for _ in 0..chunk_size.unwrap_or(usize::MAX) {
-        match stream.next().await.transpose()? {
-            Some(row) => {
-                builder.append_one_row_no_finish(row);
-            }
-            None => break,
+    // TODO(kwannoel): If necessary, we can optimize it in the future.
+    // This can be done by moving the check if builder is full from `append_one_row` to here,
+    while let Some(row) = stream.next().await.transpose()? {
+        let result = builder.append_one_row(row);
+        if let Some(chunk) = result {
+            return Ok(Some(chunk));
         }
     }
 
-    let chunk = builder.build_data_chunk();
-
-    if chunk.cardinality() == 0 {
-        Ok(None)
-    } else {
-        Ok(Some(chunk))
-    }
+    let chunk = builder.consume_all();
+    Ok(chunk)
 }
 
 pub fn get_second<T, U, E>(arg: Result<(T, U), E>) -> Result<U, E> {

--- a/src/stream/src/executor/backfill/arrangement_backfill.rs
+++ b/src/stream/src/executor/backfill/arrangement_backfill.rs
@@ -518,8 +518,8 @@ where
     /// The rows from upstream snapshot read will be buffered inside the `builder`.
     /// If snapshot is dropped before its rows are consumed,
     /// remaining data in `builder` must be flushed manually.
-    /// Otherwise when we scan a new snapshot, it is possible the rows in the `builder` would be present,
-    /// Then when we flush we contain duplicate rows.
+    /// Otherwise when we scan a new snapshot, it is possible the rows in the `builder` would be
+    /// present, Then when we flush we contain duplicate rows.
     #[try_stream(ok = Option<(VirtualNode, StreamChunk)>, error = StreamExecutorError)]
     async fn snapshot_read_per_vnode<'a>(
         upstream_table: &'a ReplicatedStateTable<S>,

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -172,7 +172,10 @@ where
                     &mut builder,
                 );
                 pin_mut!(snapshot);
-                snapshot.try_next().await?.unwrap().is_none()
+                let snapshot_is_empty = snapshot.try_next().await?.unwrap().is_none();
+                let snapshot_buffer_is_empty = builder.is_empty();
+                builder.clear();
+                snapshot_is_empty && snapshot_buffer_is_empty
             }
         };
 

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -483,8 +483,8 @@ where
     /// The rows from upstream snapshot read will be buffered inside the `builder`.
     /// If snapshot is dropped before its rows are consumed,
     /// remaining data in `builder` must be flushed manually.
-    /// Otherwise when we scan a new snapshot, it is possible the rows in the `builder` would be present,
-    /// Then when we flush we contain duplicate rows.
+    /// Otherwise when we scan a new snapshot, it is possible the rows in the `builder` would be
+    /// present, Then when we flush we contain duplicate rows.
     #[try_stream(ok = Option<StreamChunk>, error = StreamExecutorError)]
     async fn snapshot_read<'a>(
         upstream_table: &'a StorageTable<S>,

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -480,8 +480,11 @@ where
     }
 
     /// Snapshot read the upstream mv.
-    /// Remaining data in `builder` must be flushed manually.
-    /// Otherwise we will read duplicate data, if snapshot stream is refreshed.
+    /// The rows from upstream snapshot read will be buffered inside the `builder`.
+    /// If snapshot is dropped before its rows are consumed,
+    /// remaining data in `builder` must be flushed manually.
+    /// Otherwise when we scan a new snapshot, it is possible the rows in the `builder` would be present,
+    /// Then when we flush we contain duplicate rows.
     #[try_stream(ok = Option<StreamChunk>, error = StreamExecutorError)]
     async fn snapshot_read<'a>(
         upstream_table: &'a StorageTable<S>,

--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -163,16 +163,18 @@ where
                 // It is finished, so just assign a value to avoid accessing storage table again.
                 false
             } else {
-                let snapshot = Self::snapshot_read(
-                    &self.upstream_table,
-                    init_epoch,
-                    None,
-                    false,
-                    self.chunk_size,
-                    &mut builder,
-                );
-                pin_mut!(snapshot);
-                let snapshot_is_empty = snapshot.try_next().await?.unwrap().is_none();
+                let snapshot_is_empty = {
+                    let snapshot = Self::snapshot_read(
+                        &self.upstream_table,
+                        init_epoch,
+                        None,
+                        false,
+                        self.chunk_size,
+                        &mut builder,
+                    );
+                    pin_mut!(snapshot);
+                    snapshot.try_next().await?.unwrap().is_none()
+                };
                 let snapshot_buffer_is_empty = builder.is_empty();
                 builder.clear();
                 snapshot_is_empty && snapshot_buffer_is_empty

--- a/src/stream/src/executor/backfill/upstream_table/snapshot.rs
+++ b/src/stream/src/executor/backfill/upstream_table/snapshot.rs
@@ -125,7 +125,7 @@ impl UpstreamTableRead for UpstreamTableReader<ExternalStorageTable> {
 
             let mut builder =
                 DataChunkBuilder::new(self.inner.schema().data_types(), args.chunk_size);
-            let chunk_stream = iter_chunks(row_stream, args.chunk_size, &mut builder);
+            let chunk_stream = iter_chunks(row_stream, &mut builder);
             #[for_await]
             for chunk in chunk_stream {
                 yield chunk?;

--- a/src/stream/src/executor/backfill/utils.rs
+++ b/src/stream/src/executor/backfill/utils.rs
@@ -477,18 +477,14 @@ where
 }
 
 #[try_stream(ok = Option<StreamChunk>, error = StreamExecutorError)]
-pub(crate) async fn iter_chunks<'a, S, E>(
-    mut iter: S,
-    chunk_size: usize,
-    builder: &'a mut DataChunkBuilder,
-) where
+pub(crate) async fn iter_chunks<'a, S, E>(mut iter: S, builder: &'a mut DataChunkBuilder)
+where
     StreamExecutorError: From<E>,
     S: Stream<Item = Result<OwnedRow, E>> + Unpin + 'a,
 {
-    while let Some(data_chunk) =
-        collect_data_chunk_with_builder(&mut iter, Some(chunk_size), builder)
-            .instrument_await("backfill_snapshot_read")
-            .await?
+    while let Some(data_chunk) = collect_data_chunk_with_builder(&mut iter, builder)
+        .instrument_await("backfill_snapshot_read")
+        .await?
     {
         debug_assert!(data_chunk.cardinality() > 0);
         let ops = vec![Op::Insert; data_chunk.capacity()];


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Sqlsmith found a bug in arrangement backfill where the same row is read twice in snapshot. That's because initial buffer is not flushed.

To be defensive, the same is done for no_shuffle_backfill, although it's not strictly necessary.

Additionally, we also refactor some interfaces for `DataChunkBuilder`, making sure they are safe.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
