### PR TITLE
feat(frontend): add rw_catalog.rw_hummock_sstables

### DIFF
--- a/src/frontend/src/catalog/system_catalog/mod.rs
+++ b/src/frontend/src/catalog/system_catalog/mod.rs
@@ -407,6 +407,7 @@ prepare_sys_catalog! {
     { BuiltinCatalog::Table(&RW_HUMMOCK_PINNED_SNAPSHOTS), read_hummock_pinned_snapshots await },
     { BuiltinCatalog::Table(&RW_HUMMOCK_CURRENT_VERSION), read_hummock_current_version await },
     { BuiltinCatalog::Table(&RW_HUMMOCK_CHECKPOINT_VERSION), read_hummock_checkpoint_version await },
+    { BuiltinCatalog::Table(&RW_HUMMOCK_SSTABLES), read_hummock_sstables await },
     { BuiltinCatalog::Table(&RW_HUMMOCK_VERSION_DELTAS), read_hummock_version_deltas await },
     { BuiltinCatalog::Table(&RW_HUMMOCK_BRANCHED_OBJECTS), read_hummock_branched_objects await },
     { BuiltinCatalog::Table(&RW_HUMMOCK_COMPACTION_GROUP_CONFIGS), read_hummock_compaction_group_configs await },

--- a/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
+++ b/src/frontend/src/catalog/system_catalog/rw_catalog/rw_hummock_version.rs
@@ -45,15 +45,51 @@ pub const RW_HUMMOCK_CHECKPOINT_VERSION: BuiltinTable = BuiltinTable {
     pk: &[],
 };
 
+pub const RW_HUMMOCK_SSTABLES: BuiltinTable = BuiltinTable {
+    name: "rw_hummock_sstables",
+    schema: RW_CATALOG_SCHEMA_NAME,
+    columns: &[
+        (DataType::Int64, "sstable_id"),
+        (DataType::Int64, "object_id"),
+        (DataType::Int64, "compaction_group_id"),
+        (DataType::Int32, "level_id"),
+        (DataType::Int64, "sub_level_id"),
+        (DataType::Int32, "level_type"),
+        (DataType::Bytea, "key_range_left"),
+        (DataType::Bytea, "key_range_right"),
+        (DataType::Boolean, "right_exclusive"),
+        (DataType::Int64, "file_size"),
+        (DataType::Int64, "meta_offset"),
+        (DataType::Int64, "stale_key_count"),
+        (DataType::Int64, "total_key_count"),
+        (DataType::Int64, "min_epoch"),
+        (DataType::Int64, "max_epoch"),
+        (DataType::Int64, "uncompressed_file_size"),
+        (DataType::Int64, "range_tombstone_count"),
+        (DataType::Int32, "bloom_filter_kind"),
+        (DataType::Jsonb, "table_ids"),
+    ],
+    pk: &[0],
+};
+
 impl SysCatalogReaderImpl {
     pub async fn read_hummock_current_version(&self) -> Result<Vec<OwnedRow>> {
         let version = self.meta_client.get_hummock_current_version().await?;
-        Ok(version_to_rows(&remove_key_range_from_version(version)))
+        Ok(version_to_compaction_group_rows(
+            &remove_key_range_from_version(version),
+        ))
     }
 
     pub async fn read_hummock_checkpoint_version(&self) -> Result<Vec<OwnedRow>> {
         let version = self.meta_client.get_hummock_checkpoint_version().await?;
-        Ok(version_to_rows(&remove_key_range_from_version(version)))
+        Ok(version_to_compaction_group_rows(
+            &remove_key_range_from_version(version),
+        ))
+    }
+
+    pub async fn read_hummock_sstables(&self) -> Result<Vec<OwnedRow>> {
+        let version = self.meta_client.get_hummock_current_version().await?;
+        Ok(version_to_sstable_rows(version))
     }
 }
 
@@ -73,7 +109,7 @@ fn remove_key_range_from_version(mut version: HummockVersion) -> HummockVersion 
     version
 }
 
-fn version_to_rows(version: &HummockVersion) -> Vec<OwnedRow> {
+fn version_to_compaction_group_rows(version: &HummockVersion) -> Vec<OwnedRow> {
     version
         .levels
         .values()
@@ -86,4 +122,42 @@ fn version_to_rows(version: &HummockVersion) -> Vec<OwnedRow> {
             ])
         })
         .collect()
