### PR TITLE
feat(expr): support streaming `bit_and` and `bit_or` aggregate

### DIFF
--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -308,8 +308,7 @@ pub mod agg_kinds {
     #[macro_export]
     macro_rules! unimplemented_in_stream {
         () => {
-            AggKind::BitOr
-                | AggKind::JsonbAgg
+            AggKind::JsonbAgg
                 | AggKind::JsonbObjectAgg
                 | AggKind::PercentileCont
                 | AggKind::PercentileDisc
@@ -408,6 +407,7 @@ pub mod agg_kinds {
                 | AggKind::BoolAnd
                 | AggKind::BoolOr
                 | AggKind::BitAnd
+                | AggKind::BitOr
         };
     }
     pub use simply_cannot_two_phase;
@@ -421,6 +421,7 @@ pub mod agg_kinds {
                 | AggKind::Sum0
                 | AggKind::Count
                 | AggKind::BitAnd
+                | AggKind::BitOr
                 | AggKind::BitXor
                 | AggKind::BoolAnd
                 | AggKind::BoolOr
@@ -453,9 +454,7 @@ impl AggKind {
     /// Get the total phase agg kind from the partial phase agg kind.
     pub fn partial_to_total(self) -> Option<Self> {
         match self {
-            AggKind::BitOr | AggKind::BitXor | AggKind::Min | AggKind::Max | AggKind::Sum => {
-                Some(self)
-            }
+            AggKind::BitXor | AggKind::Min | AggKind::Max | AggKind::Sum => Some(self),
             AggKind::Sum0 | AggKind::Count => Some(AggKind::Sum0),
             agg_kinds::simply_cannot_two_phase!() => None,
             agg_kinds::rewritten!() => None,

--- a/src/expr/core/src/aggregate/def.rs
+++ b/src/expr/core/src/aggregate/def.rs
@@ -308,8 +308,7 @@ pub mod agg_kinds {
     #[macro_export]
     macro_rules! unimplemented_in_stream {
         () => {
-            AggKind::BitAnd
-                | AggKind::BitOr
+            AggKind::BitOr
                 | AggKind::JsonbAgg
                 | AggKind::JsonbObjectAgg
                 | AggKind::PercentileCont
@@ -408,6 +407,7 @@ pub mod agg_kinds {
                 //  after we support general merge in stateless_simple_agg
                 | AggKind::BoolAnd
                 | AggKind::BoolOr
+                | AggKind::BitAnd
         };
     }
     pub use simply_cannot_two_phase;
@@ -420,6 +420,7 @@ pub mod agg_kinds {
             AggKind::Sum
                 | AggKind::Sum0
                 | AggKind::Count
+                | AggKind::BitAnd
                 | AggKind::BitXor
                 | AggKind::BoolAnd
                 | AggKind::BoolOr
@@ -452,12 +453,9 @@ impl AggKind {
     /// Get the total phase agg kind from the partial phase agg kind.
     pub fn partial_to_total(self) -> Option<Self> {
         match self {
-            AggKind::BitAnd
-            | AggKind::BitOr
-            | AggKind::BitXor
-            | AggKind::Min
-            | AggKind::Max
-            | AggKind::Sum => Some(self),
+            AggKind::BitOr | AggKind::BitXor | AggKind::Min | AggKind::Max | AggKind::Sum => {
+                Some(self)
+            }
             AggKind::Sum0 | AggKind::Count => Some(AggKind::Sum0),
             agg_kinds::simply_cannot_two_phase!() => None,
             agg_kinds::rewritten!() => None,

--- a/src/expr/impl/src/aggregate/bit_and.rs
+++ b/src/expr/impl/src/aggregate/bit_and.rs
@@ -1,0 +1,310 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::BitAnd;
+
+use risingwave_common::types::{ListRef, ListValue, ScalarImpl};
+use risingwave_expr::aggregate;
+
+/// Computes the bitwise AND of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int2, b int4, c int8);
+///
+/// query III
+/// select bit_and(a), bit_and(b), bit_and(c) from t;
+/// ----
+/// NULL NULL NULL
+///
+/// statement ok
+/// insert into t values
+///    (6, 6, 6),
+///    (3, 3, 3),
+///    (null, null, null);
+///
+/// query III
+/// select bit_and(a), bit_and(b), bit_and(c) from t;
+/// ----
+/// 2 2 2
+///
+/// statement ok
+/// drop table t;
+/// ```
+// XXX: state = "ref" is required so that
+// for the first non-null value, the state is set to that value.
+#[aggregate("bit_and(*int) -> auto", state = "ref")]
+fn bit_and_append_only<T>(state: T, input: T) -> T
+where
+    T: BitAnd<Output = T>,
+{
+    state.bitand(input)
+}
+
+/// Computes the bitwise AND of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int2);
+///
+/// statement ok
+/// create materialized view mv as select bit_and(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 2
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitAndI16Updatable;
+
+#[aggregate("bit_and(int2) -> int2", state = "int8[]")]
+impl BitAndI16Updatable {
+    // state is the number of 0s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 16])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i16) -> ListValue {
+        for i in 0..16 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i16) -> ListValue {
+        for i in 0..16 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i16 {
+        let mut result = 0;
+        for i in 0..16 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count == 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}
+
+/// Computes the bitwise AND of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int4);
+///
+/// statement ok
+/// create materialized view mv as select bit_and(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 2
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitAndI32Updatable;
+
+#[aggregate("bit_and(int4) -> int4", state = "int8[]")]
+impl BitAndI32Updatable {
+    // state is the number of 0s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 32])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i32) -> ListValue {
+        for i in 0..32 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i32) -> ListValue {
+        for i in 0..32 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i32 {
+        let mut result = 0;
+        for i in 0..32 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count == 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}
+
+/// Computes the bitwise AND of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int8);
+///
+/// statement ok
+/// create materialized view mv as select bit_and(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 2
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitAndI64Updatable;
+
+#[aggregate("bit_and(int8) -> int8", state = "int8[]")]
+impl BitAndI64Updatable {
+    // state is the number of 0s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 64])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i64) -> ListValue {
+        for i in 0..64 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i64) -> ListValue {
+        for i in 0..64 {
+            if (input >> i) & 1 == 0 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i64 {
+        let mut result = 0;
+        for i in 0..64 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count == 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}

--- a/src/expr/impl/src/aggregate/bit_and.rs
+++ b/src/expr/impl/src/aggregate/bit_and.rs
@@ -65,9 +65,9 @@ where
 ///
 /// statement ok
 /// create materialized view mv as
-/// select bit_and(a), bit_and(b), bit_and(c) from t;
+/// select bit_and(a) a, bit_and(b) b, bit_and(c) c from t;
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// NULL NULL NULL
@@ -78,7 +78,7 @@ where
 ///    (3, 3, 3),
 ///    (null, null, null);
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// 2 2 2
@@ -86,7 +86,7 @@ where
 /// statement ok
 /// delete from t where a = 3;
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// 6 6 6

--- a/src/expr/impl/src/aggregate/bit_or.rs
+++ b/src/expr/impl/src/aggregate/bit_or.rs
@@ -65,9 +65,9 @@ where
 ///
 /// statement ok
 /// create materialized view mv as
-/// select bit_or(a), bit_or(b), bit_or(c) from t;
+/// select bit_or(a) a, bit_or(b) b, bit_or(c) c from t;
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// NULL NULL NULL
@@ -78,7 +78,7 @@ where
 ///    (3, 3, 3),
 ///    (null, null, null);
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// 7 7 7
@@ -86,7 +86,7 @@ where
 /// statement ok
 /// delete from t where a = 3;
 ///
-/// query I
+/// query III
 /// select * from mv;
 /// ----
 /// 6 6 6

--- a/src/expr/impl/src/aggregate/bit_or.rs
+++ b/src/expr/impl/src/aggregate/bit_or.rs
@@ -1,0 +1,308 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::BitOr;
+
+use risingwave_common::types::{ListRef, ListValue, ScalarImpl};
+use risingwave_expr::aggregate;
+
+/// Computes the bitwise OR of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int2, b int4, c int8);
+///
+/// query III
+/// select bit_or(a), bit_or(b), bit_or(c) from t;
+/// ----
+/// NULL NULL NULL
+///
+/// statement ok
+/// insert into t values
+///    (1, 1, 1),
+///    (2, 2, 2),
+///    (null, null, null);
+///
+/// query III
+/// select bit_or(a), bit_or(b), bit_or(c) from t;
+/// ----
+/// 3 3 3
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[aggregate("bit_or(*int) -> auto")]
+fn bit_or_append_only<T>(state: T, input: T) -> T
+where
+    T: BitOr<Output = T>,
+{
+    state.bitor(input)
+}
+
+/// Computes the bitwise OR of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int2);
+///
+/// statement ok
+/// create materialized view mv as select bit_or(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 7
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitOrI16Updatable;
+
+#[aggregate("bit_or(int2) -> int2", state = "int8[]")]
+impl BitOrI16Updatable {
+    // state is the number of 1s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 16])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i16) -> ListValue {
+        for i in 0..16 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i16) -> ListValue {
+        for i in 0..16 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i16 {
+        let mut result = 0;
+        for i in 0..16 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count != 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}
+
+/// Computes the bitwise OR of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int4);
+///
+/// statement ok
+/// create materialized view mv as select bit_or(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 7
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitOrI32Updatable;
+
+#[aggregate("bit_or(int4) -> int4", state = "int8[]")]
+impl BitOrI32Updatable {
+    // state is the number of 1s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 32])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i32) -> ListValue {
+        for i in 0..32 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i32) -> ListValue {
+        for i in 0..32 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i32 {
+        let mut result = 0;
+        for i in 0..32 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count != 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}
+
+/// Computes the bitwise OR of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int8);
+///
+/// statement ok
+/// create materialized view mv as select bit_or(a) from t;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// NULL
+///
+/// statement ok
+/// insert into t values (3), (6), (null);
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 7
+///
+/// statement ok
+/// delete from t where a = 3;
+///
+/// query I
+/// select * from mv;
+/// ----
+/// 6
+///
+/// statement ok
+/// drop materialized view mv;
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[derive(Debug, Default, Clone)]
+struct BitOrI64Updatable;
+
+#[aggregate("bit_or(int8) -> int8", state = "int8[]")]
+impl BitOrI64Updatable {
+    // state is the number of 1s for each bit.
+
+    fn create_state(&self) -> ListValue {
+        ListValue::new(vec![Some(ScalarImpl::Int64(0)); 64])
+    }
+
+    fn accumulate(&self, mut state: ListValue, input: i64) -> ListValue {
+        for i in 0..64 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count += 1;
+            }
+        }
+        state
+    }
+
+    fn retract(&self, mut state: ListValue, input: i64) -> ListValue {
+        for i in 0..64 {
+            if (input >> i) & 1 == 1 {
+                let Some(ScalarImpl::Int64(count)) = &mut state[i] else {
+                    panic!("invalid state");
+                };
+                *count -= 1;
+            }
+        }
+        state
+    }
+
+    fn finalize(&self, state: ListRef<'_>) -> i64 {
+        let mut result = 0;
+        for i in 0..64 {
+            let count = state.get(i).unwrap().unwrap().into_int64();
+            if count != 0 {
+                result |= 1 << i;
+            }
+        }
+        result
+    }
+}

--- a/src/expr/impl/src/aggregate/bit_xor.rs
+++ b/src/expr/impl/src/aggregate/bit_xor.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::ops::BitXor;
+
+use risingwave_expr::aggregate;
+
+/// Computes the bitwise OR of all non-null input values.
+///
+/// # Example
+///
+/// ```slt
+/// statement ok
+/// create table t (a int2, b int4, c int8);
+///
+/// query III
+/// select bit_xor(a), bit_xor(b), bit_xor(c) from t;
+/// ----
+/// NULL NULL NULL
+///
+/// statement ok
+/// insert into t values
+///    (3, 3, 3),
+///    (6, 6, 6),
+///    (null, null, null);
+///
+/// query III
+/// select bit_xor(a), bit_xor(b), bit_xor(c) from t;
+/// ----
+/// 5 5 5
+///
+/// statement ok
+/// drop table t;
+/// ```
+#[aggregate("bit_xor(*int) -> auto")]
+fn bit_xor<T>(state: T, input: T, _retract: bool) -> T
+where
+    T: BitXor<Output = T>,
+{
+    state.bitxor(input)
+}

--- a/src/expr/impl/src/aggregate/bit_xor.rs
+++ b/src/expr/impl/src/aggregate/bit_xor.rs
@@ -16,7 +16,7 @@ use std::ops::BitXor;
 
 use risingwave_expr::aggregate;
 
-/// Computes the bitwise OR of all non-null input values.
+/// Computes the bitwise XOR of all non-null input values.
 ///
 /// # Example
 ///

--- a/src/expr/impl/src/aggregate/general.rs
+++ b/src/expr/impl/src/aggregate/general.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::convert::From;
-use std::ops::BitXor;
 
 use num_traits::{CheckedAdd, CheckedSub};
 use risingwave_expr::{aggregate, ExprError, Result};
@@ -51,14 +50,6 @@ fn min<T: Ord>(state: T, input: T) -> T {
 #[aggregate("max(*) -> auto", state = "ref")]
 fn max<T: Ord>(state: T, input: T) -> T {
     state.max(input)
-}
-
-#[aggregate("bit_xor(*int) -> auto")]
-fn bit_xor<T>(state: T, input: T, _retract: bool) -> T
-where
-    T: BitXor<Output = T>,
-{
-    state.bitxor(input)
 }
 
 #[aggregate("first_value(*) -> auto", state = "ref")]

--- a/src/expr/impl/src/aggregate/general.rs
+++ b/src/expr/impl/src/aggregate/general.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::convert::From;
-use std::ops::{BitOr, BitXor};
+use std::ops::BitXor;
 
 use num_traits::{CheckedAdd, CheckedSub};
 use risingwave_expr::{aggregate, ExprError, Result};
@@ -51,14 +51,6 @@ fn min<T: Ord>(state: T, input: T) -> T {
 #[aggregate("max(*) -> auto", state = "ref")]
 fn max<T: Ord>(state: T, input: T) -> T {
     state.max(input)
-}
-
-#[aggregate("bit_or(*int) -> auto")]
-fn bit_or<T>(state: T, input: T) -> T
-where
-    T: BitOr<Output = T>,
-{
-    state.bitor(input)
 }
 
 #[aggregate("bit_xor(*int) -> auto")]

--- a/src/expr/impl/src/aggregate/general.rs
+++ b/src/expr/impl/src/aggregate/general.rs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 use std::convert::From;
-use std::ops::{BitAnd, BitOr, BitXor};
+use std::ops::{BitOr, BitXor};
 
 use num_traits::{CheckedAdd, CheckedSub};
 use risingwave_expr::{aggregate, ExprError, Result};
@@ -51,16 +51,6 @@ fn min<T: Ord>(state: T, input: T) -> T {
 #[aggregate("max(*) -> auto", state = "ref")]
 fn max<T: Ord>(state: T, input: T) -> T {
     state.max(input)
-}
-
-// XXX: state = "ref" is required so that
-// for the first non-null value, the state is set to that value.
-#[aggregate("bit_and(*int) -> auto", state = "ref")]
-fn bit_and<T>(state: T, input: T) -> T
-where
-    T: BitAnd<Output = T>,
-{
-    state.bitand(input)
 }
 
 #[aggregate("bit_or(*int) -> auto")]

--- a/src/expr/impl/src/aggregate/mod.rs
+++ b/src/expr/impl/src/aggregate/mod.rs
@@ -16,6 +16,7 @@ mod approx_count_distinct;
 mod array_agg;
 mod bit_and;
 mod bit_or;
+mod bit_xor;
 mod bool_and;
 mod bool_or;
 mod general;

--- a/src/expr/impl/src/aggregate/mod.rs
+++ b/src/expr/impl/src/aggregate/mod.rs
@@ -15,6 +15,7 @@
 mod approx_count_distinct;
 mod array_agg;
 mod bit_and;
+mod bit_or;
 mod bool_and;
 mod bool_or;
 mod general;

--- a/src/expr/impl/src/aggregate/mod.rs
+++ b/src/expr/impl/src/aggregate/mod.rs
@@ -14,6 +14,7 @@
 
 mod approx_count_distinct;
 mod array_agg;
+mod bit_and;
 mod bool_and;
 mod bool_or;
 mod general;

--- a/src/expr/impl/src/scalar/array_access.rs
+++ b/src/expr/impl/src/scalar/array_access.rs
@@ -23,7 +23,7 @@ fn array_access(list: ListRef<'_>, index: i32) -> Option<ScalarRefImpl<'_>> {
         return None;
     }
     // returns `NULL` if index is out of bounds
-    list.elem_at(index as usize - 1).flatten()
+    list.get(index as usize - 1).flatten()
 }
 
 #[cfg(test)]

--- a/src/expr/impl/src/table_function/generate_subscripts.rs
+++ b/src/expr/impl/src/table_function/generate_subscripts.rs
@@ -130,7 +130,7 @@ fn generate_subscripts_inner(array: ListRef<'_>, dim: i32) -> (i32, i32) {
         ..=0 => nothing,
         1 => (1, array.len() as i32 + 1),
         // Although RW's array can be zig-zag, we just look at the first element.
-        2.. => match array.elem_at(0) {
+        2.. => match array.get(0) {
             Some(Some(ScalarRefImpl::List(list))) => generate_subscripts_inner(list, dim - 1),
             _ => nothing,
         },

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -719,14 +719,22 @@ impl FunctionAttr {
             AggregateFnOrImpl::Fn(_) => quote! {},
             AggregateFnOrImpl::Impl(i) => {
                 let struct_name = format_ident!("{}", i.struct_name);
-                quote! { function: #struct_name, }
+                let generic = self.generic.as_ref().map(|g| {
+                    let g = format_ident!("{g}");
+                    quote! { <#g> }
+                });
+                quote! { function: #struct_name #generic, }
             }
         };
         let function_new = match user_fn {
             AggregateFnOrImpl::Fn(_) => quote! {},
             AggregateFnOrImpl::Impl(i) => {
                 let struct_name = format_ident!("{}", i.struct_name);
-                quote! { function: #struct_name::default(), }
+                let generic = self.generic.as_ref().map(|g| {
+                    let g = format_ident!("{g}");
+                    quote! { ::<#g> }
+                });
+                quote! { function: #struct_name #generic :: default(), }
             }
         };
 

--- a/src/expr/macro/src/gen.rs
+++ b/src/expr/macro/src/gen.rs
@@ -675,10 +675,17 @@ impl FunctionAttr {
                 }
                 1 => {
                     let first_state = if self.init_state.is_some() {
+                        // for count, the state will never be None
                         quote! { unreachable!() }
                     } else if let Some(s) = &self.state && s == "ref" {
                         // for min/max/first/last, the state is the first value
                         quote! { Some(v0) }
+                    } else if let AggregateFnOrImpl::Impl(impl_) = user_fn && impl_.create_state.is_some() {
+                        // use user-defined create_state function
+                        quote! {{
+                            let state = self.function.create_state();
+                            #next_state
+                        }}
                     } else {
                         quote! {{
                             let state = #state_type::default();

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -536,6 +536,7 @@ struct AggregateImpl {
     #[allow(dead_code)] // TODO(wrj): add merge to trait
     merge: Option<UserFunctionAttr>,
     finalize: Option<UserFunctionAttr>,
+    create_state: Option<UserFunctionAttr>,
     #[allow(dead_code)] // TODO(wrj): support encode
     encode_state: Option<UserFunctionAttr>,
     #[allow(dead_code)] // TODO(wrj): support decode

--- a/src/expr/macro/src/lib.rs
+++ b/src/expr/macro/src/lib.rs
@@ -495,6 +495,8 @@ struct FunctionAttr {
     prebuild: Option<String>,
     /// Type inference function.
     type_infer: Option<String>,
+    /// Generic type.
+    generic: Option<String>,
     /// Whether the function is volatile.
     volatile: bool,
     /// Whether the function is deprecated.

--- a/src/expr/macro/src/parse.rs
+++ b/src/expr/macro/src/parse.rs
@@ -147,6 +147,7 @@ impl Parse for AggregateImpl {
             retract: parse_function("retract"),
             merge: parse_function("merge"),
             finalize: parse_function("finalize"),
+            create_state: parse_function("create_state"),
             encode_state: parse_function("encode_state"),
             decode_state: parse_function("decode_state"),
         })


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

resolve #9281 

This PR adds streaming version `bit_and` and `bit_or` aggregate functions. The state of both functions is a list of 0/1 counts for each bit, so that input values can be retracted.

Limitation: Due to the difference of state and output type, 2-phase aggregation for both functions are disabled.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Support the following aggregate functions in materialized views:
```
bit_and ( smallint ) → smallint
bit_and ( integer ) → integer
bit_and ( bigint ) → bigint

bit_or ( smallint ) → smallint
bit_or ( integer ) → integer
bit_or ( bigint ) → bigint
```
