### PR TITLE
feat: ignore `collate` in `select` and `create table`

### DIFF
--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -61,3 +61,31 @@ t
 # parser issue
 statement error
 select varchar 't' collate "C";
+
+# collate in create table
+
+statement ok
+create table t (
+  a text collate "C",
+  b int
+);
+
+statement ok
+create table t (
+  a text collate "POSIX",
+  b int
+);
+
+statement ok
+create table t (
+  a text collate "pOsIx",
+  b int
+);
+
+# PostgreSQL raise error that collate cannot apply to type `int`
+statement ok
+create table t (
+  a text collate "POSIX",
+  b int collate "C"
+);
+

--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -1,0 +1,63 @@
+statement ok
+SET RW_IMPLICIT_FLUSH TO true;
+
+# collate in select
+
+query T
+select 'a' collate "C";
+----
+a
+
+query B
+select 'a' < 'b' collate "C";
+----
+t
+
+query B
+select 'b' < 'a' collate "POSIX";
+----
+f
+
+query T
+select (varchar 't') collate "C";
+----
+t
+
+query T
+select 'a' collate "c";
+----
+a
+
+query T
+select 'a' collate "c";
+----
+a
+
+query T
+select 'a' collate "posix";
+----
+a
+
+query T
+select 'a' collate "pOsIx";
+----
+a
+
+query BT
+select 'a' < 'b', 'a' collate "C";
+----
+t a
+
+query B
+select 'a' < ('b' collate "C");
+----
+t
+
+query B
+select ('a' < 'b') collate "C";
+----
+t
+
+# parser issue
+statement error
+select varchar 't' collate "C";

--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -65,27 +65,38 @@ select varchar 't' collate "C";
 # collate in create table
 
 statement ok
