### PR TITLE
feat(stream): handling watermark in temporal join

### DIFF
--- a/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
@@ -1,0 +1,71 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+statement ok
+create table stream(id1 int, a1 int, b1 int, v1 timestamp with time zone, watermark for v1 as v1 - INTERVAL '10' SECOND) APPEND ONLY;
+
+# FIXME. If we don't insert at first, it would cause a panic when create emoc_mv.
+statement ok
+insert into stream values (1, 1, 1, '2023-09-14 06:00:00');
+
+statement ok
+create table version(id2 int, a2 int, b2 int, primary key (id2));
+
+statement ok
+create materialized view temporal_join_mv as select id1, a1, id2, v1 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
+
+statement ok
+create materialized view emoc_mv as select window_start, array_agg(id1) from tumble(temporal_join_mv, v1, interval '5 s') group by window_start emit on window close;
+
+query IIII rowsort
+select * from temporal_join_mv;
+----
+1 1 NULL 2023-09-14 06:00:00+00:00
+
+query IIII rowsort
+select * from emoc_mv;
+----
+
+statement ok
+insert into stream values (2, 2, 2, '2023-09-14 06:00:25');
+
+sleep 5s
+
+query IIII rowsort
+select * from temporal_join_mv;
+----
+1 1 NULL 2023-09-14 06:00:00+00:00
+2 2 NULL 2023-09-14 06:00:25+00:00
+
+
+query IIII rowsort
+select * from emoc_mv;
+----
+2023-09-14 06:00:00+00:00 {1}
+
+statement ok
+insert into stream values (3, 3, 3, '2023-09-14 06:00:45');
+
+sleep 5s
+
+query IIII rowsort
+select * from temporal_join_mv;
+----
+1 1 NULL 2023-09-14 06:00:00+00:00
+2 2 NULL 2023-09-14 06:00:25+00:00
+3 3 NULL 2023-09-14 06:00:45+00:00
+
+query IIII rowsort
+select * from emoc_mv;
+----
+2023-09-14 06:00:00+00:00 {1}
+2023-09-14 06:00:25+00:00 {2}
+
+statement ok
+drop table stream cascade;
+
+statement ok
+drop table version cascade;
+
+
+

--- a/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
@@ -15,7 +15,7 @@ statement ok
 create materialized view temporal_join_mv as select id1, a1, id2, v1 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
 
 statement ok
-create materialized view eowc_mv as select window_start, array_agg(id1) from tumble(temporal_join_mv, v1, interval '5 s') group by window_start emit on window close;
+create materialized view eowc_mv as select window_start, count(id1) from tumble(temporal_join_mv, v1, interval '5 s') group by window_start emit on window close;
 
 query IIII rowsort
 select * from temporal_join_mv;
@@ -41,7 +41,7 @@ select * from temporal_join_mv;
 query IIII rowsort
 select * from eowc_mv;
 ----
-2023-09-14 06:00:00+00:00 {1}
+2023-09-14 06:00:00+00:00 1
 
 statement ok
 insert into stream values (3, 3, 3, '2023-09-14 06:00:45');
@@ -58,8 +58,8 @@ select * from temporal_join_mv;
 query IIII rowsort
 select * from eowc_mv;
 ----
-2023-09-14 06:00:00+00:00 {1}
-2023-09-14 06:00:25+00:00 {2}
+2023-09-14 06:00:00+00:00 1
+2023-09-14 06:00:25+00:00 1
 
 statement ok
 drop table stream cascade;

--- a/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
+++ b/e2e_test/streaming/temporal_join/temporal_join_watermark.slt
@@ -4,7 +4,7 @@ SET RW_IMPLICIT_FLUSH TO true;
 statement ok
 create table stream(id1 int, a1 int, b1 int, v1 timestamp with time zone, watermark for v1 as v1 - INTERVAL '10' SECOND) APPEND ONLY;
 
-# FIXME. If we don't insert at first, it would cause a panic when create emoc_mv.
+# FIXME. If we don't insert at first, it would cause a panic when create eowc_mv.
 statement ok
 insert into stream values (1, 1, 1, '2023-09-14 06:00:00');
 
@@ -15,7 +15,7 @@ statement ok
 create materialized view temporal_join_mv as select id1, a1, id2, v1 from stream left join version FOR SYSTEM_TIME AS OF PROCTIME() on id1 = id2;
 
 statement ok
-create materialized view emoc_mv as select window_start, array_agg(id1) from tumble(temporal_join_mv, v1, interval '5 s') group by window_start emit on window close;
+create materialized view eowc_mv as select window_start, array_agg(id1) from tumble(temporal_join_mv, v1, interval '5 s') group by window_start emit on window close;
 
 query IIII rowsort
 select * from temporal_join_mv;
@@ -23,7 +23,7 @@ select * from temporal_join_mv;
 1 1 NULL 2023-09-14 06:00:00+00:00
 
 query IIII rowsort
-select * from emoc_mv;
+select * from eowc_mv;
 ----
 
 statement ok
@@ -39,7 +39,7 @@ select * from temporal_join_mv;
 
 
 query IIII rowsort
-select * from emoc_mv;
+select * from eowc_mv;
 ----
 2023-09-14 06:00:00+00:00 {1}
 
