### PR TITLE
fix(udf): add graceful shutdown for python UDF server

### DIFF
--- a/ci/scripts/run-e2e-test.sh
+++ b/ci/scripts/run-e2e-test.sh
@@ -82,13 +82,15 @@ sqllogictest -p 4566 -d dev './e2e_test/superset/*.slt' --junit "batch-${profile
 
 echo "--- e2e, $mode, python udf"
 python3 e2e_test/udf/test.py &
-sleep 2
+sleep 1
 sqllogictest -p 4566 -d dev './e2e_test/udf/udf.slt'
 pkill python3
 
+sqllogictest -p 4566 -d dev './e2e_test/udf/graceful_shutdown_python.slt'
+
 echo "--- e2e, $mode, java udf"
 java -jar risingwave-udf-example.jar &
-sleep 2
+sleep 1
 sqllogictest -p 4566 -d dev './e2e_test/udf/udf.slt'
 pkill java
 

--- a/e2e_test/udf/graceful_shutdown_python.slt
+++ b/e2e_test/udf/graceful_shutdown_python.slt
@@ -1,0 +1,36 @@
+system ok
+python3 e2e_test/udf/test.py &
+
+# wait for server to start
+sleep 1s
+
+statement ok
+CREATE FUNCTION sleep(INT) RETURNS INT AS 'sleep' USING LINK 'http://localhost:8815';
+
+system ok
+sleep 1 && pkill python &
+
+# python server should not exit until the query is finished
+query I
+select sleep(2);
+----
+0
+
+# wait for server to exit
+sleep 1s
+
+system ok
+python3 e2e_test/udf/test.py &
+
+# wait for server to start
+sleep 1s
+
+# force kill python server
+system ok
+sleep 1 && pkill -9 python &
+
+query error
+select sleep(2);
+
+statement ok
+DROP FUNCTION sleep;

--- a/e2e_test/udf/test.py
+++ b/e2e_test/udf/test.py
@@ -15,6 +15,7 @@
 import socket
 import struct
 import sys
+import time
 from typing import Iterator, List, Optional, Tuple, Any
 from decimal import Decimal
 
@@ -26,6 +27,12 @@ from risingwave.udf import udf, udtf, UdfServer
 @udf(input_types=[], result_type="INT")
 def int_42() -> int:
     return 42
+
+
+@udf(input_types=["INT"], result_type="INT")
+def sleep(s: int) -> int:
+    time.sleep(s)
+    return 0
 
 
 @udf(input_types=["INT", "INT"], result_type="INT")
@@ -190,8 +197,9 @@ def return_all_arrays(
 
 
 if __name__ == "__main__":
-    server = UdfServer(location="0.0.0.0:8815")
+    server = UdfServer(location="localhost:8815")
     server.add_function(int_42)
+    server.add_function(sleep)
     server.add_function(gcd)
     server.add_function(gcd3)
     server.add_function(series)

--- a/java/udf-example/src/main/java/com/example/UdfExample.java
+++ b/java/udf-example/src/main/java/com/example/UdfExample.java
@@ -35,6 +35,7 @@ public class UdfExample {
     public static void main(String[] args) throws IOException {
         try (var server = new UdfServer("0.0.0.0", 8815)) {
             server.addFunction("int_42", new Int42());
+            server.addFunction("sleep", new Sleep());
             server.addFunction("gcd", new Gcd());
             server.addFunction("gcd3", new Gcd3());
             server.addFunction("extract_tcp_info", new ExtractTcpInfo());
@@ -59,6 +60,17 @@ public class UdfExample {
     public static class Int42 implements ScalarFunction {
         public int eval() {
             return 42;
+        }
+    }
+
+    public static class Sleep implements ScalarFunction {
+        public int eval(int x) {
+            try {
+                Thread.sleep(x * 1000);
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+            return 0;
         }
     }
 

--- a/src/udf/python/CHANGELOG.md
+++ b/src/udf/python/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.11] - 2023-11-06
+
+### Fixed
+
+- Hook SIGTERM to stop the UDF server gracefully.

--- a/src/udf/python/pyproject.toml
+++ b/src/udf/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "risingwave"
-version = "0.0.10"
+version = "0.0.11"
 authors = [{ name = "RisingWave Labs" }]
 description = "RisingWave Python API"
 readme = "README.md"

--- a/src/udf/python/risingwave/udf.py
+++ b/src/udf/python/risingwave/udf.py
@@ -21,6 +21,7 @@ import traceback
 import json
 from concurrent.futures import ThreadPoolExecutor
 import concurrent
+import signal
 
 
 class UserDefinedFunction:
@@ -392,11 +393,16 @@ class UdfServer(pa.flight.FlightServerBase):
             raise e
 
     def serve(self):
-        """Start the server."""
+        """
+        Block until the server shuts down.
+
+        This method only returns if shutdown() is called or a signal (SIGINT, SIGTERM) received.
+        """
         print(
             "Note: You can use arbitrary function names and struct field names in CREATE FUNCTION statements."
             f"\n\nlistening on {self._location}"
         )
+        signal.signal(signal.SIGTERM, lambda s, f: self.shutdown())
         super(UdfServer, self).serve()
 
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

This PR introduces a change to the Python UDF server's behavior in Kubernetes during a rolling update. Previously, the server would terminate immediately on receiving a SIGTERM signal, potentially leaving some RPCs incomplete, which could lead to expression errors and NULL outputs. The updated code now includes a SIGTERM hook that enables the Python UDF server to shut down gracefully, ensuring all RPCs are completed before exit.

Please note, this update only applies to the Python server. The Java UDF server still exits immediately on receiving SIGINT (from ctrl-c) or SIGTERM (from kill). A solution for the Java server still needs investigation.

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [ ] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)
