### PR TITLE
refactor(common): eliminate `unsafe` for iteration with estimated sizes by atomics

### DIFF
--- a/src/common/src/estimate_size/collections/hashmap.rs
+++ b/src/common/src/estimate_size/collections/hashmap.rs
@@ -15,7 +15,7 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 
-use super::{MutGuard, UnsafeMutGuard};
+use super::{AtomicMutGuard, MutGuard};
 use crate::estimate_size::{EstimateSize, KvSize};
 
 pub struct EstimatedHashMap<K, V> {
@@ -63,10 +63,11 @@ where
             .map(|v| MutGuard::new(v, &mut self.heap_size))
     }
 
-    pub fn values_mut(&mut self) -> impl Iterator<Item = UnsafeMutGuard<V>> + '_ {
+    pub fn values_mut(&mut self) -> impl Iterator<Item = AtomicMutGuard<'_, V>> + '_ {
+        let heap_size = &self.heap_size;
         self.inner
             .values_mut()
-            .map(|v| UnsafeMutGuard::new(v, &mut self.heap_size))
+            .map(move |v| AtomicMutGuard::new(v, heap_size))
     }
 
     pub fn drain(&mut self) -> impl Iterator<Item = (K, V)> + '_ {

--- a/src/common/src/estimate_size/collections/lru.rs
+++ b/src/common/src/estimate_size/collections/lru.rs
@@ -18,7 +18,7 @@ use std::hash::{BuildHasher, Hash};
 
 use lru::{DefaultHasher, KeyRef, LruCache};
 
-use super::{MutGuard, UnsafeMutGuard};
+use super::{AtomicMutGuard, MutGuard};
 use crate::estimate_size::{EstimateSize, KvSize};
 
 /// The managed cache is a lru cache that bounds the memory usage by epoch.
@@ -64,17 +64,22 @@ impl<K: Hash + Eq + EstimateSize, V: EstimateSize, S: BuildHasher, A: Clone + Al
         v.map(|inner| MutGuard::new(inner, &mut self.kv_heap_size))
     }
 
-    pub fn get_mut_unsafe(&mut self, k: &K) -> Option<UnsafeMutGuard<V>> {
-        let v = self.inner.get_mut(k);
-        v.map(|inner| UnsafeMutGuard::new(inner, &mut self.kv_heap_size))
-    }
-
     pub fn get<Q>(&mut self, k: &Q) -> Option<&V>
     where
         KeyRef<K>: Borrow<Q>,
         Q: Hash + Eq + ?Sized,
     {
         self.inner.get(k)
+    }
+
+    pub fn iter_mut(
+        &mut self,
+    ) -> impl ExactSizeIterator<Item = (&'_ K, AtomicMutGuard<'_, V>)> + '_ {
+        let kv_heap_size = &self.kv_heap_size;
+        self.inner.iter_mut().map(move |(k, v)| {
+            let guard = AtomicMutGuard::new(v, kv_heap_size);
+            (k, guard)
+        })
     }
 
     pub fn peek_mut(&mut self, k: &K) -> Option<MutGuard<'_, V>> {

--- a/src/common/src/estimate_size/collections/mod.rs
+++ b/src/common/src/estimate_size/collections/mod.rs
@@ -27,10 +27,13 @@ pub use hashmap::EstimatedHashMap as HashMap;
 mod private {
     use super::*;
 
+    /// A trait that dispatches the size update method regarding the mutability of the reference
+    /// to the [`KvSize`].
     pub trait GenericKvSize {
         fn update_size(&mut self, from: usize, to: usize);
     }
 
+    /// For mutable references, the size can be directly updated.
     impl GenericKvSize for &'_ mut KvSize {
         fn update_size(&mut self, from: usize, to: usize) {
             self.add_size(to);
@@ -38,6 +41,7 @@ mod private {
         }
     }
 
+    /// For immutable references, the size is updated atomically.
     impl GenericKvSize for &'_ KvSize {
         fn update_size(&mut self, from: usize, to: usize) {
             self.update_size_atomic(from, to)
@@ -45,6 +49,8 @@ mod private {
     }
 }
 
+/// A guard holding a mutable reference to a value in a collection. When dropped, the size of the
+/// collection will be updated.
 pub struct MutGuard<'a, V, S = &'a mut KvSize>
 where
     V: EstimateSize,
@@ -57,6 +63,8 @@ where
     total_size: S,
 }
 
+/// Similar to [`MutGuard`], but the size is updated atomically. Useful for creating shared
+/// references to the entries in a collection.
 pub type AtomicMutGuard<'a, V> = MutGuard<'a, V, &'a KvSize>;
 
 impl<'a, V, S> MutGuard<'a, V, S>

