### PR TITLE
test(regress): enable regex testcases

### DIFF
--- a/src/tests/regress/data/schedule
+++ b/src/tests/regress/data/schedule
@@ -11,3 +11,4 @@ test: boolean varchar text int2 int4 int8 float4 float8 comments
 test: strings date time timestamp interval
 test: case arrays
 test: jsonb
+test: regex

--- a/src/tests/regress/data/sql/regex.sql
+++ b/src/tests/regress/data/sql/regex.sql
@@ -21,16 +21,16 @@ select 'abc abd abc' ~ '^(.+)( \1)+$' as f;
 select 'abc abc abd' ~ '^(.+)( \1)+$' as f;
 
 -- Test some cases that crashed in 9.2beta1 due to pmatch[] array overrun
-select substring('asd TO foo' from ' TO (([a-z0-9._]+|"([^"]+|"")+")+)');
-select substring('a' from '((a))+');
-select substring('a' from '((a)+)');
+--@ select substring('asd TO foo' from ' TO (([a-z0-9._]+|"([^"]+|"")+")+)');
+--@ select substring('a' from '((a))+');
+--@ select substring('a' from '((a)+)');
 
 -- Test regexp_match()
 select regexp_match('abc', '');
 select regexp_match('abc', 'bc');
 select regexp_match('abc', 'd') is null;
 select regexp_match('abc', '(B)(c)', 'i');
-select regexp_match('abc', 'Bd', 'ig'); -- error
+--@ select regexp_match('abc', 'Bd', 'ig'); -- error
 
 -- Test lookahead constraints
 select regexp_matches('ab', 'a(?=b)b*');
@@ -47,7 +47,7 @@ select regexp_matches('abb', '(?<=a)b*');
 select regexp_matches('a', 'a(?<=a)b*');
 select regexp_matches('abc', 'a(?<=a)b*(?<=b)c*');
 select regexp_matches('ab', 'a(?<=a)b*(?<=b)c*');
-select regexp_matches('ab', 'a*(?<!a)b*');
+--@ select regexp_matches('ab', 'a*(?<!a)b*');
 select regexp_matches('ab', 'a*(?<!a)b+');
 select regexp_matches('b', 'a*(?<!a)b+');
 select regexp_matches('a', 'a(?<!a)b*');
@@ -68,15 +68,15 @@ select 'xyy' ~ '(?<![xy])yy+';
 select 'zyy' ~ '(?<![xy])yy+';
 
 -- Test conversion of regex patterns to indexable conditions
-explain (costs off) select * from pg_proc where proname ~ 'abc';
-explain (costs off) select * from pg_proc where proname ~ '^abc';
-explain (costs off) select * from pg_proc where proname ~ '^abc$';
-explain (costs off) select * from pg_proc where proname ~ '^abcd*e';
-explain (costs off) select * from pg_proc where proname ~ '^abc+d';
-explain (costs off) select * from pg_proc where proname ~ '^(abc)(def)';
-explain (costs off) select * from pg_proc where proname ~ '^(abc)$';
-explain (costs off) select * from pg_proc where proname ~ '^(abc)?d';
-explain (costs off) select * from pg_proc where proname ~ '^abcd(x|(?=\w\w)q)';
+--@ explain (costs off) select * from pg_proc where proname ~ 'abc';
+--@ explain (costs off) select * from pg_proc where proname ~ '^abc';
+--@ explain (costs off) select * from pg_proc where proname ~ '^abc$';
+--@ explain (costs off) select * from pg_proc where proname ~ '^abcd*e';
+--@ explain (costs off) select * from pg_proc where proname ~ '^abc+d';
+--@ explain (costs off) select * from pg_proc where proname ~ '^(abc)(def)';
+--@ explain (costs off) select * from pg_proc where proname ~ '^(abc)$';
+--@ explain (costs off) select * from pg_proc where proname ~ '^(abc)?d';
+--@ explain (costs off) select * from pg_proc where proname ~ '^abcd(x|(?=\w\w)q)';
 
 -- Test for infinite loop in pullback() (CVE-2007-4772)
 select 'a' ~ '($|^)*';
@@ -99,15 +99,15 @@ select 'a' ~ '((((((a)*)*)*)*)*)*';
 select 'a' ~ '((((((a+|)+|)+|)+|)+|)+|)';
 
 -- These cases used to give too-many-states failures
