### PR TITLE
fix(storage): handle delete range in same epoch as write

### DIFF
--- a/src/storage/src/hummock/sstable/block.rs
+++ b/src/storage/src/hummock/sstable/block.rs
@@ -473,13 +473,8 @@ impl BlockBuilder {
             debug_assert_eq!(
                 KeyComparator::compare_encoded_full_key(&self.last_key[..], &key[..]),
                 Ordering::Less,
-                "epoch: {}, table key: {}",
-                full_key.epoch,
-                u64::from_be_bytes(
-                    full_key.user_key.table_key.as_ref()[0..8]
-                        .try_into()
-                        .unwrap()
-                ),
+                "key: {:?}",
+                full_key
             );
         }
         // Update restart point if needed and calculate diff key.

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -291,3 +291,81 @@ async fn test_sink_decouple_basic() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_sink_decouple_blackhole() -> Result<()> {
+    let config_path = {
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(include_bytes!("../../../../../config/ci-sim.toml"))
+            .expect("failed to write config file");
+        file.into_temp_path()
+    };
+
+    let mut cluster = Cluster::start(Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 3,
+        meta_nodes: 1,
+        compactor_nodes: 1,
+        compute_node_cores: 2,
+        etcd_timeout_rate: 0.0,
+        etcd_data_path: None,
+    })
+    .await?;
+
+    let source_parallelism = 12;
+    let mut txs = Vec::new();
+    let mut rxs = Vec::new();
+    for _ in 0..source_parallelism {
+        let (tx, rx): (_, UnboundedReceiver<StreamChunk>) = unbounded_channel();
+        txs.push(tx);
+        rxs.push(Some(rx));
+    }
+
+    let _source_guard = registry_test_source(BoxSource::new(
+        move |_, _| {
+            Ok((0..source_parallelism)
+                .map(|i: usize| TestSourceSplit {
+                    id: format!("{}", i).as_str().into(),
+                    properties: Default::default(),
+                    offset: "".to_string(),
+                })
+                .collect_vec())
+        },
+        move |_, splits, _, _, _| {
+            select_all(splits.into_iter().map(|split| {
+                let id: usize = split.id.parse().unwrap();
+                let rx = rxs[id].take().unwrap();
+                UnboundedReceiverStream::new(rx).map(|chunk| Ok(StreamChunkWithState::from(chunk)))
+            }))
+            .boxed()
+        },
+    ));
+
+    let mut session = cluster.start_session();
+
+    session.run("set streaming_parallelism = 6").await?;
+    session.run("set sink_decouple = true").await?;
+    session
+        .run("create table test_table (id int primary key, name varchar) with (connector = 'test') FORMAT PLAIN ENCODE JSON")
+        .await?;
+    session
+        .run("create sink test_sink from test_table with (connector = 'blackhole')")
+        .await?;
+
+    let mut count = 0;
+    let mut id_list = (0..100000).collect_vec();
+    id_list.shuffle(&mut rand::thread_rng());
+    let flush_freq = 50;
+    for id in &id_list[0..10000] {
+        let chunk = build_stream_chunk(once((*id as i32, format!("name-{}", id))));
+        txs[id % source_parallelism].send(chunk).unwrap();
+        count += 1;
+        if count % flush_freq == 0 {
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    session.run("drop sink test_sink").await?;
+    Ok(())
+}


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix https://github.com/risingwavelabs/risingwave/issues/12650

Currently in the code of compaction runner and imm merge, we introduce an assumption that `iter_key.epoch < del_iter.earliest_delete_since(iter_key.epoch)` in a `debug_assert`. However, `del_iter.earliest_delete_since(iter_key.epoch)` returns an epoch that is `>= iter_key.epoch`. Therefore, the `debug_assert` depends on the assumption that the `==` case will never happen, which means that delete range will not delete a key written in the same epoch. However, in log store, we will write the log item to storage when the buffer is full, and after the log item is consumed by the sink, it will truncate the log with a range delete, and both operation happen in the same epoch, which breaks the assumption.

In this PR, we change our code to handle the case when the epoch of iter key is the same as the delete range. Previous when `iter_key.epoch < del_iter.earliest_delete_since(iter_key.epoch)`, it writes an extra delete in the epoch of the range delete. In this PR, in the new case that `iter_key.epoch == del_iter.earliest_delete_since(iter_key.epoch)`, we turn the insert to `HummockValue::Delete` anyway.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
