### PR TITLE
refactor(common): refine `Row` changes in #11070

### DIFF
--- a/src/common/src/row/project.rs
+++ b/src/common/src/row/project.rs
@@ -78,9 +78,7 @@ impl<'i, R: Row> Project<'i, R> {
 
 impl<R: Row> Hash for Project<'_, R> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        for i in 0..self.len() {
-            self.datum_at(i).hash(state);
-        }
+        self.hash_datums_into(state);
     }
 }
 


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

**_Hide the whitespaces to review this PR._**

- Make `RowRef` and `RowRefIter` defined in a private module to ensure `unsafe` soundness.
- Introduce `Row::hash_into_datums` to ensure consistency between `std::hash::Hash` implementations.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
