### PR TITLE
chore(ci): move release jobs to main-cron pipeline

### DIFF
--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -44,7 +44,7 @@ steps:
             DOCKER_TOKEN: docker-token
     retry: *auto-retry
 
-  - label: "release"
+  - label: "pre build binary"
     command: "ci/scripts/release.sh"
     plugins:
       - seek-oss/aws-sm#v2.3.1:

--- a/ci/workflows/main-cron.yml
+++ b/ci/workflows/main-cron.yml
@@ -581,3 +581,66 @@ steps:
           - "17"
     timeout_in_minutes: 10
     retry: *auto-retry
+
+  - label: "release"
+    command: "ci/scripts/release.sh"
+    if: build.tag != null
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GITHUB_TOKEN: github-token
+      - docker-compose#v4.9.0:
+          run: release-env
+          config: ci/docker-compose.yml
+          mount-buildkite-agent: true
+          environment:
+            - GITHUB_TOKEN
+            - BUILDKITE_TAG
+            - BUILDKITE_SOURCE
+    timeout_in_minutes: 60
+    retry: *auto-retry
+
+  - label: "release docker image: amd64"
+    command: "ci/scripts/docker.sh"
+    key: "build-amd64"
+    if: build.tag != null
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GHCR_USERNAME: ghcr-username
+            GHCR_TOKEN: ghcr-token
+            DOCKER_TOKEN: docker-token
+            GITHUB_TOKEN: github-token
+    timeout_in_minutes: 60
+    retry: *auto-retry
+
+  - label: "docker-build-push: aarch64"
+    command: "ci/scripts/docker.sh"
+    key: "build-aarch64"
+    if: build.tag != null
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GHCR_USERNAME: ghcr-username
+            GHCR_TOKEN: ghcr-token
+            DOCKER_TOKEN: docker-token
+            GITHUB_TOKEN: github-token
+    timeout_in_minutes: 60
+    agents:
+      queue: "linux-arm64"
+    retry: *auto-retry
+
+  - label: "multi arch image create push"
+    command: "ci/scripts/multi-arch-docker.sh"
+    if: build.tag != null
+    depends_on:
+      - "build-amd64"
+      - "build-aarch64"
+    plugins:
+      - seek-oss/aws-sm#v2.3.1:
+          env:
+            GHCR_USERNAME: ghcr-username
+            GHCR_TOKEN: ghcr-token
+            DOCKER_TOKEN: docker-token
+    timeout_in_minutes: 10
+    retry: *auto-retry


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We want to run main-cron pipeline when we push a new tag and release.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))
