### PR TITLE
feat(stream): support tombstone row as backfill position

### DIFF
--- a/src/storage/hummock_trace/src/opts.rs
+++ b/src/storage/hummock_trace/src/opts.rs
@@ -88,6 +88,7 @@ pub struct TracedReadOptions {
     pub retention_seconds: Option<u32>,
     pub table_id: TracedTableId,
     pub read_version_from_backup: bool,
+    pub with_tombstone: bool,
 }
 
 impl TracedReadOptions {
@@ -100,6 +101,7 @@ impl TracedReadOptions {
             retention_seconds: None,
             table_id: TracedTableId { table_id },
             read_version_from_backup: true,
+            with_tombstone: false,
         }
     }
 }

--- a/src/storage/src/hummock/iterator/forward_user.rs
+++ b/src/storage/src/hummock/iterator/forward_user.rs
@@ -310,6 +310,7 @@ impl<I: HummockIterator<Direction = Forward>> UserIterator<I> {
             min_epoch,
             None,
             ForwardMergeRangeIterator::new(read_epoch),
+            false,
         )
     }
 }

--- a/src/storage/src/hummock/store/version.rs
+++ b/src/storage/src/hummock/store/version.rs
@@ -922,6 +922,7 @@ impl HummockVersionReader {
             min_epoch,
             Some(committed),
             delete_range_iter,
+            read_options.with_tombstone,
         );
         user_iter
             .rewind()

--- a/src/storage/src/store.rs
+++ b/src/storage/src/store.rs
@@ -317,6 +317,7 @@ pub struct ReadOptions {
     /// Read from historical hummock version of meta snapshot backup.
     /// It should only be used by `StorageTable` for batch query.
     pub read_version_from_backup: bool,
+    pub with_tombstone: bool,
 }
 
 impl From<TracedReadOptions> for ReadOptions {
@@ -329,6 +330,7 @@ impl From<TracedReadOptions> for ReadOptions {
             retention_seconds: value.retention_seconds,
             table_id: value.table_id.into(),
             read_version_from_backup: value.read_version_from_backup,
+            with_tombstone: value.with_tombstone,
         }
     }
 }
