### PR TITLE
chore(storage): issue a warning when key value is too large

### DIFF
--- a/src/storage/src/hummock/sstable/builder.rs
+++ b/src/storage/src/hummock/sstable/builder.rs
@@ -293,12 +293,22 @@ impl<W: SstableWriter, F: FilterBuilder> SstableBuilder<W, F> {
         const LARGE_KEY_LEN: usize = MAX_KEY_LEN >> 1;
 
         let table_key_len = full_key.user_key.table_key.as_ref().len();
-        if table_key_len >= LARGE_KEY_LEN {
+        let table_value_len = match &value {
+            HummockValue::Put(t) => t.len(),
+            HummockValue::Delete => 0,
+        };
+        let large_value_len = self.options.max_sst_size as usize / 10;
+        let large_key_value_len = self.options.max_sst_size as usize / 2;
+        if table_key_len >= LARGE_KEY_LEN
+            || table_value_len > large_value_len
+            || table_key_len + table_value_len > large_key_value_len
+        {
             let table_id = full_key.user_key.table_id.table_id();
             tracing::warn!(
-                "A large key (table_id={}, len={}, epoch={}) is added to block",
+                "A large key/value (table_id={}, key len={}, value len={}, epoch={}) is added to block",
                 table_id,
                 table_key_len,
+                table_value_len,
                 full_key.epoch
             );
         }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR adds warning on too large key value during building SST, so that we can identify the cause of exceeding 4GB, which is the hard limit.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
