### PR TITLE
feat(stream): support set nats consumer deliver policy as latest, earliest, by sequence, by timestamp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,6 +6926,7 @@ dependencies = [
  "simd-json",
  "tempfile",
  "thiserror",
+ "time 0.3.28",
  "tokio-retry",
  "tokio-stream",
  "tokio-util",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -41,7 +41,9 @@ chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "std",
 ] }
-clickhouse = { git = "https://github.com/risingwavelabs/clickhouse.rs", rev = "622501c1c98c80baaf578c716d6903dde947804e", features = ["time"] }
+clickhouse = { git = "https://github.com/risingwavelabs/clickhouse.rs", rev = "622501c1c98c80baaf578c716d6903dde947804e", features = [
+    "time",
+] }
 csv = "1.2"
 duration-str = "0.5.1"
 enum-as-inner = "0.6"
@@ -56,8 +58,12 @@ itertools = "0.11"
 jsonschema-transpiler = "1.10.0"
 maplit = "1.0.2"
 moka = { version = "0.11", features = ["future"] }
-mysql_async = { version = "0.31", default-features = false, features = ["default"] }
-mysql_common = { version = "0.29.2", default-features = false, features = ["chrono"] }
+mysql_async = { version = "0.31", default-features = false, features = [
+    "default",
+] }
+mysql_common = { version = "0.29.2", default-features = false, features = [
+    "chrono",
+] }
 nexmark = { version = "0.2", features = ["serde"] }
 num-bigint = "0.4"
 opendal = "0.39"
@@ -109,6 +115,9 @@ tonic = { workspace = true }
 tracing = "0.1"
 url = "2"
 urlencoding = "2"
+time = "0.3.28"
+
+
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }
 

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -93,6 +93,7 @@ serde_with = { version = "3", features = ["json"] }
 simd-json = "0.10.6"
 tempfile = "3"
 thiserror = "1"
+time = "0.3.28"
 tokio = { version = "0.2", package = "madsim-tokio", features = [
     "rt",
     "rt-multi-thread",
@@ -109,8 +110,6 @@ tonic = { workspace = true }
 tracing = "0.1"
 url = "2"
 urlencoding = "2"
-time = "0.3.28"
-
 
 [target.'cfg(not(madsim))'.dependencies]
 workspace-hack = { path = "../workspace-hack" }

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -41,9 +41,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "clock",
     "std",
 ] }
-clickhouse = { git = "https://github.com/risingwavelabs/clickhouse.rs", rev = "622501c1c98c80baaf578c716d6903dde947804e", features = [
-    "time",
-] }
+clickhouse = { git = "https://github.com/risingwavelabs/clickhouse.rs", rev = "622501c1c98c80baaf578c716d6903dde947804e", features = ["time"] }
 csv = "1.2"
 duration-str = "0.5.1"
 enum-as-inner = "0.6"
@@ -58,12 +56,8 @@ itertools = "0.11"
 jsonschema-transpiler = "1.10.0"
 maplit = "1.0.2"
 moka = { version = "0.11", features = ["future"] }
-mysql_async = { version = "0.31", default-features = false, features = [
-    "default",
-] }
-mysql_common = { version = "0.29.2", default-features = false, features = [
-    "chrono",
-] }
+mysql_async = { version = "0.31", default-features = false, features = ["default"] }
+mysql_common = { version = "0.29.2", default-features = false, features = ["chrono"] }
 nexmark = { version = "0.2", features = ["serde"] }
 num-bigint = "0.4"
 opendal = "0.39"

