### PR TITLE
fix(cdc-backfill): fix recovery of cdc table that subscribed to an empty table

### DIFF
--- a/src/stream/src/executor/backfill/cdc_backfill.rs
+++ b/src/stream/src/executor/backfill/cdc_backfill.rs
@@ -227,7 +227,8 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         #[allow(unused_variables)]
         let mut total_snapshot_processed_rows: u64 = 0;
 
-        let mut last_binlog_offset: Option<CdcOffset>;
+        let mut last_binlog_offset: Option<CdcOffset> =
+            upstream_table_reader.current_binlog_offset().await?;
 
         let mut consumed_binlog_offset: Option<CdcOffset> = None;
 
@@ -251,7 +252,6 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         //
         // Once the backfill loop ends, we forward the upstream directly to the downstream.
         if to_backfill {
-            last_binlog_offset = upstream_table_reader.current_binlog_offset().await?;
             // drive the upstream changelog first to ensure we can receive timely changelog event,
             // otherwise the upstream changelog may be blocked by the snapshot read stream
             let _ = Pin::new(&mut upstream).peek().await;
@@ -442,14 +442,16 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
                 }
             }
         } else {
-            Self::write_backfill_state(
-                &mut self.source_state_handler,
-                upstream_table_id,
-                &split_id,
-                &mut cdc_split,
-                None,
-            )
-            .await?;
+            if is_snapshot_empty {
+                Self::write_backfill_state(
+                    &mut self.source_state_handler,
+                    upstream_table_id,
+                    &split_id,
+                    &mut cdc_split,
+                    last_binlog_offset,
+                )
+                .await?;
+            }
         }
 
         tracing::debug!(
@@ -485,6 +487,11 @@ impl<S: StateStore> CdcBackfillExecutor<S> {
         cdc_split: &mut Option<SplitImpl>,
         last_binlog_offset: Option<CdcOffset>,
     ) -> StreamExecutorResult<()> {
+        assert!(
+            last_binlog_offset.is_some(),
+            "last binlog offset cannot be None"
+        );
+
         if let Some(split_id) = split_id.as_ref() {
             let mut key = split_id.to_string();
             key.push_str(BACKFILL_STATE_KEY_SUFFIX);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
Persist current binlog offset when upstream snapshot is empty, so that we can recover the consumption of upstream CDC events. The persisted offset cannot be null in any scenarios.

Tested locally.


## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
