### PR TITLE
fix: temporarily remove the assert checking for split migration

### DIFF
--- a/src/stream/src/executor/source/source_executor.rs
+++ b/src/stream/src/executor/source/source_executor.rs
@@ -121,40 +121,6 @@ impl<S: StateStore> SourceExecutor<S> {
             .map_err(StreamExecutorError::connector_error)
     }
 
-    fn check_split_assignment_is_migration(
-        &self,
-        actor_splits: &HashMap<ActorId, Vec<SplitImpl>>,
-    ) -> bool {
-        let core = self.stream_source_core.as_ref().unwrap();
-
-        let mut split_to_actors_index = HashMap::new();
-
-        for (actor_id, splits) in actor_splits {
-            for split in splits {
-                split_to_actors_index
-                    .entry(split.id())
-                    .or_insert(vec![])
-                    .push(*actor_id);
-            }
-        }
-
-        for split_id in core.state_cache.keys() {
-            if let Some(actor_ids) = split_to_actors_index.remove(split_id) {
-                if !actor_ids.contains(&self.actor_ctx.id) {
-                    tracing::warn!(
-                        "split {} migration from {} detected, target might be {:?}",
-                        split_id,
-                        self.actor_ctx.id,
-                        actor_ids
-                    );
-                    return true;
-                }
-            }
-        }
-
-        false
-    }
-
     #[inline]
     fn get_metric_labels(&self) -> [String; 3] {
         [
@@ -519,15 +485,6 @@ impl<S: StateStore> SourceExecutor<S> {
                                                 actor_splits = ?actor_splits,
                                                 "source change split received"
                                             );
-
-                                            // In the context of split changes, we do not allow
-                                            // split
-                                            // migration because it can lead to inconsistent states.
-                                            // Therefore, all split migration must be done via
-                                            // update
-                                            // mutation and pause/resume
-                                            assert!(!self
-                                                .check_split_assignment_is_migration(actor_splits));
 
                                             target_state = self
                                                 .apply_split_change(


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

When a split changes, it will be pushed down to the source executor. In theory, the split of one actor should not appear in another actor under the same fragment, because it would lead to data loss. Therefore, we previously used split id to make judgments. However, this can cause misjudgement in such a situation where the split ids of two sources overlap. For now, we are temporarily taking this assert offline, and will add it back when we find a better solution.

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
