### PR TITLE
fix(integration-test): disable iceberg-sink case

### DIFF
--- a/ci/workflows/integration-tests.yml
+++ b/ci/workflows/integration-tests.yml
@@ -29,7 +29,7 @@ steps:
           - "postgres-cdc"
           - "mysql-sink"
           - "postgres-sink"
-          - "iceberg-sink"
+          # - "iceberg-sink"
           - "debezium-mysql"
         format:
           - "json"
@@ -75,10 +75,10 @@ steps:
             testcase: "postgres-sink"
             format: "protobuf"
           skip: true
-        - with:
-            testcase: "iceberg-sink"
-            format: "protobuf"
-          skip: true
+        # - with:
+        #    testcase: "iceberg-sink"
+        #    format: "protobuf"
+        #  skip: true
         - with:
             testcase: "debezium-mysql"
             format: "protobuf"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This case is an old version. We disable it first, and @liurenjie1024  will introduce a new version of the case later.

https://github.com/risingwavelabs/risingwave/issues/12893

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))
