### PR TITLE
chore: support docker build skip target

### DIFF
--- a/ci/scripts/multi-arch-docker.sh
+++ b/ci/scripts/multi-arch-docker.sh
@@ -14,13 +14,27 @@ date="$(date +%Y%m%d)"
 ghcraddr="ghcr.io/risingwavelabs/risingwave"
 dockerhubaddr="risingwavelabs/risingwave"
 
+
+arches=()
+
+if [ "${SKIP_TARGET_AMD64:-false}" != "true" ]; then 
+  arches+=("x86_64")
+fi
+
+if [ "${SKIP_TARGET_AARCH64:-false}" != "true" ]; then 
+  arches+=("aarch64")
+fi
+
 # push images to gchr
 function pushGchr() {
   GHCRTAG="${ghcraddr}:$1"
   echo "push to gchr, image tag: ${GHCRTAG}"
-  docker manifest create --insecure "$GHCRTAG" \
-    --amend "${ghcraddr}:${BUILDKITE_COMMIT}-x86_64" \
-    --amend "${ghcraddr}:${BUILDKITE_COMMIT}-aarch64"
+  args=()
+  for arch in "${arches[@]}"
+  do
+    args+=( --amend "${ghcraddr}:${BUILDKITE_COMMIT}-${arch}" )
+  done
+  docker manifest create --insecure "$GHCRTAG" "${args[@]}"
   docker manifest push --insecure "$GHCRTAG"
 }
 
@@ -28,9 +42,12 @@ function pushGchr() {
 function pushDockerhub() {
   DOCKERTAG="${dockerhubaddr}:$1"
   echo "push to dockerhub, image tag: ${DOCKERTAG}"
-  docker manifest create --insecure "$DOCKERTAG" \
-    --amend "${dockerhubaddr}:${BUILDKITE_COMMIT}-x86_64" \
-    --amend "${dockerhubaddr}:${BUILDKITE_COMMIT}-aarch64"
+  args=()
+  for arch in "${arches[@]}"
+  do
+    args+=( --amend "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}" )
+  done
+  docker manifest create --insecure "$DOCKERTAG" "${args[@]}"
   docker manifest push --insecure "$DOCKERTAG"
 }
 
@@ -74,7 +91,10 @@ if [[ -n "${BUILDKITE_TAG}" ]]; then
 fi
 
 echo "--- delete the manifest images from dockerhub"
+args=()
+for arch in "${arches[@]}"
+do
+  args+=( "${dockerhubaddr}:${BUILDKITE_COMMIT}-${arch}" )
+done
 docker run --rm lumir/remove-dockerhub-tag \
-  --user "risingwavelabs" --password "$DOCKER_TOKEN" \
-  "${dockerhubaddr}:${BUILDKITE_COMMIT}-x86_64" \
-  "${dockerhubaddr}:${BUILDKITE_COMMIT}-aarch64"
+  --user "risingwavelabs" --password "$DOCKER_TOKEN" "${args[@]}"

--- a/ci/scripts/multi-arch-docker.sh
+++ b/ci/scripts/multi-arch-docker.sh
@@ -17,11 +17,11 @@ dockerhubaddr="risingwavelabs/risingwave"
 
 arches=()
 
-if [ "${SKIP_TARGET_AMD64:-false}" != "true" ]; then 
+if [ "${SKIP_TARGET_AMD64:-false}" != "true" ]; then
   arches+=("x86_64")
 fi
 
-if [ "${SKIP_TARGET_AARCH64:-false}" != "true" ]; then 
+if [ "${SKIP_TARGET_AARCH64:-false}" != "true" ]; then
   arches+=("aarch64")
 fi
 

--- a/ci/workflows/docker.yml
+++ b/ci/workflows/docker.yml
@@ -6,6 +6,7 @@ auto-retry: &auto-retry
 
 steps:
   - label: "docker-build-push: amd64"
+    if: build.env("SKIP_TARGET_AMD64") != "true"
     command: "ci/scripts/docker.sh"
     key: "build-amd64"
     plugins:
@@ -18,6 +19,7 @@ steps:
     retry: *auto-retry
 
   - label: "docker-build-push: aarch64"
+    if: build.env("SKIP_TARGET_AARCH64") != "true"
     command: "ci/scripts/docker.sh"
     key: "build-aarch64"
     plugins:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Support use `SKIP_TARGET_AMD64=true` or `SKIP_TARGET_AARCH64=true` to skip build on the specific arch when building with docker pipeline.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
