### PR TITLE
fix(source): informative error on protobuf `build_file_descriptor_set` failure

### DIFF
--- a/src/connector/src/parser/protobuf/schema_resolver.rs
+++ b/src/connector/src/parser/protobuf/schema_resolver.rs
@@ -15,7 +15,10 @@
 use std::iter;
 use std::path::Path;
 
-use protobuf_native::compiler::{SourceTreeDescriptorDatabase, VirtualSourceTree};
+use itertools::Itertools;
+use protobuf_native::compiler::{
+    SimpleErrorCollector, SourceTreeDescriptorDatabase, VirtualSourceTree,
+};
 use protobuf_native::MessageLite;
 use risingwave_common::error::ErrorCode::{InternalError, ProtocolError};
 use risingwave_common::error::{Result, RwError};
@@ -48,16 +51,20 @@ pub(super) async fn compile_file_descriptor_from_schema_registry(
             subject.schema.content.as_bytes().to_vec(),
         );
     }
-    let mut db = SourceTreeDescriptorDatabase::new(source_tree.as_mut());
-    let fds = db
-        .as_mut()
-        .build_file_descriptor_set(&[Path::new(&primary_subject.name)])
-        .map_err(|e| {
-            RwError::from(ProtocolError(format!(
-                "build_file_descriptor_set failed, {}",
-                e
-            )))
-        })?;
+    let mut error_collector = SimpleErrorCollector::new();
+    // `db` needs to be dropped before we can iterate on `error_collector`.
+    let fds = {
+        let mut db = SourceTreeDescriptorDatabase::new(source_tree.as_mut());
+        db.as_mut().record_errors_to(error_collector.as_mut());
+        db.as_mut()
+            .build_file_descriptor_set(&[Path::new(&primary_subject.name)])
+    }
+    .map_err(|_| {
+        RwError::from(ProtocolError(format!(
+            "build_file_descriptor_set failed. Errors:\n{}",
+            error_collector.as_mut().join("\n")
+        )))
+    })?;
     fds.serialize()
         .map_err(|_| RwError::from(InternalError("serialize descriptor set failed".to_owned())))
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Before:
```
Protocol error: build_file_descriptor_set failed, operation failed
```
After:
```
Protocol error: build_file_descriptor_set failed. Errors:
aaa/common.proto: error: File not found.
```

`build_file_descriptor_set` returns an `OperationFailedError`, whose doc comment says:
> This error does not contain details about why the operation failed or what the operation was. Unfortunately this is a limitation of the underlying `libprotobuf` APIs.
> In some cases, you may be able to find an alternative API that returns a more descriptive error type (e.g., the APIs that return [`compiler::FileLoadError`])

The error collector contains multiple `FileLoadError`s with details.

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [x] I have written necessary rustdoc comments
- [ ] I have added necessary unit tests and integration tests
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [x] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