--- a/src/common/src/estimate_size/collections/mod.rs
+++ b/src/common/src/estimate_size/collections/mod.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::ops::{Deref, DerefMut};
-use std::ptr::NonNull;
 
 use super::{EstimateSize, KvSize};
 
@@ -25,16 +24,47 @@ pub use vecdeque::EstimatedVecDeque as VecDeque;
 pub mod hashmap;
 pub use hashmap::EstimatedHashMap as HashMap;
 
-pub struct MutGuard<'a, V: EstimateSize> {
+mod private {
+    use super::*;
+
+    pub trait GenericKvSize {
+        fn update_size(&mut self, from: usize, to: usize);
+    }
+
+    impl GenericKvSize for &'_ mut KvSize {
+        fn update_size(&mut self, from: usize, to: usize) {
+            self.add_size(to);
+            self.sub_size(from);
+        }
+    }
+
+    impl GenericKvSize for &'_ KvSize {
+        fn update_size(&mut self, from: usize, to: usize) {
+            self.update_size_atomic(from, to)
+        }
+    }
+}
+
+pub struct MutGuard<'a, V, S = &'a mut KvSize>
+where
+    V: EstimateSize,
+    S: private::GenericKvSize,
+{
     inner: &'a mut V,
     // The size of the original value
     original_val_size: usize,
     // The total size of a collection
-    total_size: &'a mut KvSize,
+    total_size: S,
 }
 
