### PR TITLE
feat(pgwire): listen on unix socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5942,6 +5942,7 @@ name = "pgwire"
 version = "1.3.0-alpha"
 dependencies = [
  "anyhow",
+ "auto_enums",
  "byteorder",
  "bytes",
  "futures",
@@ -5951,6 +5952,7 @@ dependencies = [
  "panic-message",
  "risingwave_common",
  "risingwave_sqlparser",
+ "tempfile",
  "thiserror",
  "tokio-openssl",
  "tokio-postgres",

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -16,7 +16,7 @@ normal = ["workspace-hack"]
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
-auto_enums = { version = "0.8", features = ["futures03", "tokio1"] }
+auto_enums = { version = "0.8", features = ["tokio1"] }
 byteorder = "1.5"
 bytes = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }

--- a/src/utils/pgwire/Cargo.toml
+++ b/src/utils/pgwire/Cargo.toml
@@ -16,6 +16,7 @@ normal = ["workspace-hack"]
 
 [dependencies]
 anyhow = { version = "1.0", default-features = false }
+auto_enums = { version = "0.8", features = ["futures03", "tokio1"] }
 byteorder = "1.5"
 bytes = "1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
@@ -33,6 +34,7 @@ tracing = "0.1"
 workspace-hack = { path = "../../workspace-hack" }
 
 [dev-dependencies]
+tempfile = "3"
 tokio-postgres = "0.7"
 
 [lints]

--- a/src/utils/pgwire/src/lib.rs
+++ b/src/utils/pgwire/src/lib.rs
@@ -22,6 +22,7 @@
 
 pub mod error;
 pub mod error_or_notice;
+pub mod net;
 pub mod pg_extended;
 pub mod pg_field_descriptor;
 pub mod pg_message;

--- a/src/utils/pgwire/src/net.rs
+++ b/src/utils/pgwire/src/net.rs
@@ -1,0 +1,87 @@
+// Copyright 2023 RisingWave Labs
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::io;
+use std::net::SocketAddr as IpSocketAddr;
+#[cfg(madsim)]
+use std::os::unix::net::SocketAddr as UnixSocketAddr;
+
+#[cfg(not(madsim))]
+use tokio::net::unix::SocketAddr as UnixSocketAddr;
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
+
+/// A wrapper of either [`TcpListener`] or [`UnixListener`].
+pub(crate) enum Listener {
+    Tcp(TcpListener),
+    Unix(UnixListener),
+}
+
+/// A wrapper of either [`TcpStream`] or [`UnixStream`].
+#[auto_enums::enum_derive(tokio1::AsyncRead, tokio1::AsyncWrite)]
+pub(crate) enum Stream {
+    Tcp(TcpStream),
+    Unix(UnixStream),
+}
+
+/// A wrapper of either [`std::net::SocketAddr`] or [`tokio::net::unix::SocketAddr`].
+pub(crate) enum Address {
+    Tcp(IpSocketAddr),
+    Unix(UnixSocketAddr),
+}
+
+impl std::fmt::Display for Address {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Address::Tcp(addr) => addr.fmt(f),
+            Address::Unix(addr) => {
+                if let Some(path) = addr.as_pathname() {
+                    path.display().fmt(f)
+                } else {
+                    std::fmt::Debug::fmt(addr, f)
+                }
+            }
+        }
+    }
+}
+
+impl Listener {
+    /// Creates a new [`Listener`] bound to the specified address.
+    ///
+    /// If the address starts with `unix:`, it will create a [`UnixListener`].
+    /// Otherwise, it will create a [`TcpListener`].
+    pub async fn bind(addr: &str) -> io::Result<Self> {
+        if let Some(path) = addr.strip_prefix("unix:") {
+            UnixListener::bind(path).map(Self::Unix)
+        } else {
+            TcpListener::bind(addr).await.map(Self::Tcp)
+        }
+    }
+
+    /// Accepts a new incoming connection from this listener.
+    ///
+    /// Returns a tuple of the stream and the string representation of the peer address.
+    pub async fn accept(&self) -> io::Result<(Stream, Address)> {
+        match self {
+            Self::Tcp(listener) => {
+                let (stream, addr) = listener.accept().await?;
+                stream.set_nodelay(true)?;
+                Ok((Stream::Tcp(stream), Address::Tcp(addr)))
+            }
+            Self::Unix(listener) => {
+                let (stream, addr) = listener.accept().await?;
+                Ok((Stream::Unix(stream), Address::Unix(addr)))
+            }
+        }
+    }
+}

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -370,6 +370,7 @@ mod tests {
         do_test_query("127.0.0.1:10000", "host=localhost port=10000").await;
     }
 
