### PR TITLE
feat(connector): structural logging for parsing error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7238,6 +7238,7 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tracing",
+ "tracing-futures",
  "url",
  "urlencoding",
  "workspace-hack",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7307,6 +7307,7 @@ dependencies = [
  "tonic 0.9.2",
  "tracing",
  "tracing-futures",
+ "tracing-test",
  "url",
  "urlencoding",
  "workspace-hack",

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -141,6 +141,7 @@ criterion = { workspace = true, features = ["async_tokio", "async"] }
 prost-types = "0.12"
 rand = "0.8"
 tempfile = "3"
+tracing-test = "0.2"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/src/connector/Cargo.toml
+++ b/src/connector/Cargo.toml
@@ -122,6 +122,7 @@ tokio-stream = "0.1"
 tokio-util = { version = "0.7", features = ["codec", "io"] }
 tonic = { workspace = true }
 tracing = "0.1"
+tracing-futures = { version = "0.2", features = ["futures-03"] }
 url = "2"
 urlencoding = "2"
 

--- a/src/connector/src/parser/csv_parser.rs
+++ b/src/connector/src/parser/csv_parser.rs
@@ -12,22 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::str::FromStr;
-
-use anyhow::anyhow;
-use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
+use risingwave_common::error::ErrorCode::ProtocolError;
 use risingwave_common::error::{ErrorCode, Result, RwError};
-use risingwave_common::types::{Date, Datum, Decimal, ScalarImpl, Time, Timestamp, Timestamptz};
+use risingwave_common::types::{Date, Decimal, Time, Timestamp, Timestamptz};
 
+use super::unified::{AccessError, AccessResult};
 use super::{ByteStreamSourceParser, CsvProperties};
 use crate::only_parse_payload;
 use crate::parser::SourceStreamChunkRowWriter;
 use crate::source::{DataType, SourceColumnDesc, SourceContext, SourceContextRef};
 
-macro_rules! to_rust_type {
+macro_rules! parse {
     ($v:ident, $t:ty) => {
-        $v.parse::<$t>()
-            .map_err(|_| anyhow!("failed parse {} from {}", stringify!($t), $v))?
+        $v.parse::<$t>().map_err(|_| AccessError::TypeError {
+            expected: stringify!($t).to_owned(),
+            got: "string".to_owned(),
+            value: $v.to_string(),
+        })
     };
 }
 
@@ -74,29 +75,26 @@ impl CsvParser {
     }
 
     #[inline]
-    fn parse_string(dtype: &DataType, v: String) -> Result<Datum> {
+    fn parse_string(dtype: &DataType, v: String) -> AccessResult {
         let v = match dtype {
             // mysql use tinyint to represent boolean
-            DataType::Boolean => ScalarImpl::Bool(to_rust_type!(v, i16) != 0),
-            DataType::Int16 => ScalarImpl::Int16(to_rust_type!(v, i16)),
-            DataType::Int32 => ScalarImpl::Int32(to_rust_type!(v, i32)),
-            DataType::Int64 => ScalarImpl::Int64(to_rust_type!(v, i64)),
-            DataType::Float32 => ScalarImpl::Float32(to_rust_type!(v, f32).into()),
-            DataType::Float64 => ScalarImpl::Float64(to_rust_type!(v, f64).into()),
+            DataType::Boolean => (parse!(v, i16)? != 0).into(),
+            DataType::Int16 => parse!(v, i16)?.into(),
+            DataType::Int32 => parse!(v, i32)?.into(),
+            DataType::Int64 => parse!(v, i64)?.into(),
+            DataType::Float32 => parse!(v, f32)?.into(),
+            DataType::Float64 => parse!(v, f64)?.into(),
             // FIXME: decimal should have more precision than f64
-            DataType::Decimal => Decimal::from_str(v.as_str())
-                .map_err(|_| anyhow!("parse decimal from string err {}", v))?
-                .into(),
+            DataType::Decimal => parse!(v, Decimal)?.into(),
             DataType::Varchar => v.into(),
-            DataType::Date => ScalarImpl::Date(to_rust_type!(v, Date)),
-            DataType::Time => ScalarImpl::Time(to_rust_type!(v, Time)),
-            DataType::Timestamp => ScalarImpl::Timestamp(to_rust_type!(v, Timestamp)),
-            DataType::Timestamptz => ScalarImpl::Timestamptz(to_rust_type!(v, Timestamptz)),
+            DataType::Date => parse!(v, Date)?.into(),
+            DataType::Time => parse!(v, Time)?.into(),
+            DataType::Timestamp => parse!(v, Timestamp)?.into(),
+            DataType::Timestamptz => parse!(v, Timestamptz)?.into(),
             _ => {
-                return Err(RwError::from(InternalError(format!(
-                    "CSV data source not support type {}",
-                    dtype
-                ))))
+                return Err(AccessError::UnsupportedType {
+                    ty: dtype.to_string(),
+                })
             }
         };
         Ok(Some(v))
@@ -109,12 +107,12 @@ impl CsvParser {
         mut writer: SourceStreamChunkRowWriter<'_>,
     ) -> Result<()> {
         let mut fields = self.read_row(&payload)?;
+
         if let Some(headers) = &mut self.headers {
             if headers.is_empty() {
                 *headers = fields;
-                // Here we want a row, but got nothing. So it's an error for the `parse_inner` but
-                // has no bad impact on the system.
-                return Err(RwError::from(ProtocolError("This message indicates a header, no row will be inserted. However, internal parser state was updated.".to_string())));
+                // The header row does not output a row, so we return early.
+                return Ok(());
             }
             writer.insert(|desc| {
                 if let Some(i) = headers.iter().position(|name| name == &desc.name) {
@@ -126,7 +124,7 @@ impl CsvParser {
                 } else {
                     Ok(None)
                 }
-            })
+            })?;
         } else {
             fields.reverse();
             writer.insert(|desc| {
@@ -138,8 +136,10 @@ impl CsvParser {
                 } else {
                     Ok(None)
                 }
-            })
+            })?;
         }
+
+        Ok(())
     }
 }
 

