### PR TITLE
fix(log-store): avoid truncate storage data written in the same epoch

### DIFF
--- a/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/buffer.rs
@@ -57,7 +57,7 @@ struct LogStoreBufferInner {
     stream_chunk_count: usize,
     max_stream_chunk_count: usize,
 
-    updated_truncation: Option<ReaderTruncationOffsetType>,
+    truncation_list: VecDeque<ReaderTruncationOffsetType>,
 
     next_chunk_id: ChunkId,
 }
@@ -246,13 +246,11 @@ impl LogStoreBufferSender {
 
     pub(crate) fn pop_truncation(&self, curr_epoch: u64) -> Option<ReaderTruncationOffsetType> {
         let mut inner = self.buffer.inner();
-        if let Some((ref epoch, _)) = &inner.updated_truncation {
-            assert!(*epoch <= curr_epoch);
-            if *epoch < curr_epoch {
-                return inner.updated_truncation.take();
-            }
+        let mut ret = None;
+        while let Some((epoch, _)) = inner.truncation_list.front() && *epoch < curr_epoch {
+            ret = inner.truncation_list.pop_front();
         }
-        None
+        ret
     }
 
     pub(crate) fn flush_all_unflushed(
@@ -377,8 +375,12 @@ impl LogStoreBufferReceiver {
                 }
             }
         }
-        if let Some(offset) = latest_offset {
-            inner.updated_truncation = Some(offset);
+        if let Some((epoch, seq_id)) = latest_offset {
+            if let Some((prev_epoch, ref mut prev_seq_id)) = inner.truncation_list.back_mut() && *prev_epoch == epoch {
+                *prev_seq_id = seq_id;
+            } else {
+                inner.truncation_list.push_back((epoch, seq_id));
+            }
         }
     }
 }
@@ -391,7 +393,7 @@ pub(crate) fn new_log_store_buffer(
         consumed_queue: VecDeque::new(),
         stream_chunk_count: 0,
         max_stream_chunk_count,
-        updated_truncation: None,
+        truncation_list: VecDeque::new(),
         next_chunk_id: 0,
     });
     let update_notify = Arc::new(Notify::new());

--- a/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
+++ b/src/stream/src/common/log_store_impl/kv_log_store/writer.rs
@@ -119,7 +119,7 @@ impl<LS: LocalStateStore> LogWriter for KvLogStoreWriter<LS> {
                 Ok(())
             })?;
         let mut delete_range = Vec::with_capacity(self.serde.vnodes().count_ones());
-        if let Some(truncation_offset) = self.tx.pop_truncation() {
+        if let Some(truncation_offset) = self.tx.pop_truncation(epoch) {
             for vnode in self.serde.vnodes().iter_vnodes() {
                 let range_begin = Bytes::from(vnode.to_be_bytes().to_vec());
                 let range_end = self

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -291,3 +291,81 @@ async fn test_sink_decouple_basic() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn test_sink_decouple_blackhole() -> Result<()> {
+    let config_path = {
+        let mut file = tempfile::NamedTempFile::new().expect("failed to create temp config file");
+        file.write_all(include_bytes!("../../../../../config/ci-sim.toml"))
+            .expect("failed to write config file");
+        file.into_temp_path()
+    };
+
+    let mut cluster = Cluster::start(Configuration {
+        config_path: ConfigPath::Temp(config_path.into()),
+        frontend_nodes: 1,
+        compute_nodes: 3,
+        meta_nodes: 1,
+        compactor_nodes: 1,
+        compute_node_cores: 2,
+        etcd_timeout_rate: 0.0,
+        etcd_data_path: None,
+    })
+        .await?;
+
+    let source_parallelism = 12;
+    let mut txs = Vec::new();
+    let mut rxs = Vec::new();
+    for _ in 0..source_parallelism {
+        let (tx, rx): (_, UnboundedReceiver<StreamChunk>) = unbounded_channel();
+        txs.push(tx);
+        rxs.push(Some(rx));
+    }
+
+    let _source_guard = registry_test_source(BoxSource::new(
+        move |_, _| {
+            Ok((0..source_parallelism)
+                .map(|i: usize| TestSourceSplit {
+                    id: format!("{}", i).as_str().into(),
+                    properties: Default::default(),
+                    offset: "".to_string(),
+                })
+                .collect_vec())
+        },
+        move |_, splits, _, _, _| {
+            select_all(splits.into_iter().map(|split| {
+                let id: usize = split.id.parse().unwrap();
+                let rx = rxs[id].take().unwrap();
+                UnboundedReceiverStream::new(rx).map(|chunk| Ok(StreamChunkWithState::from(chunk)))
+            }))
+                .boxed()
+        },
+    ));
+
+    let mut session = cluster.start_session();
+
+    session.run("set streaming_parallelism = 6").await?;
+    session.run("set sink_decouple = true").await?;
+    session
+        .run("create table test_table (id int primary key, name varchar) with (connector = 'test') FORMAT PLAIN ENCODE JSON")
+        .await?;
+    session
+        .run("create sink test_sink from test_table with (connector = 'blackhole')")
+        .await?;
+
+    let mut count = 0;
+    let mut id_list = (0..100000).collect_vec();
+    id_list.shuffle(&mut rand::thread_rng());
+    let flush_freq = 50;
+    for id in &id_list[0..10000] {
+        let chunk = build_stream_chunk(once((*id as i32, format!("name-{}", id))));
+        txs[id % source_parallelism].send(chunk).unwrap();
+        count += 1;
+        if count % flush_freq == 0 {
+            sleep(Duration::from_millis(10)).await;
+        }
+    }
+
+    session.run("drop sink test_sink").await?;
+    Ok(())
+}

--- a/src/tests/simulation/tests/integration_tests/sink/basic.rs
+++ b/src/tests/simulation/tests/integration_tests/sink/basic.rs
@@ -311,7 +311,7 @@ async fn test_sink_decouple_blackhole() -> Result<()> {
         etcd_timeout_rate: 0.0,
         etcd_data_path: None,
     })
-        .await?;
+    .await?;
 
     let source_parallelism = 12;
     let mut txs = Vec::new();
@@ -338,7 +338,7 @@ async fn test_sink_decouple_blackhole() -> Result<()> {
                 let rx = rxs[id].take().unwrap();
                 UnboundedReceiverStream::new(rx).map(|chunk| Ok(StreamChunkWithState::from(chunk)))
             }))
-                .boxed()
+            .boxed()
         },
     ));
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix https://github.com/risingwavelabs/risingwave/issues/12650

Current storage implementation has an assumption that a key inserted in an epoch cannot be range-deleted in the same epoch. Therefore, in this PR we will not do range delete to storage if the current truncate offset has the same epoch as the current epoch. The data will be truncated in the next epoch instead.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
