### PR TITLE
build: remove `workspace-hack` from proc-macro crates' dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6351,7 +6351,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.37",
- "workspace-hack",
 ]
 
 [[package]]
@@ -7125,7 +7124,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
- "workspace-hack",
 ]
 
 [[package]]

--- a/src/common/proc_macro/Cargo.toml
+++ b/src/common/proc_macro/Cargo.toml
@@ -23,7 +23,5 @@ proc-macro2 = { version = "1", default-features = false }
 syn = "1"
 bae = "0.1.7"
 
-[target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { path = "../../workspace-hack" }
 [lints]
 workspace = true

--- a/src/prost/helpers/Cargo.toml
+++ b/src/prost/helpers/Cargo.toml
@@ -11,9 +11,6 @@ proc-macro2 = { version = "1", default-features = false }
 quote = "1"
 syn = "2"
 
-[target.'cfg(not(madsim))'.dependencies]
-workspace-hack = { path = "../../workspace-hack" }
-
 [package.metadata.cargo-machete]
 ignored = ["workspace-hack"]
 


### PR DESCRIPTION


I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

To avoid many dependencies compiled twice, once as normal dependency and once as build-dependency (including very heavy onces, like zstd, aws-sdk-s3).

**This reduces fresh debug build's compile time from >400s to <300s on my mac.**

I'm not 100% sure about the mechanism yet, but it's clear that feature selection and dependency selection work differently for build-dependencies (incl proc-macros). When `workspack-hack` is used as a proc-macro crate's dependency, all its dependencies *can be* compiled twice.

See https://github.com/risingwavelabs/risingwave/issues/9553#issuecomment-1771100231 for more details.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
