### PR TITLE
feat(dashboard): dump await-tree for all compute nodes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4593,9 +4593,9 @@ dependencies = [
 
 [[package]]
 name = "madsim-tonic-build"
-version = "0.4.1+0.10.0"
+version = "0.4.2+0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3434b3d59001abcce56b9170fbd7982377858d8b931e8472056bf0c894ab257"
+checksum = "4a2ad2776ba20221ccbe4e136e2fa0f7ab90eebd608373177f3e74a198a288ec"
 dependencies = [
  "prettyplease 0.2.15",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ hashbrown = { version = "0.14.0", features = [
 ] }
 criterion = { version = "0.5", features = ["async_futures"] }
 tonic = { package = "madsim-tonic", version = "0.4.0" }
-tonic-build = { package = "madsim-tonic-build", version = "0.4.0" }
+tonic-build = { package = "madsim-tonic-build", version = "0.4.2" }
 prost = { version = "0.12" }
 icelake = { git = "https://github.com/icelake-io/icelake", rev = "16dab0e36ab337e58ee8002d828def2d212fa116" }
 arrow-array = "47"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -405,6 +405,7 @@ description = "Build dashboard"
 condition = { env_set = [
   "ENABLE_BUILD_DASHBOARD",
 ], files_modified = { input = [
+  "./dashboard/**/*.js",
   "./dashboard/**/*.ts*",
   "./dashboard/package.json",
   "./dashboard/next.config.js",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -405,7 +405,7 @@ description = "Build dashboard"
 condition = { env_set = [
   "ENABLE_BUILD_DASHBOARD",
 ], files_modified = { input = [
-  "./dashboard/**/*.js",
+  "./dashboard/**/*.ts*",
   "./dashboard/package.json",
   "./dashboard/next.config.js",
 ], output = [

--- a/dashboard/pages/await_tree.tsx
+++ b/dashboard/pages/await_tree.tsx
@@ -36,22 +36,32 @@ import { getClusterInfoComputeNode } from "./api/cluster"
 import useFetch from "./api/fetch"
 
 const SIDEBAR_WIDTH = 200
+const ALL_COMPUTE_NODES = ""
 
 export default function AwaitTreeDump() {
   const { response: computeNodes } = useFetch(getClusterInfoComputeNode)
 
-  const [computeNodeId, setComputeNodeId] = useState<number>()
-  const [dump, setDump] = useState<string | undefined>("")
+  const [computeNodeId, setComputeNodeId] = useState<string>()
+  const [dump, setDump] = useState<string>("")
 
   useEffect(() => {
-    if (computeNodes && !computeNodeId && computeNodes.length > 0) {
-      setComputeNodeId(computeNodes[0].id)
+    if (computeNodes && !computeNodeId) {
+      setComputeNodeId(ALL_COMPUTE_NODES)
     }
   }, [computeNodes, computeNodeId])
 
   const dumpTree = async () => {
-    const title = `Await-Tree Dump of Compute Node ${computeNodeId}:`
-    setDump(undefined)
+    if (computeNodeId === undefined) {
+      return
+    }
+
+    let title
+    if (computeNodeId === ALL_COMPUTE_NODES) {
+      title = "Await-Tree Dump of All Compute Nodes:"
+    } else {
+      title = `Await-Tree Dump of Compute Node ${computeNodeId}:`
+    }
+    setDump("Loading...")
 
     let result
 
@@ -92,10 +102,13 @@ export default function AwaitTreeDump() {
             <FormLabel>Compute Nodes</FormLabel>
             <VStack>
               <Select
-                onChange={(event) =>
-                  setComputeNodeId(parseInt(event.target.value))
-                }
+                onChange={(event) => setComputeNodeId(event.target.value)}
               >
+                {computeNodes && (
+                  <option value={ALL_COMPUTE_NODES} key={ALL_COMPUTE_NODES}>
+                    All
+                  </option>
+                )}
                 {computeNodes &&
                   computeNodes.map((n) => (
                     <option value={n.id} key={n.id}>

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -313,7 +313,7 @@ pub mod grpc_middleware {
                 let root = registry
                     .lock()
                     .await
-                    .register(id, format!("{}:{}", req.uri().path(), id));
+                    .register(id, req.uri().to_string());
 
                 root.instrument(inner.call(req)).await
             })

--- a/src/compute/src/rpc/service/monitor_service.rs
+++ b/src/compute/src/rpc/service/monitor_service.rs
@@ -315,7 +315,7 @@ pub mod grpc_middleware {
             };
 
             Either::Right(async move {
-                let root = registry.lock().await.register(key, req.uri().to_string());
+                let root = registry.lock().await.register(key, req.uri().path());
 
                 root.instrument(inner.call(req)).await
             })

--- a/src/ctl/src/cmd_impl.rs
+++ b/src/ctl/src/cmd_impl.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub mod await_tree;
 pub mod bench;
 pub mod compute;
 pub mod debug;
@@ -20,4 +21,3 @@ pub mod meta;
 pub mod profile;
 pub mod scale;
 pub mod table;
-pub mod trace;

--- a/src/ctl/src/cmd_impl/await_tree.rs
+++ b/src/ctl/src/cmd_impl/await_tree.rs
@@ -25,7 +25,7 @@ fn merge(a: &mut StackTraceResponse, b: StackTraceResponse) {
     a.compaction_task_traces.extend(b.compaction_task_traces);
 }
 
-pub async fn trace(context: &CtlContext) -> anyhow::Result<()> {
+pub async fn dump(context: &CtlContext) -> anyhow::Result<()> {
     let mut all = Default::default();
 
     let meta_client = context.meta_client().await?;

--- a/src/ctl/src/lib.rs
+++ b/src/ctl/src/lib.rs
@@ -68,8 +68,9 @@ enum Commands {
     /// Commands for Debug
     #[clap(subcommand)]
     Debug(DebugCommands),
-    /// Commands for tracing the compute nodes
-    Trace,
+    /// Dump the await-tree of compute nodes and compactors
+    #[clap(visible_alias("trace"))]
+    AwaitTree,
     // TODO(yuhao): profile other nodes
     /// Commands for profilng the compute nodes
     #[clap(subcommand)]
@@ -653,7 +654,7 @@ pub async fn start_impl(opts: CliOpts, context: &CtlContext) -> Result<()> {
         Commands::Meta(MetaCommands::ValidateSource { props }) => {
             cmd_impl::meta::validate_source(context, props).await?
         }
-        Commands::Trace => cmd_impl::trace::trace(context).await?,
+        Commands::AwaitTree => cmd_impl::await_tree::dump(context).await?,
         Commands::Profile(ProfileCommands::Cpu { sleep }) => {
             cmd_impl::profile::cpu_profile(context, sleep).await?
         }

--- a/src/meta/src/dashboard/mod.rs
+++ b/src/meta/src/dashboard/mod.rs
@@ -210,7 +210,7 @@ pub(super) mod handlers {
         }
 
         for worker_node in worker_nodes {
-            let client = compute_clients.get(&worker_node).await.map_err(err)?;
+            let client = compute_clients.get(worker_node).await.map_err(err)?;
             let result = client.stack_trace().await.map_err(err)?;
 
             merge(&mut all, result);

--- a/src/prost/build.rs
+++ b/src/prost/build.rs
@@ -58,6 +58,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|f| format!("{}/{}.proto", proto_dir, f))
         .collect();
 
+    // Paths to generate `BTreeMap` for protobuf maps.
+    let btree_map_paths = [".monitor_service.StackTraceResponse"];
+
     // Build protobuf structs.
 
     // We first put generated files to `OUT_DIR`, then copy them to `/src` only if they are changed.
@@ -85,6 +88,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             "stream_plan.Barrier.BarrierKind",
             "#[derive(::enum_as_inner::EnumAsInner)]",
         )
+        .btree_map(btree_map_paths)
         // Eq + Hash are for plan nodes to do common sub-plan detection.
         // The requirement is from Source node -> SourceCatalog -> WatermarkDesc -> expr
         .type_attribute("catalog.WatermarkDesc", "#[derive(Eq, Hash)]")
@@ -116,6 +120,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Implement `serde::Serialize` on those structs.
     let descriptor_set = fs_err::read(file_descriptor_set_path)?;
     pbjson_build::Builder::new()
+        .btree_map(btree_map_paths)
         .register_descriptors(&descriptor_set)?
         .out_dir(out_dir.as_path())
         .build(&["."])

--- a/src/storage/compactor/src/rpc.rs
+++ b/src/storage/compactor/src/rpc.rs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
@@ -85,7 +84,7 @@ impl MonitorService for MonitorServiceImpl {
         _request: Request<StackTraceRequest>,
     ) -> Result<Response<StackTraceResponse>, Status> {
         let compaction_task_traces = match &self.await_tree_reg {
-            None => HashMap::default(),
+            None => Default::default(),
             Some(await_tree_reg) => await_tree_reg
                 .read()
                 .iter()


### PR DESCRIPTION
Signed-off-by: Bugen Zhao <i@bugenzhao.com>I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<img width="868" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/44f6841a-7207-4098-ad3c-de54979dc4ab">

Add a new API for dumping await-trees for all compute nodes, support it in dashboard UI. Also some minor refinements for this:

- Generate `BTreeMap` for maps in async stack trace responses, so that they're naturally ordered.
- Add authority (`127.0.0.1:5687`) to the key of RPC traces, so that we can directly merge the await-trees from different worker nodes without collision on the key.
- Rename `risectl trace` to `risectl await-tree`. `trace` is still available as an alias.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