--- a/src/connector/src/common.rs
+++ b/src/connector/src/common.rs
@@ -395,7 +395,7 @@ impl NatsCommon {
 
     pub(crate) async fn build_consumer(
         &self,
-        split_id: i32,
+        split_id: String,
         start_sequence: NatsOffset,
     ) -> anyhow::Result<
         async_nats::jetstream::consumer::Consumer<async_nats::jetstream::consumer::pull::Config>,

--- a/src/connector/src/source/nats/enumerator/mod.rs
+++ b/src/connector/src/source/nats/enumerator/mod.rs
@@ -15,7 +15,7 @@
 use anyhow;
 use async_trait::async_trait;
 
-use super::source::NatsSplit;
+use super::source::{NatsSplit, NatsOffset};
 use super::NatsProperties;
 use crate::source::{SourceEnumeratorContextRef, SplitEnumerator};
 
@@ -45,7 +45,7 @@ impl SplitEnumerator for NatsSplitEnumerator {
         let nats_split = NatsSplit {
             subject: self.subject.clone(),
             split_num: 0, // be the same as `from_nats_jetstream_message`
-            start_sequence: None,
+            start_sequence: NatsOffset::None,
         };
 
         Ok(vec![nats_split])

--- a/src/connector/src/source/nats/enumerator/mod.rs
+++ b/src/connector/src/source/nats/enumerator/mod.rs
@@ -12,17 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::Arc;
+
 use anyhow;
 use async_trait::async_trait;
 
-use super::source::{NatsSplit, NatsOffset};
+use super::source::{NatsOffset, NatsSplit};
 use super::NatsProperties;
-use crate::source::{SourceEnumeratorContextRef, SplitEnumerator};
+use crate::source::{SourceEnumeratorContextRef, SplitEnumerator, SplitId};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NatsSplitEnumerator {
     subject: String,
-    split_num: i32,
+    split_id: SplitId,
 }
 
 #[async_trait]
@@ -36,7 +38,7 @@ impl SplitEnumerator for NatsSplitEnumerator {
     ) -> anyhow::Result<NatsSplitEnumerator> {
         Ok(Self {
             subject: properties.common.subject,
-            split_num: 0,
+            split_id: Arc::from("0"),
         })
     }
 
@@ -44,7 +46,7 @@ impl SplitEnumerator for NatsSplitEnumerator {
         // TODO: to simplify the logic, return 1 split for first version
         let nats_split = NatsSplit {
             subject: self.subject.clone(),
-            split_num: 0, // be the same as `from_nats_jetstream_message`
+            split_id: Arc::from("0"), // be the same as `from_nats_jetstream_message`
             start_sequence: NatsOffset::None,
         };
 

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -30,12 +30,6 @@ pub struct NatsProperties {
     pub scan_startup_mode: Option<String>,
 
     #[serde(
-        rename = "scan.startup.sequence_number",
-        alias = "nats.scan.startup.sequence_number"
-    )]
-    pub start_sequence: Option<String>,
-
-    #[serde(
         rename = "scan.startup.timestamp_millis",
         alias = "nats.scan.startup.timestamp_millis"
     )]

--- a/src/connector/src/source/nats/mod.rs
+++ b/src/connector/src/source/nats/mod.rs
@@ -25,6 +25,21 @@ pub const NATS_CONNECTOR: &str = "nats";
 pub struct NatsProperties {
     #[serde(flatten)]
     pub common: NatsCommon,
+
+    #[serde(rename = "scan.startup.mode", alias = "nats.scan.startup.mode")]
+    pub scan_startup_mode: Option<String>,
+
+    #[serde(
+        rename = "scan.startup.sequence_number",
+        alias = "nats.scan.startup.sequence_number"
+    )]
+    pub start_sequence: Option<String>,
+
+    #[serde(
+        rename = "scan.startup.timestamp_millis",
+        alias = "nats.scan.startup.timestamp_millis"
+    )]
+    pub start_time: Option<String>,
 }
 
 impl NatsProperties {}

--- a/src/connector/src/source/nats/source/reader.rs
+++ b/src/connector/src/source/nats/source/reader.rs
@@ -78,16 +78,13 @@ impl SplitReader for NatsSplitReader {
             start_position => start_position.to_owned(),
         };
 
+        // pay attention not to check timeoffset and start_time in properties. Because when recovery
+        // the policy may change to by sequence, but start time still filed.
         if !matches!(start_position, NatsOffset::SequenceNumber(_))
             && properties.start_sequence.is_some()
         {
             return Err(
                 anyhow!("scan.startup.mode need to be set to 'sequence_number' if you want to start with a specific sequence number")
-            );
-        }
-        if !matches!(start_position, NatsOffset::Timestamp(_)) && properties.start_time.is_some() {
-            return Err(
-                anyhow!("scan.startup.mode need to be set to 'timestamp_millis' if you want to start with a specific timestamp millis")
             );
         }
         let consumer = properties

--- a/src/connector/src/source/nats/source/reader.rs
+++ b/src/connector/src/source/nats/source/reader.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use anyhow::{anyhow, Result};
 use async_nats::jetstream::consumer;
 use async_trait::async_trait;

--- a/src/connector/src/source/nats/source/reader.rs
+++ b/src/connector/src/source/nats/source/reader.rs
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_nats::jetstream::consumer;
 use async_trait::async_trait;
 use futures::StreamExt;
 use futures_async_stream::try_stream;
 
+use super::NatsOffset;
 use crate::parser::ParserConfig;
 use crate::source::common::{into_chunk_stream, CommonSplitReader};
