### PR TITLE
feat(datagen): support `timestamptz`

### DIFF
--- a/e2e_test/source/basic/datagen.slt
+++ b/e2e_test/source/basic/datagen.slt
@@ -102,7 +102,7 @@ statement ok
 drop table s1;
 
 statement ok
-create table s1 (v1 struct<v2 int>, t1 timestamp, c1 varchar) with (
+create table s1 (v1 struct<v2 int>, t1 timestamp, z1 timestamptz, c1 varchar) with (
     connector = 'datagen',
     fields.v1.v2.kind = 'random',
     fields.v1.v2.min = '1',
@@ -112,6 +112,10 @@ create table s1 (v1 struct<v2 int>, t1 timestamp, c1 varchar) with (
     fields.t1.max_past = '2h 37min',
     fields.t1.max_past_mode = 'relative',
     fields.t1.seed = '3',
+    fields.z1.kind = 'random',
+    fields.z1.max_past = '2h 37min',
+    fields.z1.max_past_mode = 'relative',
+    fields.z1.seed = '3',
     fields.c1.kind = 'random',
     fields.c1.length = '100',
     fields.c1.seed = '3',

--- a/src/common/src/array/data_chunk.rs
+++ b/src/common/src/array/data_chunk.rs
@@ -919,6 +919,13 @@ impl DataChunkTestExt for DataChunk {
                                 .generate_datum(offset);
                         array_builder.append(datum);
                     }
+                    DataType::Timestamptz => {
+                        let datum =
+                            FieldGeneratorImpl::with_timestamptz(None, None, None, Self::SEED)
+                                .expect("create timestamptz generator should succeed")
+                                .generate_datum(offset);
+                        array_builder.append(datum);
+                    }
                     _ if data_type.is_numeric() => {
                         let mut data_gen = FieldGeneratorImpl::with_number_random(
                             data_type.clone(),

--- a/src/common/src/field_generator/timestamp.rs
+++ b/src/common/src/field_generator/timestamp.rs
@@ -22,7 +22,7 @@ use serde_json::Value;
 use tracing::debug;
 
 use super::DEFAULT_MAX_PAST;
-use crate::types::{Datum, Scalar, Timestamp};
+use crate::types::{Datum, Scalar, Timestamp, Timestamptz};
 
 pub struct ChronoField<T: ChronoFieldInner> {
     max_past: Duration,
@@ -104,5 +104,27 @@ impl ChronoFieldInner for Timestamp {
 
     fn to_json(&self) -> Value {
         Value::String(self.0.to_string())
+    }
+}
+
+impl ChronoFieldInner for Timestamptz {
+    fn from_now() -> Self {
+        Timestamptz::from(
+            Utc::now()
+                .duration_round(Duration::microseconds(1))
+                .unwrap(),
+        )
+    }
+
+    fn from_base(base: DateTime<FixedOffset>) -> Self {
+        Timestamptz::from(base)
+    }
+
+    fn minus(&self, duration: Duration) -> Self {
+        Timestamptz::from(self.to_datetime_utc() - duration)
+    }
+
+    fn to_json(&self) -> Value {
+        Value::String(self.to_string())
     }
 }

--- a/src/connector/src/source/datagen/source/reader.rs
+++ b/src/connector/src/source/datagen/source/reader.rs
@@ -213,7 +213,7 @@ fn generator_from_data_type(
         None => split_index,
     };
     match data_type {
-        DataType::Timestamp => {
+        ty @ (DataType::Timestamp | DataType::Timestamptz) => {
             let max_past_key = format!("fields.{}.max_past", name);
             let max_past_value = fields_option_map.get(&max_past_key).cloned();
             let max_past_mode_key = format!("fields.{}.max_past_mode", name);
@@ -230,12 +230,21 @@ fn generator_from_data_type(
                 None => None,
             };
 
-            FieldGeneratorImpl::with_timestamp(
-                basetime,
-                max_past_value,
-                max_past_mode_value,
-                random_seed,
-            )
+            if ty == DataType::Timestamptz {
+                FieldGeneratorImpl::with_timestamptz(
+                    basetime,
+                    max_past_value,
+                    max_past_mode_value,
+                    random_seed,
+                )
+            } else {
+                FieldGeneratorImpl::with_timestamp(
+                    basetime,
+                    max_past_value,
+                    max_past_mode_value,
+                    random_seed,
+                )
+            }
         }
         DataType::Varchar => {
             let length_key = format!("fields.{}.length", name);


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

Resolves #8550. The same set of `timestamp` options can be used for `timestamptz` fields:
* `max_past`
* `max_past_mode`
* `basetime`

https://docs.risingwave.com/docs/current/ingest-from-datagen/#with-options---column_parameter

<!--

**Please do not leave this empty!**

Please explain **IN DETAIL** what the changes are in this PR and why they are needed:

- Summarize your change (**mandatory**)
- How does this PR work? Need a brief introduction for the changed logic (optional)
- Describe clearly one logical change and avoid lazy messages (optional)
- Describe any limitations of the current code (optional)
- Refer to a related PR or issue link (optional)

-->

## Checklist

- [ ] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [ ] I have added test labels as necessary. See [details](https://github.com/risingwavelabs/risingwave/blob/main/docs/developer-guide.md#ci-labels-guide).
- [ ] I have added fuzzing tests or opened an issue to track them. (Optional, recommended for new SQL features #7934).
- [ ] My PR contains breaking changes. (If it deprecates some features, please create a tracking issue to remove them in the future).
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)
- [ ] My PR changes performance-critical code. (Please run macro/micro-benchmarks and show the results.)
<!-- To manually trigger a benchmark, please check out [Notion](https://www.notion.so/risingwave-labs/Manually-trigger-nexmark-performance-dashboard-test-b784f1eae1cf48889b2645d020b6b7d3). -->
- [ ] My PR contains critical fixes that are necessary to be merged into the latest release. (Please check out the [details](https://github.com/risingwavelabs/risingwave/blob/main/CONTRIBUTING.md))

## Documentation

- [x] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

The `datagen` source can now generate `timestamptz` columns.