### PR TITLE
fix(stream): remove useless stream in nats sink

### DIFF
--- a/src/connector/src/sink/nats.rs
+++ b/src/connector/src/sink/nats.rs
@@ -16,7 +16,6 @@ use std::collections::HashMap;
 
 use anyhow::anyhow;
 use async_nats::jetstream::context::Context;
-use async_nats::jetstream::stream::Stream;
 use risingwave_common::array::StreamChunk;
 use risingwave_common::buffer::Bitmap;
 use risingwave_common::catalog::Schema;
@@ -54,7 +53,6 @@ pub struct NatsSink {
 pub struct NatsSinkWriter {
     pub config: NatsConfig,
     context: Context,
-    stream: Stream,
     schema: Schema,
 }
 
@@ -118,15 +116,9 @@ impl NatsSinkWriter {
             .build_context()
             .await
             .map_err(|e| SinkError::Nats(anyhow_error!("nats sink error: {:?}", e)))?;
-        let stream = config
-            .common
-            .build_or_get_stream(context.clone())
-            .await
-            .map_err(|e| SinkError::Nats(anyhow_error!("nats sink error: {:?}", e)))?;
         Ok::<_, SinkError>(Self {
             config: config.clone(),
             context,
-            stream,
             schema: schema.clone(),
         })
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

In previous code, we add [`context`](https://docs.rs/async-nats/latest/async_nats/jetstream/context/struct.Context.html) and [`stream`](https://docs.rs/async-nats/latest/async_nats/jetstream/stream/struct.Stream.html) those two fileds in nats sink struct. But in sink, the stream is useless. Use context can satisfied our requirement.

The `stream` is useless, but the previous code need initialize it. That means the code only can work correctly under `nats-server -js`. After remove, it also can also work correctly under normal nats model without jetstream `nats-server`.
Thanks for the remind of @neverchanje 

BTW, the nats jetstream publish provide methods to do [message deduplication](https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive#message-deduplication). Do we need it?

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