+}
+
+fn version_to_sstable_rows(version: HummockVersion) -> Vec<OwnedRow> {
+    let mut sstables = vec![];
+    for cg in version.levels.into_values() {
+        for level in cg.levels.into_iter().chain(cg.l0.unwrap().sub_levels) {
+            for sst in level.table_infos {
+                let key_range = sst.key_range.unwrap();
+                let sub_level_id = if level.level_idx > 0 {
+                    None
+                } else {
+                    Some(ScalarImpl::Int64(level.sub_level_id as _))
+                };
+                sstables.push(OwnedRow::new(vec![
+                    Some(ScalarImpl::Int64(sst.sst_id as _)),
+                    Some(ScalarImpl::Int64(sst.object_id as _)),
+                    Some(ScalarImpl::Int64(cg.group_id as _)),
+                    Some(ScalarImpl::Int32(level.level_idx as _)),
+                    sub_level_id,
+                    Some(ScalarImpl::Int32(level.level_type as _)),
+                    Some(ScalarImpl::Bytea(key_range.left.into())),
+                    Some(ScalarImpl::Bytea(key_range.right.into())),
+                    Some(ScalarImpl::Bool(key_range.right_exclusive)),
+                    Some(ScalarImpl::Int64(sst.file_size as _)),
+                    Some(ScalarImpl::Int64(sst.meta_offset as _)),
+                    Some(ScalarImpl::Int64(sst.stale_key_count as _)),
+                    Some(ScalarImpl::Int64(sst.total_key_count as _)),
+                    Some(ScalarImpl::Int64(sst.min_epoch as _)),
+                    Some(ScalarImpl::Int64(sst.max_epoch as _)),
+                    Some(ScalarImpl::Int64(sst.uncompressed_file_size as _)),
+                    Some(ScalarImpl::Int64(sst.range_tombstone_count as _)),
+                    Some(ScalarImpl::Int32(sst.bloom_filter_kind as _)),
+                    Some(ScalarImpl::Jsonb(json!(sst.table_ids).into())),
+                ]));
+            }
+        }
+    }
+    sstables
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds a flattened view of all SSTables. 
Key range is stored as bytea, and thus we can query/compare/transform key range as needed.

 ```
select * from rw_catalog.rw_hummock_sstables;

 sstable_id | object_id | compaction_group_id | level_id |   sub_level_id   | level_type |                                                                                            key_range_left                                                                                            |                                                    key_range_right                                                     | right_exclusive | file_size | meta_offset | stale_key_count | total_key_count |    min_epoch     |    max_epoch     | uncompressed_file_size | range_tombstone_count | bloom_filter_kind |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      table_ids                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
------------+-----------+---------------------+----------+------------------+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+-----------------+-----------+-------------+-----------------+-----------------+------------------+------------------+------------------------+-----------------------+-------------------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
          8 |         8 |                   3 |        0 | 5142359349395456 |          1 | \x000003e900000084913cc03cc00000001244f2fd650000                                                                                                                                                     | \x000003ef00ff0080000000000003820080000003001244f8e36e0000                                                             | f               |   2171384 |     2148287 |               0 |            8564 | 5142359283793920 | 5142385339006976 |                2171051 |                     0 |                 1 | [1001, 1002, 1003, 1004, 1005, 1006, 1007]
          9 |         9 |                   3 |        0 | 5142359349395456 |          1 | \x000003ef00ff0080000000000003c10080000003001244f8e36e0000                                                                                                                                           | \x000003f200f100014e00000000000000010001460000000000000001001244f8e5c60000                                             | f               |     10605 |       10086 |               0 |              53 | 5142385339006976 | 5142385378328576 |                  10569 |                     0 |                 1 | [1007, 1008, 1009, 1010]
         24 |        24 |                   3 |        0 | 5142359349395456 |          1 | \x000003f50000ffe6a2acef00014d4f524f43434f00070001537570706c6965720923303030303030300930340000000000000200800000640080000000008000000f008000000400800000640080000064008000000400182c001244f8ee420000 | \x0000045f00d300014952414e00000000040001524f4d414e49410007001927bc001244f918630000                                     | f               |      3210 |        2496 |               0 |              26 | 5142385520672768 | 5142386227478528 |                   3156 |                     0 |                 1 | [1013, 1065, 1080, 1088, 1116, 1119]
         39 |        39 |                   3 |        0 | 5142386443616256 |          1 | \x0000047b00ae001927be001244f9215a0000                                                                                                                                                               | \x000004e900f7ff7ffffffffffffffcff7fffffffffffffe7001244f94c210000                                                     | f               |     19300 |       18230 |               0 |             181 | 5142386377883648 | 5142387095568384 |                  19246 |                     0 |                 1 | [1147, 1185, 1213, 1233, 1249, 1257]
         55 |        55 |                   3 |        0 | 5142387298861056 |          1 | \x000004f20000001244f954530000                                                                                                                                                                       | \x000005410000001244f97f600000                                                                                         | f               |     19038 |       18202 |               0 |             136 | 5142387233062912 | 5142387955335168 |                  18984 |                     0 |                 1 | [1266, 1274, 1290, 1304, 1324, 1345]
         56 |        56 |                   3 |        0 | 5142388165115904 |          2 | \x0000054900c00001537570706c696572092330303030303030093036000000000000020080000006008000000e008000000e001244f987f00000                                                                               | \x0000054900c00001537570706c696572092330303030303030093036000000000000020080000006008000000e008000000e001244f987f00000 | f               |       472 |         143 |               0 |               1 | 5142388098990080 | 5142388098990080 |                    463 |                     0 |                 1 | [1353]
         58 |        58 |                   3 |        0 | 5142388312834048 |          2 | \x000005660000ff7ffffffffffffff00001537570706c69657209233030303030303009303500000000000002001244f990c40000                                                                                           | \x000005660000ff7ffffffffffffff00001537570706c69657209233030303030303009303500000000000002001244f990c40000             | f               |       425 |         114 |               0 |               1 | 5142388247101440 | 5142388247101440 |                    416 |                     0 |                 1 | [1382]
         61 |        61 |                   3 |        0 | 5142388462714880 |          2 | \x0000058400a50001333000000000000002001244f999b20000                                                                                                                                                 | \x0000058400e40001333100000000000002001244f999b20000                                                                   | f               |       375 |         145 |               0 |               2 | 5142388396916736 | 5142388396916736 |                    366 |                     0 |                 1 | [1412]
         62 |        62 |                   2 |        6 |                  |          1 | \x000003f300a700014100000000000000010001460000000000000001001244f8e5c60000                                                                                                                           | \x0000053000a500800000000000122200800000940080000000000012220080000004001244f9766b0000                                 | f               |   8405019 |     8263937 |               0 |          111460 | 5142385378328576 | 5142387805061120 |                8402274 |                     0 |                 2 | [1011, 1012, 1014, 1015, 1016, 1018, 1020, 1022, 1024, 1026, 1028, 1029, 1030, 1031, 1033, 1035, 1036, 1037, 1038, 1039, 1041, 1042, 1043, 1045, 1047, 1049, 1051, 1052, 1053, 1055, 1057, 1058, 1059, 1061, 1063, 1064, 1066, 1067, 1068, 1069, 1071, 1073, 1075, 1077, 1078, 1079, 1081, 1082, 1083, 1084, 1086, 1087, 1089, 1090, 1092, 1094, 1096, 1098, 1099, 1100, 1102, 1104, 1106, 1108, 1109, 1110, 1112, 1114, 1115, 1117, 1118, 1120, 1121, 1123, 1125, 1127, 1129, 1131, 1133, 1134, 1135, 1136, 1138, 1140, 1142, 1144, 1145, 1146, 1148, 1149, 1151, 1153, 1155, 1157, 1159, 1161, 1162, 1163, 1164, 1166, 1168, 1170, 1172, 1174, 1176, 1177, 1178, 1180, 1182, 1183, 1184, 1186, 1187, 1189, 1191, 1193, 1195, 1196, 1197, 1199, 1201, 1203, 1205, 1206, 1207, 1209, 1211, 1212, 1214, 1215, 1216, 1217, 1219, 1221, 1223, 1225, 1226, 1227, 1229, 1231, 1232, 1234, 1235, 1236, 1237, 1239, 1241, 1243, 1245, 1246, 1247, 1248, 1250, 1251, 1253, 1255, 1256, 1258, 1259, 1260, 1261, 1262, 1264, 1265, 1267, 1268, 1270, 1272, 1273, 1275, 1277, 1279, 1281, 1283, 1284, 1285, 1286, 1287, 1288, 1289, 1291, 1292, 1293, 1297, 1299, 1301, 1302, 1303, 1305, 1306, 1308, 1310, 1312, 1314, 1315, 1316, 1317, 1318, 1319, 1321, 1322, 1323, 1325, 1326, 1327, 1328]
         63 |        63 |                   2 |        6 |                  |          1 | \x0000053000a500800000000000122200800000940080000000000012220080000005001244f9766b0000                                                                                                               | \x0000058f00ff0080ff001244f999b20000                                                                                   | f               |   2022004 |     1955644 |               0 |           43518 | 5142387805061120 | 5142388396916736 |                2021248 |                     0 |                 2 | [1328, 1330, 1332, 1334, 1336, 1338, 1340, 1341, 1342, 1343, 1344, 1346, 1347, 1349, 1351, 1352, 1354, 1355, 1356, 1358, 1360, 1362, 1363, 1364, 1366, 1368, 1370, 1372, 1373, 1374, 1375, 1376, 1377, 1379, 1380, 1381, 1383, 1384, 1385, 1386, 1387, 1388, 1390, 1391, 1392, 1394, 1396, 1398, 1400, 1402, 1403, 1404, 1406, 1408, 1409, 1410, 1411, 1413, 1414, 1415, 1416, 1417, 1418, 1420, 1421, 1422, 1423]
(10 rows)

```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
