### PR TITLE
fix(binder): only table-in-out functions can have subquery parameters

### DIFF
--- a/src/frontend/planner_test/tests/testdata/input/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/input/subquery.yaml
@@ -291,3 +291,13 @@
   expected_outputs:
     - batch_plan
     - stream_plan
+- name: Only table-in-out functions can have subquery parameters.
+  sql: |
+    SELECT * FROM generate_series(1, (select 1));
+  expected_outputs:
+    - binder_error
+- name: While this one is allowed.
+  sql: |
+    SELECT generate_series(1, (select 1));
+  expected_outputs:
+    - batch_plan

--- a/src/frontend/planner_test/tests/testdata/output/subquery.yaml
+++ b/src/frontend/planner_test/tests/testdata/output/subquery.yaml
@@ -864,3 +864,16 @@
           └─StreamHopWindow { time_col: t1.ts, slide: 00:10:00, size: 00:30:00, output: all }
             └─StreamFilter { predicate: IsNotNull(t1.ts) }
               └─StreamTableScan { table: t1, columns: [t1.k, t1.ts], pk: [t1.k], dist: UpstreamHashShard(t1.k) }
+- name: Only table-in-out functions can have subquery parameters.
+  sql: |
+    SELECT * FROM generate_series(1, (select 1));
+  binder_error: 'Invalid input syntax: Only table-in-out functions can have subquery parameters, generate_series only accepts constant parameters'
+- name: While this one is allowed.
+  sql: |
+    SELECT generate_series(1, (select 1));
+  batch_plan: |-
+    BatchProject { exprs: [GenerateSeries(1:Int32, $0)] }
+    └─BatchProjectSet { select_list: [GenerateSeries(1:Int32, $0)] }
+      └─BatchNestedLoopJoin { type: LeftOuter, predicate: true, output: all }
+        ├─BatchValues { rows: [[]] }
+        └─BatchValues { rows: [[1:Int32]] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Resolve https://github.com/risingwavelabs/risingwave/issues/12998
- We apply the same strategy as DuckDB when handling subqueries.
- In detail, we use apply to support various subqueries, but apply need a source as input. For this sql `SELECT * FROM generate_series(1, (select 1));` we don't have any input for the apply, since table function here itself is the source and depends on the subquery to give them the parameters.

```
-- This sql should be forbided.
-- Only table-in-out functions can have subquery parameters - generate_series only accepts constant parameters
SELECT * FROM generate_series(1, (select 1));

-- This one is allowed
SELECT generate_series(1, (select 1));
```

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
