### PR TITLE
feat(sink): support elasticsearch 8 sink

### DIFF
--- a/e2e_test/sink/elasticsearch/elasticsearch_sink.slt
+++ b/e2e_test/sink/elasticsearch/elasticsearch_sink.slt
@@ -3,7 +3,7 @@ CREATE TABLE t7 (v1 int primary key, v2 bigint, v3 varchar);
 
 statement ok
 CREATE SINK s7 AS select t7.v1 as v1, t7.v2 as v2, t7.v3 as v3 from t7 WITH (
-    connector = 'elasticsearch-7',
+    connector = 'elasticsearch',
     index = 'test',
     url = 'http://elasticsearch:9200',
     username = 'elastic',

--- a/integration_tests/elasticsearch-sink/README.md
+++ b/integration_tests/elasticsearch-sink/README.md
@@ -1,0 +1,41 @@
+# Demo: Sinking to ElasticSearch
+
+In this demo, we want to showcase how RisingWave is able to sink data to ElasticSearch.
+
+1. Set the compose profile accordingly:
+Demo with elasticsearch 7:
+```
+export COMPOSE_PROFILES=es7
+```
+
+Demo with elasticsearch 8
+```
+export COMPOSE_PROFILES=es8
+```
+
+2. Launch the cluster:
+
+```sh
+docker-compose up -d
+```
+
+The cluster contains a RisingWave cluster and its necessary dependencies, a datagen that generates the data, a single-node elasticsearch for sink.
+
+3. Execute the SQL queries in sequence:
+
+- create_source.sql
+- create_mv.sql
+- create_es[7/8]_sink.sql
+
+4. Check the contents in ES:
+
+```sh
+# Check the document counts
+curl -XGET -u elastic:risingwave "http://localhost:9200/test/_count" -H 'Content-Type: application/json'
+
+# Check the content of a document by user_id
+curl -XGET -u elastic:risingwave "http://localhost:9200/test/_search" -H 'Content-Type: application/json' -d '{"query":{"term": {"user_id":2}}' | jq
+
+# Get the first 10 documents sort by user_id
+curl -XGET -u elastic:risingwave "http://localhost:9200/test/_search?size=10" -H 'Content-Type: application/json' -d'{"query":{"match_all":{}}, "sort": ["user_id"]}' | jq
+```

--- a/integration_tests/elasticsearch-sink/create_es7_sink.sql
+++ b/integration_tests/elasticsearch-sink/create_es7_sink.sql
@@ -1,0 +1,9 @@
+CREATE SINK bhv_es_sink
+FROM
+    bhv_mv WITH (
+    connector = 'elasticsearch',
+    index = 'test',
+    url = 'http://elasticsearch8:9200',
+    username = 'elastic',
+    password = 'risingwave'
+);

--- a/integration_tests/elasticsearch-sink/create_es8_sink.sql
+++ b/integration_tests/elasticsearch-sink/create_es8_sink.sql
@@ -1,0 +1,9 @@
+CREATE SINK bhv_es_sink
+FROM
+    bhv_mv WITH (
+    connector = 'elasticsearch',
+    index = 'test',
+    url = 'http://elasticsearch8:9200',
+    username = 'elastic',
+    password = 'risingwave'
+);

--- a/integration_tests/elasticsearch-sink/create_mv.sql
+++ b/integration_tests/elasticsearch-sink/create_mv.sql
@@ -1,0 +1,7 @@
+CREATE MATERIALIZED VIEW bhv_mv AS
+SELECT
+    user_id,
+    target_id,
+    event_timestamp
+FROM
+    user_behaviors;

--- a/integration_tests/elasticsearch-sink/create_source.sql
+++ b/integration_tests/elasticsearch-sink/create_source.sql
@@ -1,0 +1,18 @@
+CREATE table user_behaviors (
+    user_id int,
+    target_id VARCHAR,
+    target_type VARCHAR,
+    event_timestamp TIMESTAMP,
+    behavior_type VARCHAR,
+    parent_target_type VARCHAR,
+    parent_target_id VARCHAR,
+    PRIMARY KEY(user_id)
+) WITH (
+    connector = 'datagen',
+    fields.user_id.kind = 'sequence',
+    fields.user_id.start = '1',
+    fields.user_id.end = '1000',
+    fields.user_name.kind = 'random',
+    fields.user_name.length = '10',
+    datagen.rows.per.second = '10'
+) FORMAT PLAIN ENCODE JSON;

--- a/integration_tests/elasticsearch-sink/docker-compose.yml
+++ b/integration_tests/elasticsearch-sink/docker-compose.yml
@@ -1,0 +1,73 @@
+---
+version: "3"
+services:
+  elasticsearch7:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.0
+    environment:
+      - xpack.security.enabled=true
+      - discovery.type=single-node
+      - ELASTIC_PASSWORD=risingwave
+    ports:
+      - 9200:9200
+    profiles:
+      - es7
+  elasticsearch8:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.10.0
+    environment:
+      - xpack.security.enabled=true
+      - discovery.type=single-node
+      - ELASTIC_PASSWORD=risingwave
+    ports:
+      - 9200:9200
+    profiles:
+      - es8
+  compactor-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compactor-0
+  compute-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: compute-node-0
+  etcd-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: etcd-0
+  frontend-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: frontend-node-0
+  grafana-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: grafana-0
+  meta-node-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: meta-node-0
+  connector-node:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: connector-node
+  minio-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: minio-0
+  prometheus-0:
+    extends:
+      file: ../../docker/docker-compose.yml
+      service: prometheus-0
+volumes:
+  compute-node-0:
+    external: false
+  etcd-0:
+    external: false
+  grafana-0:
+    external: false
+  minio-0:
+    external: false
+  prometheus-0:
+    external: false
+  message_queue:
+    external: false
+name: risingwave-compose

--- a/java/connector-node/python-client/integration_tests.py
+++ b/java/connector-node/python-client/integration_tests.py
@@ -272,7 +272,7 @@ def test_jdbc_sink(input_file, param):
 
 def test_elasticsearch_sink(param):
     prop = {
-        "connector": "elasticsearch-7",
+        "connector": "elasticsearch",
         "url": "http://127.0.0.1:9200",
         "index": "test",
     }

--- a/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/SinkUtils.java
+++ b/java/connector-node/risingwave-connector-service/src/main/java/com/risingwave/connector/SinkUtils.java
@@ -41,8 +41,8 @@ public class SinkUtils {
                 return new IcebergSinkFactory();
             case "deltalake":
                 return new DeltaLakeSinkFactory();
-            case "elasticsearch-7":
-                return new EsSink7Factory();
+            case "elasticsearch":
+                return new EsSinkFactory();
             case "cassandra":
                 return new CassandraFactory();
             default:

--- a/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/elasticsearch/EsSinkTest.java
+++ b/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/elasticsearch/EsSinkTest.java
@@ -19,8 +19,8 @@ import static org.junit.Assert.fail;
 
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
-import com.risingwave.connector.EsSink7;
-import com.risingwave.connector.EsSink7Config;
+import com.risingwave.connector.EsSink;
+import com.risingwave.connector.EsSinkConfig;
 import com.risingwave.connector.api.TableSchema;
 import com.risingwave.connector.api.sink.ArraySinkRow;
 import com.risingwave.proto.Data;
@@ -39,7 +39,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.Test;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
-public class EsSink7Test {
+public class EsSinkTest {
 
     static TableSchema getTestTableSchema() {
         return new TableSchema(
@@ -52,9 +52,9 @@ public class EsSink7Test {
 
     public void testEsSink(ElasticsearchContainer container, String username, String password)
             throws IOException {
-        EsSink7 sink =
-                new EsSink7(
-                        new EsSink7Config(container.getHttpHostAddress(), "test")
+        EsSink sink =
+                new EsSink(
+                        new EsSinkConfig(container.getHttpHostAddress(), "test")
                                 .withDelimiter("$")
                                 .withUsername(username)
                                 .withPassword(password),

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink7.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink7.java
@@ -36,6 +36,7 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.RestHighLevelClientBuilder;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.TimeValue;
@@ -76,8 +77,11 @@ public class EsSink7 extends SinkWriterBase {
 
         this.config = config;
         this.client =
-                new RestHighLevelClient(
-                        configureRestClientBuilder(RestClient.builder(host), config));
+                new RestHighLevelClientBuilder(
+                                configureRestClientBuilder(RestClient.builder(host), config)
+                                        .build())
+                        .setApiCompatibilityMode(true)
+                        .build();
         // Test connection
         try {
             boolean isConnected = this.client.ping(RequestOptions.DEFAULT);

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkConfig.java
@@ -20,7 +20,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.risingwave.connector.api.sink.CommonSinkConfig;
 
-public class EsSink7Config extends CommonSinkConfig {
+public class EsSinkConfig extends CommonSinkConfig {
     /** Required */
     private String url;
 
@@ -38,7 +38,7 @@ public class EsSink7Config extends CommonSinkConfig {
     private String password;
 
     @JsonCreator
-    public EsSink7Config(
+    public EsSinkConfig(
             @JsonProperty(value = "url") String url, @JsonProperty(value = "index") String index) {
         this.url = url;
         this.index = index;
@@ -64,17 +64,17 @@ public class EsSink7Config extends CommonSinkConfig {
         return password;
     }
 
-    public EsSink7Config withDelimiter(String delimiter) {
+    public EsSinkConfig withDelimiter(String delimiter) {
         this.delimiter = delimiter;
         return this;
     }
 
-    public EsSink7Config withUsername(String username) {
+    public EsSinkConfig withUsername(String username) {
         this.username = username;
         return this;
     }
 
-    public EsSink7Config withPassword(String password) {
+    public EsSinkConfig withPassword(String password) {
         this.password = password;
         return this;
     }

--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkFactory.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSinkFactory.java
@@ -36,13 +36,13 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EsSink7Factory implements SinkFactory {
-    private static final Logger LOG = LoggerFactory.getLogger(EsSink7Factory.class);
+public class EsSinkFactory implements SinkFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(EsSinkFactory.class);
 
     public SinkWriter createWriter(TableSchema tableSchema, Map<String, String> tableProperties) {
         ObjectMapper mapper = new ObjectMapper();
-        EsSink7Config config = mapper.convertValue(tableProperties, EsSink7Config.class);
-        return new SinkWriterV1.Adapter(new EsSink7(config, tableSchema));
+        EsSinkConfig config = mapper.convertValue(tableProperties, EsSinkConfig.class);
+        return new SinkWriterV1.Adapter(new EsSink(config, tableSchema));
     }
 
     @Override
@@ -52,7 +52,7 @@ public class EsSink7Factory implements SinkFactory {
             Catalog.SinkType sinkType) {
         ObjectMapper mapper = new ObjectMapper();
         mapper.configure(DeserializationFeature.FAIL_ON_MISSING_CREATOR_PROPERTIES, true);
-        EsSink7Config config = mapper.convertValue(tableProperties, EsSink7Config.class);
+        EsSinkConfig config = mapper.convertValue(tableProperties, EsSinkConfig.class);
 
         // 1. check url
         HttpHost host;

--- a/src/connector/src/sink/remote.rs
+++ b/src/connector/src/sink/remote.rs
@@ -52,7 +52,7 @@ pub const VALID_REMOTE_SINKS: [&str; 5] = [
     "jdbc",
     REMOTE_ICEBERG_SINK,
     "deltalake",
-    "elasticsearch-7",
+    "elasticsearch",
     "cassandra",
 ];
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #12234

This PR adds `setApiCompatibilityMode(true)` for the RestHighLevelClient in the es 7 client library to make it compatible with es8 server. This is a simple workaround suggested in the es [doc](https://www.elastic.co/guide/en/elasticsearch/client/java-api-client/8.9/migrate-hlrc.html#migrate-hlrc).

I have manually tested this PR with es 7.17 and es 8.10 server. Both work.

TODO:
- [x] A bunch of renames
- [x] Add integration tests for es7 and es8 sink.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [x] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note



Support elasticsearch 7 and elasticsearch 8 sink. SQL Example:
```
CREATE SINK es_sink
FROM test_mv WITH (
    connector = 'elasticsearch',
    index = 'test',
    url = 'http://elasticsearch8:9200',
    username = 'elastic',
    password = 'risingwave'
    delimiter = ','
);
```
WITH options:
- `connector`: required. Previously we use `elasticsearch-7` as the connector name and now we switch to `elasticsearch`. `elastic-search-7` is no longer a valid connector name, which is a potential breaking change. Given that es sink is not officially released, I don't think we need to mention this breaking change in the doc.
- `index`: required. The target index name in elasticsearch.
- `url`: required. The elasticsearch REST endpoint url.
- `username`: optional. User name for the elasticsearch credential. It must be used with `password`.
- `password`: optional. Password for the elasticsearch credential. It must be used with `username`.
- `delimiter`: optional. Delimiter to construct elasticsearch id if the sink's primary key is composed of multiple columns. 

Notes on ES id:
- If sink has a primary key (normally it is inherited from the streaming job), we will use the primary key as the ES id.
- If sink doesn't have a primary key (normally it is because the streaming job is append only), we will use the first column in the sink definition as the ES id.