### PR TITLE
chore(proto): standardize name of enums

### DIFF
--- a/java/common-utils/src/main/java/com/risingwave/java/utils/MetaClient.java
+++ b/java/common-utils/src/main/java/com/risingwave/java/utils/MetaClient.java
@@ -93,7 +93,7 @@ public class MetaClient implements AutoCloseable {
 
         AddWorkerNodeRequest req =
                 AddWorkerNodeRequest.newBuilder()
-                        .setWorkerType(WorkerType.RISE_CTL)
+                        .setWorkerType(WorkerType.WORKER_TYPE_RISE_CTL)
                         .setHost(
                                 HostAddress.newBuilder().setHost("127.0.0.1").setPort(8880).build())
                         .setProperty(

--- a/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/iceberg/IcebergSinkFactoryTest.java
+++ b/java/connector-node/risingwave-connector-test/src/test/java/com/risingwave/connector/sink/iceberg/IcebergSinkFactoryTest.java
@@ -117,7 +117,7 @@ public class IcebergSinkFactoryTest {
                                         .setTypeName(Data.DataType.TypeName.VARCHAR)
                                         .build()),
                         Lists.newArrayList("id"));
-        sinkFactory.validate(diffTypeTableSchema, tableProperties, SinkType.APPEND_ONLY);
+        sinkFactory.validate(diffTypeTableSchema, tableProperties, SinkType.SINK_TYPE_APPEND_ONLY);
     }
 
     @Test(expected = RuntimeException.class)
@@ -145,6 +145,6 @@ public class IcebergSinkFactoryTest {
                                         .setTypeName(Data.DataType.TypeName.INT32)
                                         .build()),
                         Lists.newArrayList("id"));
-        sinkFactory.validate(diffTypeTableSchema, tableProperties, SinkType.APPEND_ONLY);
+        sinkFactory.validate(diffTypeTableSchema, tableProperties, SinkType.SINK_TYPE_APPEND_ONLY);
     }
 }

