### PR TITLE
feat: Support `lc_collate` and `lc_ctype` session config

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -36,7 +36,7 @@ use crate::util::epoch::Epoch;
 
 // This is a hack, &'static str is not allowed as a const generics argument.
 // TODO: refine this using the adt_const_params feature.
-const CONFIG_KEYS: [&str; 37] = [
+const CONFIG_KEYS: [&str; 38] = [
     "RW_IMPLICIT_FLUSH",
     "CREATE_COMPACTION_GROUP_FOR_MV",
     "QUERY_MODE",
@@ -74,6 +74,7 @@ const CONFIG_KEYS: [&str; 37] = [
     "STREAMING_RATE_LIMIT",
     "CDC_BACKFILL",
     "RW_STREAMING_OVER_WINDOW_CACHE_POLICY",
+    "LC_COLLATE",
 ];
 
 // MUST HAVE 1v1 relationship to CONFIG_KEYS. e.g. CONFIG_KEYS[IMPLICIT_FLUSH] =
@@ -115,6 +116,7 @@ const STANDARD_CONFORMING_STRINGS: usize = 33;
 const STREAMING_RATE_LIMIT: usize = 34;
 const CDC_BACKFILL: usize = 35;
 const STREAMING_OVER_WINDOW_CACHE_POLICY: usize = 36;
+const LC_COLLATE: usize = 37;
 
 trait ConfigEntry: Default + for<'a> TryFrom<&'a [&'a str], Error = RwError> {
     fn entry_name() -> &'static str;
@@ -339,6 +341,7 @@ type RowSecurity = ConfigBool<ROW_SECURITY, true>;
 type StandardConformingStrings = ConfigString<STANDARD_CONFORMING_STRINGS>;
 type StreamingRateLimit = ConfigU64<STREAMING_RATE_LIMIT, 0>;
 type CdcBackfill = ConfigBool<CDC_BACKFILL, false>;
+type LcCollate = ConfigString<LC_COLLATE>;
 
 /// Report status or notice to caller.
 pub trait ConfigReporter {
@@ -486,6 +489,12 @@ pub struct ConfigMap {
     /// Cache policy for partition cache in streaming over window.
     /// Can be "full", "recent", "recent_first_n" or "recent_last_n".
     streaming_over_window_cache_policy: OverWindowCachePolicy,
+
+    /// the LC_COLLATE parameter can be shown but not set.
+    /// see <https://www.postgresql.org/docs/current/sql-show.html>
+    /// Locale Setting for collation (text ordering)
+    #[educe(Default(expression = "ConfigString::<LC_COLLATE>(String::from(\"C\"))"))]
+    lc_collate: LcCollate,
 }
 
 impl ConfigMap {
@@ -690,6 +699,8 @@ impl ConfigMap {
             Ok(self.cdc_backfill.to_string())
         } else if key.eq_ignore_ascii_case(OverWindowCachePolicy::entry_name()) {
             Ok(self.streaming_over_window_cache_policy.to_string())
+        } else if key.eq_ignore_ascii_case(LcCollate::entry_name()) {
+            Ok(self.lc_collate.to_string())
         } else {
             Err(ErrorCode::UnrecognizedConfigurationParameter(key.to_string()).into())
         }
@@ -1019,5 +1030,9 @@ impl ConfigMap {
 
     pub fn get_streaming_over_window_cache_policy(&self) -> OverWindowCachePolicy {
         self.streaming_over_window_cache_policy
+    }
+
+    pub fn get_lc_collate(&self) -> &str {
+        &self.lc_collate
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
For pgAdmin #11048 and tableau #10459

As of now, `lc_collate` and `lc_ctype` can always be shown as `C` but not set.
I'm not sure yet if this locale setting can actually be implemented.

see: https://www.postgresql.org/docs/current/sql-show.html:
- `LC_COLLATE` Shows the database's locale setting for collation (text ordering).
- `LC_CTYPE` Shows the database's locale setting for character classification.

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. 

## Release note
Should we wait for the refactoring #10697 to complete first?