### PR TITLE
chore(ci): remove connector start service from ci

### DIFF
--- a/ci/scripts/e2e-iceberg-sink-test.sh
+++ b/ci/scripts/e2e-iceberg-sink-test.sh
@@ -31,9 +31,8 @@ buildkite-agent artifact download risingwave-connector.tar.gz ./
 mkdir ./connector-node
 tar xf ./risingwave-connector.tar.gz -C ./connector-node
 
-echo "--- starting risingwave cluster with connector node"
+echo "--- starting risingwave cluster"
 mkdir -p .risingwave/log
-./connector-node/start-service.sh -p 50051 > .risingwave/log/connector-sink.log 2>&1 &
 cargo make ci-start ci-iceberg-test
 sleep 1
 
@@ -84,4 +83,3 @@ fi
 
 echo "--- Kill cluster"
 cargo make ci-kill
-pkill -f connector-node

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -48,9 +48,6 @@ export PGHOST=db PGUSER=postgres PGPASSWORD=postgres PGDATABASE=cdc_test
 createdb
 psql < ./e2e_test/source/cdc/postgres_cdc.sql
 
-node_port=50051
-node_timeout=10
-
 echo "--- starting risingwave cluster"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 cargo make ci-start ci-1cn-1fe-with-recovery

--- a/ci/scripts/e2e-source-test.sh
+++ b/ci/scripts/e2e-source-test.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 source ci/scripts/common.sh
 
 # prepare environment
-export CONNECTOR_RPC_ENDPOINT="localhost:50051"
 export CONNECTOR_LIBS_PATH="./connector-node/libs"
 
 while getopts 'p:' opt; do
@@ -52,33 +51,9 @@ psql < ./e2e_test/source/cdc/postgres_cdc.sql
 node_port=50051
 node_timeout=10
 
-wait_for_connector_node_start() {
-  start_time=$(date +%s)
-  while :
-  do
-      if nc -z localhost $node_port; then
-          echo "Port $node_port is listened! Connector Node is up!"
-          break
-      fi
-
-      current_time=$(date +%s)
-      elapsed_time=$((current_time - start_time))
-      if [ $elapsed_time -ge $node_timeout ]; then
-          echo "Timeout waiting for port $node_port to be listened!"
-          exit 1
-      fi
-      sleep 0.1
-  done
-  sleep 2
-}
-
-echo "--- starting risingwave cluster with connector node"
+echo "--- starting risingwave cluster"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
 cargo make ci-start ci-1cn-1fe-with-recovery
-./connector-node/start-service.sh -p $node_port > .risingwave/log/connector-node.log 2>&1 &
-
-echo "waiting for connector node to start"
-wait_for_connector_node_start
 
 echo "--- inline cdc test"
 export MYSQL_HOST=mysql MYSQL_TCP_PORT=3306 MYSQL_PWD=123456
@@ -96,7 +71,6 @@ sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check.slt'
 
 # kill cluster and the connector node
 cargo make kill
-pkill -f connector-node
 echo "cluster killed "
 
 # insert new rows
@@ -106,10 +80,6 @@ echo "inserted new rows into mysql and postgres"
 
 # start cluster w/o clean-data
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \
-touch .risingwave/log/connector-node.log
-./connector-node/start-service.sh -p $node_port >> .risingwave/log/connector-node.log 2>&1 &
-echo "(recovery) waiting for connector node to start"
-wait_for_connector_node_start
 
 cargo make dev ci-1cn-1fe-with-recovery
 echo "wait for cluster recovery finish"
@@ -120,7 +90,6 @@ sqllogictest -p 4566 -d dev './e2e_test/source/cdc/cdc.check_new_rows.slt'
 
 echo "--- Kill cluster"
 cargo make ci-kill
-pkill -f connector-node
 
 echo "--- e2e, ci-1cn-1fe, protobuf schema registry"
 RUST_LOG="info,risingwave_stream=info,risingwave_batch=info,risingwave_storage=info" \


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Since we have already support embedded connector node, we don't need to start connector services in most ci tests.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
