### PR TITLE
chore: use `--fragments` with ids separated by commas

### DIFF
--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -399,7 +399,7 @@ enum MetaCommands {
     /// ```
     /// Use ; to separate multiple fragment
     #[clap(verbatim_doc_comment)]
-    #[clap(group(clap::ArgGroup::new("input_group").required(true).args(& ["plan", "from"])))]
+    #[clap(group(clap::ArgGroup::new("input_group").required(true).args(&["plan", "from"])))]
     Reschedule {
         /// Plan of reschedule, needs to be used with `revision`
         #[clap(long, requires = "revision")]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

as title

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


