### PR TITLE
fix(standalone): should not specify dashboard ui path

### DIFF
--- a/docker/docker-compose-standalone.yml
+++ b/docker/docker-compose-standalone.yml
@@ -16,7 +16,6 @@ services:
                     --state-store hummock+minio://hummockadmin:hummockadmin@minio-0:9301/hummock001 \
                     --data-directory hummock_001 \
                     --config-path /risingwave.toml \
-                    --dashboard-ui-path ${RW_PREFIX}/ui\" \
                  --compute-opts=\" \
                     --config-path /risingwave.toml \
                     --listen-addr 0.0.0.0:5688 \


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

There's no static dashboard assets in the docker image. By specifying `ui-path` (which is meant to be used by developers), the dashboard service will fail to proxy the requests to GitHub user contents.

https://github.com/risingwavelabs/risingwave/blob/9bfa04cf25f4bf8ce5d7e6dc6e6333cceb81ab1a/src/meta/src/dashboard/mod.rs#L370-L400

This is a quick fix. However, I still think we should avoid external network requests in production and maybe we should pack the assets in the image. What do you think? @xxchan

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
