### PR TITLE
feat(metrics): remove metrics labels after being collected

### DIFF
--- a/src/common/src/metrics/guarded_metrics.rs
+++ b/src/common/src/metrics/guarded_metrics.rs
@@ -303,19 +303,23 @@ mod tests {
     fn test_label_guarded_metrics_drop() {
         let vec = LabelGuardedIntCounterVec::<3>::test_int_counter_vec();
         let m1_1 = vec.with_label_values(&["1", "2", "3"]);
-        assert_eq!(1, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
         let m1_2 = vec.with_label_values(&["1", "2", "3"]);
         let m1_3 = m1_2.clone();
-        assert_eq!(1, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
         let m2 = vec.with_label_values(&["2", "2", "3"]);
-        assert_eq!(2, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(2, vec.collect().pop().unwrap().get_metric().len());
         drop(m1_3);
-        assert_eq!(2, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(2, vec.collect().pop().unwrap().get_metric().len());
+        assert_eq!(2, vec.collect().pop().unwrap().get_metric().len());
         drop(m2);
-        assert_eq!(1, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(2, vec.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
         drop(m1_1);
-        assert_eq!(1, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
         drop(m1_2);
-        assert_eq!(0, vec.inner.collect().pop().unwrap().get_metric().len());
+        assert_eq!(1, vec.collect().pop().unwrap().get_metric().len());
+        assert_eq!(0, vec.collect().pop().unwrap().get_metric().len());
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Previously we remove the label immediately when the metrics is dropped. In this PR, we change to only adding the labels to a buffer, and remove the labels after the metrics is collected.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
