### PR TITLE
chore(test): disable prometheus in some tests

### DIFF
--- a/src/config/ci-compaction-test-meta.toml
+++ b/src/config/ci-compaction-test-meta.toml
@@ -28,3 +28,6 @@ data_directory = "hummock_001"
 checkpoint_frequency = 99999999
 barrier_interval_ms = 250
 max_concurrent_creating_streaming_jobs = 0
+
+[server]
+metrics_level = "Disabled"

--- a/src/config/ci-compaction-test.toml
+++ b/src/config/ci-compaction-test.toml
@@ -26,3 +26,6 @@ data_directory = "hummock_001"
 checkpoint_frequency = 10
 barrier_interval_ms = 250
 max_concurrent_creating_streaming_jobs = 0
+
+[server]
+metrics_level = "Disabled"

--- a/src/config/ci-meta-backup-test.toml
+++ b/src/config/ci-meta-backup-test.toml
@@ -6,3 +6,6 @@ vacuum_interval_sec = 10
 [system]
 backup_storage_url = "minio://hummockadmin:hummockadmin@127.0.0.1:9301/hummock001"
 backup_storage_directory = "backup"
+
+[server]
+metrics_level = "Disabled"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

To avoid error like "error binding to 127.0.0.1:1260: error creating server listener: Address already in use".

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
