### PR TITLE
fix(streaming): handle pause on bootstrap for `Now` and `Values`

### DIFF
--- a/e2e_test/batch/transaction/now.slt
+++ b/e2e_test/batch/transaction/now.slt
@@ -1,5 +1,3 @@
-# Disabled, see https://github.com/risingwavelabs/risingwave/issues/10887
-
 statement ok
 create table t (ts timestamp);
 

--- a/src/stream/src/executor/mod.rs
+++ b/src/stream/src/executor/mod.rs
@@ -332,13 +332,7 @@ impl Barrier {
         }
     }
 
-    /// Whether this barrier is for configuration change. Used for source executor initialization.
-    pub fn is_update(&self) -> bool {
-        matches!(self.mutation.as_deref(), Some(Mutation::Update { .. }))
-    }
-
-    /// Whether this barrier is for resume. Used for now executor to determine whether to yield a
-    /// chunk and a watermark before this barrier.
+    /// Whether this barrier is for resume.
     pub fn is_resume(&self) -> bool {
         matches!(self.mutation.as_deref(), Some(Mutation::Resume))
     }

--- a/src/stream/src/executor/now.rs
+++ b/src/stream/src/executor/now.rs
@@ -90,6 +90,7 @@ impl<S: StateStore> NowExecutor<S> {
                     }
                 };
                 last_timestamp = state_row.and_then(|row| row[0].clone());
