### PR TITLE
feat: support extended array slicing with step

### DIFF
--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -122,9 +122,12 @@ impl Binder {
             Expr::Nested(expr) => self.bind_expr_inner(*expr),
             Expr::Array(Array { elem: exprs, .. }) => self.bind_array(exprs),
             Expr::ArrayIndex { obj, index } => self.bind_array_index(*obj, *index),
-            Expr::ArrayRangeIndex { obj, start, end } => {
-                self.bind_array_range_index(*obj, start, end)
-            }
+            Expr::ArrayRangeIndex {
+                obj,
+                start,
+                end,
+                step,
+            } => self.bind_array_range_index(*obj, start, end, step),
             Expr::Function(f) => self.bind_function(f),
             Expr::Subquery(q) => self.bind_subquery_expr(*q, SubqueryKind::Scalar),
             Expr::Exists(q) => self.bind_subquery_expr(*q, SubqueryKind::Existential),

--- a/src/frontend/src/binder/expr/value.rs
+++ b/src/frontend/src/binder/expr/value.rs
@@ -153,6 +153,7 @@ impl Binder {
         obj: Expr,
         start: Option<Box<Expr>>,
         end: Option<Box<Expr>>,
+        step: Option<Box<Expr>>,
     ) -> Result<ExprImpl> {
         let obj = self.bind_expr_inner(obj)?;
         let start = match start {
@@ -169,10 +170,16 @@ impl Binder {
                 .bind_expr_inner(*expr)?
                 .cast_implicit(DataType::Int32)?,
         };
+        let step = match step {
+            None => ExprImpl::literal_int(1),
+            Some(expr) => self
+                .bind_expr_inner(*expr)?
+                .cast_implicit(DataType::Int32)?,
+        };
         match obj.return_type() {
             DataType::List(return_type) => Ok(FunctionCall::new_unchecked(
                 ExprType::ArrayRangeAccess,
-                vec![obj, start, end],
+                vec![obj, start, end, step],
                 DataType::List(return_type),
             )
             .into()),

--- a/src/sqlparser/src/ast/mod.rs
+++ b/src/sqlparser/src/ast/mod.rs
@@ -442,11 +442,12 @@ pub enum Expr {
         obj: Box<Expr>,
         index: Box<Expr>,
     },
-    /// A slice expression `arr[1:3]`
+    /// A slice expression `arr[1:3:2]`
     ArrayRangeIndex {
         obj: Box<Expr>,
         start: Option<Box<Expr>>,
         end: Option<Box<Expr>>,
+        step: Option<Box<Expr>>,
     },
     LambdaFunction {
         args: Vec<Ident>,
@@ -670,7 +671,12 @@ impl fmt::Display for Expr {
                 write!(f, "{}[{}]", obj, index)?;
                 Ok(())
             }
-            Expr::ArrayRangeIndex { obj, start, end } => {
+            Expr::ArrayRangeIndex {
+                obj,
+                start,
+                end,
+                step,
+            } => {
                 let start_str = match start {
                     None => "".to_string(),
                     Some(start) => format!("{}", start),
@@ -679,7 +685,11 @@ impl fmt::Display for Expr {
                     None => "".to_string(),
                     Some(end) => format!("{}", end),
                 };
-                write!(f, "{}[{}:{}]", obj, start_str, end_str)?;
+                let step_str = match step {
+                    None => "".to_string(),
+                    Some(step) => format!(":{}", step),
+                };
+                write!(f, "{}[{}:{}{}]", obj, start_str, end_str, step_str)?;
                 Ok(())
             }
             Expr::Array(exprs) => write!(f, "{}", exprs),


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

resolve #12405.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>

## Progress
- [ ] Dealing with problems caused by `Token::DoubleColon`

### problems caused by `Token::DoubleColon`
- Difficult to handle recursively.
- When `self.parse_expr()`, it will be parsed as cast syntax. e.g. `[N::]`, `[N::M]`.
- There is currently no way to parse an expression like this: `[N::int:M]`, `[N::int:M::int:P::int]`.

May need to update `Parser` with new field `break_last_token` to *unglue* some Doubled token.
refer to: https://github.com/rust-lang/rust/blob/c716f180e8c48b12bb055e6a7dea2a7f474cf66d/compiler/rustc_parse/src/parser/mod.rs#L142-L156
