### PR TITLE
refactor: introduce `thiserror-ext` for boxed error wrapper definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8414,6 +8414,7 @@ dependencies = [
  "madsim-tonic",
  "static_assertions",
  "thiserror",
+ "thiserror-ext",
 ]
 
 [[package]]
@@ -9954,6 +9955,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-ext"
+version = "0.1.0"
+source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=ba5d40#ba5d4012025da323e893d6d14af9502f0107272a"
+dependencies = [
+ "thiserror",
+ "thiserror-ext-derive",
+]
+
+[[package]]
+name = "thiserror-ext-derive"
+version = "0.1.0"
+source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=ba5d40#ba5d4012025da323e893d6d14af9502f0107272a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9960,7 +9960,7 @@ dependencies = [
 [[package]]
 name = "thiserror-ext"
 version = "0.1.0"
-source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=ba5d40#ba5d4012025da323e893d6d14af9502f0107272a"
+source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=5ed5fe#5ed5fe9320acd5e7dac338919400f2b21341e360"
 dependencies = [
  "thiserror",
  "thiserror-ext-derive",
@@ -9969,7 +9969,7 @@ dependencies = [
 [[package]]
 name = "thiserror-ext-derive"
 version = "0.1.0"
-source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=ba5d40#ba5d4012025da323e893d6d14af9502f0107272a"
+source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=5ed5fe#5ed5fe9320acd5e7dac338919400f2b21341e360"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9959,8 +9959,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext"
-version = "0.1.0"
-source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=5ed5fe#5ed5fe9320acd5e7dac338919400f2b21341e360"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f28a4a7351f496662affc257826b85dd2a613406ce3cc2f07b849685e166d8c"
 dependencies = [
  "thiserror",
  "thiserror-ext-derive",
@@ -9968,8 +9969,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-ext-derive"
-version = "0.1.0"
-source = "git+https://github.com/risingwavelabs/thiserror-ext.git?rev=5ed5fe#5ed5fe9320acd5e7dac338919400f2b21341e360"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67621f6d39449754da63668ddd2423ad0c81c27434c16090f8805ad1db59b621"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ arrow-buffer = "48"
 arrow-flight = "48"
 arrow-select = "48"
 arrow-ord = "48"
-thiserror-ext = { git = "https://github.com/risingwavelabs/thiserror-ext.git", rev = "ba5d40" }
+thiserror-ext = { git = "https://github.com/risingwavelabs/thiserror-ext.git", rev = "5ed5fe" }
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d9" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
   "profiling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ arrow-buffer = "48"
 arrow-flight = "48"
 arrow-select = "48"
 arrow-ord = "48"
+thiserror-ext = { git = "https://github.com/risingwavelabs/thiserror-ext.git", rev = "ba5d40" }
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d9" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
   "profiling",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,7 +120,7 @@ arrow-buffer = "48"
 arrow-flight = "48"
 arrow-select = "48"
 arrow-ord = "48"
-thiserror-ext = { git = "https://github.com/risingwavelabs/thiserror-ext.git", rev = "5ed5fe" }
+thiserror-ext = "0.0.1"
 tikv-jemalloc-ctl = { git = "https://github.com/risingwavelabs/jemallocator.git", rev = "64a2d9" }
 tikv-jemallocator = { git = "https://github.com/risingwavelabs/jemallocator.git", features = [
   "profiling",

--- a/src/expr/core/src/expr/expr_udf.rs
+++ b/src/expr/core/src/expr/expr_udf.rs
@@ -150,7 +150,7 @@ impl Build for UdfExpression {
                         "",
                         DataType::from(t)
                             .try_into()
-                            .map_err(risingwave_udf::Error::Unsupported)?,
+                            .map_err(risingwave_udf::Error::unsupported)?,
                         true,
                     ))
                 })

--- a/src/expr/core/src/table_function/user_defined.rs
+++ b/src/expr/core/src/table_function/user_defined.rs
@@ -140,7 +140,7 @@ pub fn new_user_defined(prost: &PbTableFunction, chunk_size: usize) -> Result<Bo
                     "",
                     DataType::from(t)
                         .try_into()
-                        .map_err(risingwave_udf::Error::Unsupported)?,
+                        .map_err(risingwave_udf::Error::unsupported)?,
                     true,
                 ))
             })

