### PR TITLE
fix: allow configure message.timeout.ms and max.in.flight for kafka sink

### DIFF
--- a/integration_tests/kafka-cdc-sink/risingwave.sql
+++ b/integration_tests/kafka-cdc-sink/risingwave.sql
@@ -22,6 +22,5 @@ connector = 'kafka',
 properties.bootstrap.server='message_queue:29092',
 topic = 'counts',
 type = 'debezium',
-use_transaction = 'false',
 primary_key = 'id'
 );

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -80,7 +80,7 @@ enum CompressionCodec {
     Zstd,
 }
 
-/// See https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+/// See <https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md>
 /// for the detailed meaning of these librdkafka producer properties
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -150,7 +150,7 @@ pub struct RdKafkaPropertiesProducer {
         rename = "properties.message.timeout.ms",
         default = "_default_message_timeout_ms"
     )]
-    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde_as(as = "DisplayFromStr")]
     message_timeout_ms: usize,
 
     /// The maximum number of unacknowledged requests the client will send on a single connection before blocking.
@@ -158,7 +158,7 @@ pub struct RdKafkaPropertiesProducer {
         rename = "properties.max.in.flight.requests.per.connection",
         default = "_default_max_in_flight_requests_per_connection"
     )]
-    #[serde_as(as = "Option<DisplayFromStr>")]
+    #[serde_as(as = "DisplayFromStr")]
     max_in_flight_requests_per_connection: usize,
 }
 