-use crate::source::nats::split::NatsSplit;
 use crate::source::nats::NatsProperties;
 use crate::source::{
     BoxSourceWithStateStream, Column, SourceContextRef, SourceMessage, SplitImpl, SplitReader,
@@ -31,6 +31,7 @@ pub struct NatsSplitReader {
     properties: NatsProperties,
     parser_config: ParserConfig,
     source_ctx: SourceContextRef,
+    start_position: NatsOffset,
 }
 
 #[async_trait]
@@ -46,19 +47,59 @@ impl SplitReader for NatsSplitReader {
     ) -> Result<Self> {
         // TODO: to simplify the logic, return 1 split for first version
         assert!(splits.len() == 1);
-        let splits = splits
-            .into_iter()
-            .map(|split| split.into_nats().unwrap())
-            .collect::<Vec<NatsSplit>>();
+        let split = splits.into_iter().next().unwrap().into_nats().unwrap();
+        let start_position = match &split.start_sequence {
+            NatsOffset::None => match &properties.scan_startup_mode {
+                None => NatsOffset::Earliest,
+                Some(mode) => match mode.as_str() {
+                    "latest" => NatsOffset::Latest,
+                    "earliest" => NatsOffset::Earliest,
+                    "timestamp_millis" => {
+                        if let Some(time) = &properties.start_time {
+                            NatsOffset::Timestamp(time.parse()?)
+                        } else {
+                            return Err(anyhow!("scan_startup_timestamp_millis is required"));
+                        }
+                    }
+                    "sequence_number" => {
+                        if let Some(seq) = &properties.start_sequence {
+                            NatsOffset::SequenceNumber(seq.clone())
+                        } else {
+                            return Err(anyhow!("scan_startup_sequence_number is required"));
+                        }
+                    }
+                    _ => {
+                        return Err(anyhow!(
+                            "invalid scan_startup_mode, accept earliest/latest/sequence_number/time"
+                        ))
+                    }
+                },
+            },
+            start_position => start_position.to_owned(),
+        };
+
+        if !matches!(start_position, NatsOffset::SequenceNumber(_))
+            && properties.start_sequence.is_some()
+        {
+            return Err(
+                anyhow!("scan.startup.mode need to be set to 'sequence_number' if you want to start with a specific sequence number")
+            );
+        }
+        if !matches!(start_position, NatsOffset::Timestamp(_)) && properties.start_time.is_some() {
+            return Err(
+                anyhow!("scan.startup.mode need to be set to 'timestamp_millis' if you want to start with a specific timestamp millis")
+            );
+        }
         let consumer = properties
             .common
-            .build_consumer(0, splits[0].start_sequence)
+            .build_consumer(0, start_position.clone())
             .await?;
         Ok(Self {
             consumer,
             properties,
             parser_config,
             source_ctx,
+            start_position,
         })
     }
 

--- a/src/connector/src/source/nats/source/reader.rs
+++ b/src/connector/src/source/nats/source/reader.rs
@@ -66,16 +66,9 @@ impl SplitReader for NatsSplitReader {
                             return Err(anyhow!("scan_startup_timestamp_millis is required"));
                         }
                     }
-                    "sequence_number" => {
-                        if let Some(seq) = &properties.start_sequence {
-                            NatsOffset::SequenceNumber(seq.clone())
-                        } else {
-                            return Err(anyhow!("scan_startup_sequence_number is required"));
-                        }
-                    }
                     _ => {
                         return Err(anyhow!(
-                            "invalid scan_startup_mode, accept earliest/latest/sequence_number/time"
+                            "invalid scan_startup_mode, accept earliest/latest/timestamp_millis"
                         ))
                     }
                 },
@@ -83,15 +76,6 @@ impl SplitReader for NatsSplitReader {
             start_position => start_position.to_owned(),
         };
 
-        // pay attention not to check timeoffset and start_time in properties. Because when recovery
-        // the policy may change to by sequence, but start time still filed.
-        if !matches!(start_position, NatsOffset::SequenceNumber(_))
-            && properties.start_sequence.is_some()
-        {
-            return Err(
-                anyhow!("scan.startup.mode need to be set to 'sequence_number' if you want to start with a specific sequence number")
-            );
-        }
         let consumer = properties
             .common
             .build_consumer(split_id.to_string(), start_position.clone())

