### PR TITLE
fix: unify `varchar` format_type display with PostgreSQL

### DIFF
--- a/src/common/src/types/mod.rs
+++ b/src/common/src/types/mod.rs
@@ -122,7 +122,7 @@ pub enum DataType {
     #[display("date")]
     #[from_str(regex = "(?i)^date$")]
     Date,
-    #[display("varchar")]
+    #[display("character varying")]
     #[from_str(regex = "(?i)^varchar$")]
     Varchar,
     #[display("time without time zone")]


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Make format type printing of RisingWave consistent with PostgreSQL.
The original purpose of this PR is to fix the problem that the `varchar` type in superset cannot be recognized.

superset uses sqlalchemy as the ORM, and the different format type from PostgreSQL makes the type unrecognizable to sqlalchemy.

The inconsistencies are:
```sql
SELECT format_type(1043, '-1');
```
result of RisingWave: `varchar`; of PostgreSQL: `character varying`.

SqlAlchemy test:
```sql
CREATE TABLE test (a int, b varchar);
```

```python
from sqlalchemy import create_engine
from sqlalchemy import inspect

def main():
    # engine = create_engine("postgresql://jinser:pssswd@localhost:5432/playground") # PostgreSQL
    engine = create_engine("postgresql://root@localhost:4566/dev") # RisingWave
    inspector = inspect(engine)

    columns = inspector.get_columns("test", "public")
    for column in columns:
        print(column)
```

related #9938.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