@@ -56,7 +56,7 @@ select * from temporal_join_mv;
 3 3 NULL 2023-09-14 06:00:45+00:00
 
 query IIII rowsort
-select * from emoc_mv;
+select * from eowc_mv;
 ----
 2023-09-14 06:00:00+00:00 {1}
 2023-09-14 06:00:25+00:00 {2}

--- a/src/stream/src/executor/temporal_join.rs
+++ b/src/stream/src/executor/temporal_join.rs
@@ -44,7 +44,9 @@ use crate::cache::{cache_may_stale, new_with_hasher_in, ManagedLruCache};
 use crate::common::metrics::MetricsInfo;
 use crate::common::JoinStreamChunkBuilder;
 use crate::executor::monitor::StreamingMetrics;
-use crate::executor::{ActorContextRef, BoxedExecutor, JoinType, JoinTypePrimitive, PkIndices};
+use crate::executor::{
+    ActorContextRef, BoxedExecutor, JoinType, JoinTypePrimitive, PkIndices, Watermark,
+};
 use crate::task::AtomicU64Ref;
 
 pub struct TemporalJoinExecutor<K: HashKey, S: StateStore, const T: JoinTypePrimitive> {
@@ -235,17 +237,35 @@ impl<K: HashKey, S: StateStore> TemporalSide<K, S> {
 enum InternalMessage {
     Chunk(StreamChunk),
     Barrier(Vec<StreamChunk>, Barrier),
+    WaterMark(Watermark),
 }
 
 #[try_stream(ok = StreamChunk, error = StreamExecutorError)]
-pub async fn chunks_until_barrier(stream: impl MessageStream, expected_barrier: Barrier) {
+async fn chunks_until_barrier(stream: impl MessageStream, expected_barrier: Barrier) {
     #[for_await]
     for item in stream {
         match item? {
             Message::Watermark(_) => {
-                // TODO: https://github.com/risingwavelabs/risingwave/issues/6042
+                // ignore
             }
             Message::Chunk(c) => yield c,
+            Message::Barrier(b) if b.epoch != expected_barrier.epoch => {
+                return Err(StreamExecutorError::align_barrier(expected_barrier, b));
+            }
+            Message::Barrier(_) => return Ok(()),
+        }
+    }
+}
+
+#[try_stream(ok = InternalMessage, error = StreamExecutorError)]
+async fn internal_messages_until_barrier(stream: impl MessageStream, expected_barrier: Barrier) {
+    #[for_await]
+    for item in stream {
+        match item? {
+            Message::Watermark(w) => {
+                yield InternalMessage::WaterMark(w);
+            }
+            Message::Chunk(c) => yield InternalMessage::Chunk(c),
             Message::Barrier(b) if b.epoch != expected_barrier.epoch => {
                 return Err(StreamExecutorError::align_barrier(expected_barrier, b));
             }
@@ -285,18 +305,20 @@ async fn align_input(left: Box<dyn Executor>, right: Box<dyn Executor>) {
                 }
                 Some(Either::Right(Ok(Message::Barrier(b)))) => {
                     #[for_await]
-                    for chunk in chunks_until_barrier(left.by_ref(), b.clone()) {
-                        yield InternalMessage::Chunk(chunk?);
+                    for internal_message in
+                        internal_messages_until_barrier(left.by_ref(), b.clone())
+                    {
+                        yield internal_message?;
                     }
                     yield InternalMessage::Barrier(right_chunks, b);
                     break 'inner;
                 }
                 Some(Either::Left(Err(e)) | Either::Right(Err(e))) => return Err(e),
-                Some(
-                    Either::Left(Ok(Message::Watermark(_)))
-                    | Either::Right(Ok(Message::Watermark(_))),
-                ) => {
-                    // TODO: https://github.com/risingwavelabs/risingwave/issues/6042
+                Some(Either::Left(Ok(Message::Watermark(w)))) => {
+                    yield InternalMessage::WaterMark(w);
+                }
+                Some(Either::Right(Ok(Message::Watermark(_)))) => {
+                    // ignore right side watermark
                 }
                 None => return Ok(()),
             }
@@ -381,6 +403,8 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
             self.right.schema().len(),
         );
 
+        let left_to_output: HashMap<usize, usize> = HashMap::from_iter(left_map.iter().cloned());
+
         let right_stream_key_indices = self.right.pk_indices().to_vec();
 
         let null_matched = K::Bitmap::from_bool_vec(self.null_safe);
@@ -398,6 +422,10 @@ impl<K: HashKey, S: StateStore, const T: JoinTypePrimitive> TemporalJoinExecutor
                 .with_label_values(&[&table_id_str, &actor_id_str])
                 .set(self.right_table.cache.len() as i64);
             match msg? {
+                InternalMessage::WaterMark(watermark) => {
+                    let output_watermark_col_idx = *left_to_output.get(&watermark.col_idx).unwrap();
+                    yield Message::Watermark(watermark.with_idx(output_watermark_col_idx));
+                }
                 InternalMessage::Chunk(chunk) => {
                     // Compact chunk, otherwise the following keys and chunk rows might fail to zip.
                     let chunk = chunk.compact();


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Resolve https://github.com/risingwavelabs/risingwave/issues/10621#event-10330006525
- Simply maps LHS watermark messages of temporal join to the output and ignore watermark messages from RHS.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
