### PR TITLE
fix: openssl is compiled twice, once not vendored in linux

### DIFF
--- a/src/utils/workspace-config/Cargo.toml
+++ b/src/utils/workspace-config/Cargo.toml
@@ -25,5 +25,10 @@ zstd-sys = { version = "2", optional = true, default-features = false, features 
 # workspace-hack = { path = "../../workspace-hack" }
 # Don't add workspace-hack into this crate!
 
+# FIXME(xxchan): This is a temporary fix due to how cargo and hakari works. See related PR for more details.
+# We will revisit how to handle workspace-hack and build-dependency issues later.
+[build-dependencies]
+openssl-sys = { version = "=0.9.92", optional = true, features = ["vendored"] }
+
 [lints]
 workspace = true


### PR DESCRIPTION
It’s broken since the workspace-hack change (#12961).

Openssl-sys is compiled twice on Linux, because features are not unified.

The one for build-dependency doesn’t have openssl-sys feature. It’s depended by tls-native, which is depended by sql-x, which is build-dependency in workspace-hack. (Since we didn't configure hakari to unify target os-specific dependencies, hakari unified it only *partialy*, and this cause them unnecessarily compiled twice.)

Simply put, it’s now a build-dependency so
- Feature is not unified. This can be fixed easily and is done in this PR.
- It will be compiled twice in release mode. Unless #12362, but it’s broken. Not a large problem(? Well, I’m not sure But it has been so). Just slower…

This only happens on linux, but not mac, because native-tls works differently for different os.

Temporary workaround this by manually unify feature in workspace-config to unblock daily pipeline and stuff. Later, we might delete [build-dependencies] for docker/release. Or completely get rid of workspace-hack.

TLDR: After this change, on Linux openssl is compiled once in debug mode, and still twice in release mode. Both once on mac.

I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