--- a/src/udf/Cargo.toml
+++ b/src/udf/Cargo.toml
@@ -19,6 +19,7 @@ cfg-or-panic = "0.2"
 futures-util = "0.3.28"
 static_assertions = "1"
 thiserror = "1"
+thiserror-ext = { workspace = true }
 tokio = { version = "0.2", package = "madsim-tokio", features = ["rt", "macros"] }
 tonic = { workspace = true }
 

--- a/src/udf/src/error.rs
+++ b/src/udf/src/error.rs
@@ -13,12 +13,14 @@
 // limitations under the License.
 
 use arrow_flight::error::FlightError;
+use thiserror::Error;
+use thiserror_ext::{Box, Construct};
 
 /// A specialized `Result` type for UDF operations.
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The error type for UDF operations.
-#[derive(thiserror::Error, Debug, thiserror_ext::Box, thiserror_ext::Construct)]
+#[derive(Error, Debug, Box, Construct)]
 #[thiserror_ext(type = Error)]
 pub enum ErrorInner {
     #[error("failed to connect to UDF service: {0}")]

--- a/src/udf/src/error.rs
+++ b/src/udf/src/error.rs
@@ -18,16 +18,17 @@ use arrow_flight::error::FlightError;
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 /// The error type for UDF operations.
-#[derive(thiserror::Error, Debug)]
-pub enum Error {
+#[derive(thiserror::Error, Debug, thiserror_ext::Box, thiserror_ext::Construct)]
+#[thiserror_ext(type = Error)]
+pub enum ErrorInner {
     #[error("failed to connect to UDF service: {0}")]
     Connect(#[from] tonic::transport::Error),
 
     #[error("failed to send requests to UDF service: {0}")]
-    Tonic(#[from] Box<tonic::Status>),
+    Tonic(#[from] tonic::Status),
 
     #[error("failed to call UDF: {0}")]
-    Flight(#[from] Box<FlightError>),
+    Flight(#[from] FlightError),
 
     #[error("type mismatch: {0}")]
     TypeMismatch(String),
@@ -45,16 +46,4 @@ pub enum Error {
     ServiceError(String),
 }
 
-static_assertions::const_assert_eq!(std::mem::size_of::<Error>(), 40);
-
-impl From<tonic::Status> for Error {
-    fn from(status: tonic::Status) -> Self {
-        Error::from(Box::new(status))
-    }
-}
-
-impl From<FlightError> for Error {
-    fn from(error: FlightError) -> Self {
-        Error::from(Box::new(error))
-    }
-}
+static_assertions::const_assert_eq!(std::mem::size_of::<Error>(), 8);

--- a/src/udf/src/external.rs
+++ b/src/udf/src/external.rs
@@ -59,7 +59,7 @@ impl ArrowFlightUdfClient {
         let full_schema = Schema::try_from(info)
             .map_err(|e| FlightError::DecodeError(format!("Error decoding schema: {e}")))?;
         if input_num > full_schema.fields.len() {
-            return Err(Error::ServiceError(format!(
+            return Err(Error::service_error(format!(
                 "function {:?} schema info not consistency: input_num: {}, total_fields: {}",
                 id,
                 input_num,
@@ -73,13 +73,13 @@ impl ArrowFlightUdfClient {
         let expect_input_types: Vec<_> = args.fields.iter().map(|f| f.data_type()).collect();
         let expect_result_types: Vec<_> = returns.fields.iter().map(|f| f.data_type()).collect();
         if !data_types_match(&expect_input_types, &actual_input_types) {
-            return Err(Error::TypeMismatch(format!(
+            return Err(Error::type_mismatch(format!(
                 "function: {:?}, expect arguments: {:?}, actual: {:?}",
                 id, expect_input_types, actual_input_types
             )));
         }
         if !data_types_match(&expect_result_types, &actual_result_types) {
-            return Err(Error::TypeMismatch(format!(
+            return Err(Error::type_mismatch(format!(
                 "function: {:?}, expect return: {:?}, actual: {:?}",
                 id, expect_result_types, actual_result_types
             )));
@@ -91,7 +91,10 @@ impl ArrowFlightUdfClient {
     pub async fn call(&self, id: &str, input: RecordBatch) -> Result<RecordBatch> {
         let mut output_stream = self.call_stream(id, stream::once(async { input })).await?;
         // TODO: support no output
-        let head = output_stream.next().await.ok_or(Error::NoReturned)??;
+        let head = output_stream
+            .next()
+            .await
+            .ok_or_else(|| Error::no_returned())??;
         let mut remaining = vec![];
         while let Some(batch) = output_stream.next().await {
             remaining.push(batch?);

--- a/src/udf/src/external.rs
+++ b/src/udf/src/external.rs
@@ -94,7 +94,7 @@ impl ArrowFlightUdfClient {
         let head = output_stream
             .next()
             .await
-            .ok_or_else(|| Error::no_returned())??;
+            .ok_or_else(Error::no_returned)??;
         let mut remaining = vec![];
         while let Some(batch) = output_stream.next().await {
             remaining.push(batch?);

--- a/src/udf/src/lib.rs
+++ b/src/udf/src/lib.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#![feature(error_generic_member_access)]
+
 mod error;
 mod external;
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As explained in #13215. Introducing the `thiserror-ext` proc-macros.

- `Box`: Derive a new type wrapping the `enum` with `Box`. Automatically implement all `From`s and forward error implementation.
- `Construct`: Derive constructors on the new type.

This is a first attempt so I only refactor the `udf::Error` as a demo.

Will release the proc-macros on crates.io after it gets more stable.

----

Derived:
- `Box`
```rust
/// The boxed type of [`ErrorInner`].
#[derive(thiserror_ext::__private::thiserror::Error, Debug)]
#[error(transparent)]
pub struct Error(
    #[from]
    #[backtrace]
    thiserror_ext::__private::ErrorBox<ErrorInner>,
);

impl<E> From<E> for Error
where
    E: Into<ErrorInner>,
{
    fn from(error: E) -> Self {
        Self(thiserror_ext::__private::ErrorBox::new(error.into()))
    }
}
impl Error {
    /// Returns the reference to the inner error.
    pub fn inner(&self) -> &ErrorInner {
        self.0.inner()
    }

    /// Consumes `self` and returns the inner error.
    pub fn into_inner(self) -> ErrorInner {
        self.0.into_inner()
    }
}
```
- `Construct`
```rust
#[automatically_derived]
impl Error {
    /// Constructs a [`ErrorInner::TypeMismatch`] variant.
    pub fn type_mismatch(arg_0: impl Into<String>) -> Self {
        ErrorInner::TypeMismatch { 0: arg_0.into() }.into()
    }

    /// Constructs a [`ErrorInner::Unsupported`] variant.
    pub fn unsupported(arg_0: impl Into<String>) -> Self {
        ErrorInner::Unsupported { 0: arg_0.into() }.into()
    }

    /// Constructs a [`ErrorInner::NoReturned`] variant.
    pub fn no_returned() -> Self {
        ErrorInner::NoReturned {}.into()
    }

    /// Constructs a [`ErrorInner::ServiceError`] variant.
    pub fn service_error(arg_0: impl Into<String>) -> Self {
        ErrorInner::ServiceError { 0: arg_0.into() }.into()
    }
}
```

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
