### PR TITLE
refactor(risedev): refine error reporting

### DIFF
--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -448,6 +448,7 @@ fn main() -> Result<()> {
                 style("ERROR").red().bold(),
                 err,
             );
+            println!();
             println!(
                 "* Use `{}` to enable new components, if they are missing.",
                 style("./risedev configure").blue().bold(),
@@ -467,9 +468,12 @@ fn main() -> Result<()> {
             );
             println!("---");
             println!();
-            println!();
 
-            Err(err)
+            // As we have already printed the error above, we don't need to print that error again.
+            // However, to return with a proper exit code, still return an error here.
+            Err(anyhow!(
+                "Failed to start all services. See details and instructions above."
+            ))
         }
     }
 }

--- a/src/risedevtool/src/bin/risedev-dev.rs
+++ b/src/risedevtool/src/bin/risedev-dev.rs
@@ -349,6 +349,10 @@ fn task_main(
 }
 
 fn main() -> Result<()> {
+    // Intentionally disable backtrace to provide more compact error message for `risedev dev`.
+    // Backtraces for RisingWave components are enabled in `Task::execute`.
+    std::env::set_var("RUST_BACKTRACE", "0");
+
     preflight_check()?;
 
     let task_name = std::env::args()
@@ -440,10 +444,9 @@ fn main() -> Result<()> {
         }
         Err(err) => {
             println!(
-                "{} - Failed to start: {}\nCaused by:\n\t{}",
+                "{} - Failed to start: {:?}", // with `Caused by`
                 style("ERROR").red().bold(),
                 err,
-                err.root_cause().to_string().trim(),
             );
             println!(
                 "* Use `{}` to enable new components, if they are missing.",

--- a/src/risedevtool/src/task.rs
+++ b/src/risedevtool/src/task.rs
@@ -42,9 +42,9 @@ use std::process::{Command, Output};
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use indicatif::ProgressBar;
-use reqwest::blocking::Client;
+use reqwest::blocking::{Client, Response};
 use tempfile::TempDir;
 pub use utils::*;
 
@@ -172,7 +172,9 @@ where
         let addr = server.as_ref().parse()?;
         wait(
             || {
-                TcpStream::connect_timeout(&addr, Duration::from_secs(1))?;
+                TcpStream::connect_timeout(&addr, Duration::from_secs(1)).with_context(|| {
+                    format!("failed to establish tcp connection to {}", server.as_ref())
+                })?;
                 Ok(())
             },
             &mut self.log,
@@ -184,7 +186,11 @@ where
         Ok(())
     }
 
-    pub fn wait_http(&mut self, server: impl AsRef<str>) -> anyhow::Result<()> {
+    fn wait_http_with_response_cb(
+        &mut self,
+        server: impl AsRef<str>,
+        cb: impl Fn(Response) -> anyhow::Result<()>,
+    ) -> anyhow::Result<()> {
         let server = server.as_ref();
         wait(
             || {
@@ -192,12 +198,13 @@ where
                     .get(server)
                     .timeout(Duration::from_secs(1))
                     .body("")
-                    .send()?;
-                if resp.status().is_success() {
-                    Ok(())
-                } else {
-                    Err(anyhow!("http failed with status: {}", resp.status()))
-                }
+                    .send()?
+                    .error_for_status()
+                    .with_context(|| {
+                        format!("failed to establish http connection to {}", server)
+                    })?;
+
+                cb(resp)
             },
             &mut self.log,
             self.status_file.as_ref().unwrap(),
@@ -207,39 +214,26 @@ where
         )
     }
 
-    pub fn wait_http_with_cb(
+    pub fn wait_http(&mut self, server: impl AsRef<str>) -> anyhow::Result<()> {
+        self.wait_http_with_response_cb(server, |_| Ok(()))
+    }
+
+    pub fn wait_http_with_text_cb(
         &mut self,
         server: impl AsRef<str>,
         cb: impl Fn(&str) -> bool,
     ) -> anyhow::Result<()> {
-        let server = server.as_ref();
-        wait(
-            || {
-                let resp = Client::new()
-                    .get(server)
-                    .timeout(Duration::from_secs(1))
-                    .body("")
-                    .send()?;
-                if resp.status().is_success() {
-                    let data = resp.text()?;
-                    if cb(&data) {
-                        Ok(())
-                    } else {
-                        Err(anyhow!(
-                            "http health check callback failed with body: {:?}",
-                            data
-                        ))
-                    }
-                } else {
-                    Err(anyhow!("http failed with status: {}", resp.status()))
-                }
-            },
-            &mut self.log,
-            self.status_file.as_ref().unwrap(),
-            self.id.as_ref().unwrap(),
-            Some(Duration::from_secs(30)),
-            true,
-        )
+        self.wait_http_with_response_cb(server, |resp| {
+            let data = resp.text()?;
+            if cb(&data) {
+                Ok(())
+            } else {
+                Err(anyhow!(
+                    "http health check callback failed with body: {:?}",
+                    data
+                ))
+            }
+        })
     }
 
     pub fn wait(&mut self, wait_func: impl FnMut() -> Result<()>) -> anyhow::Result<()> {

--- a/src/risedevtool/src/task/task_etcd_ready_check.rs
+++ b/src/risedevtool/src/task/task_etcd_ready_check.rs
@@ -44,7 +44,7 @@ impl Task for EtcdReadyCheckTask {
             response.health == "true"
         };
 
-        ctx.wait_http_with_cb(health_check_addr, online_cb)?;
+        ctx.wait_http_with_text_cb(health_check_addr, online_cb)?;
         ctx.pb
             .set_message(format!("api {}:{}", self.config.address, self.config.port));
         ctx.complete_spin();

--- a/src/risedevtool/src/task/task_kafka_ready_check.rs
+++ b/src/risedevtool/src/task/task_kafka_ready_check.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Context, Result};
 use rdkafka::config::FromClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 use rdkafka::ClientConfig;
@@ -48,7 +48,7 @@ impl Task for KafkaReadyCheckTask {
         let consumer = rt.block_on(async {
             BaseConsumer::from_config(&config)
                 .await
-                .map_err(|e| anyhow!("{}", e))
+                .context("failed to create consumer")
         })?;
 
         ctx.wait(|| {
@@ -56,7 +56,7 @@ impl Task for KafkaReadyCheckTask {
                 let _metadata = consumer
                     .fetch_metadata(None, Duration::from_secs(1))
                     .await
-                    .map_err(|e| anyhow!("{}", e))?;
+                    .context("failed to fetch metadata")?;
                 Ok(())
             })
         })?;

--- a/src/risedevtool/src/wait.rs
+++ b/src/risedevtool/src/wait.rs
@@ -49,6 +49,7 @@ pub fn wait(
         if let Some(ref timeout) = timeout {
             if std::time::Instant::now() - start_time >= *timeout {
                 let context = "timeout when trying to connect";
+
                 return Err(if let Some(last_error) = last_error {
                     last_error.context(context)
                 } else {
@@ -61,11 +62,17 @@ pub fn wait(
             let mut buf = String::new();
             fs_err::File::open(p)?.read_to_string(&mut buf)?;
 
-            return Err(anyhow!(
+            let context = format!(
                 "{} exited while waiting for connection: {}",
                 style(id).red().bold(),
-                buf,
-            ));
+                buf.trim(),
+            );
+
+            return Err(if let Some(last_error) = last_error {
+                last_error.context(context)
+            } else {
+                anyhow!(context)
+            });
         }
 
         sleep(Duration::from_millis(30));

--- a/src/risedevtool/src/wait.rs
+++ b/src/risedevtool/src/wait.rs
@@ -48,7 +48,12 @@ pub fn wait(
 
         if let Some(ref timeout) = timeout {
             if std::time::Instant::now() - start_time >= *timeout {
-                return Err(anyhow!("failed to connect, last error: {:?}", last_error));
+                let context = "timeout when trying to connect";
+                return Err(if let Some(last_error) = last_error {
+                    last_error.context(context)
+                } else {
+                    anyhow!(context)
+                });
             }
         }
 


### PR DESCRIPTION
I hereby agree to the terms of the [RisingWave Labs, Inc. Contributor License Agreement](https://gist.github.com/TennyZhuang/f00be7f16996ea48effb049aa7be4d66#file-rw_cla).

## What's changed and what's your intention?

- Disable backtrace for risedev-dev itself to make it more user-friendly.
- Provide more error context if possible.
- Minor refactor to `wait_http` to reduce duplication.
- Avoid repeating the error after `main` returns.

<img width="900" alt="image" src="https://github.com/risingwavelabs/risingwave/assets/25862682/8ae8d27d-e15a-4238-93f4-6be161989634">


## Checklist

- [x] I have written necessary rustdoc comments
- [x] I have added necessary unit tests and integration tests
- [x] All checks passed in `./risedev check` (or alias, `./risedev c`)

## Documentation

- [ ] My PR needs documentation updates. (Please use the **Release note** section below to summarize the impact on users)

## Release note

If this PR includes changes that directly affect users or other significant modifications relevant to the community, kindly draft a release note to provide a concise summary of these changes. Please prioritize highlighting the impact these changes will have on users.


<!--
Please create a release note for your changes.

Discuss technical details in the "What's changed" section, and
focus on the impact on users in the release note.

You should also mention the environment or conditions where the impact may occur.
-->

</details>