@@ -375,7 +375,7 @@ pub struct KafkaSinkWriter {
 }
 
 impl KafkaSinkWriter {
-    pub async fn new(mut config: KafkaConfig, formatter: SinkFormatterImpl) -> Result<Self> {
+    pub async fn new(config: KafkaConfig, formatter: SinkFormatterImpl) -> Result<Self> {
         let inner: FutureProducer<PrivateLinkProducerContext> = {
             let mut c = ClientConfig::new();
 

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -66,7 +66,7 @@ const fn _default_message_timeout_ms() -> usize {
     5000
 }
 
-const fn _default_max_in_flight_requests_per_connection() -> uszie {
+const fn _default_max_in_flight_requests_per_connection() -> usize {
     5
 }
 

--- a/src/connector/src/sink/kafka.rs
+++ b/src/connector/src/sink/kafka.rs
@@ -50,10 +50,6 @@ use crate::{
 
 pub const KAFKA_SINK: &str = "kafka";
 
-const fn _default_timeout() -> Duration {
-    Duration::from_secs(5)
-}
-
 const fn _default_max_retries() -> u32 {
     3
 }
@@ -62,12 +58,16 @@ const fn _default_retry_backoff() -> Duration {
     Duration::from_millis(100)
 }
 
-const fn _default_use_transaction() -> bool {
+const fn _default_force_append_only() -> bool {
     false
 }
 
-const fn _default_force_append_only() -> bool {
-    false
+const fn _default_message_timeout_ms() -> usize {
+    5000
+}
+
+const fn _default_max_in_flight_requests_per_connection() -> uszie {
+    5
 }
 
 #[derive(Debug, Clone, PartialEq, Display, Serialize, Deserialize, EnumString)]
@@ -80,6 +80,8 @@ enum CompressionCodec {
     Zstd,
 }
 
+/// See https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md
+/// for the detailed meaning of these librdkafka producer properties
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RdKafkaPropertiesProducer {
@@ -140,6 +142,24 @@ pub struct RdKafkaPropertiesProducer {
     #[serde(rename = "properties.compression.codec")]
     #[serde_as(as = "Option<DisplayFromStr>")]
     compression_codec: Option<CompressionCodec>,
+
+    /// Produce message timeout.
+    /// This value is used to limits the time a produced message waits for
+    /// successful delivery (including retries).
+    #[serde(
+        rename = "properties.message.timeout.ms",
+        default = "_default_message_timeout_ms"
+    )]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    message_timeout_ms: usize,
+
+    /// The maximum number of unacknowledged requests the client will send on a single connection before blocking.
+    #[serde(
+        rename = "properties.max.in.flight.requests.per.connection",
+        default = "_default_max_in_flight_requests_per_connection"
+    )]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    max_in_flight_requests_per_connection: usize,
 }
 
 impl RdKafkaPropertiesProducer {
@@ -171,6 +191,11 @@ impl RdKafkaPropertiesProducer {
         if let Some(v) = &self.compression_codec {
             c.set("compression.codec", v.to_string());
         }
+        c.set("message.timeout.ms", self.message_timeout_ms.to_string());
+        c.set(
+            "max.in.flight.requests.per.connection",
+            self.max_in_flight_requests_per_connection.to_string(),
+        );
     }
 }
 
@@ -194,13 +219,6 @@ pub struct KafkaConfig {
     pub force_append_only: bool,
 
     #[serde(
-        rename = "properties.timeout",
-        default = "_default_timeout",
-        deserialize_with = "deserialize_duration_from_string"
-    )]
-    pub timeout: Duration,
-
-    #[serde(
         rename = "properties.retry.max",
         default = "_default_max_retries",
         deserialize_with = "deserialize_u32_from_string"
@@ -213,12 +231,6 @@ pub struct KafkaConfig {
         deserialize_with = "deserialize_duration_from_string"
     )]
     pub retry_interval: Duration,
-
-    #[serde(
-        default = "_default_use_transaction",
-        deserialize_with = "deserialize_bool_from_string"
-    )]
-    pub use_transaction: bool,
 
     /// We have parsed the primary key for an upsert kafka sink into a `usize` vector representing
     /// the indices of the pk columns in the frontend, so we simply store the primary key here
@@ -372,10 +384,7 @@ impl KafkaSinkWriter {
             config.set_client(&mut c);
 
             // ClientConfig configuration
-            c.set("bootstrap.servers", &config.common.brokers)
-                .set("message.timeout.ms", "5000");
-            // Note that we will not use transaction during sinking, thus set it to false
-            config.use_transaction = false;
+            c.set("bootstrap.servers", &config.common.brokers);
 
             // Create the producer context, will be used to create the producer
             let producer_ctx = PrivateLinkProducerContext::new(
@@ -598,6 +607,8 @@ mod test {
             "properties.batch.num.messages".to_string() => "114514".to_string(),
             "properties.batch.size".to_string() => "114514".to_string(),
             "properties.compression.codec".to_string() => "zstd".to_string(),
+            "properties.message.timeout.ms".to_string() => "114514".to_string(),
+            "properties.max.in.flight.requests.per.connection".to_string() => "114514".to_string(),
         };
         let c = KafkaConfig::from_hashmap(props).unwrap();
         assert_eq!(
@@ -607,6 +618,11 @@ mod test {
         assert_eq!(
             c.rdkafka_properties.compression_codec,
             Some(CompressionCodec::Zstd)
+        );
+        assert_eq!(c.rdkafka_properties.message_timeout_ms, 114514);
+        assert_eq!(
+            c.rdkafka_properties.max_in_flight_requests_per_connection,
+            114514
         );
 
         let props: HashMap<String, String> = hashmap! {
@@ -649,12 +665,10 @@ mod test {
             "topic".to_string() => "test".to_string(),
             "type".to_string() => "append-only".to_string(),
             "force_append_only".to_string() => "true".to_string(),
-            "use_transaction".to_string() => "False".to_string(),
             "properties.security.protocol".to_string() => "SASL".to_string(),
             "properties.sasl.mechanism".to_string() => "SASL".to_string(),
             "properties.sasl.username".to_string() => "test".to_string(),
             "properties.sasl.password".to_string() => "test".to_string(),
-            "properties.timeout".to_string() => "10s".to_string(),
             "properties.retry.max".to_string() => "20".to_string(),
             "properties.retry.interval".to_string() => "500ms".to_string(),
         };
@@ -663,8 +677,6 @@ mod test {
         assert_eq!(config.common.topic, "test");
         assert_eq!(config.r#type, "append-only");
         assert!(config.force_append_only);
-        assert!(!config.use_transaction);
-        assert_eq!(config.timeout, Duration::from_secs(10));
         assert_eq!(config.max_retry_num, 20);
         assert_eq!(config.retry_interval, Duration::from_millis(500));
 
@@ -677,8 +689,6 @@ mod test {
         };
         let config = KafkaConfig::from_hashmap(properties).unwrap();
         assert!(!config.force_append_only);
-        assert!(!config.use_transaction);
-        assert_eq!(config.timeout, Duration::from_secs(5));
         assert_eq!(config.max_retry_num, 3);
         assert_eq!(config.retry_interval, Duration::from_millis(100));
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Expose `message.timeout.ms` and `max.in.flight.requests.per.connection` for kafka sink.
- Change the default `max.in.flight.requests.per.connection` to 5, which is recommended in the [confluent doc](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#max-in-flight-requests-per-connection). Note that the [previous default](https://github.com/confluentinc/librdkafka/blob/32747f5eb7aea23d79d31bcd56747dd5aa694d72/src/rdkafka_conf.c#L436) set by librdkafka is `1000000`, which is not reasonable since it will create excessive produce requests that can potentially overload kafka broker and may cause a large number of duplicates on network blips.
- Remove unused kafka sink option `timeout` and `use_transaction`

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

- Expose `message.timeout.ms` and `max.in.flight.requests.per.connection` for kafka sink.
- Change the default `max.in.flight.requests.per.connection` to 5.

See [here](https://docs.confluent.io/platform/current/installation/configuration/producer-configs.html#search-by-configuration-property-name) for the meaning of these kafka client configs.