+    #[cfg(not(madsim))]
     #[tokio::test]
     async fn test_query_unix() {
         let port: i16 = 10000;

--- a/src/utils/pgwire/src/pg_server.rs
+++ b/src/utils/pgwire/src/pg_server.rs
@@ -18,12 +18,10 @@ use std::result::Result;
 use std::sync::Arc;
 
 use bytes::Bytes;
-use futures::TryFutureExt;
 use risingwave_common::types::DataType;
 use risingwave_sqlparser::ast::Statement;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpListener;
-use tracing::debug;
+use tokio::net::{TcpListener, TcpStream, UnixListener, UnixStream};
 
 use crate::pg_field_descriptor::PgFieldDescriptor;
 use crate::pg_message::TransactionStatus;
@@ -130,53 +128,99 @@ impl UserAuthenticator {
     }
 }
 
-/// Binds a Tcp listener at `addr`. Spawn a coroutine to serve every new connection.
-pub async fn pg_serve(
-    addr: &str,
-    session_mgr: Arc<impl SessionManager>,
-    ssl_config: Option<TlsConfig>,
-) -> io::Result<()> {
-    let listener = TcpListener::bind(addr).await.unwrap();
-    // accept connections and process them, spawning a new thread for each one
-    tracing::info!("Server Listening at {}", addr);
-    loop {
-        let session_mgr = session_mgr.clone();
-        let conn_ret = listener.accept().await;
-        match conn_ret {
-            Ok((stream, peer_addr)) => {
-                tracing::info!("New connection: {}", peer_addr);
-                stream.set_nodelay(true)?;
-                let ssl_config = ssl_config.clone();
-                let fut = handle_connection(stream, session_mgr, ssl_config);
-                tokio::spawn(fut.inspect_err(|e| debug!("error handling connection: {e}")));
-            }
+enum Listener {
+    Tcp(TcpListener),
+    Unix(UnixListener),
+}
 
-            Err(e) => {
-                tracing::error!("Connection failure: {}", e);
+#[auto_enums::enum_derive(tokio1::AsyncRead, tokio1::AsyncWrite)]
+enum Stream {
+    Tcp(TcpStream),
+    Unix(UnixStream),
+}
+
+impl Listener {
+    async fn bind(addr: &str) -> io::Result<Self> {
+        if addr.starts_with("unix:") {
+            let path = &addr[5..];
+            UnixListener::bind(path).map(Self::Unix)
+        } else {
+            TcpListener::bind(addr).await.map(Self::Tcp)
+        }
+    }
+
+    async fn accept(&self) -> io::Result<(Stream, String)> {
+        match self {
+            Self::Tcp(listener) => {
+                let (stream, addr) = listener.accept().await?;
+                stream.set_nodelay(true)?;
+
+                Ok((Stream::Tcp(stream), format!("{addr}")))
+            }
+            Self::Unix(listener) => {
+                let (stream, addr) = listener.accept().await?;
+
+                Ok((Stream::Unix(stream), format!("{addr:?}")))
             }
         }
     }
 }
 
-#[tracing::instrument(level = "debug", skip_all)]
-pub fn handle_connection<S, SM>(
+/// Binds a Tcp or Unox listener at `addr`. Spawn a coroutine to serve every new connection.
+pub async fn pg_serve(
+    addr: &str,
+    session_mgr: Arc<impl SessionManager>,
+    tls_config: Option<TlsConfig>,
+) -> io::Result<()> {
+    let listener = Listener::bind(addr).await?;
+    tracing::info!(addr, "server started");
+
+    loop {
+        let conn_ret = listener.accept().await;
+        match conn_ret {
+            Ok((stream, peer_addr)) => {
+                tracing::info!(peer_addr, "accept connection");
+                tokio::spawn(handle_connection(
+                    stream,
+                    session_mgr.clone(),
+                    tls_config.clone(),
+                ));
+            }
+
+            Err(e) => {
+                tracing::error!(
+                    error = &e as &dyn std::error::Error,
+                    "failed to accept connection",
+                );
+            }
+        }
+    }
+}
+
+pub async fn handle_connection<S, SM>(
     stream: S,
     session_mgr: Arc<SM>,
     tls_config: Option<TlsConfig>,
-) -> impl Future<Output = Result<(), anyhow::Error>>
-where
+) where
     S: AsyncWrite + AsyncRead + Unpin,
     SM: SessionManager,
 {
     let mut pg_proto = PgProtocol::new(stream, session_mgr, tls_config);
-    async {
-        loop {
-            let msg = pg_proto.read_message().await?;
-            tracing::trace!("Received message: {:?}", msg);
-            let ret = pg_proto.process(msg).await;
-            if ret {
-                return Ok(());
+    loop {
+        let msg = match pg_proto.read_message().await {
+            Ok(msg) => msg,
+            Err(e) => {
+                tracing::error!(
+                    error = &e as &dyn std::error::Error,
+                    "error when reading message"
+                );
+                break;
             }
+        };
+        tracing::trace!("Received message: {:?}", msg);
+        let ret = pg_proto.process(msg).await;
+        if ret {
+            break;
         }
     }
 }
@@ -325,17 +369,17 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_query() {
+    async fn do_test_query(bind_addr: impl Into<String>, pg_config: impl Into<String>) {
+        let bind_addr = bind_addr.into();
+        let pg_config = pg_config.into();
+
         let session_mgr = Arc::new(MockSessionManager {});
-        tokio::spawn(async move { pg_serve("127.0.0.1:10000", session_mgr, None).await });
+        tokio::spawn(async move { pg_serve(&bind_addr, session_mgr, None).await });
         // wait for server to start
-        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
 
         // Connect to the database.
-        let (client, connection) = tokio_postgres::connect("host=localhost port=10000", NoTls)
-            .await
-            .unwrap();
+        let (client, connection) = tokio_postgres::connect(&pg_config, NoTls).await.unwrap();
 
         // The connection object performs the actual communication with the database,
         // so spawn it off to run on its own.
@@ -357,5 +401,23 @@ mod tests {
             .await
             .expect("Error executing query");
         assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_query_tcp() {
+        do_test_query("127.0.0.1:10000", "host=localhost port=10000").await;
+    }
+
+    #[tokio::test]
+    async fn test_query_unix() {
+        let port: i16 = 10000;
+        let dir = tempfile::TempDir::new().unwrap();
+        let sock = dir.path().join(format!(".s.PGSQL.{port}"));
+
+        do_test_query(
+            format!("unix:{}", sock.to_str().unwrap()),
+            format!("host={} port={}", dir.path().to_str().unwrap(), port),
+        )
+        .await;
     }
 }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -146,7 +146,7 @@ whoami = { version = "1" }
 ahash = { version = "0.8" }
 allocator-api2 = { version = "0.2", default-features = false, features = ["alloc", "nightly"] }
 anyhow = { version = "1", features = ["backtrace"] }
-auto_enums = { version = "0.8", features = ["futures03"] }
+auto_enums = { version = "0.8", features = ["futures03", "tokio1"] }
 bitflags = { version = "2", default-features = false, features = ["serde", "std"] }
 bytes = { version = "1", features = ["serde"] }
 cc = { version = "1", default-features = false, features = ["parallel"] }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Allow listening on a unix socket for pgwire. Not much useful now but it's the default behavior of the Postgres server.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
