### PR TITLE
feat: support impure `DEFAULT` expressions for columns

### DIFF
--- a/e2e_test/batch/basic/table_with_default_columns.slt.part
+++ b/e2e_test/batch/basic/table_with_default_columns.slt.part
@@ -72,11 +72,45 @@ select * from t2;
 1 2
 2 2
 
-statement error db error: ERROR: QueryError: Bind error: impure default expr is not supported.
-create table tt (v1 time default now());
+# `now()` as default value
+statement ok
+alter table t2 add column v3 timestamp with time zone default now();
 
-statement error db error: ERROR: QueryError: Bind error: impure default expr is not supported.
-alter table t2 add column v3 timestamptz default now();
+query IT
+select v1, v3 >= date '2021-01-01' as later_than_2021 from t2;
+----
+1 t
+2 t
+
+# `now()` filled for historical data should be the same
+query II
+select max(v1), count(*) from t2 group by v3 order by v3;
+----
+2 2
+
+statement ok
+flush;
+
+statement ok
+insert into t2 values (3);
+
+# Newly inserted record should have a later timestamp
+query II
+select max(v1), count(*) from t2 group by v3 order by v3;
+----
+2 2
+3 1
+
+# Historical data can be correctly updated
+statement ok
+update t2 set v3 = '2000-01-01 00:00:00+00:00' where v1 = 1;
+
+query II
+select max(v1), count(*) from t2 group by v3 order by v3;
+----
+1 1
+2 1
+3 1
 
 statement ok
 drop table t1;

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -49,7 +49,11 @@ message GeneratedColumnDesc {
 }
 
 message DefaultColumnDesc {
+  // Expression of the `DEFAULT`. Used when inserting new records.
   expr.ExprNode expr = 1;
+  // Evaluated value of the expression at the time of the table creation or the
+  // column addition. Used when filling the default value for the records where
+  // the column is missing.
   data.Datum snapshot_value = 2;
 }
 

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -50,6 +50,7 @@ message GeneratedColumnDesc {
 
 message DefaultColumnDesc {
   expr.ExprNode expr = 1;
+  data.Datum snapshot_value = 2;
 }
 
 message StorageTableDesc {

--- a/src/frontend/src/catalog/table_catalog.rs
+++ b/src/frontend/src/catalog/table_catalog.rs
@@ -429,23 +429,20 @@ impl TableCatalog {
     }
 
     pub fn default_columns(&self) -> impl Iterator<Item = (usize, ExprImpl)> + '_ {
-        self.columns
-            .iter()
-            .enumerate()
-            .filter(|(_, c)| c.is_default())
-            .map(|(i, c)| {
-                if let GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc { expr }) =
-                    c.column_desc.generated_or_default_column.clone().unwrap()
-                {
-                    (
-                        i,
-                        ExprImpl::from_expr_proto(&expr.unwrap())
-                            .expect("expr in default columns corrupted"),
-                    )
-                } else {
-                    unreachable!()
-                }
-            })
+        self.columns.iter().enumerate().filter_map(|(i, c)| {
+            if let Some(GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc {
+                expr, ..
+            })) = c.column_desc.generated_or_default_column.as_ref()
+            {
+                Some((
+                    i,
+                    ExprImpl::from_expr_proto(expr.as_ref().unwrap())
+                        .expect("expr in default columns corrupted"),
+                ))
+            } else {
+                None
+            }
+        })
     }
 
     pub fn has_generated_column(&self) -> bool {

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -323,7 +323,13 @@ impl ExprImpl {
         if self.is_const() {
             self.eval_row(&OwnedRow::empty())
                 .now_or_never()
-                .expect("constant expression should not be async")
+                .unwrap_or_else(|| {
+                    // TODO: error type
+                    Err(ErrorCode::ExprError(
+                        anyhow::anyhow!("constant expression should not be async").into(),
+                    )
+                    .into())
+                })
                 .into()
         } else {
             None

--- a/src/frontend/src/expr/mod.rs
+++ b/src/frontend/src/expr/mod.rs
@@ -323,13 +323,7 @@ impl ExprImpl {
         if self.is_const() {
             self.eval_row(&OwnedRow::empty())
                 .now_or_never()
-                .unwrap_or_else(|| {
-                    // TODO: error type
-                    Err(ErrorCode::ExprError(
-                        anyhow::anyhow!("constant expression should not be async").into(),
-                    )
-                    .into())
-                })
+                .expect("constant expression should not be async")
                 .into()
         } else {
             None

--- a/src/storage/src/row_serde/value_serde.rs
+++ b/src/storage/src/row_serde/value_serde.rs
@@ -27,8 +27,8 @@ use risingwave_common::util::value_encoding::column_aware_row_encoding::{
 };
 use risingwave_common::util::value_encoding::error::ValueEncodingError;
 use risingwave_common::util::value_encoding::{
-    BasicSerde, BasicSerializer, EitherSerde, ValueRowDeserializer, ValueRowSerdeKind,
-    ValueRowSerializer,
+    BasicSerde, BasicSerializer, DatumFromProtoExt, EitherSerde, ValueRowDeserializer,
+    ValueRowSerdeKind, ValueRowSerializer,
 };
 use risingwave_expr::expr::build_from_prost;
 use risingwave_pb::plan_common::column_desc::GeneratedOrDefaultColumn;
@@ -98,21 +98,27 @@ impl ValueRowSerdeNew for ColumnAwareSerde {
         }
 
         let column_with_default = table_columns.iter().enumerate().filter_map(|(i, c)| {
-            if c.is_default() {
-                if let GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc { expr }) =
-                    c.generated_or_default_column.clone().unwrap()
-                {
-                    Some((
-                        i,
-                        build_from_prost(&expr.expect("expr should not be none"))
-                            .expect("build_from_prost error")
-                            .eval_row_infallible(&OwnedRow::empty())
-                            .now_or_never()
-                            .expect("constant expression should not be async"),
-                    ))
+            if let Some(GeneratedOrDefaultColumn::DefaultColumn(DefaultColumnDesc {
+                snapshot_value,
+                expr,
+            })) = c.generated_or_default_column.clone()
+            {
+                // TODO: may not panic on error
+                let value = if let Some(snapshot_value) = snapshot_value {
+                    // If there's a `snapshot_value`, we can use it directly.
+                    Datum::from_protobuf(&snapshot_value, &c.data_type)
+                        .expect("invalid default value")
                 } else {
-                    unreachable!()
-                }
+                    // For backward compatibility, default columns in old tables may not have `snapshot_value`.
+                    // In this case, we need to evaluate the expression to get the default value.
+                    // It's okay since we previously banned impure expressions in default columns.
+                    build_from_prost(&expr.expect("expr should not be none"))
+                        .expect("build_from_prost error")
+                        .eval_row_infallible(&OwnedRow::empty())
+                        .now_or_never()
+                        .expect("constant expression should not be async")
+                };
+                Some((i, value))
             } else {
                 None
             }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?


Add a `snapshot_value` field to the `DefaultColumnDesc`, which is the evaluation result of the default expression at the time when it's created or added with `ALTER TABLE`. The column-aware serde will now directly use this `snapshot_value` instead of evaluating the expression every time.

This has no effect on pure expressions, but matters for the correctness of `ALTER TABLE ADD COLUMN now()`: Historical data will have the same default value of `snapshot_value`, while newly inserted records will fill in the current timestamp by evaluating `now()` in the `BatchInsert` executor. This follows the behavior of PostgreSQL.

Close #11021 

### Why we banned it before

Note that there's no way to evaluate `NOW` in the backend, but its protobuf variant still exists for persisting the default expressions. Previously we always built and evaluated the expression in column-aware serde, which leads to failure if users specify `NOW` as the default expressions.

### Limitations

Suppose we've supported `RAND`, then the default value for historical data will be the same due to using the snapshot value, which is inconsistent with PostgreSQL. This is a limitation of Instant DDL itself.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