+                paused = barrier.is_pause_on_startup();
                 initialized = true;
             } else if paused {
                 // Assert that no data is updated.
@@ -104,7 +105,7 @@ impl<S: StateStore> NowExecutor<S> {
             // Update paused state.
             if let Some(mutation) = barrier.mutation.as_deref() {
                 match mutation {
-                    Mutation::Pause | Mutation::Update { .. } => paused = true,
+                    Mutation::Pause => paused = true,
                     Mutation::Resume => paused = false,
                     _ => {}
                 }

--- a/src/stream/src/executor/values.rs
+++ b/src/stream/src/executor/values.rs
@@ -25,8 +25,8 @@ use risingwave_expr::expr::BoxedExpression;
 use tokio::sync::mpsc::UnboundedReceiver;
 
 use super::{
-    ActorContextRef, Barrier, BoxedMessageStream, Executor, Message, Mutation, PkIndices,
-    PkIndicesRef, StreamExecutorError,
+    ActorContextRef, Barrier, BoxedMessageStream, Executor, Message, PkIndices, PkIndicesRef,
+    StreamExecutorError,
 };
 use crate::task::CreateMviewProgress;
 

--- a/src/tests/simulation/src/cluster.rs
+++ b/src/tests/simulation/src/cluster.rs
@@ -655,6 +655,12 @@ impl Session {
         self.query_tx.send((sql.into(), tx)).await?;
         rx.await?
     }
+
+    /// Run `FLUSH` on the session.
+    pub async fn flush(&mut self) -> Result<()> {
+        self.run("FLUSH").await?;
+        Ok(())
+    }
 }
 
 /// Options for killing nodes.

--- a/src/tests/simulation/tests/integration_tests/recovery/pause_on_bootstrap.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/pause_on_bootstrap.rs
@@ -29,10 +29,11 @@ enum ResumeBy {
 
 impl ResumeBy {
     async fn resume(&self, cluster: &mut Cluster) -> Result<()> {
-        Ok(match self {
+        match self {
             ResumeBy::Risectl => cluster.resume().await?,
             ResumeBy::Restart => cluster.kill_nodes(["meta-1"], 0).await,
-        })
+        };
+        Ok(())
     }
 }
 

--- a/src/tests/simulation/tests/integration_tests/recovery/pause_on_bootstrap.rs
+++ b/src/tests/simulation/tests/integration_tests/recovery/pause_on_bootstrap.rs
@@ -15,20 +15,10 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use risingwave_simulation::cluster::Configuration;
+use risingwave_simulation::cluster::{Cluster, Configuration};
 use risingwave_simulation::nexmark::NexmarkCluster;
 use risingwave_simulation::utils::AssertResult;
 use tokio::time::{sleep, timeout};
-
-const CREATE_TABLE: &str = "CREATE TABLE t (v int)";
-const INSERT_INTO_TABLE: &str = "INSERT INTO t VALUES (1)";
-const SELECT_COUNT_TABLE: &str = "SELECT COUNT(*) FROM t";
-
-const CREATE: &str = "CREATE MATERIALIZED VIEW count_bid as SELECT COUNT(*) FROM bid";
-const SELECT: &str = "SELECT * FROM count_bid";
-
-const CREATE_2: &str = "CREATE MATERIALIZED VIEW count_auction as SELECT COUNT(*) FROM auction";
-const SELECT_2: &str = "SELECT * FROM count_auction";
 
 const SET_PARAMETER: &str = "ALTER SYSTEM SET pause_on_next_bootstrap TO true";
 
@@ -37,7 +27,29 @@ enum ResumeBy {
     Restart,
 }
 
+impl ResumeBy {
+    async fn resume(&self, cluster: &mut Cluster) -> Result<()> {
+        Ok(match self {
+            ResumeBy::Risectl => cluster.resume().await?,
+            ResumeBy::Restart => cluster.kill_nodes(["meta-1"], 0).await,
+        })
+    }
+}
+
 async fn test_impl(resume_by: ResumeBy) -> Result<()> {
+    const CREATE_TABLE: &str = "CREATE TABLE t (v int)";
+    const INSERT_INTO_TABLE: &str = "INSERT INTO t VALUES (1)";
+    const SELECT_COUNT_TABLE: &str = "SELECT COUNT(*) FROM t";
+
+    const CREATE: &str = "CREATE MATERIALIZED VIEW count_bid as SELECT COUNT(*) FROM bid";
+    const SELECT: &str = "SELECT * FROM count_bid";
+
+    const CREATE_2: &str = "CREATE MATERIALIZED VIEW count_auction as SELECT COUNT(*) FROM auction";
+    const SELECT_2: &str = "SELECT * FROM count_auction";
+
+    const CREATE_3: &str = "CREATE MATERIALIZED VIEW values as VALUES (1), (2), (3)";
+    const SELECT_3: &str = "SELECT count(*) FROM values";
+
     let mut cluster = NexmarkCluster::new(
         Configuration {
             meta_nodes: 1,
@@ -77,18 +89,19 @@ async fn test_impl(resume_by: ResumeBy) -> Result<()> {
     // New streaming jobs should also start from paused.
     cluster.run(CREATE_2).await?;
     sleep(Duration::from_secs(10)).await;
-    cluster.run(SELECT_2).await?.assert_result_eq("0"); // even there's no data from source, the
+    cluster.run(SELECT_2).await?.assert_result_eq("0"); // even there's no data from source, the aggregation
                                                         // result will be 0 instead of empty or NULL
+    cluster.run(CREATE_3).await?;
+    sleep(Duration::from_secs(10)).await;
+    cluster.run(SELECT_3).await?.assert_result_eq("0"); // `VALUES` should be paused
 
     // DML on tables should be blocked.
     let result = timeout(Duration::from_secs(10), cluster.run(INSERT_INTO_TABLE)).await;
     assert!(result.is_err());
     cluster.run(SELECT_COUNT_TABLE).await?.assert_result_eq("0");
 
-    match resume_by {
-        ResumeBy::Risectl => cluster.resume().await?,
-        ResumeBy::Restart => cluster.kill_nodes(["meta-1"], 0).await,
-    }
+    // Resume the cluster.
+    resume_by.resume(&mut cluster).await?;
     sleep(Duration::from_secs(10)).await;
 
     // The source should be resumed.
@@ -122,4 +135,65 @@ async fn test_pause_on_bootstrap_resume_by_risectl() -> Result<()> {
 #[tokio::test]
 async fn test_pause_on_bootstrap_resume_by_restart() -> Result<()> {
     test_impl(ResumeBy::Restart).await
+}
+
+// The idea is similar to `e2e_test/batch/transaction/now.slt`.
+async fn test_temporal_filter(resume_by: ResumeBy) -> Result<()> {
+    const CREATE_TABLE: &str = "create table t (ts timestamp)";
+    const CREATE_TEMPORAL_FILTER: &str =
+        "create materialized view mv as select count(*) from t where ts at time zone 'utc' >= now()";
+    const INSERT_TIMESTAMPS: &str = "
+    insert into t select * from generate_series(
+        now() at time zone 'utc' - interval '10' second,
+        now() at time zone 'utc' + interval '20' second,
+        interval '1' second / 20
+    );
+    ";
+    const SELECT: &str = "select * from mv";
+
+    let mut cluster = Cluster::start(Configuration {
+        meta_nodes: 1,
+        ..Configuration::for_scale()
+    })
+    .await?;
+
+    cluster.run(SET_PARAMETER).await?;
+
+    {
+        let mut session = cluster.start_session();
+        session.run(CREATE_TABLE).await?;
+        session.run(CREATE_TEMPORAL_FILTER).await?;
+        session.run(INSERT_TIMESTAMPS).await?;
+        session.flush().await?;
+    };
+
+    // Kill the meta node and wait for the service to recover.
+    cluster.kill_nodes(["meta-1"], 0).await;
+    sleep(Duration::from_secs(10)).await;
+
+    let count: i32 = cluster.run(SELECT).await?.parse()?;
+    assert_ne!(count, 0, "the following tests are meaningless");
+
+    sleep(Duration::from_secs(10)).await;
+    let new_count: i32 = cluster.run(SELECT).await?.parse()?;
+    assert_eq!(count, new_count, "temporal filter should have been paused");
+
+    // Resume the cluster.
+    resume_by.resume(&mut cluster).await?;
+    sleep(Duration::from_secs(40)).await; // 40 seconds is enough for all timestamps to be expired
+
+    let count: i32 = cluster.run(SELECT).await?.parse()?;
+    assert_eq!(count, 0, "temporal filter should have been resumed");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_pause_on_bootstrap_temporal_filter_resume_by_risectl() -> Result<()> {
+    test_temporal_filter(ResumeBy::Risectl).await
+}
+
+#[tokio::test]
+async fn test_pause_on_bootstrap_temporal_filter_resume_by_restart() -> Result<()> {
+    test_temporal_filter(ResumeBy::Restart).await
 }


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Follow-up of #11936, it seems that we didn't handle the `pause_on_bootstrap` logic in `Now` and `Values` executors. Could at least help us to diagnose https://github.com/risingwavelabs/risingwave/issues/12715.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
