### PR TITLE
feat(sink): use 'create sink ... format ... encode' to create redis sink

### DIFF
--- a/integration_tests/redis-sink/create_sink.sql
+++ b/integration_tests/redis-sink/create_sink.sql
@@ -3,19 +3,13 @@ FROM
     bhv_mv WITH (
     primary_key = 'user_id',
     connector = 'redis',
-    type = 'append-only',
-    force_append_only='true',
     redis.url= 'redis://127.0.0.1:6379/',
-);
+)FORMAT PLAIN ENCODE JSON(force_append_only='true');
 
 CREATE SINK bhv_redis_sink_2
 FROM
     bhv_mv WITH (
     primary_key = 'user_id',
     connector = 'redis',
-    type = 'append-only',
-    force_append_only='true',
     redis.url= 'redis://127.0.0.1:6379/',
-    redis.keyformat='user_id:{user_id}',
-    redis.valueformat='username:{username},event_timestamp{event_timestamp}'
-);
+)FORMAT PLAIN ENCODE TEMPLATE(force_append_only='true', redis_key_format = 'UserID:{user_id}', redis_value_format = 'TargetID:{target_id},EventTimestamp{event_timestamp}');

--- a/integration_tests/redis-sink/create_sink.sql
+++ b/integration_tests/redis-sink/create_sink.sql
@@ -12,4 +12,4 @@ FROM
     primary_key = 'user_id',
     connector = 'redis',
     redis.url= 'redis://127.0.0.1:6379/',