--- a/src/connector/src/parser/debezium/debezium_parser.rs
+++ b/src/connector/src/parser/debezium/debezium_parser.rs
@@ -111,7 +111,7 @@ impl DebeziumParser {
                 if let Ok(transaction_control) = row_op.transaction_control() {
                     Ok(ParseResult::TransactionControl(transaction_control))
                 } else {
-                    Err(err)
+                    Err(err)?
                 }
             }
         }

--- a/src/connector/src/parser/debezium/mongo_json_parser.rs
+++ b/src/connector/src/parser/debezium/mongo_json_parser.rs
@@ -99,7 +99,7 @@ impl DebeziumMongoJsonParser {
 
         let row_op = DebeziumChangeEvent::with_value(MongoProjection::new(accessor));
 
-        apply_row_operation_on_stream_chunk_writer(row_op, &mut writer)
+        apply_row_operation_on_stream_chunk_writer(row_op, &mut writer).map_err(Into::into)
     }
 }
 

--- a/src/connector/src/parser/debezium/simd_json_parser.rs
+++ b/src/connector/src/parser/debezium/simd_json_parser.rs
@@ -447,6 +447,7 @@ mod tests {
             assert_json_eq(&row[12], "{\"k1\": \"v1_updated\", \"k2\": 33}");
         }
 
+        #[cfg(not(madsim))] // Traced test does not work with madsim
         #[tokio::test]
         #[tracing_test::traced_test]
         async fn test2_debezium_json_parser_overflow() {

--- a/src/connector/src/parser/maxwell/maxwell_parser.rs
+++ b/src/connector/src/parser/maxwell/maxwell_parser.rs
@@ -61,7 +61,7 @@ impl MaxwellParser {
         let payload_accessor = self.payload_builder.generate_accessor(payload).await?;
         let row_op = MaxwellChangeEvent::new(payload_accessor);
 
-        apply_row_operation_on_stream_chunk_writer(row_op, &mut writer)
+        apply_row_operation_on_stream_chunk_writer(row_op, &mut writer).map_err(Into::into)
     }
 }
 