-create table t (
+create table t1 (
   a text collate "C",
   b int
 );
 
 statement ok
-create table t (
+create table t2 (
   a text collate "POSIX",
   b int
 );
 
 statement ok
-create table t (
+create table t3 (
   a text collate "pOsIx",
   b int
 );
 
 # PostgreSQL raise error that collate cannot apply to type `int`
 statement ok
-create table t (
+create table t4 (
   a text collate "POSIX",
   b int collate "C"
 );
 
+statement ok
+drop table t1;
+
+statement ok
+drop table t2;
+
+statement ok
+drop table t3;
+
+statement ok
+drop table t4;

--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -23,25 +23,17 @@ select (varchar 't') collate "C";
 ----
 t
 
-query T
+# case-sensitive
+statement error
 select 'a' collate "c";
-----
-a
 
-query T
-select 'a' collate "c";
-----
-a
-
-query T
+# case-sensitive
+statement error
 select 'a' collate "posix";
-----
-a
 
-query T
+# case-sensitive
+statement error
 select 'a' collate "pOsIx";
-----
-a
 
 query BT
 select 'a' < 'b', 'a' collate "C";
@@ -53,14 +45,22 @@ select 'a' < ('b' collate "C");
 ----
 t
 
-query B
-select ('a' < 'b') collate "C";
-----
-t
+# only `text`, 'varchar' and `char` are built-in collatable types (in PostgreSQL)
+# the type of `('a' < 'b')` is Bool, it SHOULD be failed,
+# but we don't support real collation, we simply ignore it, so it WOULD be succeed.
+#
+# This is not a correct behavior
+# and is expected to be corrected in the future when collation is truly supported.
+
+# statement error
+# select ('a' < 'b') collate "C";
 
 # parser issue
 statement error
 select varchar 't' collate "C";
+
+statement error
+select 'a' collate "Invalid";
 
 # collate in create table
 
@@ -76,7 +76,7 @@ create table t2 (
   b int
 );
 
-statement ok
+statement error
 create table t3 (
   a text collate "pOsIx",
   b int
@@ -94,9 +94,6 @@ drop table t1;
 
 statement ok
 drop table t2;
-
-statement ok
-drop table t3;
 
 statement ok
 drop table t4;

--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -47,13 +47,11 @@ t
 
 # only `text`, 'varchar' and `char` are built-in collatable types (in PostgreSQL)
 # the type of `('a' < 'b')` is Bool, it SHOULD be failed,
-# but we don't support real collation, we simply ignore it, so it WOULD be succeed.
-#
-# This is not a correct behavior
-# and is expected to be corrected in the future when collation is truly supported.
+statement error
+select ('a' < 'b') collate "C";
 
-# statement error
-# select ('a' < 'b') collate "C";
+statement error
+select 123 collate "C";
 
 # parser issue
 statement error
@@ -82,8 +80,7 @@ create table t3 (
   b int
 );
 
-# PostgreSQL raise error that collate cannot apply to type `int`
-statement ok
+statement error
 create table t4 (
   a text collate "POSIX",
   b int collate "C"
@@ -94,6 +91,3 @@ drop table t1;
 
 statement ok
 drop table t2;
-
-statement ok
-drop table t4;

--- a/e2e_test/batch/basic/collation.slt.part
+++ b/e2e_test/batch/basic/collation.slt.part
@@ -45,6 +45,21 @@ select 'a' < ('b' collate "C");
 ----
 t
 
+query B
+select '1' collate "C" > 2;
+----
+f
+
+query B
+select ('1' collate "C") = 1;
+----
+t
+
+query I
+select '10' collate "C" - 1;
+----
+9
+
 # only `text`, 'varchar' and `char` are built-in collatable types (in PostgreSQL)
 # the type of `('a' < 'b')` is Bool, it SHOULD be failed,
 statement error

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -572,7 +572,20 @@ impl Binder {
             .into());
         }
 
-        self.bind_expr_inner(expr)
+        let bound_inner = self.bind_expr_inner(expr)?;
+        let ret_type = bound_inner.return_type();
+
+        match ret_type {
+            DataType::Varchar => {}
+            _ => {
+                return Err(ErrorCode::NotSupported(
+                        format!("{} is not a collatable data type", ret_type),
+                        "The only built-in collatable data types are `varchar`, please check your type".into()
+                    ).into());
+            }
+        }
+
+        Ok(bound_inner)
     }
 }
 

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -565,9 +565,9 @@ impl Binder {
 
     pub fn bind_collate(&mut self, expr: Expr, collation: ObjectName) -> Result<ExprImpl> {
         if !["C", "POSIX"].contains(&collation.real_value().to_uppercase().as_str()) {
-            return Err(ErrorCode::NotSupported(
-                "Collate collation other than `C` or `POSIX` is not supported".into(),
-                "Please remove collate or change collation to `C` or `POSIX`".into(),
+            return Err(ErrorCode::NotImplemented(
+                "Collate collation other than `C` or `POSIX` is not implemented".into(),
+                None.into(),
             )
             .into());
         }

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -564,7 +564,7 @@ impl Binder {
     }
 
     pub fn bind_collate(&mut self, expr: Expr, collation: ObjectName) -> Result<ExprImpl> {
-        if !["C", "POSIX"].contains(&collation.real_value().to_uppercase().as_str()) {
+        if !["C", "POSIX"].contains(&collation.real_value().as_str()) {
             return Err(ErrorCode::NotImplemented(
                 "Collate collation other than `C` or `POSIX` is not implemented".into(),
                 None.into(),

--- a/src/frontend/src/binder/expr/mod.rs
+++ b/src/frontend/src/binder/expr/mod.rs
@@ -579,9 +579,11 @@ impl Binder {
             DataType::Varchar => {}
             _ => {
                 return Err(ErrorCode::NotSupported(
-                        format!("{} is not a collatable data type", ret_type),
-                        "The only built-in collatable data types are `varchar`, please check your type".into()
-                    ).into());
+                    format!("{} is not a collatable data type", ret_type),
+                    "The only built-in collatable data types are `varchar`, please check your type"
+                        .into(),
+                )
+                .into());
             }
         }
 

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -184,7 +184,7 @@ pub fn bind_sql_columns(column_defs: &[ColumnDef]) -> Result<Vec<ColumnCatalog>>
             }
 
             match data_type {
-                AstDataType::Text | AstDataType::Varchar | AstDataType::Char(_) => {},
+                AstDataType::Text | AstDataType::Varchar | AstDataType::Char(_) => {}
                 _ => {
                     return Err(ErrorCode::NotSupported(
                         format!("{} is not a collatable data type", data_type),

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -170,11 +170,15 @@ pub fn bind_sql_columns(column_defs: &[ColumnDef]) -> Result<Vec<ColumnCatalog>>
             .clone()
             .ok_or_else(|| ErrorCode::InvalidInputSyntax("data type is not specified".into()))?;
         if let Some(collation) = collation {
-            return Err(ErrorCode::NotImplemented(
-                format!("collation \"{}\"", collation),
-                None.into(),
-            )
-            .into());
+            // PostgreSQL will limit the datatypes that collate can work on.
+            // But we don't support real collation, we simply ignore it here.
+            if !["C", "POSIX"].contains(&collation.real_value().to_uppercase().as_str()) {
+                return Err(ErrorCode::NotImplemented(
+                    "Collate collation other than `C` or `POSIX` is not implemented".into(),
+                    None.into(),
+                )
+                .into());
+            }
         }
 
         check_valid_column_name(&name.real_value())?;

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -171,8 +171,11 @@ pub fn bind_sql_columns(column_defs: &[ColumnDef]) -> Result<Vec<ColumnCatalog>>
             .ok_or_else(|| ErrorCode::InvalidInputSyntax("data type is not specified".into()))?;
         if let Some(collation) = collation {
             // PostgreSQL will limit the datatypes that collate can work on.
+            // https://www.postgresql.org/docs/16/collation.html#COLLATION-CONCEPTS
+            //   > The built-in collatable data types are `text`, `varchar`, and `char`.
+            //
             // But we don't support real collation, we simply ignore it here.
-            if !["C", "POSIX"].contains(&collation.real_value().to_uppercase().as_str()) {
+            if !["C", "POSIX"].contains(&collation.real_value().as_str()) {
                 return Err(ErrorCode::NotImplemented(
                     "Collate collation other than `C` or `POSIX` is not implemented".into(),
                     None.into(),

--- a/src/frontend/src/handler/create_table.rs
+++ b/src/frontend/src/handler/create_table.rs
@@ -182,6 +182,16 @@ pub fn bind_sql_columns(column_defs: &[ColumnDef]) -> Result<Vec<ColumnCatalog>>
                 )
                 .into());
             }
+
+            match data_type {
+                AstDataType::Text | AstDataType::Varchar | AstDataType::Char(_) => {},
+                _ => {
+                    return Err(ErrorCode::NotSupported(
+                        format!("{} is not a collatable data type", data_type),
+                        "The only built-in collatable data types are `varchar`, please check your type".into()
+                    ).into());
+                }
+            }
         }
 
         check_valid_column_name(&name.real_value())?;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

We don't support real collations, but we ignore it when the collation is "C" or "POSIX" as it is RisingWave's current default behavior.
The purpose of this PR is to make dremio work properly. resolve #13171.

When writing e2e test, I discovered a parser problem: `select varchar 't' collate "C"` cannot be parsed normally.
In order to make this PR easier, the parser problem will be solved in other PRs in the future.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
