### PR TITLE
fix(sqlsmith): recover functions for sqlsmith

### DIFF
--- a/src/tests/sqlsmith/src/bin/main.rs
+++ b/src/tests/sqlsmith/src/bin/main.rs
@@ -20,8 +20,6 @@ use risingwave_sqlsmith::print_function_table;
 use risingwave_sqlsmith::runner::{generate, run, run_differential_testing};
 use tokio_postgres::NoTls;
 
-risingwave_expr_impl::enable!();
-
 #[derive(ClapParser, Debug, Clone)]
 #[clap(about, version, author)]
 struct Opt {

--- a/src/tests/sqlsmith/src/lib.rs
+++ b/src/tests/sqlsmith/src/lib.rs
@@ -17,6 +17,8 @@
 #![feature(lazy_cell)]
 #![feature(box_patterns)]
 
+risingwave_expr_impl::enable!();
+
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Result};


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

fix #12577

This bug was introduced by #12485, where we separated function implementations into the new `expr_impl` crate, but it was not linked into the sqlsmith(test) target. So when running cargo-test for sqlsmith, it can't find any functions. 🥲

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))
