### PR TITLE
feat: use Map to represent json field when building doc in es sink

### DIFF
--- a/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
+++ b/java/connector-node/risingwave-sink-es-7/src/main/java/com/risingwave/connector/EsSink.java
@@ -14,6 +14,10 @@
 
 package com.risingwave.connector;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.risingwave.connector.api.TableSchema;
 import com.risingwave.connector.api.sink.SinkRow;
 import com.risingwave.connector.api.sink.SinkWriterBase;
@@ -183,17 +187,35 @@ public class EsSink extends SinkWriterBase {
      *
      * @param row
      * @return Map from Field name to Value
+     * @throws JsonProcessingException
+     * @throws JsonMappingException
      */
-    private Map<String, Object> buildDoc(SinkRow row) {
+    private Map<String, Object> buildDoc(SinkRow row)
+            throws JsonMappingException, JsonProcessingException {
         Map<String, Object> doc = new HashMap();
-        for (int i = 0; i < getTableSchema().getNumColumns(); i++) {
+        var tableSchema = getTableSchema();
+        var columnDescs = tableSchema.getColumnDescs();
+        for (int i = 0; i < row.size(); i++) {
+            var type = columnDescs.get(i).getDataType().getTypeName();
             Object col = row.get(i);
-            if (col instanceof Date) {
-                // es client doesn't natively support java.sql.Timestamp/Time/Date
-                // so we need to convert Date type into a string as suggested in
-                // https://github.com/elastic/elasticsearch/issues/31377#issuecomment-398102292
-                col = col.toString();
+            switch (type) {
+                case DATE:
+                    // es client doesn't natively support java.sql.Timestamp/Time/Date
+                    // so we need to convert Date type into a string as suggested in
+                    // https://github.com/elastic/elasticsearch/issues/31377#issuecomment-398102292
+                    col = col.toString();
+                    break;
+                case JSONB:
+                    ObjectMapper mapper = new ObjectMapper();
+                    col =
+                            mapper.readValue(
+                                    (String) col, new TypeReference<Map<String, Object>>() {});
+                    break;
+                default:
+                    break;
             }
+            if (col instanceof Date) {}
+
             doc.put(getTableSchema().getColumnDesc(i).getName(), col);
         }
         return doc;
@@ -219,7 +241,7 @@ public class EsSink extends SinkWriterBase {
         return id;
     }
 
-    private void processUpsert(SinkRow row) {
+    private void processUpsert(SinkRow row) throws JsonMappingException, JsonProcessingException {
         Map<String, Object> doc = buildDoc(row);
         final String key = buildId(row);
 
@@ -234,7 +256,7 @@ public class EsSink extends SinkWriterBase {
         bulkProcessor.add(deleteRequest);
     }
 
-    private void writeRow(SinkRow row) {
+    private void writeRow(SinkRow row) throws JsonMappingException, JsonProcessingException {
         switch (row.getOp()) {
             case INSERT:
             case UPDATE_INSERT:


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

so that json can be written to ES with the correct structure.

Example:
RW:
```
dev=> create table rw_table(k int primary key, v jsonb);
CREATE_TABLE
dev=> insert into rw_table values(1, '{"nested": {"array_field":[1, 2, 3], "normal_field": 3.14}}');
INSERT 0 1
dev=> create sink es_sink from rw_table with (connector='elasticsearch', index='test_index', url='http://localhost:9200', username='elastic', password='risingwave');
CREATE_SINK
```

ES:
```
{
  "took": 2,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "test_index",
        "_id": "1",
        "_score": 1,
        "_source": {
          "v": {
            "nested": {
              "array_field": [
                1,
                2,
                3
              ],
              "normal_field": 3.14
            }
          },
          "k": 1
        }
      }
    ]
  }
}
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