-impl<'a, V: EstimateSize> MutGuard<'a, V> {
-    pub fn new(inner: &'a mut V, total_size: &'a mut KvSize) -> Self {
+pub type AtomicMutGuard<'a, V> = MutGuard<'a, V, &'a KvSize>;
+
+impl<'a, V, S> MutGuard<'a, V, S>
+where
+    V: EstimateSize,
+    S: private::GenericKvSize,
+{
+    pub fn new(inner: &'a mut V, total_size: S) -> Self {
         let original_val_size = inner.estimated_size();
         Self {
             inner,
@@ -44,14 +74,22 @@ impl<'a, V: EstimateSize> MutGuard<'a, V> {
     }
 }
 
-impl<'a, V: EstimateSize> Drop for MutGuard<'a, V> {
+impl<'a, V, S> Drop for MutGuard<'a, V, S>
+where
+    V: EstimateSize,
+    S: private::GenericKvSize,
+{
     fn drop(&mut self) {
-        self.total_size.add_size(self.inner.estimated_size());
-        self.total_size.sub_size(self.original_val_size);
+        self.total_size
+            .update_size(self.original_val_size, self.inner.estimated_size());
     }
 }
 
-impl<'a, V: EstimateSize> Deref for MutGuard<'a, V> {
+impl<'a, V, S> Deref for MutGuard<'a, V, S>
+where
+    V: EstimateSize,
+    S: private::GenericKvSize,
+{
     type Target = V;
 
     fn deref(&self) -> &Self::Target {
@@ -59,39 +97,12 @@ impl<'a, V: EstimateSize> Deref for MutGuard<'a, V> {
     }
 }
 
-impl<'a, V: EstimateSize> DerefMut for MutGuard<'a, V> {
+impl<'a, V, S> DerefMut for MutGuard<'a, V, S>
+where
+    V: EstimateSize,
+    S: private::GenericKvSize,
+{
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner
-    }
-}
-
-pub struct UnsafeMutGuard<V: EstimateSize> {
-    inner: NonNull<V>,
-    // The size of the original value
-    original_val_size: usize,
-    // The total size of a collection
-    total_size: NonNull<KvSize>,
-}
-
-impl<V: EstimateSize> UnsafeMutGuard<V> {
-    pub fn new(inner: &mut V, total_size: &mut KvSize) -> Self {
-        let original_val_size = inner.estimated_size();
-        Self {
-            inner: inner.into(),
-            original_val_size,
-            total_size: total_size.into(),
-        }
-    }
-
-    /// # Safety
-    ///
-    /// 1. Only 1 `MutGuard` should be held for each value.
-    /// 2. The returned `MutGuard` should not be moved to other threads.
-    pub unsafe fn as_mut_guard<'a>(&mut self) -> MutGuard<'a, V> {
-        MutGuard {
-            inner: self.inner.as_mut(),
-            original_val_size: self.original_val_size,
-            total_size: self.total_size.as_mut(),
-        }
     }
 }

--- a/src/common/src/estimate_size/mod.rs
+++ b/src/common/src/estimate_size/mod.rs
@@ -15,6 +15,7 @@
 pub mod collections;
 
 use std::marker::PhantomData;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use bytes::Bytes;
 use fixedbitset::FixedBitSet;
@@ -186,54 +187,66 @@ impl<T: EstimateSize> IntoIterator for VecWithKvSize<T> {
     }
 }
 
-#[derive(Default, Clone)]
-pub struct KvSize(usize);
+#[derive(Default)]
+pub struct KvSize(AtomicUsize);
+
+impl Clone for KvSize {
+    fn clone(&self) -> Self {
+        Self(self.size().into())
+    }
+}
 
 impl KvSize {
     pub fn new() -> Self {
-        Self(0)
+        Self(0.into())
     }
 
     pub fn with_size(size: usize) -> Self {
-        Self(size)
+        Self(size.into())
     }
 
     pub fn add<K: EstimateSize, V: EstimateSize>(&mut self, key: &K, val: &V) {
-        self.0 = self
-            .0
-            .saturating_add(key.estimated_size() + val.estimated_size());
+        self.add_size(key.estimated_size());
+        self.add_size(val.estimated_size());
     }
 
     pub fn sub<K: EstimateSize, V: EstimateSize>(&mut self, key: &K, val: &V) {
-        self.0 = self
-            .0
-            .saturating_sub(key.estimated_size() + val.estimated_size());
+        self.sub_size(key.estimated_size());
+        self.sub_size(val.estimated_size());
     }
 
     /// Add the size of `val` and return it.
     pub fn add_val<V: EstimateSize>(&mut self, val: &V) -> usize {
         let size = val.estimated_size();
-        self.0 = self.0.saturating_add(size);
+        self.add_size(size);
         size
     }
 
     pub fn sub_val<V: EstimateSize>(&mut self, val: &V) {
-        self.0 = self.0.saturating_sub(val.estimated_size());
+        self.sub_size(val.estimated_size());
     }
 
     pub fn add_size(&mut self, size: usize) {
-        self.0 += size;
+        let this = self.0.get_mut();
+        *this = this.saturating_add(size);
     }
 
     pub fn sub_size(&mut self, size: usize) {
-        self.0 -= size;
+        let this = self.0.get_mut();
+        *this = this.saturating_sub(size);
+    }
+
+    pub fn update_size_atomic(&self, from: usize, to: usize) {
+        let _ = (self.0).fetch_update(Ordering::Relaxed, Ordering::Relaxed, |this| {
+            Some(this.saturating_add(to).saturating_sub(from))
+        });
     }
 
     pub fn set(&mut self, size: usize) {
-        self.0 = size;
+        self.0 = size.into();
     }
 
     pub fn size(&self) -> usize {
-        self.0
+        self.0.load(Ordering::Relaxed)
     }
 }

--- a/src/stream/src/executor/hash_agg.rs
+++ b/src/stream/src/executor/hash_agg.rs
@@ -493,12 +493,7 @@ impl<K: HashKey, S: StateStore> HashAggExecutor<K, S> {
         } else {
             // emit on update
             // TODO(wrj,rc): we may need to parallelize it and set a reasonable concurrency limit.
-            for mut agg_group in vars
-                .dirty_groups
-                .values_mut()
-                // SAFETY: we access the values in `dirty_groups` one by one, so it's safe to deref the `UnsafeMutGuard`
-                .map(|mut g| unsafe { g.as_mut_guard() })
-            {
+            for mut agg_group in vars.dirty_groups.values_mut() {
                 let agg_group = agg_group.as_mut();
                 let change = agg_group
                     .build_change(&this.storages, &this.agg_funcs)


### PR DESCRIPTION
## What's changed and what's your intention?

See https://github.com/risingwavelabs/risingwave/pull/12453#discussion_r1335624855.

We introduced `MutGuard` for collections with estimated sizes in #9134, which holds a mutable reference to a value in a collection and will update the `total_size` of the collection after dropped. 

Everything worked well except for `iter_mut`, where we had to _split_ the mutable reference of the collection into multiple entries. While this is not an issue for the collection itself, it becomes problematic when trying to split the mutable reference to `total_size`, which is impossible (and certainly, unsafe) in Rust. So we further introduced `UnsafeMutGuard`, where callers had to manually turn it into a `MutGuard` before using it, based on the guarantee that there's no concurrent or parallel accessing.

To get rid of `unsafe`, this PR introduces `AtomicMutGuard`. By making the `total_size` an atomic value, we can safely access it without a mutable reference, **without hurting the original performance** since we can still directly access the underlying value with [`Atomic::get_mut`](https://doc.rust-lang.org/stable/std/sync/atomic/struct.AtomicUsize.html#method.get_mut) if we have a mutable reference!

## Checklist




- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
