### PR TITLE
fix(meta): singleton requirement should be propagated through no-shuffle edges in scheduler

### DIFF
--- a/e2e_test/streaming/bug_fixes/issue_13094.slt
+++ b/e2e_test/streaming/bug_fixes/issue_13094.slt
@@ -1,0 +1,29 @@
+# https://github.com/risingwavelabs/risingwave/issues/13094
+# The singleton requirement should be propagated through no-shuffle edges in the scheduler.
+
+statement ok
+create table t(v int);
+
+statement ok
+create materialized view m as
+with sub(v1) as (select max(v) as v1 from t)
+select s1.v1 as sv1, s2.v1 as sv2
+from sub as s1, sub as s2
+where s1.v1 = s2.v1;
+
+statement ok
+insert into t values (1);
+
+statement ok
+flush;
+
+query II
+select * from m;
+----
+1 1
+
+statement ok
+drop materialized view m;
+
+statement ok
+drop table t;

--- a/src/meta/src/stream/stream_graph/schedule.rs
+++ b/src/meta/src/stream/stream_graph/schedule.rs
@@ -104,7 +104,7 @@ crepe::crepe! {
 
     // Requirements from the facts.
     Requirement(x, d) <- ExternalReq(x, d);
-    // Requirements of `NoShuffle` edges.
+    // Requirements propagate through `NoShuffle` edges.
     Requirement(x, d) <- Edge(x, y, NoShuffle), Requirement(y, d);
     Requirement(y, d) <- Edge(x, y, NoShuffle), Requirement(x, d);
 
@@ -112,6 +112,9 @@ crepe::crepe! {
     SingletonReq(y) <- Edge(_, y, Simple);
     // The downstream fragment of a `CdcTablename` edge must be singleton.
     SingletonReq(y) <- Edge(_, y, CdcTablename);
+    // Singleton requirements propagate through `NoShuffle` edges.
+    SingletonReq(x) <- Edge(x, y, NoShuffle), SingletonReq(y);
+    SingletonReq(y) <- Edge(x, y, NoShuffle), SingletonReq(x);
 
     // Multiple requirements conflict.
     Failed(x) <- Requirement(x, d1), Requirement(x, d2), (d1 != d2);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Fix #13094.

There's a singleton requirement on the fragment 6, and no-shuffle edges of 6-5 and 6-8. Then fragment 5 and 8 should also be singleton. Previously we don't have this rule.

<img width="963" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/af029665-e7ff-4110-803e-a4e17a58c05a">


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
