### PR TITLE
fix(stream): yield upstream updates for backfill after last barrier in the interval

### DIFF
--- a/src/stream/src/executor/backfill/no_shuffle_backfill.rs
+++ b/src/stream/src/executor/backfill/no_shuffle_backfill.rs
@@ -348,14 +348,6 @@ where
                                                 ])
                                                 .inc_by(cur_barrier_snapshot_processed_rows);
 
-                                            self.metrics
-                                                .backfill_upstream_output_row_count
-                                                .with_label_values(&[
-                                                    upstream_table_id.to_string().as_str(),
-                                                    self.actor_id.to_string().as_str(),
-                                                ])
-                                                .inc_by(cur_barrier_upstream_processed_rows);
-
                                             // Update snapshot read epoch.
                                             snapshot_read_epoch = barrier.epoch.prev;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow up of #12644 .

For backfill spanning N >= 2 barriers, we must make sure not to drop updates until the start of the next interval.
That could happen currently, if the update record's PK is larger than the current backfill position.
If that happens, the update gets dropped, even though we may read its snapshot record within the barriers.

This also means now more memory will be used, since we buffer it all the way until the first barrier of the next interval, and if there are heavy updates incoming during backfill, we could contribute to oom.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
