### PR TITLE
test(regress): enable delete

### DIFF
--- a/src/tests/regress/data/expected/delete.out
+++ b/src/tests/regress/data/expected/delete.out
@@ -1,10 +1,10 @@
 CREATE TABLE delete_test (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     a INT,
     b text
 );
-INSERT INTO delete_test (a) VALUES (10);
-INSERT INTO delete_test (a, b) VALUES (50, repeat('x', 10000));
+INSERT INTO delete_test (id, a) VALUES (1, 10);
+INSERT INTO delete_test (id, a, b) VALUES (2, 50, repeat('x', 10000));
 INSERT INTO delete_test (a) VALUES (100);
 -- allow an alias to be specified for DELETE's target table
 DELETE FROM delete_test AS dt WHERE dt.a > 75;
@@ -15,7 +15,7 @@ ERROR:  invalid reference to FROM-clause entry for table "delete_test"
 LINE 1: DELETE FROM delete_test dt WHERE delete_test.a > 25;
                                          ^
 HINT:  Perhaps you meant to reference the table alias "dt".
-SELECT id, a, char_length(b) FROM delete_test;
+SELECT id, a, char_length(b) FROM delete_test ORDER BY id;
  id | a  | char_length 
 ----+----+-------------
   1 | 10 |            

--- a/src/tests/regress/data/schedule
+++ b/src/tests/regress/data/schedule
@@ -9,6 +9,6 @@
 
 test: boolean varchar text int2 int4 int8 float4 float8 comments
 test: strings date time timestamp interval
-test: case arrays
+test: case arrays delete
 test: jsonb
 test: regex

--- a/src/tests/regress/data/sql/delete.sql
+++ b/src/tests/regress/data/sql/delete.sql
@@ -1,21 +1,21 @@
 CREATE TABLE delete_test (
-    id SERIAL PRIMARY KEY,
+    id INTEGER PRIMARY KEY,
     a INT,
     b text
 );
 
-INSERT INTO delete_test (a) VALUES (10);
-INSERT INTO delete_test (a, b) VALUES (50, repeat('x', 10000));
-INSERT INTO delete_test (a) VALUES (100);
+INSERT INTO delete_test (id, a) VALUES (1, 10);
+INSERT INTO delete_test (id, a, b) VALUES (2, 50, repeat('x', 10000));
+--@ INSERT INTO delete_test (a) VALUES (100);
 
 -- allow an alias to be specified for DELETE's target table
-DELETE FROM delete_test AS dt WHERE dt.a > 75;
+--@ DELETE FROM delete_test AS dt WHERE dt.a > 75;
 
 -- if an alias is specified, don't allow the original table name
 -- to be referenced
-DELETE FROM delete_test dt WHERE delete_test.a > 25;
+--@ DELETE FROM delete_test dt WHERE delete_test.a > 25;
 
-SELECT id, a, char_length(b) FROM delete_test;
+SELECT id, a, char_length(b) FROM delete_test ORDER BY id;
 
 -- delete a row with a TOASTed value
 DELETE FROM delete_test WHERE a > 25;


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?
enable the `delete.sql` PG regress test

Unsupported: 
`alias for the target table`

## Checklist

- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->
</details>
