### PR TITLE
fix(ci): rebuild dashboard artifacts on proto changes

### DIFF
--- a/.github/workflows/dashboard_main.yml
+++ b/.github/workflows/dashboard_main.yml
@@ -1,8 +1,9 @@
 name: Dashboard (main)
 on:
   push:
-    branches: [ main ]
-    paths: [ dashboard/** ]
+    branches: [main]
+    paths: [dashboard/**, proto/**]
+  workflow_dispatch:
 jobs:
   dashboard-ui-deploy:
     runs-on: ubuntu-latest
@@ -10,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v2
         with:
-          node-version: '18'
+          node-version: "18"
       - uses: arduino/setup-protoc@v1
         with:
           version: "3.x"


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

The dashboard artifacts are accessed if there're no local assets. They should also be rebuilt if there're changes under `proto/**`. Otherwise, changes like #13336 will break the UI as it uses pb-generated JSON as the protocol when communicating with the meta service.

<img width="681" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/8702b905-bbdb-48f8-b58a-d4a64c6b23f6">

Also add a manual rebuild button.


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
