### PR TITLE
refactor: replace more GAT-based async trait with RPITIT

### DIFF
--- a/src/batch/src/execution/grpc_exchange.rs
+++ b/src/batch/src/execution/grpc_exchange.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::{Debug, Formatter};
-use std::future::Future;
 
 use futures::StreamExt;
 use risingwave_common::array::DataChunk;
@@ -73,26 +72,22 @@ impl Debug for GrpcExchangeSource {
 }
 
 impl ExchangeSource for GrpcExchangeSource {
-    type TakeDataFuture<'a> = impl Future<Output = Result<Option<DataChunk>>> + 'a;
+    async fn take_data(&mut self) -> Result<Option<DataChunk>> {
+        let res = match self.stream.next().await {
+            None => {
+                return Ok(None);
+            }
+            Some(r) => r,
+        };
+        let task_data = res?;
+        let data = DataChunk::from_protobuf(task_data.get_record_batch()?)?.compact();
+        trace!(
+            "Receiver taskOutput = {:?}, data = {:?}",
+            self.task_output_id,
+            data
+        );
 
-    fn take_data(&mut self) -> Self::TakeDataFuture<'_> {
-        async {
-            let res = match self.stream.next().await {
-                None => {
-                    return Ok(None);
-                }
-                Some(r) => r,
-            };
-            let task_data = res?;
-            let data = DataChunk::from_protobuf(task_data.get_record_batch()?)?.compact();
-            trace!(
-                "Receiver taskOutput = {:?}, data = {:?}",
-                self.task_output_id,
-                data
-            );
-
-            Ok(Some(data))
-        }
+        Ok(Some(data))
     }
 
     fn get_task_id(&self) -> TaskId {

--- a/src/batch/src/execution/local_exchange.rs
+++ b/src/batch/src/execution/local_exchange.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::fmt::{Debug, Formatter};
-use std::future::Future;
 
 use risingwave_common::array::DataChunk;
 use risingwave_common::error::Result;
@@ -52,23 +51,19 @@ impl Debug for LocalExchangeSource {
 }
 
 impl ExchangeSource for LocalExchangeSource {
-    type TakeDataFuture<'a> = impl Future<Output = Result<Option<DataChunk>>> + 'a;
-
-    fn take_data(&mut self) -> Self::TakeDataFuture<'_> {
-        async {
-            let ret = self.task_output.direct_take_data().await?;
-            if let Some(data) = ret {
-                let data = data.compact();
-                trace!(
-                    "Receiver task: {:?}, source task output: {:?}, data: {:?}",
-                    self.task_id,
-                    self.task_output.id(),
-                    data
-                );
-                Ok(Some(data))
-            } else {
-                Ok(None)
-            }
+    async fn take_data(&mut self) -> Result<Option<DataChunk>> {
+        let ret = self.task_output.direct_take_data().await?;
+        if let Some(data) = ret {
+            let data = data.compact();
+            trace!(
+                "Receiver task: {:?}, source task output: {:?}, data: {:?}",
+                self.task_id,
+                self.task_output.id(),
+                data
+            );
+            Ok(Some(data))
+        } else {
+            Ok(None)
         }
     }
 

--- a/src/batch/src/executor/test_utils.rs
+++ b/src/batch/src/executor/test_utils.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::collections::VecDeque;
-use std::future::Future;
 
 use assert_matches::assert_matches;
 use futures::StreamExt;
@@ -246,15 +245,11 @@ impl FakeExchangeSource {
 }
 
 impl ExchangeSource for FakeExchangeSource {
-    type TakeDataFuture<'a> = impl Future<Output = Result<Option<DataChunk>>> + 'a;
-
-    fn take_data(&mut self) -> Self::TakeDataFuture<'_> {
-        async {
-            if let Some(chunk) = self.chunks.pop() {
-                Ok(chunk)
-            } else {
-                Ok(None)
-            }
+    async fn take_data(&mut self) -> Result<Option<DataChunk>> {
+        if let Some(chunk) = self.chunks.pop() {
+            Ok(chunk)
+        } else {
+            Ok(None)
         }
     }
 

--- a/src/batch/src/lib.rs
+++ b/src/batch/src/lib.rs
@@ -34,6 +34,7 @@
 #![feature(result_option_inspect)]
 #![feature(assert_matches)]
 #![feature(lazy_cell)]
+#![feature(return_position_impl_trait_in_trait)]
 
 mod error;
 pub mod exchange_source;

--- a/src/connector/src/source/external.rs
+++ b/src/connector/src/source/external.rs
@@ -200,13 +200,9 @@ impl MySqlOffset {
 }
 
 pub trait ExternalTableReader {
-    type CdcOffsetFuture<'a>: Future<Output = ConnectorResult<CdcOffset>> + Send + 'a
-    where
-        Self: 'a;
-
     fn get_normalized_table_name(&self, table_name: &SchemaTableName) -> String;
 
-    fn current_cdc_offset(&self) -> Self::CdcOffsetFuture<'_>;
+    fn current_cdc_offset(&self) -> impl Future<Output = ConnectorResult<CdcOffset>> + Send + '_;
 
     fn parse_binlog_offset(&self, offset: &str) -> ConnectorResult<CdcOffset>;
 
@@ -248,32 +244,28 @@ pub struct ExternalTableConfig {
 }
 
 impl ExternalTableReader for MySqlExternalTableReader {
-    type CdcOffsetFuture<'a> = impl Future<Output = ConnectorResult<CdcOffset>> + 'a;
-
     fn get_normalized_table_name(&self, table_name: &SchemaTableName) -> String {
         format!("`{}`", table_name.table_name)
     }
 
-    fn current_cdc_offset(&self) -> Self::CdcOffsetFuture<'_> {
-        async move {
-            let mut conn = self
-                .pool
-                .get_conn()
-                .await
-                .map_err(|e| ConnectorError::Connection(anyhow!(e)))?;
+    async fn current_cdc_offset(&self) -> ConnectorResult<CdcOffset> {
+        let mut conn = self
+            .pool
+            .get_conn()
+            .await
+            .map_err(|e| ConnectorError::Connection(anyhow!(e)))?;
 
-            let sql = "SHOW MASTER STATUS".to_string();
-            let mut rs = conn.query::<mysql_async::Row, _>(sql).await?;
-            let row = rs
-                .iter_mut()
-                .exactly_one()
-                .map_err(|e| ConnectorError::Internal(anyhow!("read binlog error: {}", e)))?;
+        let sql = "SHOW MASTER STATUS".to_string();
+        let mut rs = conn.query::<mysql_async::Row, _>(sql).await?;
+        let row = rs
+            .iter_mut()
+            .exactly_one()
+            .map_err(|e| ConnectorError::Internal(anyhow!("read binlog error: {}", e)))?;
 
-            Ok(CdcOffset::MySql(MySqlOffset {
-                filename: row.take("File").unwrap(),
-                position: row.take("Position").unwrap(),
-            }))
-        }
+        Ok(CdcOffset::MySql(MySqlOffset {
+            filename: row.take("File").unwrap(),
+            position: row.take("Position").unwrap(),
+        }))
     }
 
     fn parse_binlog_offset(&self, offset: &str) -> ConnectorResult<CdcOffset> {
@@ -478,8 +470,6 @@ impl MySqlExternalTableReader {
 }
 
 impl ExternalTableReader for ExternalTableReaderImpl {
-    type CdcOffsetFuture<'a> = impl Future<Output = ConnectorResult<CdcOffset>> + 'a;
-
     fn get_normalized_table_name(&self, table_name: &SchemaTableName) -> String {
         match self {
             ExternalTableReaderImpl::MySql(mysql) => mysql.get_normalized_table_name(table_name),
@@ -487,12 +477,10 @@ impl ExternalTableReader for ExternalTableReaderImpl {
         }
     }
 
-    fn current_cdc_offset(&self) -> Self::CdcOffsetFuture<'_> {
-        async move {
-            match self {
-                ExternalTableReaderImpl::MySql(mysql) => mysql.current_cdc_offset().await,
-                ExternalTableReaderImpl::Mock(mock) => mock.current_cdc_offset().await,
-            }
+    async fn current_cdc_offset(&self) -> ConnectorResult<CdcOffset> {
+        match self {
+            ExternalTableReaderImpl::MySql(mysql) => mysql.current_cdc_offset().await,
+            ExternalTableReaderImpl::Mock(mock) => mock.current_cdc_offset().await,
         }
     }
 

--- a/src/stream/src/executor/dispatch.rs
+++ b/src/stream/src/executor/dispatch.rs
@@ -433,27 +433,15 @@ macro_rules! for_all_dispatcher_variants {
 
 for_all_dispatcher_variants! { impl_dispatcher }
 
-macro_rules! define_dispatcher_associated_types {
-    () => {
-        type DataFuture<'a> = impl DispatchFuture<'a>;
-        type BarrierFuture<'a> = impl DispatchFuture<'a>;
-        type WatermarkFuture<'a> = impl DispatchFuture<'a>;
-    };
-}
-
 pub trait DispatchFuture<'a> = Future<Output = StreamResult<()>> + Send;
 
 pub trait Dispatcher: Debug + 'static {
-    type DataFuture<'a>: DispatchFuture<'a>;
-    type BarrierFuture<'a>: DispatchFuture<'a>;
-    type WatermarkFuture<'a>: DispatchFuture<'a>;
-
     /// Dispatch a data chunk to downstream actors.
-    fn dispatch_data(&mut self, chunk: StreamChunk) -> Self::DataFuture<'_>;
+    fn dispatch_data(&mut self, chunk: StreamChunk) -> impl DispatchFuture<'_>;
     /// Dispatch a barrier to downstream actors, generally by broadcasting it.
-    fn dispatch_barrier(&mut self, barrier: Barrier) -> Self::BarrierFuture<'_>;
+    fn dispatch_barrier(&mut self, barrier: Barrier) -> impl DispatchFuture<'_>;
     /// Dispatch a watermark to downstream actors, generally by broadcasting it.
-    fn dispatch_watermark(&mut self, watermark: Watermark) -> Self::WatermarkFuture<'_>;
+    fn dispatch_watermark(&mut self, watermark: Watermark) -> impl DispatchFuture<'_>;
 
     /// Add new outputs to the dispatcher.
     fn add_outputs(&mut self, outputs: impl IntoIterator<Item = BoxedOutput>);
@@ -493,38 +481,30 @@ impl RoundRobinDataDispatcher {
 }
 
 impl Dispatcher for RoundRobinDataDispatcher {
-    define_dispatcher_associated_types!();
-
-    fn dispatch_data(&mut self, chunk: StreamChunk) -> Self::DataFuture<'_> {
-        async move {
-            let chunk = chunk.project(&self.output_indices);
-            self.outputs[self.cur].send(Message::Chunk(chunk)).await?;
-            self.cur += 1;
-            self.cur %= self.outputs.len();
-            Ok(())
-        }
+    async fn dispatch_data(&mut self, chunk: StreamChunk) -> StreamResult<()> {
+        let chunk = chunk.project(&self.output_indices);
+        self.outputs[self.cur].send(Message::Chunk(chunk)).await?;
+        self.cur += 1;
+        self.cur %= self.outputs.len();
+        Ok(())
     }
 
-    fn dispatch_barrier(&mut self, barrier: Barrier) -> Self::BarrierFuture<'_> {
-        async move {
-            // always broadcast barrier
+    async fn dispatch_barrier(&mut self, barrier: Barrier) -> StreamResult<()> {
+        // always broadcast barrier
+        for output in &mut self.outputs {
+            output.send(Message::Barrier(barrier.clone())).await?;
+        }
+        Ok(())
+    }
+
+    async fn dispatch_watermark(&mut self, watermark: Watermark) -> StreamResult<()> {
+        if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
+            // always broadcast watermark
             for output in &mut self.outputs {
-                output.send(Message::Barrier(barrier.clone())).await?;
+                output.send(Message::Watermark(watermark.clone())).await?;
             }
-            Ok(())
         }
-    }
-
-    fn dispatch_watermark(&mut self, watermark: Watermark) -> Self::WatermarkFuture<'_> {
-        async move {
-            if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
-                // always broadcast watermark
-                for output in &mut self.outputs {
-                    output.send(Message::Watermark(watermark.clone())).await?;
-                }
-            }
-            Ok(())
-        }
+        Ok(())
     }
 
     fn add_outputs(&mut self, outputs: impl IntoIterator<Item = BoxedOutput>) {
@@ -586,112 +566,102 @@ impl HashDataDispatcher {
 }
 
 impl Dispatcher for HashDataDispatcher {
-    define_dispatcher_associated_types!();
-
     fn add_outputs(&mut self, outputs: impl IntoIterator<Item = BoxedOutput>) {
         self.outputs.extend(outputs);
     }
 
-    fn dispatch_barrier(&mut self, barrier: Barrier) -> Self::BarrierFuture<'_> {
-        async move {
-            // always broadcast barrier
+    async fn dispatch_barrier(&mut self, barrier: Barrier) -> StreamResult<()> {
+        // always broadcast barrier
+        for output in &mut self.outputs {
+            output.send(Message::Barrier(barrier.clone())).await?;
+        }
+        Ok(())
+    }
+
+    async fn dispatch_watermark(&mut self, watermark: Watermark) -> StreamResult<()> {
+        if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
+            // always broadcast watermark
             for output in &mut self.outputs {
-                output.send(Message::Barrier(barrier.clone())).await?;
+                output.send(Message::Watermark(watermark.clone())).await?;
             }
-            Ok(())
         }
+        Ok(())
     }
 
-    fn dispatch_watermark(&mut self, watermark: Watermark) -> Self::WatermarkFuture<'_> {
-        async move {
-            if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
-                // always broadcast watermark
-                for output in &mut self.outputs {
-                    output.send(Message::Watermark(watermark.clone())).await?;
-                }
+    async fn dispatch_data(&mut self, chunk: StreamChunk) -> StreamResult<()> {
+        // A chunk can be shuffled into multiple output chunks that to be sent to downstreams.
+        // In these output chunks, the only difference are visibility map, which is calculated
+        // by the hash value of each line in the input chunk.
+        let num_outputs = self.outputs.len();
+
+        // get hash value of every line by its key
+        let vnodes = VirtualNode::compute_chunk(chunk.data_chunk(), &self.keys);
+
+        tracing::trace!(target: "events::stream::dispatch::hash", "\n{}\n keys {:?} => {:?}", chunk.to_pretty(), self.keys, vnodes);
+
+        let mut vis_maps = repeat_with(|| BitmapBuilder::with_capacity(chunk.capacity()))
+            .take(num_outputs)
+            .collect_vec();
+        let mut last_vnode_when_update_delete = None;
+        let mut new_ops: Vec<Op> = Vec::with_capacity(chunk.capacity());
+
+        // Apply output indices after calculating the vnode.
+        let chunk = chunk.project(&self.output_indices);
+
+        for ((vnode, &op), visible) in vnodes
+            .iter()
+            .copied()
+            .zip_eq_fast(chunk.ops())
+            .zip_eq_fast(chunk.vis().iter())
+        {
+            // Build visibility map for every output chunk.
+            for (output, vis_map) in self.outputs.iter().zip_eq_fast(vis_maps.iter_mut()) {
+                vis_map.append(visible && self.hash_mapping[vnode.to_index()] == output.actor_id());
             }
-            Ok(())
-        }
-    }
 
-    fn dispatch_data(&mut self, chunk: StreamChunk) -> Self::DataFuture<'_> {
-        async move {
-            // A chunk can be shuffled into multiple output chunks that to be sent to downstreams.
-            // In these output chunks, the only difference are visibility map, which is calculated
-            // by the hash value of each line in the input chunk.
-            let num_outputs = self.outputs.len();
+            if !visible {
+                new_ops.push(op);
+                continue;
+            }
 
-            // get hash value of every line by its key
-            let vnodes = VirtualNode::compute_chunk(chunk.data_chunk(), &self.keys);
-
-            tracing::trace!(target: "events::stream::dispatch::hash", "\n{}\n keys {:?} => {:?}", chunk.to_pretty(), self.keys, vnodes);
-
-            let mut vis_maps = repeat_with(|| BitmapBuilder::with_capacity(chunk.capacity()))
-                .take(num_outputs)
-                .collect_vec();
-            let mut last_vnode_when_update_delete = None;
-            let mut new_ops: Vec<Op> = Vec::with_capacity(chunk.capacity());
-
-            // Apply output indices after calculating the vnode.
-            let chunk = chunk.project(&self.output_indices);
-
-            for ((vnode, &op), visible) in vnodes
-                .iter()
-                .copied()
-                .zip_eq_fast(chunk.ops())
-                .zip_eq_fast(chunk.vis().iter())
-            {
-                // Build visibility map for every output chunk.
-                for (output, vis_map) in self.outputs.iter().zip_eq_fast(vis_maps.iter_mut()) {
-                    vis_map.append(
-                        visible && self.hash_mapping[vnode.to_index()] == output.actor_id(),
-                    );
-                }
-
-                if !visible {
-                    new_ops.push(op);
-                    continue;
-                }
-
-                // The 'update' message, noted by an `UpdateDelete` and a successive `UpdateInsert`,
-                // need to be rewritten to common `Delete` and `Insert` if they were dispatched to
-                // different actors.
-                if op == Op::UpdateDelete {
-                    last_vnode_when_update_delete = Some(vnode);
-                } else if op == Op::UpdateInsert {
-                    if vnode != last_vnode_when_update_delete.unwrap() {
-                        new_ops.push(Op::Delete);
-                        new_ops.push(Op::Insert);
-                    } else {
-                        new_ops.push(Op::UpdateDelete);
-                        new_ops.push(Op::UpdateInsert);
-                    }
+            // The 'update' message, noted by an `UpdateDelete` and a successive `UpdateInsert`,
+            // need to be rewritten to common `Delete` and `Insert` if they were dispatched to
+            // different actors.
+            if op == Op::UpdateDelete {
+                last_vnode_when_update_delete = Some(vnode);
+            } else if op == Op::UpdateInsert {
+                if vnode != last_vnode_when_update_delete.unwrap() {
+                    new_ops.push(Op::Delete);
+                    new_ops.push(Op::Insert);
                 } else {
-                    new_ops.push(op);
+                    new_ops.push(Op::UpdateDelete);
+                    new_ops.push(Op::UpdateInsert);
                 }
+            } else {
+                new_ops.push(op);
             }
-
-            let ops = new_ops;
-
-            // individually output StreamChunk integrated with vis_map
-            for (vis_map, output) in vis_maps.into_iter().zip_eq_fast(self.outputs.iter_mut()) {
-                let vis_map = vis_map.finish();
-                // columns is not changed in this function
-                let new_stream_chunk =
-                    StreamChunk::new(ops.clone(), chunk.columns().into(), Some(vis_map));
-                if new_stream_chunk.cardinality() > 0 {
-                    event!(
-                        tracing::Level::TRACE,
-                        msg = "chunk",
-                        downstream = output.actor_id(),
-                        "send = \n{:#?}",
-                        new_stream_chunk
-                    );
-                    output.send(Message::Chunk(new_stream_chunk)).await?;
-                }
-            }
-            Ok(())
         }
+
+        let ops = new_ops;
+
+        // individually output StreamChunk integrated with vis_map
+        for (vis_map, output) in vis_maps.into_iter().zip_eq_fast(self.outputs.iter_mut()) {
+            let vis_map = vis_map.finish();
+            // columns is not changed in this function
+            let new_stream_chunk =
+                StreamChunk::new(ops.clone(), chunk.columns().into(), Some(vis_map));
+            if new_stream_chunk.cardinality() > 0 {
+                event!(
+                    tracing::Level::TRACE,
+                    msg = "chunk",
+                    downstream = output.actor_id(),
+                    "send = \n{:#?}",
+                    new_stream_chunk
+                );
+                output.send(Message::Chunk(new_stream_chunk)).await?;
+            }
+        }
+        Ok(())
     }
 
     fn remove_outputs(&mut self, actor_ids: &HashSet<ActorId>) {
@@ -740,37 +710,29 @@ impl BroadcastDispatcher {
 }
 
 impl Dispatcher for BroadcastDispatcher {
-    define_dispatcher_associated_types!();
-
-    fn dispatch_data(&mut self, chunk: StreamChunk) -> Self::DataFuture<'_> {
-        async move {
-            let chunk = chunk.project(&self.output_indices);
-            for output in self.outputs.values_mut() {
-                output.send(Message::Chunk(chunk.clone())).await?;
-            }
-            Ok(())
+    async fn dispatch_data(&mut self, chunk: StreamChunk) -> StreamResult<()> {
+        let chunk = chunk.project(&self.output_indices);
+        for output in self.outputs.values_mut() {
+            output.send(Message::Chunk(chunk.clone())).await?;
         }
+        Ok(())
     }
 
-    fn dispatch_barrier(&mut self, barrier: Barrier) -> Self::BarrierFuture<'_> {
-        async move {
-            for output in self.outputs.values_mut() {
-                output.send(Message::Barrier(barrier.clone())).await?;
-            }
-            Ok(())
+    async fn dispatch_barrier(&mut self, barrier: Barrier) -> StreamResult<()> {
+        for output in self.outputs.values_mut() {
+            output.send(Message::Barrier(barrier.clone())).await?;
         }
+        Ok(())
     }
 
-    fn dispatch_watermark(&mut self, watermark: Watermark) -> Self::WatermarkFuture<'_> {
-        async move {
-            if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
-                // always broadcast watermark
-                for output in self.outputs.values_mut() {
-                    output.send(Message::Watermark(watermark.clone())).await?;
-                }
+    async fn dispatch_watermark(&mut self, watermark: Watermark) -> StreamResult<()> {
+        if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
+            // always broadcast watermark
+            for output in self.outputs.values_mut() {
+                output.send(Message::Watermark(watermark.clone())).await?;
             }
-            Ok(())
         }
+        Ok(())
     }
 
     fn add_outputs(&mut self, outputs: impl IntoIterator<Item = BoxedOutput>) {
@@ -828,49 +790,41 @@ impl SimpleDispatcher {
 }
 
 impl Dispatcher for SimpleDispatcher {
-    define_dispatcher_associated_types!();
-
     fn add_outputs(&mut self, outputs: impl IntoIterator<Item = BoxedOutput>) {
         self.output.extend(outputs);
         assert!(self.output.len() <= 2);
     }
 
-    fn dispatch_barrier(&mut self, barrier: Barrier) -> Self::BarrierFuture<'_> {
-        async move {
-            // Only barrier is allowed to be dispatched to multiple outputs during migration.
-            for output in &mut self.output {
-                output.send(Message::Barrier(barrier.clone())).await?;
-            }
-            Ok(())
+    async fn dispatch_barrier(&mut self, barrier: Barrier) -> StreamResult<()> {
+        // Only barrier is allowed to be dispatched to multiple outputs during migration.
+        for output in &mut self.output {
+            output.send(Message::Barrier(barrier.clone())).await?;
         }
+        Ok(())
     }
 
-    fn dispatch_data(&mut self, chunk: StreamChunk) -> Self::DataFuture<'_> {
-        async move {
-            let output = self
-                .output
-                .iter_mut()
-                .exactly_one()
-                .expect("expect exactly one output");
+    async fn dispatch_data(&mut self, chunk: StreamChunk) -> StreamResult<()> {
+        let output = self
+            .output
+            .iter_mut()
+            .exactly_one()
+            .expect("expect exactly one output");
 
-            let chunk = chunk.project(&self.output_indices);
-            output.send(Message::Chunk(chunk)).await
-        }
+        let chunk = chunk.project(&self.output_indices);
+        output.send(Message::Chunk(chunk)).await
     }
 
-    fn dispatch_watermark(&mut self, watermark: Watermark) -> Self::WatermarkFuture<'_> {
-        async move {
-            let output = self
-                .output
-                .iter_mut()
-                .exactly_one()
-                .expect("expect exactly one output");
+    async fn dispatch_watermark(&mut self, watermark: Watermark) -> StreamResult<()> {
+        let output = self
+            .output
+            .iter_mut()
+            .exactly_one()
+            .expect("expect exactly one output");
 
-            if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
-                output.send(Message::Watermark(watermark)).await?;
-            }
-            Ok(())
+        if let Some(watermark) = watermark.transform_with_indices(&self.output_indices) {
+            output.send(Message::Watermark(watermark)).await?;
         }
+        Ok(())
     }
 
     fn remove_outputs(&mut self, actor_ids: &HashSet<ActorId>) {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

**_Hide the whitespaces and you'll find few changes._**

As `return-position-impl-trait-in-trait` is now complete, we can replace more GAT-based async trait with that.

- #10554

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