--- a/src/connector/src/parser/mod.rs
+++ b/src/connector/src/parser/mod.rs
@@ -512,9 +512,13 @@ async fn into_chunk_stream<P: ByteStreamSourceParser>(mut parser: P, data_stream
             if msg.key.is_none() && msg.payload.is_none() {
                 continue;
             }
-            split_offset_mapping.insert(msg.split_id, msg.offset.clone());
+            let parse_span = tracing::info_span!(
+                "parse_one",
+                split_id = msg.split_id.as_ref(),
+                offset = msg.offset
+            );
 
-            let parse_span = tracing::info_span!("parse_one", offset = msg.offset);
+            split_offset_mapping.insert(msg.split_id, msg.offset.clone());
 
             let old_op_num = builder.op_num();
             match parser

--- a/src/connector/src/parser/plain_parser.rs
+++ b/src/connector/src/parser/plain_parser.rs
@@ -62,7 +62,7 @@ impl PlainParser {
     ) -> Result<()> {
         let accessor = self.payload_builder.generate_accessor(payload).await?;
 
-        apply_row_accessor_on_stream_chunk_writer(accessor, &mut writer)
+        apply_row_accessor_on_stream_chunk_writer(accessor, &mut writer).map_err(Into::into)
     }
 }
 

--- a/src/connector/src/parser/unified/mod.rs
+++ b/src/connector/src/parser/unified/mod.rs
@@ -32,7 +32,7 @@ pub mod protobuf;
 pub mod upsert;
 pub mod util;
 
-pub type AccessResult = std::result::Result<Datum, AccessError>;
+pub type AccessResult<T = Datum> = std::result::Result<T, AccessError>;
 
 /// Access a certain field in an object according to the path
 pub trait Access {
@@ -87,14 +87,16 @@ where
 
 #[derive(Error, Debug)]
 pub enum AccessError {
-    #[error("Undefined {name} at {path}")]
+    #[error("Undefined field `{name}` at `{path}`")]
     Undefined { name: String, path: String },
-    #[error("TypeError {expected} expected, got {got} {value}")]
+    #[error("Expected type `{expected}` but got `{got}` for `{value}`")]
     TypeError {
         expected: String,
         got: String,
         value: String,
     },
+    #[error("Unsupported data type `{ty}`")]
+    UnsupportedType { ty: String },
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/src/connector/src/parser/unified/util.rs
+++ b/src/connector/src/parser/unified/util.rs
@@ -37,7 +37,8 @@ pub fn apply_delete_on_stream_chunk_writer(
                 }
             }
         }