-select 'x' ~ 'abcd(\m)+xyz';
-select 'a' ~ '^abcd*(((((^(a c(e?d)a+|)+|)+|)+|)+|a)+|)';
-select 'x' ~ 'a^(^)bcd*xy(((((($a+|)+|)+|)+$|)+|)+|)^$';
-select 'x' ~ 'xyz(\Y\Y)+';
-select 'x' ~ 'x|(?:\M)+';
+--@ select 'x' ~ 'abcd(\m)+xyz';
+--@ select 'a' ~ '^abcd*(((((^(a c(e?d)a+|)+|)+|)+|)+|a)+|)';
+--@ select 'x' ~ 'a^(^)bcd*xy(((((($a+|)+|)+|)+$|)+|)+|)^$';
+--@ select 'x' ~ 'xyz(\Y\Y)+';
+--@ select 'x' ~ 'x|(?:\M)+';
 
 -- This generates O(N) states but O(N^2) arcs, so it causes problems
 -- if arc count is not constrained
-select 'x' ~ repeat('x*y*z*', 1000);
+--@ select 'x' ~ repeat('x*y*z*', 1000);
 
 -- Test backref in combination with non-greedy quantifier
 -- https://core.tcl.tk/tcl/tktview/6585b21ca8fa6f3678d442b97241fdd43dba2ec0
@@ -121,29 +121,29 @@ select regexp_matches('foo/bar/baz',
 -- Test that greediness can be overridden by outer quantifier
 select regexp_matches('llmmmfff', '^(l*)(.*)(f*)$');
 select regexp_matches('llmmmfff', '^(l*){1,1}(.*)(f*)$');
-select regexp_matches('llmmmfff', '^(l*){1,1}?(.*)(f*)$');
-select regexp_matches('llmmmfff', '^(l*){1,1}?(.*){1,1}?(f*)$');
+--@ select regexp_matches('llmmmfff', '^(l*){1,1}?(.*)(f*)$');
+--@ select regexp_matches('llmmmfff', '^(l*){1,1}?(.*){1,1}?(f*)$');
 select regexp_matches('llmmmfff', '^(l*?)(.*)(f*)$');
-select regexp_matches('llmmmfff', '^(l*?){1,1}(.*)(f*)$');
+--@ select regexp_matches('llmmmfff', '^(l*?){1,1}(.*)(f*)$');
 select regexp_matches('llmmmfff', '^(l*?){1,1}?(.*)(f*)$');
-select regexp_matches('llmmmfff', '^(l*?){1,1}?(.*){1,1}?(f*)$');
+--@ select regexp_matches('llmmmfff', '^(l*?){1,1}?(.*){1,1}?(f*)$');
 
 -- Test for infinite loop in cfindloop with zero-length possible match
 -- but no actual match (can only happen in the presence of backrefs)
-select 'a' ~ '$()|^\1';
+--@ select 'a' ~ '$()|^\1';
 select 'a' ~ '.. ()|\1';
-select 'a' ~ '()*\1';
-select 'a' ~ '()+\1';
+--@ select 'a' ~ '()*\1';
+--@ select 'a' ~ '()+\1';
 
 -- Add coverage for some cases in checkmatchall
 select regexp_match('xy', '.|...');
-select regexp_match('xyz', '.|...');
+--@ select regexp_match('xyz', '.|...');
 select regexp_match('xy', '.*');
 select regexp_match('fooba', '(?:..)*');
 select regexp_match('xyz', repeat('.', 260));
 select regexp_match('foo', '(?:.|){99}');
 
 -- Error conditions
-select 'xyz' ~ 'x(\w)(?=\1)';  -- no backrefs in LACONs
-select 'xyz' ~ 'x(\w)(?=(\1))';
-select 'a' ~ '\x7fffffff';  -- invalid chr code
+--@ select 'xyz' ~ 'x(\w)(?=\1)';  -- no backrefs in LACONs
+--@ select 'xyz' ~ 'x(\w)(?=(\1))';
+--@ select 'a' ~ '\x7fffffff';  -- invalid chr code


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

After #12329 , we support more regex features in postgresql, so we enable the testcases.


## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
