### PR TITLE
feat(expr): support list and struct in `jsonb_agg`/`jsonb_object_agg`

### DIFF
--- a/e2e_test/streaming/aggregate/jsonb_agg.slt
+++ b/e2e_test/streaming/aggregate/jsonb_agg.slt
@@ -2,7 +2,7 @@ statement ok
 SET RW_IMPLICIT_FLUSH TO true;
 
 statement ok
-create table t(v1 boolean, v2 int, v3 varchar, v4 jsonb);
+create table t(v1 boolean, v2 int, v3 varchar, v4 jsonb, v5 struct<key int, val int[]>, v6 struct<key int, val varchar>[]);
 
 statement ok
 create materialized view mv_tmp as
@@ -16,28 +16,30 @@ create materialized view mv1 as
 select
     jsonb_agg(v1 order by v2) as j1,
     jsonb_agg(v2 order by v2) as j2,
-    jsonb_object_agg(v3, v4) as j3
+    jsonb_object_agg(v3, v4) as j3,
+    jsonb_agg(v5 order by v2) as j4,
+    jsonb_object_agg(v3, v6) as j5
 from t;
 
 statement ok
 insert into t values
-    (null, 2, 'bbb', null),
-    (false, 1, 'ccc', 'null');
+    (null, 2, 'bbb', null, row(3, array[1, 2, 3]), null),
+    (false, 1, 'ccc', 'null', null, array[row(21, 'v21'), row(22, 'v22')]);
 
 query TTT
 select * from mv1;
 ----
-[false, null]  [1, 2]  {"bbb": null, "ccc": null}
+[false, null]  [1, 2]  {"bbb": null, "ccc": null}  [null, {"key": 3, "val": [1, 2, 3]}]  {"bbb": null, "ccc": [{"key": 21, "val": "v21"}, {"key": 22, "val": "v22"}]}
 
 statement ok
 insert into t values
-    (true, 0, 'bbb', '999'),
-    (true, 8, 'ddd', '{"foo": "bar"}');
+    (true, 0, 'bbb', '999', row(1, array[1, 3]), array[row(31, 'v31')]),
+    (true, 8, 'ddd', '{"foo": "bar"}', row(9, array[10]), null);
 
 query TTT
 select * from mv1;
 ----
-[true, false, null, true]  [0, 1, 2, 8]  {"bbb": 999, "ccc": null, "ddd": {"foo": "bar"}}
+[true, false, null, true]  [0, 1, 2, 8]  {"bbb": 999, "ccc": null, "ddd": {"foo": "bar"}} [{"key": 1, "val": [1, 3]}, null, {"key": 3, "val": [1, 2, 3]}, {"key": 9, "val": [10]}]  {"bbb": [{"key": 31, "val": "v31"}], "ccc": [{"key": 21, "val": "v21"}, {"key": 22, "val": "v22"}], "ddd": null}
 
 statement ok
 drop materialized view mv1;

--- a/src/expr/impl/src/aggregate/jsonb_agg.rs
+++ b/src/expr/impl/src/aggregate/jsonb_agg.rs
@@ -13,72 +13,39 @@
 // limitations under the License.
 
 use risingwave_common::estimate_size::EstimateSize;
-use risingwave_common::types::{DataType, JsonbVal, ScalarImpl};
+use risingwave_common::types::{JsonbVal, ScalarImpl};
 use risingwave_expr::aggregate::AggStateDyn;
+use risingwave_expr::expr::Context;
 use risingwave_expr::{aggregate, ExprError, Result};
 
 use crate::scalar::ToJsonb;
 
 /// Collects all the input values, including nulls, into a JSON array.
 /// Values are converted to JSON as per `to_jsonb`.