-    })
+    })?;
+    Ok(())
 }
 
 pub fn apply_upsert_on_stream_chunk_writer(
@@ -62,7 +63,8 @@ pub fn apply_upsert_on_stream_chunk_writer(
             res
         );
         Ok(res?)
-    })
+    })?;
+    Ok(())
 }
 
 pub fn apply_row_operation_on_stream_chunk_writer_with_op(
@@ -89,9 +91,7 @@ pub fn apply_row_accessor_on_stream_chunk_writer(
     writer: &mut SourceStreamChunkRowWriter<'_>,
 ) -> Result<(), RwError> {
     writer.insert(|column| {
-        let res: Result<Datum, RwError> = match accessor
-            .access(&[&column.name], Some(&column.data_type))
-        {
+        let res = match accessor.access(&[&column.name], Some(&column.data_type)) {
             Ok(o) => Ok(o),
             Err(AccessError::Undefined { name, .. }) if !column.is_pk && name == column.name => {
                 // Fill in null value for non-pk column
@@ -117,7 +117,8 @@ pub fn apply_row_accessor_on_stream_chunk_writer(
             res
         );
         res
-    })
+    })?;
+    Ok(())
 }
 
 impl From<AccessError> for RwError {

--- a/src/connector/src/parser/unified/util.rs
+++ b/src/connector/src/parser/unified/util.rs
@@ -13,75 +13,28 @@
 // limitations under the License.
 
 use risingwave_common::error::{ErrorCode, RwError};
-use risingwave_common::types::Datum;
 
-use super::{Access, AccessError, ChangeEvent};
+use super::{Access, AccessError, AccessResult, ChangeEvent};
 use crate::parser::unified::ChangeEventOperation;
 use crate::parser::SourceStreamChunkRowWriter;
-
-pub fn apply_delete_on_stream_chunk_writer(
-    row_op: impl ChangeEvent,
-    writer: &mut SourceStreamChunkRowWriter<'_>,
-) -> std::result::Result<(), RwError> {
-    writer.delete(|column| {
-        let res = row_op.access_field(&column.name, &column.data_type);
-        match res {
-            Ok(datum) => Ok(datum),
-            Err(e) => {
-                tracing::error!(name=column.name, data_type=%column.data_type, err=%e, "delete column error");
-                if column.is_pk {
-                    // It should be an error when pk column is missing in the message
-                    Err(e)?
-                } else {
-                    Ok(None)
-                }
-            }
-        }
-    })?;
-    Ok(())
-}
-
-pub fn apply_upsert_on_stream_chunk_writer(
-    row_op: impl ChangeEvent,
-    writer: &mut SourceStreamChunkRowWriter<'_>,
-) -> std::result::Result<(), RwError> {
-    writer.insert(|column| {
-        let res = match row_op.access_field(&column.name, &column.data_type) {
-            Ok(o) => Ok(o),
-            Err(AccessError::Undefined { name, .. }) if !column.is_pk && name == column.name => {
-                // Fill in null value for non-pk column
-                // TODO: figure out a way to fill in not-null default value if user specifies one
-                Ok(None)
-            }
-            Err(e) => Err(e),
-        };
-        tracing::trace!(
-            "inserted {:?} {:?} is_pk:{:?} {:?} ",
-            &column.name,
-            &column.data_type,
-            &column.is_pk,
-            res
-        );
-        Ok(res?)
-    })?;
-    Ok(())
-}
+use crate::source::SourceColumnDesc;
 
 pub fn apply_row_operation_on_stream_chunk_writer_with_op(
     row_op: impl ChangeEvent,
     writer: &mut SourceStreamChunkRowWriter<'_>,
     op: ChangeEventOperation,
-) -> std::result::Result<(), RwError> {
+) -> AccessResult<()> {
+    let f = |column: &SourceColumnDesc| row_op.access_field(&column.name, &column.data_type);
     match op {
-        ChangeEventOperation::Upsert => apply_upsert_on_stream_chunk_writer(row_op, writer),
-        ChangeEventOperation::Delete => apply_delete_on_stream_chunk_writer(row_op, writer),
+        ChangeEventOperation::Upsert => writer.insert(f),
+        ChangeEventOperation::Delete => writer.delete(f),
     }
 }
 
 pub fn apply_row_operation_on_stream_chunk_writer(
     row_op: impl ChangeEvent,
     writer: &mut SourceStreamChunkRowWriter<'_>,
-) -> std::result::Result<(), RwError> {
+) -> AccessResult<()> {
     let op = row_op.op()?;
     apply_row_operation_on_stream_chunk_writer_with_op(row_op, writer, op)
 }
@@ -89,36 +42,8 @@ pub fn apply_row_operation_on_stream_chunk_writer(
 pub fn apply_row_accessor_on_stream_chunk_writer(
     accessor: impl Access,
     writer: &mut SourceStreamChunkRowWriter<'_>,
-) -> Result<(), RwError> {
-    writer.insert(|column| {
-        let res = match accessor.access(&[&column.name], Some(&column.data_type)) {
-            Ok(o) => Ok(o),
-            Err(AccessError::Undefined { name, .. }) if !column.is_pk && name == column.name => {
-                // Fill in null value for non-pk column
-                // TODO: figure out a way to fill in not-null default value if user specifies one
-                Ok(None)
-            }
-            Err(e) => {
-                // if want to discard the row, return Err(e) here
-                tracing::warn!(
-                    "access error when fetch {} with type {}, err {:?}. Fill None instead.",
-                    &column.name,
-                    &column.data_type,
-                    e
-                );
-                Ok(None)
-            }
-        };
-        tracing::trace!(
-            "inserted {:?} {:?} is_pk:{:?} {:?} ",
-            &column.name,
-            &column.data_type,
-            &column.is_pk,
-            res
-        );
-        res
-    })?;
-    Ok(())
+) -> AccessResult<()> {
+    writer.insert(|column| accessor.access(&[&column.name], Some(&column.data_type)))
 }
 
 impl From<AccessError> for RwError {

--- a/src/connector/src/parser/upsert_parser.rs
+++ b/src/connector/src/parser/upsert_parser.rs
@@ -117,6 +117,7 @@ impl UpsertParser {
         }
 
         apply_row_operation_on_stream_chunk_writer_with_op(row_op, &mut writer, change_event_op)
+            .map_err(Into::into)
     }
 }
 

--- a/src/meta/src/barrier/mod.rs
+++ b/src/meta/src/barrier/mod.rs
@@ -688,9 +688,7 @@ impl GlobalBarrierManager {
         };
 
         // Tracing related stuff
-        prev_epoch.span().in_scope(|| {
-            tracing::info!(target: "rw_tracing", epoch = curr_epoch.value().0, "new barrier enqueued");
-        });
+        tracing::info!(target: "rw_tracing", parent: prev_epoch.span(), epoch = curr_epoch.value().0, "new barrier enqueued");
         span.record("epoch", curr_epoch.value().0);
 
         let command_ctx = Arc::new(CommandContext::new(


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

See #12366 for the background.

The error-handling path in the connector parser is kind of complicated, and users often complain about the confusion of the behavior when parsing a message fails. We've had some attempts before (like #10454). In this PR, we further unify the error handling strategy and code path, then provide tracing observability on that.

Specifically,
- To write a record to the chunk builder, the only way is through `SourceStreamChunkRowWriter`. Based on a similar idea to #12542, we can also unify the error handling to the `do_action` method. This means that parser implementors don't have to care about error handling anymore.
- Follows the convention that **whoever consumes the error is responsible for logging it**. So there'll be redundant error messages in the log.
- Provide tracing spans for the parsing procedure, and log the errors in a structural way.

Take the logs for plain JSON parser as an example:

- If the message itself is an invalid JSON, an error will be produced at the very first step of parsing into a `json::Value` before any calling to `Writer::{insert|delete|update}`. Therefore, the error will be thrown and lead to the whole message being skipped. 
```
2023-10-08T12:01:38.612275+08:00 ERROR 
actor{otel.name="Actor 4" actor_id=4 prev_epoch=5210273369423872 curr_epoch=5210273377091584}:..:
executor{otel.name="SourceExecutor 40000273C (actor 4)" actor_id=4}:
source_parser{actor_id=4 source_id=1001}:
parse_one{offset="0"}: 
risingwave_connector::parser: failed to parse message, skipping 
error=Protocol error: ExpectedObjectContent at character 1 ('v')
```

- If the message is valid, while some (non-primary key) fields are missing or in the wrong types, the error will be logged as a warning and ignored in `Writer`.
```
2023-10-08T12:04:15.503359+08:00  WARN 
actor{otel.name="Actor 4" actor_id=4 prev_epoch=5210273369423872 curr_epoch=5210273377091584}:..:
executor{otel.name="SourceExecutor 40000273C (actor 4)" actor_id=4}:
source_parser{actor_id=4 source_id=1001}:
parse_one{offset="2"}: 
risingwave_connector::parser: failed to parse non-pk column, padding with `NULL` 
error=Expected type `Some(Int32)` but got `string` for `bbbb` 
column="v1"
```

As a result, we may instruct users to filter the logs with the target `risingwave_connector::parser` and `source_id`s to inspect the messages that are failed to parse.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
