### PR TITLE
fix(test): set correct row per second

### DIFF
--- a/src/tests/state_cleaning_test/data/agg.toml
+++ b/src/tests/state_cleaning_test/data/agg.toml
@@ -11,7 +11,7 @@ init_sqls = [
         WATERMARK FOR created_at AS created_at - interval '9' second
     ) APPEND ONLY WITH (
         connector = 'datagen',
-        rows_per_second = 100,
+        datagen.rows.per.second = 100,
         datagen.split.num = 16,
         fields.created_at.max_past_mode = 'relative',
         fields.created_at.max_past = '10s',

--- a/src/tests/state_cleaning_test/data/join.toml
+++ b/src/tests/state_cleaning_test/data/join.toml
@@ -10,7 +10,7 @@ init_sqls = [
         WATERMARK FOR created_at AS created_at - interval '9' second
     ) APPEND ONLY WITH (
         connector = 'datagen',
-        rows_per_second = 100,
+        datagen.rows.per.second = 100,
         datagen.split.num = 16,
         fields.created_at.max_past_mode = 'relative',
         fields.created_at.max_past = '10s',
@@ -30,7 +30,7 @@ init_sqls = [
         WATERMARK FOR created_at AS created_at - interval '9' second
     ) APPEND ONLY WITH (
         connector = 'datagen',
-        rows_per_second = 200,
+        datagen.rows.per.second = 200,
         datagen.split.num = 16,
         fields.created_at.max_past_mode = 'relative',
         fields.created_at.max_past = '10s',

--- a/src/tests/state_cleaning_test/data/temporal_filter.toml
+++ b/src/tests/state_cleaning_test/data/temporal_filter.toml
@@ -9,7 +9,7 @@ init_sqls = [
         WATERMARK FOR created_at AS created_at - interval '9' second
     ) APPEND ONLY WITH (
         connector = 'datagen',
-        rows_per_second = 200,
+        datagen.rows.per.second = 200,
         datagen.split.num = 16,
         fields.created_at.max_past_mode = 'relative',
         fields.created_at.max_past = '10s',


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled. Otherwise `rows_per_second` doesn't take effect, and the actual rows_per_second is 10 by default.

After correct this, the state_cleaning_test fails: `Error: Table __internal_mv_tumble_join_9_hashjoinleft_1027 has 676 rows, which is more than limit 300`.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