--- a/src/connector/src/source/nats/split.rs
+++ b/src/connector/src/source/nats/split.rs
@@ -18,6 +18,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::source::{SplitId, SplitMetaData};
 
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub enum NatsOffset {
+    Earliest,
+    Latest,
+    SequenceNumber(String),
+    Timestamp(i128),
+    None,
+}
+
 /// The states of a NATS split, which will be persisted to checkpoint.
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Hash)]
 pub struct NatsSplit {
@@ -25,7 +34,7 @@ pub struct NatsSplit {
     // TODO: to simplify the logic, return 1 split for first version. May use parallelism in
     // future.
     pub(crate) split_num: i32,
-    pub(crate) start_sequence: Option<u64>,
+    pub(crate) start_sequence: NatsOffset,
 }
 
 impl SplitMetaData for NatsSplit {
@@ -44,7 +53,7 @@ impl SplitMetaData for NatsSplit {
 }
 
 impl NatsSplit {
-    pub fn new(subject: String, split_num: i32, start_sequence: Option<u64>) -> Self {
+    pub fn new(subject: String, split_num: i32, start_sequence: NatsOffset) -> Self {
         Self {
             subject,
             split_num,
@@ -53,7 +62,12 @@ impl NatsSplit {
     }
 
     pub fn update_with_offset(&mut self, start_sequence: String) -> anyhow::Result<()> {
-        self.start_sequence = Some(start_sequence.as_str().parse::<u64>().unwrap());
+        let start_sequence = if start_sequence.is_empty() {
+            NatsOffset::Earliest
+        } else {
+            NatsOffset::SequenceNumber(start_sequence)
+        };
+        self.start_sequence = start_sequence;
         Ok(())
     }
 }

--- a/src/connector/src/source/nats/split.rs
+++ b/src/connector/src/source/nats/split.rs
@@ -33,14 +33,14 @@ pub struct NatsSplit {
     pub(crate) subject: String,
     // TODO: to simplify the logic, return 1 split for first version. May use parallelism in
     // future.
-    pub(crate) split_num: i32,
+    pub(crate) split_id: SplitId,
     pub(crate) start_sequence: NatsOffset,
 }
 
 impl SplitMetaData for NatsSplit {
     fn id(&self) -> SplitId {
         // TODO: should avoid constructing a string every time
-        format!("{}", self.split_num).into()
+        format!("{}", self.split_id).into()
     }
 
     fn restore_from_json(value: JsonbVal) -> anyhow::Result<Self> {
@@ -53,10 +53,10 @@ impl SplitMetaData for NatsSplit {
 }
 
 impl NatsSplit {
-    pub fn new(subject: String, split_num: i32, start_sequence: NatsOffset) -> Self {
+    pub fn new(subject: String, split_id: SplitId, start_sequence: NatsOffset) -> Self {
         Self {
             subject,
-            split_num,
+            split_id,
             start_sequence,
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

This PR try to add several deliver policies (latest, earliest, ~~by sequence~~, by timestamp). 

Test the policy under
1. normal source
2. recover the data after CN break down. And also can correctly consume data

We decide to merge it into the #12227 firstly. Will use that branch to build a image for user. 

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.

Add the `latest`, `earliest`, `by timestamp` policy. Currently decide not support `by sequence` policy

default is earliest
```
CREATE TABLE test
(
  id integer,
  name varchar,
)
WITH (
  connector='nats',
    nats.server_url='0.0.0.0:4222',
    nats.subject='event1',
) FORMAT PLAIN ENCODE JSON;
```

latest policy, need to set `scan.startup.mode='latest'`
```
CREATE TABLE test_latest
(
  id integer,
  name varchar,
)
WITH (
  connector='nats',
    nats.server_url='0.0.0.0:4222',
    nats.subject='event1',
    scan.startup.mode='latest',
) FORMAT PLAIN ENCODE JSON;
```

earliest policy, need to set `scan.startup.mode='earliest',`
```
CREATE TABLE test_earliest
(
  id integer,
  name varchar,
)
WITH (
  connector='nats',
    nats.server_url='0.0.0.0:4222',
    nats.subject='event1',
    scan.startup.mode='earliest',
) FORMAT PLAIN ENCODE JSON;
```

// by timestamp millis policy, need to set `scan.startup.mode='timestamp_millis'`, and also set `nats.scan.startup.timestamp_millis`
```
CREATE TABLE test_timestamp
(
  id integer,
  name varchar,
)
WITH (
  connector='nats',
    nats.server_url='0.0.0.0:4222',
    nats.subject='event1',
    scan.startup.mode='timestamp_millis',
    nats.scan.startup.timestamp_millis='1694157849359',
) FORMAT PLAIN ENCODE JSON;
```

</details>