@@ -343,6 +345,7 @@ impl From<ReadOptions> for TracedReadOptions {
             retention_seconds: value.retention_seconds,
             table_id: value.table_id.into(),
             read_version_from_backup: value.read_version_from_backup,
+            with_tombstone: value.with_tombstone,
         }
     }
 }

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -758,11 +758,6 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInnerIterInner<S, SD> {
             .verbose_instrument_await("storage_table_iter_next")
             .await?
         {
-            let full_row = self.row_deserializer.deserialize(&value)?;
-            let result_row_in_value = self
-                .mapping
-                .project(OwnedRow::new(full_row))
-                .into_owned_row();
             match &self.key_output_indices {
                 Some(key_output_indices) => {
                     let result_row_in_key = match self.pk_serializer.clone() {
@@ -785,6 +780,11 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInnerIterInner<S, SD> {
 
                         yield KeyedRow::new_tombstone(table_key, result_row_in_key);
                     } else {
+                        let full_row = self.row_deserializer.deserialize(&value)?;
+                        let result_row_in_value = self
+                            .mapping
+                            .project(OwnedRow::new(full_row))
+                            .into_owned_row();
                         let mut result_row_vec = vec![];
                         for idx in &self.output_indices {
                             if self.value_output_indices.contains(idx) {

--- a/src/storage/src/table/batch_table/storage_table.rs
+++ b/src/storage/src/table/batch_table/storage_table.rs
@@ -648,7 +648,7 @@ impl<S: StateStore, SD: ValueRowSerde> StorageTableInner<S, SD> {
 
     /// Construct a [`StorageTableInnerIter`] for batch executors.
     /// Differs from the streaming one, this iterator will wait for the epoch before iteration
-    pub async fn iter_tombstone_with_pk_bounds(
+    pub async fn batch_iter_with_tombstone(
         &self,
         epoch: HummockReadEpoch,
         pk_prefix: impl Row,

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -248,6 +248,14 @@ impl<T: AsRef<[u8]>> KeyedRow<T> {
         }
     }
 
+    pub fn new_tombstone(table_key: TableKey<T>, row: OwnedRow) -> Self {
+        Self {
+            vnode_prefixed_key: table_key,
+            row,
+            is_tombstone: true,
+        }
+    }
+
     pub fn into_owned_row(self) -> OwnedRow {
         self.row
     }

--- a/src/storage/src/table/mod.rs
+++ b/src/storage/src/table/mod.rs
@@ -209,6 +209,7 @@ fn check_vnode_is_set(vnode: VirtualNode, vnodes: &Bitmap) {
 pub struct KeyedRow<T: AsRef<[u8]>> {
     vnode_prefixed_key: TableKey<T>,
     row: OwnedRow,
+    is_tombstone: bool,
 }
 
 impl<T: AsRef<[u8]>> KeyedRow<T> {
@@ -216,6 +217,7 @@ impl<T: AsRef<[u8]>> KeyedRow<T> {
         Self {
             vnode_prefixed_key: table_key,
             row,
+            is_tombstone: false,
         }
     }
 

--- a/src/stream/src/common/table/state_table.rs
+++ b/src/stream/src/common/table/state_table.rs
@@ -1149,6 +1149,7 @@ where
             read_version_from_backup: false,
             prefetch_options,
             cache_policy: CachePolicy::Fill(CachePriority::High),
+            ..Default::default()
         };
         let table_key_range = map_table_key_range(key_range);
 
@@ -1285,6 +1286,7 @@ where
             read_version_from_backup: false,
             prefetch_options: Default::default(),
             cache_policy: CachePolicy::Fill(CachePriority::High),
+            ..Default::default()
         };
 
         self.local_store

--- a/src/tests/compaction_test/src/delete_range_runner.rs
+++ b/src/tests/compaction_test/src/delete_range_runner.rs
@@ -425,13 +425,10 @@ impl NormalState {
             .get(
                 TableKey(Bytes::copy_from_slice(key)),
                 ReadOptions {
-                    prefix_hint: None,
                     ignore_range_tombstone,
-                    retention_seconds: None,
                     table_id: self.table_id,
-                    read_version_from_backup: false,
-                    prefetch_options: Default::default(),
                     cache_policy: CachePolicy::Fill(CachePriority::High),
+                    ..Default::default()
                 },
             )
             .await
@@ -452,13 +449,11 @@ impl NormalState {
                     Bound::Excluded(TableKey(Bytes::copy_from_slice(right))),
                 ),
                 ReadOptions {
-                    prefix_hint: None,
                     ignore_range_tombstone,
-                    retention_seconds: None,
                     table_id: self.table_id,
-                    read_version_from_backup: false,
                     prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
                     cache_policy: CachePolicy::Fill(CachePriority::High),
+                    ..Default::default()
                 },
             )
             .await
@@ -491,6 +486,7 @@ impl CheckState for NormalState {
                         read_version_from_backup: false,
                         prefetch_options: PrefetchOptions::new_for_exhaust_iter(),
                         cache_policy: CachePolicy::Fill(CachePriority::High),
+                        ..Default::default()
                     },
                 )
                 .await


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

https://github.com/risingwavelabs/risingwave/issues/12680

Currently when backfill attempts to `store_create_iter` for its `snapshot_read`, it could stall, if the leading rows are tombstones.

This PR makes the backfill aware of tombstone rows, so it can use them when computing its current_position.

Backfill will now receive tombstone rows for state store's iterator. Then, it will maintain a separate single-row buffer for the latest tombstone row.
At the end of the epoch, it will compare this row to the latest row from non-tombstone rows. If this row has a higher pk, it will use it as its current_pos.

We separate it from the collected chunks, since tombstone rows shouldn't be yielded downstream. Setting visibility to invisible for tombstone rows is also an option, but it makes the cardinality of the chunk large, and could lead to OOM.

In all, now tombstone rows can also occupy the current_pos, but won't be yielded downstream.

This makes sure that in the scenario that the current epoch has long runs of tombstone rows, in the next epoch, we can resume progress from the last tombstone row, instead of starting from scratch, as is currently the case.

In terms of correctness, since tombstone rows are treated as current_pos, at the end of the epoch, updates which are BEFORE the current_pos will still get flushed downstream.
As such, although these updates are not included in the next snapshot_read (since it will only read records AFTER current_pos), they will be included, since the previous epoch still flushes them downstream.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
