### PR TITLE
fix(frontend): fix dml output fields

### DIFF
--- a/src/frontend/src/binder/statement.rs
+++ b/src/frontend/src/binder/statement.rs
@@ -32,18 +32,18 @@ pub enum BoundStatement {
 impl BoundStatement {
     pub fn output_fields(&self) -> Vec<Field> {
         match self {
-            BoundStatement::Insert(i) => i.returning_schema.as_ref().map_or(
-                vec![Field::unnamed(risingwave_common::types::DataType::Int64)],
-                |s| s.fields().into(),
-            ),
-            BoundStatement::Delete(d) => d.returning_schema.as_ref().map_or(
-                vec![Field::unnamed(risingwave_common::types::DataType::Int64)],
-                |s| s.fields().into(),
-            ),
-            BoundStatement::Update(u) => u.returning_schema.as_ref().map_or(
-                vec![Field::unnamed(risingwave_common::types::DataType::Int64)],
-                |s| s.fields().into(),
-            ),
+            BoundStatement::Insert(i) => i
+                .returning_schema
+                .as_ref()
+                .map_or(vec![], |s| s.fields().into()),
+            BoundStatement::Delete(d) => d
+                .returning_schema
+                .as_ref()
+                .map_or(vec![], |s| s.fields().into()),
+            BoundStatement::Update(u) => u
+                .returning_schema
+                .as_ref()
+                .map_or(vec![], |s| s.fields().into()),
             BoundStatement::Query(q) => q.schema().fields().into(),
         }
     }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Fix dml output fields
- Resolve https://github.com/risingwavelabs/risingwave/issues/12781#issuecomment-1763900002

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