-#[aggregate("jsonb_agg(boolean) -> jsonb")]
-#[aggregate("jsonb_agg(*int) -> jsonb")]
-#[aggregate("jsonb_agg(*float) -> jsonb")]
-#[aggregate("jsonb_agg(decimal) -> jsonb")]
-#[aggregate("jsonb_agg(serial) -> jsonb")]
-#[aggregate("jsonb_agg(int256) -> jsonb")]
-#[aggregate("jsonb_agg(date) -> jsonb")]
-#[aggregate("jsonb_agg(time) -> jsonb")]
-#[aggregate("jsonb_agg(timestamp) -> jsonb")]
-#[aggregate("jsonb_agg(timestamptz) -> jsonb")]
-#[aggregate("jsonb_agg(interval) -> jsonb")]
-#[aggregate("jsonb_agg(varchar) -> jsonb")]
-#[aggregate("jsonb_agg(bytea) -> jsonb")]
-#[aggregate("jsonb_agg(jsonb) -> jsonb")]
-fn jsonb_agg(state: &mut JsonbArrayState, input: Option<impl ToJsonb>) -> Result<()> {
-    // FIXME(runji):
-    // None of the input types we currently support depend on `data_type` in `add_to`.
-    // So we just use a dummy type here.
-    // To get the correct type, we need to support `ctx: &Context` argument in `#[aggregate]`.
-    let data_type = &DataType::Int32;
-
-    input.add_to(data_type, &mut state.0)?;
+#[aggregate("jsonb_agg(*) -> jsonb")]
+fn jsonb_agg(
+    state: &mut JsonbArrayState,
+    input: Option<impl ToJsonb>,
+    ctx: &Context,
+) -> Result<()> {
+    input.add_to(&ctx.arg_types[0], &mut state.0)?;
     Ok(())
 }
 
 /// Collects all the key/value pairs into a JSON object.
-/// // TODO: support "any" type key
 /// // Key arguments are coerced to text;
 /// value arguments are converted as per `to_jsonb`.
 /// Values can be null, but keys cannot.
-#[aggregate("jsonb_object_agg(varchar, boolean) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, *int) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, *float) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, decimal) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, serial) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, int256) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, date) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, time) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, timestamp) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, timestamptz) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, interval) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, varchar) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, bytea) -> jsonb")]
-#[aggregate("jsonb_object_agg(varchar, jsonb) -> jsonb")]
+#[aggregate("jsonb_object_agg(varchar, *) -> jsonb")]
 fn jsonb_object_agg(
     state: &mut JsonbObjectState,
     key: Option<&str>,
     value: Option<impl ToJsonb>,
+    ctx: &Context,
 ) -> Result<()> {
-    // FIXME(runji):
-    // None of the input types we currently support depend on `data_type` in `add_to`.
-    // So we just use a dummy type here.
-    // To get the correct type, we need to support `ctx: &Context` argument in `#[aggregate]`.
-    let data_type = &DataType::Int32;
-
     let key = key.ok_or(ExprError::FieldNameNull)?;
     state.0.add_string(key);
-    value.add_to(data_type, &mut state.0)?;
+    value.add_to(&ctx.arg_types[1], &mut state.0)?;
     Ok(())
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

As titled. 
With this PR, `Aggregation` can now use `Context` to get `arg_type/return_type`, just like what `Function` can do.

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

### `jsonb_agg`

Aggregates values, including nulls, as a JSON array. The `ORDER BY` clause is optional and specifies the order of rows processed in the aggregation, which determines the order of the elements in the result array.

```bash title=Syntax
jsonb_agg ( expression ) -> jsonb    
```

~~Currently, input types include boolean, smallint, int, bigint, real, double precision, varchar and jsonb.~~

### `jsonb_object_agg`

Aggregates name/value pairs as a JSON object.

```bash title=Syntax
jsonb_object_agg ( key , value ) -> jsonb   
```

`key`: varchar only.

~~`value`: Currently supports null, boolean, smallint, int, bigint, real, double precision, varchar, and jsonb.~~

---  
<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
