### PR TITLE
feat: use seperated runtime for source manager

### DIFF
--- a/src/meta/src/rpc/election/mod.rs
+++ b/src/meta/src/rpc/election/mod.rs
@@ -14,9 +14,6 @@
 pub mod etcd;
 pub mod sql;
 
-use std::sync::Arc;
-
-use risingwave_common::util::runtime::BackgroundShutdownRuntime;
 use serde::Serialize;
 use tokio::sync::watch::Receiver;
 
@@ -38,8 +35,4 @@ pub trait ElectionClient: Send + Sync + 'static {
     async fn leader(&self) -> MetaResult<Option<ElectionMember>>;
     async fn get_members(&self) -> MetaResult<Vec<ElectionMember>>;
     async fn is_leader(&self) -> bool;
-
-    fn runtime_ref(&self) -> Option<Arc<BackgroundShutdownRuntime>> {
-        None
-    }
 }

--- a/src/meta/src/rpc/server.rs
+++ b/src/meta/src/rpc/server.rs
@@ -226,22 +226,14 @@ pub fn rpc_serve_with_store(
     let leader_lost_handle = if let Some(election_client) = election_client.clone() {
         let stop_rx = svc_shutdown_tx.subscribe();
 
-        let runtime_ref = election_client.runtime_ref();
-
-        let future = async move {
+        let handle = tokio::spawn(async move {
             while let Err(e) = election_client
                 .run_once(lease_interval_secs as i64, stop_rx.clone())
                 .await
             {
                 tracing::error!("election error happened, {}", e.to_string());
             }
-        };
-
-        let handle = if let Some(runtime) = runtime_ref {
-            runtime.spawn(future)
-        } else {
-            tokio::spawn(future)
-        };
+        });
 
         Some(handle)
     } else {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After testing, we found that a large number of enumerator operations after the source manager starts can affect Tokio’s scheduling. Therefore, we tried to put the source manager into a new runtime. Tests show this can resolve the issue of election timeouts during the startup process.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
