### PR TITLE
fix(expr): `date_trunc` and `+/-` on `timestamptz` during DST jump-back

### DIFF
--- a/e2e_test/batch/functions/issue_12072.slt.part
+++ b/e2e_test/batch/functions/issue_12072.slt.part
@@ -1,0 +1,129 @@
+# Some exprs on `timestamptz` are implemented by a chain of 3 steps:
+# * convert `timestamptz` into naive `timestamp` in the given zone
+# * perform actual operation on the naive `timestamp`
+# * convert naive `timestamp` in the given zone back to `timestamptz`
+#
+# This can lead to unintuitive results, because the first and last steps are not perfect inverse.
+
+# Two different `timestamptz` values collapse into the same naive `timestamp`.
+query T
+select
+  '2023-11-05 08:40:00Z'::timestamptz AT TIME ZONE 'US/Pacific',
+  '2023-11-05 09:40:00Z'::timestamptz AT TIME ZONE 'US/Pacific';
+----
+2023-11-05 01:40:00 2023-11-05 01:40:00
+
+# When ambiguous, the `timestamptz` after a jump-back transition is returned.
+query T
+select '2023-11-05 01:40:00'::timestamp AT TIME ZONE 'US/Pacific';
+----
+2023-11-05 09:40:00+00:00
+
+# Tests below are about exprs following the 3-step pattern:
+# * `date_trunc(field, timestamptz, zone)` -> `timestamptz`
+# * `timestamptz + interval` -> `timestamptz`
+#   * Also used by `interval + timestamptz` and `timestamptz - interval`
+
+# (A) intuitive cases without anomalies observed (but require special care behind the scenes)
+
+query R
+with t(id, v) as (values
+	('a', '2023-11-05 01:40:00-07:00'::timestamptz),
+	('b', '2023-11-05 01:40:00-08:00'::timestamptz))
+select extract(epoch from date_trunc('hour', v, 'US/Pacific')) from t order by id;
+----
+1699171200.000000
+1699174800.000000
+
+statement ok
+set timezone = 'US/Pacific';
+
+query T
+with t(id, v) as (values
+	('a', '2023-11-05 01:40:00-07:00'::timestamptz),
+	('b', '2023-11-05 01:40:00-08:00'::timestamptz))
+select v + interval '5' minute from t order by id;
+----
+2023-11-05 01:45:00-07:00
+2023-11-05 01:45:00-08:00
+
+statement ok
+set timezone = 'UTC';
+
+# (B) common 1-hour jump-back for whole-hour zones
+
+query R
+with t(id, v) as (values
+	('a', '2023-11-05 01:40:00-07:00'::timestamptz),
+	('b', '2023-11-05 01:40:00-08:00'::timestamptz))
+select extract(epoch from date_trunc('day', v, 'US/Pacific')) from t order by id;
+----
+1699167600.000000
+1699167600.000000
+
+statement ok
+set timezone = 'US/Pacific';
+
+query T
+with t(id, v) as (values
+	('a', '2023-11-05 01:40:00-07:00'::timestamptz),
+	('b', '2023-11-05 01:40:00-08:00'::timestamptz),
+	('c', '2023-11-04 01:40:00-07:00'::timestamptz))
+select v + interval '1' day from t order by id;
+----
+2023-11-06 01:40:00-08:00
+2023-11-06 01:40:00-08:00
+2023-11-05 01:40:00-08:00
+
+statement ok
+set timezone = 'UTC';
+
+# (C) 1-hour jump-back for half-hour zones
+
+query T
+with t(id, v) as (values
+	('a', '2023-04-01 15:58:00Z'::timestamptz),
+	('b', '2023-04-01 16:58:00Z'::timestamptz))
+select date_trunc('hour', v, 'Australia/South') from t order by id;
+----
+2023-04-01 15:30:00+00:00
+2023-04-01 16:30:00+00:00
+
+# (D) half-hour jump-back
+# Note that `01:45:00+10:30` is truncated to non-existent `01:00:00+10:30` whose canonical form is `01:30:00+11:00`
+
+statement ok
+set timezone = 'Australia/Lord_Howe';
+
+query TTT
+with t(id, v) as (values
+	('a', '2023-04-01 14:45:00Z'::timestamptz),
+	('b', '2023-04-01 15:15:00Z'::timestamptz))
+select date_trunc('hour', v, 'Australia/Lord_Howe'), 'truncated from', v from t order by id;
+----
+2023-04-02 01:00:00+11:00 truncated from 2023-04-02 01:45:00+11:00
+2023-04-02 01:30:00+11:00 truncated from 2023-04-02 01:45:00+10:30
+
+statement ok
+set timezone = 'UTC';
+
+# (E) jump-back to day boundary, making it ambiguous
+# Due to the disambiguation rule selecting post-transition value,
+# `date_trunc` effectively returns an instant in the future, rather than the past.
+
+query T
+with t(id, v) as (values
+	('a', '2023-11-05 04:40:00Z'::timestamptz),
+	('b', '2023-11-05 05:40:00Z'::timestamptz))
+select date_trunc('day', v, 'America/Havana') from t order by id;
+----
+2023-11-05 05:00:00+00:00
+2023-11-05 05:00:00+00:00
+
+# (F) jump-forward from day boundary, making it invalid
+# Here `2023-09-02 23:59:59-04:00` is followed by `2023-09-03 01:00:00-03:00`.
+# There is no `2023-09-03 00:00:00-04:00` or `2023-09-03 00:00:00-03:00`.
+# PostgreSQL returns `2023-09-03 01:00:00-03:00` but it is hard using `chrono` crate.
+
+statement error interpret
+select date_trunc('day', '2023-09-03 12:00:00Z'::timestamptz, 'America/Santiago');


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

For context, `2023-11-05 01:59:59-07:00` is followed by `2023-11-05 01:00:00-08:00` in `US/Pacific`.

There are two `2023-11-05 01:40:00` in local time, corresponding to UTC time `2023-11-05T08:40:00Z` (1699173600s since the unix epoch) and `2023-11-05T09:40:00Z` (1699177200s since the unix epoch).

And also two `2023-11-05 01:00:00` in local time, corresponding to UTC time `2023-11-05T08:00:00Z` (1699171200s since the unix epoch) and `2023-11-05T09:00:00Z` (1699174800s since the unix epoch).


Fixes #12072

In short:
* `date_trunc` to `hour` of `2023-11-05 01:40:00` in Pacific **Daylight** Time (`-07:00`) shall return `2023-11-05 01:00:00` in Pacific **Daylight** Time, rather than Pacific **Standard** Time (`-08:00`).
  * `date_trunc` to `microseconds` of `2023-11-05 08:40:00Z` and `2023-11-05 09:35:00Z` under `US/Pacific` shall return them unchanged, rather than `2023-11-05 09:40:00Z` and `2023-11-05 09:35:00Z` (non-monotonic).
* Under `set timezone = 'US/Pacific'`, `'2023-11-05 01:40:00-07:00'::timestamptz + interval '5' minute` shall return `2023-11-05 01:45:00-07:00` rather than `2023-11-05 01:45:00-08:00` (which is 65 minutes later).

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
