### PR TITLE
feat(parser): support "jsonb" as typed string

### DIFF
--- a/e2e_test/batch/types/jsonb.slt.part
+++ b/e2e_test/batch/types/jsonb.slt.part
@@ -34,10 +34,10 @@ true
 NULL
 
 # typed string
-query T
-select jsonb 'true';
+query TT
+select jsonb 'true', JsonB '{}';
 ----
-true
+true {}
 
 query T
 select 'true'::jsonb::bool;

--- a/e2e_test/batch/types/jsonb.slt.part
+++ b/e2e_test/batch/types/jsonb.slt.part
@@ -33,6 +33,12 @@ null
 true
 NULL
 
+# typed string
+query T
+select jsonb 'true';
+----
+true
+
 query T
 select 'true'::jsonb::bool;
 ----

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -642,7 +642,6 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
                 "float4" => DataType::Float32,
                 "float8" => DataType::Float64,
                 "timestamptz" => DataType::Timestamptz,
-                "jsonb" => DataType::Jsonb,
                 "serial" => {
                     return Err(ErrorCode::NotSupported(
                         "Column type SERIAL is not supported".into(),
@@ -654,6 +653,7 @@ pub fn bind_data_type(data_type: &AstDataType) -> Result<DataType> {
             }
         }
         AstDataType::Bytea => DataType::Bytea,
+        AstDataType::Jsonb => DataType::Jsonb,
         AstDataType::Regclass
         | AstDataType::Regproc
         | AstDataType::Uuid

--- a/src/frontend/src/binder/select.rs
+++ b/src/frontend/src/binder/select.rs
@@ -905,6 +905,7 @@ fn data_type_to_alias(data_type: &AstDataType) -> Option<String> {
         AstDataType::Regproc => "regproc".to_string(),
         AstDataType::Text => "text".to_string(),
         AstDataType::Bytea => "bytea".to_string(),
+        AstDataType::Jsonb => "jsonb".to_string(),
         AstDataType::Array(ty) => return data_type_to_alias(ty),
         AstDataType::Custom(ty) => format!("{}", ty),
         AstDataType::Struct(_) => {

--- a/src/sqlparser/src/ast/data_type.rs
+++ b/src/sqlparser/src/ast/data_type.rs
@@ -62,6 +62,8 @@ pub enum DataType {
     Text,
     /// Bytea
     Bytea,
+    /// JSONB
+    Jsonb,
     /// Custom type such as enums
     Custom(ObjectName),
     /// Arrays
@@ -102,6 +104,7 @@ impl fmt::Display for DataType {
             DataType::Regproc => write!(f, "REGPROC"),
             DataType::Text => write!(f, "TEXT"),
             DataType::Bytea => write!(f, "BYTEA"),
+            DataType::Jsonb => write!(f, "JSONB"),
             DataType::Array(ty) => write!(f, "{}[]", ty),
             DataType::Custom(ty) => write!(f, "{}", ty),
             DataType::Struct(defs) => {

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -280,7 +280,6 @@ define_keywords!(
     JOBS,
     JOIN,
     JSON,
-    JSONB,
     KEY,
     KEYS,
     LANGUAGE,

--- a/src/sqlparser/src/keywords.rs
+++ b/src/sqlparser/src/keywords.rs
@@ -280,6 +280,7 @@ define_keywords!(
     JOBS,
     JOIN,
     JSON,
+    JSONB,
     KEY,
     KEYS,
     LANGUAGE,

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3247,6 +3247,7 @@ impl Parser {
                 }
                 Keyword::STRUCT => Ok(DataType::Struct(self.parse_struct_data_type()?)),
                 Keyword::BYTEA => Ok(DataType::Bytea),
+                Keyword::JSONB => Ok(DataType::Jsonb),
                 Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => {
                     let (precision, scale) = self.parse_optional_precision_scale()?;
                     Ok(DataType::Decimal(precision, scale))

--- a/src/sqlparser/src/parser.rs
+++ b/src/sqlparser/src/parser.rs
@@ -3247,7 +3247,6 @@ impl Parser {
                 }
                 Keyword::STRUCT => Ok(DataType::Struct(self.parse_struct_data_type()?)),
                 Keyword::BYTEA => Ok(DataType::Bytea),
-                Keyword::JSONB => Ok(DataType::Jsonb),
                 Keyword::NUMERIC | Keyword::DECIMAL | Keyword::DEC => {
                     let (precision, scale) = self.parse_optional_precision_scale()?;
                     Ok(DataType::Decimal(precision, scale))
@@ -3255,7 +3254,12 @@ impl Parser {
                 _ => {
                     self.prev_token();
                     let type_name = self.parse_object_name()?;
-                    Ok(DataType::Custom(type_name))
+                    // JSONB is not a keyword
+                    if type_name.to_string().eq_ignore_ascii_case("jsonb") {
+                        Ok(DataType::Jsonb)
+                    } else {
+                        Ok(DataType::Custom(type_name))
+                    }
                 }
             },
             unexpected => {


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR add a variant `AstDataType::Jsonb` in parser, so that we can use `jsonb` as typed string.

```sql
select jsonb '{}';
```

This syntax is used in regress tests.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

added a new way to create jsonb value:
```sql
jsonb '{"key": 1}'
```

This can be added as an example in the [table](https://docs.risingwave.com/docs/current/sql-data-types/).
