### PR TITLE
feat(expr): add `jsonb_pretty` function

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -218,6 +218,7 @@ message ExprNode {
     JSONB_ARRAY_LENGTH = 603;
     IS_JSON = 604;
     JSONB_CAT = 605;
+    JSONB_PRETTY = 607;
 
     // Non-pure functions below (> 1000)
     // ------------------------

--- a/src/expr/impl/src/scalar/jsonb_info.rs
+++ b/src/expr/impl/src/scalar/jsonb_info.rs
@@ -56,7 +56,8 @@ pub fn is_json_type(s: &str, t: &str) -> bool {
 /// Converts the given JSON value to pretty-printed, indented text.
 ///
 /// # Examples
-/// ```slt
+// TODO: enable docslt after sqllogictest supports multiline output
+/// ```text
 /// query T
 /// select jsonb_pretty('[{"f1":1,"f2":null}, 2]');
 /// ----

--- a/src/expr/impl/src/scalar/jsonb_info.rs
+++ b/src/expr/impl/src/scalar/jsonb_info.rs
@@ -52,3 +52,23 @@ pub fn is_json_type(s: &str, t: &str) -> bool {
         }
     })
 }
+
+/// Converts the given JSON value to pretty-printed, indented text.
+///
+/// # Examples
+/// ```slt
+/// query T
+/// select jsonb_pretty('[{"f1":1,"f2":null}, 2]');
+/// ----
+/// [
+///     {
+///         "f1": 1,
+///         "f2": null
+///     },
+///     2
+/// ]
+/// ```
+#[function("jsonb_pretty(jsonb) -> varchar")]
+pub fn jsonb_pretty(v: JsonbRef<'_>, writer: &mut impl Write) {
+    v.pretty(writer).unwrap()
+}

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -864,6 +864,7 @@ impl Binder {
                 ("jsonb_array_element_text", raw_call(ExprType::JsonbAccessStr)),
                 ("jsonb_typeof", raw_call(ExprType::JsonbTypeof)),
                 ("jsonb_array_length", raw_call(ExprType::JsonbArrayLength)),
+                ("jsonb_pretty", raw_call(ExprType::JsonbPretty)),
                 // Functions that return a constant value
                 ("pi", pi()),
                 // greatest and least

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -177,6 +177,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | expr_node::Type::JsonbAccessStr
             | expr_node::Type::JsonbTypeof
             | expr_node::Type::JsonbArrayLength
+            | expr_node::Type::JsonbPretty
             | expr_node::Type::IsJson
             | expr_node::Type::Sind
             | expr_node::Type::Cosd

--- a/src/risedevtool/src/bin/risedev-docslt.rs
+++ b/src/risedevtool/src/bin/risedev-docslt.rs
@@ -53,11 +53,12 @@ fn extract_slt(filepath: &Path) -> Vec<SltBlock> {
             if !(line.starts_with("///") || line.starts_with("//!")) {
                 panic!("expect /// or //! at {}:{}", filepath.display(), i + 1);
             }
-            line = line[3..].trim();
-            if line == "```" {
+            line = &line[3..];
+            if line.trim() == "```" {
                 break;
             }
-            content += line;
+            // strip one leading space
+            content += line.strip_prefix(' ').unwrap_or(line);
             content += "\n";
         }
         blocks.push(SltBlock {

--- a/src/tests/regress/data/sql/jsonb.sql
+++ b/src/tests/regress/data/sql/jsonb.sql
@@ -1047,9 +1047,9 @@ SELECT '["a","b","c",[1,2],null]'::jsonb -> -6;
 --@ select jsonb_strip_nulls('{"a": {"b": null, "c": null}, "d": {} }');
 
 
---@ select jsonb_pretty('{"a": "test", "b": [1, 2, 3], "c": "test3", "d":{"dd": "test4", "dd2":{"ddd": "test5"}}}');
---@ select jsonb_pretty('[{"f1":1,"f2":null},2,null,[[{"x":true},6,7],8],3]');
---@ select jsonb_pretty('{"a":["b", "c"], "d": {"e":"f"}}');
+select jsonb_pretty('{"a": "test", "b": [1, 2, 3], "c": "test3", "d":{"dd": "test4", "dd2":{"ddd": "test5"}}}');
+select jsonb_pretty('[{"f1":1,"f2":null},2,null,[[{"x":true},6,7],8],3]');
+select jsonb_pretty('{"a":["b", "c"], "d": {"e":"f"}}');
 --@ 
 --@ select jsonb_concat('{"d": "test", "a": [1, 2]}', '{"g": "test2", "c": {"c1":1, "c2":2}}');
 --@ 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title. based on #11805 

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

Support `jsonb_pretty` function.

```
jsonb_pretty ( jsonb ) → text
Converts the given JSON value to pretty-printed, 4 spaces indented text.
jsonb_pretty('[{"f1":1,"f2":null}, 2]') →
[
    {
        "f1": 1,
        "f2": null
    },
    2
]
```