### PR TITLE
feat(expr): add `jsonb_strip_nulls` function

### DIFF
--- a/proto/expr.proto
+++ b/proto/expr.proto
@@ -244,6 +244,7 @@ message ExprNode {
     //
     // jsonb #- text[] -> jsonb
     JSONB_DELETE_PATH = 615;
+    JSONB_STRIP_NULLS = 616;
 
     // Non-pure functions below (> 1000)
     // ------------------------

--- a/src/expr/impl/src/scalar/jsonb_delete.rs
+++ b/src/expr/impl/src/scalar/jsonb_delete.rs
@@ -377,7 +377,7 @@ fn normalize_array_index(len: usize, index: i32) -> Option<usize> {
 /// query T
 /// SELECT jsonb_strip_nulls('[{"f1":1, "f2":null}, 2, null, 3]');
 /// ----
-/// [{"f1":1},2,null,3]
+/// [{"f1": 1}, 2, null, 3]
 /// ```
 #[function("jsonb_strip_nulls(jsonb) -> jsonb")]
 fn jsonb_strip_nulls(v: JsonbRef<'_>) -> JsonbVal {

--- a/src/expr/impl/src/scalar/jsonb_delete.rs
+++ b/src/expr/impl/src/scalar/jsonb_delete.rs
@@ -367,3 +367,47 @@ fn normalize_array_index(len: usize, index: i32) -> Option<usize> {
         Some((len as i32 + index) as usize)
     }
 }
+
+/// Recursively removes all object fields that have null values from the given JSON value.
+/// Null values that are not object fields are untouched.
+///
+/// Examples:
+///
+/// ```slt
+/// query T
+/// SELECT jsonb_strip_nulls('[{"f1":1, "f2":null}, 2, null, 3]');
+/// ----
+/// [{"f1":1},2,null,3]
+/// ```
+#[function("jsonb_strip_nulls(jsonb) -> jsonb")]
+fn jsonb_strip_nulls(v: JsonbRef<'_>) -> JsonbVal {
+    let jsonb: ValueRef<'_> = v.into();
+    let mut builder = jsonbb::Builder::<Vec<u8>>::with_capacity(jsonb.capacity());
+    jsonbb_strip_nulls(jsonb, &mut builder);
+    JsonbVal::from(builder.finish())
+}
+
+/// Recursively removes all object fields that have null values from the given JSON value.
+fn jsonbb_strip_nulls(jsonb: ValueRef<'_>, builder: &mut jsonbb::Builder) {
+    match jsonb {
+        ValueRef::Object(obj) => {
+            builder.begin_object();
+            for (k, v) in obj.iter() {
+                if let ValueRef::Null = v {
+                    continue;
+                }
+                builder.add_string(k);
+                jsonbb_strip_nulls(v, builder);
+            }
+            builder.end_object();
+        }
+        ValueRef::Array(array) => {
+            builder.begin_array();
+            for v in array.iter() {
+                jsonbb_strip_nulls(v, builder);
+            }
+            builder.end_array();
+        }
+        _ => builder.add_value(jsonb),
+    }
+}

--- a/src/frontend/src/binder/expr/function.rs
+++ b/src/frontend/src/binder/expr/function.rs
@@ -893,6 +893,7 @@ impl Binder {
                 ("jsonb_exists_all", raw_call(ExprType::JsonbExistsAll)),
                 ("jsonb_delete", raw_call(ExprType::Subtract)),
                 ("jsonb_delete_path", raw_call(ExprType::JsonbDeletePath)),
+                ("jsonb_strip_nulls", raw_call(ExprType::JsonbStripNulls)),
                 // Functions that return a constant value
                 ("pi", pi()),
                 // greatest and least

--- a/src/frontend/src/expr/pure.rs
+++ b/src/frontend/src/expr/pure.rs
@@ -188,6 +188,7 @@ impl ExprVisitor for ImpureAnalyzer {
             | expr_node::Type::JsonbExists
             | expr_node::Type::JsonbExistsAny
             | expr_node::Type::JsonbExistsAll
+            | expr_node::Type::JsonbStripNulls
             | expr_node::Type::IsJson
             | expr_node::Type::Sind
             | expr_node::Type::Cosd

--- a/src/tests/regress/data/sql/jsonb.sql
+++ b/src/tests/regress/data/sql/jsonb.sql
@@ -1029,22 +1029,22 @@ SELECT '{"n":null,"a":1,"b":[1,2],"c":{"1":2},"d":{"1":[2,3]}}'::jsonb ? 'e';
 
 -- jsonb_strip_nulls
 
---@ select jsonb_strip_nulls(null);
---@ 
---@ select jsonb_strip_nulls('1');
---@ 
---@ select jsonb_strip_nulls('"a string"');
---@ 
---@ select jsonb_strip_nulls('null');
---@ 
---@ select jsonb_strip_nulls('[1,2,null,3,4]');
---@ 
---@ select jsonb_strip_nulls('{"a":1,"b":null,"c":[2,null,3],"d":{"e":4,"f":null}}');
---@ 
---@ select jsonb_strip_nulls('[1,{"a":1,"b":null,"c":2},3]');
---@ 
---@ -- an empty object is not null and should not be stripped
---@ select jsonb_strip_nulls('{"a": {"b": null, "c": null}, "d": {} }');
+select jsonb_strip_nulls(null);
+
+select jsonb_strip_nulls('1');
+
+select jsonb_strip_nulls('"a string"');
+
+select jsonb_strip_nulls('null');
+
+select jsonb_strip_nulls('[1,2,null,3,4]');
+
+select jsonb_strip_nulls('{"a":1,"b":null,"c":[2,null,3],"d":{"e":4,"f":null}}');
+
+select jsonb_strip_nulls('[1,{"a":1,"b":null,"c":2},3]');
+
+-- an empty object is not null and should not be stripped
+select jsonb_strip_nulls('{"a": {"b": null, "c": null}, "d": {} }');
 
 
 select jsonb_pretty('{"a": "test", "b": [1, 2, 3], "c": "test3", "d":{"dd": "test4", "dd2":{"ddd": "test5"}}}');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As title.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

Add this function:
```
jsonb_strip_nulls ( jsonb ) → jsonb
Deletes all object fields that have null values from the given JSON value, recursively. Null values that are not object fields are untouched.
json_strip_nulls('[{"f1":1, "f2":null}, 2, null, 3]') → [{"f1":1},2,null,3]
```