-)FORMAT PLAIN ENCODE TEMPLATE(force_append_only='true', redis_key_format = 'UserID:{user_id}', redis_value_format = 'TargetID:{target_id},EventTimestamp{event_timestamp}');
+)FORMAT PLAIN ENCODE TEMPLATE(force_append_only='true', key_format = 'UserID:{user_id}', value_format = 'TargetID:{target_id},EventTimestamp{event_timestamp}');

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -106,6 +106,7 @@ enum EncodeType {
   ENCODE_TYPE_PROTOBUF = 4;
   ENCODE_TYPE_JSON = 5;
   ENCODE_TYPE_BYTES = 6;
+  ENCODE_TYPE_TEMPLATE = 7;
 }
 
 enum RowFormatType {

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -140,7 +140,6 @@ impl SinkFormatDesc {
         use crate::sink::kafka::KafkaSink;
         use crate::sink::kinesis::KinesisSink;
         use crate::sink::pulsar::PulsarSink;
-        use crate::sink::redis::RedisSink;
         use crate::sink::Sink as _;
 
         let format = match r#type {
@@ -155,10 +154,9 @@ impl SinkFormatDesc {
             }
         };
         let encode = match connector {
-            KafkaSink::SINK_NAME
-            | KinesisSink::SINK_NAME
-            | PulsarSink::SINK_NAME
-            | RedisSink::SINK_NAME => SinkEncode::Json,
+            KafkaSink::SINK_NAME | KinesisSink::SINK_NAME | PulsarSink::SINK_NAME => {
+                SinkEncode::Json
+            }
             _ => return Ok(None),
         };
         Ok(Some(Self {

--- a/src/connector/src/sink/catalog/mod.rs
+++ b/src/connector/src/sink/catalog/mod.rs
@@ -132,6 +132,7 @@ pub enum SinkEncode {
     Json,
     Protobuf,
     Avro,
+    Template,
 }
 
 impl SinkFormatDesc {
@@ -139,6 +140,7 @@ impl SinkFormatDesc {
         use crate::sink::kafka::KafkaSink;
         use crate::sink::kinesis::KinesisSink;
         use crate::sink::pulsar::PulsarSink;
+        use crate::sink::redis::RedisSink;
         use crate::sink::Sink as _;
 
         let format = match r#type {
@@ -153,9 +155,10 @@ impl SinkFormatDesc {
             }
         };
         let encode = match connector {
-            KafkaSink::SINK_NAME | KinesisSink::SINK_NAME | PulsarSink::SINK_NAME => {
-                SinkEncode::Json
-            }
+            KafkaSink::SINK_NAME
+            | KinesisSink::SINK_NAME
+            | PulsarSink::SINK_NAME
+            | RedisSink::SINK_NAME => SinkEncode::Json,
             _ => return Ok(None),
         };
         Ok(Some(Self {
@@ -177,6 +180,7 @@ impl SinkFormatDesc {
             SinkEncode::Json => E::Json,
             SinkEncode::Protobuf => E::Protobuf,
             SinkEncode::Avro => E::Avro,
+            SinkEncode::Template => E::Template,
         };
         let options = self
             .options
@@ -212,6 +216,7 @@ impl TryFrom<PbSinkFormatDesc> for SinkFormatDesc {
         let encode = match value.encode() {
             E::Json => SinkEncode::Json,
             E::Protobuf => SinkEncode::Protobuf,
+            E::Template => SinkEncode::Template,
             E::Avro => SinkEncode::Avro,
             e @ (E::Unspecified | E::Native | E::Csv | E::Bytes) => {
                 return Err(SinkError::Config(anyhow!(

--- a/src/connector/src/sink/formatter/mod.rs
+++ b/src/connector/src/sink/formatter/mod.rs
@@ -116,11 +116,9 @@ impl SinkFormatterImpl {
                         Ok(SinkFormatterImpl::AppendOnlyProto(formatter))
                     }
                     SinkEncode::Avro => err_unsupported(),
-                    SinkEncode::Template => {
-                        return Err(SinkError::Config(anyhow!(
-                            "Template only support with redis sink"
-                        )))
-                    }
+                    SinkEncode::Template => Err(SinkError::Config(anyhow!(
+                        "Template only support with redis sink"
+                    ))),
                 }
             }
             SinkFormat::Debezium => {
@@ -184,9 +182,9 @@ impl SinkFormatterImpl {
                 let key_encoder = JsonEncoder::new(
                     schema.clone(),
                     Some(pk_indices),
-                    TimestampHandlingMode::Milli,
+                    TimestampHandlingMode::String,
                 );
-                let val_encoder = JsonEncoder::new(schema, None, TimestampHandlingMode::Milli);
+                let val_encoder = JsonEncoder::new(schema, None, TimestampHandlingMode::String);
                 match format_desc.format {
                     SinkFormat::AppendOnly => Ok(SinkFormatterImpl::AppendOnlyJson(
                         AppendOnlyFormatter::new(Some(key_encoder), val_encoder),
@@ -227,11 +225,9 @@ impl SinkFormatterImpl {
                     ))),
                 }
             }
-            _ => {
-                return Err(SinkError::Config(anyhow!(
-                    "Redis sink only support Json and Template"
-                )))
-            }
+            _ => Err(SinkError::Config(anyhow!(
+                "Redis sink only support Json and Template"
+            ))),
         }
     }
 }

--- a/src/connector/src/sink/redis.rs
+++ b/src/connector/src/sink/redis.rs
@@ -71,7 +71,7 @@ pub struct RedisSink {
     format_desc: SinkFormatDesc,
 }
 
-fn check_string_format(format: &String, set: &HashSet<String>) -> Result<()> {
+fn check_string_format(format: &str, set: &HashSet<String>) -> Result<()> {
     // We will check if the string inside {} corresponds to a column name in rw.
     // In other words, the content within {} should exclusively consist of column names from rw,
     // which means '{{column_name}}' or '{{column_name1},{column_name2}}' would be incorrect.
@@ -380,7 +380,7 @@ mod test {
         let format_desc = SinkFormatDesc {
             format: SinkFormat::AppendOnly,
             encode: SinkEncode::Template,
-            options: BTreeMap::default(),
+            options: btree_map,
         };
 
         let mut redis_sink_writer = RedisSinkWriter::mock(schema, vec![0], &format_desc).unwrap();

--- a/src/frontend/src/handler/create_sink.rs
+++ b/src/frontend/src/handler/create_sink.rs
@@ -244,6 +244,7 @@ fn bind_sink_format_desc(value: SinkSchema) -> Result<SinkFormatDesc> {
         E::Json => SinkEncode::Json,
         E::Protobuf => SinkEncode::Protobuf,
         E::Avro => SinkEncode::Avro,
+        E::Template => SinkEncode::Template,
         e @ (E::Native | E::Csv | E::Bytes) => {
             return Err(ErrorCode::BindError(format!("sink encode unsupported: {e}")).into())
         }
@@ -262,6 +263,7 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
         use risingwave_connector::sink::kafka::KafkaSink;
         use risingwave_connector::sink::kinesis::KinesisSink;
         use risingwave_connector::sink::pulsar::PulsarSink;
+        use risingwave_connector::sink::redis::RedisSink;
         use risingwave_connector::sink::Sink as _;
 
         convert_args!(hashmap!(
@@ -279,6 +281,10 @@ static CONNECTORS_COMPATIBLE_FORMATS: LazyLock<HashMap<String, HashMap<Format, V
                     Format::Plain => vec![Encode::Json],
                     Format::Upsert => vec![Encode::Json],
                     Format::Debezium => vec![Encode::Json],
+                ),
+                RedisSink::SINK_NAME => hashmap!(
+                    Format::Plain => vec![Encode::Json,Encode::Template],
+                    Format::Upsert => vec![Encode::Json,Encode::Template],
                 ),
         ))
     });

--- a/src/sqlparser/src/ast/statement.rs
+++ b/src/sqlparser/src/ast/statement.rs
@@ -294,6 +294,7 @@ pub enum Encode {
     Json,     // Keyword::JSON
     Bytes,    // Keyword::BYTES
     Native,
+    Template,
 }
 
 // TODO: unify with `from_keyword`
@@ -309,6 +310,7 @@ impl fmt::Display for Encode {
                 Encode::Json => "JSON",
                 Encode::Bytes => "BYTES",
                 Encode::Native => "NATIVE",
+                Encode::Template => "TEMPLATE",
             }
         )
     }
@@ -322,13 +324,12 @@ impl Encode {
             "CSV" => Encode::Csv,
             "PROTOBUF" => Encode::Protobuf,
             "JSON" => Encode::Json,
+            "TEMPLATE" => Encode::Template,
             "NATIVE" => Encode::Native, // used internally for schema change
-            _ => {
-                return Err(ParserError::ParserError(
-                    "expected AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE after Encode"
-                        .to_string(),
-                ))
-            }
+            _ => return Err(ParserError::ParserError(
+                "expected AVRO | BYTES | CSV | PROTOBUF | JSON | NATIVE | TEMPLATE after Encode"
+                    .to_string(),
+            )),
         })
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
use 'create sink ... format ... encode' to create redis sink like kafka.
And add Template encode to support custom format for strings input into redis
<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests


## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note
create table 
```
create table t1(v1 int, v2 int);
```

create redis sink with append_only and json
```
CREATE SINK s1 AS t1 WITH (
    primary_key = 'v1 ',
    connector = 'redis',
    redis.url= 'redis://127.0.0.1:6379/',
)FORMAT PLAIN ENCODE JSON(force_append_only='true');
```
create redis sink with upsert and json
```
CREATE SINK s1 AS t1  WITH (
    primary_key = 'v1 ',
    connector = 'redis',
    redis.url= 'redis://127.0.0.1:6379/',
)FORMAT UPSERT ENCODE JSON;
```
create redis sink with append_only and template
```
CREATE SINK s1 AS t1  WITH (
    primary_key = 'v1 ',
    connector = 'redis',
    redis.url= 'redis://127.0.0.1:6379/',
)FORMAT PLAIN ENCODE TEMPLATE(force_append_only='true', redis_key_format = 'V1 is:{v1}', redis_value_format = 'V2 is:{v2}');
```
create redis sink with upsert and template
```
CREATE SINK s1 AS t1  WITH (
    primary_key = 'v1 ',
    connector = 'redis',
    redis.url= 'redis://127.0.0.1:6379/',
)FORMAT UPSERT ENCODE TEMPLATE(redis_key_format = 'V1 is:{v1}', redis_value_format = 'V2 is:{v2}');
```


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