--- a/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraFactory.java
+++ b/java/connector-node/risingwave-sink-cassandra/src/main/java/com/risingwave/connector/CassandraFactory.java
@@ -85,12 +85,12 @@ public class CassandraFactory implements SinkFactory {
         // 3. close client
         session.close();
         switch (sinkType) {
-            case UPSERT:
+            case SINK_TYPE_UPSERT:
                 CassandraUtil.checkPrimaryKey(
                         tableMetadata.getPrimaryKey(), tableSchema.getPrimaryKeys());
                 break;
-            case APPEND_ONLY:
-            case FORCE_APPEND_ONLY:
+            case SINK_TYPE_APPEND_ONLY:
+            case SINK_TYPE_FORCE_APPEND_ONLY:
                 break;
             default:
                 throw Status.INTERNAL.asRuntimeException();

--- a/java/connector-node/risingwave-sink-deltalake/src/main/java/com/risingwave/connector/DeltaLakeSinkFactory.java
+++ b/java/connector-node/risingwave-sink-deltalake/src/main/java/com/risingwave/connector/DeltaLakeSinkFactory.java
@@ -49,7 +49,8 @@ public class DeltaLakeSinkFactory implements SinkFactory {
     @Override
     public void validate(
             TableSchema tableSchema, Map<String, String> tableProperties, SinkType sinkType) {
-        if (sinkType != SinkType.APPEND_ONLY && sinkType != SinkType.FORCE_APPEND_ONLY) {
+        if (sinkType != SinkType.SINK_TYPE_APPEND_ONLY
+                && sinkType != SinkType.SINK_TYPE_FORCE_APPEND_ONLY) {
             throw Status.INVALID_ARGUMENT
                     .withDescription("only append-only delta lake sink is supported")
                     .asRuntimeException();

--- a/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/IcebergSinkFactory.java
+++ b/java/connector-node/risingwave-sink-iceberg/src/main/java/com/risingwave/connector/IcebergSinkFactory.java
@@ -144,7 +144,7 @@ public class IcebergSinkFactory implements SinkFactory {
         }
 
         switch (sinkType) {
-            case UPSERT:
+            case SINK_TYPE_UPSERT:
                 // For upsert iceberg sink, the user must specify its primary key explicitly.
                 if (tableSchema.getPrimaryKeys().isEmpty()) {
                     throw Status.INVALID_ARGUMENT
@@ -152,8 +152,8 @@ public class IcebergSinkFactory implements SinkFactory {
                             .asRuntimeException();
                 }
                 break;
-            case APPEND_ONLY:
-            case FORCE_APPEND_ONLY:
+            case SINK_TYPE_APPEND_ONLY:
+            case SINK_TYPE_FORCE_APPEND_ONLY:
                 break;
             default:
                 throw Status.INTERNAL.asRuntimeException();

--- a/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkFactory.java
+++ b/java/connector-node/risingwave-sink-jdbc/src/main/java/com/risingwave/connector/JDBCSinkFactory.java
@@ -96,7 +96,7 @@ public class JDBCSinkFactory implements SinkFactory {
             }
         }
 
-        if (sinkType == SinkType.UPSERT) {
+        if (sinkType == SinkType.SINK_TYPE_UPSERT) {
             // For upsert JDBC sink, the primary key defined on the table must match the one in
             // config and cannot be empty
             var pkInWith = new HashSet<>(tableSchema.getPrimaryKeys());

--- a/java/udf-example/pom.xml
+++ b/java/udf-example/pom.xml
@@ -24,6 +24,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <dependencies>

--- a/proto/catalog.proto
+++ b/proto/catalog.proto
@@ -27,24 +27,24 @@ message WatermarkDesc {
 }
 
 enum SchemaRegistryNameStrategy {
-  TOPIC_NAME_STRATEGY_UNSPECIFIED = 0;
-  RECORD_NAME_STRATEGY = 1;
-  TOPIC_RECORD_NAME_STRATEGY = 2;
+  SCHEMA_REGISTRY_NAME_STRATEGY_UNSPECIFIED = 0;
+  SCHEMA_REGISTRY_NAME_STRATEGY_RECORD_NAME_STRATEGY = 1;
+  SCHEMA_REGISTRY_NAME_STRATEGY_TOPIC_RECORD_NAME_STRATEGY = 2;
 }
 
 enum StreamJobStatus {
   // Prefixed by `STREAM_JOB_STATUS` due to protobuf namespacing rules.
   STREAM_JOB_STATUS_UNSPECIFIED = 0;
-  CREATING = 1;
-  CREATED = 2;
+  STREAM_JOB_STATUS_CREATING = 1;
+  STREAM_JOB_STATUS_CREATED = 2;
 }
 
 // How the stream job was created will determine
 // whether they are persisted.
 enum CreateType {
   CREATE_TYPE_UNSPECIFIED = 0;
-  BACKGROUND = 1;
-  FOREGROUND = 2;
+  CREATE_TYPE_BACKGROUND = 1;
+  CREATE_TYPE_FOREGROUND = 2;
 }
 
 message StreamSourceInfo {
@@ -104,10 +104,10 @@ message Source {
 }
 
 enum SinkType {
-  UNSPECIFIED = 0;
-  APPEND_ONLY = 1;
-  FORCE_APPEND_ONLY = 2;
-  UPSERT = 3;
+  SINK_TYPE_UNSPECIFIED = 0;
+  SINK_TYPE_APPEND_ONLY = 1;
+  SINK_TYPE_FORCE_APPEND_ONLY = 2;
+  SINK_TYPE_UPSERT = 3;
 }
 
 // Similar to `StreamSourceInfo`, and may replace `SinkType` later.
@@ -293,10 +293,10 @@ message Table {
 }
 
 enum HandleConflictBehavior {
-  CONFLICT_BEHAVIOR_UNSPECIFIED = 0;
-  OVERWRITE = 1;
-  IGNORE = 2;
-  NO_CHECK = 3;
+  HANDLE_CONFLICT_BEHAVIOR_UNSPECIFIED = 0;
+  HANDLE_CONFLICT_BEHAVIOR_OVERWRITE = 1;
+  HANDLE_CONFLICT_BEHAVIOR_IGNORE = 2;
+  HANDLE_CONFLICT_BEHAVIOR_NO_CHECK = 3;
 }
 
 message View {

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -27,12 +27,12 @@ message ActorInfo {
 }
 
 enum WorkerType {
-  UNSPECIFIED = 0;
-  FRONTEND = 1;
-  COMPUTE_NODE = 2;
-  RISE_CTL = 3;
-  COMPACTOR = 4;
-  META = 5;
+  WORKER_TYPE_UNSPECIFIED = 0;
+  WORKER_TYPE_FRONTEND = 1;
+  WORKER_TYPE_COMPUTE_NODE = 2;
+  WORKER_TYPE_RISE_CTL = 3;
+  WORKER_TYPE_COMPACTOR = 4;
+  WORKER_TYPE_META = 5;
 }
 
 message ParallelUnit {

--- a/proto/ddl_service.proto
+++ b/proto/ddl_service.proto
@@ -144,11 +144,11 @@ message DropViewResponse {
 // - SHARED_CDC_SOURCE: The table streaming job is created based on a shared CDC source job (risingwavelabs/rfcs#73).
 // And one may add other types to support Table jobs that based on other backfill-able sources (risingwavelabs/rfcs#72).
 enum TableJobType {
-  UNSPECIFIED = 0;
+  TABLE_JOB_TYPE_UNSPECIFIED = 0;
   // table streaming jobs excepts the `SHARED_CDC_SOURCE` type
-  GENERAL = 1;
+  TABLE_JOB_TYPE_GENERAL = 1;
   // table streaming job sharing a CDC source job
-  SHARED_CDC_SOURCE = 2;
+  TABLE_JOB_TYPE_SHARED_CDC_SOURCE = 2;
 }
 
 message CreateTableRequest {

--- a/proto/hummock.proto
+++ b/proto/hummock.proto
@@ -31,9 +31,9 @@ message SstableInfo {
 }
 
 enum LevelType {
-  UNSPECIFIED = 0;
-  NONOVERLAPPING = 1;
-  OVERLAPPING = 2;
+  LEVEL_TYPE_UNSPECIFIED = 0;
+  LEVEL_TYPE_NONOVERLAPPING = 1;
+  LEVEL_TYPE_OVERLAPPING = 2;
 }
 
 message OverlappingLevel {

--- a/proto/plan_common.proto
+++ b/proto/plan_common.proto
@@ -89,15 +89,15 @@ message ExternalTableDesc {
 enum JoinType {
   // Note that it comes from Calcite's JoinRelType.
   // DO NOT HAVE direction for SEMI and ANTI now.
-  UNSPECIFIED = 0;
-  INNER = 1;
-  LEFT_OUTER = 2;
-  RIGHT_OUTER = 3;
-  FULL_OUTER = 4;
-  LEFT_SEMI = 5;
-  LEFT_ANTI = 6;
-  RIGHT_SEMI = 7;
-  RIGHT_ANTI = 8;
+  JOIN_TYPE_UNSPECIFIED = 0;
+  JOIN_TYPE_INNER = 1;
+  JOIN_TYPE_LEFT_OUTER = 2;
+  JOIN_TYPE_RIGHT_OUTER = 3;
+  JOIN_TYPE_FULL_OUTER = 4;
+  JOIN_TYPE_LEFT_SEMI = 5;
+  JOIN_TYPE_LEFT_ANTI = 6;
+  JOIN_TYPE_RIGHT_SEMI = 7;
+  JOIN_TYPE_RIGHT_ANTI = 8;
 }
 
 // https://github.com/tokio-rs/prost/issues/80

--- a/proto/stream_plan.proto
+++ b/proto/stream_plan.proto
@@ -205,8 +205,8 @@ message SinkDesc {
 enum SinkLogStoreType {
   /// Default value is the normal in memory log store to be backward compatible with the previously unset value
   SINK_LOG_STORE_TYPE_UNSPECIFIED = 0;
-  KV_LOG_STORE = 1;
-  IN_MEMORY_LOG_STORE = 2;
+  SINK_LOG_STORE_TYPE_KV_LOG_STORE = 1;
+  SINK_LOG_STORE_TYPE_IN_MEMORY_LOG_STORE = 2;
 }
 
 message SinkNode {
@@ -449,22 +449,22 @@ message ExchangeNode {
 
 // Decides which kind of Executor will be used
 enum StreamScanType {
-  CHAIN_UNSPECIFIED = 0;
+  STREAM_SCAN_TYPE_UNSPECIFIED = 0;
 
   // ChainExecutor
-  CHAIN = 1;
+  STREAM_SCAN_TYPE_CHAIN = 1;
 
   // RearrangedChainExecutor
-  REARRANGE = 2;
+  STREAM_SCAN_TYPE_REARRANGE = 2;
 
   // BackfillExecutor
-  BACKFILL = 3;
+  STREAM_SCAN_TYPE_BACKFILL = 3;
 
   // ChainExecutor with upstream_only = true
-  UPSTREAM_ONLY = 4;
+  STREAM_SCAN_TYPE_UPSTREAM_ONLY = 4;
 
   // CdcBackfillExecutor
-  CDC_BACKFILL = 5;
+  STREAM_SCAN_TYPE_CDC_BACKFILL = 5;
 }
 
 // StreamScanNode reads data from upstream table first, and then pass all events to downstream.
@@ -713,25 +713,25 @@ message StreamNode {
 }
 
 enum DispatcherType {
-  UNSPECIFIED = 0;
+  DISPATCHER_TYPE_UNSPECIFIED = 0;
   // Dispatch by hash key, hashed by consistent hash.
-  HASH = 1;
+  DISPATCHER_TYPE_HASH = 1;
   // Broadcast to all downstreams.
   //
   // Note a broadcast cannot be represented as multiple simple dispatchers, since they are
   // different when we update dispatchers during scaling.
-  BROADCAST = 2;
+  DISPATCHER_TYPE_BROADCAST = 2;
   // Only one downstream.
-  SIMPLE = 3;
+  DISPATCHER_TYPE_SIMPLE = 3;
   // A special kind of exchange that doesn't involve shuffle. The upstream actor will be directly
   // piped into the downstream actor, if there are the same number of actors. If number of actors
   // are not the same, should use hash instead. Should be only used when distribution is the same.
-  NO_SHUFFLE = 4;
+  DISPATCHER_TYPE_NO_SHUFFLE = 4;
 
   // Dispatch by table name from upstream DB, used in CDC scenario which should has only one downstream actor.
   // From the optimizer's point of view, it can be treated as a specialized version of HASH distribution
   // that the hash key is the upstream table name.
-  CDC_TABLENAME = 5;
+  DISPATCHER_TYPE_CDC_TABLENAME = 5;
 }
 
 // The property of an edge in the fragment graph.

--- a/src/common/src/catalog/mod.rs
+++ b/src/common/src/catalog/mod.rs
@@ -483,9 +483,10 @@ impl ConflictBehavior {
             PbHandleConflictBehavior::Overwrite => ConflictBehavior::Overwrite,
             PbHandleConflictBehavior::Ignore => ConflictBehavior::IgnoreConflict,
             // This is for backward compatibility, in the previous version
-            // `ConflictBehaviorUnspecified' represented `NoCheck`, so just treat it as `NoCheck`.
-            PbHandleConflictBehavior::NoCheck
-            | PbHandleConflictBehavior::ConflictBehaviorUnspecified => ConflictBehavior::NoCheck,
+            // `HandleConflictBehavior::Unspecified` represented `NoCheck`, so just treat it as `NoCheck`.
+            PbHandleConflictBehavior::NoCheck | PbHandleConflictBehavior::Unspecified => {
+                ConflictBehavior::NoCheck
+            }
         }
     }
 

--- a/src/connector/src/parser/debezium/avro_parser.rs
+++ b/src/connector/src/parser/debezium/avro_parser.rs
@@ -113,7 +113,7 @@ impl DebeziumAvroParserConfig {
         let client = Client::new(url, client_config)?;
         let resolver = ConfluentSchemaResolver::new(client);
 
-        let name_strategy = &PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified;
+        let name_strategy = &PbSchemaRegistryNameStrategy::Unspecified;
         let key_subject = get_subject_by_strategy(name_strategy, kafka_topic, None, true)?;
         let val_subject = get_subject_by_strategy(name_strategy, kafka_topic, None, false)?;
         let key_schema = resolver.get_by_subject_name(&key_subject).await?;

--- a/src/connector/src/schema/schema_registry/mod.rs
+++ b/src/connector/src/schema/schema_registry/mod.rs
@@ -22,7 +22,7 @@ pub(crate) use util::*;
 
 pub fn name_strategy_from_str(value: &str) -> Option<PbSchemaRegistryNameStrategy> {
     match value {
-        "topic_name_strategy" => Some(PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified),
+        "topic_name_strategy" => Some(PbSchemaRegistryNameStrategy::Unspecified),
         "record_name_strategy" => Some(PbSchemaRegistryNameStrategy::RecordNameStrategy),
         "topic_record_name_strategy" => Some(PbSchemaRegistryNameStrategy::TopicRecordNameStrategy),
         _ => None,
@@ -44,7 +44,7 @@ pub fn get_subject_by_strategy(
     };
     let record_option_name = if is_key { "key.message" } else { "message" };
     match name_strategy {
-        PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified => {
+        PbSchemaRegistryNameStrategy::Unspecified => {
             // default behavior
             let suffix = if is_key { "key" } else { "value" };
             Ok(format!("{topic}-{suffix}",))

--- a/src/frontend/src/handler/create_source.rs
+++ b/src/frontend/src/handler/create_source.rs
@@ -350,9 +350,8 @@ pub(crate) async fn bind_columns_from_source(
                     use_schema_registry: protobuf_schema.use_schema_registry,
                     proto_message_name: protobuf_schema.message_name.0.clone(),
                     key_message_name: get_key_message_name(&mut options),
-                    name_strategy: name_strategy.unwrap_or(
-                        PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified as i32,
-                    ),
+                    name_strategy: name_strategy
+                        .unwrap_or(PbSchemaRegistryNameStrategy::Unspecified as i32),
                     ..Default::default()
                 },
             )
@@ -395,7 +394,7 @@ pub(crate) async fn bind_columns_from_source(
                 proto_message_name: message_name.unwrap_or(AstString("".into())).0,
                 key_message_name,
                 name_strategy: name_strategy
-                    .unwrap_or(PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified as i32),
+                    .unwrap_or(PbSchemaRegistryNameStrategy::Unspecified as i32),
                 ..Default::default()
             };
             (
@@ -459,7 +458,7 @@ pub(crate) async fn bind_columns_from_source(
 
             let name_strategy =
                 get_sr_name_strategy_check(&mut options, avro_schema.use_schema_registry)?
-                    .unwrap_or(PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified as i32);
+                    .unwrap_or(PbSchemaRegistryNameStrategy::Unspecified as i32);
             let key_message_name = get_key_message_name(&mut options);
             let message_name = try_consume_string_from_options(&mut options, MESSAGE_NAME_KEY);
 
@@ -511,7 +510,7 @@ pub(crate) async fn bind_columns_from_source(
                 use_schema_registry,
                 proto_message_name: message_name.unwrap_or(AstString("".into())).0,
                 name_strategy: name_strategy
-                    .unwrap_or(PbSchemaRegistryNameStrategy::TopicNameStrategyUnspecified as i32),
+                    .unwrap_or(PbSchemaRegistryNameStrategy::Unspecified as i32),
                 format: FormatType::Debezium as i32,
                 row_encode: EncodeType::Avro as i32,
                 row_schema_location: avro_schema.row_schema_location.0.clone(),

--- a/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
+++ b/src/frontend/src/optimizer/plan_node/stream_table_scan.rs
@@ -254,7 +254,7 @@ impl StreamTableScan {
             StreamScanType::Chain | StreamScanType::Rearrange | StreamScanType::UpstreamOnly => {
                 self.core.output_column_ids()
             }
-            StreamScanType::ChainUnspecified => unreachable!(),
+            StreamScanType::Unspecified => unreachable!(),
         }
         .iter()
         .map(ColumnId::get_id)

--- a/src/stream/src/from_proto/stream_scan.rs
+++ b/src/stream/src/from_proto/stream_scan.rs
@@ -244,7 +244,7 @@ impl ExecutorBuilder for ChainExecutorBuilder {
                 )
                 .boxed()
             }
-            StreamScanType::ChainUnspecified => unreachable!(),
+            StreamScanType::Unspecified => unreachable!(),
         };
         let rate_limit = node.get_rate_limit().cloned().ok();
         Ok(FlowControlExecutor::new(executor, rate_limit).boxed())


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Naming of `Enum`s should follow one of the below styles:

- Uppercase underscore style e.g. `STREAM_JOB_STATUS_UNSPECIFIED`
- Place the `Enum` in smaller namespace

This PR cleans the occurrences that doesn't follow either of them.

## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

