### PR TITLE
fix(streaming): avoid shadowing identity when flow controlled

### DIFF
--- a/src/stream/src/executor/flow_control.rs
+++ b/src/stream/src/executor/flow_control.rs
@@ -32,12 +32,22 @@ use super::*;
 /// It is used to throttle problematic MVs that are consuming too much resources.
 pub struct FlowControlExecutor {
     input: BoxedExecutor,
+    identity: String,
     rate_limit: Option<u32>,
 }
 
 impl FlowControlExecutor {
     pub fn new(input: Box<dyn Executor>, rate_limit: Option<u32>) -> Self {
-        Self { input, rate_limit }
+        let identity = if rate_limit.is_some() {
+            format!("{} (flow controlled)", input.identity())
+        } else {
+            input.identity().to_owned()
+        };
+        Self {
+            input,
+            identity,
+            rate_limit,
+        }
     }
 
     #[try_stream(ok = Message, error = StreamExecutorError)]
@@ -97,6 +107,6 @@ impl Executor for FlowControlExecutor {
     }
 
     fn identity(&self) -> &str {
-        "FlowControlExecutor"
+        &self.identity
     }
 }


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

To reveal the real name of the wrapped executor in await-tree and tracing spans:

```diff
[Actor 21]
Actor 21: `CREATE MATERIALIZED VIEW mv AS SELECT * FROM t` [48.585s]
  Epoch 5419982432698368 [889.601ms]
    Materialize 1500000001 (actor 21) [889.601ms]
-     FlowControlExecutor 1500002743 (actor 21) [889.579ms]
+     StreamScan 1500002743 (flow controlled) (actor 21) [889.579ms]
        ReceiverExecutor (actor 21) [889.579ms]
```


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
