### PR TITLE
feat: make `enable.auto.commit` configurable

### DIFF
--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -75,6 +75,14 @@ pub struct RdKafkaPropertiesConsumer {
     #[serde(rename = "properties.fetch.max.bytes")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     pub fetch_max_bytes: Option<usize>,
+
+    /// Automatically and periodically commit offsets in the background.
+    /// Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
+    /// To circumvent this behaviour set specific start offsets per partition in the call to assign().
+    /// default: true
+    #[serde(rename = "properties.enable.auto.commit")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub enable_auto_commit: Option<bool>,
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -143,6 +151,9 @@ impl RdKafkaPropertiesConsumer {
         if let Some(v) = &self.fetch_max_bytes {
             c.set("fetch.max.bytes", v.to_string());
         }
+        if let Some(v) = &self.enable_auto_commit {
+            c.set("enable.auto.commit", v.to_string());
+        }
     }
 }
 
@@ -170,6 +181,7 @@ mod test {
             "properties.queued.max.messages.kbytes".to_string() => "114514".to_string(),
             "properties.fetch.wait.max.ms".to_string() => "114514".to_string(),
             "properties.fetch.max.bytes".to_string() => "114514".to_string(),
+            "properties.enable.auto.commit".to_string() => "true".to_string(),
         };
 
         let props: KafkaProperties =
@@ -191,5 +203,6 @@ mod test {
         );
         assert_eq!(props.rdkafka_properties.fetch_wait_max_ms, Some(114514));
         assert_eq!(props.rdkafka_properties.fetch_max_bytes, Some(114514));
+        assert_eq!(props.rdkafka_properties.enable_auto_commit, Some(true));
     }
 }

--- a/src/connector/src/source/kafka/source/reader.rs
+++ b/src/connector/src/source/kafka/source/reader.rs
@@ -64,7 +64,8 @@ impl SplitReader for KafkaSplitReader {
 
         // disable partition eof
         config.set("enable.partition.eof", "false");
-        config.set("enable.auto.commit", "false");
+        // change to `RdKafkaPropertiesConsumer::enable_auto_commit` to enable auto commit
+        // config.set("enable.auto.commit", "false");
         config.set("auto.offset.reset", "smallest");
         config.set("isolation.level", KAFKA_ISOLATION_LEVEL);
         config.set("bootstrap.servers", bootstrap_servers);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

introducing a new option `properties.enable.auto.commit` in kafka consumer, which sets `enable.auto.commit` in Kafka client. It is an option bool, and the default is `true`. 

please remove the `group.id` option in kafka consumer. Risingwave will automatically generate one to work with `enable.auto.commit` without affecting the normal consuming process.

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
