### PR TITLE
feat(frontend): stub session server_encoding

### DIFF
--- a/src/common/src/session_config/mod.rs
+++ b/src/common/src/session_config/mod.rs
@@ -619,6 +619,8 @@ impl ConfigMap {
         } else if key.eq_ignore_ascii_case(BackgroundDdl::entry_name()) {
             self.background_ddl = val.as_slice().try_into()?;
         } else if key.eq_ignore_ascii_case(ServerEncoding::entry_name()) {
+            let enc: ServerEncoding = val.as_slice().try_into()?;
+            // https://github.com/postgres/postgres/blob/REL_15_3/src/common/encnames.c#L525
             let clean = enc
                 .as_str()
                 .replace(|c: char| !c.is_ascii_alphanumeric(), "");


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

BI and data analytic platforms Intergration: Aliyun DMS
DMS platform allow to create a self-building database connection on the VPC internal.
So when we create a cluster on the Aliyun, We can use the DMS to connect the RisingWave Frontend Service Port.
But we need to support the initial query by `current_setting('server_encoding')` first.

As of now, while `server_encoding` only accepts utf8.


## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR contains user-facing changes.

### Types of user-facing changes
Please keep the types that apply to your changes, and remove the others.

Installation and deployment
Connector (sources & sinks)
SQL commands, functions, and operators
RisingWave cluster configuration changes
Other (please specify in the release note below)

## Release note
