### PR TITLE
feat: add `properties.fetch.queue.backoff.ms` for kafka source

### DIFF
--- a/src/connector/src/source/kafka/mod.rs
+++ b/src/connector/src/source/kafka/mod.rs
@@ -63,10 +63,9 @@ pub struct RdKafkaPropertiesConsumer {
     /// exceeded. This property may need to be decreased if the queue thresholds are set low
     /// and the application is experiencing long (~1s) delays between messages. Low values may
     /// increase CPU utilization.
-    // FIXME: need to upgrade rdkafka to v2.2.0 to use this property
-    // #[serde(rename = "properties.fetch.queue.backoff.ms")]
-    // #[serde_as(as = "Option<DisplayFromStr>")]
-    // pub fetch_queue_backoff_ms: Option<usize>,
+    #[serde(rename = "properties.fetch.queue.backoff.ms")]
+    #[serde_as(as = "Option<DisplayFromStr>")]
+    pub fetch_queue_backoff_ms: Option<usize>,
 
     /// Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in
     /// batches by the consumer and if the first message batch in the first non-empty partition of
@@ -156,9 +155,9 @@ impl RdKafkaPropertiesConsumer {
         if let Some(v) = &self.fetch_wait_max_ms {
             c.set("fetch.wait.max.ms", v.to_string());
         }
-        // if let Some(v) = &self.fetch_queue_backoff_ms {
-        //     c.set("fetch.queue.backoff.ms", v.to_string());
-        // }
+        if let Some(v) = &self.fetch_queue_backoff_ms {
+            c.set("fetch.queue.backoff.ms", v.to_string());
+        }
         if let Some(v) = &self.fetch_max_bytes {
             c.set("fetch.max.bytes", v.to_string());
         }
@@ -193,6 +192,7 @@ mod test {
             "properties.fetch.wait.max.ms".to_string() => "114514".to_string(),
             "properties.fetch.max.bytes".to_string() => "114514".to_string(),
             "properties.enable.auto.commit".to_string() => "true".to_string(),
+            "properties.fetch.queue.backoff.ms".to_string() => "114514".to_string(),
         };
 
         let props: KafkaProperties =
@@ -215,5 +215,9 @@ mod test {
         assert_eq!(props.rdkafka_properties.fetch_wait_max_ms, Some(114514));
         assert_eq!(props.rdkafka_properties.fetch_max_bytes, Some(114514));
         assert_eq!(props.rdkafka_properties.enable_auto_commit, Some(true));
+        assert_eq!(
+            props.rdkafka_properties.fetch_queue_backoff_ms,
+            Some(114514)
+        );
     }
 }

--- a/src/connector/with_options.yaml
+++ b/src/connector/with_options.yaml
@@ -379,9 +379,13 @@ KafkaProperties:
     field_type: Option < usize >
     comments: Maximum time the broker may wait to fill the Fetch response with `fetch.min.`bytes of  messages.
     required: false
+  - name: properties.fetch.queue.backoff.ms
+    field_type: Option < usize >
+    comments: How long to postpone the next fetch request for a topic+partition in case the current fetch  queue thresholds (`queued.min.messages` or `queued.max.messages.kbytes`) have been  exceeded. This property may need to be decreased if the queue thresholds are set low  and the application is experiencing long (~1s) delays between messages. Low values may  increase CPU utilization.
+    required: false
   - name: properties.fetch.max.bytes
     field_type: Option < usize >
-    comments: How long to postpone the next fetch request for a topic+partition in case the current fetch  queue thresholds (`queued.min.messages` or `queued.max.messages.kbytes`) have been  exceeded. This property may need to be decreased if the queue thresholds are set low  and the application is experiencing long (~1s) delays between messages. Low values may  increase CPU utilization.  Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in  batches by the consumer and if the first message batch in the first non-empty partition of  the Fetch request is larger than this value, then the message batch will still be returned  to ensure the consumer can make progress. The maximum message batch size accepted by the  broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker  topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least  `message.max.bytes` (consumer config).
+    comments: Maximum amount of data the broker shall return for a Fetch request. Messages are fetched in  batches by the consumer and if the first message batch in the first non-empty partition of  the Fetch request is larger than this value, then the message batch will still be returned  to ensure the consumer can make progress. The maximum message batch size accepted by the  broker is defined via `message.max.bytes` (broker config) or `max.message.bytes` (broker  topic config). `fetch.max.bytes` is automatically adjusted upwards to be at least  `message.max.bytes` (consumer config).
     required: false
   - name: properties.enable.auto.commit
     field_type: Option < bool >


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

resolve #12846

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

ref `fetch.queue.backoff.ms` in https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md 

add `properties.fetch.queue.backoff.ms`, not required. accept `(0 .. 300000)`, default 1000 (1s)

<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
